### PR TITLE
feat(ts#agent): add session management support

### DIFF
--- a/docs/src/content/docs/en/guides/ts-agent.mdx
+++ b/docs/src/content/docs/en/guides/ts-agent.mdx
@@ -60,6 +60,7 @@ The generator will add the following files to your existing TypeScript project. 
         - init.ts tRPC initialization
         - router.ts tRPC router with agent procedures
         - agent.ts Main agent definition with sample tools
+        - session.ts Resolves the SessionManager used to persist conversation state
         - client.ts Vended client for invoking your agent
         - agent-core-trpc-client.ts Client factory for connecting to agents on AgentCore Runtime
         - Dockerfile Entry point for hosting your agent (excluded when `infra` is set to `None`)
@@ -79,6 +80,7 @@ The entry point uses the [Strands A2A Express Server](https://strandsagents.com/
       - agent/ (or custom name if specified)
         - index.ts A2A Express server entry point
         - agent.ts Main agent definition with sample tools
+        - session.ts Resolves the SessionManager used to persist conversation state
         - Dockerfile Entry point for hosting your agent (excluded when `infra` is set to `None`)
     - package.json Updated with Strands and Express dependencies
     - project.json Updated with agent serve targets
@@ -96,6 +98,7 @@ The entry point uses [`@ag-ui/aws-strands`](https://www.npmjs.com/package/@ag-ui
       - agent/ (or custom name if specified)
         - index.ts AG-UI server entry point (Express + SSE)
         - agent.ts Main agent definition with sample tools
+        - session.ts Resolves the SessionManager used to persist conversation state
         - Dockerfile Entry point for hosting your agent (excluded when `infra` is set to `None`)
     - package.json Updated with Strands and AG-UI dependencies
     - project.json Updated with agent serve targets
@@ -185,7 +188,7 @@ const letterCounter = tool({
 });
 
 // Add tools to your agent
-export const getAgent = async (sessionId: string) => {
+export const getAgent = async () => {
   return new Agent({
     systemPrompt: 'You are a helpful assistant with access to various tools.',
     tools: [letterCounter],
@@ -347,6 +350,37 @@ Your agent is automatically configured with observability using the [AWS Distro 
 You can find traces in the CloudWatch AWS Console, by selecting "GenAI Observability" in the menu. Note that for traces to be populated you will need to enable [Transaction Search](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Transaction-Search.html).
 
 For more details, refer to the [AgentCore documentation on observability](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/observability-configure.html).
+
+### Session Management
+
+The `session` option controls how your agent persists conversation state (message history, tool state, etc.) across invocations, using the Strands SDK's [SessionManager](https://strandsagents.com/docs/user-guide/concepts/agents/session-management/):
+
+- **`s3`** (default): The CDK/Terraform infrastructure provisions a dedicated S3 bucket for session data, encrypted with SSE-S3 and with all public access blocked. The agent's IAM role is granted read/write/list/delete access to it, and the bucket name is registered alongside the agent's ARN in AppConfig runtime configuration.
+- **`in-memory`**: No bucket is provisioned. Conversation state is kept in memory only for the lifetime of the running process and does not survive restarts or scale-in.
+
+This is implemented in the generated `session.ts`, which exports a `getSessionManager()` function resolving a `SessionManager` for the current session:
+
+```typescript
+export const getSessionManager = async (): Promise<SessionManager> => {
+  const sessionId = getCurrentSessionId();
+  // local development always uses local file storage...
+  // ...otherwise S3Storage (session: 's3') or InMemoryStorage (session: 'in-memory')
+};
+```
+
+<OptionFilter when={{ protocol: 'ag-ui' }} description="AG-UI session wiring">
+Since AG-UI clones a template agent per conversation thread, `getSessionManager` is wired in as a `sessionManagerProvider` on the `StrandsAgent` config in `index.ts`, so a fresh `SessionManager` is resolved for each thread rather than baked into the shared template agent.
+</OptionFilter>
+
+<OptionFilter when={{ protocol: ['http', 'a2a'] }} description="HTTP/A2A session wiring">
+Since `withSessionId` already caches one `Agent` instance per session, `getSessionManager` is called directly inside `getAgent`'s `new Agent({ sessionManager: await getSessionManager() })` call in `agent.ts`.
+</OptionFilter>
+
+The session ID itself comes from the AgentCore Runtime session (propagated via the `x-amzn-bedrock-agentcore-runtime-session-id` header for A2A/AG-UI, or the WebSocket connection context for HTTP/tRPC) and is bound to an [`AsyncLocalStorage`](https://nodejs.org/api/async_context.html#class-asynclocalstorage)-based context so `getCurrentSessionId()` can resolve it anywhere in the request — including in any downstream MCP or A2A clients wired up via the <Link path="/guides/connection">`connection` generator</Link>, so the whole call chain shares a consistent session.
+
+:::note[Local Development]
+When running locally (`LOCAL_DEV=true`, set automatically by the `-dev` target), session data is always stored on disk under `tmp/agents/strands/<agent-name>` at the workspace root, regardless of the configured `session` option, for convenience.
+:::
 </OptionFilter>
 
 ## Invoking your Agent

--- a/docs/src/content/docs/en/guides/ts-agent.mdx
+++ b/docs/src/content/docs/en/guides/ts-agent.mdx
@@ -355,18 +355,10 @@ For more details, refer to the [AgentCore documentation on observability](https:
 
 The `session` option controls how your agent persists conversation state (message history, tool state, etc.) across invocations, using the Strands SDK's [SessionManager](https://strandsagents.com/docs/user-guide/concepts/agents/session-management/):
 
-- **`s3`** (default): The CDK/Terraform infrastructure provisions a dedicated S3 bucket for session data, encrypted with SSE-S3 and with all public access blocked. The agent's IAM role is granted read/write/list/delete access to it, and the bucket name is registered alongside the agent's ARN in AppConfig runtime configuration.
+- **`s3`** (default): The CDK/Terraform infrastructure provisions a dedicated S3 bucket for session data, encrypted with a dedicated KMS key and with all public access blocked; server access logs are delivered to a CloudWatch Logs log group via the same key. The agent's IAM role is granted read/write/list/delete access to the bucket and decrypt/generate-data-key access to the key, and the bucket name is registered alongside the agent's ARN in AppConfig runtime configuration.
 - **`in-memory`**: No bucket is provisioned. Conversation state is kept in memory only for the lifetime of the running process and does not survive restarts or scale-in.
 
-This is implemented in the generated `session.ts`, which exports a `getSessionManager()` function resolving a `SessionManager` for the current session:
-
-```typescript
-export const getSessionManager = async (): Promise<SessionManager> => {
-  const sessionId = getCurrentSessionId();
-  // local development always uses local file storage...
-  // ...otherwise S3Storage (session: 's3') or InMemoryStorage (session: 'in-memory')
-};
-```
+This is implemented in the generated `session.ts`, which exports a `getSessionManager()` function resolving a `SessionManager` for the current session.
 
 <OptionFilter when={{ protocol: 'ag-ui' }} description="AG-UI session wiring">
 Since AG-UI clones a template agent per conversation thread, `getSessionManager` is wired in as a `sessionManagerProvider` on the `StrandsAgent` config in `index.ts`, so a fresh `SessionManager` is resolved for each thread rather than baked into the shared template agent.

--- a/docs/src/content/docs/es/guides/ts-agent.mdx
+++ b/docs/src/content/docs/es/guides/ts-agent.mdx
@@ -355,18 +355,10 @@ Para más detalles, consulta la [documentación de AgentCore sobre observabilida
 
 La opción `session` controla cómo tu agente persiste el estado de la conversación (historial de mensajes, estado de herramientas, etc.) a través de invocaciones, usando el [SessionManager](https://strandsagents.com/docs/user-guide/concepts/agents/session-management/) del SDK de Strands:
 
-- **`s3`** (predeterminado): La infraestructura CDK/Terraform aprovisiona un bucket S3 dedicado para datos de sesión, encriptado con SSE-S3 y con todo el acceso público bloqueado. El rol IAM del agente recibe acceso de lectura/escritura/listado/eliminación, y el nombre del bucket se registra junto con el ARN del agente en la configuración de runtime de AppConfig.
+- **`s3`** (predeterminado): La infraestructura CDK/Terraform aprovisiona un bucket S3 dedicado para datos de sesión, encriptado con una clave KMS dedicada y con todo el acceso público bloqueado; los registros de acceso del servidor se envían a un grupo de registros de CloudWatch Logs mediante la misma clave. El rol IAM del agente recibe acceso de lectura/escritura/listado/eliminación al bucket y acceso de descifrado/generación de clave de datos a la clave, y el nombre del bucket se registra junto con el ARN del agente en la configuración de runtime de AppConfig.
 - **`in-memory`**: No se aprovisiona ningún bucket. El estado de la conversación se mantiene solo en memoria durante la vida del proceso en ejecución y no sobrevive a reinicios o reducción de escala.
 
-Esto se implementa en el `session.ts` generado, que exporta una función `getSessionManager()` que resuelve un `SessionManager` para la sesión actual:
-
-```typescript
-export const getSessionManager = async (): Promise<SessionManager> => {
-  const sessionId = getCurrentSessionId();
-  // local development always uses local file storage...
-  // ...otherwise S3Storage (session: 's3') or InMemoryStorage (session: 'none')
-};
-```
+Esto se implementa en el `session.ts` generado, que exporta una función `getSessionManager()` que resuelve un `SessionManager` para la sesión actual.
 
 <OptionFilter when={{ protocol: 'ag-ui' }} description="AG-UI session wiring">
 Dado que AG-UI clona un agente plantilla por hilo de conversación, `getSessionManager` se conecta como un `sessionManagerProvider` en la configuración de `StrandsAgent` en `index.ts`, de modo que se resuelve un `SessionManager` fresco para cada hilo en lugar de estar integrado en el agente plantilla compartido.

--- a/docs/src/content/docs/es/guides/ts-agent.mdx
+++ b/docs/src/content/docs/es/guides/ts-agent.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Agente Strands de TypeScript"
-description: "Genera un Agente Strands de TypeScript para construir agentes de IA con herramientas y despliega en Amazon Bedrock AgentCore Runtime"
+title: TypeScript Agent
+description: Genera un TypeScript Agent para construir agentes de IA con herramientas y despliega en Amazon Bedrock AgentCore Runtime
 generator: ts#agent
 ---
 
@@ -16,7 +16,7 @@ import GeneratorParameters from '@components/generator-parameters.astro';
 import PackageManagerExecCommand from '@components/package-manager-exec-command.astro';
 import OptionFilter from '@components/option-filter.astro';
 
-Genera un TypeScript [Agent](https://strandsagents.com/) para construir agentes de IA con herramientas, y opcionalmente despliégalo en [Amazon Bedrock AgentCore Runtime](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/). Por defecto, el generador utiliza [tRPC](https://trpc.io/) sobre WebSocket para aprovechar el [soporte de streaming bidireccional de AgentCore](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-get-started-websocket.html) para comunicación en tiempo real y con seguridad de tipos. Alternativamente, puedes elegir el protocolo [Agent-to-Agent (A2A)](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-a2a.html) para interoperabilidad con otros agentes compatibles con A2A, o el protocolo [AG-UI](https://docs.ag-ui.com/) para integración directa con el frontend a través de [CopilotKit](https://docs.copilotkit.ai/aws-strands).
+Genera un TypeScript [Strands Agent](https://strandsagents.com/) para construir agentes de IA con herramientas, y opcionalmente despliégalo en [Amazon Bedrock AgentCore Runtime](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/). Por defecto, el generador utiliza [tRPC](https://trpc.io/) sobre WebSocket para aprovechar el [soporte de streaming bidireccional de AgentCore](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-get-started-websocket.html) para comunicación en tiempo real y con seguridad de tipos. Alternativamente, puedes elegir el protocolo [Agent-to-Agent (A2A)](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-a2a.html) para interoperabilidad con otros agentes compatibles con A2A, o el protocolo [AG-UI](https://docs.ag-ui.com/) para integración directa con el frontend a través de [CopilotKit](https://docs.copilotkit.ai/aws-strands).
 
 ## ¿Qué es Strands?
 
@@ -60,6 +60,7 @@ El generador agregará los siguientes archivos a tu proyecto TypeScript existent
         - init.ts Inicialización de tRPC
         - router.ts Router de tRPC con procedimientos del agente
         - agent.ts Definición principal del agente con herramientas de ejemplo
+        - session.ts Resuelve el SessionManager usado para persistir el estado de la conversación
         - client.ts Cliente provisto para invocar tu agente
         - agent-core-trpc-client.ts Fábrica de cliente para conectar a agentes en AgentCore Runtime
         - Dockerfile Punto de entrada para alojar tu agente (excluido cuando `infra` está establecido en `None`)
@@ -79,6 +80,7 @@ El punto de entrada usa el [Strands A2A Express Server](https://strandsagents.co
       - agent/ (o nombre personalizado si se especifica)
         - index.ts Punto de entrada del servidor A2A Express
         - agent.ts Definición principal del agente con herramientas de ejemplo
+        - session.ts Resuelve el SessionManager usado para persistir el estado de la conversación
         - Dockerfile Punto de entrada para alojar tu agente (excluido cuando `infra` está establecido en `None`)
     - package.json Actualizado con dependencias de Strands y Express
     - project.json Actualizado con targets de servicio del agente
@@ -96,6 +98,7 @@ El punto de entrada usa [`@ag-ui/aws-strands`](https://www.npmjs.com/package/@ag
       - agent/ (o nombre personalizado si se especifica)
         - index.ts Punto de entrada del servidor AG-UI (Express + SSE)
         - agent.ts Definición principal del agente con herramientas de ejemplo
+        - session.ts Resuelve el SessionManager usado para persistir el estado de la conversación
         - Dockerfile Punto de entrada para alojar tu agente (excluido cuando `infra` está establecido en `None`)
     - package.json Actualizado con dependencias de Strands y AG-UI
     - project.json Actualizado con targets de servicio del agente
@@ -134,8 +137,8 @@ Para desplegar tu Agent, se generan los siguientes archivos:
 </Infrastructure>
 </OptionFilter>
 
-<OptionFilter when={{ infra: 'none' }} description="No infrastructure is vended for infra=None">
-Si seleccionaste `None` para `infra`, no se generan constructos CDK ni módulos Terraform — el Agent solo puede ejecutarse localmente. La opción `auth` se ignora en este modo ya que no hay un endpoint alojado para autenticar.
+<OptionFilter when={{ infra: 'none' }} description="No infrastructure is vended for infra=none">
+Si seleccionaste `none` para `infra`, no se generan constructos CDK ni módulos Terraform — el Agent solo puede ejecutarse localmente. La opción `auth` se ignora en este modo ya que no hay un endpoint alojado para autenticar.
 </OptionFilter>
 
 #### Arquitectura
@@ -185,7 +188,7 @@ const letterCounter = tool({
 });
 
 // Add tools to your agent
-export const getAgent = async (sessionId: string) => {
+export const getAgent = async () => {
   return new Agent({
     systemPrompt: 'You are a helpful assistant with access to various tools.',
     tools: [letterCounter],
@@ -347,6 +350,37 @@ Tu agente está configurado automáticamente con observabilidad usando el [AWS D
 Puedes encontrar trazas en la Consola AWS CloudWatch, seleccionando "GenAI Observability" en el menú. Ten en cuenta que para que las trazas se completen necesitarás habilitar [Transaction Search](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Transaction-Search.html).
 
 Para más detalles, consulta la [documentación de AgentCore sobre observabilidad](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/observability-configure.html).
+
+### Gestión de Sesiones
+
+La opción `session` controla cómo tu agente persiste el estado de la conversación (historial de mensajes, estado de herramientas, etc.) a través de invocaciones, usando el [SessionManager](https://strandsagents.com/docs/user-guide/concepts/agents/session-management/) del SDK de Strands:
+
+- **`s3`** (predeterminado): La infraestructura CDK/Terraform aprovisiona un bucket S3 dedicado para datos de sesión, encriptado con SSE-S3 y con todo el acceso público bloqueado. El rol IAM del agente recibe acceso de lectura/escritura/listado/eliminación, y el nombre del bucket se registra junto con el ARN del agente en la configuración de runtime de AppConfig.
+- **`in-memory`**: No se aprovisiona ningún bucket. El estado de la conversación se mantiene solo en memoria durante la vida del proceso en ejecución y no sobrevive a reinicios o reducción de escala.
+
+Esto se implementa en el `session.ts` generado, que exporta una función `getSessionManager()` que resuelve un `SessionManager` para la sesión actual:
+
+```typescript
+export const getSessionManager = async (): Promise<SessionManager> => {
+  const sessionId = getCurrentSessionId();
+  // local development always uses local file storage...
+  // ...otherwise S3Storage (session: 's3') or InMemoryStorage (session: 'none')
+};
+```
+
+<OptionFilter when={{ protocol: 'ag-ui' }} description="AG-UI session wiring">
+Dado que AG-UI clona un agente plantilla por hilo de conversación, `getSessionManager` se conecta como un `sessionManagerProvider` en la configuración de `StrandsAgent` en `index.ts`, de modo que se resuelve un `SessionManager` fresco para cada hilo en lugar de estar integrado en el agente plantilla compartido.
+</OptionFilter>
+
+<OptionFilter when={{ protocol: ['http', 'a2a'] }} description="HTTP/A2A session wiring">
+Dado que `withSessionId` ya almacena en caché una instancia de `Agent` por sesión, `getSessionManager` se llama directamente dentro de la llamada `new Agent({ sessionManager: await getSessionManager() })` de `getAgent` en `agent.ts`.
+</OptionFilter>
+
+El ID de sesión en sí proviene de la sesión de AgentCore Runtime (propagado a través del encabezado `x-amzn-bedrock-agentcore-runtime-session-id` para A2A/AG-UI, o el contexto de conexión WebSocket para HTTP/tRPC) y está vinculado a un contexto basado en [`AsyncLocalStorage`](https://nodejs.org/api/async_context.html#class-asynclocalstorage) para que `getCurrentSessionId()` pueda resolverlo en cualquier lugar de la solicitud — incluyendo en cualquier cliente MCP o A2A descendente conectado a través del <Link path="/guides/connection">generador `connection`</Link>, de modo que toda la cadena de llamadas comparta una sesión consistente.
+
+:::note[Desarrollo Local]
+Cuando se ejecuta localmente (`LOCAL_DEV=true`, establecido automáticamente por el target `-dev`), los datos de sesión siempre se almacenan en disco bajo `tmp/agents/strands/<agent-name>` en la raíz del workspace, independientemente de la opción `session` configurada, por conveniencia.
+:::
 </OptionFilter>
 
 ## Invocar tu Agent
@@ -400,7 +434,7 @@ const client = AgentClient.withIamAuth({
   agentRuntimeArn: 'arn:aws:bedrock-agentcore:us-west-2:123456789012:runtime/my-agent',
 });
 
-client.invoke.subscribe({ message: 'what is 1 plus 1?' }, {
+client.invoke.subscribe({ prompt: 'what is 1 plus 1?' }, {
   onData: (message) => console.log(message),
   onError: (error) => console.error(error),
   onComplete: () => console.log('Done'),
@@ -423,7 +457,7 @@ const client = AgentClient.withJwtAuth({
   accessTokenProvider: async () => `<access-token>`,
 });
 
-client.invoke.subscribe({ message: 'what is 1 plus 1?' }, {
+client.invoke.subscribe({ prompt: 'what is 1 plus 1?' }, {
   onData: console.log,
 });
 ```

--- a/docs/src/content/docs/fr/guides/ts-agent.mdx
+++ b/docs/src/content/docs/fr/guides/ts-agent.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Agent TypeScript Strands"
-description: "Générer un Agent TypeScript Strands pour créer des agents IA avec des outils et le déployer sur Amazon Bedrock AgentCore Runtime"
+title: TypeScript Agent
+description: Générer un TypeScript Agent pour créer des agents IA avec des outils et le déployer sur Amazon Bedrock AgentCore Runtime
 generator: ts#agent
 ---
 
@@ -16,7 +16,7 @@ import GeneratorParameters from '@components/generator-parameters.astro';
 import PackageManagerExecCommand from '@components/package-manager-exec-command.astro';
 import OptionFilter from '@components/option-filter.astro';
 
-Générez un [Agent](https://strandsagents.com/) TypeScript pour créer des agents IA avec des outils, et déployez-le optionnellement sur [Amazon Bedrock AgentCore Runtime](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/). Par défaut, le générateur utilise [tRPC](https://trpc.io/) sur WebSocket pour tirer parti de [la prise en charge du streaming bidirectionnel d'AgentCore](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-get-started-websocket.html) pour une communication en temps réel et type-safe. Alternativement, vous pouvez choisir le protocole [Agent-to-Agent (A2A)](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-a2a.html) pour l'interopérabilité avec d'autres agents compatibles A2A, ou le protocole [AG-UI](https://docs.ag-ui.com/) pour une intégration frontend directe via [CopilotKit](https://docs.copilotkit.ai/aws-strands).
+Générez un [Strands Agent](https://strandsagents.com/) TypeScript pour créer des agents IA avec des outils, et déployez-le optionnellement sur [Amazon Bedrock AgentCore Runtime](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/). Par défaut, le générateur utilise [tRPC](https://trpc.io/) sur WebSocket pour tirer parti de [la prise en charge du streaming bidirectionnel d'AgentCore](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-get-started-websocket.html) pour une communication en temps réel et type-safe. Alternativement, vous pouvez choisir le protocole [Agent-to-Agent (A2A)](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-a2a.html) pour l'interopérabilité avec d'autres agents compatibles A2A, ou le protocole [AG-UI](https://docs.ag-ui.com/) pour une intégration frontend directe via [CopilotKit](https://docs.copilotkit.ai/aws-strands).
 
 ## Qu'est-ce que Strands ?
 
@@ -60,6 +60,7 @@ Le générateur ajoutera les fichiers suivants à votre projet TypeScript exista
         - init.ts Initialisation tRPC
         - router.ts Routeur tRPC avec procédures d'agent
         - agent.ts Définition principale de l'agent avec exemples d'outils
+        - session.ts Résout le SessionManager utilisé pour persister l'état de conversation
         - client.ts Client fourni pour invoquer votre agent
         - agent-core-trpc-client.ts Factory de client pour se connecter aux agents sur AgentCore Runtime
         - Dockerfile Point d'entrée pour héberger votre agent (exclu lorsque `infra` est défini sur `None`)
@@ -79,6 +80,7 @@ Le point d'entrée utilise le [Strands A2A Express Server](https://strandsagents
       - agent/ (ou nom personnalisé si spécifié)
         - index.ts Point d'entrée du serveur A2A Express
         - agent.ts Définition principale de l'agent avec exemples d'outils
+        - session.ts Résout le SessionManager utilisé pour persister l'état de conversation
         - Dockerfile Point d'entrée pour héberger votre agent (exclu lorsque `infra` est défini sur `None`)
     - package.json Mis à jour avec les dépendances Strands et Express
     - project.json Mis à jour avec les cibles de service de l'agent
@@ -96,6 +98,7 @@ Le point d'entrée utilise [`@ag-ui/aws-strands`](https://www.npmjs.com/package/
       - agent/ (ou nom personnalisé si spécifié)
         - index.ts Point d'entrée du serveur AG-UI (Express + SSE)
         - agent.ts Définition principale de l'agent avec exemples d'outils
+        - session.ts Résout le SessionManager utilisé pour persister l'état de conversation
         - Dockerfile Point d'entrée pour héberger votre agent (exclu lorsque `infra` est défini sur `None`)
     - package.json Mis à jour avec les dépendances Strands et AG-UI
     - project.json Mis à jour avec les cibles de service de l'agent
@@ -134,8 +137,8 @@ Pour déployer votre Agent, les fichiers suivants sont générés :
 </Infrastructure>
 </OptionFilter>
 
-<OptionFilter when={{ infra: 'none' }} description="No infrastructure is vended for infra=None">
-Si vous avez sélectionné `None` pour `infra`, aucun construct CDK ou module Terraform n'est généré — le Agent ne peut être exécuté que localement. L'option `auth` est ignorée dans ce mode car il n'y a pas de point de terminaison hébergé à authentifier.
+<OptionFilter when={{ infra: 'none' }} description="No infrastructure is vended for infra=none">
+Si vous avez sélectionné `none` pour `infra`, aucun construct CDK ou module Terraform n'est généré — l'Agent ne peut être exécuté que localement. L'option `auth` est ignorée dans ce mode car il n'y a pas de point de terminaison hébergé à authentifier.
 </OptionFilter>
 
 #### Architecture
@@ -185,7 +188,7 @@ const letterCounter = tool({
 });
 
 // Add tools to your agent
-export const getAgent = async (sessionId: string) => {
+export const getAgent = async () => {
   return new Agent({
     systemPrompt: 'You are a helpful assistant with access to various tools.',
     tools: [letterCounter],
@@ -285,10 +288,10 @@ Ensuite, dans un autre terminal, démarrez le chat :
 
 <NxCommands commands={['run your-project:agent-chat']} />
 
-Le générateur émet un `scripts/<your-agent-name>/chat.ts` pour chaque protocole. Vous pouvez le personnaliser au fur et à mesure que vous faites évoluer la forme d'entrée de l'agent. Il se connecte à l'agent local par défaut, ou à votre agent déployé lorsque `RUNTIME_CONFIG_APP_ID` est défini (voir [Discuter avec votre agent déployé](#chat-with-your-deployed-agent) ci-dessous).
+Le générateur émet un `scripts/<your-agent-name>/chat.ts` pour chaque protocole. Vous pouvez le personnaliser au fur et à mesure que vous faites évoluer la forme d'entrée de l'agent. Il se connecte à l'agent local par défaut, ou à votre agent déployé lorsque `RUNTIME_CONFIG_APP_ID` est défini (voir [Discuter avec votre agent déployé](#discuter-avec-votre-agent-déployé) ci-dessous).
 
 <OptionFilter when={{ infra: 'agentcore' }} description="Deployed agent chat details">
-#### Chat with your deployed agent
+#### Discuter avec votre agent déployé
 
 Pour discuter avec votre agent déployé sur Bedrock AgentCore, définissez la variable d'environnement `RUNTIME_CONFIG_APP_ID` sur l'identifiant d'application AppConfig du déploiement (sortie en tant que `RuntimeConfigApplicationId` par la pile déployée). Le script de chat résout l'ARN d'exécution de votre agent à partir de la configuration d'exécution et se connecte au point de terminaison déployé :
 
@@ -347,6 +350,37 @@ Votre agent est automatiquement configuré avec l'observabilité en utilisant [A
 Vous pouvez trouver les traces dans la console AWS CloudWatch, en sélectionnant "GenAI Observability" dans le menu. Notez que pour que les traces soient remplies, vous devrez activer [Transaction Search](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Transaction-Search.html).
 
 Pour plus de détails, consultez la [documentation AgentCore sur l'observabilité](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/observability-configure.html).
+
+### Gestion de session
+
+L'option `session` contrôle comment votre agent persiste l'état de conversation (historique des messages, état des outils, etc.) entre les invocations, en utilisant le [SessionManager](https://strandsagents.com/docs/user-guide/concepts/agents/session-management/) du SDK Strands :
+
+- **`s3`** (par défaut) : L'infrastructure CDK/Terraform provisionne un bucket S3 dédié pour les données de session, chiffré avec SSE-S3 et avec tout accès public bloqué. Le rôle IAM de l'agent reçoit les accès lecture/écriture/liste/suppression sur celui-ci, et le nom du bucket est enregistré aux côtés de l'ARN de l'agent dans la configuration d'exécution AppConfig.
+- **`in-memory`** : Aucun bucket n'est provisionné. L'état de conversation est conservé en mémoire uniquement pendant la durée de vie du processus en cours d'exécution et ne survit pas aux redémarrages ou à la réduction d'échelle.
+
+Ceci est implémenté dans le fichier `session.ts` généré, qui exporte une fonction `getSessionManager()` résolvant un `SessionManager` pour la session actuelle :
+
+```typescript
+export const getSessionManager = async (): Promise<SessionManager> => {
+  const sessionId = getCurrentSessionId();
+  // local development always uses local file storage...
+  // ...otherwise S3Storage (session: 's3') or InMemoryStorage (session: 'none')
+};
+```
+
+<OptionFilter when={{ protocol: 'ag-ui' }} description="AG-UI session wiring">
+Puisque AG-UI clone un agent modèle par fil de conversation, `getSessionManager` est câblé en tant que `sessionManagerProvider` sur la configuration `StrandsAgent` dans `index.ts`, de sorte qu'un nouveau `SessionManager` est résolu pour chaque fil plutôt que d'être intégré dans l'agent modèle partagé.
+</OptionFilter>
+
+<OptionFilter when={{ protocol: ['http', 'a2a'] }} description="HTTP/A2A session wiring">
+Puisque `withSessionId` met déjà en cache une instance `Agent` par session, `getSessionManager` est appelé directement à l'intérieur de l'appel `new Agent({ sessionManager: await getSessionManager() })` de `getAgent` dans `agent.ts`.
+</OptionFilter>
+
+L'ID de session lui-même provient de la session AgentCore Runtime (propagée via l'en-tête `x-amzn-bedrock-agentcore-runtime-session-id` pour A2A/AG-UI, ou le contexte de connexion WebSocket pour HTTP/tRPC) et est lié à un contexte basé sur [`AsyncLocalStorage`](https://nodejs.org/api/async_context.html#class-asynclocalstorage) afin que `getCurrentSessionId()` puisse le résoudre n'importe où dans la requête — y compris dans tous les clients MCP ou A2A en aval câblés via le <Link path="/guides/connection">générateur `connection`</Link>, de sorte que toute la chaîne d'appel partage une session cohérente.
+
+:::note[Développement local]
+Lors de l'exécution locale (`LOCAL_DEV=true`, défini automatiquement par la cible `-dev`), les données de session sont toujours stockées sur disque sous `tmp/agents/strands/<agent-name>` à la racine de l'espace de travail, quelle que soit l'option `session` configurée, pour plus de commodité.
+:::
 </OptionFilter>
 
 ## Invocation de votre Agent
@@ -366,7 +400,7 @@ import { AgentClient } from '../packages/<project>/src/agent/client.js';
 
 const client = AgentClient.local({ url: 'http://localhost:8081/ws' });
 
-client.invoke.subscribe({ message: 'what is 1 plus 1?' }, { onData: console.log });
+client.invoke.subscribe({ prompt: 'what is 1 plus 1?' }, { onData: console.log });
 ```
 
 :::tip[Test rapide]
@@ -423,7 +457,7 @@ const client = AgentClient.withJwtAuth({
   accessTokenProvider: async () => `<access-token>`,
 });
 
-client.invoke.subscribe({ message: 'what is 1 plus 1?' }, {
+client.invoke.subscribe({ prompt: 'what is 1 plus 1?' }, {
   onData: console.log,
 });
 ```
@@ -483,9 +517,9 @@ Pour invoquer votre agent AG-UI depuis un site web React, utilisez le <Link path
 Consultez le <Link path="/guides/connection/react-agui">guide du générateur `connection`</Link> pour plus de détails sur la façon dont la connexion est configurée.
 </OptionFilter>
 
-## Sécurisation de votre agent
+## Sécurisation de votre Agent
 
-<Snippet name="agent/securing-your-agent" parentHeading="Securing your Agent" />
+<Snippet name="agent/securing-your-agent" parentHeading="Sécurisation de votre Agent" />
 
 ```typescript
 // agent.ts

--- a/docs/src/content/docs/fr/guides/ts-agent.mdx
+++ b/docs/src/content/docs/fr/guides/ts-agent.mdx
@@ -355,18 +355,10 @@ Pour plus de détails, consultez la [documentation AgentCore sur l'observabilit�
 
 L'option `session` contrôle comment votre agent persiste l'état de conversation (historique des messages, état des outils, etc.) entre les invocations, en utilisant le [SessionManager](https://strandsagents.com/docs/user-guide/concepts/agents/session-management/) du SDK Strands :
 
-- **`s3`** (par défaut) : L'infrastructure CDK/Terraform provisionne un bucket S3 dédié pour les données de session, chiffré avec SSE-S3 et avec tout accès public bloqué. Le rôle IAM de l'agent reçoit les accès lecture/écriture/liste/suppression sur celui-ci, et le nom du bucket est enregistré aux côtés de l'ARN de l'agent dans la configuration d'exécution AppConfig.
+- **`s3`** (par défaut) : L'infrastructure CDK/Terraform provisionne un bucket S3 dédié pour les données de session, chiffré avec une clé KMS dédiée et avec tout accès public bloqué ; les journaux d'accès au serveur sont transmis à un groupe de journaux CloudWatch Logs via la même clé. Le rôle IAM de l'agent reçoit les accès lecture/écriture/liste/suppression sur le bucket et l'accès déchiffrement/génération de clé de données sur la clé, et le nom du bucket est enregistré aux côtés de l'ARN de l'agent dans la configuration d'exécution AppConfig.
 - **`in-memory`** : Aucun bucket n'est provisionné. L'état de conversation est conservé en mémoire uniquement pendant la durée de vie du processus en cours d'exécution et ne survit pas aux redémarrages ou à la réduction d'échelle.
 
-Ceci est implémenté dans le fichier `session.ts` généré, qui exporte une fonction `getSessionManager()` résolvant un `SessionManager` pour la session actuelle :
-
-```typescript
-export const getSessionManager = async (): Promise<SessionManager> => {
-  const sessionId = getCurrentSessionId();
-  // local development always uses local file storage...
-  // ...otherwise S3Storage (session: 's3') or InMemoryStorage (session: 'none')
-};
-```
+Ceci est implémenté dans le fichier `session.ts` généré, qui exporte une fonction `getSessionManager()` résolvant un `SessionManager` pour la session actuelle.
 
 <OptionFilter when={{ protocol: 'ag-ui' }} description="AG-UI session wiring">
 Puisque AG-UI clone un agent modèle par fil de conversation, `getSessionManager` est câblé en tant que `sessionManagerProvider` sur la configuration `StrandsAgent` dans `index.ts`, de sorte qu'un nouveau `SessionManager` est résolu pour chaque fil plutôt que d'être intégré dans l'agent modèle partagé.

--- a/docs/src/content/docs/it/guides/ts-agent.mdx
+++ b/docs/src/content/docs/it/guides/ts-agent.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Agente TypeScript Strands"
-description: "Genera un Agente TypeScript Strands per costruire agenti AI con strumenti e distribuirlo su Amazon Bedrock AgentCore Runtime"
+title: TypeScript Agent
+description: Genera un TypeScript Agent per la creazione di agenti AI con strumenti e distribuiscilo su Amazon Bedrock AgentCore Runtime
 generator: ts#agent
 ---
 
@@ -16,7 +16,7 @@ import GeneratorParameters from '@components/generator-parameters.astro';
 import PackageManagerExecCommand from '@components/package-manager-exec-command.astro';
 import OptionFilter from '@components/option-filter.astro';
 
-Genera un TypeScript [Agent](https://strandsagents.com/) per la creazione di agenti AI con strumenti e, facoltativamente, distribuiscilo su [Amazon Bedrock AgentCore Runtime](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/). Per impostazione predefinita, il generatore utilizza [tRPC](https://trpc.io/) su WebSocket per sfruttare il [supporto di streaming bidirezionale di AgentCore](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-get-started-websocket.html) per una comunicazione in tempo reale e type-safe. In alternativa, puoi scegliere il protocollo [Agent-to-Agent (A2A)](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-a2a.html) per l'interoperabilità con altri agenti compatibili con A2A, o il protocollo [AG-UI](https://docs.ag-ui.com/) per l'integrazione diretta con il frontend tramite [CopilotKit](https://docs.copilotkit.ai/aws-strands).
+Genera un TypeScript [Strands Agent](https://strandsagents.com/) per la creazione di agenti AI con strumenti e, facoltativamente, distribuiscilo su [Amazon Bedrock AgentCore Runtime](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/). Per impostazione predefinita, il generatore utilizza [tRPC](https://trpc.io/) su WebSocket per sfruttare il [supporto di streaming bidirezionale di AgentCore](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-get-started-websocket.html) per una comunicazione in tempo reale e type-safe. In alternativa, puoi scegliere il protocollo [Agent-to-Agent (A2A)](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-a2a.html) per l'interoperabilità con altri agenti compatibili con A2A, o il protocollo [AG-UI](https://docs.ag-ui.com/) per l'integrazione diretta con il frontend tramite [CopilotKit](https://docs.copilotkit.ai/aws-strands).
 
 ## Cos'è Strands?
 
@@ -31,7 +31,7 @@ Genera un TypeScript [Agent](https://strandsagents.com/) per la creazione di age
 
 ## Utilizzo
 
-### Generare uno Agent
+### Generare un Agent
 
 Puoi generare un TypeScript Agent in due modi:
 
@@ -60,6 +60,7 @@ Il generatore aggiungerà i seguenti file al tuo progetto TypeScript esistente. 
         - init.ts Inizializzazione tRPC
         - router.ts Router tRPC con procedure dell'agente
         - agent.ts Definizione principale dell'agente con strumenti di esempio
+        - session.ts Risolve il SessionManager utilizzato per persistere lo stato della conversazione
         - client.ts Client fornito per invocare il tuo agente
         - agent-core-trpc-client.ts Factory del client per connettersi agli agenti su AgentCore Runtime
         - Dockerfile Punto di ingresso per l'hosting del tuo agente (escluso quando `infra` è impostato su `None`)
@@ -79,6 +80,7 @@ Il punto di ingresso utilizza il [Strands A2A Express Server](https://strandsage
       - agent/ (o nome personalizzato se specificato)
         - index.ts Punto di ingresso del server A2A Express
         - agent.ts Definizione principale dell'agente con strumenti di esempio
+        - session.ts Risolve il SessionManager utilizzato per persistere lo stato della conversazione
         - Dockerfile Punto di ingresso per l'hosting del tuo agente (escluso quando `infra` è impostato su `None`)
     - package.json Aggiornato con le dipendenze di Strands ed Express
     - project.json Aggiornato con i target di serve dell'agente
@@ -96,6 +98,7 @@ Il punto di ingresso utilizza [`@ag-ui/aws-strands`](https://www.npmjs.com/packa
       - agent/ (o nome personalizzato se specificato)
         - index.ts Punto di ingresso del server AG-UI (Express + SSE)
         - agent.ts Definizione principale dell'agente con strumenti di esempio
+        - session.ts Risolve il SessionManager utilizzato per persistere lo stato della conversazione
         - Dockerfile Punto di ingresso per l'hosting del tuo agente (escluso quando `infra` è impostato su `None`)
     - package.json Aggiornato con le dipendenze di Strands e AG-UI
     - project.json Aggiornato con i target di serve dell'agente
@@ -134,8 +137,8 @@ Per distribuire il tuo Agent, vengono generati i seguenti file:
 </Infrastructure>
 </OptionFilter>
 
-<OptionFilter when={{ infra: 'none' }} description="No infrastructure is vended for infra=None">
-Se hai selezionato `None` per `infra`, non vengono generati costrutti CDK o moduli Terraform — lo Agent può essere eseguito solo localmente. L'opzione `auth` viene ignorata in questa modalità poiché non esiste un endpoint ospitato da autenticare.
+<OptionFilter when={{ infra: 'none' }} description="No infrastructure is vended for infra=none">
+Se hai selezionato `none` per `infra`, non vengono generati costrutti CDK o moduli Terraform — l'Agent può essere eseguito solo localmente. L'opzione `auth` viene ignorata in questa modalità poiché non esiste un endpoint ospitato da autenticare.
 </OptionFilter>
 
 #### Architecture
@@ -185,7 +188,7 @@ const letterCounter = tool({
 });
 
 // Add tools to your agent
-export const getAgent = async (sessionId: string) => {
+export const getAgent = async () => {
   return new Agent({
     systemPrompt: 'You are a helpful assistant with access to various tools.',
     tools: [letterCounter],
@@ -285,10 +288,10 @@ Quindi, in un altro terminale, avvia la chat:
 
 <NxCommands commands={['run your-project:agent-chat']} />
 
-Il generatore emette un `scripts/<your-agent-name>/chat.ts` per ogni protocollo. Puoi personalizzarlo mentre evolvi la forma di input dell'agente. Si connette all'agente locale per impostazione predefinita, o al tuo agente distribuito quando è impostato `RUNTIME_CONFIG_APP_ID` (vedi [Chatta con il tuo agente distribuito](#chat-with-your-deployed-agent) di seguito).
+Il generatore emette un `scripts/<your-agent-name>/chat.ts` per ogni protocollo. Puoi personalizzarlo mentre evolvi la forma di input dell'agente. Si connette all'agente locale per impostazione predefinita, o al tuo agente distribuito quando è impostato `RUNTIME_CONFIG_APP_ID` (vedi [Chatta con il tuo agente distribuito](#chatta-con-il-tuo-agente-distribuito) di seguito).
 
 <OptionFilter when={{ infra: 'agentcore' }} description="Deployed agent chat details">
-#### Chat with your deployed agent
+#### Chatta con il tuo agente distribuito
 
 Per chattare con il tuo agente distribuito su Bedrock AgentCore, imposta la variabile d'ambiente `RUNTIME_CONFIG_APP_ID` sull'id dell'applicazione AppConfig della distribuzione (output come `RuntimeConfigApplicationId` dallo stack distribuito). Lo script di chat risolve l'ARN del runtime del tuo agente dalla configurazione del runtime e si connette all'endpoint distribuito:
 
@@ -338,7 +341,7 @@ Viene generato anche un target `docker` che prepara il contesto docker per tutti
 
 ### Scansione delle Immagini
 
-<Snippet name="trivy-image-scan" parentHeading="Image Scanning" />
+<Snippet name="trivy-image-scan" parentHeading="Scansione delle Immagini" />
 
 ### Osservabilità
 
@@ -347,6 +350,37 @@ Il tuo agente è automaticamente configurato con l'osservabilità utilizzando [A
 Puoi trovare le tracce nella Console AWS di CloudWatch, selezionando "GenAI Observability" nel menu. Nota che affinché le tracce vengano popolate dovrai abilitare [Transaction Search](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Transaction-Search.html).
 
 Per maggiori dettagli, fai riferimento alla [documentazione di AgentCore sull'osservabilità](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/observability-configure.html).
+
+### Gestione delle Sessioni
+
+L'opzione `session` controlla come il tuo agente persiste lo stato della conversazione (cronologia dei messaggi, stato degli strumenti, ecc.) tra le invocazioni, utilizzando il [SessionManager](https://strandsagents.com/docs/user-guide/concepts/agents/session-management/) dell'SDK Strands:
+
+- **`s3`** (predefinito): L'infrastruttura CDK/Terraform fornisce un bucket S3 dedicato per i dati di sessione, crittografato con SSE-S3 e con tutto l'accesso pubblico bloccato. Al ruolo IAM dell'agente viene concesso l'accesso in lettura/scrittura/elenco/eliminazione ad esso, e il nome del bucket viene registrato insieme all'ARN dell'agente nella configurazione del runtime AppConfig.
+- **`in-memory`**: Non viene fornito alcun bucket. Lo stato della conversazione viene mantenuto in memoria solo per la durata del processo in esecuzione e non sopravvive ai riavvii o alla riduzione della scala.
+
+Questo è implementato nel file `session.ts` generato, che esporta una funzione `getSessionManager()` che risolve un `SessionManager` per la sessione corrente:
+
+```typescript
+export const getSessionManager = async (): Promise<SessionManager> => {
+  const sessionId = getCurrentSessionId();
+  // local development always uses local file storage...
+  // ...otherwise S3Storage (session: 's3') or InMemoryStorage (session: 'in-memory')
+};
+```
+
+<OptionFilter when={{ protocol: 'ag-ui' }} description="AG-UI session wiring">
+Poiché AG-UI clona un agente modello per thread di conversazione, `getSessionManager` viene collegato come `sessionManagerProvider` nella configurazione di `StrandsAgent` in `index.ts`, in modo che un nuovo `SessionManager` venga risolto per ogni thread anziché essere incorporato nell'agente modello condiviso.
+</OptionFilter>
+
+<OptionFilter when={{ protocol: ['http', 'a2a'] }} description="HTTP/A2A session wiring">
+Poiché `withSessionId` già memorizza nella cache un'istanza di `Agent` per sessione, `getSessionManager` viene chiamato direttamente all'interno della chiamata `new Agent({ sessionManager: await getSessionManager() })` di `getAgent` in `agent.ts`.
+</OptionFilter>
+
+L'ID di sessione stesso proviene dalla sessione AgentCore Runtime (propagata tramite l'intestazione `x-amzn-bedrock-agentcore-runtime-session-id` per A2A/AG-UI, o il contesto della connessione WebSocket per HTTP/tRPC) ed è associato a un contesto basato su [`AsyncLocalStorage`](https://nodejs.org/api/async_context.html#class-asynclocalstorage) in modo che `getCurrentSessionId()` possa risolverlo ovunque nella richiesta — inclusi eventuali client MCP o A2A downstream collegati tramite il <Link path="/guides/connection">generatore `connection`</Link>, in modo che l'intera catena di chiamate condivida una sessione coerente.
+
+:::note[Sviluppo Locale]
+Quando si esegue localmente (`LOCAL_DEV=true`, impostato automaticamente dal target `-dev`), i dati di sessione vengono sempre memorizzati su disco in `tmp/agents/strands/<agent-name>` alla radice del workspace, indipendentemente dall'opzione `session` configurata, per comodità.
+:::
 </OptionFilter>
 
 ## Invocare il Tuo Agent
@@ -366,7 +400,7 @@ import { AgentClient } from '../packages/<project>/src/agent/client.js';
 
 const client = AgentClient.local({ url: 'http://localhost:8081/ws' });
 
-client.invoke.subscribe({ message: 'what is 1 plus 1?' }, { onData: console.log });
+client.invoke.subscribe({ prompt: 'what is 1 plus 1?' }, { onData: console.log });
 ```
 
 :::tip[Test rapido]
@@ -400,7 +434,7 @@ const client = AgentClient.withIamAuth({
   agentRuntimeArn: 'arn:aws:bedrock-agentcore:us-west-2:123456789012:runtime/my-agent',
 });
 
-client.invoke.subscribe({ message: 'what is 1 plus 1?' }, {
+client.invoke.subscribe({ prompt: 'what is 1 plus 1?' }, {
   onData: (message) => console.log(message),
   onError: (error) => console.error(error),
   onComplete: () => console.log('Done'),

--- a/docs/src/content/docs/it/guides/ts-agent.mdx
+++ b/docs/src/content/docs/it/guides/ts-agent.mdx
@@ -355,18 +355,10 @@ Per maggiori dettagli, fai riferimento alla [documentazione di AgentCore sull'os
 
 L'opzione `session` controlla come il tuo agente persiste lo stato della conversazione (cronologia dei messaggi, stato degli strumenti, ecc.) tra le invocazioni, utilizzando il [SessionManager](https://strandsagents.com/docs/user-guide/concepts/agents/session-management/) dell'SDK Strands:
 
-- **`s3`** (predefinito): L'infrastruttura CDK/Terraform fornisce un bucket S3 dedicato per i dati di sessione, crittografato con SSE-S3 e con tutto l'accesso pubblico bloccato. Al ruolo IAM dell'agente viene concesso l'accesso in lettura/scrittura/elenco/eliminazione ad esso, e il nome del bucket viene registrato insieme all'ARN dell'agente nella configurazione del runtime AppConfig.
+- **`s3`** (predefinito): L'infrastruttura CDK/Terraform fornisce un bucket S3 dedicato per i dati di sessione, crittografato con una chiave KMS dedicata e con tutto l'accesso pubblico bloccato; i log di accesso del server vengono inviati a un gruppo di log di CloudWatch Logs tramite la stessa chiave. Al ruolo IAM dell'agente viene concesso l'accesso in lettura/scrittura/elenco/eliminazione al bucket e l'accesso di decrittazione/generazione della chiave dati alla chiave, e il nome del bucket viene registrato insieme all'ARN dell'agente nella configurazione del runtime AppConfig.
 - **`in-memory`**: Non viene fornito alcun bucket. Lo stato della conversazione viene mantenuto in memoria solo per la durata del processo in esecuzione e non sopravvive ai riavvii o alla riduzione della scala.
 
-Questo è implementato nel file `session.ts` generato, che esporta una funzione `getSessionManager()` che risolve un `SessionManager` per la sessione corrente:
-
-```typescript
-export const getSessionManager = async (): Promise<SessionManager> => {
-  const sessionId = getCurrentSessionId();
-  // local development always uses local file storage...
-  // ...otherwise S3Storage (session: 's3') or InMemoryStorage (session: 'in-memory')
-};
-```
+Questo è implementato nel file `session.ts` generato, che esporta una funzione `getSessionManager()` che risolve un `SessionManager` per la sessione corrente.
 
 <OptionFilter when={{ protocol: 'ag-ui' }} description="AG-UI session wiring">
 Poiché AG-UI clona un agente modello per thread di conversazione, `getSessionManager` viene collegato come `sessionManagerProvider` nella configurazione di `StrandsAgent` in `index.ts`, in modo che un nuovo `SessionManager` venga risolto per ogni thread anziché essere incorporato nell'agente modello condiviso.

--- a/docs/src/content/docs/jp/guides/ts-agent.mdx
+++ b/docs/src/content/docs/jp/guides/ts-agent.mdx
@@ -355,18 +355,10 @@ CloudWatch AWS コンソールでトレースを見つけるには、メニュ�
 
 `session` オプションは、Strands SDK の [SessionManager](https://strandsagents.com/docs/user-guide/concepts/agents/session-management/) を使用して、エージェントが呼び出し間で会話状態（メッセージ履歴、ツール状態など）を永続化する方法を制御します:
 
-- **`s3`** (デフォルト): CDK/Terraform インフラストラクチャは、セッションデータ用の専用 S3 バケットをプロビジョニングします。SSE-S3 で暗号化され、すべてのパブリックアクセスがブロックされます。エージェントの IAM ロールには読み取り/書き込み/リスト/削除アクセスが付与され、バケット名はエージェントの ARN と共に AppConfig ランタイム設定に登録されます。
+- **`s3`** (デフォルト): CDK/Terraform インフラストラクチャは、セッションデータ用の専用 S3 バケットをプロビジョニングします。専用の KMS キーで暗号化され、すべてのパブリックアクセスがブロックされます。サーバーアクセスログは、同じキーを介して CloudWatch Logs のロググループに配信されます。エージェントの IAM ロールには、バケットへの読み取り/書き込み/リスト/削除アクセスと、キーへの復号/データキー生成アクセスが付与され、バケット名はエージェントの ARN と共に AppConfig ランタイム設定に登録されます。
 - **`in-memory`**: バケットはプロビジョニングされません。会話状態は実行中のプロセスの存続期間中のみメモリに保持され、再起動やスケールインでは保持されません。
 
-これは生成された `session.ts` に実装されており、現在のセッションの `SessionManager` を解決する `getSessionManager()` 関数をエクスポートします:
-
-```typescript
-export const getSessionManager = async (): Promise<SessionManager> => {
-  const sessionId = getCurrentSessionId();
-  // ローカル開発では常にローカルファイルストレージを使用...
-  // ...それ以外の場合は S3Storage (session: 's3') または InMemoryStorage (session: 'in-memory')
-};
-```
+これは生成された `session.ts` に実装されており、現在のセッションの `SessionManager` を解決する `getSessionManager()` 関数をエクスポートします。
 
 <OptionFilter when={{ protocol: 'ag-ui' }} description="AG-UI session wiring">
 AG-UI は会話スレッドごとにテンプレートエージェントをクローンするため、`getSessionManager` は `index.ts` の `StrandsAgent` 設定で `sessionManagerProvider` として接続されます。これにより、共有テンプレートエージェントに組み込まれるのではなく、各スレッドに対して新しい `SessionManager` が解決されます。

--- a/docs/src/content/docs/jp/guides/ts-agent.mdx
+++ b/docs/src/content/docs/jp/guides/ts-agent.mdx
@@ -1,6 +1,6 @@
 ---
-title: "TypeScript Strands エージェント"
-description: "ツールを使用して AI エージェントを構築するための TypeScript Strands エージェントを生成し、Amazon Bedrock AgentCore Runtime にデプロイします"
+title: TypeScript Agent
+description: ツールを使用してAIエージェントを構築するためのTypeScript Agentを生成し、Amazon Bedrock AgentCore Runtimeにデプロイします
 generator: ts#agent
 ---
 
@@ -16,7 +16,7 @@ import GeneratorParameters from '@components/generator-parameters.astro';
 import PackageManagerExecCommand from '@components/package-manager-exec-command.astro';
 import OptionFilter from '@components/option-filter.astro';
 
-TypeScript [Strands Agent](https://strandsagents.com/) を生成し、ツールを使用したAIエージェントを構築します。オプションで [Amazon Bedrock AgentCore Runtime](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/) にデプロイできます。デフォルトでは、このジェネレーターは WebSocket 上の [tRPC](https://trpc.io/) を使用して、[AgentCore の双方向ストリーミングサポート](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-get-started-websocket.html)を活用し、リアルタイムで型安全な通信を実現します。または、他の A2A 互換エージェントとの相互運用性のために [Agent-to-Agent (A2A)](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-a2a.html) プロトコルを選択することもできます。また、[CopilotKit](https://docs.copilotkit.ai/aws-strands) を介した直接的なフロントエンド統合のために [AG-UI](https://docs.ag-ui.com/) プロトコルを選択することもできます。
+ツールを使用してAIエージェントを構築するための TypeScript [Strands Agent](https://strandsagents.com/) を生成し、オプションで [Amazon Bedrock AgentCore Runtime](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/) にデプロイします。デフォルトでは、ジェネレーターは WebSocket 上の [tRPC](https://trpc.io/) を使用して、[AgentCore の双方向ストリーミングサポート](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-get-started-websocket.html)を活用し、リアルタイムで型安全な通信を実現します。または、他の A2A 互換エージェントとの相互運用性のために [Agent-to-Agent (A2A)](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-a2a.html) プロトコルを選択するか、[CopilotKit](https://docs.copilotkit.ai/aws-strands) を介した直接的なフロントエンド統合のために [AG-UI](https://docs.ag-ui.com/) プロトコルを選択することもできます。
 
 ## Strands とは?
 
@@ -60,6 +60,7 @@ TypeScript Agent は2つの方法で生成できます:
         - init.ts tRPC の初期化
         - router.ts エージェントプロシージャを含む tRPC ルーター
         - agent.ts サンプルツールを含むメインエージェント定義
+        - session.ts 会話状態を永続化するために使用される SessionManager を解決
         - client.ts エージェントを呼び出すための提供されたクライアント
         - agent-core-trpc-client.ts AgentCore Runtime 上のエージェントに接続するためのクライアントファクトリー
         - Dockerfile エージェントをホストするためのエントリーポイント (`infra` が `None` に設定されている場合は除外)
@@ -79,6 +80,7 @@ TypeScript Agent は2つの方法で生成できます:
       - agent/ (指定した場合はカスタム名)
         - index.ts A2A Express サーバーのエントリーポイント
         - agent.ts サンプルツールを含むメインエージェント定義
+        - session.ts 会話状態を永続化するために使用される SessionManager を解決
         - Dockerfile エージェントをホストするためのエントリーポイント (`infra` が `None` に設定されている場合は除外)
     - package.json Strands と Express 依存関係で更新
     - project.json エージェント serve ターゲットで更新
@@ -96,6 +98,7 @@ TypeScript Agent は2つの方法で生成できます:
       - agent/ (指定した場合はカスタム名)
         - index.ts AG-UI サーバーのエントリーポイント (Express + SSE)
         - agent.ts サンプルツールを含むメインエージェント定義
+        - session.ts 会話状態を永続化するために使用される SessionManager を解決
         - Dockerfile エージェントをホストするためのエントリーポイント (`infra` が `None` に設定されている場合は除外)
     - package.json Strands と AG-UI 依存関係で更新
     - project.json エージェント serve ターゲットで更新
@@ -134,8 +137,8 @@ Agent をデプロイするために、次のファイルが生成されます:
 </Infrastructure>
 </OptionFilter>
 
-<OptionFilter when={{ infra: 'none' }} description="No infrastructure is vended for infra=None">
-`infra` に `None` を選択した場合、CDK コンストラクトや Terraform モジュールは生成されません — Agent はローカルでのみ実行できます。このモードでは、認証するホストされたエンドポイントが存在しないため、`auth` オプションは無視されます。
+<OptionFilter when={{ infra: 'none' }} description="No infrastructure is vended for infra=none">
+`infra` に `none` を選択した場合、CDK コンストラクトや Terraform モジュールは生成されません — Agent はローカルでのみ実行できます。このモードでは、認証するホストされたエンドポイントが存在しないため、`auth` オプションは無視されます。
 </OptionFilter>
 
 #### アーキテクチャ
@@ -185,7 +188,7 @@ const letterCounter = tool({
 });
 
 // エージェントにツールを追加
-export const getAgent = async (sessionId: string) => {
+export const getAgent = async () => {
   return new Agent({
     systemPrompt: 'You are a helpful assistant with access to various tools.',
     tools: [letterCounter],
@@ -347,6 +350,37 @@ bundle ターゲットは、Bedrock AgentCore Runtime でホストする WebSock
 CloudWatch AWS コンソールでトレースを見つけるには、メニューで "GenAI Observability" を選択します。トレースを入力するには、[Transaction Search](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Transaction-Search.html) を有効にする必要があることに注意してください。
 
 詳細については、[可観測性に関する AgentCore ドキュメント](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/observability-configure.html)を参照してください。
+
+### セッション管理
+
+`session` オプションは、Strands SDK の [SessionManager](https://strandsagents.com/docs/user-guide/concepts/agents/session-management/) を使用して、エージェントが呼び出し間で会話状態（メッセージ履歴、ツール状態など）を永続化する方法を制御します:
+
+- **`s3`** (デフォルト): CDK/Terraform インフラストラクチャは、セッションデータ用の専用 S3 バケットをプロビジョニングします。SSE-S3 で暗号化され、すべてのパブリックアクセスがブロックされます。エージェントの IAM ロールには読み取り/書き込み/リスト/削除アクセスが付与され、バケット名はエージェントの ARN と共に AppConfig ランタイム設定に登録されます。
+- **`in-memory`**: バケットはプロビジョニングされません。会話状態は実行中のプロセスの存続期間中のみメモリに保持され、再起動やスケールインでは保持されません。
+
+これは生成された `session.ts` に実装されており、現在のセッションの `SessionManager` を解決する `getSessionManager()` 関数をエクスポートします:
+
+```typescript
+export const getSessionManager = async (): Promise<SessionManager> => {
+  const sessionId = getCurrentSessionId();
+  // ローカル開発では常にローカルファイルストレージを使用...
+  // ...それ以外の場合は S3Storage (session: 's3') または InMemoryStorage (session: 'in-memory')
+};
+```
+
+<OptionFilter when={{ protocol: 'ag-ui' }} description="AG-UI session wiring">
+AG-UI は会話スレッドごとにテンプレートエージェントをクローンするため、`getSessionManager` は `index.ts` の `StrandsAgent` 設定で `sessionManagerProvider` として接続されます。これにより、共有テンプレートエージェントに組み込まれるのではなく、各スレッドに対して新しい `SessionManager` が解決されます。
+</OptionFilter>
+
+<OptionFilter when={{ protocol: ['http', 'a2a'] }} description="HTTP/A2A session wiring">
+`withSessionId` は既にセッションごとに 1 つの `Agent` インスタンスをキャッシュしているため、`getSessionManager` は `agent.ts` の `getAgent` 内の `new Agent({ sessionManager: await getSessionManager() })` 呼び出しで直接呼び出されます。
+</OptionFilter>
+
+セッション ID 自体は AgentCore Runtime セッションから取得され（A2A/AG-UI の場合は `x-amzn-bedrock-agentcore-runtime-session-id` ヘッダー経由、HTTP/tRPC の場合は WebSocket 接続コンテキスト経由で伝播されます）、[`AsyncLocalStorage`](https://nodejs.org/api/async_context.html#class-asynclocalstorage) ベースのコンテキストにバインドされるため、`getCurrentSessionId()` はリクエスト内のどこでも解決できます — <Link path="/guides/connection">`connection` ジェネレーター</Link>を介して接続されたダウンストリームの MCP または A2A クライアントを含め、呼び出しチェーン全体が一貫したセッションを共有します。
+
+:::note[ローカル開発]
+ローカルで実行する場合（`LOCAL_DEV=true`、`-dev` ターゲットによって自動的に設定されます）、設定された `session` オプションに関係なく、セッションデータは常にワークスペースルートの `tmp/agents/strands/<agent-name>` の下のディスクに保存されます。これは便宜上のためです。
+:::
 </OptionFilter>
 
 ## Agent の呼び出し
@@ -366,7 +400,7 @@ import { AgentClient } from '../packages/<project>/src/agent/client.js';
 
 const client = AgentClient.local({ url: 'http://localhost:8081/ws' });
 
-client.invoke.subscribe({ message: 'what is 1 plus 1?' }, { onData: console.log });
+client.invoke.subscribe({ prompt: 'what is 1 plus 1?' }, { onData: console.log });
 ```
 
 :::tip[クイックテスト]
@@ -423,7 +457,7 @@ const client = AgentClient.withJwtAuth({
   accessTokenProvider: async () => `<access-token>`,
 });
 
-client.invoke.subscribe({ message: 'what is 1 plus 1?' }, {
+client.invoke.subscribe({ prompt: 'what is 1 plus 1?' }, {
   onData: console.log,
 });
 ```
@@ -485,7 +519,7 @@ React ウェブサイトから AG-UI エージェントを呼び出すには、<
 
 ## エージェントの保護
 
-<Snippet name="agent/securing-your-agent" parentHeading="Securing your Agent" />
+<Snippet name="agent/securing-your-agent" parentHeading="エージェントの保護" />
 
 ```typescript
 // agent.ts

--- a/docs/src/content/docs/ko/guides/ts-agent.mdx
+++ b/docs/src/content/docs/ko/guides/ts-agent.mdx
@@ -355,18 +355,10 @@ CloudWatch AWS 콘솔에서 메뉴의 "GenAI Observability"를 선택하여 추�
 
 `session` 옵션은 Strands SDK의 [SessionManager](https://strandsagents.com/docs/user-guide/concepts/agents/session-management/)를 사용하여 에이전트가 호출 간에 대화 상태(메시지 기록, 도구 상태 등)를 유지하는 방법을 제어합니다:
 
-- **`s3`** (기본값): CDK/Terraform 인프라는 세션 데이터를 위한 전용 S3 버킷을 프로비저닝하며, SSE-S3로 암호화되고 모든 공개 액세스가 차단됩니다. 에이전트의 IAM 역할에는 읽기/쓰기/목록/삭제 액세스 권한이 부여되며, 버킷 이름은 AppConfig 런타임 구성에서 에이전트의 ARN과 함께 등록됩니다.
+- **`s3`** (기본값): CDK/Terraform 인프라는 세션 데이터를 위한 전용 S3 버킷을 프로비저닝하며, 전용 KMS 키로 암호화되고 모든 공개 액세스가 차단됩니다. 서버 액세스 로그는 동일한 키를 통해 CloudWatch Logs 로그 그룹으로 전달됩니다. 에이전트의 IAM 역할에는 버킷에 대한 읽기/쓰기/목록/삭제 액세스 권한과 키에 대한 복호화/데이터 키 생성 액세스 권한이 부여되며, 버킷 이름은 AppConfig 런타임 구성에서 에이전트의 ARN과 함께 등록됩니다.
 - **`in-memory`**: 버킷이 프로비저닝되지 않습니다. 대화 상태는 실행 중인 프로세스의 수명 동안만 메모리에 유지되며 재시작이나 스케일 인 시 유지되지 않습니다.
 
-이는 생성된 `session.ts`에 구현되어 있으며, 현재 세션에 대한 `SessionManager`를 확인하는 `getSessionManager()` 함수를 내보냅니다:
-
-```typescript
-export const getSessionManager = async (): Promise<SessionManager> => {
-  const sessionId = getCurrentSessionId();
-  // local development always uses local file storage...
-  // ...otherwise S3Storage (session: 's3') or InMemoryStorage (session: 'in-memory')
-};
-```
+이는 생성된 `session.ts`에 구현되어 있으며, 현재 세션에 대한 `SessionManager`를 확인하는 `getSessionManager()` 함수를 내보냅니다.
 
 <OptionFilter when={{ protocol: 'ag-ui' }} description="AG-UI session wiring">
 AG-UI는 대화 스레드당 템플릿 에이전트를 복제하므로, `getSessionManager`는 `index.ts`의 `StrandsAgent` 구성에서 `sessionManagerProvider`로 연결되어 공유 템플릿 에이전트에 포함되는 대신 각 스레드에 대해 새로운 `SessionManager`가 확인됩니다.

--- a/docs/src/content/docs/ko/guides/ts-agent.mdx
+++ b/docs/src/content/docs/ko/guides/ts-agent.mdx
@@ -1,6 +1,6 @@
 ---
-title: "TypeScript Strands 에이전트"
-description: "도구를 사용하여 AI 에이전트를 구축하기 위한 TypeScript Strands 에이전트를 생성하고 Amazon Bedrock AgentCore Runtime에 배포합니다"
+title: TypeScript Agent
+description: 도구를 사용하여 AI 에이전트를 구축하기 위한 TypeScript Agent를 생성하고 Amazon Bedrock AgentCore Runtime에 배포합니다
 generator: ts#agent
 ---
 
@@ -16,7 +16,7 @@ import GeneratorParameters from '@components/generator-parameters.astro';
 import PackageManagerExecCommand from '@components/package-manager-exec-command.astro';
 import OptionFilter from '@components/option-filter.astro';
 
-도구를 사용하여 AI 에이전트를 구축하기 위한 TypeScript [Agent](https://strandsagents.com/)를 생성하고, 선택적으로 [Amazon Bedrock AgentCore Runtime](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/)에 배포합니다. 기본적으로 이 생성기는 WebSocket을 통한 [tRPC](https://trpc.io/)를 사용하여 [AgentCore의 양방향 스트리밍 지원](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-get-started-websocket.html)을 활용하여 실시간 타입 안전 통신을 제공합니다. 또는 다른 A2A 호환 에이전트와의 상호 운용성을 위해 [Agent-to-Agent (A2A)](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-a2a.html) 프로토콜을 선택하거나, [CopilotKit](https://docs.copilotkit.ai/aws-strands)을 통한 직접적인 프론트엔드 통합을 위해 [AG-UI](https://docs.ag-ui.com/) 프로토콜을 선택할 수 있습니다.
+도구를 사용하여 AI 에이전트를 구축하기 위한 TypeScript [Strands Agent](https://strandsagents.com/)를 생성하고, 선택적으로 [Amazon Bedrock AgentCore Runtime](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/)에 배포합니다. 기본적으로 이 생성기는 WebSocket을 통한 [tRPC](https://trpc.io/)를 사용하여 [AgentCore의 양방향 스트리밍 지원](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-get-started-websocket.html)을 활용하여 실시간 타입 안전 통신을 제공합니다. 또는 다른 A2A 호환 에이전트와의 상호 운용성을 위해 [Agent-to-Agent (A2A)](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-a2a.html) 프로토콜을 선택하거나, [CopilotKit](https://docs.copilotkit.ai/aws-strands)을 통한 직접적인 프론트엔드 통합을 위해 [AG-UI](https://docs.ag-ui.com/) 프로토콜을 선택할 수 있습니다.
 
 ## Strands란 무엇인가요?
 
@@ -60,6 +60,7 @@ import OptionFilter from '@components/option-filter.astro';
         - init.ts tRPC 초기화
         - router.ts 에이전트 프로시저가 포함된 tRPC 라우터
         - agent.ts 샘플 도구가 포함된 메인 에이전트 정의
+        - session.ts 대화 상태를 유지하는 데 사용되는 SessionManager를 확인합니다
         - client.ts 에이전트를 호출하기 위한 제공된 클라이언트
         - agent-core-trpc-client.ts AgentCore Runtime의 에이전트에 연결하기 위한 클라이언트 팩토리
         - Dockerfile 에이전트 호스팅을 위한 진입점 (`infra`이 `None`으로 설정된 경우 제외)
@@ -79,6 +80,7 @@ import OptionFilter from '@components/option-filter.astro';
       - agent/ (또는 지정된 경우 사용자 정의 이름)
         - index.ts A2A Express 서버 진입점
         - agent.ts 샘플 도구가 포함된 메인 에이전트 정의
+        - session.ts 대화 상태를 유지하는 데 사용되는 SessionManager를 확인합니다
         - Dockerfile 에이전트 호스팅을 위한 진입점 (`infra`이 `None`으로 설정된 경우 제외)
     - package.json Strands 및 Express 종속성으로 업데이트됨
     - project.json 에이전트 서브 타겟으로 업데이트됨
@@ -96,6 +98,7 @@ import OptionFilter from '@components/option-filter.astro';
       - agent/ (또는 지정된 경우 사용자 정의 이름)
         - index.ts AG-UI 서버 진입점 (Express + SSE)
         - agent.ts 샘플 도구가 포함된 메인 에이전트 정의
+        - session.ts 대화 상태를 유지하는 데 사용되는 SessionManager를 확인합니다
         - Dockerfile 에이전트 호스팅을 위한 진입점 (`infra`이 `None`으로 설정된 경우 제외)
     - package.json Strands 및 AG-UI 종속성으로 업데이트됨
     - project.json 에이전트 서브 타겟으로 업데이트됨
@@ -134,8 +137,8 @@ Agent 배포를 위해 다음 파일이 생성됩니다:
 </Infrastructure>
 </OptionFilter>
 
-<OptionFilter when={{ infra: 'none' }} description="No infrastructure is vended for infra=None">
-`infra`에 대해 `None`을 선택한 경우 CDK 구성 또는 Terraform 모듈이 생성되지 않습니다 — Agent는 로컬에서만 실행할 수 있습니다. 이 모드에서는 인증할 호스팅된 엔드포인트가 없으므로 `auth` 옵션은 무시됩니다.
+<OptionFilter when={{ infra: 'none' }} description="No infrastructure is vended for infra=none">
+`infra`에 대해 `none`을 선택한 경우 CDK 구성 또는 Terraform 모듈이 생성되지 않습니다 — Agent는 로컬에서만 실행할 수 있습니다. 이 모드에서는 인증할 호스팅된 엔드포인트가 없으므로 `auth` 옵션은 무시됩니다.
 </OptionFilter>
 
 #### Architecture
@@ -167,7 +170,7 @@ tRPC는 WebSocket을 통한 Query, Mutation 및 Subscription 프로시저를 지
 도구는 AI 에이전트가 작업을 수행하기 위해 호출할 수 있는 함수입니다. `agent.ts` 파일에 새 도구를 추가할 수 있습니다:
 
 ```typescript
-import { Agent, tool } from '@agents/sdk';
+import { Agent, tool } from '@strands-agents/sdk';
 import { z } from 'zod';
 
 const letterCounter = tool({
@@ -185,7 +188,7 @@ const letterCounter = tool({
 });
 
 // Add tools to your agent
-export const getAgent = async (sessionId: string) => {
+export const getAgent = async () => {
   return new Agent({
     systemPrompt: 'You are a helpful assistant with access to various tools.',
     tools: [letterCounter],
@@ -203,9 +206,9 @@ Strands 프레임워크는 다음을 자동으로 처리합니다:
 기본적으로 Strands 에이전트는 Claude 4 Sonnet을 사용하지만, 모델 제공업체 간에 쉽게 전환할 수 있습니다:
 
 ```typescript
-import { Agent } from '@agents/sdk';
-import { BedrockModel } from '@agents/sdk/models/bedrock';
-import { OpenAIModel } from '@agents/sdk/models/openai';
+import { Agent } from '@strands-agents/sdk';
+import { BedrockModel } from '@strands-agents/sdk/models/bedrock';
+import { OpenAIModel } from '@strands-agents/sdk/models/openai';
 
 // Use Bedrock
 const bedrockModel = new BedrockModel({
@@ -347,6 +350,37 @@ aws cognito-idp admin-initiate-auth \
 CloudWatch AWS 콘솔에서 메뉴의 "GenAI Observability"를 선택하여 추적을 찾을 수 있습니다. 추적이 채워지려면 [Transaction Search](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Transaction-Search.html)를 활성화해야 합니다.
 
 자세한 내용은 [관찰성에 대한 AgentCore 문서](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/observability-configure.html)를 참조하세요.
+
+### 세션 관리
+
+`session` 옵션은 Strands SDK의 [SessionManager](https://strandsagents.com/docs/user-guide/concepts/agents/session-management/)를 사용하여 에이전트가 호출 간에 대화 상태(메시지 기록, 도구 상태 등)를 유지하는 방법을 제어합니다:
+
+- **`s3`** (기본값): CDK/Terraform 인프라는 세션 데이터를 위한 전용 S3 버킷을 프로비저닝하며, SSE-S3로 암호화되고 모든 공개 액세스가 차단됩니다. 에이전트의 IAM 역할에는 읽기/쓰기/목록/삭제 액세스 권한이 부여되며, 버킷 이름은 AppConfig 런타임 구성에서 에이전트의 ARN과 함께 등록됩니다.
+- **`in-memory`**: 버킷이 프로비저닝되지 않습니다. 대화 상태는 실행 중인 프로세스의 수명 동안만 메모리에 유지되며 재시작이나 스케일 인 시 유지되지 않습니다.
+
+이는 생성된 `session.ts`에 구현되어 있으며, 현재 세션에 대한 `SessionManager`를 확인하는 `getSessionManager()` 함수를 내보냅니다:
+
+```typescript
+export const getSessionManager = async (): Promise<SessionManager> => {
+  const sessionId = getCurrentSessionId();
+  // local development always uses local file storage...
+  // ...otherwise S3Storage (session: 's3') or InMemoryStorage (session: 'in-memory')
+};
+```
+
+<OptionFilter when={{ protocol: 'ag-ui' }} description="AG-UI session wiring">
+AG-UI는 대화 스레드당 템플릿 에이전트를 복제하므로, `getSessionManager`는 `index.ts`의 `StrandsAgent` 구성에서 `sessionManagerProvider`로 연결되어 공유 템플릿 에이전트에 포함되는 대신 각 스레드에 대해 새로운 `SessionManager`가 확인됩니다.
+</OptionFilter>
+
+<OptionFilter when={{ protocol: ['http', 'a2a'] }} description="HTTP/A2A session wiring">
+`withSessionId`가 이미 세션당 하나의 `Agent` 인스턴스를 캐시하므로, `getSessionManager`는 `agent.ts`의 `getAgent` 내부에서 `new Agent({ sessionManager: await getSessionManager() })` 호출에서 직접 호출됩니다.
+</OptionFilter>
+
+세션 ID 자체는 AgentCore Runtime 세션에서 가져오며(A2A/AG-UI의 경우 `x-amzn-bedrock-agentcore-runtime-session-id` 헤더를 통해, HTTP/tRPC의 경우 WebSocket 연결 컨텍스트를 통해 전파됨), [`AsyncLocalStorage`](https://nodejs.org/api/async_context.html#class-asynclocalstorage) 기반 컨텍스트에 바인딩되어 `getCurrentSessionId()`가 요청의 어디에서나 이를 확인할 수 있습니다 — <Link path="/guides/connection">`connection` 생성기</Link>를 통해 연결된 다운스트림 MCP 또는 A2A 클라이언트를 포함하여 전체 호출 체인이 일관된 세션을 공유하도록 합니다.
+
+:::note[로컬 개발]
+로컬에서 실행할 때(`LOCAL_DEV=true`, `-dev` 타겟에 의해 자동으로 설정됨), 구성된 `session` 옵션에 관계없이 세션 데이터는 편의를 위해 항상 워크스페이스 루트의 `tmp/agents/strands/<agent-name>` 아래 디스크에 저장됩니다.
+:::
 </OptionFilter>
 
 ## Agent 호출
@@ -366,7 +400,7 @@ import { AgentClient } from '../packages/<project>/src/agent/client.js';
 
 const client = AgentClient.local({ url: 'http://localhost:8081/ws' });
 
-client.invoke.subscribe({ message: 'what is 1 plus 1?' }, { onData: console.log });
+client.invoke.subscribe({ prompt: 'what is 1 plus 1?' }, { onData: console.log });
 ```
 
 :::tip[빠른 테스트]
@@ -423,7 +457,7 @@ const client = AgentClient.withJwtAuth({
   accessTokenProvider: async () => `<access-token>`,
 });
 
-client.invoke.subscribe({ message: 'what is 1 plus 1?' }, {
+client.invoke.subscribe({ prompt: 'what is 1 plus 1?' }, {
   onData: console.log,
 });
 ```

--- a/docs/src/content/docs/pt/guides/ts-agent.mdx
+++ b/docs/src/content/docs/pt/guides/ts-agent.mdx
@@ -355,18 +355,10 @@ Para mais detalhes, consulte a [documentação do AgentCore sobre observabilidad
 
 A opção `session` controla como seu agente persiste o estado da conversa (histórico de mensagens, estado de ferramentas, etc.) entre invocações, usando o [SessionManager](https://strandsagents.com/docs/user-guide/concepts/agents/session-management/) do Strands SDK:
 
-- **`s3`** (padrão): A infraestrutura CDK/Terraform provisiona um bucket S3 dedicado para dados de sessão, criptografado com SSE-S3 e com todo acesso público bloqueado. A função IAM do agente recebe acesso de leitura/escrita/listagem/exclusão a ele, e o nome do bucket é registrado junto com o ARN do agente na configuração de runtime do AppConfig.
+- **`s3`** (padrão): A infraestrutura CDK/Terraform provisiona um bucket S3 dedicado para dados de sessão, criptografado com uma chave KMS dedicada e com todo acesso público bloqueado; os logs de acesso do servidor são entregues a um grupo de logs do CloudWatch Logs através da mesma chave. A função IAM do agente recebe acesso de leitura/escrita/listagem/exclusão ao bucket e acesso de descriptografia/geração de chave de dados à chave, e o nome do bucket é registrado junto com o ARN do agente na configuração de runtime do AppConfig.
 - **`in-memory`**: Nenhum bucket é provisionado. O estado da conversa é mantido apenas na memória durante o tempo de vida do processo em execução e não sobrevive a reinicializações ou scale-in.
 
-Isso é implementado no `session.ts` gerado, que exporta uma função `getSessionManager()` resolvendo um `SessionManager` para a sessão atual:
-
-```typescript
-export const getSessionManager = async (): Promise<SessionManager> => {
-  const sessionId = getCurrentSessionId();
-  // local development always uses local file storage...
-  // ...otherwise S3Storage (session: 's3') or InMemoryStorage (session: 'none')
-};
-```
+Isso é implementado no `session.ts` gerado, que exporta uma função `getSessionManager()` resolvendo um `SessionManager` para a sessão atual.
 
 <OptionFilter when={{ protocol: 'ag-ui' }} description="AG-UI session wiring">
 Como o AG-UI clona um agente modelo por thread de conversa, `getSessionManager` é conectado como um `sessionManagerProvider` na configuração do `StrandsAgent` em `index.ts`, para que um `SessionManager` novo seja resolvido para cada thread em vez de ser incorporado ao agente modelo compartilhado.

--- a/docs/src/content/docs/pt/guides/ts-agent.mdx
+++ b/docs/src/content/docs/pt/guides/ts-agent.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Agente TypeScript Strands"
-description: "Gere um Agente TypeScript Strands para construir agentes de IA com ferramentas e implante no Amazon Bedrock AgentCore Runtime"
+title: TypeScript Agent
+description: Gere um TypeScript Agent para construir agentes de IA com ferramentas e implante no Amazon Bedrock AgentCore Runtime
 generator: ts#agent
 ---
 
@@ -16,7 +16,7 @@ import GeneratorParameters from '@components/generator-parameters.astro';
 import PackageManagerExecCommand from '@components/package-manager-exec-command.astro';
 import OptionFilter from '@components/option-filter.astro';
 
-Gere um [Agent](https://strandsagents.com/) TypeScript para construir agentes de IA com ferramentas e, opcionalmente, implante-o no [Amazon Bedrock AgentCore Runtime](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/). Por padrão, o gerador usa [tRPC](https://trpc.io/) sobre WebSocket para aproveitar o [suporte de streaming bidirecional do AgentCore](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-get-started-websocket.html) para comunicação em tempo real com segurança de tipo. Alternativamente, você pode escolher o protocolo [Agent-to-Agent (A2A)](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-a2a.html) para interoperabilidade com outros agentes compatíveis com A2A, ou o protocolo [AG-UI](https://docs.ag-ui.com/) para integração direta com frontend via [CopilotKit](https://docs.copilotkit.ai/aws-strands).
+Gere um TypeScript [Strands Agent](https://strandsagents.com/) para construir agentes de IA com ferramentas e, opcionalmente, implante-o no [Amazon Bedrock AgentCore Runtime](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/). Por padrão, o gerador usa [tRPC](https://trpc.io/) sobre WebSocket para aproveitar o [suporte de streaming bidirecional do AgentCore](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-get-started-websocket.html) para comunicação em tempo real com segurança de tipo. Alternativamente, você pode escolher o protocolo [Agent-to-Agent (A2A)](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-a2a.html) para interoperabilidade com outros agentes compatíveis com A2A, ou o protocolo [AG-UI](https://docs.ag-ui.com/) para integração direta com frontend via [CopilotKit](https://docs.copilotkit.ai/aws-strands).
 
 ## O que é Strands?
 
@@ -60,6 +60,7 @@ O gerador adicionará os seguintes arquivos ao seu projeto TypeScript existente.
         - init.ts Inicialização do tRPC
         - router.ts Roteador tRPC com procedimentos de agente
         - agent.ts Definição principal do agente com ferramentas de exemplo
+        - session.ts Resolve o SessionManager usado para persistir o estado da conversa
         - client.ts Cliente fornecido para invocar seu agente
         - agent-core-trpc-client.ts Fábrica de cliente para conectar a agentes no AgentCore Runtime
         - Dockerfile Ponto de entrada para hospedar seu agente (excluído quando `infra` está definido como `None`)
@@ -79,6 +80,7 @@ O ponto de entrada usa o [Strands A2A Express Server](https://strandsagents.com/
       - agent/ (ou nome personalizado se especificado)
         - index.ts Ponto de entrada do servidor A2A Express
         - agent.ts Definição principal do agente com ferramentas de exemplo
+        - session.ts Resolve o SessionManager usado para persistir o estado da conversa
         - Dockerfile Ponto de entrada para hospedar seu agente (excluído quando `infra` está definido como `None`)
     - package.json Atualizado com dependências do Strands e Express
     - project.json Atualizado com destinos de servir do agente
@@ -96,6 +98,7 @@ O ponto de entrada usa [`@ag-ui/aws-strands`](https://www.npmjs.com/package/@ag-
       - agent/ (ou nome personalizado se especificado)
         - index.ts Ponto de entrada do servidor AG-UI (Express + SSE)
         - agent.ts Definição principal do agente com ferramentas de exemplo
+        - session.ts Resolve o SessionManager usado para persistir o estado da conversa
         - Dockerfile Ponto de entrada para hospedar seu agente (excluído quando `infra` está definido como `None`)
     - package.json Atualizado com dependências do Strands e AG-UI
     - project.json Atualizado com destinos de servir do agente
@@ -134,8 +137,8 @@ Para implantar seu Agent, os seguintes arquivos são gerados:
 </Infrastructure>
 </OptionFilter>
 
-<OptionFilter when={{ infra: 'none' }} description="No infrastructure is vended for infra=None">
-Se você selecionou `None` para `infra`, nenhum construto CDK ou módulo Terraform é gerado — o Agent só pode ser executado localmente. A opção `auth` é ignorada neste modo, pois não há endpoint hospedado para autenticar.
+<OptionFilter when={{ infra: 'none' }} description="No infrastructure is vended for infra=none">
+Se você selecionou `none` para `infra`, nenhum construto CDK ou módulo Terraform é gerado — o Agent só pode ser executado localmente. A opção `auth` é ignorada neste modo, pois não há endpoint hospedado para autenticar.
 </OptionFilter>
 
 #### Architecture
@@ -167,7 +170,7 @@ Como o tRPC suporta procedimentos Query, Mutation e Subscription sobre WebSocket
 Ferramentas são funções que o agente de IA pode chamar para executar ações. Você pode adicionar novas ferramentas no arquivo `agent.ts`:
 
 ```typescript
-import { Agent, tool } from '@agents/sdk';
+import { Agent, tool } from '@strands-agents/sdk';
 import { z } from 'zod';
 
 const letterCounter = tool({
@@ -185,7 +188,7 @@ const letterCounter = tool({
 });
 
 // Add tools to your agent
-export const getAgent = async (sessionId: string) => {
+export const getAgent = async () => {
   return new Agent({
     systemPrompt: 'You are a helpful assistant with access to various tools.',
     tools: [letterCounter],
@@ -203,9 +206,9 @@ O framework Strands trata automaticamente:
 Por padrão, os agentes Strands usam Claude 4 Sonnet, mas você pode alternar facilmente entre provedores de modelo:
 
 ```typescript
-import { Agent } from '@agents/sdk';
-import { BedrockModel } from '@agents/sdk/models/bedrock';
-import { OpenAIModel } from '@agents/sdk/models/openai';
+import { Agent } from '@strands-agents/sdk';
+import { BedrockModel } from '@strands-agents/sdk/models/bedrock';
+import { OpenAIModel } from '@strands-agents/sdk/models/openai';
 
 // Use Bedrock
 const bedrockModel = new BedrockModel({
@@ -347,6 +350,37 @@ Seu agente é automaticamente configurado com observabilidade usando o [AWS Dist
 Você pode encontrar traces no Console AWS do CloudWatch, selecionando "GenAI Observability" no menu. Observe que para que os traces sejam populados você precisará habilitar [Transaction Search](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Transaction-Search.html).
 
 Para mais detalhes, consulte a [documentação do AgentCore sobre observabilidade](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/observability-configure.html).
+
+### Gerenciamento de Sessão
+
+A opção `session` controla como seu agente persiste o estado da conversa (histórico de mensagens, estado de ferramentas, etc.) entre invocações, usando o [SessionManager](https://strandsagents.com/docs/user-guide/concepts/agents/session-management/) do Strands SDK:
+
+- **`s3`** (padrão): A infraestrutura CDK/Terraform provisiona um bucket S3 dedicado para dados de sessão, criptografado com SSE-S3 e com todo acesso público bloqueado. A função IAM do agente recebe acesso de leitura/escrita/listagem/exclusão a ele, e o nome do bucket é registrado junto com o ARN do agente na configuração de runtime do AppConfig.
+- **`in-memory`**: Nenhum bucket é provisionado. O estado da conversa é mantido apenas na memória durante o tempo de vida do processo em execução e não sobrevive a reinicializações ou scale-in.
+
+Isso é implementado no `session.ts` gerado, que exporta uma função `getSessionManager()` resolvendo um `SessionManager` para a sessão atual:
+
+```typescript
+export const getSessionManager = async (): Promise<SessionManager> => {
+  const sessionId = getCurrentSessionId();
+  // local development always uses local file storage...
+  // ...otherwise S3Storage (session: 's3') or InMemoryStorage (session: 'none')
+};
+```
+
+<OptionFilter when={{ protocol: 'ag-ui' }} description="AG-UI session wiring">
+Como o AG-UI clona um agente modelo por thread de conversa, `getSessionManager` é conectado como um `sessionManagerProvider` na configuração do `StrandsAgent` em `index.ts`, para que um `SessionManager` novo seja resolvido para cada thread em vez de ser incorporado ao agente modelo compartilhado.
+</OptionFilter>
+
+<OptionFilter when={{ protocol: ['http', 'a2a'] }} description="HTTP/A2A session wiring">
+Como `withSessionId` já armazena em cache uma instância de `Agent` por sessão, `getSessionManager` é chamado diretamente dentro da chamada `new Agent({ sessionManager: await getSessionManager() })` de `getAgent` em `agent.ts`.
+</OptionFilter>
+
+O próprio ID de sessão vem da sessão do AgentCore Runtime (propagado via cabeçalho `x-amzn-bedrock-agentcore-runtime-session-id` para A2A/AG-UI, ou o contexto de conexão WebSocket para HTTP/tRPC) e é vinculado a um contexto baseado em [`AsyncLocalStorage`](https://nodejs.org/api/async_context.html#class-asynclocalstorage) para que `getCurrentSessionId()` possa resolvê-lo em qualquer lugar na solicitação — incluindo em quaisquer clientes MCP ou A2A downstream conectados via <Link path="/guides/connection">gerador `connection`</Link>, para que toda a cadeia de chamadas compartilhe uma sessão consistente.
+
+:::note[Desenvolvimento Local]
+Ao executar localmente (`LOCAL_DEV=true`, definido automaticamente pelo destino `-dev`), os dados de sessão são sempre armazenados em disco sob `tmp/agents/strands/<agent-name>` na raiz do workspace, independentemente da opção `session` configurada, por conveniência.
+:::
 </OptionFilter>
 
 ## Invocando seu Agent
@@ -366,7 +400,7 @@ import { AgentClient } from '../packages/<project>/src/agent/client.js';
 
 const client = AgentClient.local({ url: 'http://localhost:8081/ws' });
 
-client.invoke.subscribe({ message: 'what is 1 plus 1?' }, { onData: console.log });
+client.invoke.subscribe({ prompt: 'what is 1 plus 1?' }, { onData: console.log });
 ```
 
 :::tip[Teste rápido]
@@ -400,7 +434,7 @@ const client = AgentClient.withIamAuth({
   agentRuntimeArn: 'arn:aws:bedrock-agentcore:us-west-2:123456789012:runtime/my-agent',
 });
 
-client.invoke.subscribe({ message: 'what is 1 plus 1?' }, {
+client.invoke.subscribe({ prompt: 'what is 1 plus 1?' }, {
   onData: (message) => console.log(message),
   onError: (error) => console.error(error),
   onComplete: () => console.log('Done'),

--- a/docs/src/content/docs/vi/guides/ts-agent.mdx
+++ b/docs/src/content/docs/vi/guides/ts-agent.mdx
@@ -355,18 +355,10 @@ Bạn có thể tìm thấy các trace trong CloudWatch AWS Console, bằng các
 
 Tùy chọn `session` kiểm soát cách agent của bạn lưu trữ trạng thái hội thoại (lịch sử tin nhắn, trạng thái công cụ, v.v.) qua các lần gọi, sử dụng [SessionManager](https://strandsagents.com/docs/user-guide/concepts/agents/session-management/) của Strands SDK:
 
-- **`s3`** (mặc định): Hạ tầng CDK/Terraform cung cấp một S3 bucket chuyên dụng cho dữ liệu session, được mã hóa bằng SSE-S3 và chặn mọi truy cập công khai. IAM role của agent được cấp quyền read/write/list/delete đối với nó, và tên bucket được đăng ký cùng với ARN của agent trong runtime configuration của AppConfig.
+- **`s3`** (mặc định): Hạ tầng CDK/Terraform cung cấp một S3 bucket chuyên dụng cho dữ liệu session, được mã hóa bằng một KMS key chuyên dụng và chặn mọi truy cập công khai; server access log được gửi đến một CloudWatch Logs log group thông qua cùng key đó. IAM role của agent được cấp quyền read/write/list/delete đối với bucket và quyền decrypt/generate-data-key đối với key, và tên bucket được đăng ký cùng với ARN của agent trong runtime configuration của AppConfig.
 - **`in-memory`**: Không có bucket nào được cung cấp. Trạng thái hội thoại chỉ được giữ trong bộ nhớ trong suốt thời gian sống của tiến trình đang chạy và không tồn tại qua các lần khởi động lại hoặc scale-in.
 
-Điều này được triển khai trong file `session.ts` được tạo ra, xuất một hàm `getSessionManager()` phân giải một `SessionManager` cho session hiện tại:
-
-```typescript
-export const getSessionManager = async (): Promise<SessionManager> => {
-  const sessionId = getCurrentSessionId();
-  // local development always uses local file storage...
-  // ...otherwise S3Storage (session: 's3') or InMemoryStorage (session: 'none')
-};
-```
+Điều này được triển khai trong file `session.ts` được tạo ra, xuất một hàm `getSessionManager()` phân giải một `SessionManager` cho session hiện tại.
 
 <OptionFilter when={{ protocol: 'ag-ui' }} description="AG-UI session wiring">
 Vì AG-UI sao chép một template agent cho mỗi conversation thread, `getSessionManager` được kết nối như một `sessionManagerProvider` trên cấu hình `StrandsAgent` trong `index.ts`, do đó một `SessionManager` mới được phân giải cho mỗi thread thay vì được nhúng vào template agent được chia sẻ.

--- a/docs/src/content/docs/vi/guides/ts-agent.mdx
+++ b/docs/src/content/docs/vi/guides/ts-agent.mdx
@@ -1,6 +1,6 @@
 ---
-title: "TypeScript Agent"
-description: "Tạo TypeScript Agent để xây dựng các AI agent với công cụ và triển khai lên Amazon Bedrock AgentCore Runtime"
+title: TypeScript Agent
+description: Tạo TypeScript Agent để xây dựng các AI agent với công cụ và triển khai lên Amazon Bedrock AgentCore Runtime
 generator: ts#agent
 ---
 
@@ -16,7 +16,7 @@ import GeneratorParameters from '@components/generator-parameters.astro';
 import PackageManagerExecCommand from '@components/package-manager-exec-command.astro';
 import OptionFilter from '@components/option-filter.astro';
 
-Tạo một TypeScript [Agent](https://strandsagents.com/) để xây dựng các AI agent với công cụ, và tùy chọn triển khai nó lên [Amazon Bedrock AgentCore Runtime](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/). Mặc định, generator sử dụng [tRPC](https://trpc.io/) qua WebSocket để tận dụng [hỗ trợ streaming hai chiều của AgentCore](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-get-started-websocket.html) cho giao tiếp thời gian thực, type-safe. Ngoài ra, bạn có thể chọn giao thức [Agent-to-Agent (A2A)](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-a2a.html) để tương tác với các agent tương thích A2A khác, hoặc giao thức [AG-UI](https://docs.ag-ui.com/) để tích hợp trực tiếp với frontend thông qua [CopilotKit](https://docs.copilotkit.ai/aws-strands).
+Tạo một TypeScript [Strands Agent](https://strandsagents.com/) để xây dựng các AI agent với công cụ, và tùy chọn triển khai nó lên [Amazon Bedrock AgentCore Runtime](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/). Mặc định, generator sử dụng [tRPC](https://trpc.io/) qua WebSocket để tận dụng [hỗ trợ streaming hai chiều của AgentCore](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-get-started-websocket.html) cho giao tiếp thời gian thực, type-safe. Ngoài ra, bạn có thể chọn giao thức [Agent-to-Agent (A2A)](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-a2a.html) để tương tác với các agent tương thích A2A khác, hoặc giao thức [AG-UI](https://docs.ag-ui.com/) để tích hợp trực tiếp với frontend thông qua [CopilotKit](https://docs.copilotkit.ai/aws-strands).
 
 ## Strands là gì?
 
@@ -60,6 +60,7 @@ Generator sẽ thêm các file sau vào dự án TypeScript hiện có của b�
         - init.ts Khởi tạo tRPC
         - router.ts tRPC router với các agent procedure
         - agent.ts Định nghĩa agent chính với các công cụ mẫu
+        - session.ts Phân giải SessionManager được sử dụng để lưu trữ trạng thái hội thoại
         - client.ts Client được cung cấp để gọi agent của bạn
         - agent-core-trpc-client.ts Client factory để kết nối với các agent trên AgentCore Runtime
         - Dockerfile Điểm vào để host agent của bạn (loại trừ khi `infra` được đặt thành `None`)
@@ -79,6 +80,7 @@ Generator sẽ thêm các file sau vào dự án TypeScript hiện có của b�
       - agent/ (hoặc tên tùy chỉnh nếu được chỉ định)
         - index.ts Điểm vào A2A Express server
         - agent.ts Định nghĩa agent chính với các công cụ mẫu
+        - session.ts Phân giải SessionManager được sử dụng để lưu trữ trạng thái hội thoại
         - Dockerfile Điểm vào để host agent của bạn (loại trừ khi `infra` được đặt thành `None`)
     - package.json Được cập nhật với các dependency của Strands và Express
     - project.json Được cập nhật với các target serve agent
@@ -96,6 +98,7 @@ Generator sẽ thêm các file sau vào dự án TypeScript hiện có của b�
       - agent/ (hoặc tên tùy chỉnh nếu được chỉ định)
         - index.ts Điểm vào AG-UI server (Express + SSE)
         - agent.ts Định nghĩa agent chính với các công cụ mẫu
+        - session.ts Phân giải SessionManager được sử dụng để lưu trữ trạng thái hội thoại
         - Dockerfile Điểm vào để host agent của bạn (loại trừ khi `infra` được đặt thành `None`)
     - package.json Được cập nhật với các dependency của Strands và AG-UI
     - project.json Được cập nhật với các target serve agent
@@ -134,8 +137,8 @@ Generator sẽ thêm các file sau vào dự án TypeScript hiện có của b�
 </Infrastructure>
 </OptionFilter>
 
-<OptionFilter when={{ infra: 'none' }} description="No infrastructure is vended for infra=None">
-Nếu bạn chọn `None` cho `infra`, không có CDK construct hoặc Terraform module nào được tạo ra — Agent chỉ có thể chạy locally. Tùy chọn `auth` sẽ bị bỏ qua trong chế độ này vì không có endpoint được host để xác thực.
+<OptionFilter when={{ infra: 'none' }} description="No infrastructure is vended for infra=none">
+Nếu bạn chọn `none` cho `infra`, không có CDK construct hoặc Terraform module nào được tạo ra — Agent chỉ có thể chạy locally. Tùy chọn `auth` sẽ bị bỏ qua trong chế độ này vì không có endpoint được host để xác thực.
 </OptionFilter>
 
 #### Architecture
@@ -167,7 +170,7 @@ Vì tRPC hỗ trợ các procedure Query, Mutation và Subscription qua WebSocke
 Công cụ là các hàm mà AI agent có thể gọi để thực hiện các hành động. Bạn có thể thêm công cụ mới trong file `agent.ts`:
 
 ```typescript
-import { Agent, tool } from '@agents/sdk';
+import { Agent, tool } from '@strands-agents/sdk';
 import { z } from 'zod';
 
 const letterCounter = tool({
@@ -185,7 +188,7 @@ const letterCounter = tool({
 });
 
 // Add tools to your agent
-export const getAgent = async (sessionId: string) => {
+export const getAgent = async () => {
   return new Agent({
     systemPrompt: 'You are a helpful assistant with access to various tools.',
     tools: [letterCounter],
@@ -203,9 +206,9 @@ Framework Strands tự động xử lý:
 Mặc định, các Strands agent sử dụng Claude 4 Sonnet, nhưng bạn có thể dễ dàng chuyển đổi giữa các model provider:
 
 ```typescript
-import { Agent } from '@agents/sdk';
-import { BedrockModel } from '@agents/sdk/models/bedrock';
-import { OpenAIModel } from '@agents/sdk/models/openai';
+import { Agent } from '@strands-agents/sdk';
+import { BedrockModel } from '@strands-agents/sdk/models/bedrock';
+import { OpenAIModel } from '@strands-agents/sdk/models/openai';
 
 // Use Bedrock
 const bedrockModel = new BedrockModel({
@@ -347,6 +350,37 @@ Agent của bạn được tự động cấu hình với khả năng quan sát 
 Bạn có thể tìm thấy các trace trong CloudWatch AWS Console, bằng cách chọn "GenAI Observability" trong menu. Lưu ý rằng để các trace được điền, bạn sẽ cần bật [Transaction Search](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Transaction-Search.html).
 
 Để biết thêm chi tiết, tham khảo [tài liệu AgentCore về khả năng quan sát](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/observability-configure.html).
+
+### Quản lý Session
+
+Tùy chọn `session` kiểm soát cách agent của bạn lưu trữ trạng thái hội thoại (lịch sử tin nhắn, trạng thái công cụ, v.v.) qua các lần gọi, sử dụng [SessionManager](https://strandsagents.com/docs/user-guide/concepts/agents/session-management/) của Strands SDK:
+
+- **`s3`** (mặc định): Hạ tầng CDK/Terraform cung cấp một S3 bucket chuyên dụng cho dữ liệu session, được mã hóa bằng SSE-S3 và chặn mọi truy cập công khai. IAM role của agent được cấp quyền read/write/list/delete đối với nó, và tên bucket được đăng ký cùng với ARN của agent trong runtime configuration của AppConfig.
+- **`in-memory`**: Không có bucket nào được cung cấp. Trạng thái hội thoại chỉ được giữ trong bộ nhớ trong suốt thời gian sống của tiến trình đang chạy và không tồn tại qua các lần khởi động lại hoặc scale-in.
+
+Điều này được triển khai trong file `session.ts` được tạo ra, xuất một hàm `getSessionManager()` phân giải một `SessionManager` cho session hiện tại:
+
+```typescript
+export const getSessionManager = async (): Promise<SessionManager> => {
+  const sessionId = getCurrentSessionId();
+  // local development always uses local file storage...
+  // ...otherwise S3Storage (session: 's3') or InMemoryStorage (session: 'none')
+};
+```
+
+<OptionFilter when={{ protocol: 'ag-ui' }} description="AG-UI session wiring">
+Vì AG-UI sao chép một template agent cho mỗi conversation thread, `getSessionManager` được kết nối như một `sessionManagerProvider` trên cấu hình `StrandsAgent` trong `index.ts`, do đó một `SessionManager` mới được phân giải cho mỗi thread thay vì được nhúng vào template agent được chia sẻ.
+</OptionFilter>
+
+<OptionFilter when={{ protocol: ['http', 'a2a'] }} description="HTTP/A2A session wiring">
+Vì `withSessionId` đã cache một instance `Agent` cho mỗi session, `getSessionManager` được gọi trực tiếp bên trong lệnh gọi `new Agent({ sessionManager: await getSessionManager() })` của `getAgent` trong `agent.ts`.
+</OptionFilter>
+
+Session ID chính nó đến từ session của AgentCore Runtime (được truyền qua header `x-amzn-bedrock-agentcore-runtime-session-id` cho A2A/AG-UI, hoặc context kết nối WebSocket cho HTTP/tRPC) và được ràng buộc với một context dựa trên [`AsyncLocalStorage`](https://nodejs.org/api/async_context.html#class-asynclocalstorage) để `getCurrentSessionId()` có thể phân giải nó ở bất kỳ đâu trong request — bao gồm trong bất kỳ MCP hoặc A2A client downstream nào được kết nối qua <Link path="/guides/connection">`connection` generator</Link>, do đó toàn bộ chuỗi gọi chia sẻ một session nhất quán.
+
+:::note[Phát triển Local]
+Khi chạy locally (`LOCAL_DEV=true`, được thiết lập tự động bởi target `-dev`), dữ liệu session luôn được lưu trữ trên đĩa dưới `tmp/agents/strands/<agent-name>` tại workspace root, bất kể tùy chọn `session` được cấu hình, để thuận tiện.
+:::
 </OptionFilter>
 
 ## Gọi Agent của bạn
@@ -400,7 +434,7 @@ const client = AgentClient.withIamAuth({
   agentRuntimeArn: 'arn:aws:bedrock-agentcore:us-west-2:123456789012:runtime/my-agent',
 });
 
-client.invoke.subscribe({ message: 'what is 1 plus 1?' }, {
+client.invoke.subscribe({ prompt: 'what is 1 plus 1?' }, {
   onData: (message) => console.log(message),
   onError: (error) => console.error(error),
   onComplete: () => console.log('Done'),
@@ -423,7 +457,7 @@ const client = AgentClient.withJwtAuth({
   accessTokenProvider: async () => `<access-token>`,
 });
 
-client.invoke.subscribe({ message: 'what is 1 plus 1?' }, {
+client.invoke.subscribe({ prompt: 'what is 1 plus 1?' }, {
   onData: console.log,
 });
 ```
@@ -513,7 +547,7 @@ Sử dụng generator <Link path="guides/connection">`connection`</Link> để t
   <ConnectionCard
     title="React to TypeScript Agent"
     description="Gọi TypeScript Agent từ một trang web React"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/react-ts-agent`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'vi'}/guides/connection/react-ts-agent`}
     source="react"
     target="strands"
     targetBadge="typescript"
@@ -521,14 +555,14 @@ Sử dụng generator <Link path="guides/connection">`connection`</Link> để t
   <ConnectionCard
     title="React to AG-UI Agent"
     description="Gọi Agent hỗ trợ giao thức AG-UI từ một trang web React thông qua CopilotKit"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/react-agui`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'vi'}/guides/connection/react-agui`}
     source="react"
     target="copilotkit"
   />
   <ConnectionCard
     title="TypeScript Agent to MCP"
     description="Kết nối TypeScript Agent với MCP server"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/ts-agent-mcp`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'vi'}/guides/connection/ts-agent-mcp`}
     source="strands"
     sourceBadge="typescript"
     target="mcp"
@@ -536,7 +570,7 @@ Sử dụng generator <Link path="guides/connection">`connection`</Link> để t
   <ConnectionCard
     title="TypeScript Agent to A2A Agent"
     description="Kết nối TypeScript Agent với A2A agent từ xa"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/ts-agent-a2a`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'vi'}/guides/connection/ts-agent-a2a`}
     source="strands"
     sourceBadge="typescript"
     target="a2a"
@@ -544,7 +578,7 @@ Sử dụng generator <Link path="guides/connection">`connection`</Link> để t
   <ConnectionCard
     title="Python Agent to A2A Agent"
     description="Kết nối Python Agent với A2A agent từ xa"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/py-agent-a2a`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'vi'}/guides/connection/py-agent-a2a`}
     source="strands"
     sourceBadge="python"
     target="a2a"
@@ -552,7 +586,7 @@ Sử dụng generator <Link path="guides/connection">`connection`</Link> để t
   <ConnectionCard
     title="TypeScript Agent to Relational Database"
     description="Kết nối TypeScript Agent với cơ sở dữ liệu quan hệ Aurora"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/ts-agent-rdb`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'vi'}/guides/connection/ts-agent-rdb`}
     source="strands"
     sourceBadge="typescript"
     target="aurora"
@@ -560,7 +594,7 @@ Sử dụng generator <Link path="guides/connection">`connection`</Link> để t
   <ConnectionCard
     title="TypeScript Agent to TypeScript DynamoDB"
     description="Kết nối TypeScript Agent với bảng DynamoDB"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/ts-agent-dynamodb`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'vi'}/guides/connection/ts-agent-dynamodb`}
     source="strands"
     sourceBadge="typescript"
     target="dynamodb"
@@ -568,7 +602,7 @@ Sử dụng generator <Link path="guides/connection">`connection`</Link> để t
   <ConnectionCard
     title="TypeScript Agent to AgentCore Gateway"
     description="Kết nối TypeScript Agent với AgentCore Gateway"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/ts-agent-gateway`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'vi'}/guides/connection/ts-agent-gateway`}
     source="strands"
     sourceBadge="typescript"
     target="agentcore"

--- a/docs/src/content/docs/zh/guides/ts-agent.mdx
+++ b/docs/src/content/docs/zh/guides/ts-agent.mdx
@@ -1,6 +1,6 @@
 ---
-title: "TypeScript Strands 代理"
-description: "生成用于构建带工具的 AI 代理的 TypeScript Strands 代理,并部署到 Amazon Bedrock AgentCore Runtime"
+title: TypeScript Agent
+description: 生成用于构建带工具的 AI 代理的 TypeScript Agent,并部署到 Amazon Bedrock AgentCore Runtime
 generator: ts#agent
 ---
 
@@ -16,7 +16,7 @@ import GeneratorParameters from '@components/generator-parameters.astro';
 import PackageManagerExecCommand from '@components/package-manager-exec-command.astro';
 import OptionFilter from '@components/option-filter.astro';
 
-生成一个 TypeScript [Agent](https://strandsagents.com/) 用于构建带有工具的 AI 代理,并可选择将其部署到 [Amazon Bedrock AgentCore Runtime](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/)。默认情况下,该生成器使用基于 WebSocket 的 [tRPC](https://trpc.io/) 来利用 [AgentCore 的双向流支持](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-get-started-websocket.html),实现实时、类型安全的通信。或者,您可以选择 [Agent-to-Agent (A2A)](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-a2a.html) 协议,以实现与其他 A2A 兼容代理的互操作性,或者选择 [AG-UI](https://docs.ag-ui.com/) 协议,通过 [CopilotKit](https://docs.copilotkit.ai/aws-strands) 实现直接的前端集成。
+生成一个 TypeScript [Strands Agent](https://strandsagents.com/) 用于构建带有工具的 AI 代理,并可选择将其部署到 [Amazon Bedrock AgentCore Runtime](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/)。默认情况下,该生成器使用基于 WebSocket 的 [tRPC](https://trpc.io/) 来利用 [AgentCore 的双向流支持](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-get-started-websocket.html),实现实时、类型安全的通信。或者,您可以选择 [Agent-to-Agent (A2A)](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-a2a.html) 协议,以实现与其他 A2A 兼容代理的互操作性,或者选择 [AG-UI](https://docs.ag-ui.com/) 协议,通过 [CopilotKit](https://docs.copilotkit.ai/aws-strands) 实现直接的前端集成。
 
 ## 什么是 Strands?
 
@@ -55,11 +55,12 @@ import OptionFilter from '@components/option-filter.astro';
 <FileTree>
   - your-project/
     - src/
-      - agent/ (如果指定,则为自定义名称)
+      - agent/ (或自定义名称,如果指定)
         - index.ts Bedrock AgentCore Runtime 的入口点(tRPC/WebSocket 服务器)
         - init.ts tRPC 初始化
         - router.ts 带有代理过程的 tRPC 路由器
         - agent.ts 带有示例工具的主代理定义
+        - session.ts 解析用于持久化会话状态的 SessionManager
         - client.ts 用于调用代理的客户端
         - agent-core-trpc-client.ts 用于连接到 AgentCore Runtime 上的代理的客户端工厂
         - Dockerfile 托管代理的入口点(当 `infra` 设置为 `None` 时排除)
@@ -76,9 +77,10 @@ import OptionFilter from '@components/option-filter.astro';
 <FileTree>
   - your-project/
     - src/
-      - agent/ (如果指定,则为自定义名称)
+      - agent/ (或自定义名称,如果指定)
         - index.ts A2A Express 服务器入口点
         - agent.ts 带有示例工具的主代理定义
+        - session.ts 解析用于持久化会话状态的 SessionManager
         - Dockerfile 托管代理的入口点(当 `infra` 设置为 `None` 时排除)
     - package.json 已更新 Strands 和 Express 依赖项
     - project.json 已更新代理服务目标
@@ -93,9 +95,10 @@ import OptionFilter from '@components/option-filter.astro';
 <FileTree>
   - your-project/
     - src/
-      - agent/ (如果指定,则为自定义名称)
+      - agent/ (或自定义名称,如果指定)
         - index.ts AG-UI 服务器入口点(Express + SSE)
         - agent.ts 带有示例工具的主代理定义
+        - session.ts 解析用于持久化会话状态的 SessionManager
         - Dockerfile 托管代理的入口点(当 `infra` 设置为 `None` 时排除)
     - package.json 已更新 Strands 和 AG-UI 依赖项
     - project.json 已更新代理服务目标
@@ -134,8 +137,8 @@ import OptionFilter from '@components/option-filter.astro';
 </Infrastructure>
 </OptionFilter>
 
-<OptionFilter when={{ infra: 'none' }} description="No infrastructure is vended for infra=None">
-如果您为 `infra` 选择了 `None`,则不会生成 CDK 构造或 Terraform 模块 — Agent 只能在本地运行。在此模式下,`auth` 选项会被忽略,因为没有需要进行身份验证的托管端点。
+<OptionFilter when={{ infra: 'none' }} description="No infrastructure is vended for infra=none">
+如果您为 `infra` 选择了 `none`,则不会生成 CDK 构造或 Terraform 模块 — Agent 只能在本地运行。在此模式下,`auth` 选项会被忽略,因为没有需要进行身份验证的托管端点。
 </OptionFilter>
 
 #### 架构
@@ -167,7 +170,7 @@ TypeScript Agent 使用基于 WebSocket 的 [tRPC](https://trpc.io/),利用 [Age
 工具是 AI 代理可以调用以执行操作的函数。您可以在 `agent.ts` 文件中添加新工具:
 
 ```typescript
-import { Agent, tool } from '@agents/sdk';
+import { Agent, tool } from '@strands-agents/sdk';
 import { z } from 'zod';
 
 const letterCounter = tool({
@@ -185,7 +188,7 @@ const letterCounter = tool({
 });
 
 // Add tools to your agent
-export const getAgent = async (sessionId: string) => {
+export const getAgent = async () => {
   return new Agent({
     systemPrompt: 'You are a helpful assistant with access to various tools.',
     tools: [letterCounter],
@@ -203,9 +206,9 @@ Strands 框架自动处理:
 默认情况下,Strands 代理使用 Claude 4 Sonnet,但您可以轻松切换模型提供商:
 
 ```typescript
-import { Agent } from '@agents/sdk';
-import { BedrockModel } from '@agents/sdk/models/bedrock';
-import { OpenAIModel } from '@agents/sdk/models/openai';
+import { Agent } from '@strands-agents/sdk';
+import { BedrockModel } from '@strands-agents/sdk/models/bedrock';
+import { OpenAIModel } from '@strands-agents/sdk/models/openai';
 
 // Use Bedrock
 const bedrockModel = new BedrockModel({
@@ -288,7 +291,7 @@ AG-UI 代理设计为直接由前端使用。使用 <Link path="/guides/connecti
 生成器为每个协议生成一个 `scripts/<your-agent-name>/chat.ts` 文件。您可以在演进代理的输入形状时对其进行自定义。默认情况下它连接到本地代理,或者在设置 `RUNTIME_CONFIG_APP_ID` 时连接到已部署的代理(请参阅下面的[与已部署的代理聊天](#chat-with-your-deployed-agent))。
 
 <OptionFilter when={{ infra: 'agentcore' }} description="Deployed agent chat details">
-#### Chat with your deployed agent
+#### 与已部署的代理聊天
 
 要与部署到 Bedrock AgentCore 的代理聊天,请将 `RUNTIME_CONFIG_APP_ID` 环境变量设置为部署的 AppConfig 应用程序 ID(由已部署堆栈输出为 `RuntimeConfigApplicationId`)。聊天脚本从运行时配置中解析代理的运行时 ARN 并连接到已部署的端点:
 
@@ -347,6 +350,37 @@ bundle 目标使用 `index.ts` 作为在 Bedrock AgentCore Runtime 上托管的 
 您可以在 CloudWatch AWS 控制台中找到追踪,方法是在菜单中选择"GenAI Observability"。请注意,要填充追踪,您需要启用 [Transaction Search](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Transaction-Search.html)。
 
 有关更多详细信息,请参阅 [AgentCore 关于可观测性的文档](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/observability-configure.html)。
+
+### 会话管理
+
+`session` 选项控制您的代理如何在调用之间持久化会话状态(消息历史、工具状态等),使用 Strands SDK 的 [SessionManager](https://strandsagents.com/docs/user-guide/concepts/agents/session-management/):
+
+- **`s3`**(默认): CDK/Terraform 基础设施为会话数据提供专用的 S3 存储桶,使用 SSE-S3 加密并阻止所有公共访问。代理的 IAM 角色被授予对其的读/写/列表/删除访问权限,存储桶名称与代理的 ARN 一起注册在 AppConfig 运行时配置中。
+- **`in-memory`**: 不提供存储桶。会话状态仅在运行进程的生命周期内保存在内存中,不会在重启或缩容后保留。
+
+这在生成的 `session.ts` 中实现,它导出一个 `getSessionManager()` 函数,为当前会话解析 `SessionManager`:
+
+```typescript
+export const getSessionManager = async (): Promise<SessionManager> => {
+  const sessionId = getCurrentSessionId();
+  // local development always uses local file storage...
+  // ...otherwise S3Storage (session: 's3') or InMemoryStorage (session: 'none')
+};
+```
+
+<OptionFilter when={{ protocol: 'ag-ui' }} description="AG-UI session wiring">
+由于 AG-UI 为每个会话线程克隆一个模板代理,`getSessionManager` 在 `index.ts` 中作为 `sessionManagerProvider` 连接到 `StrandsAgent` 配置中,因此为每个线程解析一个新的 `SessionManager`,而不是烘焙到共享的模板代理中。
+</OptionFilter>
+
+<OptionFilter when={{ protocol: ['http', 'a2a'] }} description="HTTP/A2A session wiring">
+由于 `withSessionId` 已经为每个会话缓存一个 `Agent` 实例,`getSessionManager` 在 `agent.ts` 中的 `getAgent` 的 `new Agent({ sessionManager: await getSessionManager() })` 调用中直接调用。
+</OptionFilter>
+
+会话 ID 本身来自 AgentCore Runtime 会话(通过 A2A/AG-UI 的 `x-amzn-bedrock-agentcore-runtime-session-id` 标头传播,或 HTTP/tRPC 的 WebSocket 连接上下文),并绑定到基于 [`AsyncLocalStorage`](https://nodejs.org/api/async_context.html#class-asynclocalstorage) 的上下文,因此 `getCurrentSessionId()` 可以在请求中的任何位置解析它 — 包括通过 <Link path="/guides/connection">`connection` 生成器</Link>连接的任何下游 MCP 或 A2A 客户端,因此整个调用链共享一致的会话。
+
+:::note[本地开发]
+在本地运行时(`LOCAL_DEV=true`,由 `-dev` 目标自动设置),无论配置的 `session` 选项如何,会话数据始终存储在工作区根目录的 `tmp/agents/strands/<agent-name>` 下的磁盘上,以方便使用。
+:::
 </OptionFilter>
 
 ## 调用您的 Agent
@@ -366,7 +400,7 @@ import { AgentClient } from '../packages/<project>/src/agent/client.js';
 
 const client = AgentClient.local({ url: 'http://localhost:8081/ws' });
 
-client.invoke.subscribe({ message: 'what is 1 plus 1?' }, { onData: console.log });
+client.invoke.subscribe({ prompt: 'what is 1 plus 1?' }, { onData: console.log });
 ```
 
 :::tip[快速测试]
@@ -400,7 +434,7 @@ const client = AgentClient.withIamAuth({
   agentRuntimeArn: 'arn:aws:bedrock-agentcore:us-west-2:123456789012:runtime/my-agent',
 });
 
-client.invoke.subscribe({ message: 'what is 1 plus 1?' }, {
+client.invoke.subscribe({ prompt: 'what is 1 plus 1?' }, {
   onData: (message) => console.log(message),
   onError: (error) => console.error(error),
   onComplete: () => console.log('Done'),

--- a/docs/src/content/docs/zh/guides/ts-agent.mdx
+++ b/docs/src/content/docs/zh/guides/ts-agent.mdx
@@ -355,18 +355,10 @@ bundle 目标使用 `index.ts` 作为在 Bedrock AgentCore Runtime 上托管的 
 
 `session` 选项控制您的代理如何在调用之间持久化会话状态(消息历史、工具状态等),使用 Strands SDK 的 [SessionManager](https://strandsagents.com/docs/user-guide/concepts/agents/session-management/):
 
-- **`s3`**(默认): CDK/Terraform 基础设施为会话数据提供专用的 S3 存储桶,使用 SSE-S3 加密并阻止所有公共访问。代理的 IAM 角色被授予对其的读/写/列表/删除访问权限,存储桶名称与代理的 ARN 一起注册在 AppConfig 运行时配置中。
+- **`s3`**(默认): CDK/Terraform 基础设施为会话数据提供专用的 S3 存储桶,使用专用的 KMS 密钥加密并阻止所有公共访问;服务器访问日志通过同一密钥传送到 CloudWatch Logs 日志组。代理的 IAM 角色被授予对存储桶的读/写/列表/删除访问权限以及对密钥的解密/生成数据密钥访问权限,存储桶名称与代理的 ARN 一起注册在 AppConfig 运行时配置中。
 - **`in-memory`**: 不提供存储桶。会话状态仅在运行进程的生命周期内保存在内存中,不会在重启或缩容后保留。
 
-这在生成的 `session.ts` 中实现,它导出一个 `getSessionManager()` 函数,为当前会话解析 `SessionManager`:
-
-```typescript
-export const getSessionManager = async (): Promise<SessionManager> => {
-  const sessionId = getCurrentSessionId();
-  // local development always uses local file storage...
-  // ...otherwise S3Storage (session: 's3') or InMemoryStorage (session: 'none')
-};
-```
+这在生成的 `session.ts` 中实现,它导出一个 `getSessionManager()` 函数,为当前会话解析 `SessionManager`。
 
 <OptionFilter when={{ protocol: 'ag-ui' }} description="AG-UI session wiring">
 由于 AG-UI 为每个会话线程克隆一个模板代理,`getSessionManager` 在 `index.ts` 中作为 `sessionManagerProvider` 连接到 `StrandsAgent` 配置中,因此为每个线程解析一个新的 `SessionManager`,而不是烘焙到共享的模板代理中。

--- a/docs/src/i18n/schema-translations.json
+++ b/docs/src/i18n/schema-translations.json
@@ -341,6 +341,17 @@
       "zh": "是否在生成器运行后优先安装依赖项。设置为 false 可在批量运行多个生成器时延迟安装（如果后续生成器需要计算 Nx 项目图，仍会运行安装）；在最后统一安装一次。",
       "it": "Se preferire l'installazione delle dipendenze dopo l'esecuzione del generatore. Impostare su false per rimandare l'installazione quando si eseguono più generatori in batch (l'installazione viene comunque eseguita se necessaria affinché i generatori successivi possano calcolare il grafo dei progetti Nx); installare una volta alla fine.",
       "vi": "Có nên cài đặt các dependencies sau khi generator chạy hay không. Đặt thành false để trì hoãn việc cài đặt khi chạy nhiều generator liên tiếp (việc cài đặt vẫn sẽ chạy nếu cần thiết để các generator tiếp theo có thể tính toán Nx project graph); cài đặt một lần vào cuối."
+    },
+    "session": {
+      "en": "The storage used to persist session for your Agent. Only 'in-memory' is currently supported for Python agents.",
+      "fr": "Le stockage utilisé pour persister la session de votre Agent. Seul 'in-memory' est actuellement pris en charge pour les agents Python.",
+      "pt": "O armazenamento usado para persistir a sessão do seu Agent. Apenas 'in-memory' é atualmente suportado para agents Python.",
+      "ko": "Agent의 세션을 유지하는 데 사용되는 스토리지입니다. 현재 Python agent에서는 'in-memory'만 지원됩니다.",
+      "es": "El almacenamiento utilizado para persistir la sesión de tu Agent. Solo 'in-memory' está actualmente soportado para agents de Python.",
+      "jp": "Agentのセッションを永続化するために使用されるストレージ。現在、PythonエージェントではOnly 'in-memory'のみがサポートされています。",
+      "it": "L'archiviazione utilizzata per persistere la sessione del tuo Agent. Attualmente solo 'in-memory' è supportato per gli agent Python.",
+      "zh": "用于持久化 Agent 会话的存储。Python agent 目前仅支持 'in-memory'。",
+      "vi": "Bộ nhớ được sử dụng để lưu trữ phiên làm việc cho Agent của bạn. Hiện tại chỉ hỗ trợ 'in-memory' cho các agent Python."
     }
   },
   "py#agent#a2a-connection": {
@@ -1166,6 +1177,17 @@
       "it": "Se preferire l'installazione delle dipendenze dopo l'esecuzione del generatore. Impostare su false per rimandare l'installazione quando si eseguono più generatori in batch (l'installazione viene comunque eseguita se necessaria affinché i generatori successivi possano calcolare il grafo dei progetti Nx); installare una volta alla fine.",
       "zh": "是否在生成器运行后优先安装依赖项。设置为 false 可在批量运行多个生成器时延迟安装（如果后续生成器需要计算 Nx 项目图，仍会运行安装）；在最后统一安装一次。",
       "vi": "Có nên cài đặt dependencies sau khi generator chạy hay không. Đặt thành false để hoãn việc cài đặt khi chạy nhiều generator liên tiếp (việc cài đặt vẫn sẽ chạy nếu cần thiết để các generator tiếp theo có thể tính toán Nx project graph); cài đặt một lần vào cuối."
+    },
+    "session": {
+      "en": "The storage used to persist session for your Agent.",
+      "jp": "エージェントのセッションを永続化するために使用されるストレージ。",
+      "ko": "Agent의 세션을 유지하기 위해 사용되는 스토리지입니다.",
+      "pt": "O armazenamento usado para persistir a sessão do seu Agent.",
+      "es": "El almacenamiento utilizado para persistir la sesión de tu Agent.",
+      "fr": "Le stockage utilisé pour persister la session de votre Agent.",
+      "zh": "用于持久化 Agent 会话的存储。",
+      "it": "Lo storage utilizzato per persistere la sessione del tuo Agent.",
+      "vi": "Bộ nhớ được sử dụng để lưu trữ phiên làm việc cho Agent của bạn."
     }
   },
   "ts#agent#a2a-connection": {

--- a/packages/nx-plugin/migrations.json
+++ b/packages/nx-plugin/migrations.json
@@ -34,6 +34,10 @@
     "latest-dynamodb-local-remove-optimize-flag": {
       "description": "Drop -optimizeDbBeforeStartup from the vended DynamoDB Local container script, which can corrupt shared-local-instance.db",
       "implementation": "./src/migrations/latest/dynamodb-local-remove-optimize-flag/migration"
+    },
+    "latest-ts-agent-session-management-support": {
+      "description": "Add session management support to ts#agent",
+      "implementation": "./src/migrations/latest/ts-agent-session-management-support/migration"
     }
   },
   "packageJsonUpdates": {

--- a/packages/nx-plugin/src/connection/agent-runtime-config.ts
+++ b/packages/nx-plugin/src/connection/agent-runtime-config.ts
@@ -28,6 +28,8 @@ export const addAgentRuntimeToConnectionNamespace = async (
     agentNameKebabCase: string;
     /** The class name of the agent, e.g. 'StoryAgent'. */
     agentNameClassName: string;
+    /** How the agent's session is persisted, e.g. 's3'. */
+    session: string;
   },
 ) => {
   const cdkConstructPath = joinPathFragments(
@@ -47,7 +49,10 @@ export const addAgentRuntimeToConnectionNamespace = async (
 
     rc.set('connection', 'agentRuntimes', {
       ...rc.get('connection').agentRuntimes,
-      ${options.agentNameClassName}: this.agentCoreRuntime.agentRuntimeArn,
+      ${options.agentNameClassName}: {
+        arn: this.agentCoreRuntime.agentRuntimeArn,
+        session: { storage: '${options.session}' },
+      },
     });\` where { $program <: not contains \`rc.set('connection', 'agentRuntimes', $_)\` }`,
     );
   }
@@ -79,7 +84,7 @@ module "${CONNECTION_TF_MODULE_NAME}" {
 
   namespace = "connection"
   key       = "agentRuntimes"
-  value     = { "${options.agentNameClassName}" = module.agent_core_runtime.agent_core_runtime_arn }
+  value     = { "${options.agentNameClassName}" = { arn = module.agent_core_runtime.agent_core_runtime_arn, session = { storage = "${options.session}" } } }
 
   depends_on = [module.agent_core_runtime]
 }

--- a/packages/nx-plugin/src/connection/agent-runtime-config.ts
+++ b/packages/nx-plugin/src/connection/agent-runtime-config.ts
@@ -28,8 +28,6 @@ export const addAgentRuntimeToConnectionNamespace = async (
     agentNameKebabCase: string;
     /** The class name of the agent, e.g. 'StoryAgent'. */
     agentNameClassName: string;
-    /** How the agent's session is persisted, e.g. 's3'. */
-    session: string;
   },
 ) => {
   const cdkConstructPath = joinPathFragments(
@@ -49,10 +47,7 @@ export const addAgentRuntimeToConnectionNamespace = async (
 
     rc.set('connection', 'agentRuntimes', {
       ...rc.get('connection').agentRuntimes,
-      ${options.agentNameClassName}: {
-        arn: this.agentCoreRuntime.agentRuntimeArn,
-        session: { storage: '${options.session}' },
-      },
+      ${options.agentNameClassName}: this.agentCoreRuntime.agentRuntimeArn,
     });\` where { $program <: not contains \`rc.set('connection', 'agentRuntimes', $_)\` }`,
     );
   }
@@ -84,7 +79,7 @@ module "${CONNECTION_TF_MODULE_NAME}" {
 
   namespace = "connection"
   key       = "agentRuntimes"
-  value     = { "${options.agentNameClassName}" = { arn = module.agent_core_runtime.agent_core_runtime_arn, session = { storage = "${options.session}" } } }
+  value     = { "${options.agentNameClassName}" = module.agent_core_runtime.agent_core_runtime_arn }
 
   depends_on = [module.agent_core_runtime]
 }

--- a/packages/nx-plugin/src/migrations/latest/ts-agent-session-management-support/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/latest/ts-agent-session-management-support/migration.spec.ts
@@ -476,6 +476,13 @@ const DIVERGED_MODEL_ERRORS_FILE = OLD_MODEL_ERRORS_FILE.replace(
   'export const logModelErrors = (agent: LocalAgent): void => {\n  agent.addHook(AfterModelCallEvent, (event) => {',
   "export const logModelErrors = (agent: LocalAgent): void => {\n  console.log('custom logging setup');\n  agent.addHook(AfterModelCallEvent, (event) => {",
 );
+// Mirror of DIVERGED_MODEL_ERRORS_FILE, for the reverse all-or-nothing case:
+// tool-errors-strands.ts diverged while model-errors-strands.ts would convert
+// cleanly on its own.
+const DIVERGED_TOOL_ERRORS_FILE = OLD_TOOL_ERRORS_FILE.replace(
+  'export const logToolErrors = (agent: LocalAgent): void => {\n  agent.addHook(AfterToolCallEvent, (event) => {',
+  "export const logToolErrors = (agent: LocalAgent): void => {\n  console.log('custom logging setup');\n  agent.addHook(AfterToolCallEvent, (event) => {",
+);
 
 describe('ts-agent-session-manager-support migration', () => {
   let tree: Tree;
@@ -779,6 +786,16 @@ describe('ts-agent-session-manager-support migration', () => {
       ),
     ).toBe(true);
 
+    // tool-errors-strands.ts's own conversion would succeed in isolation, but
+    // it's left untouched too — all-or-nothing: both convert, or neither does.
+    expect(tree.read(TOOL_ERRORS_FILE, 'utf-8')).toEqual(OLD_TOOL_ERRORS_FILE);
+    // No nextStep reported specifically about tool-errors-strands.ts itself —
+    // it's not diverged, just held back by its sibling, which the model
+    // file's own nextStep already explains (and does reference this path).
+    expect(
+      result.nextSteps.some((s) => s.startsWith(`${TOOL_ERRORS_FILE}:`)),
+    ).toBe(false);
+
     // ModelErrorLoggingPlugin isn't available, so agent.ts is left entirely
     // untouched — its working logModelErrors/logToolErrors calls are not
     // removed even though ToolErrorLoggingPlugin alone would be available.
@@ -790,6 +807,44 @@ describe('ts-agent-session-manager-support migration', () => {
           s.includes(HTTP_AGENT_TS_FILE) && s.includes('are not available yet'),
       ),
     ).toBe(true);
+  });
+
+  it('leaves a diverged tool-errors-strands.ts untouched and, all-or-nothing, leaves model-errors-strands.ts untouched too', async () => {
+    registerAgentProject(
+      tree,
+      'http-project',
+      'apps/http-project',
+      'http',
+      'HttpProjectAgent',
+    );
+    tree.write(MODEL_ERRORS_FILE, OLD_MODEL_ERRORS_FILE);
+    tree.write(TOOL_ERRORS_FILE, DIVERGED_TOOL_ERRORS_FILE);
+    tree.write(HTTP_AGENT_TS_FILE, OLD_AGENT_TS_FILE);
+    tree.write(HTTP_INDEX_TS_FILE, HTTP_INDEX_TS_FILE_CONTENT);
+
+    const result = await migration(tree);
+
+    // tool-errors-strands.ts has diverged, so it's left as-is.
+    expect(tree.read(TOOL_ERRORS_FILE, 'utf-8')).toEqual(
+      DIVERGED_TOOL_ERRORS_FILE,
+    );
+    expect(
+      result.nextSteps.some(
+        (s) =>
+          s.includes(TOOL_ERRORS_FILE) && s.includes('ToolErrorLoggingPlugin'),
+      ),
+    ).toBe(true);
+
+    // model-errors-strands.ts would convert cleanly on its own, but is left
+    // untouched too — all-or-nothing applies here as well.
+    expect(tree.read(MODEL_ERRORS_FILE, 'utf-8')).toEqual(
+      OLD_MODEL_ERRORS_FILE,
+    );
+    expect(
+      result.nextSteps.some((s) => s.startsWith(`${MODEL_ERRORS_FILE}:`)),
+    ).toBe(false);
+
+    expect(tree.read(HTTP_AGENT_TS_FILE, 'utf-8')).toEqual(OLD_AGENT_TS_FILE);
   });
 
   it('leaves a non-AG-UI agent.ts content untouched when its owning project cannot be found', async () => {

--- a/packages/nx-plugin/src/migrations/latest/ts-agent-session-management-support/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/latest/ts-agent-session-management-support/migration.spec.ts
@@ -44,6 +44,8 @@ const TS_A2A_CLIENT_FILE =
   'packages/common/agent-connection/src/app/my-target-agent-client-strands.ts';
 const PY_A2A_CLIENT_FILE =
   'packages/common/agent_connection/app/my_target_agent_client_strands.py';
+const AGENTCORE_CHAT_SCRIPT_FILE =
+  'apps/test-project/scripts/agent/agentcore.ts';
 const REACT_PROVIDER_FILE =
   'packages/website/src/components/MyAgentAgentClientProvider.tsx';
 
@@ -175,6 +177,30 @@ class MyTargetAgentClientStrands:
         if not agent_runtime_arn:
             raise RuntimeError("No connected agent runtime found.")
         return AgentCoreA2aClientStrands.with_iam_auth(agent_runtime_arn)
+`;
+
+// Unlike the a2a/mcp client templates, agentcore.ts (the agent-chat CLI's
+// runtime-config resolver) calls getAppConfig directly and casts the result
+// inline rather than importing the shared AgentCoreRuntimeConfig type, so it
+// needs its own reshape.
+const OLD_AGENTCORE_CHAT_SCRIPT_FILE = `import { getAppConfig } from '@aws-lambda-powertools/parameters/appconfig';
+
+export const resolveRemoteAgent = async () => {
+  const application = process.env.RUNTIME_CONFIG_APP_ID;
+  if (!application) {
+    return undefined;
+  }
+  const config = (await getAppConfig('agentcore', {
+    application,
+    environment: 'default',
+    transform: 'json',
+  })) as { agentRuntimes?: Record<string, string> };
+  const arn = config.agentRuntimes?.['MyAgent'];
+  if (!arn) {
+    throw new Error("No deployed agent named 'MyAgent' found.");
+  }
+  return { arn, region: arn.split(':')[3] };
+};
 `;
 
 const OLD_REACT_PROVIDER_FILE = `import { useRuntimeConfig } from '../hooks/useRuntimeConfig';
@@ -526,6 +552,22 @@ describe('ts-agent-session-manager-support migration', () => {
 
     const content = tree.read(TS_A2A_CLIENT_FILE, 'utf-8');
     expect(content).toContain("config.agentRuntimes?.['MyTargetAgent']?.arn");
+  });
+
+  it('reshapes the agent-chat CLI agentcore.ts inline cast to { arn }', async () => {
+    tree.write(AGENTCORE_CHAT_SCRIPT_FILE, OLD_AGENTCORE_CHAT_SCRIPT_FILE);
+
+    await migration(tree);
+
+    const content = tree.read(AGENTCORE_CHAT_SCRIPT_FILE, 'utf-8');
+    expect(content).toContain(
+      'agentRuntimes?: Record<string, { arn: string }>',
+    );
+    expect(content).not.toContain('agentRuntimes?: Record<string, string>');
+    // The access expression is reshaped by the existing TS_CLIENT_ARN_PATTERNS
+    // rewrite — asserted here too since a type that no longer matches what's
+    // read off it is exactly the bug this migration must not reintroduce.
+    expect(content).toContain("config.agentRuntimes?.['MyAgent']?.arn");
   });
 
   it('appends .get("arn") to Python client agentRuntimes access', async () => {

--- a/packages/nx-plugin/src/migrations/latest/ts-agent-session-management-support/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/latest/ts-agent-session-management-support/migration.spec.ts
@@ -3,8 +3,34 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { addProjectConfiguration, type Tree } from '@nx/devkit';
+import { TS_AGENT_GENERATOR_INFO } from '../../../ts/agent/generator';
 import { createTreeUsingTsSolutionSetup } from '../../../utils/test';
 import migration from './migration';
+
+// Registers a project with the ComponentMetadata the ts#agent generator
+// itself writes, since the migration now reads protocol/name from it rather
+// than guessing from file contents.
+const registerAgentProject = (
+  tree: Tree,
+  name: string,
+  root: string,
+  protocol: string,
+  rc: string,
+  agentDir = 'src/agent',
+) =>
+  addProjectConfiguration(tree, name, {
+    root,
+    metadata: {
+      components: [
+        {
+          generator: TS_AGENT_GENERATOR_INFO.id,
+          path: agentDir,
+          rc,
+          protocol,
+        },
+      ],
+    } as any,
+  });
 
 const CDK_AGENT_FILE =
   'packages/common/constructs/src/app/agents/my-agent/my-agent.ts';
@@ -190,6 +216,25 @@ export const getAgent = async () => {
 };
 `;
 
+// Regression fixture: the Agent is constructed from a variable rather than an
+// inline object literal, so the constructor rewrites can't apply.
+const NON_LITERAL_CONSTRUCTOR_OLD_AGENT_TS_FILE = `import { Agent, tool } from '@strands-agents/sdk';
+import { logModelErrors, logToolErrors } from '@proj/agent-connection';
+import { z } from 'zod';
+
+const agentProps = {
+  systemPrompt: 'You are a mathematical wizard.',
+  tools: [],
+};
+
+export const getAgent = async () => {
+  const agent = new Agent(agentProps);
+  logModelErrors(agent);
+  logToolErrors(agent);
+  return agent;
+};
+`;
+
 // Regression fixture: a long npm scope name pushes the import past prettier's
 // print width, so it wraps onto multiple lines. The migration must detect
 // this via GritQL (AST-based) rather than a literal `logModelErrors, logToolErrors`
@@ -276,6 +321,25 @@ void (async () => {
     agent,
     name: 'TestProjectAgent',
     description: 'A Strands Agent exposed via the AG-UI protocol.',
+  });
+})();
+`;
+
+// Regression fixture: a customised StrandsAgent constructor (an extra prop)
+// no longer matches the exact 3-prop shape the plugin rewrite targets.
+const CUSTOMISED_AGUI_INDEX_TS_FILE_CONTENT = `import { StrandsAgent } from '@ag-ui/aws-strands';
+import { runWithSessionId } from '@proj/agent-connection';
+import { getAgent } from './agent.js';
+
+void (async () => {
+  const agent = await getAgent();
+  await agent.initialize();
+
+  const aguiAgent = new StrandsAgent({
+    agent,
+    name: 'TestProjectAgent',
+    description: 'A Strands Agent exposed via the AG-UI protocol.',
+    tags: ['custom'],
   });
 })();
 `;
@@ -380,6 +444,12 @@ export const logToolErrors = (agent: LocalAgent): void => {
   });
 };
 `;
+// Regression fixture: an extra statement in the hook body no longer matches
+// the exact single-statement shape MODEL_ERRORS_CLASS_PATTERN targets.
+const DIVERGED_MODEL_ERRORS_FILE = OLD_MODEL_ERRORS_FILE.replace(
+  'export const logModelErrors = (agent: LocalAgent): void => {\n  agent.addHook(AfterModelCallEvent, (event) => {',
+  "export const logModelErrors = (agent: LocalAgent): void => {\n  console.log('custom logging setup');\n  agent.addHook(AfterModelCallEvent, (event) => {",
+);
 
 describe('ts-agent-session-manager-support migration', () => {
   let tree: Tree;
@@ -396,7 +466,7 @@ describe('ts-agent-session-manager-support migration', () => {
   it('reshapes the CDK agent construct agentcore namespace only, leaving connection as a bare string', async () => {
     tree.write(CDK_AGENT_FILE, OLD_CDK_AGENT_FILE);
 
-    const result = await migration(tree);
+    await migration(tree);
 
     const content = tree.read(CDK_AGENT_FILE, 'utf-8') ?? '';
     // Existing agents predate session management support and have no S3
@@ -410,7 +480,6 @@ describe('ts-agent-session-manager-support migration', () => {
     expect(
       content.match(/MyAgent: this\.agentCoreRuntime\.agentRuntimeArn,/g),
     ).toHaveLength(1);
-    expect(result.nextSteps.some((s) => s.includes(CDK_AGENT_FILE))).toBe(true);
   });
 
   it('does not add a session field for MCP server runtimes', async () => {
@@ -483,17 +552,50 @@ describe('ts-agent-session-manager-support migration', () => {
   });
 
   it('removes the model/tool error logging hooks from an AG-UI agent.ts', async () => {
+    registerAgentProject(
+      tree,
+      'test-project',
+      'apps/test-project',
+      'ag-ui',
+      'TestProjectAgent',
+    );
     tree.write(AGUI_AGENT_TS_FILE, OLD_AGENT_TS_FILE);
     tree.write(AGUI_INDEX_TS_FILE, AGUI_INDEX_TS_FILE_CONTENT);
 
-    const result = await migration(tree);
+    await migration(tree);
 
     const content = tree.read(AGUI_AGENT_TS_FILE, 'utf-8') ?? '';
     expect(content).not.toContain('logModelErrors');
     expect(content).not.toContain('logToolErrors');
-    expect(result.nextSteps.some((s) => s.includes(AGUI_AGENT_TS_FILE))).toBe(
-      true,
+  });
+
+  it('leaves an AG-UI agent.ts entirely untouched (all-or-nothing) when the sibling index.ts constructor has diverged', async () => {
+    registerAgentProject(
+      tree,
+      'test-project',
+      'apps/test-project',
+      'ag-ui',
+      'TestProjectAgent',
     );
+    tree.write(AGUI_AGENT_TS_FILE, OLD_AGENT_TS_FILE);
+    tree.write(AGUI_INDEX_TS_FILE, CUSTOMISED_AGUI_INDEX_TS_FILE_CONTENT);
+
+    const result = await migration(tree);
+
+    // index.ts can't be wired with the equivalent plugins (it no longer
+    // matches the 3-prop shape the rewrite targets), so agent.ts's calls are
+    // left in place rather than being dropped with no replacement.
+    expect(tree.read(AGUI_AGENT_TS_FILE, 'utf-8')).toEqual(OLD_AGENT_TS_FILE);
+    expect(tree.read(AGUI_INDEX_TS_FILE, 'utf-8')).toEqual(
+      CUSTOMISED_AGUI_INDEX_TS_FILE_CONTENT,
+    );
+    expect(
+      result.nextSteps.some(
+        (s) =>
+          s.includes(AGUI_AGENT_TS_FILE) &&
+          s.includes('could not be automatically wired'),
+      ),
+    ).toBe(true);
   });
 
   it('wires the error-logging plugins into an AG-UI index.ts', async () => {
@@ -515,13 +617,17 @@ describe('ts-agent-session-manager-support migration', () => {
   });
 
   it('wires sessionManagerProvider into an AG-UI index.ts and creates session.ts when its project is registered', async () => {
-    addProjectConfiguration(tree, 'test-project', {
-      root: 'apps/test-project',
-    });
+    registerAgentProject(
+      tree,
+      'test-project',
+      'apps/test-project',
+      'ag-ui',
+      'TestProjectAgent',
+    );
     tree.write(AGUI_AGENT_TS_FILE, OLD_AGENT_TS_FILE);
     tree.write(AGUI_INDEX_TS_FILE, AGUI_INDEX_TS_FILE_CONTENT);
 
-    const result = await migration(tree);
+    await migration(tree);
 
     const content = tree.read(AGUI_INDEX_TS_FILE, 'utf-8') ?? '';
     expect(content).toContain(
@@ -537,13 +643,6 @@ describe('ts-agent-session-manager-support migration', () => {
       "import { getCurrentSessionId } from '@proj/agent-connection';",
     );
     expect(sessionManagerContent).toContain('new LocalFileStorage(');
-    expect(
-      result.nextSteps.some(
-        (s) =>
-          s.includes(AGUI_INDEX_TS_FILE) &&
-          s.includes('wired sessionManagerProvider'),
-      ),
-    ).toBe(true);
   });
 
   it('leaves an AG-UI index.ts sessionManagerProvider wiring for manual follow-up when its project cannot be found', async () => {
@@ -587,7 +686,7 @@ describe('ts-agent-session-manager-support migration', () => {
   it('adds the ModelErrorLoggingPlugin class to model-errors-strands.ts', async () => {
     tree.write(MODEL_ERRORS_FILE, OLD_MODEL_ERRORS_FILE);
 
-    const result = await migration(tree);
+    await migration(tree);
 
     const content = tree.read(MODEL_ERRORS_FILE, 'utf-8') ?? '';
     expect(content).toContain('type Plugin');
@@ -595,15 +694,12 @@ describe('ts-agent-session-manager-support migration', () => {
       'export class ModelErrorLoggingPlugin implements Plugin',
     );
     expect(content).not.toContain('logModelErrors');
-    expect(result.nextSteps.some((s) => s.includes(MODEL_ERRORS_FILE))).toBe(
-      true,
-    );
   });
 
   it('adds the ToolErrorLoggingPlugin class to tool-errors-strands.ts', async () => {
     tree.write(TOOL_ERRORS_FILE, OLD_TOOL_ERRORS_FILE);
 
-    const result = await migration(tree);
+    await migration(tree);
 
     const content = tree.read(TOOL_ERRORS_FILE, 'utf-8') ?? '';
     expect(content).toContain('type Plugin');
@@ -611,9 +707,47 @@ describe('ts-agent-session-manager-support migration', () => {
       'export class ToolErrorLoggingPlugin implements Plugin',
     );
     expect(content).not.toContain('logToolErrors');
-    expect(result.nextSteps.some((s) => s.includes(TOOL_ERRORS_FILE))).toBe(
-      true,
+  });
+
+  it('leaves a diverged model-errors-strands.ts untouched and, all-or-nothing, leaves agent.ts files referencing it untouched too', async () => {
+    registerAgentProject(
+      tree,
+      'http-project',
+      'apps/http-project',
+      'http',
+      'HttpProjectAgent',
     );
+    tree.write(MODEL_ERRORS_FILE, DIVERGED_MODEL_ERRORS_FILE);
+    tree.write(TOOL_ERRORS_FILE, OLD_TOOL_ERRORS_FILE);
+    tree.write(HTTP_AGENT_TS_FILE, OLD_AGENT_TS_FILE);
+    tree.write(HTTP_INDEX_TS_FILE, HTTP_INDEX_TS_FILE_CONTENT);
+
+    const result = await migration(tree);
+
+    // model-errors-strands.ts has diverged from the generated shape, so it's
+    // left as-is rather than partially rewritten.
+    expect(tree.read(MODEL_ERRORS_FILE, 'utf-8')).toEqual(
+      DIVERGED_MODEL_ERRORS_FILE,
+    );
+    expect(
+      result.nextSteps.some(
+        (s) =>
+          s.includes(MODEL_ERRORS_FILE) &&
+          s.includes('ModelErrorLoggingPlugin'),
+      ),
+    ).toBe(true);
+
+    // ModelErrorLoggingPlugin isn't available, so agent.ts is left entirely
+    // untouched — its working logModelErrors/logToolErrors calls are not
+    // removed even though ToolErrorLoggingPlugin alone would be available.
+    expect(tree.read(HTTP_AGENT_TS_FILE, 'utf-8')).toEqual(OLD_AGENT_TS_FILE);
+    expect(tree.exists('apps/http-project/src/agent/session.ts')).toBe(false);
+    expect(
+      result.nextSteps.some(
+        (s) =>
+          s.includes(HTTP_AGENT_TS_FILE) && s.includes('are not available yet'),
+      ),
+    ).toBe(true);
   });
 
   it('leaves a non-AG-UI agent.ts content untouched when its owning project cannot be found', async () => {
@@ -643,14 +777,48 @@ describe('ts-agent-session-manager-support migration', () => {
     ).toBe(true);
   });
 
-  it('wires sessionManager and the error-logging plugins into a non-AG-UI agent.ts and creates session.ts when its project is registered', async () => {
-    addProjectConfiguration(tree, 'http-project', {
-      root: 'apps/http-project',
-    });
-    tree.write(HTTP_AGENT_TS_FILE, OLD_AGENT_TS_FILE);
+  it('leaves a non-AG-UI agent.ts entirely untouched (all-or-nothing) when the Agent is not constructed with an inline object literal', async () => {
+    registerAgentProject(
+      tree,
+      'http-project',
+      'apps/http-project',
+      'http',
+      'HttpProjectAgent',
+    );
+    tree.write(HTTP_AGENT_TS_FILE, NON_LITERAL_CONSTRUCTOR_OLD_AGENT_TS_FILE);
     tree.write(HTTP_INDEX_TS_FILE, HTTP_INDEX_TS_FILE_CONTENT);
 
     const result = await migration(tree);
+
+    // Neither the imports nor the logModelErrors/logToolErrors calls are
+    // touched — wiring sessionManager/plugins into the constructor isn't
+    // possible, so removing the working calls would silently drop error
+    // logging rather than move it.
+    expect(tree.read(HTTP_AGENT_TS_FILE, 'utf-8')).toEqual(
+      NON_LITERAL_CONSTRUCTOR_OLD_AGENT_TS_FILE,
+    );
+    expect(tree.exists('apps/http-project/src/agent/session.ts')).toBe(false);
+    expect(
+      result.nextSteps.some(
+        (s) =>
+          s.includes(HTTP_AGENT_TS_FILE) &&
+          s.includes('not constructed with an inline object literal'),
+      ),
+    ).toBe(true);
+  });
+
+  it('wires sessionManager and the error-logging plugins into a non-AG-UI agent.ts and creates session.ts when its project is registered', async () => {
+    registerAgentProject(
+      tree,
+      'http-project',
+      'apps/http-project',
+      'http',
+      'HttpProjectAgent',
+    );
+    tree.write(HTTP_AGENT_TS_FILE, OLD_AGENT_TS_FILE);
+    tree.write(HTTP_INDEX_TS_FILE, HTTP_INDEX_TS_FILE_CONTENT);
+
+    await migration(tree);
 
     const content = tree.read(HTTP_AGENT_TS_FILE, 'utf-8') ?? '';
     expect(content).toContain(
@@ -675,25 +843,43 @@ describe('ts-agent-session-manager-support migration', () => {
     expect(sessionManagerContent).toContain(
       "'../../tmp/agents/strands/http-project-agent'",
     );
-    expect(
-      result.nextSteps.some(
-        (s) =>
-          s.includes(HTTP_AGENT_TS_FILE) &&
-          s.includes(
-            'wired sessionManager and the error-logging plugins into the Agent constructor',
-          ),
-      ),
-    ).toBe(true);
+  });
+
+  it('prefers the ComponentMetadata name over the directory-name formula, disambiguating an explicit `--name agent` from the default', async () => {
+    // Both the generator's own "no name given" default and an explicit
+    // `--name agent` land in a `src/agent` directory, but produce different
+    // real names (`http-project-agent` vs plain `agent`) — only the recorded
+    // `rc` class name (from an explicit --name agent) can tell them apart.
+    registerAgentProject(
+      tree,
+      'http-project',
+      'apps/http-project',
+      'http',
+      'Agent',
+    );
+    tree.write(HTTP_AGENT_TS_FILE, OLD_AGENT_TS_FILE);
+    tree.write(HTTP_INDEX_TS_FILE, HTTP_INDEX_TS_FILE_CONTENT);
+
+    await migration(tree);
+
+    const sessionPath = 'apps/http-project/src/agent/session.ts';
+    const sessionManagerContent = tree.read(sessionPath, 'utf-8') ?? '';
+    expect(sessionManagerContent).toContain("'../../tmp/agents/strands/agent'");
+    expect(sessionManagerContent).not.toContain('http-project-agent');
   });
 
   it('wires sessionManager into a non-AG-UI agent.ts even when the logModelErrors/logToolErrors import wraps across multiple lines', async () => {
-    addProjectConfiguration(tree, 'http-project', {
-      root: 'apps/http-project',
-    });
+    registerAgentProject(
+      tree,
+      'http-project',
+      'apps/http-project',
+      'http',
+      'HttpProjectAgent',
+    );
     tree.write(HTTP_AGENT_TS_FILE, MULTI_LINE_IMPORT_OLD_AGENT_TS_FILE);
     tree.write(HTTP_INDEX_TS_FILE, HTTP_INDEX_TS_FILE_CONTENT);
 
-    const result = await migration(tree);
+    await migration(tree);
 
     const content = tree.read(HTTP_AGENT_TS_FILE, 'utf-8') ?? '';
     expect(content).toContain(
@@ -706,25 +892,20 @@ describe('ts-agent-session-manager-support migration', () => {
     expect(content).not.toContain('logModelErrors');
     expect(content).not.toContain('logToolErrors');
     expect(tree.exists('apps/http-project/src/agent/session.ts')).toBe(true);
-    expect(
-      result.nextSteps.some(
-        (s) =>
-          s.includes(HTTP_AGENT_TS_FILE) &&
-          s.includes(
-            'wired sessionManager and the error-logging plugins into the Agent constructor',
-          ),
-      ),
-    ).toBe(true);
   });
 
   it('wires sessionManager into a non-AG-UI agent.ts when a connection generator merged its own import into the logModelErrors/logToolErrors import', async () => {
-    addProjectConfiguration(tree, 'http-project', {
-      root: 'apps/http-project',
-    });
+    registerAgentProject(
+      tree,
+      'http-project',
+      'apps/http-project',
+      'http',
+      'HttpProjectAgent',
+    );
     tree.write(HTTP_AGENT_TS_FILE, MERGED_IMPORT_OLD_AGENT_TS_FILE);
     tree.write(HTTP_INDEX_TS_FILE, HTTP_INDEX_TS_FILE_CONTENT);
 
-    const result = await migration(tree);
+    await migration(tree);
 
     const content = tree.read(HTTP_AGENT_TS_FILE, 'utf-8') ?? '';
     expect(content).toContain(
@@ -739,22 +920,20 @@ describe('ts-agent-session-manager-support migration', () => {
     // The merged client import must survive intact
     expect(content).toContain('AgentsMcpServerClientStrands');
     expect(tree.exists('apps/http-project/src/agent/session.ts')).toBe(true);
-    expect(
-      result.nextSteps.some(
-        (s) =>
-          s.includes(HTTP_AGENT_TS_FILE) &&
-          s.includes(
-            'wired sessionManager and the error-logging plugins into the Agent constructor',
-          ),
-      ),
-    ).toBe(true);
   });
 
   it('removes the model/tool error logging hooks from an AG-UI agent.ts even when a connection generator merged its own import into the same statement', async () => {
+    registerAgentProject(
+      tree,
+      'test-project',
+      'apps/test-project',
+      'ag-ui',
+      'TestProjectAgent',
+    );
     tree.write(AGUI_AGENT_TS_FILE, MERGED_IMPORT_OLD_AGENT_TS_FILE);
     tree.write(AGUI_INDEX_TS_FILE, AGUI_INDEX_TS_FILE_CONTENT);
 
-    const result = await migration(tree);
+    await migration(tree);
 
     const content = tree.read(AGUI_AGENT_TS_FILE, 'utf-8') ?? '';
     expect(content).not.toContain('logModelErrors');
@@ -764,16 +943,20 @@ describe('ts-agent-session-manager-support migration', () => {
     expect(content).toContain(
       "import { AgentsMcpServerClientStrands } from '@my-agent-project/agent-connection';",
     );
-    expect(result.nextSteps.some((s) => s.includes(AGUI_AGENT_TS_FILE))).toBe(
-      true,
-    );
   });
 
   it('removes the model/tool error logging hooks from an AG-UI agent.ts even when TWO connection generators merged their imports into the same statement', async () => {
+    registerAgentProject(
+      tree,
+      'test-project',
+      'apps/test-project',
+      'ag-ui',
+      'TestProjectAgent',
+    );
     tree.write(AGUI_AGENT_TS_FILE, DOUBLY_MERGED_IMPORT_OLD_AGENT_TS_FILE);
     tree.write(AGUI_INDEX_TS_FILE, AGUI_INDEX_TS_FILE_CONTENT);
 
-    const result = await migration(tree);
+    await migration(tree);
 
     const content = tree.read(AGUI_AGENT_TS_FILE, 'utf-8') ?? '';
     expect(content).not.toContain('logModelErrors');
@@ -787,9 +970,6 @@ describe('ts-agent-session-manager-support migration', () => {
     );
     expect(content).toContain(
       'const a2aAgent = await A2aAgentClientStrands.create();',
-    );
-    expect(result.nextSteps.some((s) => s.includes(AGUI_AGENT_TS_FILE))).toBe(
-      true,
     );
   });
 
@@ -811,12 +991,20 @@ describe('ts-agent-session-manager-support migration', () => {
   });
 
   it('is idempotent', async () => {
-    addProjectConfiguration(tree, 'http-project', {
-      root: 'apps/http-project',
-    });
-    addProjectConfiguration(tree, 'test-project', {
-      root: 'apps/test-project',
-    });
+    registerAgentProject(
+      tree,
+      'http-project',
+      'apps/http-project',
+      'http',
+      'HttpProjectAgent',
+    );
+    registerAgentProject(
+      tree,
+      'test-project',
+      'apps/test-project',
+      'ag-ui',
+      'TestProjectAgent',
+    );
     tree.write(CDK_AGENT_FILE, OLD_CDK_AGENT_FILE);
     tree.write(TF_AGENT_FILE, OLD_TF_AGENT_FILE);
     tree.write(TS_RUNTIME_CONFIG_FILE, OLD_TS_RUNTIME_CONFIG_FILE);

--- a/packages/nx-plugin/src/migrations/latest/ts-agent-session-management-support/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/latest/ts-agent-session-management-support/migration.spec.ts
@@ -1,0 +1,829 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { addProjectConfiguration, type Tree } from '@nx/devkit';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test';
+import migration from './migration';
+
+const CDK_AGENT_FILE =
+  'packages/common/constructs/src/app/agents/my-agent/my-agent.ts';
+const CDK_MCP_SERVER_FILE =
+  'packages/common/constructs/src/app/mcp-servers/my-mcp/my-mcp.ts';
+const TF_AGENT_FILE =
+  'packages/common/terraform/src/app/agents/my-agent/my-agent.tf';
+const TS_RUNTIME_CONFIG_FILE =
+  'packages/common/agent-connection/src/core/runtime-config.ts';
+const TS_A2A_CLIENT_FILE =
+  'packages/common/agent-connection/src/app/my-target-agent-client-strands.ts';
+const PY_A2A_CLIENT_FILE =
+  'packages/common/agent_connection/app/my_target_agent_client_strands.py';
+const REACT_PROVIDER_FILE =
+  'packages/website/src/components/MyAgentAgentClientProvider.tsx';
+
+const OLD_CDK_AGENT_FILE = `import { Construct } from 'constructs';
+import { RuntimeConfig } from '../../../core/runtime-config.js';
+
+export class MyAgent extends Construct {
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+
+    const rc = RuntimeConfig.ensure(this);
+
+    rc.grantReadAppConfig(this.agentCoreRuntime);
+
+    rc.set('agentcore', 'agentRuntimes', {
+      ...rc.get('agentcore').agentRuntimes,
+      MyAgent: this.agentCoreRuntime.agentRuntimeArn,
+    });
+
+    rc.set('connection', 'agentRuntimes', {
+      ...rc.get('connection').agentRuntimes,
+      MyAgent: this.agentCoreRuntime.agentRuntimeArn,
+    });
+  }
+}
+`;
+
+const OLD_CDK_MCP_SERVER_FILE = `import { Construct } from 'constructs';
+import { RuntimeConfig } from '../../../core/runtime-config.js';
+
+export class MyMcp extends Construct {
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+
+    const rc = RuntimeConfig.ensure(this);
+
+    rc.grantReadAppConfig(this.agentCoreRuntime);
+
+    rc.set('agentcore', 'agentRuntimes', {
+      ...rc.get('agentcore').agentRuntimes,
+      MyMcp: this.agentCoreRuntime.agentRuntimeArn,
+    });
+  }
+}
+`;
+
+const OLD_TF_AGENT_FILE = `module "agent_core_runtime" {
+  source = "../../../core/agent-core"
+  agent_runtime_name = "MyAgent"
+}
+
+# Add agent runtime ARN to runtime config
+module "add_agent_runtime_to_runtime_config" {
+  source = "../../../core/runtime-config/entry"
+
+  namespace = "agentcore"
+  key       = "agentRuntimes"
+  value     = { "MyAgent" = module.agent_core_runtime.agent_core_runtime_arn }
+
+  depends_on = [module.agent_core_runtime]
+}
+
+# Also expose the agent runtime ARN to the frontend via the 'connection' namespace
+module "add_agent_runtime_to_connection_runtime_config" {
+  source = "../../../core/runtime-config/entry"
+
+  namespace = "connection"
+  key       = "agentRuntimes"
+  value     = { "MyAgent" = module.agent_core_runtime.agent_core_runtime_arn }
+
+  depends_on = [module.agent_core_runtime]
+}
+`;
+
+const OLD_TS_RUNTIME_CONFIG_FILE = `import { getAppConfig } from '@aws-lambda-powertools/parameters/appconfig';
+
+/**
+ * Shape of this project's runtime configuration in AppConfig. Keys are the
+ * class names of connected target constructs (e.g. \`MyAgent\`, \`MyGateway\`).
+ */
+export interface AgentCoreRuntimeConfig {
+  agentRuntimes?: Record<string, string>;
+  gateways?: Record<string, string>;
+}
+
+export const getAgentCoreRuntimeConfig =
+  async (): Promise<AgentCoreRuntimeConfig> => {
+    const application = process.env.RUNTIME_CONFIG_APP_ID;
+    return (await getAppConfig('agentcore', {
+      application,
+      environment: 'default',
+      transform: 'json',
+    })) as AgentCoreRuntimeConfig;
+  };
+`;
+
+const OLD_TS_A2A_CLIENT_FILE = `import { A2AAgent } from '@strands-agents/sdk/a2a';
+import { getAgentCoreRuntimeConfig } from '../core/runtime-config.js';
+
+export class MyTargetAgentClientStrands {
+  static async create(): Promise<A2AAgent> {
+    const config = await getAgentCoreRuntimeConfig();
+    const agentRuntimeArn =
+      config.agentRuntimes?.['MyTargetAgent'];
+    if (!agentRuntimeArn) {
+      throw new Error('No connected agent runtime found.');
+    }
+    return AgentCoreA2aClientStrands.withIamAuth({ agentRuntimeArn });
+  }
+}
+`;
+
+const OLD_PY_A2A_CLIENT_FILE = `import os
+
+from strands.agent.a2a_agent import A2AAgent
+
+from packages.common.agent_connection.core.runtime_config import (
+    get_agentcore_runtime_config,
+)
+
+
+class MyTargetAgentClientStrands:
+    @staticmethod
+    def create() -> A2AAgent:
+        config = get_agentcore_runtime_config()
+        agent_runtime_arn = config.get("agentRuntimes", {}).get(
+            "MyTargetAgent"
+        )
+        if not agent_runtime_arn:
+            raise RuntimeError("No connected agent runtime found.")
+        return AgentCoreA2aClientStrands.with_iam_auth(agent_runtime_arn)
+`;
+
+const OLD_REACT_PROVIDER_FILE = `import { useRuntimeConfig } from '../hooks/useRuntimeConfig';
+
+function buildAgentCoreWsUrl(agentRuntimeArn: string): string {
+  const region = agentRuntimeArn.split(':')[3];
+  return \`wss://bedrock-agentcore.\${region}.amazonaws.com/runtimes/\${encodeURIComponent(agentRuntimeArn)}/ws\`;
+}
+
+export const MyAgentAgentClientProvider = () => {
+  const runtimeConfig = useRuntimeConfig();
+  const agentRuntimeValue = runtimeConfig.agentRuntimes.MyAgent;
+
+  const wsUrl = agentRuntimeValue.startsWith('arn:')
+    ? buildAgentCoreWsUrl(agentRuntimeValue)
+    : agentRuntimeValue;
+
+  return wsUrl;
+};
+`;
+
+const AGUI_AGENT_TS_FILE = 'apps/test-project/src/agent/agent.ts';
+const AGUI_INDEX_TS_FILE = 'apps/test-project/src/agent/index.ts';
+const HTTP_AGENT_TS_FILE = 'apps/http-project/src/agent/agent.ts';
+const HTTP_INDEX_TS_FILE = 'apps/http-project/src/agent/index.ts';
+
+const OLD_AGENT_TS_FILE = `import { Agent, tool } from '@strands-agents/sdk';
+import { logModelErrors, logToolErrors } from '@proj/agent-connection';
+import { z } from 'zod';
+
+export const getAgent = async () => {
+  const agent = new Agent({
+    systemPrompt: 'You are a mathematical wizard.',
+    tools: [],
+  });
+  logModelErrors(agent);
+  logToolErrors(agent);
+  return agent;
+};
+`;
+
+// Regression fixture: a long npm scope name pushes the import past prettier's
+// print width, so it wraps onto multiple lines. The migration must detect
+// this via GritQL (AST-based) rather than a literal `logModelErrors, logToolErrors`
+// substring check, which this exact shape used to defeat silently.
+const MULTI_LINE_IMPORT_OLD_AGENT_TS_FILE = `import { Agent, tool } from '@strands-agents/sdk';
+import {
+  logModelErrors,
+  logToolErrors,
+} from '@my-really-long-npm-scope-name/agent-connection';
+import { z } from 'zod';
+
+export const getAgent = async () => {
+  const agent = new Agent({
+    systemPrompt: 'You are a mathematical wizard.',
+    tools: [],
+  });
+  logModelErrors(agent);
+  logToolErrors(agent);
+  return agent;
+};
+`;
+
+// Regression fixture: a connection generator (mcp-connection/a2a-connection)
+// merges its own client import into this same import statement via
+// addDestructuredImport (which only ever appends), so logModelErrors/
+// logToolErrors aren't always the only two specifiers.
+const MERGED_IMPORT_OLD_AGENT_TS_FILE = `import { Agent, tool } from '@strands-agents/sdk';
+import {
+  logModelErrors,
+  logToolErrors,
+  AgentsMcpServerClientStrands,
+} from '@my-agent-project/agent-connection';
+import { z } from 'zod';
+
+export const getAgent = async () => {
+  const agentsMcpServer = await AgentsMcpServerClientStrands.create();
+  const agent = new Agent({
+    systemPrompt: 'You are a mathematical wizard.',
+    tools: [agentsMcpServer],
+  });
+  logModelErrors(agent);
+  logToolErrors(agent);
+  return agent;
+};
+`;
+
+const AGUI_INDEX_TS_FILE_CONTENT = `import { StrandsAgent } from '@ag-ui/aws-strands';
+import { runWithSessionId } from '@proj/agent-connection';
+import { getAgent } from './agent.js';
+
+void (async () => {
+  const agent = await getAgent();
+  await agent.initialize();
+
+  const aguiAgent = new StrandsAgent({
+    agent,
+    name: 'TestProjectAgent',
+    description: 'A Strands Agent exposed via the AG-UI protocol.',
+  });
+})();
+`;
+
+const HTTP_INDEX_TS_FILE_CONTENT = `import { createServer } from 'http';
+import { getAgent } from './agent.js';
+
+createServer();
+`;
+
+const S3_SESSION_FILE = 'apps/test-project/src/agent/session.ts';
+
+const S3_SESSION_FILE_CONTENT = `import { SessionManager } from '@strands-agents/sdk';
+import { LocalFileStorage, S3Storage } from '@strands-agents/sdk/storage';
+import {
+  getCurrentSessionId,
+  getAgentCoreRuntimeConfig,
+} from '@proj/agent-connection';
+
+export const getSessionManager = async (): Promise<
+  SessionManager | undefined
+> => {
+  const sessionId = getCurrentSessionId();
+  if (!sessionId) {
+    throw new Error('No current session id.');
+  }
+  if (process.env.LOCAL_DEV === 'true') {
+    return new SessionManager({
+      sessionId,
+      storage: new LocalFileStorage('../../tmp/agentCore/agentRuntimes/sessions'),
+    });
+  }
+  const config = await getAgentCoreRuntimeConfig();
+  const bucketName = config.agentRuntimes?.['TestAgent']?.session?.bucketName;
+  if (!bucketName) {
+    throw new Error("No S3 bucket configured for this agent's session.");
+  }
+  return new SessionManager({ sessionId, storage: new S3Storage(bucketName) });
+};
+`;
+
+const MODEL_ERRORS_FILE =
+  'packages/common/agent-connection/src/core/model-errors-strands.ts';
+const TOOL_ERRORS_FILE =
+  'packages/common/agent-connection/src/core/tool-errors-strands.ts';
+
+const OLD_MODEL_ERRORS_FILE = `import { AfterModelCallEvent, type LocalAgent } from '@strands-agents/sdk';
+
+const NO_CREDENTIALS =
+  'Unable to invoke the model: no AWS credentials found. Configure credentials ' +
+  '(e.g. run \`aws configure\`, set AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY / ' +
+  'AWS_SESSION_TOKEN, or assume a role) before running the agent.';
+const ACCESS_DENIED =
+  'Unable to invoke the model: access denied. Grant your AWS principal permission ' +
+  'to call bedrock:InvokeModelWithResponseStream for your model.';
+
+const hasErrorNamed = (error: unknown, name: string): boolean => {
+  let current: unknown = error;
+  while (current instanceof Error) {
+    if (current.name === name) return true;
+    current = current.cause;
+  }
+  return false;
+};
+
+/** Logs model invocation errors, calling out missing credentials or denied permissions. */
+export const logModelErrors = (agent: LocalAgent): void => {
+  agent.addHook(AfterModelCallEvent, (event) => {
+    const error = event.error;
+    if (!error) return;
+    if (hasErrorNamed(error, 'CredentialsProviderError')) {
+      console.error(NO_CREDENTIALS);
+    } else if (hasErrorNamed(error, 'AccessDeniedException')) {
+      console.error(ACCESS_DENIED);
+    } else {
+      console.error(\`Model invocation failed: \${error.message}\`);
+    }
+  });
+};
+`;
+
+const OLD_TOOL_ERRORS_FILE = `import {
+  AfterToolCallEvent,
+  type LocalAgent,
+  TextBlock,
+} from '@strands-agents/sdk';
+
+/** Logs tool execution errors, including the tool name and underlying error or message when available. */
+export const logToolErrors = (agent: LocalAgent): void => {
+  agent.addHook(AfterToolCallEvent, (event) => {
+    if (event.result.status !== 'error') return;
+    const error = event.result.error ?? event.error;
+    const message =
+      error?.message ??
+      event.result.content
+        .filter((block): block is TextBlock => block instanceof TextBlock)
+        .map((block) => block.text)
+        .join(' ');
+    console.error(
+      \`Tool '\${event.toolUse.name}' failed\${message ? \`: \${message}\` : ''}\`,
+    );
+  });
+};
+`;
+
+describe('ts-agent-session-manager-support migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeUsingTsSolutionSetup();
+  });
+
+  it('should be a no-op when there is nothing to migrate', async () => {
+    const result = await migration(tree);
+    expect(result.nextSteps).toEqual([]);
+  });
+
+  it('reshapes the CDK agent construct (agentcore + connection namespaces)', async () => {
+    tree.write(CDK_AGENT_FILE, OLD_CDK_AGENT_FILE);
+
+    const result = await migration(tree);
+
+    const content = tree.read(CDK_AGENT_FILE, 'utf-8') ?? '';
+    // Both the 'agentcore' and connection-generator-patched 'connection'
+    // namespaces should be reshaped to { arn, session }. Existing agents
+    // predate session management support, so they migrate to 'none' rather than
+    // being opted into a persisted session behind their back.
+    expect(
+      content.match(/arn: this\.agentCoreRuntime\.agentRuntimeArn,/g),
+    ).toHaveLength(2);
+    expect(content.match(/session: \{ storage: 'none' \}/g)).toHaveLength(2);
+    expect(content).not.toMatch(
+      /MyAgent: this\.agentCoreRuntime\.agentRuntimeArn,/,
+    );
+    expect(result.nextSteps.some((s) => s.includes(CDK_AGENT_FILE))).toBe(true);
+  });
+
+  it("defaults MCP server sessions to 'none'", async () => {
+    tree.write(CDK_MCP_SERVER_FILE, OLD_CDK_MCP_SERVER_FILE);
+
+    await migration(tree);
+
+    const content = tree.read(CDK_MCP_SERVER_FILE, 'utf-8');
+    expect(content).toContain("session: { storage: 'none' }");
+  });
+
+  it('reshapes the Terraform agentcore + connection value entries', async () => {
+    tree.write(TF_AGENT_FILE, OLD_TF_AGENT_FILE);
+
+    await migration(tree);
+
+    const content = tree.read(TF_AGENT_FILE, 'utf-8') ?? '';
+    const occurrences = content.match(
+      /\{ arn = module\.agent_core_runtime\.agent_core_runtime_arn, session = \{ storage = "none" \} \}/g,
+    );
+    expect(occurrences).toHaveLength(2);
+    expect(content).not.toContain(
+      'value     = { "MyAgent" = module.agent_core_runtime.agent_core_runtime_arn }',
+    );
+  });
+
+  it('reshapes the shared TS AgentCoreRuntimeConfig interface', async () => {
+    tree.write(TS_RUNTIME_CONFIG_FILE, OLD_TS_RUNTIME_CONFIG_FILE);
+
+    await migration(tree);
+
+    const content = tree.read(TS_RUNTIME_CONFIG_FILE, 'utf-8');
+    expect(content).toContain('export interface AgentRuntimeEntry');
+    expect(content).toContain(
+      'agentRuntimes?: Record<string, AgentRuntimeEntry>;',
+    );
+  });
+
+  it('appends .arn to TS client agentRuntimes access', async () => {
+    tree.write(TS_A2A_CLIENT_FILE, OLD_TS_A2A_CLIENT_FILE);
+
+    await migration(tree);
+
+    const content = tree.read(TS_A2A_CLIENT_FILE, 'utf-8');
+    expect(content).toContain("config.agentRuntimes?.['MyTargetAgent']?.arn");
+  });
+
+  it('appends .get("arn") to Python client agentRuntimes access', async () => {
+    tree.write(PY_A2A_CLIENT_FILE, OLD_PY_A2A_CLIENT_FILE);
+
+    await migration(tree);
+
+    const content = tree.read(PY_A2A_CLIENT_FILE, 'utf-8');
+    expect(content).toContain(
+      'agent_runtime_arn = agent_runtime.get("arn") if agent_runtime else None',
+    );
+  });
+
+  it('rewrites the React client duck-typing to use typeof', async () => {
+    tree.write(REACT_PROVIDER_FILE, OLD_REACT_PROVIDER_FILE);
+
+    await migration(tree);
+
+    const content = tree.read(REACT_PROVIDER_FILE, 'utf-8') ?? '';
+    expect(content).toContain("typeof agentRuntimeValue === 'string'");
+    expect(content).toContain('buildAgentCoreWsUrl(agentRuntimeValue.arn)');
+    expect(content).not.toContain("agentRuntimeValue.startsWith('arn:')");
+  });
+
+  it('removes the model/tool error logging hooks from an AG-UI agent.ts', async () => {
+    tree.write(AGUI_AGENT_TS_FILE, OLD_AGENT_TS_FILE);
+    tree.write(AGUI_INDEX_TS_FILE, AGUI_INDEX_TS_FILE_CONTENT);
+
+    const result = await migration(tree);
+
+    const content = tree.read(AGUI_AGENT_TS_FILE, 'utf-8') ?? '';
+    expect(content).not.toContain('logModelErrors');
+    expect(content).not.toContain('logToolErrors');
+    expect(result.nextSteps.some((s) => s.includes(AGUI_AGENT_TS_FILE))).toBe(
+      true,
+    );
+  });
+
+  it('wires the error-logging plugins into an AG-UI index.ts', async () => {
+    tree.write(AGUI_AGENT_TS_FILE, OLD_AGENT_TS_FILE);
+    tree.write(AGUI_INDEX_TS_FILE, AGUI_INDEX_TS_FILE_CONTENT);
+
+    const result = await migration(tree);
+
+    const content = tree.read(AGUI_INDEX_TS_FILE, 'utf-8') ?? '';
+    expect(content).toContain('ModelErrorLoggingPlugin');
+    expect(content).toContain('ToolErrorLoggingPlugin');
+    expect(content).toContain('runWithSessionId');
+    expect(content).toContain(
+      'plugins: [new ModelErrorLoggingPlugin(), new ToolErrorLoggingPlugin()]',
+    );
+    expect(result.nextSteps.some((s) => s.includes(AGUI_INDEX_TS_FILE))).toBe(
+      true,
+    );
+  });
+
+  it('wires sessionManagerProvider into an AG-UI index.ts and creates session.ts when its project is registered', async () => {
+    addProjectConfiguration(tree, 'test-project', {
+      root: 'apps/test-project',
+    });
+    tree.write(AGUI_AGENT_TS_FILE, OLD_AGENT_TS_FILE);
+    tree.write(AGUI_INDEX_TS_FILE, AGUI_INDEX_TS_FILE_CONTENT);
+
+    const result = await migration(tree);
+
+    const content = tree.read(AGUI_INDEX_TS_FILE, 'utf-8') ?? '';
+    expect(content).toContain(
+      "import { getSessionManager } from './session.js';",
+    );
+    expect(content).toContain(
+      'config: { sessionManagerProvider: getSessionManager }',
+    );
+
+    const sessionPath = 'apps/test-project/src/agent/session.ts';
+    const sessionManagerContent = tree.read(sessionPath, 'utf-8') ?? '';
+    expect(sessionManagerContent).toContain(
+      "import { getCurrentSessionId } from '@proj/agent-connection';",
+    );
+    expect(sessionManagerContent).toContain('new LocalFileStorage(');
+    expect(
+      result.nextSteps.some(
+        (s) =>
+          s.includes(AGUI_INDEX_TS_FILE) &&
+          s.includes('wired sessionManagerProvider'),
+      ),
+    ).toBe(true);
+  });
+
+  it('leaves an AG-UI index.ts sessionManagerProvider wiring for manual follow-up when its project cannot be found', async () => {
+    tree.write(AGUI_AGENT_TS_FILE, OLD_AGENT_TS_FILE);
+    tree.write(AGUI_INDEX_TS_FILE, AGUI_INDEX_TS_FILE_CONTENT);
+
+    const result = await migration(tree);
+
+    const content = tree.read(AGUI_INDEX_TS_FILE, 'utf-8') ?? '';
+    expect(content).not.toContain('sessionManagerProvider');
+    expect(content).not.toContain('getSessionManager');
+    expect(
+      tree.exists(
+        `${AGUI_INDEX_TS_FILE.split('/').slice(0, -1).join('/')}/session.ts`,
+      ),
+    ).toBe(false);
+    expect(
+      result.nextSteps.some(
+        (s) =>
+          s.includes(AGUI_INDEX_TS_FILE) &&
+          s.includes('could not determine the project root'),
+      ),
+    ).toBe(true);
+  });
+
+  it('leaves an existing S3-session session.ts untouched (regression: agentRuntimes reshape must not mangle its ?.session?.bucketName chain)', async () => {
+    tree.write(S3_SESSION_FILE, S3_SESSION_FILE_CONTENT);
+
+    const result = await migration(tree);
+
+    const content = tree.read(S3_SESSION_FILE, 'utf-8') ?? '';
+    expect(content).toContain(
+      "config.agentRuntimes?.['TestAgent']?.session?.bucketName",
+    );
+    expect(content).not.toContain('?.arn?.session');
+    expect(result.nextSteps.some((s) => s.includes(S3_SESSION_FILE))).toBe(
+      false,
+    );
+  });
+
+  it('adds the ModelErrorLoggingPlugin class to model-errors-strands.ts', async () => {
+    tree.write(MODEL_ERRORS_FILE, OLD_MODEL_ERRORS_FILE);
+
+    const result = await migration(tree);
+
+    const content = tree.read(MODEL_ERRORS_FILE, 'utf-8') ?? '';
+    expect(content).toContain('type Plugin');
+    expect(content).toContain(
+      'export class ModelErrorLoggingPlugin implements Plugin',
+    );
+    expect(content).toContain(
+      'export const logModelErrors = (agent: LocalAgent): void =>',
+    );
+    expect(content).toContain('new ModelErrorLoggingPlugin().initAgent(agent)');
+    expect(result.nextSteps.some((s) => s.includes(MODEL_ERRORS_FILE))).toBe(
+      true,
+    );
+  });
+
+  it('adds the ToolErrorLoggingPlugin class to tool-errors-strands.ts', async () => {
+    tree.write(TOOL_ERRORS_FILE, OLD_TOOL_ERRORS_FILE);
+
+    const result = await migration(tree);
+
+    const content = tree.read(TOOL_ERRORS_FILE, 'utf-8') ?? '';
+    expect(content).toContain('type Plugin');
+    expect(content).toContain(
+      'export class ToolErrorLoggingPlugin implements Plugin',
+    );
+    expect(content).toContain(
+      'export const logToolErrors = (agent: LocalAgent): void =>',
+    );
+    expect(content).toContain('new ToolErrorLoggingPlugin().initAgent(agent)');
+    expect(result.nextSteps.some((s) => s.includes(TOOL_ERRORS_FILE))).toBe(
+      true,
+    );
+  });
+
+  it('leaves a non-AG-UI agent.ts content untouched when its owning project cannot be found', async () => {
+    tree.write(HTTP_AGENT_TS_FILE, OLD_AGENT_TS_FILE);
+    tree.write(HTTP_INDEX_TS_FILE, HTTP_INDEX_TS_FILE_CONTENT);
+
+    const result = await migration(tree);
+
+    const content = tree.read(HTTP_AGENT_TS_FILE, 'utf-8') ?? '';
+    expect(content).toContain('logModelErrors(agent);');
+    expect(content).toContain('logToolErrors(agent);');
+    expect(content).not.toContain('getSessionManager');
+    expect(
+      tree.exists(
+        `${HTTP_AGENT_TS_FILE.split('/').slice(0, -1).join('/')}/session.ts`,
+      ),
+    ).toBe(false);
+    // No project is registered for HTTP_AGENT_TS_FILE, so the migration can't
+    // compute a local-dev sessions path and reports this for manual follow-up
+    // rather than guessing.
+    expect(
+      result.nextSteps.some(
+        (s) =>
+          s.includes(HTTP_AGENT_TS_FILE) &&
+          s.includes('could not determine the project root'),
+      ),
+    ).toBe(true);
+  });
+
+  it('wires sessionManager into a non-AG-UI agent.ts and creates session.ts when its project is registered', async () => {
+    addProjectConfiguration(tree, 'http-project', {
+      root: 'apps/http-project',
+    });
+    tree.write(HTTP_AGENT_TS_FILE, OLD_AGENT_TS_FILE);
+    tree.write(HTTP_INDEX_TS_FILE, HTTP_INDEX_TS_FILE_CONTENT);
+
+    const result = await migration(tree);
+
+    const content = tree.read(HTTP_AGENT_TS_FILE, 'utf-8') ?? '';
+    expect(content).toContain(
+      "import { getSessionManager } from './session.js';",
+    );
+    expect(content).toContain('sessionManager: await getSessionManager()');
+    expect(content).toContain('logModelErrors(agent);');
+    expect(content).toContain('logToolErrors(agent);');
+
+    const sessionPath = 'apps/http-project/src/agent/session.ts';
+    const sessionManagerContent = tree.read(sessionPath, 'utf-8') ?? '';
+    expect(sessionManagerContent).toContain(
+      "import { getCurrentSessionId } from '@proj/agent-connection';",
+    );
+    expect(sessionManagerContent).toContain('new LocalFileStorage(');
+    expect(sessionManagerContent).toContain(
+      "'../../tmp/agentCore/agentRuntimes/sessions'",
+    );
+    expect(
+      result.nextSteps.some(
+        (s) =>
+          s.includes(HTTP_AGENT_TS_FILE) &&
+          s.includes('wired sessionManager into the Agent constructor'),
+      ),
+    ).toBe(true);
+  });
+
+  it('wires sessionManager into a non-AG-UI agent.ts even when the logModelErrors/logToolErrors import wraps across multiple lines', async () => {
+    addProjectConfiguration(tree, 'http-project', {
+      root: 'apps/http-project',
+    });
+    tree.write(HTTP_AGENT_TS_FILE, MULTI_LINE_IMPORT_OLD_AGENT_TS_FILE);
+    tree.write(HTTP_INDEX_TS_FILE, HTTP_INDEX_TS_FILE_CONTENT);
+
+    const result = await migration(tree);
+
+    const content = tree.read(HTTP_AGENT_TS_FILE, 'utf-8') ?? '';
+    expect(content).toContain(
+      "import { getSessionManager } from './session.js';",
+    );
+    expect(content).toContain('sessionManager: await getSessionManager()');
+    expect(content).toContain('logModelErrors(agent);');
+    expect(content).toContain('logToolErrors(agent);');
+    expect(tree.exists('apps/http-project/src/agent/session.ts')).toBe(true);
+    expect(
+      result.nextSteps.some(
+        (s) =>
+          s.includes(HTTP_AGENT_TS_FILE) &&
+          s.includes('wired sessionManager into the Agent constructor'),
+      ),
+    ).toBe(true);
+  });
+
+  it('wires sessionManager into a non-AG-UI agent.ts when a connection generator merged its own import into the logModelErrors/logToolErrors import', async () => {
+    addProjectConfiguration(tree, 'http-project', {
+      root: 'apps/http-project',
+    });
+    tree.write(HTTP_AGENT_TS_FILE, MERGED_IMPORT_OLD_AGENT_TS_FILE);
+    tree.write(HTTP_INDEX_TS_FILE, HTTP_INDEX_TS_FILE_CONTENT);
+
+    const result = await migration(tree);
+
+    const content = tree.read(HTTP_AGENT_TS_FILE, 'utf-8') ?? '';
+    expect(content).toContain(
+      "import { getSessionManager } from './session.js';",
+    );
+    expect(content).toContain('sessionManager: await getSessionManager()');
+    expect(content).toContain('logModelErrors(agent);');
+    expect(content).toContain('logToolErrors(agent);');
+    // The merged client import must survive intact
+    expect(content).toContain('AgentsMcpServerClientStrands');
+    expect(tree.exists('apps/http-project/src/agent/session.ts')).toBe(true);
+    expect(
+      result.nextSteps.some(
+        (s) =>
+          s.includes(HTTP_AGENT_TS_FILE) &&
+          s.includes('wired sessionManager into the Agent constructor'),
+      ),
+    ).toBe(true);
+  });
+
+  it('removes the model/tool error logging hooks from an AG-UI agent.ts even when a connection generator merged its own import into the same statement', async () => {
+    tree.write(AGUI_AGENT_TS_FILE, MERGED_IMPORT_OLD_AGENT_TS_FILE);
+    tree.write(AGUI_INDEX_TS_FILE, AGUI_INDEX_TS_FILE_CONTENT);
+
+    const result = await migration(tree);
+
+    const content = tree.read(AGUI_AGENT_TS_FILE, 'utf-8') ?? '';
+    expect(content).not.toContain('logModelErrors');
+    expect(content).not.toContain('logToolErrors');
+    // The merged client import and its usage must survive intact
+    expect(content).toContain('AgentsMcpServerClientStrands');
+    expect(content).toContain(
+      "import { AgentsMcpServerClientStrands } from '@my-agent-project/agent-connection';",
+    );
+    expect(result.nextSteps.some((s) => s.includes(AGUI_AGENT_TS_FILE))).toBe(
+      true,
+    );
+  });
+
+  it('leaves a customised CDK construct untouched', async () => {
+    const customised = OLD_CDK_AGENT_FILE.replaceAll(
+      'MyAgent: this.agentCoreRuntime.agentRuntimeArn,',
+      'MyAgent: this.customAgentRuntimeArnGetter(),',
+    );
+    tree.write(CDK_AGENT_FILE, customised);
+
+    const result = await migration(tree);
+
+    expect(tree.read(CDK_AGENT_FILE, 'utf-8')).toContain(
+      'this.customAgentRuntimeArnGetter()',
+    );
+    expect(result.nextSteps.some((s) => s.includes(CDK_AGENT_FILE))).toBe(
+      false,
+    );
+  });
+
+  it('is idempotent', async () => {
+    addProjectConfiguration(tree, 'http-project', {
+      root: 'apps/http-project',
+    });
+    addProjectConfiguration(tree, 'test-project', {
+      root: 'apps/test-project',
+    });
+    tree.write(CDK_AGENT_FILE, OLD_CDK_AGENT_FILE);
+    tree.write(TF_AGENT_FILE, OLD_TF_AGENT_FILE);
+    tree.write(TS_RUNTIME_CONFIG_FILE, OLD_TS_RUNTIME_CONFIG_FILE);
+    tree.write(TS_A2A_CLIENT_FILE, OLD_TS_A2A_CLIENT_FILE);
+    tree.write(PY_A2A_CLIENT_FILE, OLD_PY_A2A_CLIENT_FILE);
+    tree.write(REACT_PROVIDER_FILE, OLD_REACT_PROVIDER_FILE);
+    tree.write(AGUI_AGENT_TS_FILE, OLD_AGENT_TS_FILE);
+    tree.write(AGUI_INDEX_TS_FILE, AGUI_INDEX_TS_FILE_CONTENT);
+    tree.write(MODEL_ERRORS_FILE, OLD_MODEL_ERRORS_FILE);
+    tree.write(TOOL_ERRORS_FILE, OLD_TOOL_ERRORS_FILE);
+    tree.write(HTTP_AGENT_TS_FILE, OLD_AGENT_TS_FILE);
+    tree.write(HTTP_INDEX_TS_FILE, HTTP_INDEX_TS_FILE_CONTENT);
+
+    await migration(tree);
+    const httpSessionManagerPath = 'apps/http-project/src/agent/session.ts';
+    const aguiSessionManagerPath = 'apps/test-project/src/agent/session.ts';
+    const afterFirstRun = {
+      cdk: tree.read(CDK_AGENT_FILE, 'utf-8'),
+      tf: tree.read(TF_AGENT_FILE, 'utf-8'),
+      ts: tree.read(TS_RUNTIME_CONFIG_FILE, 'utf-8'),
+      tsClient: tree.read(TS_A2A_CLIENT_FILE, 'utf-8'),
+      pyClient: tree.read(PY_A2A_CLIENT_FILE, 'utf-8'),
+      react: tree.read(REACT_PROVIDER_FILE, 'utf-8'),
+      aguiAgent: tree.read(AGUI_AGENT_TS_FILE, 'utf-8'),
+      aguiIndex: tree.read(AGUI_INDEX_TS_FILE, 'utf-8'),
+      modelErrors: tree.read(MODEL_ERRORS_FILE, 'utf-8'),
+      toolErrors: tree.read(TOOL_ERRORS_FILE, 'utf-8'),
+      httpAgent: tree.read(HTTP_AGENT_TS_FILE, 'utf-8'),
+      httpSessionManager: tree.read(httpSessionManagerPath, 'utf-8'),
+      aguiSessionManager: tree.read(aguiSessionManagerPath, 'utf-8'),
+    };
+    expect(afterFirstRun.httpAgent).toContain('getSessionManager');
+    expect(afterFirstRun.httpSessionManager).toBeTruthy();
+    expect(afterFirstRun.aguiIndex).toContain('sessionManagerProvider');
+    expect(afterFirstRun.aguiSessionManager).toBeTruthy();
+
+    const secondResult = await migration(tree);
+
+    expect(tree.read(CDK_AGENT_FILE, 'utf-8')).toEqual(afterFirstRun.cdk);
+    expect(tree.read(TF_AGENT_FILE, 'utf-8')).toEqual(afterFirstRun.tf);
+    expect(tree.read(TS_RUNTIME_CONFIG_FILE, 'utf-8')).toEqual(
+      afterFirstRun.ts,
+    );
+    expect(tree.read(TS_A2A_CLIENT_FILE, 'utf-8')).toEqual(
+      afterFirstRun.tsClient,
+    );
+    expect(tree.read(PY_A2A_CLIENT_FILE, 'utf-8')).toEqual(
+      afterFirstRun.pyClient,
+    );
+    expect(tree.read(REACT_PROVIDER_FILE, 'utf-8')).toEqual(
+      afterFirstRun.react,
+    );
+    expect(tree.read(AGUI_AGENT_TS_FILE, 'utf-8')).toEqual(
+      afterFirstRun.aguiAgent,
+    );
+    expect(tree.read(AGUI_INDEX_TS_FILE, 'utf-8')).toEqual(
+      afterFirstRun.aguiIndex,
+    );
+    expect(tree.read(MODEL_ERRORS_FILE, 'utf-8')).toEqual(
+      afterFirstRun.modelErrors,
+    );
+    expect(tree.read(TOOL_ERRORS_FILE, 'utf-8')).toEqual(
+      afterFirstRun.toolErrors,
+    );
+    expect(tree.read(HTTP_AGENT_TS_FILE, 'utf-8')).toEqual(
+      afterFirstRun.httpAgent,
+    );
+    expect(tree.read(httpSessionManagerPath, 'utf-8')).toEqual(
+      afterFirstRun.httpSessionManager,
+    );
+    expect(tree.read(aguiSessionManagerPath, 'utf-8')).toEqual(
+      afterFirstRun.aguiSessionManager,
+    );
+    expect(secondResult.nextSteps).toEqual([]);
+  });
+});

--- a/packages/nx-plugin/src/migrations/latest/ts-agent-session-management-support/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/latest/ts-agent-session-management-support/migration.spec.ts
@@ -393,48 +393,47 @@ describe('ts-agent-session-manager-support migration', () => {
     expect(result.nextSteps).toEqual([]);
   });
 
-  it('reshapes the CDK agent construct (agentcore + connection namespaces)', async () => {
+  it('reshapes the CDK agent construct agentcore namespace only, leaving connection as a bare string', async () => {
     tree.write(CDK_AGENT_FILE, OLD_CDK_AGENT_FILE);
 
     const result = await migration(tree);
 
     const content = tree.read(CDK_AGENT_FILE, 'utf-8') ?? '';
-    // Both the 'agentcore' and connection-generator-patched 'connection'
-    // namespaces should be reshaped to { arn, session }. Existing agents
-    // predate session management support, so they migrate to 'in-memory' rather
-    // than being opted into a persisted session behind their back.
+    // Existing agents predate session management support and have no S3
+    // bucket to reference, so no session field is added here — they get
+    // in-memory session storage via a fresh session.ts instead.
     expect(
       content.match(/arn: this\.agentCoreRuntime\.agentRuntimeArn,/g),
-    ).toHaveLength(2);
-    expect(content.match(/session: \{ storage: 'in-memory' \}/g)).toHaveLength(
-      2,
-    );
-    expect(content).not.toMatch(
-      /MyAgent: this\.agentCoreRuntime\.agentRuntimeArn,/,
-    );
+    ).toHaveLength(1);
+    expect(content).not.toContain('session:');
+    // The connection namespace keeps its bare ARN string.
+    expect(
+      content.match(/MyAgent: this\.agentCoreRuntime\.agentRuntimeArn,/g),
+    ).toHaveLength(1);
     expect(result.nextSteps.some((s) => s.includes(CDK_AGENT_FILE))).toBe(true);
   });
 
-  it("defaults MCP server sessions to 'in-memory'", async () => {
+  it('does not add a session field for MCP server runtimes', async () => {
     tree.write(CDK_MCP_SERVER_FILE, OLD_CDK_MCP_SERVER_FILE);
 
     await migration(tree);
 
     const content = tree.read(CDK_MCP_SERVER_FILE, 'utf-8');
-    expect(content).toContain("session: { storage: 'in-memory' }");
+    expect(content).not.toContain('session:');
   });
 
-  it('reshapes the Terraform agentcore + connection value entries', async () => {
+  it('reshapes the Terraform agentcore module only, leaving the connection module as a bare string', async () => {
     tree.write(TF_AGENT_FILE, OLD_TF_AGENT_FILE);
 
     await migration(tree);
 
     const content = tree.read(TF_AGENT_FILE, 'utf-8') ?? '';
-    const occurrences = content.match(
-      /\{ arn = module\.agent_core_runtime\.agent_core_runtime_arn, session = \{ storage = "in-memory" \} \}/g,
+    expect(content).toContain(
+      'value     = { "MyAgent" = { arn = module.agent_core_runtime.agent_core_runtime_arn } }',
     );
-    expect(occurrences).toHaveLength(2);
-    expect(content).not.toContain(
+    expect(content).not.toContain('session');
+    // The connection module keeps its bare ARN string.
+    expect(content).toContain(
       'value     = { "MyAgent" = module.agent_core_runtime.agent_core_runtime_arn }',
     );
   });
@@ -471,15 +470,16 @@ describe('ts-agent-session-manager-support migration', () => {
     );
   });
 
-  it('rewrites the React client duck-typing to use typeof', async () => {
+  it('leaves the React client provider untouched (connection namespace stays a bare ARN string)', async () => {
     tree.write(REACT_PROVIDER_FILE, OLD_REACT_PROVIDER_FILE);
 
-    await migration(tree);
+    const result = await migration(tree);
 
-    const content = tree.read(REACT_PROVIDER_FILE, 'utf-8') ?? '';
-    expect(content).toContain("typeof agentRuntimeValue === 'string'");
-    expect(content).toContain('buildAgentCoreWsUrl(agentRuntimeValue.arn)');
-    expect(content).not.toContain("agentRuntimeValue.startsWith('arn:')");
+    const content = tree.read(REACT_PROVIDER_FILE, 'utf-8');
+    expect(content).toEqual(OLD_REACT_PROVIDER_FILE);
+    expect(result.nextSteps.some((s) => s.includes(REACT_PROVIDER_FILE))).toBe(
+      false,
+    );
   });
 
   it('removes the model/tool error logging hooks from an AG-UI agent.ts', async () => {
@@ -594,10 +594,7 @@ describe('ts-agent-session-manager-support migration', () => {
     expect(content).toContain(
       'export class ModelErrorLoggingPlugin implements Plugin',
     );
-    expect(content).toContain(
-      'export const logModelErrors = (agent: LocalAgent): void =>',
-    );
-    expect(content).toContain('new ModelErrorLoggingPlugin().initAgent(agent)');
+    expect(content).not.toContain('logModelErrors');
     expect(result.nextSteps.some((s) => s.includes(MODEL_ERRORS_FILE))).toBe(
       true,
     );
@@ -613,10 +610,7 @@ describe('ts-agent-session-manager-support migration', () => {
     expect(content).toContain(
       'export class ToolErrorLoggingPlugin implements Plugin',
     );
-    expect(content).toContain(
-      'export const logToolErrors = (agent: LocalAgent): void =>',
-    );
-    expect(content).toContain('new ToolErrorLoggingPlugin().initAgent(agent)');
+    expect(content).not.toContain('logToolErrors');
     expect(result.nextSteps.some((s) => s.includes(TOOL_ERRORS_FILE))).toBe(
       true,
     );
@@ -649,7 +643,7 @@ describe('ts-agent-session-manager-support migration', () => {
     ).toBe(true);
   });
 
-  it('wires sessionManager into a non-AG-UI agent.ts and creates session.ts when its project is registered', async () => {
+  it('wires sessionManager and the error-logging plugins into a non-AG-UI agent.ts and creates session.ts when its project is registered', async () => {
     addProjectConfiguration(tree, 'http-project', {
       root: 'apps/http-project',
     });
@@ -662,9 +656,15 @@ describe('ts-agent-session-manager-support migration', () => {
     expect(content).toContain(
       "import { getSessionManager } from './session.js';",
     );
+    expect(content).toContain('ModelErrorLoggingPlugin');
+    expect(content).toContain('ToolErrorLoggingPlugin');
+    expect(content).toContain("from '@proj/agent-connection';");
     expect(content).toContain('sessionManager: await getSessionManager()');
-    expect(content).toContain('logModelErrors(agent);');
-    expect(content).toContain('logToolErrors(agent);');
+    expect(content).toContain(
+      'plugins: [new ModelErrorLoggingPlugin(), new ToolErrorLoggingPlugin()]',
+    );
+    expect(content).not.toContain('logModelErrors');
+    expect(content).not.toContain('logToolErrors');
 
     const sessionPath = 'apps/http-project/src/agent/session.ts';
     const sessionManagerContent = tree.read(sessionPath, 'utf-8') ?? '';
@@ -679,7 +679,9 @@ describe('ts-agent-session-manager-support migration', () => {
       result.nextSteps.some(
         (s) =>
           s.includes(HTTP_AGENT_TS_FILE) &&
-          s.includes('wired sessionManager into the Agent constructor'),
+          s.includes(
+            'wired sessionManager and the error-logging plugins into the Agent constructor',
+          ),
       ),
     ).toBe(true);
   });
@@ -698,14 +700,19 @@ describe('ts-agent-session-manager-support migration', () => {
       "import { getSessionManager } from './session.js';",
     );
     expect(content).toContain('sessionManager: await getSessionManager()');
-    expect(content).toContain('logModelErrors(agent);');
-    expect(content).toContain('logToolErrors(agent);');
+    expect(content).toContain(
+      'plugins: [new ModelErrorLoggingPlugin(), new ToolErrorLoggingPlugin()]',
+    );
+    expect(content).not.toContain('logModelErrors');
+    expect(content).not.toContain('logToolErrors');
     expect(tree.exists('apps/http-project/src/agent/session.ts')).toBe(true);
     expect(
       result.nextSteps.some(
         (s) =>
           s.includes(HTTP_AGENT_TS_FILE) &&
-          s.includes('wired sessionManager into the Agent constructor'),
+          s.includes(
+            'wired sessionManager and the error-logging plugins into the Agent constructor',
+          ),
       ),
     ).toBe(true);
   });
@@ -724,8 +731,11 @@ describe('ts-agent-session-manager-support migration', () => {
       "import { getSessionManager } from './session.js';",
     );
     expect(content).toContain('sessionManager: await getSessionManager()');
-    expect(content).toContain('logModelErrors(agent);');
-    expect(content).toContain('logToolErrors(agent);');
+    expect(content).toContain(
+      'plugins: [new ModelErrorLoggingPlugin(), new ToolErrorLoggingPlugin()]',
+    );
+    expect(content).not.toContain('logModelErrors');
+    expect(content).not.toContain('logToolErrors');
     // The merged client import must survive intact
     expect(content).toContain('AgentsMcpServerClientStrands');
     expect(tree.exists('apps/http-project/src/agent/session.ts')).toBe(true);
@@ -733,7 +743,9 @@ describe('ts-agent-session-manager-support migration', () => {
       result.nextSteps.some(
         (s) =>
           s.includes(HTTP_AGENT_TS_FILE) &&
-          s.includes('wired sessionManager into the Agent constructor'),
+          s.includes(
+            'wired sessionManager and the error-logging plugins into the Agent constructor',
+          ),
       ),
     ).toBe(true);
   });

--- a/packages/nx-plugin/src/migrations/latest/ts-agent-session-management-support/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/latest/ts-agent-session-management-support/migration.spec.ts
@@ -401,25 +401,27 @@ describe('ts-agent-session-manager-support migration', () => {
     const content = tree.read(CDK_AGENT_FILE, 'utf-8') ?? '';
     // Both the 'agentcore' and connection-generator-patched 'connection'
     // namespaces should be reshaped to { arn, session }. Existing agents
-    // predate session management support, so they migrate to 'none' rather than
-    // being opted into a persisted session behind their back.
+    // predate session management support, so they migrate to 'in-memory' rather
+    // than being opted into a persisted session behind their back.
     expect(
       content.match(/arn: this\.agentCoreRuntime\.agentRuntimeArn,/g),
     ).toHaveLength(2);
-    expect(content.match(/session: \{ storage: 'none' \}/g)).toHaveLength(2);
+    expect(content.match(/session: \{ storage: 'in-memory' \}/g)).toHaveLength(
+      2,
+    );
     expect(content).not.toMatch(
       /MyAgent: this\.agentCoreRuntime\.agentRuntimeArn,/,
     );
     expect(result.nextSteps.some((s) => s.includes(CDK_AGENT_FILE))).toBe(true);
   });
 
-  it("defaults MCP server sessions to 'none'", async () => {
+  it("defaults MCP server sessions to 'in-memory'", async () => {
     tree.write(CDK_MCP_SERVER_FILE, OLD_CDK_MCP_SERVER_FILE);
 
     await migration(tree);
 
     const content = tree.read(CDK_MCP_SERVER_FILE, 'utf-8');
-    expect(content).toContain("session: { storage: 'none' }");
+    expect(content).toContain("session: { storage: 'in-memory' }");
   });
 
   it('reshapes the Terraform agentcore + connection value entries', async () => {
@@ -429,7 +431,7 @@ describe('ts-agent-session-manager-support migration', () => {
 
     const content = tree.read(TF_AGENT_FILE, 'utf-8') ?? '';
     const occurrences = content.match(
-      /\{ arn = module\.agent_core_runtime\.agent_core_runtime_arn, session = \{ storage = "none" \} \}/g,
+      /\{ arn = module\.agent_core_runtime\.agent_core_runtime_arn, session = \{ storage = "in-memory" \} \}/g,
     );
     expect(occurrences).toHaveLength(2);
     expect(content).not.toContain(

--- a/packages/nx-plugin/src/migrations/latest/ts-agent-session-management-support/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/latest/ts-agent-session-management-support/migration.spec.ts
@@ -236,6 +236,34 @@ export const getAgent = async () => {
 };
 `;
 
+// Regression fixture: TWO connection generators (mcp-connection AND
+// a2a-connection) have each merged their own client import into the same
+// statement — this is the exact shape found in a real workspace where the
+// migration silently left logModelErrors/logToolErrors dangling in the
+// import (GritQL's `$rest` metavariable only binds a single remaining
+// specifier, not an arbitrary-length list).
+const DOUBLY_MERGED_IMPORT_OLD_AGENT_TS_FILE = `import { Agent, tool } from '@strands-agents/sdk';
+import {
+  logModelErrors,
+  logToolErrors,
+  A2aAgentClientStrands,
+  AgentsMcpServerClientStrands,
+} from '@my-agent-project/agent-connection';
+import { z } from 'zod';
+
+export const getAgent = async () => {
+  const agentsMcpServer = await AgentsMcpServerClientStrands.create();
+  const a2aAgent = await A2aAgentClientStrands.create();
+  const agent = new Agent({
+    systemPrompt: 'You are a mathematical wizard.',
+    tools: [agentsMcpServer],
+  });
+  logModelErrors(agent);
+  logToolErrors(agent);
+  return agent;
+};
+`;
+
 const AGUI_INDEX_TS_FILE_CONTENT = `import { StrandsAgent } from '@ag-ui/aws-strands';
 import { runWithSessionId } from '@proj/agent-connection';
 import { getAgent } from './agent.js';
@@ -277,7 +305,7 @@ export const getSessionManager = async (): Promise<
   if (process.env.LOCAL_DEV === 'true') {
     return new SessionManager({
       sessionId,
-      storage: new LocalFileStorage('../../tmp/agentCore/agentRuntimes/sessions'),
+      storage: new LocalFileStorage('../../tmp/agents/strands/test-project-agent'),
     });
   }
   const config = await getAgentCoreRuntimeConfig();
@@ -643,7 +671,7 @@ describe('ts-agent-session-manager-support migration', () => {
     );
     expect(sessionManagerContent).toContain('new LocalFileStorage(');
     expect(sessionManagerContent).toContain(
-      "'../../tmp/agentCore/agentRuntimes/sessions'",
+      "'../../tmp/agents/strands/http-project-agent'",
     );
     expect(
       result.nextSteps.some(
@@ -721,6 +749,30 @@ describe('ts-agent-session-manager-support migration', () => {
     expect(content).toContain('AgentsMcpServerClientStrands');
     expect(content).toContain(
       "import { AgentsMcpServerClientStrands } from '@my-agent-project/agent-connection';",
+    );
+    expect(result.nextSteps.some((s) => s.includes(AGUI_AGENT_TS_FILE))).toBe(
+      true,
+    );
+  });
+
+  it('removes the model/tool error logging hooks from an AG-UI agent.ts even when TWO connection generators merged their imports into the same statement', async () => {
+    tree.write(AGUI_AGENT_TS_FILE, DOUBLY_MERGED_IMPORT_OLD_AGENT_TS_FILE);
+    tree.write(AGUI_INDEX_TS_FILE, AGUI_INDEX_TS_FILE_CONTENT);
+
+    const result = await migration(tree);
+
+    const content = tree.read(AGUI_AGENT_TS_FILE, 'utf-8') ?? '';
+    expect(content).not.toContain('logModelErrors');
+    expect(content).not.toContain('logToolErrors');
+    // Both merged client imports and their usages must survive intact
+    expect(content).toContain('A2aAgentClientStrands');
+    expect(content).toContain('AgentsMcpServerClientStrands');
+    expect(content).toContain("} from '@my-agent-project/agent-connection';");
+    expect(content).toContain(
+      'const agentsMcpServer = await AgentsMcpServerClientStrands.create();',
+    );
+    expect(content).toContain(
+      'const a2aAgent = await A2aAgentClientStrands.create();',
     );
     expect(result.nextSteps.some((s) => s.includes(AGUI_AGENT_TS_FILE))).toBe(
       true,

--- a/packages/nx-plugin/src/migrations/latest/ts-agent-session-management-support/migration.ts
+++ b/packages/nx-plugin/src/migrations/latest/ts-agent-session-management-support/migration.ts
@@ -13,6 +13,7 @@ import { applyGritQL, captureGritQL, matchGritQL } from '../../../utils/ast';
 import { formatFilesInSubtree } from '../../../utils/format';
 import { isEsmWorkspace } from '../../../utils/module-format';
 import { kebabCase } from '../../../utils/names';
+import { getRelativePathToRootByDirectory } from '../../../utils/paths';
 
 /**
  * Add session management support to ts#agent.
@@ -30,45 +31,60 @@ import { kebabCase } from '../../../utils/names';
  *   migration wrote are formatted correctly.
  */
 
-// Existing agents predate session management support, so migrate them to
-// 'in-memory' rather than opting them into a persisted session behind their
-// back. MCP servers have no session regardless.
-const LEGACY_SESSION_STORAGE = 'in-memory';
-
-// Matches `rc.set('<namespace>', 'agentRuntimes', { ...rc.get('<namespace>').agentRuntimes, $name: this.agentCoreRuntime.agentRuntimeArn });`
-// as vended by the CDK agent-core construct (for both the 'agentcore' and the
-// connection-generator-patched 'connection' namespace). Naturally idempotent:
-// once migrated, `$name`'s value is a `{ arn, session }` object rather than
-// `this.agentCoreRuntime.agentRuntimeArn` directly, so this no longer matches.
-const cdkRcSetPattern = (namespace: 'agentcore' | 'connection') =>
-  `\`rc.set('${namespace}', 'agentRuntimes', { ...rc.get('${namespace}').agentRuntimes, $name: this.agentCoreRuntime.agentRuntimeArn });\` => raw\`rc.set('${namespace}', 'agentRuntimes', {
-  ...rc.get('${namespace}').agentRuntimes,
+// Matches `rc.set('agentcore', 'agentRuntimes', { ...rc.get('agentcore').agentRuntimes, $name: this.agentCoreRuntime.agentRuntimeArn });`
+// as vended by the CDK agent-core construct. Only the 'agentcore' namespace
+// takes this `{ arn }` shape; the connection-generator-patched 'connection'
+// namespace (client-facing, published to runtime-config.json) stays a bare
+// ARN string, since it shouldn't carry fields like a session's bucket name
+// to the browser. Naturally idempotent: once migrated, `$name`'s value is a
+// `{ arn }` object rather than `this.agentCoreRuntime.agentRuntimeArn`
+// directly, so this no longer matches. Existing agents predate session
+// management support and have no S3 bucket to reference, so there's no
+// `session` field to add here — a fresh session.ts created below defaults
+// them to in-memory storage. MCP servers have no session regardless.
+const CDK_RC_SET_PATTERN = `\`rc.set('agentcore', 'agentRuntimes', { ...rc.get('agentcore').agentRuntimes, $name: this.agentCoreRuntime.agentRuntimeArn });\` => raw\`rc.set('agentcore', 'agentRuntimes', {
+  ...rc.get('agentcore').agentRuntimes,
   $name: {
     arn: this.agentCoreRuntime.agentRuntimeArn,
-    session: { storage: '${LEGACY_SESSION_STORAGE}' },
   },
 });\``;
 
-// Matches the equivalent `value = { "$name" = module.agent_core_runtime.agent_core_runtime_arn }`
-// line as vended by the Terraform agent-core construct, for both the
-// 'agentcore' and connection-generator-patched 'connection' modules. Naturally
-// idempotent (see cdkRcSetPattern).
-const TF_VALUE_PATTERN = `language hcl\n\`value     = { "$name" = module.agent_core_runtime.agent_core_runtime_arn }\` => \`value     = { "$name" = { arn = module.agent_core_runtime.agent_core_runtime_arn, session = { storage = "${LEGACY_SESSION_STORAGE}" } } }\``;
+// Matches the equivalent `add_agent_runtime_to_runtime_config` module block
+// vended by the Terraform agent-core construct, anchored on its fixed module
+// name/shape since the connection-generator-patched
+// `add_agent_runtime_to_connection_runtime_config` module has an identical-
+// looking `value` line but keeps its bare ARN string shape (see
+// CDK_RC_SET_PATTERN's comment). Naturally idempotent (see CDK_RC_SET_PATTERN).
+const TF_VALUE_PATTERN = `language hcl\n\`module "add_agent_runtime_to_runtime_config" {
+  source = "../../../core/runtime-config/entry"
+
+  namespace = "agentcore"
+  key       = "agentRuntimes"
+  value     = { "$name" = module.agent_core_runtime.agent_core_runtime_arn }
+
+  depends_on = [module.agent_core_runtime]
+}\` => \`module "add_agent_runtime_to_runtime_config" {
+  source = "../../../core/runtime-config/entry"
+
+  namespace = "agentcore"
+  key       = "agentRuntimes"
+  value     = { "$name" = { arn = module.agent_core_runtime.agent_core_runtime_arn } }
+
+  depends_on = [module.agent_core_runtime]
+}\``;
 
 // Exact shape of the shared `AgentCoreRuntimeConfig` interface prior to this
 // change, as vended into `packages/common/agent-connection/src/core/runtime-config.ts`.
 const TS_RUNTIME_CONFIG_INTERFACE_PATTERN = `\`export interface AgentCoreRuntimeConfig {
   agentRuntimes?: Record<string, string>;
   gateways?: Record<string, string>;
-}\` => raw\`export interface AgentRuntimeSession {
-  storage: 's3' | 'in-memory';
-  /** Name of the S3 bucket storing session data. Only set when storage is 's3'. */
-  bucketName?: string;
-}
-
-export interface AgentRuntimeEntry {
+}\` => raw\`export interface AgentRuntimeEntry {
   arn: string;
-  session: AgentRuntimeSession;
+  /** Session storage details. Only set when the agent has S3 session storage configured. */
+  session?: {
+    /** Name of the S3 bucket storing session data. */
+    bucketName: string;
+  };
 }
 
 export interface AgentCoreRuntimeConfig {
@@ -90,24 +106,20 @@ const TS_CLIENT_ARN_PATTERNS = [
 const PY_CLIENT_ARN_PATTERN =
   'language python\n`agent_runtime_arn = config.get("agentRuntimes", {}).get($name)` => `agent_runtime = config.get("agentRuntimes", {}).get($name)\nagent_runtime_arn = agent_runtime.get("arn") if agent_runtime else None`';
 
-// Matches the `$val.startsWith('arn:') ? $fn($val) : $val` duck-typing used by
-// the generated React trpc/AG-UI/OpenAPI client providers to distinguish a
-// deployed runtime ARN from a local-dev override URL. Generic over the
-// value/build-function identifiers so it covers all three providers.
-// Naturally idempotent (the rewritten form no longer contains `.startsWith('arn:')`).
-const REACT_DUCK_TYPING_PATTERN =
-  "`$val.startsWith('arn:') ? $fn($val) : $val` => `typeof $val === 'string' ? $val : $fn($val.arn)`";
-
-// AG-UI's adapter clones the template agent per-thread, but hooks added
-// directly to the template (as logModelErrors/logToolErrors do) are NOT
-// carried over onto those clones, so the per-thread agents would silently
-// run without error logging. Removes the (AG-UI-incompatible) import and
-// calls from an existing agent.ts — the equivalent behaviour is restored via
-// AGUI_INDEX_*_PATTERN below, which wires the same logic in as StrandsAgent
-// plugins instead (plugins are applied to each per-thread agent via
-// initAgent). Naturally idempotent (nothing to match once removed). The
-// import itself is removed via removeLogErrorsImport below (see its comment
-// for why a plain GritQL rewrite can't express this).
+// Removes the imperative logModelErrors(agent)/logToolErrors(agent) calls
+// from an existing agent.ts, for both AG-UI and HTTP/A2A agents. For AG-UI
+// this is required, not just cosmetic: its adapter clones the template agent
+// per-thread, and hooks added directly to the template (as these calls do)
+// are NOT carried over onto those clones, so the per-thread agents would
+// silently run without error logging — the equivalent behaviour is restored
+// via AGUI_INDEX_*_PATTERN below, which wires the same logic in as
+// StrandsAgent plugins instead (plugins are applied to each per-thread agent
+// via initAgent). For HTTP/A2A it's purely a style unification with the
+// AG-UI form (see AGENT_TS_PLUGINS_CONSTRUCTOR_PATTERN), since one Agent per
+// session means the imperative form already worked correctly there. Naturally
+// idempotent (nothing to match once removed). The import itself is removed
+// via removeLogErrorsImport below (see its comment for why a plain GritQL
+// rewrite can't express this).
 const AGENT_TS_LOG_MODEL_CALL_PATTERN = '`logModelErrors(agent);` => .';
 const AGENT_TS_LOG_TOOL_CALL_PATTERN = '`logToolErrors(agent);` => .';
 
@@ -136,10 +148,21 @@ const isAgUiAgentDir = (tree: Tree, agentTsPath: string): boolean => {
 const AGENT_TS_SESSION_MANAGER_CONSTRUCTOR_PATTERN =
   '`new Agent({ $props })` => `new Agent({ sessionManager: await getSessionManager(), $props })` where { $props <: not contains `sessionManager` }';
 
+// Moves the model/tool error logging hooks from imperative logModelErrors/
+// logToolErrors calls to Agent constructor plugins, mirroring the AG-UI
+// rewrite (AGUI_INDEX_CONSTRUCTOR_PATTERN below) for consistency — HTTP/A2A
+// agents already worked correctly with the imperative form (one Agent per
+// session, unlike AG-UI's per-thread cloning), so this is purely a style
+// unification rather than a bug fix. Same prepend rationale as
+// AGENT_TS_SESSION_MANAGER_CONSTRUCTOR_PATTERN.
+const AGENT_TS_PLUGINS_CONSTRUCTOR_PATTERN =
+  '`new Agent({ $props })` => `new Agent({ plugins: [new ModelErrorLoggingPlugin(), new ToolErrorLoggingPlugin()], $props })` where { $props <: not contains `plugins` }';
+
 // Captures the agent-connection package specifier from the existing
-// logModelErrors/logToolErrors import so the new getSessionManager import
-// (and the fresh session.ts this migration creates) target the same
-// module, without needing to know the workspace's npm scope directly. Generic
+// logModelErrors/logToolErrors import so the new getSessionManager and
+// ModelErrorLoggingPlugin/ToolErrorLoggingPlugin imports (and the fresh
+// session.ts this migration creates) target the same module, without needing
+// to know the workspace's npm scope directly. Generic
 // over `$names` (rather than requiring an exact 2-specifier import) since a
 // connection generator (mcp-connection/a2a-connection) may have merged its
 // own client import into this same statement via addDestructuredImport.
@@ -162,7 +185,8 @@ const AGENT_TS_REMOVE_LOG_ERRORS_IMPORT_PATTERN =
   "`import $clause from '$mod';` as $import where { $clause <: import_clause(name=named_imports($imports)), $imports <: contains `logModelErrors`, $imports <: contains `logToolErrors`, if ($imports <: [`logModelErrors`, `logToolErrors`]) { $import => . } else { $imports <: some import_specifier(name=or { `logModelErrors`, `logToolErrors` }) => . } }";
 
 // Existing agents predate session.ts entirely, so there is no prior
-// session storage to preserve here — this mirrors LEGACY_SESSION_STORAGE ('in-memory').
+// session storage to preserve here — default to in-memory, matching the
+// (session-less) agentRuntimes entry this migration writes above.
 const legacySessionManagerContent = (
   agentConnectionModule: string,
   localSessionsDir: string,
@@ -225,13 +249,11 @@ const agentTmpNameFor = (projectName: string, dirName: string): string => {
 const localSessionsDirFor = (
   projectRoot: string,
   agentTmpName: string,
-): string => {
-  const depth = projectRoot.split('/').filter(Boolean).length;
-  return joinPathFragments(
-    Array(depth).fill('..').join('/'),
+): string =>
+  joinPathFragments(
+    getRelativePathToRootByDirectory(projectRoot),
     `tmp/agents/strands/${agentTmpName}`,
   );
-};
 
 // Adds the ModelErrorLoggingPlugin/ToolErrorLoggingPlugin import (generic over
 // the agent-connection package's npm scope) and wires them into the
@@ -263,24 +285,27 @@ const AGUI_INDEX_SESSION_MANAGER_MATCH_PATTERN =
   '`new StrandsAgent({ agent, name: $name, description: $desc, plugins: $plugins })`';
 const AGUI_INDEX_SESSION_MANAGER_CONSTRUCTOR_PATTERN = `${AGUI_INDEX_SESSION_MANAGER_MATCH_PATTERN} => \`new StrandsAgent({ agent, name: $name, description: $desc, plugins: $plugins, config: { sessionManagerProvider: getSessionManager } })\``;
 
-// The AGUI_INDEX_* patterns above reference ModelErrorLoggingPlugin/
-// ToolErrorLoggingPlugin, but those classes only exist in the current
-// model-errors-strands.ts/tool-errors-strands.ts templates — an existing
-// workspace's already-generated copies (vended with `KeepExisting`, so never
-// overwritten by re-running the generator) still have only the plain
-// logModelErrors/logToolErrors functions. Without these, the AG-UI index.ts
-// patch above would reference undefined classes. Anchored on the
-// `agent.addHook(AfterXCallEvent, ...)` call so this doesn't re-match its own
-// output (the delegating one-liner it produces contains no such call).
+// The AGUI_INDEX_*/AGENT_TS_PLUGINS_CONSTRUCTOR_PATTERN patterns above
+// reference ModelErrorLoggingPlugin/ToolErrorLoggingPlugin, but those classes
+// only exist in the current model-errors-strands.ts/tool-errors-strands.ts
+// templates — an existing workspace's already-generated copies (vended with
+// `KeepExisting`, so never overwritten by re-running the generator) still
+// have only the plain logModelErrors/logToolErrors functions. Without these,
+// the AG-UI/HTTP/A2A rewrites above would reference undefined classes. The
+// plain functions are dropped entirely (not kept as a delegating wrapper) —
+// every call site is migrated to the plugin classes directly, so nothing
+// references them any more. Anchored on the `agent.addHook(AfterXCallEvent,
+// ...)` call so this doesn't re-match its own output (the class it produces
+// contains no such top-level call).
 const MODEL_ERRORS_IMPORT_PATTERN =
   "`import { AfterModelCallEvent, type LocalAgent } from '@strands-agents/sdk';` => `import { AfterModelCallEvent, type LocalAgent, type Plugin } from '@strands-agents/sdk';`";
 const MODEL_ERRORS_CLASS_PATTERN =
-  "`export const logModelErrors = (agent: LocalAgent): void => { agent.addHook(AfterModelCallEvent, $callback); };` => raw`export class ModelErrorLoggingPlugin implements Plugin {\n  readonly name = 'model-error-logging';\n\n  initAgent(agent: LocalAgent): void {\n    agent.addHook(AfterModelCallEvent, $callback);\n  }\n}\n\nexport const logModelErrors = (agent: LocalAgent): void =>\n  new ModelErrorLoggingPlugin().initAgent(agent);`";
+  "`export const logModelErrors = (agent: LocalAgent): void => { agent.addHook(AfterModelCallEvent, $callback); };` => raw`export class ModelErrorLoggingPlugin implements Plugin {\n  readonly name = 'model-error-logging';\n\n  initAgent(agent: LocalAgent): void {\n    agent.addHook(AfterModelCallEvent, $callback);\n  }\n}`";
 
 const TOOL_ERRORS_IMPORT_PATTERN =
   "`import { AfterToolCallEvent, type LocalAgent, TextBlock } from '@strands-agents/sdk';` => `import { AfterToolCallEvent, type LocalAgent, type Plugin, TextBlock } from '@strands-agents/sdk';`";
 const TOOL_ERRORS_CLASS_PATTERN =
-  "`export const logToolErrors = (agent: LocalAgent): void => { agent.addHook(AfterToolCallEvent, $callback); };` => raw`export class ToolErrorLoggingPlugin implements Plugin {\n  readonly name = 'tool-error-logging';\n\n  initAgent(agent: LocalAgent): void {\n    agent.addHook(AfterToolCallEvent, $callback);\n  }\n}\n\nexport const logToolErrors = (agent: LocalAgent): void =>\n  new ToolErrorLoggingPlugin().initAgent(agent);`";
+  "`export const logToolErrors = (agent: LocalAgent): void => { agent.addHook(AfterToolCallEvent, $callback); };` => raw`export class ToolErrorLoggingPlugin implements Plugin {\n  readonly name = 'tool-error-logging';\n\n  initAgent(agent: LocalAgent): void {\n    agent.addHook(AfterToolCallEvent, $callback);\n  }\n}`";
 
 export default async function migration(
   tree: Tree,
@@ -378,16 +403,27 @@ export default async function migration(
         }
       }
 
-      // Leaves the existing import's specifier list untouched (rather than
-      // requiring it to be exactly `{ logModelErrors, logToolErrors }`) and
-      // just appends a new import statement after it, since a connection
-      // generator may have merged its own client import into the same
-      // statement via addDestructuredImport.
+      // Merges ModelErrorLoggingPlugin/ToolErrorLoggingPlugin into the same
+      // import clause as the existing logModelErrors/logToolErrors specifiers
+      // (rather than adding a redundant second import statement for the same
+      // module — mirrors AGUI_INDEX_IMPORT_PATTERN's approach for AG-UI), and
+      // adds getSessionManager as its own import line since it comes from a
+      // different module (the sibling session.ts). Generic over `$names`
+      // (rather than requiring an exact 2-specifier import) since a
+      // connection generator may have merged its own client import into the
+      // same statement via addDestructuredImport. Both are added together,
+      // guarded by a single check: this migration is what introduces both, so
+      // a legacy agent.ts either has neither yet or (after this same run)
+      // both — there's no shipped prior version of this migration that could
+      // have added one without the other. The old logModelErrors/
+      // logToolErrors specifiers are stripped out separately below (via
+      // AGENT_TS_REMOVE_LOG_ERRORS_IMPORT_PATTERN) — this must happen after,
+      // since it's what this rewrite anchors on.
       const esm = isEsmWorkspace(tree);
       await applyGritQL(
         tree,
         filePath,
-        `\`import { $names } from '$mod';\` => raw\`import { $names } from '$mod';
+        `\`import { $names } from '$mod';\` => raw\`import { ModelErrorLoggingPlugin, ToolErrorLoggingPlugin, $names } from '$mod';
 import { getSessionManager } from './session${esm ? '.js' : ''}';\` where { $names <: contains \`logModelErrors\`, $names <: contains \`logToolErrors\`, $program <: not contains \`getSessionManager\` }`,
       );
 
@@ -400,14 +436,32 @@ import { getSessionManager } from './session${esm ? '.js' : ''}';\` where { $nam
         continue;
       }
 
+      // Moves the model/tool error logging hooks from imperative calls to
+      // Agent constructor plugins (see AGENT_TS_PLUGINS_CONSTRUCTOR_PATTERN),
+      // then removes the now-unused logModelErrors/logToolErrors specifiers
+      // (preserving any merged connection-generator import — see
+      // AGENT_TS_REMOVE_LOG_ERRORS_IMPORT_PATTERN's comment).
+      await applyGritQL(tree, filePath, AGENT_TS_LOG_MODEL_CALL_PATTERN);
+      await applyGritQL(tree, filePath, AGENT_TS_LOG_TOOL_CALL_PATTERN);
+      await applyGritQL(
+        tree,
+        filePath,
+        AGENT_TS_REMOVE_LOG_ERRORS_IMPORT_PATTERN,
+      );
+
+      const rewrotePlugins = await applyGritQL(
+        tree,
+        filePath,
+        AGENT_TS_PLUGINS_CONSTRUCTOR_PATTERN,
+      );
       const rewroteConstructor = await applyGritQL(
         tree,
         filePath,
         AGENT_TS_SESSION_MANAGER_CONSTRUCTOR_PATTERN,
       );
-      if (rewroteConstructor) {
+      if (rewrotePlugins || rewroteConstructor) {
         nextSteps.push(
-          `${filePath}: wired sessionManager into the Agent constructor (see ${sessionPath}).`,
+          `${filePath}: wired sessionManager and the error-logging plugins into the Agent constructor (see ${sessionPath}).`,
         );
         anyChanges = true;
       }
@@ -553,16 +607,12 @@ import { getSessionManager } from './session${esm ? '.js' : ''}';\` where { $nam
         continue;
       }
       // Each rewrite is attempted independently (not short-circuited) since
-      // a single file may match more than one shape.
+      // a single file may match more than one shape. Only the 'agentcore'
+      // namespace is reshaped here — see CDK_RC_SET_PATTERN's comment.
       const rewroteAgentcoreRcSet = await applyGritQL(
         tree,
         filePath,
-        cdkRcSetPattern('agentcore'),
-      );
-      const rewroteConnectionRcSet = await applyGritQL(
-        tree,
-        filePath,
-        cdkRcSetPattern('connection'),
+        CDK_RC_SET_PATTERN,
       );
       const rewroteInterface = await applyGritQL(
         tree,
@@ -575,21 +625,10 @@ import { getSessionManager } from './session${esm ? '.js' : ''}';\` where { $nam
           ? true
           : rewroteClientArn;
       }
-      const rewroteDuckTyping = await applyGritQL(
-        tree,
-        filePath,
-        REACT_DUCK_TYPING_PATTERN,
-      );
 
-      if (
-        rewroteAgentcoreRcSet ||
-        rewroteConnectionRcSet ||
-        rewroteInterface ||
-        rewroteClientArn ||
-        rewroteDuckTyping
-      ) {
+      if (rewroteAgentcoreRcSet || rewroteInterface || rewroteClientArn) {
         nextSteps.push(
-          `${filePath}: reshaped agentRuntimes entries to { arn, session }.`,
+          `${filePath}: reshaped agentRuntimes entries to { arn }.`,
         );
         anyChanges = true;
       }
@@ -601,7 +640,7 @@ import { getSessionManager } from './session${esm ? '.js' : ''}';\` where { $nam
       const rewrote = await applyGritQL(tree, filePath, TF_VALUE_PATTERN);
       if (rewrote) {
         nextSteps.push(
-          `${filePath}: reshaped agentRuntimes entries to { arn, session }.`,
+          `${filePath}: reshaped agentRuntimes entries to { arn }.`,
         );
         anyChanges = true;
       }
@@ -613,7 +652,7 @@ import { getSessionManager } from './session${esm ? '.js' : ''}';\` where { $nam
       const rewrote = await applyGritQL(tree, filePath, PY_CLIENT_ARN_PATTERN);
       if (rewrote) {
         nextSteps.push(
-          `${filePath}: reshaped agentRuntimes entries to { arn, session }.`,
+          `${filePath}: reshaped agentRuntimes entries to { arn }.`,
         );
         anyChanges = true;
       }
@@ -624,7 +663,7 @@ import { getSessionManager } from './session${esm ? '.js' : ''}';\` where { $nam
     nextSteps.push(
       'If you have custom code reading agentRuntimes entries as plain ARN strings ' +
         '(e.g. custom Lambda handlers or agent code), update it to read the ARN from `.arn` ' +
-        'on the new `{ arn, session }` shape.',
+        'on the new `{ arn }` shape.',
     );
   }
 

--- a/packages/nx-plugin/src/migrations/latest/ts-agent-session-management-support/migration.ts
+++ b/packages/nx-plugin/src/migrations/latest/ts-agent-session-management-support/migration.ts
@@ -100,6 +100,13 @@ const TS_CLIENT_ARN_PATTERNS = [
   '`config?.agentRuntimes?.[$name]` => `config?.agentRuntimes?.[$name]?.arn` where { $program <: not contains `config?.agentRuntimes?.[$name]?.arn` }',
 ];
 
+// The agent-chat CLI's agentcore.ts calls `getAppConfig` directly rather than
+// the shared `AgentCoreRuntimeConfig` type, so its own inline cast needs the
+// same { arn } reshape TS_RUNTIME_CONFIG_INTERFACE_PATTERN gives the shared
+// interface.
+const AGENTCORE_CHAT_SCRIPT_TYPE_PATTERN =
+  '`{ agentRuntimes?: Record<string, string> }` => `{ agentRuntimes?: Record<string, { arn: string }> }`';
+
 // Python equivalent (Strands + LangChain client templates).
 const PY_CLIENT_ARN_PATTERN =
   'language python\n`agent_runtime_arn = config.get("agentRuntimes", {}).get($name)` => `agent_runtime = config.get("agentRuntimes", {}).get($name)\nagent_runtime_arn = agent_runtime.get("arn") if agent_runtime else None`';
@@ -685,8 +692,18 @@ import { getSessionManager } from './session${esm ? '.js' : ''}';\` where { $nam
           ? true
           : rewroteClientArn;
       }
+      const rewroteChatScriptType = await applyGritQL(
+        tree,
+        filePath,
+        AGENTCORE_CHAT_SCRIPT_TYPE_PATTERN,
+      );
 
-      if (rewroteAgentcoreRcSet || rewroteInterface || rewroteClientArn) {
+      if (
+        rewroteAgentcoreRcSet ||
+        rewroteInterface ||
+        rewroteClientArn ||
+        rewroteChatScriptType
+      ) {
         anyChanges = true;
       }
     } else if (filePath.endsWith('.tf')) {

--- a/packages/nx-plugin/src/migrations/latest/ts-agent-session-management-support/migration.ts
+++ b/packages/nx-plugin/src/migrations/latest/ts-agent-session-management-support/migration.ts
@@ -30,10 +30,10 @@ import { kebabCase } from '../../../utils/names';
  *   migration wrote are formatted correctly.
  */
 
-// Existing agents predate session management support, so migrate them to 'none'
-// rather than opting them into a persisted session behind their back.
-// MCP servers have no session regardless.
-const LEGACY_SESSION_STORAGE = 'none';
+// Existing agents predate session management support, so migrate them to
+// 'in-memory' rather than opting them into a persisted session behind their
+// back. MCP servers have no session regardless.
+const LEGACY_SESSION_STORAGE = 'in-memory';
 
 // Matches `rc.set('<namespace>', 'agentRuntimes', { ...rc.get('<namespace>').agentRuntimes, $name: this.agentCoreRuntime.agentRuntimeArn });`
 // as vended by the CDK agent-core construct (for both the 'agentcore' and the
@@ -61,7 +61,7 @@ const TS_RUNTIME_CONFIG_INTERFACE_PATTERN = `\`export interface AgentCoreRuntime
   agentRuntimes?: Record<string, string>;
   gateways?: Record<string, string>;
 }\` => raw\`export interface AgentRuntimeSession {
-  storage: 's3' | 'none';
+  storage: 's3' | 'in-memory';
   /** Name of the S3 bucket storing session data. Only set when storage is 's3'. */
   bucketName?: string;
 }
@@ -162,7 +162,7 @@ const AGENT_TS_REMOVE_LOG_ERRORS_IMPORT_PATTERN =
   "`import $clause from '$mod';` as $import where { $clause <: import_clause(name=named_imports($imports)), $imports <: contains `logModelErrors`, $imports <: contains `logToolErrors`, if ($imports <: [`logModelErrors`, `logToolErrors`]) { $import => . } else { $imports <: some import_specifier(name=or { `logModelErrors`, `logToolErrors` }) => . } }";
 
 // Existing agents predate session.ts entirely, so there is no prior
-// session storage to preserve here — this mirrors LEGACY_SESSION_STORAGE ('none').
+// session storage to preserve here — this mirrors LEGACY_SESSION_STORAGE ('in-memory').
 const legacySessionManagerContent = (
   agentConnectionModule: string,
   localSessionsDir: string,

--- a/packages/nx-plugin/src/migrations/latest/ts-agent-session-management-support/migration.ts
+++ b/packages/nx-plugin/src/migrations/latest/ts-agent-session-management-support/migration.ts
@@ -267,51 +267,61 @@ const AGUI_INDEX_SESSION_MANAGER_CONSTRUCTOR_PATTERN = `${AGUI_INDEX_SESSION_MAN
 
 // The plugin classes referenced above only exist once model-errors-strands.ts
 // / tool-errors-strands.ts are converted from their plain logXErrors function
-// form (see ensurePluginClass below). Anchored on the `agent.addHook(...)`
-// call so this doesn't re-match its own output.
+// form (see checkPluginClass/applyPluginClass below). Anchored on the
+// `agent.addHook(...)` call so this doesn't re-match its own output.
 const MODEL_ERRORS_IMPORT_PATTERN =
   "`import { AfterModelCallEvent, type LocalAgent } from '@strands-agents/sdk';` => `import { AfterModelCallEvent, type LocalAgent, type Plugin } from '@strands-agents/sdk';`";
-const MODEL_ERRORS_CLASS_PATTERN =
-  "`export const logModelErrors = (agent: LocalAgent): void => { agent.addHook(AfterModelCallEvent, $callback); };` => raw`export class ModelErrorLoggingPlugin implements Plugin {\n  readonly name = 'model-error-logging';\n\n  initAgent(agent: LocalAgent): void {\n    agent.addHook(AfterModelCallEvent, $callback);\n  }\n}`";
+// Match-only form of the target shape, checked before committing to either
+// this or the sibling tool-errors conversion — see checkPluginClass.
+const MODEL_ERRORS_CLASS_MATCH_PATTERN =
+  '`export const logModelErrors = (agent: LocalAgent): void => { agent.addHook(AfterModelCallEvent, $callback); };`';
+const MODEL_ERRORS_CLASS_PATTERN = `${MODEL_ERRORS_CLASS_MATCH_PATTERN} => raw\`export class ModelErrorLoggingPlugin implements Plugin {\n  readonly name = 'model-error-logging';\n\n  initAgent(agent: LocalAgent): void {\n    agent.addHook(AfterModelCallEvent, $callback);\n  }\n}\``;
 
 const TOOL_ERRORS_IMPORT_PATTERN =
   "`import { AfterToolCallEvent, type LocalAgent, TextBlock } from '@strands-agents/sdk';` => `import { AfterToolCallEvent, type LocalAgent, type Plugin, TextBlock } from '@strands-agents/sdk';`";
-const TOOL_ERRORS_CLASS_PATTERN =
-  "`export const logToolErrors = (agent: LocalAgent): void => { agent.addHook(AfterToolCallEvent, $callback); };` => raw`export class ToolErrorLoggingPlugin implements Plugin {\n  readonly name = 'tool-error-logging';\n\n  initAgent(agent: LocalAgent): void {\n    agent.addHook(AfterToolCallEvent, $callback);\n  }\n}`";
+const TOOL_ERRORS_CLASS_MATCH_PATTERN =
+  '`export const logToolErrors = (agent: LocalAgent): void => { agent.addHook(AfterToolCallEvent, $callback); };`';
+const TOOL_ERRORS_CLASS_PATTERN = `${TOOL_ERRORS_CLASS_MATCH_PATTERN} => raw\`export class ToolErrorLoggingPlugin implements Plugin {\n  readonly name = 'tool-error-logging';\n\n  initAgent(agent: LocalAgent): void {\n    agent.addHook(AfterToolCallEvent, $callback);\n  }\n}\``;
+
+type PluginClassStatus = 'ready' | 'done' | 'diverged';
 
 /**
- * Converts a plain `logXErrors` function into its `XErrorLoggingPlugin` class
- * if it still has the generated shape. Returns whether the class is present
- * (freshly converted or already done) — false only when diverged, reported
- * via `nextSteps` here so callers can silently skip their own wiring.
+ * Checks (without writing) whether `filePath` still needs converting from its
+ * plain `logXErrors` function to `className`, and whether the conversion
+ * pattern would actually apply. `'done'` covers both "already converted" and
+ * "file doesn't exist" — either way there's nothing to do and nothing
+ * blocking the sibling conversion.
  */
-async function ensurePluginClass(
+async function checkPluginClass(
   tree: Tree,
-  nextSteps: string[],
   filePath: string,
   className: string,
-  importPattern: string,
-  classPattern: string,
-): Promise<boolean> {
+  classMatchPattern: string,
+): Promise<PluginClassStatus> {
   if (!tree.exists(filePath)) {
-    return true;
+    return 'done';
   }
   if ((tree.read(filePath, 'utf-8') ?? '').includes(`class ${className}`)) {
-    return true;
+    return 'done';
   }
+  return (await matchGritQL(tree, filePath, classMatchPattern))
+    ? 'ready'
+    : 'diverged';
+}
 
-  // Only add the `Plugin` type import once the class rewrite is confirmed to
-  // apply, so a diverged file isn't left with an unused import and no class.
-  const rewroteClass = await applyGritQL(tree, filePath, classPattern);
-
-  if (!rewroteClass) {
-    nextSteps.push(
-      `${filePath}: diverged from the generated shape - left as-is. Manually convert it to a \`${className}\` class implementing \`Plugin\` (see the ts#agent generator's template); agent.ts/index.ts files that reference \`${className}\` are left unmigrated until this exists.`,
-    );
-    return false;
-  }
+/** Applies the class + import rewrite for a file already confirmed `'ready'`. */
+async function applyPluginClass(
+  tree: Tree,
+  filePath: string,
+  importPattern: string,
+  classPattern: string,
+): Promise<void> {
+  // The class rewrite is applied first, and the import only added once it's
+  // confirmed to have actually happened here — not because either could fail
+  // at this point (checkPluginClass already confirmed the pattern matches),
+  // but to keep this file's own edit order self-evidently safe to read.
+  await applyGritQL(tree, filePath, classPattern);
   await applyGritQL(tree, filePath, importPattern);
-  return true;
 }
 
 export default async function migration(
@@ -334,23 +344,52 @@ export default async function migration(
     'core',
     'tool-errors-strands.ts',
   );
-  const modelPluginReady = await ensurePluginClass(
+  // Checked together, before writing either: all-or-nothing, so a run either
+  // converts both or leaves both untouched — never just one.
+  const modelPluginStatus = await checkPluginClass(
     tree,
-    nextSteps,
     modelErrorsPath,
     'ModelErrorLoggingPlugin',
-    MODEL_ERRORS_IMPORT_PATTERN,
-    MODEL_ERRORS_CLASS_PATTERN,
+    MODEL_ERRORS_CLASS_MATCH_PATTERN,
   );
-  const toolPluginReady = await ensurePluginClass(
+  const toolPluginStatus = await checkPluginClass(
     tree,
-    nextSteps,
     toolErrorsPath,
     'ToolErrorLoggingPlugin',
-    TOOL_ERRORS_IMPORT_PATTERN,
-    TOOL_ERRORS_CLASS_PATTERN,
+    TOOL_ERRORS_CLASS_MATCH_PATTERN,
   );
-  const pluginsReady = modelPluginReady && toolPluginReady;
+  const pluginsReady =
+    modelPluginStatus !== 'diverged' && toolPluginStatus !== 'diverged';
+
+  if (pluginsReady) {
+    if (modelPluginStatus === 'ready') {
+      await applyPluginClass(
+        tree,
+        modelErrorsPath,
+        MODEL_ERRORS_IMPORT_PATTERN,
+        MODEL_ERRORS_CLASS_PATTERN,
+      );
+    }
+    if (toolPluginStatus === 'ready') {
+      await applyPluginClass(
+        tree,
+        toolErrorsPath,
+        TOOL_ERRORS_IMPORT_PATTERN,
+        TOOL_ERRORS_CLASS_PATTERN,
+      );
+    }
+  } else {
+    if (modelPluginStatus === 'diverged') {
+      nextSteps.push(
+        `${modelErrorsPath}: diverged from the generated shape - left as-is. Manually convert it to a \`ModelErrorLoggingPlugin\` class implementing \`Plugin\` (see the ts#agent generator's template); agent.ts/index.ts files that reference it are left unmigrated until both this and ${toolErrorsPath} are converted.`,
+      );
+    }
+    if (toolPluginStatus === 'diverged') {
+      nextSteps.push(
+        `${toolErrorsPath}: diverged from the generated shape - left as-is. Manually convert it to a \`ToolErrorLoggingPlugin\` class implementing \`Plugin\` (see the ts#agent generator's template); agent.ts/index.ts files that reference it are left unmigrated until both this and ${modelErrorsPath} are converted.`,
+      );
+    }
+  }
 
   const filePaths: string[] = [];
   visitNotIgnoredFiles(tree, '', (filePath) => filePaths.push(filePath));

--- a/packages/nx-plugin/src/migrations/latest/ts-agent-session-management-support/migration.ts
+++ b/packages/nx-plugin/src/migrations/latest/ts-agent-session-management-support/migration.ts
@@ -1,0 +1,603 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import {
+  getProjects,
+  joinPathFragments,
+  type MigrationReturnObject,
+  type Tree,
+  visitNotIgnoredFiles,
+} from '@nx/devkit';
+import { applyGritQL, captureGritQL, matchGritQL } from '../../../utils/ast';
+import { formatFilesInSubtree } from '../../../utils/format';
+import { isEsmWorkspace } from '../../../utils/module-format';
+
+/**
+ * Add session management support to ts#agent.
+ *
+ * How to write a migration:
+ * - https://nx.dev/docs/kb/migration-generators
+ * - What `nextSteps` means: https://nx.dev/docs/reference/devkit/MigrationReturnObject
+ *
+ * Guardrails:
+ * - Pattern-match before writing: skip files that have diverged from the shape
+ *   your generators produce and report them via `nextSteps`, or consider a
+ *   hybrid migration, rather than clobbering the user's changes.
+ * - Idempotent: re-running must be a no-op.
+ * - Format what you write: finish with `formatFilesInSubtree` so the files your
+ *   migration wrote are formatted correctly.
+ */
+
+// Existing agents predate session management support, so migrate them to 'none'
+// rather than opting them into a persisted session behind their back.
+// MCP servers have no session regardless.
+const LEGACY_SESSION_STORAGE = 'none';
+
+// Matches `rc.set('<namespace>', 'agentRuntimes', { ...rc.get('<namespace>').agentRuntimes, $name: this.agentCoreRuntime.agentRuntimeArn });`
+// as vended by the CDK agent-core construct (for both the 'agentcore' and the
+// connection-generator-patched 'connection' namespace). Naturally idempotent:
+// once migrated, `$name`'s value is a `{ arn, session }` object rather than
+// `this.agentCoreRuntime.agentRuntimeArn` directly, so this no longer matches.
+const cdkRcSetPattern = (namespace: 'agentcore' | 'connection') =>
+  `\`rc.set('${namespace}', 'agentRuntimes', { ...rc.get('${namespace}').agentRuntimes, $name: this.agentCoreRuntime.agentRuntimeArn });\` => raw\`rc.set('${namespace}', 'agentRuntimes', {
+  ...rc.get('${namespace}').agentRuntimes,
+  $name: {
+    arn: this.agentCoreRuntime.agentRuntimeArn,
+    session: { storage: '${LEGACY_SESSION_STORAGE}' },
+  },
+});\``;
+
+// Matches the equivalent `value = { "$name" = module.agent_core_runtime.agent_core_runtime_arn }`
+// line as vended by the Terraform agent-core construct, for both the
+// 'agentcore' and connection-generator-patched 'connection' modules. Naturally
+// idempotent (see cdkRcSetPattern).
+const TF_VALUE_PATTERN = `language hcl\n\`value     = { "$name" = module.agent_core_runtime.agent_core_runtime_arn }\` => \`value     = { "$name" = { arn = module.agent_core_runtime.agent_core_runtime_arn, session = { storage = "${LEGACY_SESSION_STORAGE}" } } }\``;
+
+// Exact shape of the shared `AgentCoreRuntimeConfig` interface prior to this
+// change, as vended into `packages/common/agent-connection/src/core/runtime-config.ts`.
+const TS_RUNTIME_CONFIG_INTERFACE_PATTERN = `\`export interface AgentCoreRuntimeConfig {
+  agentRuntimes?: Record<string, string>;
+  gateways?: Record<string, string>;
+}\` => raw\`export interface AgentRuntimeSession {
+  storage: 's3' | 'none';
+  /** Name of the S3 bucket storing session data. Only set when storage is 's3'. */
+  bucketName?: string;
+}
+
+export interface AgentRuntimeEntry {
+  arn: string;
+  session: AgentRuntimeSession;
+}
+
+export interface AgentCoreRuntimeConfig {
+  agentRuntimes?: Record<string, AgentRuntimeEntry>;
+  gateways?: Record<string, string>;
+}\``;
+
+// Matches `config.agentRuntimes?.['Name']` / `config?.agentRuntimes?.['Name']`
+// as read by the generated TS a2a/mcp client and agent-chat CLI templates.
+// The `where` clause guards idempotency: once `?.arn` is appended, the
+// program no longer matches the bare pre-`.arn` form so this doesn't re-fire.
+const TS_CLIENT_ARN_PATTERNS = [
+  '`config.agentRuntimes?.[$name]` => `config.agentRuntimes?.[$name]?.arn` where { $program <: not contains `config.agentRuntimes?.[$name]?.arn` }',
+  '`config?.agentRuntimes?.[$name]` => `config?.agentRuntimes?.[$name]?.arn` where { $program <: not contains `config?.agentRuntimes?.[$name]?.arn` }',
+];
+
+// Matches `agent_runtime_arn = config.get("agentRuntimes", {}).get($name)` as
+// read by the generated Python a2a/mcp client templates (Strands + LangChain).
+const PY_CLIENT_ARN_PATTERN =
+  'language python\n`agent_runtime_arn = config.get("agentRuntimes", {}).get($name)` => `agent_runtime = config.get("agentRuntimes", {}).get($name)\nagent_runtime_arn = agent_runtime.get("arn") if agent_runtime else None`';
+
+// Matches the `$val.startsWith('arn:') ? $fn($val) : $val` duck-typing used by
+// the generated React trpc/AG-UI/OpenAPI client providers to distinguish a
+// deployed runtime ARN from a local-dev override URL. Generic over the
+// value/build-function identifiers so it covers all three providers.
+// Naturally idempotent (the rewritten form no longer contains `.startsWith('arn:')`).
+const REACT_DUCK_TYPING_PATTERN =
+  "`$val.startsWith('arn:') ? $fn($val) : $val` => `typeof $val === 'string' ? $val : $fn($val.arn)`";
+
+// AG-UI's adapter clones the template agent per-thread, but hooks added
+// directly to the template (as logModelErrors/logToolErrors do) are NOT
+// carried over onto those clones, so the per-thread agents would silently
+// run without error logging. Removes the (AG-UI-incompatible) import and
+// calls from an existing agent.ts — the equivalent behaviour is restored via
+// AGUI_INDEX_*_PATTERN below, which wires the same logic in as StrandsAgent
+// plugins instead (plugins are applied to each per-thread agent via
+// initAgent). Naturally idempotent (nothing to match once removed).
+//
+// A connection generator (mcp-connection/a2a-connection) may have merged its
+// own client import into this same import statement via addDestructuredImport
+// (which only ever appends), so logModelErrors/logToolErrors won't always be
+// the only two specifiers — three patterns cover: exactly the two of them
+// (delete the whole statement), the two of them followed by others (keep the
+// rest), and — defensively, though addDestructuredImport never produces this
+// ordering — others followed by the two of them.
+const AGENT_TS_LOG_IMPORT_PATTERNS = [
+  "`import { logModelErrors, logToolErrors } from '$module';` => .",
+  "`import { logModelErrors, logToolErrors, $rest } from '$module';` => `import { $rest } from '$module';`",
+  "`import { $rest, logModelErrors, logToolErrors } from '$module';` => `import { $rest } from '$module';`",
+];
+const AGENT_TS_LOG_MODEL_CALL_PATTERN = '`logModelErrors(agent);` => .';
+const AGENT_TS_LOG_TOOL_CALL_PATTERN = '`logToolErrors(agent);` => .';
+
+// AG-UI is the only protocol whose index.ts imports from '@ag-ui/aws-strands'
+// (see files/ag-ui/index.ts.template), so that's a reliable signal that the
+// sibling agent.ts belongs to an AG-UI agent.
+const isAgUiAgentDir = (tree: Tree, agentTsPath: string): boolean => {
+  const dir = agentTsPath.split('/').slice(0, -1).join('/');
+  const indexTsPath = `${dir}/index.ts`;
+  const indexContents = tree.read(indexTsPath, 'utf-8') ?? '';
+  return indexContents.includes('@ag-ui/aws-strands');
+};
+
+// HTTP/A2A agents (unlike AG-UI) construct one Agent per session via
+// `withSessionId(getAgent)`, so wiring `sessionManager` directly into
+// `getAgent`'s `new Agent({ ... })` call is safe. Generic over `$props`
+// (the object literal's own property list) so this applies regardless of how
+// the user has customised systemPrompt/tools — only requires the props to be
+// passed as an inline object literal (not a variable). `sessionManager` is
+// prepended rather than appended: `$props` is captured as raw source text and
+// commonly ends with prettier's trailing comma, so appending `, sessionManager: ...`
+// after it would produce a double comma (invalid syntax); prepending before
+// `$props` sidesteps that entirely, and `formatFilesInSubtree` reformats the
+// result cleanly regardless of property order. Naturally idempotent via the
+// `not contains sessionManager` guard.
+const AGENT_TS_SESSION_MANAGER_CONSTRUCTOR_PATTERN =
+  '`new Agent({ $props })` => `new Agent({ sessionManager: await getSessionManager(), $props })` where { $props <: not contains `sessionManager` }';
+
+// Captures the agent-connection package specifier from the existing
+// logModelErrors/logToolErrors import so the new getSessionManager import
+// (and the fresh session.ts this migration creates) target the same
+// module, without needing to know the workspace's npm scope directly. Generic
+// over `$names` (rather than requiring an exact 2-specifier import) since a
+// connection generator (mcp-connection/a2a-connection) may have merged its
+// own client import into this same statement via addDestructuredImport.
+const AGENT_TS_LOG_IMPORT_CAPTURE_PATTERN =
+  "`import { $names } from '$mod';` where { $names <: contains `logModelErrors`, $names <: contains `logToolErrors` }";
+
+// Existing agents predate session.ts entirely, so there is no prior
+// session type to preserve here — this mirrors LEGACY_SESSION_TYPE ('none').
+const legacySessionManagerContent = (
+  agentConnectionModule: string,
+  localSessionsDir: string,
+): string => `import { SessionManager } from '@strands-agents/sdk';
+import { InMemoryStorage, LocalFileStorage } from '@strands-agents/sdk/storage';
+import { getCurrentSessionId } from '${agentConnectionModule}';
+
+/**
+ * Returns a SessionManager for persisting conversation state across
+ * invocations. Local development always uses local file storage for
+ * convenience, regardless of the configured session option. Without a
+ * configured session option, conversation state is kept in memory only and
+ * does not survive process restarts.
+ */
+export const getSessionManager = async (): Promise<SessionManager> => {
+  const sessionId = getCurrentSessionId();
+  if (!sessionId) {
+    throw new Error(
+      'No current session id — cannot resolve a SessionManager outside of a request scope.',
+    );
+  }
+  if (process.env.LOCAL_DEV === 'true') {
+    return new SessionManager({
+      sessionId,
+      storage: new LocalFileStorage('${localSessionsDir}'),
+    });
+  }
+  return new SessionManager({ sessionId, storage: new InMemoryStorage() });
+};
+`;
+
+/** The relative path from `dirPath` up to the root of its owning Nx project. */
+const findOwningProjectRoot = (
+  tree: Tree,
+  dirPath: string,
+): string | undefined => {
+  let best: string | undefined;
+  for (const project of getProjects(tree).values()) {
+    if (
+      (dirPath === project.root || dirPath.startsWith(`${project.root}/`)) &&
+      (!best || project.root.length > best.length)
+    ) {
+      best = project.root;
+    }
+  }
+  return best;
+};
+
+/** The relative path from `projectRoot` up to the workspace root's local session storage. */
+const localSessionsDirFor = (projectRoot: string): string => {
+  const depth = projectRoot.split('/').filter(Boolean).length;
+  return joinPathFragments(
+    Array(depth).fill('..').join('/'),
+    'tmp/agentCore/agentRuntimes/sessions',
+  );
+};
+
+// Adds the ModelErrorLoggingPlugin/ToolErrorLoggingPlugin import (generic over
+// the agent-connection package's npm scope) and wires them into the
+// StrandsAgent constructor, restoring the error-logging behaviour removed
+// from agent.ts above. Naturally idempotent.
+const AGUI_INDEX_IMPORT_PATTERN =
+  "`import { $names } from '$mod'` => `import { ModelErrorLoggingPlugin, ToolErrorLoggingPlugin, $names } from '$mod'` where { $names <: contains `runWithSessionId`, $names <: not contains `ModelErrorLoggingPlugin` }";
+const AGUI_INDEX_CONSTRUCTOR_PATTERN =
+  '`new StrandsAgent({ agent, name: $name, description: $desc })` => `new StrandsAgent({ agent, name: $name, description: $desc, plugins: [new ModelErrorLoggingPlugin(), new ToolErrorLoggingPlugin()] })`';
+
+// Captures the same agent-connection package specifier via index.ts's
+// existing runWithSessionId import, for the same reason as
+// AGENT_TS_LOG_IMPORT_CAPTURE_PATTERN above.
+const AGUI_INDEX_IMPORT_CAPTURE_PATTERN =
+  "`import { $names } from '$mod';` where { $names <: contains `runWithSessionId` }";
+
+// AG-UI's StrandsAgent adapter also needs a sessionManagerProvider (called
+// once per threadId) to persist conversation state, mirroring
+// AGENT_TS_SESSION_MANAGER_CONSTRUCTOR_PATTERN's role for HTTP/A2A agents.
+// Anchored on the literal `getAgent` import, which every ts#agent index.ts has.
+const aguiIndexSessionManagerImportPattern = (esm: boolean) =>
+  `\`import { getAgent } from '$mod';\` => raw\`import { getAgent } from '$mod';
+import { getSessionManager } from './session${esm ? '.js' : ''}';\` where { $program <: not contains \`getSessionManager\` }`;
+// Anchored on the exact 4-property shape AGUI_INDEX_CONSTRUCTOR_PATTERN
+// produces, so this only fires once plugins have been wired in, and stops
+// matching once config is added (naturally idempotent). Used both to gate
+// (via matchGritQL, before creating session.ts) and to rewrite.
+const AGUI_INDEX_SESSION_MANAGER_MATCH_PATTERN =
+  '`new StrandsAgent({ agent, name: $name, description: $desc, plugins: $plugins })`';
+const AGUI_INDEX_SESSION_MANAGER_CONSTRUCTOR_PATTERN = `${AGUI_INDEX_SESSION_MANAGER_MATCH_PATTERN} => \`new StrandsAgent({ agent, name: $name, description: $desc, plugins: $plugins, config: { sessionManagerProvider: getSessionManager } })\``;
+
+// The AGUI_INDEX_* patterns above reference ModelErrorLoggingPlugin/
+// ToolErrorLoggingPlugin, but those classes only exist in the current
+// model-errors-strands.ts/tool-errors-strands.ts templates — an existing
+// workspace's already-generated copies (vended with `KeepExisting`, so never
+// overwritten by re-running the generator) still have only the plain
+// logModelErrors/logToolErrors functions. Without these, the AG-UI index.ts
+// patch above would reference undefined classes. Anchored on the
+// `agent.addHook(AfterXCallEvent, ...)` call so this doesn't re-match its own
+// output (the delegating one-liner it produces contains no such call).
+const MODEL_ERRORS_IMPORT_PATTERN =
+  "`import { AfterModelCallEvent, type LocalAgent } from '@strands-agents/sdk';` => `import { AfterModelCallEvent, type LocalAgent, type Plugin } from '@strands-agents/sdk';`";
+const MODEL_ERRORS_CLASS_PATTERN =
+  "`export const logModelErrors = (agent: LocalAgent): void => { agent.addHook(AfterModelCallEvent, $callback); };` => raw`export class ModelErrorLoggingPlugin implements Plugin {\n  readonly name = 'model-error-logging';\n\n  initAgent(agent: LocalAgent): void {\n    agent.addHook(AfterModelCallEvent, $callback);\n  }\n}\n\nexport const logModelErrors = (agent: LocalAgent): void =>\n  new ModelErrorLoggingPlugin().initAgent(agent);`";
+
+const TOOL_ERRORS_IMPORT_PATTERN =
+  "`import { AfterToolCallEvent, type LocalAgent, TextBlock } from '@strands-agents/sdk';` => `import { AfterToolCallEvent, type LocalAgent, type Plugin, TextBlock } from '@strands-agents/sdk';`";
+const TOOL_ERRORS_CLASS_PATTERN =
+  "`export const logToolErrors = (agent: LocalAgent): void => { agent.addHook(AfterToolCallEvent, $callback); };` => raw`export class ToolErrorLoggingPlugin implements Plugin {\n  readonly name = 'tool-error-logging';\n\n  initAgent(agent: LocalAgent): void {\n    agent.addHook(AfterToolCallEvent, $callback);\n  }\n}\n\nexport const logToolErrors = (agent: LocalAgent): void =>\n  new ToolErrorLoggingPlugin().initAgent(agent);`";
+
+export default async function migration(
+  tree: Tree,
+): Promise<MigrationReturnObject> {
+  const nextSteps: string[] = [];
+  let anyChanges = false;
+
+  const filePaths: string[] = [];
+  visitNotIgnoredFiles(tree, '', (filePath) => filePaths.push(filePath));
+
+  for (const filePath of filePaths) {
+    if (filePath.endsWith('.d.ts')) {
+      continue;
+    }
+
+    // session.ts (whether generator-vended or created by this
+    // migration above) already targets the new { arn, session } shape via
+    // `config.agentRuntimes?.[$name]?.session?.bucketName` — the generic
+    // reshape branch below would otherwise mis-match that expression's
+    // `config.agentRuntimes?.[$name]` prefix and corrupt it into
+    // `?.arn?.session?.bucketName`.
+    if (filePath.endsWith('/session.ts')) {
+      continue;
+    }
+
+    if (filePath.endsWith('/agent.ts') && isAgUiAgentDir(tree, filePath)) {
+      let rewroteImport = false;
+      for (const pattern of AGENT_TS_LOG_IMPORT_PATTERNS) {
+        rewroteImport = (await applyGritQL(tree, filePath, pattern))
+          ? true
+          : rewroteImport;
+      }
+      const rewroteModelCall = await applyGritQL(
+        tree,
+        filePath,
+        AGENT_TS_LOG_MODEL_CALL_PATTERN,
+      );
+      const rewroteToolCall = await applyGritQL(
+        tree,
+        filePath,
+        AGENT_TS_LOG_TOOL_CALL_PATTERN,
+      );
+      if (rewroteImport || rewroteModelCall || rewroteToolCall) {
+        nextSteps.push(
+          `${filePath}: moved the model/tool error logging hooks to StrandsAgent plugins (see the sibling index.ts).`,
+        );
+        anyChanges = true;
+      }
+      continue;
+    }
+
+    // HTTP/A2A agent.ts: wire sessionManager into the Agent constructor and
+    // create the sibling session.ts if it doesn't exist yet. Existing
+    // agents predate session.ts entirely, so (unlike the reshape
+    // patterns above) there's no "old shape" to pattern-match for the file's
+    // own existence — gate on the logModelErrors/logToolErrors import as the
+    // signal this is a ts#agent-generated agent.ts. Matched via GritQL (not a
+    // literal substring check) so this isn't fooled by prettier wrapping the
+    // import onto multiple lines (e.g. a long npm scope name). The
+    // constructor is only ever rewritten once the getSessionManager import is
+    // confirmed present, so a failed session.ts creation can never
+    // leave a dangling reference to an undefined function.
+    if (
+      filePath.endsWith('/agent.ts') &&
+      (await matchGritQL(tree, filePath, AGENT_TS_LOG_IMPORT_CAPTURE_PATTERN))
+    ) {
+      const dir = filePath.split('/').slice(0, -1).join('/');
+      const sessionPath = `${dir}/session.ts`;
+
+      if (!tree.exists(sessionPath)) {
+        const projectRoot = findOwningProjectRoot(tree, dir);
+        const capturedImport = await captureGritQL(
+          tree,
+          filePath,
+          AGENT_TS_LOG_IMPORT_CAPTURE_PATTERN,
+        );
+        const mod = capturedImport?.match(/from '([^']+)'/)?.[1];
+
+        if (projectRoot && mod) {
+          tree.write(
+            sessionPath,
+            legacySessionManagerContent(mod, localSessionsDirFor(projectRoot)),
+          );
+        } else {
+          nextSteps.push(
+            `${filePath}: could not determine the project root or agent-connection module — manually create a session.ts (see the ts#agent generator's template) and wire \`sessionManager: await getSessionManager()\` into the Agent constructor.`,
+          );
+          continue;
+        }
+      }
+
+      // Leaves the existing import's specifier list untouched (rather than
+      // requiring it to be exactly `{ logModelErrors, logToolErrors }`) and
+      // just appends a new import statement after it, since a connection
+      // generator may have merged its own client import into the same
+      // statement via addDestructuredImport.
+      const esm = isEsmWorkspace(tree);
+      await applyGritQL(
+        tree,
+        filePath,
+        `\`import { $names } from '$mod';\` => raw\`import { $names } from '$mod';
+import { getSessionManager } from './session${esm ? '.js' : ''}';\` where { $names <: contains \`logModelErrors\`, $names <: contains \`logToolErrors\`, $program <: not contains \`getSessionManager\` }`,
+      );
+
+      // Only rewrite the constructor once the import is confirmed present —
+      // either just added above, or already there from a prior partial run.
+      if (!(tree.read(filePath, 'utf-8') ?? '').includes('getSessionManager')) {
+        nextSteps.push(
+          `${filePath}: found ${sessionPath} but couldn't confirm the getSessionManager import — wire \`sessionManager: await getSessionManager()\` into the Agent constructor manually.`,
+        );
+        continue;
+      }
+
+      const rewroteConstructor = await applyGritQL(
+        tree,
+        filePath,
+        AGENT_TS_SESSION_MANAGER_CONSTRUCTOR_PATTERN,
+      );
+      if (rewroteConstructor) {
+        nextSteps.push(
+          `${filePath}: wired sessionManager into the Agent constructor (see ${sessionPath}).`,
+        );
+        anyChanges = true;
+      }
+      continue;
+    }
+
+    if (
+      filePath.endsWith('/index.ts') &&
+      (tree.read(filePath, 'utf-8') ?? '').includes('@ag-ui/aws-strands')
+    ) {
+      const rewroteImport = await applyGritQL(
+        tree,
+        filePath,
+        AGUI_INDEX_IMPORT_PATTERN,
+      );
+      const rewroteConstructor = await applyGritQL(
+        tree,
+        filePath,
+        AGUI_INDEX_CONSTRUCTOR_PATTERN,
+      );
+      if (rewroteImport || rewroteConstructor) {
+        nextSteps.push(
+          `${filePath}: wired ModelErrorLoggingPlugin/ToolErrorLoggingPlugin into the StrandsAgent constructor.`,
+        );
+        anyChanges = true;
+      }
+
+      // The StrandsAgent adapter also needs a sessionManagerProvider — create
+      // the sibling session.ts if it doesn't exist yet, same as the
+      // HTTP/A2A branch above, then wire it in once the plugins are present.
+      // Gated on the exact shape the rewrite targets, checked up front via
+      // matchGritQL, so a customised (non-standard) constructor is left
+      // entirely alone rather than creating an unused session.ts.
+      if (
+        !(await matchGritQL(
+          tree,
+          filePath,
+          AGUI_INDEX_SESSION_MANAGER_MATCH_PATTERN,
+        ))
+      ) {
+        continue;
+      }
+
+      const dir = filePath.split('/').slice(0, -1).join('/');
+      const sessionPath = `${dir}/session.ts`;
+
+      if (!tree.exists(sessionPath)) {
+        const projectRoot = findOwningProjectRoot(tree, dir);
+        const capturedImport = await captureGritQL(
+          tree,
+          filePath,
+          AGUI_INDEX_IMPORT_CAPTURE_PATTERN,
+        );
+        const mod = capturedImport?.match(/from '([^']+)'/)?.[1];
+
+        if (projectRoot && mod) {
+          tree.write(
+            sessionPath,
+            legacySessionManagerContent(mod, localSessionsDirFor(projectRoot)),
+          );
+        } else {
+          nextSteps.push(
+            `${filePath}: could not determine the project root or agent-connection module — manually create a session.ts (see the ts#agent generator's template) and wire \`config: { sessionManagerProvider: getSessionManager }\` into the StrandsAgent constructor.`,
+          );
+          continue;
+        }
+      }
+
+      const esm = isEsmWorkspace(tree);
+      await applyGritQL(
+        tree,
+        filePath,
+        aguiIndexSessionManagerImportPattern(esm),
+      );
+
+      if (!(tree.read(filePath, 'utf-8') ?? '').includes('getSessionManager')) {
+        nextSteps.push(
+          `${filePath}: found ${sessionPath} but couldn't confirm the getSessionManager import — wire \`config: { sessionManagerProvider: getSessionManager }\` into the StrandsAgent constructor manually.`,
+        );
+        continue;
+      }
+
+      const rewroteSessionManagerConstructor = await applyGritQL(
+        tree,
+        filePath,
+        AGUI_INDEX_SESSION_MANAGER_CONSTRUCTOR_PATTERN,
+      );
+      if (rewroteSessionManagerConstructor) {
+        nextSteps.push(
+          `${filePath}: wired sessionManagerProvider into the StrandsAgent constructor (see ${sessionPath}).`,
+        );
+        anyChanges = true;
+      }
+      continue;
+    }
+
+    if (filePath.endsWith('/model-errors-strands.ts')) {
+      const rewroteImport = await applyGritQL(
+        tree,
+        filePath,
+        MODEL_ERRORS_IMPORT_PATTERN,
+      );
+      const rewroteClass = await applyGritQL(
+        tree,
+        filePath,
+        MODEL_ERRORS_CLASS_PATTERN,
+      );
+      if (rewroteImport || rewroteClass) {
+        nextSteps.push(`${filePath}: added the ModelErrorLoggingPlugin class.`);
+        anyChanges = true;
+      }
+      continue;
+    }
+
+    if (filePath.endsWith('/tool-errors-strands.ts')) {
+      const rewroteImport = await applyGritQL(
+        tree,
+        filePath,
+        TOOL_ERRORS_IMPORT_PATTERN,
+      );
+      const rewroteClass = await applyGritQL(
+        tree,
+        filePath,
+        TOOL_ERRORS_CLASS_PATTERN,
+      );
+      if (rewroteImport || rewroteClass) {
+        nextSteps.push(`${filePath}: added the ToolErrorLoggingPlugin class.`);
+        anyChanges = true;
+      }
+      continue;
+    }
+
+    if (filePath.endsWith('.ts') || filePath.endsWith('.tsx')) {
+      const contents = tree.read(filePath, 'utf-8') ?? '';
+      if (!contents.includes('agentRuntimes')) {
+        continue;
+      }
+      // Each rewrite is attempted independently (not short-circuited) since
+      // a single file may match more than one shape.
+      const rewroteAgentcoreRcSet = await applyGritQL(
+        tree,
+        filePath,
+        cdkRcSetPattern('agentcore'),
+      );
+      const rewroteConnectionRcSet = await applyGritQL(
+        tree,
+        filePath,
+        cdkRcSetPattern('connection'),
+      );
+      const rewroteInterface = await applyGritQL(
+        tree,
+        filePath,
+        TS_RUNTIME_CONFIG_INTERFACE_PATTERN,
+      );
+      let rewroteClientArn = false;
+      for (const pattern of TS_CLIENT_ARN_PATTERNS) {
+        rewroteClientArn = (await applyGritQL(tree, filePath, pattern))
+          ? true
+          : rewroteClientArn;
+      }
+      const rewroteDuckTyping = await applyGritQL(
+        tree,
+        filePath,
+        REACT_DUCK_TYPING_PATTERN,
+      );
+
+      if (
+        rewroteAgentcoreRcSet ||
+        rewroteConnectionRcSet ||
+        rewroteInterface ||
+        rewroteClientArn ||
+        rewroteDuckTyping
+      ) {
+        nextSteps.push(
+          `${filePath}: reshaped agentRuntimes entries to { arn, session }.`,
+        );
+        anyChanges = true;
+      }
+    } else if (filePath.endsWith('.tf')) {
+      const contents = tree.read(filePath, 'utf-8') ?? '';
+      if (!contents.includes('"agentRuntimes"')) {
+        continue;
+      }
+      const rewrote = await applyGritQL(tree, filePath, TF_VALUE_PATTERN);
+      if (rewrote) {
+        nextSteps.push(
+          `${filePath}: reshaped agentRuntimes entries to { arn, session }.`,
+        );
+        anyChanges = true;
+      }
+    } else if (filePath.endsWith('.py')) {
+      const contents = tree.read(filePath, 'utf-8') ?? '';
+      if (!contents.includes('agentRuntimes')) {
+        continue;
+      }
+      const rewrote = await applyGritQL(tree, filePath, PY_CLIENT_ARN_PATTERN);
+      if (rewrote) {
+        nextSteps.push(
+          `${filePath}: reshaped agentRuntimes entries to { arn, session }.`,
+        );
+        anyChanges = true;
+      }
+    }
+  }
+
+  if (anyChanges) {
+    nextSteps.push(
+      'If you have custom code reading agentRuntimes entries as plain ARN strings ' +
+        '(e.g. custom Lambda handlers or agent code), update it to read the ARN from `.arn` ' +
+        'on the new `{ arn, session }` shape.',
+    );
+  }
+
+  await formatFilesInSubtree(tree);
+
+  return { nextSteps };
+}

--- a/packages/nx-plugin/src/migrations/latest/ts-agent-session-management-support/migration.ts
+++ b/packages/nx-plugin/src/migrations/latest/ts-agent-session-management-support/migration.ts
@@ -12,6 +12,7 @@ import {
 import { applyGritQL, captureGritQL, matchGritQL } from '../../../utils/ast';
 import { formatFilesInSubtree } from '../../../utils/format';
 import { isEsmWorkspace } from '../../../utils/module-format';
+import { kebabCase } from '../../../utils/names';
 
 /**
  * Add session management support to ts#agent.
@@ -104,20 +105,9 @@ const REACT_DUCK_TYPING_PATTERN =
 // calls from an existing agent.ts — the equivalent behaviour is restored via
 // AGUI_INDEX_*_PATTERN below, which wires the same logic in as StrandsAgent
 // plugins instead (plugins are applied to each per-thread agent via
-// initAgent). Naturally idempotent (nothing to match once removed).
-//
-// A connection generator (mcp-connection/a2a-connection) may have merged its
-// own client import into this same import statement via addDestructuredImport
-// (which only ever appends), so logModelErrors/logToolErrors won't always be
-// the only two specifiers — three patterns cover: exactly the two of them
-// (delete the whole statement), the two of them followed by others (keep the
-// rest), and — defensively, though addDestructuredImport never produces this
-// ordering — others followed by the two of them.
-const AGENT_TS_LOG_IMPORT_PATTERNS = [
-  "`import { logModelErrors, logToolErrors } from '$module';` => .",
-  "`import { logModelErrors, logToolErrors, $rest } from '$module';` => `import { $rest } from '$module';`",
-  "`import { $rest, logModelErrors, logToolErrors } from '$module';` => `import { $rest } from '$module';`",
-];
+// initAgent). Naturally idempotent (nothing to match once removed). The
+// import itself is removed via removeLogErrorsImport below (see its comment
+// for why a plain GritQL rewrite can't express this).
 const AGENT_TS_LOG_MODEL_CALL_PATTERN = '`logModelErrors(agent);` => .';
 const AGENT_TS_LOG_TOOL_CALL_PATTERN = '`logToolErrors(agent);` => .';
 
@@ -156,8 +146,23 @@ const AGENT_TS_SESSION_MANAGER_CONSTRUCTOR_PATTERN =
 const AGENT_TS_LOG_IMPORT_CAPTURE_PATTERN =
   "`import { $names } from '$mod';` where { $names <: contains `logModelErrors`, $names <: contains `logToolErrors` }";
 
+// Removes `logModelErrors`/`logToolErrors` from the import, preserving any
+// other specifiers a connection generator has merged into the same statement
+// (or removing the whole statement if none remain). A naive rewrite like
+// `import { logModelErrors, logToolErrors, $rest } from '$mod'` can't express
+// this: `$rest` binds a *fixed* number of sibling nodes and silently fails to
+// match once 2+ other specifiers are merged in (verified — it works for
+// exactly 1 remaining specifier, not 2+). Decomposing via
+// `import_clause(name=named_imports($imports))` instead exposes `$imports`
+// as an actual GritQL list, so `some import_specifier(name=or {...}) => .`
+// can delete each matching specifier individually regardless of how many
+// others remain or what order they're in; deletes the whole import only when
+// the list is exactly the two of them.
+const AGENT_TS_REMOVE_LOG_ERRORS_IMPORT_PATTERN =
+  "`import $clause from '$mod';` as $import where { $clause <: import_clause(name=named_imports($imports)), $imports <: contains `logModelErrors`, $imports <: contains `logToolErrors`, if ($imports <: [`logModelErrors`, `logToolErrors`]) { $import => . } else { $imports <: some import_specifier(name=or { `logModelErrors`, `logToolErrors` }) => . } }";
+
 // Existing agents predate session.ts entirely, so there is no prior
-// session type to preserve here — this mirrors LEGACY_SESSION_TYPE ('none').
+// session storage to preserve here — this mirrors LEGACY_SESSION_STORAGE ('none').
 const legacySessionManagerContent = (
   agentConnectionModule: string,
   localSessionsDir: string,
@@ -189,29 +194,42 @@ export const getSessionManager = async (): Promise<SessionManager> => {
 };
 `;
 
-/** The relative path from `dirPath` up to the root of its owning Nx project. */
-const findOwningProjectRoot = (
+/** The root and name of the Nx project owning `dirPath`, if any. */
+const findOwningProject = (
   tree: Tree,
   dirPath: string,
-): string | undefined => {
-  let best: string | undefined;
+): { root: string; name: string } | undefined => {
+  let best: { root: string; name: string } | undefined;
   for (const project of getProjects(tree).values()) {
     if (
       (dirPath === project.root || dirPath.startsWith(`${project.root}/`)) &&
-      (!best || project.root.length > best.length)
+      (!best || project.root.length > best.root.length)
     ) {
-      best = project.root;
+      best = { root: project.root, name: project.name ?? project.root };
     }
   }
   return best;
 };
 
-/** The relative path from `projectRoot` up to the workspace root's local session storage. */
-const localSessionsDirFor = (projectRoot: string): string => {
+// Mirrors the ts#agent generator's own default-name formula (`<project>-agent`
+// when no custom name is given, else the custom name directly) so migrated
+// agents land in the same per-agent folder a fresh generate would produce.
+// `dirName` is the agent's source directory name (e.g. `agent` for the
+// default, or the custom kebab-case name the user passed to the generator).
+const agentTmpNameFor = (projectName: string, dirName: string): string => {
+  const lastSegment = projectName.split('/').pop() ?? projectName;
+  return dirName === 'agent' ? `${kebabCase(lastSegment)}-agent` : dirName;
+};
+
+/** The relative path from `projectRoot` up to this agent's workspace-root-level local session storage. */
+const localSessionsDirFor = (
+  projectRoot: string,
+  agentTmpName: string,
+): string => {
   const depth = projectRoot.split('/').filter(Boolean).length;
   return joinPathFragments(
     Array(depth).fill('..').join('/'),
-    'tmp/agentCore/agentRuntimes/sessions',
+    `tmp/agents/strands/${agentTmpName}`,
   );
 };
 
@@ -289,12 +307,11 @@ export default async function migration(
     }
 
     if (filePath.endsWith('/agent.ts') && isAgUiAgentDir(tree, filePath)) {
-      let rewroteImport = false;
-      for (const pattern of AGENT_TS_LOG_IMPORT_PATTERNS) {
-        rewroteImport = (await applyGritQL(tree, filePath, pattern))
-          ? true
-          : rewroteImport;
-      }
+      const rewroteImport = await applyGritQL(
+        tree,
+        filePath,
+        AGENT_TS_REMOVE_LOG_ERRORS_IMPORT_PATTERN,
+      );
       const rewroteModelCall = await applyGritQL(
         tree,
         filePath,
@@ -333,7 +350,7 @@ export default async function migration(
       const sessionPath = `${dir}/session.ts`;
 
       if (!tree.exists(sessionPath)) {
-        const projectRoot = findOwningProjectRoot(tree, dir);
+        const project = findOwningProject(tree, dir);
         const capturedImport = await captureGritQL(
           tree,
           filePath,
@@ -341,10 +358,17 @@ export default async function migration(
         );
         const mod = capturedImport?.match(/from '([^']+)'/)?.[1];
 
-        if (projectRoot && mod) {
+        if (project && mod) {
+          const dirName = dir.split('/').filter(Boolean).pop() ?? dir;
           tree.write(
             sessionPath,
-            legacySessionManagerContent(mod, localSessionsDirFor(projectRoot)),
+            legacySessionManagerContent(
+              mod,
+              localSessionsDirFor(
+                project.root,
+                agentTmpNameFor(project.name, dirName),
+              ),
+            ),
           );
         } else {
           nextSteps.push(
@@ -431,7 +455,7 @@ import { getSessionManager } from './session${esm ? '.js' : ''}';\` where { $nam
       const sessionPath = `${dir}/session.ts`;
 
       if (!tree.exists(sessionPath)) {
-        const projectRoot = findOwningProjectRoot(tree, dir);
+        const project = findOwningProject(tree, dir);
         const capturedImport = await captureGritQL(
           tree,
           filePath,
@@ -439,10 +463,17 @@ import { getSessionManager } from './session${esm ? '.js' : ''}';\` where { $nam
         );
         const mod = capturedImport?.match(/from '([^']+)'/)?.[1];
 
-        if (projectRoot && mod) {
+        if (project && mod) {
+          const dirName = dir.split('/').filter(Boolean).pop() ?? dir;
           tree.write(
             sessionPath,
-            legacySessionManagerContent(mod, localSessionsDirFor(projectRoot)),
+            legacySessionManagerContent(
+              mod,
+              localSessionsDirFor(
+                project.root,
+                agentTmpNameFor(project.name, dirName),
+              ),
+            ),
           );
         } else {
           nextSteps.push(

--- a/packages/nx-plugin/src/migrations/latest/ts-agent-session-management-support/migration.ts
+++ b/packages/nx-plugin/src/migrations/latest/ts-agent-session-management-support/migration.ts
@@ -6,14 +6,25 @@ import {
   getProjects,
   joinPathFragments,
   type MigrationReturnObject,
+  type ProjectConfiguration,
   type Tree,
   visitNotIgnoredFiles,
 } from '@nx/devkit';
-import { applyGritQL, captureGritQL, matchGritQL } from '../../../utils/ast';
+import { TS_AGENT_GENERATOR_INFO } from '../../../ts/agent/generator';
+import { AGENT_CONNECTION_PROJECT_DIR } from '../../../utils/agent-connection/agent-connection';
+import {
+  applyGritQL,
+  captureGritQLVariable,
+  matchGritQL,
+} from '../../../utils/ast';
 import { formatFilesInSubtree } from '../../../utils/format';
 import { isEsmWorkspace } from '../../../utils/module-format';
 import { kebabCase } from '../../../utils/names';
-import { getRelativePathToRootByDirectory } from '../../../utils/paths';
+import type { ComponentMetadata } from '../../../utils/nx';
+import {
+  getRelativePathToRootByDirectory,
+  toProjectRelativePath,
+} from '../../../utils/paths';
 
 /**
  * Add session management support to ts#agent.
@@ -31,17 +42,11 @@ import { getRelativePathToRootByDirectory } from '../../../utils/paths';
  *   migration wrote are formatted correctly.
  */
 
-// Matches `rc.set('agentcore', 'agentRuntimes', { ...rc.get('agentcore').agentRuntimes, $name: this.agentCoreRuntime.agentRuntimeArn });`
-// as vended by the CDK agent-core construct. Only the 'agentcore' namespace
-// takes this `{ arn }` shape; the connection-generator-patched 'connection'
-// namespace (client-facing, published to runtime-config.json) stays a bare
-// ARN string, since it shouldn't carry fields like a session's bucket name
-// to the browser. Naturally idempotent: once migrated, `$name`'s value is a
-// `{ arn }` object rather than `this.agentCoreRuntime.agentRuntimeArn`
-// directly, so this no longer matches. Existing agents predate session
-// management support and have no S3 bucket to reference, so there's no
-// `session` field to add here — a fresh session.ts created below defaults
-// them to in-memory storage. MCP servers have no session regardless.
+// Reshapes an `agentRuntimes` rc.set entry from a bare ARN to `{ arn }`. Only
+// the 'agentcore' namespace — 'connection' (client-facing) stays a string,
+// since it shouldn't carry the session bucket name to the browser. No
+// `session` field added here; a fresh session.ts (created below) defaults to
+// in-memory. Idempotent: only matches the pre-migration shape.
 const CDK_RC_SET_PATTERN = `\`rc.set('agentcore', 'agentRuntimes', { ...rc.get('agentcore').agentRuntimes, $name: this.agentCoreRuntime.agentRuntimeArn });\` => raw\`rc.set('agentcore', 'agentRuntimes', {
   ...rc.get('agentcore').agentRuntimes,
   $name: {
@@ -49,12 +54,8 @@ const CDK_RC_SET_PATTERN = `\`rc.set('agentcore', 'agentRuntimes', { ...rc.get('
   },
 });\``;
 
-// Matches the equivalent `add_agent_runtime_to_runtime_config` module block
-// vended by the Terraform agent-core construct, anchored on its fixed module
-// name/shape since the connection-generator-patched
-// `add_agent_runtime_to_connection_runtime_config` module has an identical-
-// looking `value` line but keeps its bare ARN string shape (see
-// CDK_RC_SET_PATTERN's comment). Naturally idempotent (see CDK_RC_SET_PATTERN).
+// Terraform equivalent, anchored on the module's fixed name/shape so it
+// doesn't also match the 'connection' module's identical-looking `value` line.
 const TF_VALUE_PATTERN = `language hcl\n\`module "add_agent_runtime_to_runtime_config" {
   source = "../../../core/runtime-config/entry"
 
@@ -73,8 +74,8 @@ const TF_VALUE_PATTERN = `language hcl\n\`module "add_agent_runtime_to_runtime_c
   depends_on = [module.agent_core_runtime]
 }\``;
 
-// Exact shape of the shared `AgentCoreRuntimeConfig` interface prior to this
-// change, as vended into `packages/common/agent-connection/src/core/runtime-config.ts`.
+// Shared `AgentCoreRuntimeConfig` interface, vended into
+// `packages/common/agent-connection/src/core/runtime-config.ts`.
 const TS_RUNTIME_CONFIG_INTERFACE_PATTERN = `\`export interface AgentCoreRuntimeConfig {
   agentRuntimes?: Record<string, string>;
   gateways?: Record<string, string>;
@@ -92,101 +93,58 @@ export interface AgentCoreRuntimeConfig {
   gateways?: Record<string, string>;
 }\``;
 
-// Matches `config.agentRuntimes?.['Name']` / `config?.agentRuntimes?.['Name']`
-// as read by the generated TS a2a/mcp client and agent-chat CLI templates.
-// The `where` clause guards idempotency: once `?.arn` is appended, the
-// program no longer matches the bare pre-`.arn` form so this doesn't re-fire.
+// `config.agentRuntimes?.['Name']` as read by generated TS a2a/mcp clients and
+// the agent-chat CLI. Idempotent via the `not contains ?.arn` guard.
 const TS_CLIENT_ARN_PATTERNS = [
   '`config.agentRuntimes?.[$name]` => `config.agentRuntimes?.[$name]?.arn` where { $program <: not contains `config.agentRuntimes?.[$name]?.arn` }',
   '`config?.agentRuntimes?.[$name]` => `config?.agentRuntimes?.[$name]?.arn` where { $program <: not contains `config?.agentRuntimes?.[$name]?.arn` }',
 ];
 
-// Matches `agent_runtime_arn = config.get("agentRuntimes", {}).get($name)` as
-// read by the generated Python a2a/mcp client templates (Strands + LangChain).
+// Python equivalent (Strands + LangChain client templates).
 const PY_CLIENT_ARN_PATTERN =
   'language python\n`agent_runtime_arn = config.get("agentRuntimes", {}).get($name)` => `agent_runtime = config.get("agentRuntimes", {}).get($name)\nagent_runtime_arn = agent_runtime.get("arn") if agent_runtime else None`';
 
-// Removes the imperative logModelErrors(agent)/logToolErrors(agent) calls
-// from an existing agent.ts, for both AG-UI and HTTP/A2A agents. For AG-UI
-// this is required, not just cosmetic: its adapter clones the template agent
-// per-thread, and hooks added directly to the template (as these calls do)
-// are NOT carried over onto those clones, so the per-thread agents would
-// silently run without error logging — the equivalent behaviour is restored
-// via AGUI_INDEX_*_PATTERN below, which wires the same logic in as
-// StrandsAgent plugins instead (plugins are applied to each per-thread agent
-// via initAgent). For HTTP/A2A it's purely a style unification with the
-// AG-UI form (see AGENT_TS_PLUGINS_CONSTRUCTOR_PATTERN), since one Agent per
-// session means the imperative form already worked correctly there. Naturally
-// idempotent (nothing to match once removed). The import itself is removed
-// via removeLogErrorsImport below (see its comment for why a plain GritQL
-// rewrite can't express this).
+// Removes the imperative logModelErrors(agent)/logToolErrors(agent) calls.
+// Required for AG-UI (its adapter clones the template agent per-thread, and
+// hooks added directly to the template don't carry over — the equivalent
+// behaviour is restored via the AGUI_INDEX_* plugins below). For HTTP/A2A
+// it's a style unification, since the imperative form already worked there.
 const AGENT_TS_LOG_MODEL_CALL_PATTERN = '`logModelErrors(agent);` => .';
 const AGENT_TS_LOG_TOOL_CALL_PATTERN = '`logToolErrors(agent);` => .';
 
-// AG-UI is the only protocol whose index.ts imports from '@ag-ui/aws-strands'
-// (see files/ag-ui/index.ts.template), so that's a reliable signal that the
-// sibling agent.ts belongs to an AG-UI agent.
-const isAgUiAgentDir = (tree: Tree, agentTsPath: string): boolean => {
-  const dir = agentTsPath.split('/').slice(0, -1).join('/');
-  const indexTsPath = `${dir}/index.ts`;
-  const indexContents = tree.read(indexTsPath, 'utf-8') ?? '';
-  return indexContents.includes('@ag-ui/aws-strands');
-};
-
-// HTTP/A2A agents (unlike AG-UI) construct one Agent per session via
-// `withSessionId(getAgent)`, so wiring `sessionManager` directly into
-// `getAgent`'s `new Agent({ ... })` call is safe. Generic over `$props`
-// (the object literal's own property list) so this applies regardless of how
-// the user has customised systemPrompt/tools — only requires the props to be
-// passed as an inline object literal (not a variable). `sessionManager` is
-// prepended rather than appended: `$props` is captured as raw source text and
-// commonly ends with prettier's trailing comma, so appending `, sessionManager: ...`
-// after it would produce a double comma (invalid syntax); prepending before
-// `$props` sidesteps that entirely, and `formatFilesInSubtree` reformats the
-// result cleanly regardless of property order. Naturally idempotent via the
-// `not contains sessionManager` guard.
+// HTTP/A2A agents build one Agent per session, so wiring `sessionManager`
+// directly into the constructor is safe. Generic over `$props` so this works
+// regardless of customised systemPrompt/tools, as long as it's an inline
+// object literal. Prepended (not appended) to sidestep a trailing-comma
+// double-comma when `$props` is captured as raw source text.
 const AGENT_TS_SESSION_MANAGER_CONSTRUCTOR_PATTERN =
   '`new Agent({ $props })` => `new Agent({ sessionManager: await getSessionManager(), $props })` where { $props <: not contains `sessionManager` }';
 
-// Moves the model/tool error logging hooks from imperative logModelErrors/
-// logToolErrors calls to Agent constructor plugins, mirroring the AG-UI
-// rewrite (AGUI_INDEX_CONSTRUCTOR_PATTERN below) for consistency — HTTP/A2A
-// agents already worked correctly with the imperative form (one Agent per
-// session, unlike AG-UI's per-thread cloning), so this is purely a style
-// unification rather than a bug fix. Same prepend rationale as
-// AGENT_TS_SESSION_MANAGER_CONSTRUCTOR_PATTERN.
+// Match-only gate for the rewrites above/below: only applies when the Agent
+// is an inline object literal, not e.g. a variable.
+const AGENT_TS_CONSTRUCTOR_MATCH_PATTERN = '`new Agent({ $props })`';
+
+// Moves the model/tool error hooks to Agent constructor plugins, mirroring
+// the AG-UI rewrite for consistency (HTTP/A2A already worked with the
+// imperative form).
 const AGENT_TS_PLUGINS_CONSTRUCTOR_PATTERN =
   '`new Agent({ $props })` => `new Agent({ plugins: [new ModelErrorLoggingPlugin(), new ToolErrorLoggingPlugin()], $props })` where { $props <: not contains `plugins` }';
 
-// Captures the agent-connection package specifier from the existing
-// logModelErrors/logToolErrors import so the new getSessionManager and
-// ModelErrorLoggingPlugin/ToolErrorLoggingPlugin imports (and the fresh
-// session.ts this migration creates) target the same module, without needing
-// to know the workspace's npm scope directly. Generic
-// over `$names` (rather than requiring an exact 2-specifier import) since a
-// connection generator (mcp-connection/a2a-connection) may have merged its
-// own client import into this same statement via addDestructuredImport.
+// Captures the agent-connection package specifier so the new imports (and the
+// session.ts this migration creates) target the same module. Generic over
+// `$names` since a connection generator may have merged its own import here.
 const AGENT_TS_LOG_IMPORT_CAPTURE_PATTERN =
   "`import { $names } from '$mod';` where { $names <: contains `logModelErrors`, $names <: contains `logToolErrors` }";
 
 // Removes `logModelErrors`/`logToolErrors` from the import, preserving any
-// other specifiers a connection generator has merged into the same statement
-// (or removing the whole statement if none remain). A naive rewrite like
-// `import { logModelErrors, logToolErrors, $rest } from '$mod'` can't express
-// this: `$rest` binds a *fixed* number of sibling nodes and silently fails to
-// match once 2+ other specifiers are merged in (verified — it works for
-// exactly 1 remaining specifier, not 2+). Decomposing via
-// `import_clause(name=named_imports($imports))` instead exposes `$imports`
-// as an actual GritQL list, so `some import_specifier(name=or {...}) => .`
-// can delete each matching specifier individually regardless of how many
-// others remain or what order they're in; deletes the whole import only when
-// the list is exactly the two of them.
+// other merged specifiers (or the whole statement if none remain). Decomposed
+// via `import_clause(name=named_imports($imports))` since a naive
+// `$rest`-based rewrite silently fails once 2+ other specifiers are merged in.
 const AGENT_TS_REMOVE_LOG_ERRORS_IMPORT_PATTERN =
   "`import $clause from '$mod';` as $import where { $clause <: import_clause(name=named_imports($imports)), $imports <: contains `logModelErrors`, $imports <: contains `logToolErrors`, if ($imports <: [`logModelErrors`, `logToolErrors`]) { $import => . } else { $imports <: some import_specifier(name=or { `logModelErrors`, `logToolErrors` }) => . } }";
 
-// Existing agents predate session.ts entirely, so there is no prior
-// session storage to preserve here — default to in-memory, matching the
-// (session-less) agentRuntimes entry this migration writes above.
+// Existing agents predate session.ts, so there's no prior storage to
+// preserve — default to in-memory.
 const legacySessionManagerContent = (
   agentConnectionModule: string,
   localSessionsDir: string,
@@ -218,31 +176,52 @@ export const getSessionManager = async (): Promise<SessionManager> => {
 };
 `;
 
-/** The root and name of the Nx project owning `dirPath`, if any. */
+/** The Nx project owning `dirPath`, if any (the longest-matching project.root). */
 const findOwningProject = (
   tree: Tree,
   dirPath: string,
-): { root: string; name: string } | undefined => {
-  let best: { root: string; name: string } | undefined;
+): ProjectConfiguration | undefined => {
+  let best: ProjectConfiguration | undefined;
   for (const project of getProjects(tree).values()) {
     if (
       (dirPath === project.root || dirPath.startsWith(`${project.root}/`)) &&
       (!best || project.root.length > best.root.length)
     ) {
-      best = { root: project.root, name: project.name ?? project.root };
+      best = project;
     }
   }
   return best;
 };
 
-// Mirrors the ts#agent generator's own default-name formula (`<project>-agent`
-// when no custom name is given, else the custom name directly) so migrated
-// agents land in the same per-agent folder a fresh generate would produce.
-// `dirName` is the agent's source directory name (e.g. `agent` for the
-// default, or the custom kebab-case name the user passed to the generator).
-const agentTmpNameFor = (projectName: string, dirName: string): string => {
-  const lastSegment = projectName.split('/').pop() ?? projectName;
-  return dirName === 'agent' ? `${kebabCase(lastSegment)}-agent` : dirName;
+/** This agent's own ComponentMetadata entry, as written by the ts#agent generator. */
+const findAgentComponentMetadata = (
+  project: ProjectConfiguration,
+  dirRelativeToProjectRoot: string,
+): ComponentMetadata | undefined =>
+  (project.metadata as { components?: ComponentMetadata[] })?.components?.find(
+    (component) =>
+      component.generator === TS_AGENT_GENERATOR_INFO.id &&
+      component.path === dirRelativeToProjectRoot,
+  );
+
+/** This agent's real kebab-case name, from ComponentMetadata's `rc` (class-name) field. */
+const agentTmpNameFor = (
+  project: ProjectConfiguration,
+  dir: string,
+): string | undefined => {
+  const dirRelativeToProjectRoot = toProjectRelativePath(project, dir);
+  const rc = findAgentComponentMetadata(project, dirRelativeToProjectRoot)?.rc;
+  return rc ? kebabCase(rc) : undefined;
+};
+
+/** This agent's protocol, from ComponentMetadata's `protocol` field. */
+const agentProtocolFor = (
+  project: ProjectConfiguration,
+  dir: string,
+): string | undefined => {
+  const dirRelativeToProjectRoot = toProjectRelativePath(project, dir);
+  return findAgentComponentMetadata(project, dirRelativeToProjectRoot)
+    ?.protocol;
 };
 
 /** The relative path from `projectRoot` up to this agent's workspace-root-level local session storage. */
@@ -255,48 +234,34 @@ const localSessionsDirFor = (
     `tmp/agents/strands/${agentTmpName}`,
   );
 
-// Adds the ModelErrorLoggingPlugin/ToolErrorLoggingPlugin import (generic over
-// the agent-connection package's npm scope) and wires them into the
-// StrandsAgent constructor, restoring the error-logging behaviour removed
-// from agent.ts above. Naturally idempotent.
+// Wires ModelErrorLoggingPlugin/ToolErrorLoggingPlugin into the StrandsAgent
+// constructor, restoring the error-logging behaviour removed from agent.ts.
 const AGUI_INDEX_IMPORT_PATTERN =
   "`import { $names } from '$mod'` => `import { ModelErrorLoggingPlugin, ToolErrorLoggingPlugin, $names } from '$mod'` where { $names <: contains `runWithSessionId`, $names <: not contains `ModelErrorLoggingPlugin` }";
-const AGUI_INDEX_CONSTRUCTOR_PATTERN =
-  '`new StrandsAgent({ agent, name: $name, description: $desc })` => `new StrandsAgent({ agent, name: $name, description: $desc, plugins: [new ModelErrorLoggingPlugin(), new ToolErrorLoggingPlugin()] })`';
+// Match-only form of the target shape, used to gate before touching the
+// sibling agent.ts, and before committing to the rewrite here.
+const AGUI_INDEX_CONSTRUCTOR_MATCH_PATTERN =
+  '`new StrandsAgent({ agent, name: $name, description: $desc })`';
+const AGUI_INDEX_CONSTRUCTOR_PATTERN = `${AGUI_INDEX_CONSTRUCTOR_MATCH_PATTERN} => \`new StrandsAgent({ agent, name: $name, description: $desc, plugins: [new ModelErrorLoggingPlugin(), new ToolErrorLoggingPlugin()] })\``;
 
-// Captures the same agent-connection package specifier via index.ts's
-// existing runWithSessionId import, for the same reason as
-// AGENT_TS_LOG_IMPORT_CAPTURE_PATTERN above.
 const AGUI_INDEX_IMPORT_CAPTURE_PATTERN =
   "`import { $names } from '$mod';` where { $names <: contains `runWithSessionId` }";
 
-// AG-UI's StrandsAgent adapter also needs a sessionManagerProvider (called
-// once per threadId) to persist conversation state, mirroring
-// AGENT_TS_SESSION_MANAGER_CONSTRUCTOR_PATTERN's role for HTTP/A2A agents.
-// Anchored on the literal `getAgent` import, which every ts#agent index.ts has.
+// AG-UI's StrandsAgent adapter needs a sessionManagerProvider (called once
+// per threadId), mirroring AGENT_TS_SESSION_MANAGER_CONSTRUCTOR_PATTERN.
 const aguiIndexSessionManagerImportPattern = (esm: boolean) =>
   `\`import { getAgent } from '$mod';\` => raw\`import { getAgent } from '$mod';
 import { getSessionManager } from './session${esm ? '.js' : ''}';\` where { $program <: not contains \`getSessionManager\` }`;
-// Anchored on the exact 4-property shape AGUI_INDEX_CONSTRUCTOR_PATTERN
-// produces, so this only fires once plugins have been wired in, and stops
-// matching once config is added (naturally idempotent). Used both to gate
-// (via matchGritQL, before creating session.ts) and to rewrite.
+// Anchored on the exact 4-property shape produced above, so this only fires
+// once plugins are wired in. Used both to gate and to rewrite.
 const AGUI_INDEX_SESSION_MANAGER_MATCH_PATTERN =
   '`new StrandsAgent({ agent, name: $name, description: $desc, plugins: $plugins })`';
 const AGUI_INDEX_SESSION_MANAGER_CONSTRUCTOR_PATTERN = `${AGUI_INDEX_SESSION_MANAGER_MATCH_PATTERN} => \`new StrandsAgent({ agent, name: $name, description: $desc, plugins: $plugins, config: { sessionManagerProvider: getSessionManager } })\``;
 
-// The AGUI_INDEX_*/AGENT_TS_PLUGINS_CONSTRUCTOR_PATTERN patterns above
-// reference ModelErrorLoggingPlugin/ToolErrorLoggingPlugin, but those classes
-// only exist in the current model-errors-strands.ts/tool-errors-strands.ts
-// templates — an existing workspace's already-generated copies (vended with
-// `KeepExisting`, so never overwritten by re-running the generator) still
-// have only the plain logModelErrors/logToolErrors functions. Without these,
-// the AG-UI/HTTP/A2A rewrites above would reference undefined classes. The
-// plain functions are dropped entirely (not kept as a delegating wrapper) —
-// every call site is migrated to the plugin classes directly, so nothing
-// references them any more. Anchored on the `agent.addHook(AfterXCallEvent,
-// ...)` call so this doesn't re-match its own output (the class it produces
-// contains no such top-level call).
+// The plugin classes referenced above only exist once model-errors-strands.ts
+// / tool-errors-strands.ts are converted from their plain logXErrors function
+// form (see ensurePluginClass below). Anchored on the `agent.addHook(...)`
+// call so this doesn't re-match its own output.
 const MODEL_ERRORS_IMPORT_PATTERN =
   "`import { AfterModelCallEvent, type LocalAgent } from '@strands-agents/sdk';` => `import { AfterModelCallEvent, type LocalAgent, type Plugin } from '@strands-agents/sdk';`";
 const MODEL_ERRORS_CLASS_PATTERN =
@@ -307,118 +272,242 @@ const TOOL_ERRORS_IMPORT_PATTERN =
 const TOOL_ERRORS_CLASS_PATTERN =
   "`export const logToolErrors = (agent: LocalAgent): void => { agent.addHook(AfterToolCallEvent, $callback); };` => raw`export class ToolErrorLoggingPlugin implements Plugin {\n  readonly name = 'tool-error-logging';\n\n  initAgent(agent: LocalAgent): void {\n    agent.addHook(AfterToolCallEvent, $callback);\n  }\n}`";
 
+/**
+ * Converts a plain `logXErrors` function into its `XErrorLoggingPlugin` class
+ * if it still has the generated shape. Returns whether the class is present
+ * (freshly converted or already done) — false only when diverged, reported
+ * via `nextSteps` here so callers can silently skip their own wiring.
+ */
+async function ensurePluginClass(
+  tree: Tree,
+  nextSteps: string[],
+  filePath: string,
+  className: string,
+  importPattern: string,
+  classPattern: string,
+): Promise<boolean> {
+  if (!tree.exists(filePath)) {
+    return true;
+  }
+  if ((tree.read(filePath, 'utf-8') ?? '').includes(`class ${className}`)) {
+    return true;
+  }
+
+  // Only add the `Plugin` type import once the class rewrite is confirmed to
+  // apply, so a diverged file isn't left with an unused import and no class.
+  const rewroteClass = await applyGritQL(tree, filePath, classPattern);
+
+  if (!rewroteClass) {
+    nextSteps.push(
+      `${filePath}: diverged from the generated shape - left as-is. Manually convert it to a \`${className}\` class implementing \`Plugin\` (see the ts#agent generator's template); agent.ts/index.ts files that reference \`${className}\` are left unmigrated until this exists.`,
+    );
+    return false;
+  }
+  await applyGritQL(tree, filePath, importPattern);
+  return true;
+}
+
 export default async function migration(
   tree: Tree,
 ): Promise<MigrationReturnObject> {
   const nextSteps: string[] = [];
   let anyChanges = false;
 
+  // Both classes live in one shared agent-connection package, so their
+  // readiness is resolved once up front rather than per agent.
+  const modelErrorsPath = joinPathFragments(
+    AGENT_CONNECTION_PROJECT_DIR,
+    'src',
+    'core',
+    'model-errors-strands.ts',
+  );
+  const toolErrorsPath = joinPathFragments(
+    AGENT_CONNECTION_PROJECT_DIR,
+    'src',
+    'core',
+    'tool-errors-strands.ts',
+  );
+  const modelPluginReady = await ensurePluginClass(
+    tree,
+    nextSteps,
+    modelErrorsPath,
+    'ModelErrorLoggingPlugin',
+    MODEL_ERRORS_IMPORT_PATTERN,
+    MODEL_ERRORS_CLASS_PATTERN,
+  );
+  const toolPluginReady = await ensurePluginClass(
+    tree,
+    nextSteps,
+    toolErrorsPath,
+    'ToolErrorLoggingPlugin',
+    TOOL_ERRORS_IMPORT_PATTERN,
+    TOOL_ERRORS_CLASS_PATTERN,
+  );
+  const pluginsReady = modelPluginReady && toolPluginReady;
+
   const filePaths: string[] = [];
   visitNotIgnoredFiles(tree, '', (filePath) => filePaths.push(filePath));
 
   for (const filePath of filePaths) {
+    if (filePath === modelErrorsPath || filePath === toolErrorsPath) {
+      continue;
+    }
     if (filePath.endsWith('.d.ts')) {
       continue;
     }
 
-    // session.ts (whether generator-vended or created by this
-    // migration above) already targets the new { arn, session } shape via
+    // session.ts already targets the new { arn, session } shape via
     // `config.agentRuntimes?.[$name]?.session?.bucketName` — the generic
-    // reshape branch below would otherwise mis-match that expression's
-    // `config.agentRuntimes?.[$name]` prefix and corrupt it into
-    // `?.arn?.session?.bucketName`.
+    // reshape branch below would otherwise corrupt that into `?.arn?.session?.bucketName`.
     if (filePath.endsWith('/session.ts')) {
       continue;
     }
 
-    if (filePath.endsWith('/agent.ts') && isAgUiAgentDir(tree, filePath)) {
-      const rewroteImport = await applyGritQL(
-        tree,
-        filePath,
-        AGENT_TS_REMOVE_LOG_ERRORS_IMPORT_PATTERN,
-      );
-      const rewroteModelCall = await applyGritQL(
-        tree,
-        filePath,
-        AGENT_TS_LOG_MODEL_CALL_PATTERN,
-      );
-      const rewroteToolCall = await applyGritQL(
-        tree,
-        filePath,
-        AGENT_TS_LOG_TOOL_CALL_PATTERN,
-      );
-      if (rewroteImport || rewroteModelCall || rewroteToolCall) {
-        nextSteps.push(
-          `${filePath}: moved the model/tool error logging hooks to StrandsAgent plugins (see the sibling index.ts).`,
-        );
-        anyChanges = true;
-      }
-      continue;
-    }
-
-    // HTTP/A2A agent.ts: wire sessionManager into the Agent constructor and
-    // create the sibling session.ts if it doesn't exist yet. Existing
-    // agents predate session.ts entirely, so (unlike the reshape
-    // patterns above) there's no "old shape" to pattern-match for the file's
-    // own existence — gate on the logModelErrors/logToolErrors import as the
-    // signal this is a ts#agent-generated agent.ts. Matched via GritQL (not a
-    // literal substring check) so this isn't fooled by prettier wrapping the
-    // import onto multiple lines (e.g. a long npm scope name). The
-    // constructor is only ever rewritten once the getSessionManager import is
-    // confirmed present, so a failed session.ts creation can never
-    // leave a dangling reference to an undefined function.
-    if (
-      filePath.endsWith('/agent.ts') &&
-      (await matchGritQL(tree, filePath, AGENT_TS_LOG_IMPORT_CAPTURE_PATTERN))
-    ) {
+    if (filePath.endsWith('/agent.ts')) {
       const dir = filePath.split('/').slice(0, -1).join('/');
-      const sessionPath = `${dir}/session.ts`;
+      const project = findOwningProject(tree, dir);
 
-      if (!tree.exists(sessionPath)) {
-        const project = findOwningProject(tree, dir);
-        const capturedImport = await captureGritQL(
+      // Without a registered project there's no ComponentMetadata, so this
+      // agent's protocol/name/agent-connection module can't be resolved — and
+      // a pre-migration AG-UI agent.ts is textually identical to an
+      // HTTP/A2A one, so there's nothing left to safely guess from.
+      if (!project) {
+        if (
+          await matchGritQL(tree, filePath, AGENT_TS_LOG_IMPORT_CAPTURE_PATTERN)
+        ) {
+          nextSteps.push(
+            `${filePath}: could not determine the project root — manually verify whether this is an AG-UI or HTTP/A2A agent and complete its session-manager/error-logging-plugin migration accordingly (see the ts#agent generator's template).`,
+          );
+        }
+        continue;
+      }
+
+      const protocol = agentProtocolFor(project, dir);
+
+      if (protocol === 'ag-ui') {
+        const hasLogCalls =
+          (await matchGritQL(
+            tree,
+            filePath,
+            AGENT_TS_LOG_MODEL_CALL_PATTERN,
+          )) ||
+          (await matchGritQL(tree, filePath, AGENT_TS_LOG_TOOL_CALL_PATTERN));
+        if (!hasLogCalls) {
+          continue;
+        }
+
+        // The sibling index.ts restores error-logging via StrandsAgent
+        // plugins — removing the calls here without that succeeding would
+        // drop error logging rather than move it.
+        const indexPath = `${dir}/index.ts`;
+        const indexReady =
+          pluginsReady &&
+          (await matchGritQL(
+            tree,
+            indexPath,
+            AGUI_INDEX_CONSTRUCTOR_MATCH_PATTERN,
+          ));
+
+        if (!indexReady) {
+          nextSteps.push(
+            `${filePath}: left the logModelErrors/logToolErrors calls in place — ${indexPath} could not be automatically wired with the equivalent StrandsAgent plugins. Move error logging to plugins there manually (see the ts#agent generator's template), then remove these calls.`,
+          );
+          continue;
+        }
+
+        const rewroteImport = await applyGritQL(
+          tree,
+          filePath,
+          AGENT_TS_REMOVE_LOG_ERRORS_IMPORT_PATTERN,
+        );
+        const rewroteModelCall = await applyGritQL(
+          tree,
+          filePath,
+          AGENT_TS_LOG_MODEL_CALL_PATTERN,
+        );
+        const rewroteToolCall = await applyGritQL(
+          tree,
+          filePath,
+          AGENT_TS_LOG_TOOL_CALL_PATTERN,
+        );
+        if (rewroteImport || rewroteModelCall || rewroteToolCall) {
+          anyChanges = true;
+        }
+        continue;
+      }
+
+      if (!protocol) {
+        if (
+          await matchGritQL(tree, filePath, AGENT_TS_LOG_IMPORT_CAPTURE_PATTERN)
+        ) {
+          nextSteps.push(
+            `${filePath}: could not determine this agent's protocol from its ComponentMetadata — manually verify whether it's AG-UI or HTTP/A2A and wire sessionManager/the error-logging plugins in accordingly (see the ts#agent generator's template).`,
+          );
+        }
+        continue;
+      }
+
+      // HTTP/A2A: wire sessionManager into the Agent constructor and create
+      // the sibling session.ts if it doesn't exist yet.
+      if (
+        !(await matchGritQL(
           tree,
           filePath,
           AGENT_TS_LOG_IMPORT_CAPTURE_PATTERN,
-        );
-        const mod = capturedImport?.match(/from '([^']+)'/)?.[1];
+        ))
+      ) {
+        continue;
+      }
 
-        if (project && mod) {
-          const dirName = dir.split('/').filter(Boolean).pop() ?? dir;
+      const sessionPath = `${dir}/session.ts`;
+
+      // Checked before any writes: if the plugin classes aren't available, or
+      // the Agent isn't an inline object literal, leave the file untouched
+      // entirely rather than ending up half-migrated.
+      if (!pluginsReady) {
+        nextSteps.push(
+          `${filePath}: left as-is — ModelErrorLoggingPlugin/ToolErrorLoggingPlugin are not available yet (see the model-errors-strands.ts/tool-errors-strands.ts next step above). Wire sessionManager and the plugins in manually once those classes exist.`,
+        );
+        continue;
+      }
+      if (
+        !(await matchGritQL(tree, filePath, AGENT_TS_CONSTRUCTOR_MATCH_PATTERN))
+      ) {
+        nextSteps.push(
+          `${filePath}: the Agent is not constructed with an inline object literal (\`new Agent({ ... })\`), so sessionManager and the error-logging plugins could not be wired in automatically. Manually add \`sessionManager: await getSessionManager()\` and \`plugins: [new ModelErrorLoggingPlugin(), new ToolErrorLoggingPlugin()]\` to its constructor (see the ts#agent generator's template), creating ${sessionPath} first if it doesn't already exist.`,
+        );
+        continue;
+      }
+
+      if (!tree.exists(sessionPath)) {
+        const mod = await captureGritQLVariable(
+          tree,
+          filePath,
+          AGENT_TS_LOG_IMPORT_CAPTURE_PATTERN,
+          'mod',
+        );
+        const agentName = agentTmpNameFor(project, dir);
+
+        if (mod && agentName) {
           tree.write(
             sessionPath,
             legacySessionManagerContent(
               mod,
-              localSessionsDirFor(
-                project.root,
-                agentTmpNameFor(project.name, dirName),
-              ),
+              localSessionsDirFor(project.root, agentName),
             ),
           );
         } else {
           nextSteps.push(
-            `${filePath}: could not determine the project root or agent-connection module — manually create a session.ts (see the ts#agent generator's template) and wire \`sessionManager: await getSessionManager()\` into the Agent constructor.`,
+            `${filePath}: could not determine the agent-connection module or this agent's name from its ComponentMetadata — manually create a session.ts (see the ts#agent generator's template) and wire \`sessionManager: await getSessionManager()\` into the Agent constructor.`,
           );
           continue;
         }
       }
 
-      // Merges ModelErrorLoggingPlugin/ToolErrorLoggingPlugin into the same
-      // import clause as the existing logModelErrors/logToolErrors specifiers
-      // (rather than adding a redundant second import statement for the same
-      // module — mirrors AGUI_INDEX_IMPORT_PATTERN's approach for AG-UI), and
-      // adds getSessionManager as its own import line since it comes from a
-      // different module (the sibling session.ts). Generic over `$names`
-      // (rather than requiring an exact 2-specifier import) since a
-      // connection generator may have merged its own client import into the
-      // same statement via addDestructuredImport. Both are added together,
-      // guarded by a single check: this migration is what introduces both, so
-      // a legacy agent.ts either has neither yet or (after this same run)
-      // both — there's no shipped prior version of this migration that could
-      // have added one without the other. The old logModelErrors/
-      // logToolErrors specifiers are stripped out separately below (via
-      // AGENT_TS_REMOVE_LOG_ERRORS_IMPORT_PATTERN) — this must happen after,
-      // since it's what this rewrite anchors on.
+      // Merges the plugin imports into the existing logModelErrors/
+      // logToolErrors import clause (rather than a redundant second import),
+      // and adds getSessionManager as its own line. The old specifiers are
+      // stripped separately below, after this rewrite anchors on them.
       const esm = isEsmWorkspace(tree);
       await applyGritQL(
         tree,
@@ -427,8 +516,7 @@ export default async function migration(
 import { getSessionManager } from './session${esm ? '.js' : ''}';\` where { $names <: contains \`logModelErrors\`, $names <: contains \`logToolErrors\`, $program <: not contains \`getSessionManager\` }`,
       );
 
-      // Only rewrite the constructor once the import is confirmed present —
-      // either just added above, or already there from a prior partial run.
+      // Only rewrite the constructor once the import is confirmed present.
       if (!(tree.read(filePath, 'utf-8') ?? '').includes('getSessionManager')) {
         nextSteps.push(
           `${filePath}: found ${sessionPath} but couldn't confirm the getSessionManager import — wire \`sessionManager: await getSessionManager()\` into the Agent constructor manually.`,
@@ -436,11 +524,6 @@ import { getSessionManager } from './session${esm ? '.js' : ''}';\` where { $nam
         continue;
       }
 
-      // Moves the model/tool error logging hooks from imperative calls to
-      // Agent constructor plugins (see AGENT_TS_PLUGINS_CONSTRUCTOR_PATTERN),
-      // then removes the now-unused logModelErrors/logToolErrors specifiers
-      // (preserving any merged connection-generator import — see
-      // AGENT_TS_REMOVE_LOG_ERRORS_IMPORT_PATTERN's comment).
       await applyGritQL(tree, filePath, AGENT_TS_LOG_MODEL_CALL_PATTERN);
       await applyGritQL(tree, filePath, AGENT_TS_LOG_TOOL_CALL_PATTERN);
       await applyGritQL(
@@ -460,9 +543,6 @@ import { getSessionManager } from './session${esm ? '.js' : ''}';\` where { $nam
         AGENT_TS_SESSION_MANAGER_CONSTRUCTOR_PATTERN,
       );
       if (rewrotePlugins || rewroteConstructor) {
-        nextSteps.push(
-          `${filePath}: wired sessionManager and the error-logging plugins into the Agent constructor (see ${sessionPath}).`,
-        );
         anyChanges = true;
       }
       continue;
@@ -472,29 +552,53 @@ import { getSessionManager } from './session${esm ? '.js' : ''}';\` where { $nam
       filePath.endsWith('/index.ts') &&
       (tree.read(filePath, 'utf-8') ?? '').includes('@ag-ui/aws-strands')
     ) {
-      const rewroteImport = await applyGritQL(
-        tree,
-        filePath,
-        AGUI_INDEX_IMPORT_PATTERN,
+      const alreadyWired = (tree.read(filePath, 'utf-8') ?? '').includes(
+        'ModelErrorLoggingPlugin',
       );
-      const rewroteConstructor = await applyGritQL(
-        tree,
-        filePath,
-        AGUI_INDEX_CONSTRUCTOR_PATTERN,
-      );
-      if (rewroteImport || rewroteConstructor) {
-        nextSteps.push(
-          `${filePath}: wired ModelErrorLoggingPlugin/ToolErrorLoggingPlugin into the StrandsAgent constructor.`,
+
+      if (!alreadyWired) {
+        // Import and constructor only apply cleanly together — adding the
+        // import while the constructor can't be rewritten would leave an
+        // unused import and no plugins wired in.
+        const needsPluginWiring = await matchGritQL(
+          tree,
+          filePath,
+          AGUI_INDEX_CONSTRUCTOR_MATCH_PATTERN,
         );
-        anyChanges = true;
+        if (!pluginsReady) {
+          if (needsPluginWiring) {
+            nextSteps.push(
+              `${filePath}: left the StrandsAgent constructor as-is — ModelErrorLoggingPlugin/ToolErrorLoggingPlugin are not available yet (see the model-errors-strands.ts/tool-errors-strands.ts next step above). Wire them in manually once those classes exist.`,
+            );
+          }
+          continue;
+        }
+        if (!needsPluginWiring) {
+          nextSteps.push(
+            `${filePath}: the StrandsAgent constructor has diverged from the generated shape - left as-is. Manually add \`plugins: [new ModelErrorLoggingPlugin(), new ToolErrorLoggingPlugin()]\` to it (see the ts#agent generator's template).`,
+          );
+          continue;
+        }
+
+        const rewroteImport = await applyGritQL(
+          tree,
+          filePath,
+          AGUI_INDEX_IMPORT_PATTERN,
+        );
+        const rewroteConstructor = await applyGritQL(
+          tree,
+          filePath,
+          AGUI_INDEX_CONSTRUCTOR_PATTERN,
+        );
+        if (rewroteImport || rewroteConstructor) {
+          anyChanges = true;
+        }
       }
 
-      // The StrandsAgent adapter also needs a sessionManagerProvider — create
-      // the sibling session.ts if it doesn't exist yet, same as the
-      // HTTP/A2A branch above, then wire it in once the plugins are present.
-      // Gated on the exact shape the rewrite targets, checked up front via
-      // matchGritQL, so a customised (non-standard) constructor is left
-      // entirely alone rather than creating an unused session.ts.
+      // Create the sibling session.ts (once plugins are present) and wire in
+      // sessionManagerProvider. Gated on the exact post-plugins shape, so a
+      // customised constructor is left alone rather than creating an unused
+      // session.ts.
       if (
         !(await matchGritQL(
           tree,
@@ -510,28 +614,25 @@ import { getSessionManager } from './session${esm ? '.js' : ''}';\` where { $nam
 
       if (!tree.exists(sessionPath)) {
         const project = findOwningProject(tree, dir);
-        const capturedImport = await captureGritQL(
+        const mod = await captureGritQLVariable(
           tree,
           filePath,
           AGUI_INDEX_IMPORT_CAPTURE_PATTERN,
+          'mod',
         );
-        const mod = capturedImport?.match(/from '([^']+)'/)?.[1];
+        const agentName = project && agentTmpNameFor(project, dir);
 
-        if (project && mod) {
-          const dirName = dir.split('/').filter(Boolean).pop() ?? dir;
+        if (project && mod && agentName) {
           tree.write(
             sessionPath,
             legacySessionManagerContent(
               mod,
-              localSessionsDirFor(
-                project.root,
-                agentTmpNameFor(project.name, dirName),
-              ),
+              localSessionsDirFor(project.root, agentName),
             ),
           );
         } else {
           nextSteps.push(
-            `${filePath}: could not determine the project root or agent-connection module — manually create a session.ts (see the ts#agent generator's template) and wire \`config: { sessionManagerProvider: getSessionManager }\` into the StrandsAgent constructor.`,
+            `${filePath}: could not determine the project root, agent-connection module, or this agent's name from its ComponentMetadata — manually create a session.ts (see the ts#agent generator's template) and wire \`config: { sessionManagerProvider: getSessionManager }\` into the StrandsAgent constructor.`,
           );
           continue;
         }
@@ -557,45 +658,6 @@ import { getSessionManager } from './session${esm ? '.js' : ''}';\` where { $nam
         AGUI_INDEX_SESSION_MANAGER_CONSTRUCTOR_PATTERN,
       );
       if (rewroteSessionManagerConstructor) {
-        nextSteps.push(
-          `${filePath}: wired sessionManagerProvider into the StrandsAgent constructor (see ${sessionPath}).`,
-        );
-        anyChanges = true;
-      }
-      continue;
-    }
-
-    if (filePath.endsWith('/model-errors-strands.ts')) {
-      const rewroteImport = await applyGritQL(
-        tree,
-        filePath,
-        MODEL_ERRORS_IMPORT_PATTERN,
-      );
-      const rewroteClass = await applyGritQL(
-        tree,
-        filePath,
-        MODEL_ERRORS_CLASS_PATTERN,
-      );
-      if (rewroteImport || rewroteClass) {
-        nextSteps.push(`${filePath}: added the ModelErrorLoggingPlugin class.`);
-        anyChanges = true;
-      }
-      continue;
-    }
-
-    if (filePath.endsWith('/tool-errors-strands.ts')) {
-      const rewroteImport = await applyGritQL(
-        tree,
-        filePath,
-        TOOL_ERRORS_IMPORT_PATTERN,
-      );
-      const rewroteClass = await applyGritQL(
-        tree,
-        filePath,
-        TOOL_ERRORS_CLASS_PATTERN,
-      );
-      if (rewroteImport || rewroteClass) {
-        nextSteps.push(`${filePath}: added the ToolErrorLoggingPlugin class.`);
         anyChanges = true;
       }
       continue;
@@ -606,9 +668,7 @@ import { getSessionManager } from './session${esm ? '.js' : ''}';\` where { $nam
       if (!contents.includes('agentRuntimes')) {
         continue;
       }
-      // Each rewrite is attempted independently (not short-circuited) since
-      // a single file may match more than one shape. Only the 'agentcore'
-      // namespace is reshaped here — see CDK_RC_SET_PATTERN's comment.
+      // Only the 'agentcore' namespace is reshaped — see CDK_RC_SET_PATTERN.
       const rewroteAgentcoreRcSet = await applyGritQL(
         tree,
         filePath,
@@ -627,9 +687,6 @@ import { getSessionManager } from './session${esm ? '.js' : ''}';\` where { $nam
       }
 
       if (rewroteAgentcoreRcSet || rewroteInterface || rewroteClientArn) {
-        nextSteps.push(
-          `${filePath}: reshaped agentRuntimes entries to { arn }.`,
-        );
         anyChanges = true;
       }
     } else if (filePath.endsWith('.tf')) {
@@ -639,9 +696,6 @@ import { getSessionManager } from './session${esm ? '.js' : ''}';\` where { $nam
       }
       const rewrote = await applyGritQL(tree, filePath, TF_VALUE_PATTERN);
       if (rewrote) {
-        nextSteps.push(
-          `${filePath}: reshaped agentRuntimes entries to { arn }.`,
-        );
         anyChanges = true;
       }
     } else if (filePath.endsWith('.py')) {
@@ -651,9 +705,6 @@ import { getSessionManager } from './session${esm ? '.js' : ''}';\` where { $nam
       }
       const rewrote = await applyGritQL(tree, filePath, PY_CLIENT_ARN_PATTERN);
       if (rewrote) {
-        nextSteps.push(
-          `${filePath}: reshaped agentRuntimes entries to { arn }.`,
-        );
         anyChanges = true;
       }
     }
@@ -661,9 +712,9 @@ import { getSessionManager } from './session${esm ? '.js' : ''}';\` where { $nam
 
   if (anyChanges) {
     nextSteps.push(
-      'If you have custom code reading agentRuntimes entries as plain ARN strings ' +
-        '(e.g. custom Lambda handlers or agent code), update it to read the ARN from `.arn` ' +
-        'on the new `{ arn }` shape.',
+      'If you have custom code reading the runtime config `agentcore.agentRuntimes` entries ' +
+        'as plain ARN strings (e.g. custom Lambda handlers or agent code), update it to read ' +
+        'the ARN from `.arn` on the new `{ arn }` shape.',
     );
   }
 

--- a/packages/nx-plugin/src/py/agent/__snapshots__/generator.constructs.spec.ts.snap
+++ b/packages/nx-plugin/src/py/agent/__snapshots__/generator.constructs.spec.ts.snap
@@ -105,9 +105,6 @@ export class SnapshotBedrockAgent
       ...rc.get('agentcore').agentRuntimes,
       SnapshotBedrockAgent: {
         arn: this.agentCoreRuntime.agentRuntimeArn,
-        session: {
-          storage: 'in-memory',
-        },
       },
     });
   }

--- a/packages/nx-plugin/src/py/agent/__snapshots__/generator.constructs.spec.ts.snap
+++ b/packages/nx-plugin/src/py/agent/__snapshots__/generator.constructs.spec.ts.snap
@@ -103,7 +103,12 @@ export class SnapshotBedrockAgent
 
     rc.set('agentcore', 'agentRuntimes', {
       ...rc.get('agentcore').agentRuntimes,
-      SnapshotBedrockAgent: this.agentCoreRuntime.agentRuntimeArn,
+      SnapshotBedrockAgent: {
+        arn: this.agentCoreRuntime.agentRuntimeArn,
+        session: {
+          storage: 'none',
+        },
+      },
     });
   }
 

--- a/packages/nx-plugin/src/py/agent/__snapshots__/generator.constructs.spec.ts.snap
+++ b/packages/nx-plugin/src/py/agent/__snapshots__/generator.constructs.spec.ts.snap
@@ -106,7 +106,7 @@ export class SnapshotBedrockAgent
       SnapshotBedrockAgent: {
         arn: this.agentCoreRuntime.agentRuntimeArn,
         session: {
-          storage: 'none',
+          storage: 'in-memory',
         },
       },
     });

--- a/packages/nx-plugin/src/py/agent/__snapshots__/generator.frameworks.spec.ts.snap
+++ b/packages/nx-plugin/src/py/agent/__snapshots__/generator.frameworks.spec.ts.snap
@@ -29,8 +29,8 @@ export const resolveRemoteAgent = async (): Promise<
     application,
     environment: 'default',
     transform: 'json',
-  })) as { agentRuntimes?: Record<string, string> };
-  const arn = config?.agentRuntimes?.['TestProjectAgent'];
+  })) as { agentRuntimes?: Record<string, { arn: string }> };
+  const arn = config?.agentRuntimes?.['TestProjectAgent']?.arn;
   if (!arn) {
     throw new Error(
       \`No deployed agent named 'TestProjectAgent' found in runtime configuration (application \${application}).\`,
@@ -131,8 +131,8 @@ export const resolveRemoteAgent = async (): Promise<
     application,
     environment: 'default',
     transform: 'json',
-  })) as { agentRuntimes?: Record<string, string> };
-  const arn = config?.agentRuntimes?.['TestProjectAgent'];
+  })) as { agentRuntimes?: Record<string, { arn: string }> };
+  const arn = config?.agentRuntimes?.['TestProjectAgent']?.arn;
   if (!arn) {
     throw new Error(
       \`No deployed agent named 'TestProjectAgent' found in runtime configuration (application \${application}).\`,
@@ -224,8 +224,8 @@ export const resolveRemoteAgent = async (): Promise<
     application,
     environment: 'default',
     transform: 'json',
-  })) as { agentRuntimes?: Record<string, string> };
-  const arn = config?.agentRuntimes?.['TestProjectAgent'];
+  })) as { agentRuntimes?: Record<string, { arn: string }> };
+  const arn = config?.agentRuntimes?.['TestProjectAgent']?.arn;
   if (!arn) {
     throw new Error(
       \`No deployed agent named 'TestProjectAgent' found in runtime configuration (application \${application}).\`,
@@ -308,8 +308,8 @@ export const resolveRemoteAgent = async (): Promise<
     application,
     environment: 'default',
     transform: 'json',
-  })) as { agentRuntimes?: Record<string, string> };
-  const arn = config?.agentRuntimes?.['TestProjectAgent'];
+  })) as { agentRuntimes?: Record<string, { arn: string }> };
+  const arn = config?.agentRuntimes?.['TestProjectAgent']?.arn;
   if (!arn) {
     throw new Error(
       \`No deployed agent named 'TestProjectAgent' found in runtime configuration (application \${application}).\`,
@@ -383,8 +383,8 @@ export const resolveRemoteAgent = async (): Promise<
     application,
     environment: 'default',
     transform: 'json',
-  })) as { agentRuntimes?: Record<string, string> };
-  const arn = config?.agentRuntimes?.['TestProjectAgent'];
+  })) as { agentRuntimes?: Record<string, { arn: string }> };
+  const arn = config?.agentRuntimes?.['TestProjectAgent']?.arn;
   if (!arn) {
     throw new Error(
       \`No deployed agent named 'TestProjectAgent' found in runtime configuration (application \${application}).\`,
@@ -495,8 +495,8 @@ export const resolveRemoteAgent = async (): Promise<
     application,
     environment: 'default',
     transform: 'json',
-  })) as { agentRuntimes?: Record<string, string> };
-  const arn = config?.agentRuntimes?.['TestProjectAgent'];
+  })) as { agentRuntimes?: Record<string, { arn: string }> };
+  const arn = config?.agentRuntimes?.['TestProjectAgent']?.arn;
   if (!arn) {
     throw new Error(
       \`No deployed agent named 'TestProjectAgent' found in runtime configuration (application \${application}).\`,

--- a/packages/nx-plugin/src/py/agent/__snapshots__/generator.protocols.spec.ts.snap
+++ b/packages/nx-plugin/src/py/agent/__snapshots__/generator.protocols.spec.ts.snap
@@ -95,7 +95,7 @@ module "add_agent_runtime_to_runtime_config" {
 
   namespace = "agentcore"
   key       = "agentRuntimes"
-  value     = { "TerraformSnapshotAgent" = module.agent_core_runtime.agent_core_runtime_arn }
+  value     = { "TerraformSnapshotAgent" = { arn = module.agent_core_runtime.agent_core_runtime_arn, session = { storage = "none" } } }
 
   depends_on = [module.agent_core_runtime]
 }

--- a/packages/nx-plugin/src/py/agent/__snapshots__/generator.protocols.spec.ts.snap
+++ b/packages/nx-plugin/src/py/agent/__snapshots__/generator.protocols.spec.ts.snap
@@ -95,7 +95,7 @@ module "add_agent_runtime_to_runtime_config" {
 
   namespace = "agentcore"
   key       = "agentRuntimes"
-  value     = { "TerraformSnapshotAgent" = { arn = module.agent_core_runtime.agent_core_runtime_arn, session = { storage = "none" } } }
+  value     = { "TerraformSnapshotAgent" = { arn = module.agent_core_runtime.agent_core_runtime_arn, session = { storage = "in-memory" } } }
 
   depends_on = [module.agent_core_runtime]
 }

--- a/packages/nx-plugin/src/py/agent/__snapshots__/generator.protocols.spec.ts.snap
+++ b/packages/nx-plugin/src/py/agent/__snapshots__/generator.protocols.spec.ts.snap
@@ -95,7 +95,7 @@ module "add_agent_runtime_to_runtime_config" {
 
   namespace = "agentcore"
   key       = "agentRuntimes"
-  value     = { "TerraformSnapshotAgent" = { arn = module.agent_core_runtime.agent_core_runtime_arn, session = { storage = "in-memory" } } }
+  value     = { "TerraformSnapshotAgent" = { arn = module.agent_core_runtime.agent_core_runtime_arn } }
 
   depends_on = [module.agent_core_runtime]
 }

--- a/packages/nx-plugin/src/py/agent/a2a-connection/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/agent/a2a-connection/__snapshots__/generator.spec.ts.snap
@@ -128,7 +128,8 @@ class RemoteClientStrands:
         if os.environ.get("LOCAL_DEV") == "true":
             return AgentCoreA2aClientStrands.without_auth("http://localhost:9001/")
         config = get_agentcore_runtime_config()
-        agent_runtime_arn = config.get("agentRuntimes", {}).get("Remote")
+        agent_runtime = config.get("agentRuntimes", {}).get("Remote")
+        agent_runtime_arn = agent_runtime.get("arn") if agent_runtime else None
         if not agent_runtime_arn:
             raise RuntimeError("No connected agent runtime named 'Remote' found in runtime configuration.")
         return AgentCoreA2aClientStrands.with_iam_auth(agent_runtime_arn)

--- a/packages/nx-plugin/src/py/agent/a2a-connection/files/agent-connection/app/__targetAgentSnakeCase___client_strands.py.template
+++ b/packages/nx-plugin/src/py/agent/a2a-connection/files/agent-connection/app/__targetAgentSnakeCase___client_strands.py.template
@@ -20,9 +20,10 @@ class <%- targetAgentClassName %>ClientStrands:
                 "http://localhost:<%- targetAgentPort %>/"
             )
         config = get_agentcore_runtime_config()
-        agent_runtime_arn = config.get("agentRuntimes", {}).get(
+        agent_runtime = config.get("agentRuntimes", {}).get(
             "<%- targetAgentClassName %>"
         )
+        agent_runtime_arn = agent_runtime.get("arn") if agent_runtime else None
         if not agent_runtime_arn:
             raise RuntimeError(
                 "No connected agent runtime named '<%- targetAgentClassName %>' found in runtime configuration."

--- a/packages/nx-plugin/src/py/agent/a2a-connection/files/langchain/agent-connection/app/__targetAgentSnakeCase___client_langchain.py.template
+++ b/packages/nx-plugin/src/py/agent/a2a-connection/files/langchain/agent-connection/app/__targetAgentSnakeCase___client_langchain.py.template
@@ -18,9 +18,10 @@ class <%- targetAgentClassName %>ClientLangChain:
                 "http://localhost:<%- targetAgentPort %>/"
             )
         config = get_agentcore_runtime_config()
-        agent_runtime_arn = config.get("agentRuntimes", {}).get(
+        agent_runtime = config.get("agentRuntimes", {}).get(
             "<%- targetAgentClassName %>"
         )
+        agent_runtime_arn = agent_runtime.get("arn") if agent_runtime else None
         if not agent_runtime_arn:
             raise RuntimeError(
                 "No connected agent runtime named '<%- targetAgentClassName %>' found in runtime configuration."

--- a/packages/nx-plugin/src/py/agent/generator.ts
+++ b/packages/nx-plugin/src/py/agent/generator.ts
@@ -226,9 +226,9 @@ export const pyAgentGenerator = async (
 
   const auth = options.auth ?? 'iam';
 
-  // Only 'none' is currently supported for Python agents (session manager
+  // Only 'in-memory' is currently supported for Python agents (session manager
   // support for Python is not yet implemented).
-  const session = options.session ?? 'none';
+  const session = options.session ?? 'in-memory';
 
   // Ensure the shared agent-connection project exists so the server entry
   // point can import `session_id_context` and propagate the AgentCore

--- a/packages/nx-plugin/src/py/agent/generator.ts
+++ b/packages/nx-plugin/src/py/agent/generator.ts
@@ -226,6 +226,10 @@ export const pyAgentGenerator = async (
 
   const auth = options.auth ?? 'iam';
 
+  // Only 'none' is currently supported for Python agents (session manager
+  // support for Python is not yet implemented).
+  const session = options.session ?? 'none';
+
   // Ensure the shared agent-connection project exists so the server entry
   // point can import `session_id_context` and propagate the AgentCore
   // session ID to any downstream MCP / A2A clients a later connection
@@ -394,6 +398,7 @@ export const pyAgentGenerator = async (
       iac,
       projectName: project.name,
       auth,
+      session,
       serverProtocol: infraProtocol,
       containers,
     });

--- a/packages/nx-plugin/src/py/agent/mcp-connection/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/agent/mcp-connection/__snapshots__/generator.spec.ts.snap
@@ -140,7 +140,8 @@ class InventoryMcpClientStrands:
         if os.environ.get("LOCAL_DEV") == "true":
             return AgentCoreMCPClientStrands.without_auth("http://localhost:8082/mcp")
         config = get_agentcore_runtime_config()
-        agent_runtime_arn = config.get("agentRuntimes", {}).get("InventoryMcp")
+        agent_runtime = config.get("agentRuntimes", {}).get("InventoryMcp")
+        agent_runtime_arn = agent_runtime.get("arn") if agent_runtime else None
         if not agent_runtime_arn:
             raise RuntimeError("No connected MCP server runtime named 'InventoryMcp' found in runtime configuration.")
         return AgentCoreMCPClientStrands.with_iam_auth(agent_runtime_arn)

--- a/packages/nx-plugin/src/py/agent/mcp-connection/files/agent-connection/app/__mcpServerSnakeCase___client_strands.py.template
+++ b/packages/nx-plugin/src/py/agent/mcp-connection/files/agent-connection/app/__mcpServerSnakeCase___client_strands.py.template
@@ -20,9 +20,10 @@ class <%- mcpServerClassName %>ClientStrands:
                 "http://localhost:<%- mcpServerPort %>/mcp"
             )
         config = get_agentcore_runtime_config()
-        agent_runtime_arn = config.get("agentRuntimes", {}).get(
+        agent_runtime = config.get("agentRuntimes", {}).get(
             "<%- mcpServerClassName %>"
         )
+        agent_runtime_arn = agent_runtime.get("arn") if agent_runtime else None
         if not agent_runtime_arn:
             raise RuntimeError(
                 "No connected MCP server runtime named '<%- mcpServerClassName %>' found in runtime configuration."

--- a/packages/nx-plugin/src/py/agent/mcp-connection/files/langchain/agent-connection/app/__mcpServerSnakeCase___client_langchain.py.template
+++ b/packages/nx-plugin/src/py/agent/mcp-connection/files/langchain/agent-connection/app/__mcpServerSnakeCase___client_langchain.py.template
@@ -20,9 +20,10 @@ class <%- mcpServerClassName %>ClientLangChain:
                 "http://localhost:<%- mcpServerPort %>/mcp"
             )
         config = get_agentcore_runtime_config()
-        agent_runtime_arn = config.get("agentRuntimes", {}).get(
+        agent_runtime = config.get("agentRuntimes", {}).get(
             "<%- mcpServerClassName %>"
         )
+        agent_runtime_arn = agent_runtime.get("arn") if agent_runtime else None
         if not agent_runtime_arn:
             raise RuntimeError(
                 "No connected MCP server runtime named '<%- mcpServerClassName %>' found in runtime configuration."

--- a/packages/nx-plugin/src/py/agent/react-connection/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/agent/react-connection/__snapshots__/generator.spec.ts.snap
@@ -39,9 +39,12 @@ export const TestAgentClientContext = createContext<TestAgent | undefined>(
 const useCreateTestAgentClient = (): TestAgent => {
   const runtimeConfig = useRuntimeConfig();
   const agentRuntimeValue = runtimeConfig.agentRuntimes.TestAgent;
-  const apiUrl = agentRuntimeValue.startsWith('arn:')
-    ? buildAgentCoreHttpUrl(agentRuntimeValue)
-    : agentRuntimeValue;
+  // A string value is a local-dev override URL; otherwise it's the deployed
+  // runtime entry, so build the invocation URL from its ARN.
+  const apiUrl =
+    typeof agentRuntimeValue === 'string'
+      ? agentRuntimeValue
+      : buildAgentCoreHttpUrl(agentRuntimeValue.arn);
   const sigv4Client = useSigV4();
   return useMemo(
     () =>
@@ -99,9 +102,12 @@ export const TestAgentClientContext = createContext<TestAgent | undefined>(
 const useCreateTestAgentClient = (): TestAgent => {
   const runtimeConfig = useRuntimeConfig();
   const agentRuntimeValue = runtimeConfig.agentRuntimes.TestAgent;
-  const apiUrl = agentRuntimeValue.startsWith('arn:')
-    ? buildAgentCoreHttpUrl(agentRuntimeValue)
-    : agentRuntimeValue;
+  // A string value is a local-dev override URL; otherwise it's the deployed
+  // runtime entry, so build the invocation URL from its ARN.
+  const apiUrl =
+    typeof agentRuntimeValue === 'string'
+      ? agentRuntimeValue
+      : buildAgentCoreHttpUrl(agentRuntimeValue.arn);
   const auth = useAuth();
   const user = auth?.user;
   const cognitoClient: typeof fetch = (url, init) => {
@@ -165,9 +171,12 @@ export const TestAgentClientContext = createContext<TestAgent | undefined>(
 const useCreateTestAgentClient = (): TestAgent => {
   const runtimeConfig = useRuntimeConfig();
   const agentRuntimeValue = runtimeConfig.agentRuntimes.TestAgent;
-  const apiUrl = agentRuntimeValue.startsWith('arn:')
-    ? buildAgentCoreHttpUrl(agentRuntimeValue)
-    : agentRuntimeValue;
+  // A string value is a local-dev override URL; otherwise it's the deployed
+  // runtime entry, so build the invocation URL from its ARN.
+  const apiUrl =
+    typeof agentRuntimeValue === 'string'
+      ? agentRuntimeValue
+      : buildAgentCoreHttpUrl(agentRuntimeValue.arn);
   const sigv4Client = useSigV4();
   return useMemo(
     () =>
@@ -312,9 +321,11 @@ export const useAguiTestAgent = (): Record<string, AbstractAgent> => {
 
   const url = useMemo(
     () =>
-      agentRuntimeValue.startsWith('arn:')
-        ? buildAgentCoreUrl(agentRuntimeValue)
-        : agentRuntimeValue,
+      // A string value is a local-dev override URL; otherwise it's the
+      // deployed runtime entry, so build the invocation URL from its ARN.
+      typeof agentRuntimeValue === 'string'
+        ? agentRuntimeValue
+        : buildAgentCoreUrl(agentRuntimeValue.arn),
     [agentRuntimeValue],
   );
 

--- a/packages/nx-plugin/src/py/agent/react-connection/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/agent/react-connection/__snapshots__/generator.spec.ts.snap
@@ -318,8 +318,6 @@ export const useAguiTestAgent = (): Record<string, AbstractAgent> => {
 
   const url = useMemo(
     () =>
-      // A local-dev override is a plain URL; otherwise it's the agent's
-      // runtime ARN, so build the invocation URL from it.
       agentRuntimeValue.startsWith('arn:')
         ? buildAgentCoreUrl(agentRuntimeValue)
         : agentRuntimeValue,

--- a/packages/nx-plugin/src/py/agent/react-connection/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/agent/react-connection/__snapshots__/generator.spec.ts.snap
@@ -39,12 +39,11 @@ export const TestAgentClientContext = createContext<TestAgent | undefined>(
 const useCreateTestAgentClient = (): TestAgent => {
   const runtimeConfig = useRuntimeConfig();
   const agentRuntimeValue = runtimeConfig.agentRuntimes.TestAgent;
-  // A string value is a local-dev override URL; otherwise it's the deployed
-  // runtime entry, so build the invocation URL from its ARN.
-  const apiUrl =
-    typeof agentRuntimeValue === 'string'
-      ? agentRuntimeValue
-      : buildAgentCoreHttpUrl(agentRuntimeValue.arn);
+  // A local-dev override is a plain URL; otherwise it's the agent's runtime
+  // ARN, so build the invocation URL from it.
+  const apiUrl = agentRuntimeValue.startsWith('arn:')
+    ? buildAgentCoreHttpUrl(agentRuntimeValue)
+    : agentRuntimeValue;
   const sigv4Client = useSigV4();
   return useMemo(
     () =>
@@ -102,12 +101,11 @@ export const TestAgentClientContext = createContext<TestAgent | undefined>(
 const useCreateTestAgentClient = (): TestAgent => {
   const runtimeConfig = useRuntimeConfig();
   const agentRuntimeValue = runtimeConfig.agentRuntimes.TestAgent;
-  // A string value is a local-dev override URL; otherwise it's the deployed
-  // runtime entry, so build the invocation URL from its ARN.
-  const apiUrl =
-    typeof agentRuntimeValue === 'string'
-      ? agentRuntimeValue
-      : buildAgentCoreHttpUrl(agentRuntimeValue.arn);
+  // A local-dev override is a plain URL; otherwise it's the agent's runtime
+  // ARN, so build the invocation URL from it.
+  const apiUrl = agentRuntimeValue.startsWith('arn:')
+    ? buildAgentCoreHttpUrl(agentRuntimeValue)
+    : agentRuntimeValue;
   const auth = useAuth();
   const user = auth?.user;
   const cognitoClient: typeof fetch = (url, init) => {
@@ -171,12 +169,11 @@ export const TestAgentClientContext = createContext<TestAgent | undefined>(
 const useCreateTestAgentClient = (): TestAgent => {
   const runtimeConfig = useRuntimeConfig();
   const agentRuntimeValue = runtimeConfig.agentRuntimes.TestAgent;
-  // A string value is a local-dev override URL; otherwise it's the deployed
-  // runtime entry, so build the invocation URL from its ARN.
-  const apiUrl =
-    typeof agentRuntimeValue === 'string'
-      ? agentRuntimeValue
-      : buildAgentCoreHttpUrl(agentRuntimeValue.arn);
+  // A local-dev override is a plain URL; otherwise it's the agent's runtime
+  // ARN, so build the invocation URL from it.
+  const apiUrl = agentRuntimeValue.startsWith('arn:')
+    ? buildAgentCoreHttpUrl(agentRuntimeValue)
+    : agentRuntimeValue;
   const sigv4Client = useSigV4();
   return useMemo(
     () =>
@@ -321,11 +318,11 @@ export const useAguiTestAgent = (): Record<string, AbstractAgent> => {
 
   const url = useMemo(
     () =>
-      // A string value is a local-dev override URL; otherwise it's the
-      // deployed runtime entry, so build the invocation URL from its ARN.
-      typeof agentRuntimeValue === 'string'
-        ? agentRuntimeValue
-        : buildAgentCoreUrl(agentRuntimeValue.arn),
+      // A local-dev override is a plain URL; otherwise it's the agent's
+      // runtime ARN, so build the invocation URL from it.
+      agentRuntimeValue.startsWith('arn:')
+        ? buildAgentCoreUrl(agentRuntimeValue)
+        : agentRuntimeValue,
     [agentRuntimeValue],
   );
 

--- a/packages/nx-plugin/src/py/agent/react-connection/generator.ts
+++ b/packages/nx-plugin/src/py/agent/react-connection/generator.ts
@@ -98,7 +98,7 @@ export const pyAgentReactConnectionGenerator = async (
   const session = (
     targetComponent?.session ??
     metadata?.session ??
-    'none'
+    'in-memory'
   ).toLowerCase();
 
   // Recorded below and read by the declaration's predicates, so the packages

--- a/packages/nx-plugin/src/py/agent/react-connection/generator.ts
+++ b/packages/nx-plugin/src/py/agent/react-connection/generator.ts
@@ -95,6 +95,11 @@ export const pyAgentReactConnectionGenerator = async (
   const agentPort = targetComponent?.port ?? metadata?.ports?.[0] ?? 8081;
   const auth = (targetComponent?.auth ?? metadata?.auth ?? 'iam').toLowerCase();
   const protocol = (targetComponent?.protocol ?? 'http').toLowerCase();
+  const session = (
+    targetComponent?.session ??
+    metadata?.session ??
+    'none'
+  ).toLowerCase();
 
   // Recorded below and read by the declaration's predicates, so the packages
   // added here are exactly the ones the version sync will own.
@@ -119,6 +124,7 @@ export const pyAgentReactConnectionGenerator = async (
       agentName,
       agentNameClassName,
       auth: auth as AgUiAuth,
+      session,
     });
   } else {
     const moduleName = getModuleName(agentProjectConfig);
@@ -196,6 +202,7 @@ export const pyAgentReactConnectionGenerator = async (
     await addAgentRuntimeToConnectionNamespace(tree, {
       agentNameKebabCase: kebabCase(agentNameClassName),
       agentNameClassName,
+      session,
     });
   }
 

--- a/packages/nx-plugin/src/py/agent/react-connection/generator.ts
+++ b/packages/nx-plugin/src/py/agent/react-connection/generator.ts
@@ -95,11 +95,6 @@ export const pyAgentReactConnectionGenerator = async (
   const agentPort = targetComponent?.port ?? metadata?.ports?.[0] ?? 8081;
   const auth = (targetComponent?.auth ?? metadata?.auth ?? 'iam').toLowerCase();
   const protocol = (targetComponent?.protocol ?? 'http').toLowerCase();
-  const session = (
-    targetComponent?.session ??
-    metadata?.session ??
-    'in-memory'
-  ).toLowerCase();
 
   // Recorded below and read by the declaration's predicates, so the packages
   // added here are exactly the ones the version sync will own.
@@ -124,7 +119,6 @@ export const pyAgentReactConnectionGenerator = async (
       agentName,
       agentNameClassName,
       auth: auth as AgUiAuth,
-      session,
     });
   } else {
     const moduleName = getModuleName(agentProjectConfig);
@@ -202,7 +196,6 @@ export const pyAgentReactConnectionGenerator = async (
     await addAgentRuntimeToConnectionNamespace(tree, {
       agentNameKebabCase: kebabCase(agentNameClassName),
       agentNameClassName,
-      session,
     });
   }
 

--- a/packages/nx-plugin/src/py/agent/schema.d.ts
+++ b/packages/nx-plugin/src/py/agent/schema.d.ts
@@ -11,7 +11,7 @@ export type AgentProtocol = 'http' | 'a2a' | 'ag-ui';
 
 export type PyAgentAuth = 'iam' | 'cognito';
 
-export type PyAgentSession = 'none';
+export type PyAgentSession = 'in-memory';
 
 export interface PyAgentGeneratorSchema {
   project: string;

--- a/packages/nx-plugin/src/py/agent/schema.d.ts
+++ b/packages/nx-plugin/src/py/agent/schema.d.ts
@@ -11,6 +11,8 @@ export type AgentProtocol = 'http' | 'a2a' | 'ag-ui';
 
 export type PyAgentAuth = 'iam' | 'cognito';
 
+export type PyAgentSession = 'none';
+
 export interface PyAgentGeneratorSchema {
   project: string;
   framework?: PyAgentFramework;
@@ -18,6 +20,7 @@ export interface PyAgentGeneratorSchema {
   infra?: PyAgentInfra;
   auth?: PyAgentAuth;
   protocol?: AgentProtocol;
+  session?: PyAgentSession;
   iac: IacOption;
   preferInstallDependencies?: boolean;
 }

--- a/packages/nx-plugin/src/py/agent/schema.json
+++ b/packages/nx-plugin/src/py/agent/schema.json
@@ -62,10 +62,10 @@
     },
     "session": {
       "type": "string",
-      "description": "The storage used to persist session for your Agent. Only 'none' is currently supported for Python agents.",
+      "description": "The storage used to persist session for your Agent. Only 'in-memory' is currently supported for Python agents.",
       "x-prompt": "How would you like to persist session for your Agent?",
-      "enum": ["none"],
-      "default": "none",
+      "enum": ["in-memory"],
+      "default": "in-memory",
       "x-priority": "important"
     },
     "preferInstallDependencies": {

--- a/packages/nx-plugin/src/py/agent/schema.json
+++ b/packages/nx-plugin/src/py/agent/schema.json
@@ -60,6 +60,14 @@
       "default": "agentcore",
       "x-priority": "important"
     },
+    "session": {
+      "type": "string",
+      "description": "The storage used to persist session for your Agent. Only 'none' is currently supported for Python agents.",
+      "x-prompt": "How would you like to persist session for your Agent?",
+      "enum": ["none"],
+      "default": "none",
+      "x-priority": "important"
+    },
     "preferInstallDependencies": {
       "type": "boolean",
       "description": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",

--- a/packages/nx-plugin/src/py/mcp-server/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/mcp-server/__snapshots__/generator.spec.ts.snap
@@ -87,9 +87,6 @@ export class SnapshotBedrockServer
       ...rc.get('agentcore').agentRuntimes,
       SnapshotBedrockServer: {
         arn: this.agentCoreRuntime.agentRuntimeArn,
-        session: {
-          storage: 'in-memory',
-        },
       },
     });
   }
@@ -743,7 +740,7 @@ module "add_agent_runtime_to_runtime_config" {
 
   namespace = "agentcore"
   key       = "agentRuntimes"
-  value     = { "TerraformSnapshotServer" = { arn = module.agent_core_runtime.agent_core_runtime_arn, session = { storage = "in-memory" } } }
+  value     = { "TerraformSnapshotServer" = { arn = module.agent_core_runtime.agent_core_runtime_arn } }
 
   depends_on = [module.agent_core_runtime]
 }

--- a/packages/nx-plugin/src/py/mcp-server/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/mcp-server/__snapshots__/generator.spec.ts.snap
@@ -85,7 +85,12 @@ export class SnapshotBedrockServer
 
     rc.set('agentcore', 'agentRuntimes', {
       ...rc.get('agentcore').agentRuntimes,
-      SnapshotBedrockServer: this.agentCoreRuntime.agentRuntimeArn,
+      SnapshotBedrockServer: {
+        arn: this.agentCoreRuntime.agentRuntimeArn,
+        session: {
+          storage: 'none',
+        },
+      },
     });
   }
 
@@ -738,7 +743,7 @@ module "add_agent_runtime_to_runtime_config" {
 
   namespace = "agentcore"
   key       = "agentRuntimes"
-  value     = { "TerraformSnapshotServer" = module.agent_core_runtime.agent_core_runtime_arn }
+  value     = { "TerraformSnapshotServer" = { arn = module.agent_core_runtime.agent_core_runtime_arn, session = { storage = "none" } } }
 
   depends_on = [module.agent_core_runtime]
 }

--- a/packages/nx-plugin/src/py/mcp-server/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/mcp-server/__snapshots__/generator.spec.ts.snap
@@ -88,7 +88,7 @@ export class SnapshotBedrockServer
       SnapshotBedrockServer: {
         arn: this.agentCoreRuntime.agentRuntimeArn,
         session: {
-          storage: 'none',
+          storage: 'in-memory',
         },
       },
     });
@@ -743,7 +743,7 @@ module "add_agent_runtime_to_runtime_config" {
 
   namespace = "agentcore"
   key       = "agentRuntimes"
-  value     = { "TerraformSnapshotServer" = { arn = module.agent_core_runtime.agent_core_runtime_arn, session = { storage = "none" } } }
+  value     = { "TerraformSnapshotServer" = { arn = module.agent_core_runtime.agent_core_runtime_arn, session = { storage = "in-memory" } } }
 
   depends_on = [module.agent_core_runtime]
 }

--- a/packages/nx-plugin/src/ts/agent/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/agent/__snapshots__/generator.spec.ts.snap
@@ -604,6 +604,14 @@ import {
   Bucket,
   BucketEncryption,
 } from 'aws-cdk-lib/aws-s3';
+import { Key } from 'aws-cdk-lib/aws-kms';
+import {
+  CfnDelivery,
+  CfnDeliveryDestination,
+  CfnDeliverySource,
+  LogGroup,
+  RetentionDays,
+} from 'aws-cdk-lib/aws-logs';
 import { Construct } from 'constructs';
 import * as path from 'path';
 import * as url from 'url';
@@ -615,6 +623,8 @@ import {
 } from 'aws-cdk-lib/aws-bedrockagentcore';
 import {
   PolicyStatement,
+  Effect,
+  ServicePrincipal,
   IGrantable,
   IPrincipal,
   Grant,
@@ -653,22 +663,51 @@ export class SnapshotBedrockAgent
       platform: Platform.LINUX_ARM64,
     });
 
+    const sessionKey = new Key(this, 'SessionKey', {
+      enableKeyRotation: true,
+    });
+
+    // Allow CloudWatch Logs to use the session key for server access log delivery.
+    const stack = Stack.of(this);
+    sessionKey.addToResourcePolicy(
+      new PolicyStatement({
+        effect: Effect.ALLOW,
+        principals: [
+          new ServicePrincipal(\`logs.\${stack.region}.amazonaws.com\`),
+        ],
+        actions: [
+          'kms:Encrypt',
+          'kms:Decrypt',
+          'kms:ReEncrypt*',
+          'kms:GenerateDataKey*',
+          'kms:DescribeKey',
+        ],
+        resources: ['*'],
+        conditions: {
+          ArnLike: {
+            'kms:EncryptionContext:aws:logs:arn': \`arn:aws:logs:\${stack.region}:\${stack.account}:log-group:*\`,
+          },
+        },
+      }),
+    );
+
+    const sessionAccessLogs = new LogGroup(this, 'SessionAccessLogs', {
+      retention: RetentionDays.ONE_YEAR,
+      encryptionKey: sessionKey,
+      removalPolicy: RemovalPolicy.DESTROY,
+    });
+
     const sessionBucket = new Bucket(this, 'SessionBucket', {
       enforceSSL: true,
-      autoDeleteObjects: true,
-      removalPolicy: RemovalPolicy.DESTROY,
-      encryption: BucketEncryption.S3_MANAGED,
+      removalPolicy: RemovalPolicy.RETAIN,
+      encryption: BucketEncryption.KMS,
+      encryptionKey: sessionKey,
       blockPublicAccess: BlockPublicAccess.BLOCK_ALL,
     });
     suppressRules(
       sessionBucket,
       ['CKV_AWS_21'],
       'Session data does not need versioning enabled',
-    );
-    suppressRules(
-      sessionBucket,
-      ['CKV_AWS_145'],
-      'AES256 (S3-managed) encryption is sufficient for session data',
     );
     suppressRules(
       sessionBucket,
@@ -688,8 +727,45 @@ export class SnapshotBedrockAgent
     suppressRules(
       sessionBucket,
       ['CKV_AWS_18'],
-      'Access logging not required for session data',
+      'Server access logs are delivered to CloudWatch Logs',
     );
+
+    const sessionAccessLogsSource = new CfnDeliverySource(
+      this,
+      'SessionAccessLogsSource',
+      {
+        name: Lazy.string({
+          produce: () =>
+            Names.uniqueResourceName(sessionAccessLogsSource, {
+              maxLength: 60,
+            }),
+        }),
+        logType: 'S3_SERVER_ACCESS_LOGS',
+        resourceArn: sessionBucket.bucketArn,
+      },
+    );
+    const sessionAccessLogsDestination = new CfnDeliveryDestination(
+      this,
+      'SessionAccessLogsDestination',
+      {
+        name: Lazy.string({
+          produce: () =>
+            Names.uniqueResourceName(sessionAccessLogsDestination, {
+              maxLength: 60,
+            }),
+        }),
+        destinationResourceArn: sessionAccessLogs.logGroupArn,
+      },
+    );
+    const sessionAccessLogsDelivery = new CfnDelivery(
+      this,
+      'SessionAccessLogsDelivery',
+      {
+        deliverySourceName: sessionAccessLogsSource.name,
+        deliveryDestinationArn: sessionAccessLogsDestination.attrArn,
+      },
+    );
+    sessionAccessLogsDelivery.addDependency(sessionAccessLogsSource);
 
     this.agentCoreRuntime = new Runtime(this, 'SnapshotBedrockAgent', {
       runtimeName: Lazy.string({
@@ -727,10 +803,7 @@ export class SnapshotBedrockAgent
       ...rc.get('agentcore').agentRuntimes,
       SnapshotBedrockAgent: {
         arn: this.agentCoreRuntime.agentRuntimeArn,
-        session: {
-          storage: 's3',
-          bucketName: sessionBucket.bucketName,
-        },
+        session: { bucketName: sessionBucket.bucketName },
       },
     });
   }
@@ -806,7 +879,16 @@ export * from './workspace.js';
 `;
 
 exports[`ts#agent generator > should match snapshot for Terraform generated files > terraform-agent.tf 1`] = `
-"variable "env" {
+"terraform {
+  required_providers {
+    random = {
+      source  = "hashicorp/random"
+      version = "3.9.0"
+    }
+  }
+}
+
+variable "env" {
   description = "Environment variables to pass to the agent core runtime"
   type        = map(string)
   default     = {}
@@ -857,15 +939,78 @@ variable "appconfig_application_arn" {
   type        = string
 }
 
+data "aws_region" "current" {}
+data "aws_caller_identity" "current" {}
+
+locals {
+  # Delivery source/destination names have a 60 character maximum. Truncate
+  # the agent name so these stay within the limit.
+  session_access_logs_name_prefix = substr("terraform-snapshot-agent", 0, 30)
+}
+
+# Uniquifies resource names below so this construct can be deployed more than
+# once (e.g. across stages) within the same account/region.
+resource "random_id" "session_unique_suffix" {
+  byte_length = 4
+}
+
+# KMS key encrypting the session bucket and its server access logs.
+resource "aws_kms_key" "session" {
+  description             = "KMS key for terraform-snapshot-agent agent session data"
+  enable_key_rotation     = true
+  deletion_window_in_days = 7
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "EnableIAMUserPermissions"
+        Effect    = "Allow"
+        Principal = { AWS = "arn:aws:iam::\${data.aws_caller_identity.current.account_id}:root" }
+        Action    = "kms:*"
+        Resource  = "*"
+      },
+      {
+        Sid       = "AllowCloudWatchLogs"
+        Effect    = "Allow"
+        Principal = { Service = "logs.\${data.aws_region.current.region}.amazonaws.com" }
+        Action = [
+          "kms:Encrypt",
+          "kms:Decrypt",
+          "kms:ReEncrypt*",
+          "kms:GenerateDataKey*",
+          "kms:DescribeKey"
+        ]
+        Resource = "*"
+        Condition = {
+          ArnLike = {
+            "kms:EncryptionContext:aws:logs:arn" = "arn:aws:logs:\${data.aws_region.current.region}:\${data.aws_caller_identity.current.account_id}:log-group:*"
+          }
+        }
+      }
+    ]
+  })
+
+  tags = var.tags
+}
+
+# CloudWatch log group receiving the session bucket's server access logs.
+resource "aws_cloudwatch_log_group" "session_access_logs" {
+  name              = "/aws/s3/terraform-snapshot-agent-session-access-logs-\${random_id.session_unique_suffix.hex}"
+  retention_in_days = 365
+  kms_key_id        = aws_kms_key.session.arn
+
+  tags = var.tags
+}
+
 # Bucket storing the agent's session data
 resource "aws_s3_bucket" "session" {
   #checkov:skip=CKV2_AWS_61:Lifecycle configuration not required for session data
   #checkov:skip=CKV_AWS_144:Cross-region replication not required for session data
   #checkov:skip=CKV2_AWS_62:Event notifications not required for session data
-  #checkov:skip=CKV_AWS_18:Access logging not required for session data
+  #checkov:skip=CKV_AWS_18:Server access logs are delivered to CloudWatch Logs (see aws_cloudwatch_log_delivery.session)
   #checkov:skip=CKV_AWS_21:Session data does not need versioning enabled
-  #checkov:skip=CKV_AWS_145:AES256 (S3-managed) encryption is sufficient for session data
-  force_destroy = true
+  force_destroy = false
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "session" {
@@ -873,7 +1018,8 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "session" {
 
   rule {
     apply_server_side_encryption_by_default {
-      sse_algorithm = "AES256"
+      kms_master_key_id = aws_kms_key.session.arn
+      sse_algorithm     = "aws:kms"
     }
   }
 }
@@ -885,6 +1031,51 @@ resource "aws_s3_bucket_public_access_block" "session" {
   block_public_policy     = true
   ignore_public_acls      = true
   restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_policy" "session" {
+  bucket = aws_s3_bucket.session.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "DenyInsecureConnections"
+        Effect    = "Deny"
+        Principal = "*"
+        Action    = "s3:*"
+        Resource = [
+          aws_s3_bucket.session.arn,
+          "\${aws_s3_bucket.session.arn}/*"
+        ]
+        Condition = {
+          Bool = {
+            "aws:SecureTransport" = "false"
+          }
+        }
+      }
+    ]
+  })
+}
+
+# Deliver the session bucket's server access logs to CloudWatch Logs.
+resource "aws_cloudwatch_log_delivery_source" "session" {
+  name         = "\${local.session_access_logs_name_prefix}-access-logs-source-\${random_id.session_unique_suffix.hex}"
+  log_type     = "S3_SERVER_ACCESS_LOGS"
+  resource_arn = aws_s3_bucket.session.arn
+}
+
+resource "aws_cloudwatch_log_delivery_destination" "session" {
+  name = "\${local.session_access_logs_name_prefix}-access-logs-dest-\${random_id.session_unique_suffix.hex}"
+
+  delivery_destination_configuration {
+    destination_resource_arn = aws_cloudwatch_log_group.session_access_logs.arn
+  }
+}
+
+resource "aws_cloudwatch_log_delivery" "session" {
+  delivery_source_name     = aws_cloudwatch_log_delivery_source.session.name
+  delivery_destination_arn = aws_cloudwatch_log_delivery_destination.session.arn
 }
 
 module "agent_core_runtime" {
@@ -933,6 +1124,15 @@ module "agent_core_runtime" {
         aws_s3_bucket.session.arn,
         "\${aws_s3_bucket.session.arn}/*"
       ]
+    },
+    # Grant access for the agent to use the session bucket's KMS key
+    {
+      Effect = "Allow"
+      Action = [
+        "kms:Decrypt",
+        "kms:GenerateDataKey*"
+      ]
+      Resource = [aws_kms_key.session.arn]
     }
   ], var.additional_iam_policy_statements)
   tags = var.tags
@@ -944,7 +1144,7 @@ module "add_agent_runtime_to_runtime_config" {
 
   namespace = "agentcore"
   key       = "agentRuntimes"
-  value     = { "TerraformSnapshotAgent" = { arn = module.agent_core_runtime.agent_core_runtime_arn, session = { storage = "s3", bucketName = aws_s3_bucket.session.bucket } } }
+  value     = { "TerraformSnapshotAgent" = { arn = module.agent_core_runtime.agent_core_runtime_arn, session = { bucketName = aws_s3_bucket.session.bucket } } }
 
   depends_on = [module.agent_core_runtime]
 }
@@ -1487,7 +1687,10 @@ output "security_group_id" {
 
 exports[`ts#agent generator > should match snapshot for generated files > agent-agent.ts 1`] = `
 "import { Agent, tool } from '@strands-agents/sdk';
-import { logModelErrors, logToolErrors } from '@proj/agent-connection';
+import {
+  ModelErrorLoggingPlugin,
+  ToolErrorLoggingPlugin,
+} from '@proj/agent-connection';
 import { getSessionManager } from './session.js';
 import { z } from 'zod';
 
@@ -1508,9 +1711,8 @@ export const getAgent = async () => {
   Refer to tools as your 'spellbook'.\`,
     tools: [multiply],
     sessionManager: await getSessionManager(),
+    plugins: [new ModelErrorLoggingPlugin(), new ToolErrorLoggingPlugin()],
   });
-  logModelErrors(agent);
-  logToolErrors(agent);
   return agent;
 };
 "

--- a/packages/nx-plugin/src/ts/agent/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/agent/__snapshots__/generator.spec.ts.snap
@@ -564,6 +564,81 @@ await chatLoop(new TrpcWebSocketAdapter(), process.env.URL ?? '');
 "
 `;
 
+exports[`ts#agent generator > should generate session.ts using S3 storage by default > session.ts (s3) 1`] = `
+"import { SessionManager } from '@strands-agents/sdk';
+import { LocalFileStorage, S3Storage } from '@strands-agents/sdk/storage';
+import {
+  getCurrentSessionId,
+  getAgentCoreRuntimeConfig,
+} from '@proj/agent-connection';
+
+/**
+ * Returns a SessionManager for persisting conversation state across
+ * invocations. Local development always uses local file storage for
+ * convenience, regardless of the configured session option. Without a
+ * configured session option, conversation state is kept in memory only and
+ * does not survive process restarts.
+ */
+export const getSessionManager = async (): Promise<SessionManager> => {
+  const sessionId = getCurrentSessionId();
+  if (!sessionId) {
+    throw new Error(
+      'No current session id — cannot resolve a SessionManager outside of a request scope.',
+    );
+  }
+  if (process.env.LOCAL_DEV === 'true') {
+    return new SessionManager({
+      sessionId,
+      storage: new LocalFileStorage(
+        '../../tmp/agents/strands/test-project-agent',
+      ),
+    });
+  }
+  const config = await getAgentCoreRuntimeConfig();
+  const bucketName =
+    config.agentRuntimes?.['TestProjectAgent']?.session?.bucketName;
+  if (!bucketName) {
+    throw new Error(
+      "No S3 bucket configured for this agent's session in runtime configuration.",
+    );
+  }
+  return new SessionManager({ sessionId, storage: new S3Storage(bucketName) });
+};
+"
+`;
+
+exports[`ts#agent generator > should generate session.ts using in-memory storage when session is in-memory > session.ts (in-memory) 1`] = `
+"import { SessionManager } from '@strands-agents/sdk';
+import { LocalFileStorage, InMemoryStorage } from '@strands-agents/sdk/storage';
+import { getCurrentSessionId } from '@proj/agent-connection';
+
+/**
+ * Returns a SessionManager for persisting conversation state across
+ * invocations. Local development always uses local file storage for
+ * convenience, regardless of the configured session option. Without a
+ * configured session option, conversation state is kept in memory only and
+ * does not survive process restarts.
+ */
+export const getSessionManager = async (): Promise<SessionManager> => {
+  const sessionId = getCurrentSessionId();
+  if (!sessionId) {
+    throw new Error(
+      'No current session id — cannot resolve a SessionManager outside of a request scope.',
+    );
+  }
+  if (process.env.LOCAL_DEV === 'true') {
+    return new SessionManager({
+      sessionId,
+      storage: new LocalFileStorage(
+        '../../tmp/agents/strands/test-project-agent',
+      ),
+    });
+  }
+  return new SessionManager({ sessionId, storage: new InMemoryStorage() });
+};
+"
+`;
+
 exports[`ts#agent generator > should match snapshot for BedrockAgentCoreRuntime generated constructs files > agent-Dockerfile 1`] = `
 "FROM public.ecr.aws/docker/library/node:lts-slim
 
@@ -2113,6 +2188,274 @@ export function zAsyncIterable<
       TReturnOut
     >
   >;
+}
+"
+`;
+
+exports[`ts#agent generator > should not create session bucket infrastructure when session is in-memory (Terraform) > terraform-agent.tf (in-memory) 1`] = `
+"variable "env" {
+  description = "Environment variables to pass to the agent core runtime"
+  type        = map(string)
+  default     = {}
+}
+
+variable "additional_iam_policy_statements" {
+  description = "Additional IAM policy statements to attach to the agent core runtime role"
+  type = list(object({
+    Effect   = string
+    Action   = list(string)
+    Resource = list(string)
+  }))
+  default = []
+}
+
+variable "tags" {
+  description = "Tags to apply to resources"
+  type        = map(string)
+  default     = {}
+}
+
+# VPC Configuration (optional)
+variable "enable_vpc" {
+  description = "Run the agent core runtime inside a VPC. Set alongside vpc_id/subnet_ids."
+  type        = bool
+  default     = false
+}
+
+variable "vpc_id" {
+  description = "VPC ID to run the agent core runtime in. Required when enable_vpc is true."
+  type        = string
+  default     = null
+}
+
+variable "subnet_ids" {
+  description = "Subnet IDs to run the agent core runtime in. Required when enable_vpc is true."
+  type        = list(string)
+  default     = null
+}
+
+variable "appconfig_application_id" {
+  description = "ID of the shared runtime-config AppConfig application (from \`core/runtime-config/appconfig.application_id\`). The agent reads its runtime configuration from this application."
+  type        = string
+}
+
+variable "appconfig_application_arn" {
+  description = "ARN of the shared runtime-config AppConfig application (from \`core/runtime-config/appconfig.application_arn\`). Used to scope the IAM read permission granted to the agent runtime."
+  type        = string
+}
+
+module "agent_core_runtime" {
+  source = "../../../core/agent-core"
+  agent_runtime_name = "InMemoryTerraformAgent"
+  docker_image_tag = "proj-in-memory-terraform-agent:latest"
+  server_protocol = "HTTP"
+  enable_vpc = var.enable_vpc
+  vpc_id = var.vpc_id
+  subnet_ids = var.subnet_ids
+
+  env = merge({
+    RUNTIME_CONFIG_APP_ID = var.appconfig_application_id
+  }, var.env)
+  additional_iam_policy_statements = concat([
+    {
+      Effect   = "Allow"
+      Action   = [
+        "appconfig:StartConfigurationSession",
+        "appconfig:GetLatestConfiguration"
+      ]
+      Resource = ["\${var.appconfig_application_arn}/*"]
+    },
+    # Grant access for the agent to invoke bedrock models
+    {
+      Effect = "Allow"
+      Action = [
+        "bedrock:InvokeModel",
+        "bedrock:InvokeModelWithResponseStream"
+      ]
+      Resource = [
+        "arn:aws:bedrock:*:*:foundation-model/*",
+        "arn:aws:bedrock:*:*:inference-profile/*"
+      ]
+    }
+  ], var.additional_iam_policy_statements)
+  tags = var.tags
+}
+
+# Add agent runtime ARN to runtime config
+module "add_agent_runtime_to_runtime_config" {
+  source = "../../../core/runtime-config/entry"
+
+  namespace = "agentcore"
+  key       = "agentRuntimes"
+  value     = { "InMemoryTerraformAgent" = { arn = module.agent_core_runtime.agent_core_runtime_arn } }
+
+  depends_on = [module.agent_core_runtime]
+}
+
+output "agent_core_runtime_role_arn" {
+  description = "ARN of the agent core runtime role"
+  value       = module.agent_core_runtime.agent_core_runtime_role_arn
+}
+
+output "agent_core_runtime_arn" {
+  description = "ARN of the Bedrock Agent Core runtime"
+  value       = module.agent_core_runtime.agent_core_runtime_arn
+}
+
+output "invocation_url" {
+  description = "HTTPS invocation URL of the runtime"
+  value       = module.agent_core_runtime.invocation_url
+}
+
+output "appconfig_application_id" {
+  description = "AppConfig Application ID for runtime config (passthrough of the shared \`appconfig_application_id\` input)."
+  value       = var.appconfig_application_id
+}
+
+output "security_group_id" {
+  description = "Security group ID of the agent core runtime, for use in ingress rules on resources it must reach (e.g. a database). Null unless enable_vpc is true."
+  value       = module.agent_core_runtime.security_group_id
+}
+"
+`;
+
+exports[`ts#agent generator > should not create session bucket infrastructure when session is in-memory > agent-construct.ts (in-memory) 1`] = `
+"import { Fn, Lazy, Names, Stack } from 'aws-cdk-lib';
+import { Platform } from 'aws-cdk-lib/aws-ecr-assets';
+import { Connections, IConnectable } from 'aws-cdk-lib/aws-ec2';
+import { Construct } from 'constructs';
+import * as path from 'path';
+import * as url from 'url';
+import {
+  AgentRuntimeArtifact,
+  ProtocolType,
+  Runtime,
+  RuntimeProps,
+} from 'aws-cdk-lib/aws-bedrockagentcore';
+import {
+  PolicyStatement,
+  IGrantable,
+  IPrincipal,
+  Grant,
+} from 'aws-cdk-lib/aws-iam';
+import { RuntimeConfig } from '../../../core/runtime-config.js';
+import { findWorkspaceRoot } from '../../../core/workspace.js';
+
+export type InMemoryAgentProps = Omit<
+  RuntimeProps,
+  | 'runtimeName'
+  | 'protocolConfiguration'
+  | 'agentRuntimeArtifact'
+  | 'authorizerConfiguration'
+>;
+
+export class InMemoryAgent
+  extends Construct
+  implements IGrantable, IConnectable
+{
+  public readonly dockerImage: AgentRuntimeArtifact;
+  public readonly agentCoreRuntime: Runtime;
+
+  constructor(scope: Construct, id: string, props?: InMemoryAgentProps) {
+    super(scope, id);
+
+    const rc = RuntimeConfig.ensure(this);
+
+    // Resolve the bundle output directory containing the Dockerfile and built artifacts
+    const bundleDir = path.join(
+      findWorkspaceRoot(url.fileURLToPath(new URL(import.meta.url))),
+      'dist/apps/test-project/bundle/agent/in-memory-agent',
+    );
+
+    this.dockerImage = AgentRuntimeArtifact.fromAsset(bundleDir, {
+      platform: Platform.LINUX_ARM64,
+    });
+
+    this.agentCoreRuntime = new Runtime(this, 'InMemoryAgent', {
+      runtimeName: Lazy.string({
+        produce: () =>
+          Names.uniqueResourceName(this.agentCoreRuntime, { maxLength: 40 }),
+      }),
+      protocolConfiguration: ProtocolType.HTTP,
+      agentRuntimeArtifact: this.dockerImage,
+      ...props,
+      environmentVariables: {
+        RUNTIME_CONFIG_APP_ID: rc.appConfigApplicationId,
+        ...props?.environmentVariables,
+      },
+    });
+
+    // Grant access for the agent to invoke bedrock models
+    this.agentCoreRuntime.addToRolePolicy(
+      new PolicyStatement({
+        actions: [
+          'bedrock:InvokeModel',
+          'bedrock:InvokeModelWithResponseStream',
+        ],
+        resources: [
+          'arn:aws:bedrock:*:*:foundation-model/*',
+          'arn:aws:bedrock:*:*:inference-profile/*',
+        ],
+      }),
+    );
+
+    rc.grantReadAppConfig(this.agentCoreRuntime);
+
+    rc.set('agentcore', 'agentRuntimes', {
+      ...rc.get('agentcore').agentRuntimes,
+      InMemoryAgent: {
+        arn: this.agentCoreRuntime.agentRuntimeArn,
+      },
+    });
+  }
+
+  /**
+   * The principal to grant permissions to.
+   */
+  public get grantPrincipal(): IPrincipal {
+    return this.agentCoreRuntime.grantPrincipal;
+  }
+
+  /**
+   * Network connections for this agent runtime.
+   */
+  public get connections(): Connections {
+    return this.agentCoreRuntime.connections;
+  }
+
+  /**
+   * The HTTPS invocation URL of the runtime.
+   */
+  public get invocationUrl(): string {
+    // The URL must URL-encode the runtime ARN (':' -> '%3A', '/' -> '%2F').
+    // The ARN is a CDK token, so encode at deploy time via Fn.join/Fn.split.
+    const encodedArn = Fn.join(
+      '%2F',
+      Fn.split(
+        '/',
+        Fn.join('%3A', Fn.split(':', this.agentCoreRuntime.agentRuntimeArn)),
+      ),
+    );
+    return \`https://bedrock-agentcore.\${Stack.of(this).region}.amazonaws.com/runtimes/\${encodedArn}/invocations?qualifier=DEFAULT\`;
+  }
+
+  /**
+   * Grants IAM permissions to invoke this agent runtime.
+   *
+   * @param grantee - The IAM principal to grant permissions to
+   */
+  public grantInvokeAccess(grantee: IGrantable) {
+    this.agentCoreRuntime.grantInvoke(grantee);
+
+    Grant.addToPrincipal({
+      grantee,
+      actions: ['bedrock-agentcore:InvokeAgentRuntimeWithWebSocketStream'],
+      resourceArns: [
+        this.agentCoreRuntime.agentRuntimeArn,
+        \`\${this.agentCoreRuntime.agentRuntimeArn}/*\`,
+      ],
+    });
+  }
 }
 "
 `;

--- a/packages/nx-plugin/src/ts/agent/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/agent/__snapshots__/generator.spec.ts.snap
@@ -730,7 +730,7 @@ export class SnapshotBedrockAgent
       'Server access logs are delivered to CloudWatch Logs',
     );
 
-    const sessionAccessLogsSource = new CfnDeliverySource(
+    const sessionAccessLogsSource: CfnDeliverySource = new CfnDeliverySource(
       this,
       'SessionAccessLogsSource',
       {
@@ -744,10 +744,8 @@ export class SnapshotBedrockAgent
         resourceArn: sessionBucket.bucketArn,
       },
     );
-    const sessionAccessLogsDestination = new CfnDeliveryDestination(
-      this,
-      'SessionAccessLogsDestination',
-      {
+    const sessionAccessLogsDestination: CfnDeliveryDestination =
+      new CfnDeliveryDestination(this, 'SessionAccessLogsDestination', {
         name: Lazy.string({
           produce: () =>
             Names.uniqueResourceName(sessionAccessLogsDestination, {
@@ -755,8 +753,7 @@ export class SnapshotBedrockAgent
             }),
         }),
         destinationResourceArn: sessionAccessLogs.logGroupArn,
-      },
-    );
+      });
     const sessionAccessLogsDelivery = new CfnDelivery(
       this,
       'SessionAccessLogsDelivery',

--- a/packages/nx-plugin/src/ts/agent/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/agent/__snapshots__/generator.spec.ts.snap
@@ -744,6 +744,10 @@ export class SnapshotBedrockAgent
         resourceArn: sessionBucket.bucketArn,
       },
     );
+    const sessionBucketPolicy = sessionBucket.policy;
+    if (sessionBucketPolicy) {
+      sessionAccessLogsSource.node.addDependency(sessionBucketPolicy);
+    }
     const sessionAccessLogsDestination: CfnDeliveryDestination =
       new CfnDeliveryDestination(this, 'SessionAccessLogsDestination', {
         name: Lazy.string({

--- a/packages/nx-plugin/src/ts/agent/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/agent/__snapshots__/generator.spec.ts.snap
@@ -29,8 +29,8 @@ export const resolveRemoteAgent = async (): Promise<
     application,
     environment: 'default',
     transform: 'json',
-  })) as { agentRuntimes?: Record<string, string> };
-  const arn = config?.agentRuntimes?.['TestProjectAgent'];
+  })) as { agentRuntimes?: Record<string, { arn: string }> };
+  const arn = config?.agentRuntimes?.['TestProjectAgent']?.arn;
   if (!arn) {
     throw new Error(
       \`No deployed agent named 'TestProjectAgent' found in runtime configuration (application \${application}).\`,
@@ -131,8 +131,8 @@ export const resolveRemoteAgent = async (): Promise<
     application,
     environment: 'default',
     transform: 'json',
-  })) as { agentRuntimes?: Record<string, string> };
-  const arn = config?.agentRuntimes?.['TestProjectAgent'];
+  })) as { agentRuntimes?: Record<string, { arn: string }> };
+  const arn = config?.agentRuntimes?.['TestProjectAgent']?.arn;
   if (!arn) {
     throw new Error(
       \`No deployed agent named 'TestProjectAgent' found in runtime configuration (application \${application}).\`,
@@ -224,8 +224,8 @@ export const resolveRemoteAgent = async (): Promise<
     application,
     environment: 'default',
     transform: 'json',
-  })) as { agentRuntimes?: Record<string, string> };
-  const arn = config?.agentRuntimes?.['TestProjectAgent'];
+  })) as { agentRuntimes?: Record<string, { arn: string }> };
+  const arn = config?.agentRuntimes?.['TestProjectAgent']?.arn;
   if (!arn) {
     throw new Error(
       \`No deployed agent named 'TestProjectAgent' found in runtime configuration (application \${application}).\`,
@@ -308,8 +308,8 @@ export const resolveRemoteAgent = async (): Promise<
     application,
     environment: 'default',
     transform: 'json',
-  })) as { agentRuntimes?: Record<string, string> };
-  const arn = config?.agentRuntimes?.['TestProjectAgent'];
+  })) as { agentRuntimes?: Record<string, { arn: string }> };
+  const arn = config?.agentRuntimes?.['TestProjectAgent']?.arn;
   if (!arn) {
     throw new Error(
       \`No deployed agent named 'TestProjectAgent' found in runtime configuration (application \${application}).\`,
@@ -383,8 +383,8 @@ export const resolveRemoteAgent = async (): Promise<
     application,
     environment: 'default',
     transform: 'json',
-  })) as { agentRuntimes?: Record<string, string> };
-  const arn = config?.agentRuntimes?.['TestProjectAgent'];
+  })) as { agentRuntimes?: Record<string, { arn: string }> };
+  const arn = config?.agentRuntimes?.['TestProjectAgent']?.arn;
   if (!arn) {
     throw new Error(
       \`No deployed agent named 'TestProjectAgent' found in runtime configuration (application \${application}).\`,
@@ -493,8 +493,8 @@ export const resolveRemoteAgent = async (): Promise<
     application,
     environment: 'default',
     transform: 'json',
-  })) as { agentRuntimes?: Record<string, string> };
-  const arn = config?.agentRuntimes?.['TestProjectAgent'];
+  })) as { agentRuntimes?: Record<string, { arn: string }> };
+  const arn = config?.agentRuntimes?.['TestProjectAgent']?.arn;
   if (!arn) {
     throw new Error(
       \`No deployed agent named 'TestProjectAgent' found in runtime configuration (application \${application}).\`,
@@ -596,9 +596,14 @@ CMD [ "node", "--require", "@aws/aws-distro-opentelemetry-node-autoinstrumentati
 `;
 
 exports[`ts#agent generator > should match snapshot for BedrockAgentCoreRuntime generated constructs files > agent-construct.ts 1`] = `
-"import { Fn, Lazy, Names, Stack } from 'aws-cdk-lib';
+"import { Fn, Lazy, Names, RemovalPolicy, Stack } from 'aws-cdk-lib';
 import { Platform } from 'aws-cdk-lib/aws-ecr-assets';
 import { Connections, IConnectable } from 'aws-cdk-lib/aws-ec2';
+import {
+  BlockPublicAccess,
+  Bucket,
+  BucketEncryption,
+} from 'aws-cdk-lib/aws-s3';
 import { Construct } from 'constructs';
 import * as path from 'path';
 import * as url from 'url';
@@ -614,6 +619,7 @@ import {
   IPrincipal,
   Grant,
 } from 'aws-cdk-lib/aws-iam';
+import { suppressRules } from '../../../core/checkov.js';
 import { RuntimeConfig } from '../../../core/runtime-config.js';
 import { findWorkspaceRoot } from '../../../core/workspace.js';
 
@@ -647,6 +653,44 @@ export class SnapshotBedrockAgent
       platform: Platform.LINUX_ARM64,
     });
 
+    const sessionBucket = new Bucket(this, 'SessionBucket', {
+      enforceSSL: true,
+      autoDeleteObjects: true,
+      removalPolicy: RemovalPolicy.DESTROY,
+      encryption: BucketEncryption.S3_MANAGED,
+      blockPublicAccess: BlockPublicAccess.BLOCK_ALL,
+    });
+    suppressRules(
+      sessionBucket,
+      ['CKV_AWS_21'],
+      'Session data does not need versioning enabled',
+    );
+    suppressRules(
+      sessionBucket,
+      ['CKV_AWS_145'],
+      'AES256 (S3-managed) encryption is sufficient for session data',
+    );
+    suppressRules(
+      sessionBucket,
+      ['CKV2_AWS_61'],
+      'Lifecycle configuration not required for session data',
+    );
+    suppressRules(
+      sessionBucket,
+      ['CKV_AWS_144'],
+      'Cross-region replication not required for session data',
+    );
+    suppressRules(
+      sessionBucket,
+      ['CKV2_AWS_62'],
+      'Event notifications not required for session data',
+    );
+    suppressRules(
+      sessionBucket,
+      ['CKV_AWS_18'],
+      'Access logging not required for session data',
+    );
+
     this.agentCoreRuntime = new Runtime(this, 'SnapshotBedrockAgent', {
       runtimeName: Lazy.string({
         produce: () =>
@@ -675,11 +719,19 @@ export class SnapshotBedrockAgent
       }),
     );
 
+    sessionBucket.grantReadWrite(this.agentCoreRuntime);
+
     rc.grantReadAppConfig(this.agentCoreRuntime);
 
     rc.set('agentcore', 'agentRuntimes', {
       ...rc.get('agentcore').agentRuntimes,
-      SnapshotBedrockAgent: this.agentCoreRuntime.agentRuntimeArn,
+      SnapshotBedrockAgent: {
+        arn: this.agentCoreRuntime.agentRuntimeArn,
+        session: {
+          storage: 's3',
+          bucketName: sessionBucket.bucketName,
+        },
+      },
     });
   }
 
@@ -805,6 +857,36 @@ variable "appconfig_application_arn" {
   type        = string
 }
 
+# Bucket storing the agent's session data
+resource "aws_s3_bucket" "session" {
+  #checkov:skip=CKV2_AWS_61:Lifecycle configuration not required for session data
+  #checkov:skip=CKV_AWS_144:Cross-region replication not required for session data
+  #checkov:skip=CKV2_AWS_62:Event notifications not required for session data
+  #checkov:skip=CKV_AWS_18:Access logging not required for session data
+  #checkov:skip=CKV_AWS_21:Session data does not need versioning enabled
+  #checkov:skip=CKV_AWS_145:AES256 (S3-managed) encryption is sufficient for session data
+  force_destroy = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "session" {
+  bucket = aws_s3_bucket.session.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "session" {
+  bucket = aws_s3_bucket.session.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
 module "agent_core_runtime" {
   source = "../../../core/agent-core"
   agent_runtime_name = "TerraformSnapshotAgent"
@@ -837,6 +919,20 @@ module "agent_core_runtime" {
         "arn:aws:bedrock:*:*:foundation-model/*",
         "arn:aws:bedrock:*:*:inference-profile/*"
       ]
+    },
+    # Grant access for the agent to read/write its session data
+    {
+      Effect = "Allow"
+      Action = [
+        "s3:GetObject",
+        "s3:PutObject",
+        "s3:DeleteObject",
+        "s3:ListBucket"
+      ]
+      Resource = [
+        aws_s3_bucket.session.arn,
+        "\${aws_s3_bucket.session.arn}/*"
+      ]
     }
   ], var.additional_iam_policy_statements)
   tags = var.tags
@@ -848,7 +944,7 @@ module "add_agent_runtime_to_runtime_config" {
 
   namespace = "agentcore"
   key       = "agentRuntimes"
-  value     = { "TerraformSnapshotAgent" = module.agent_core_runtime.agent_core_runtime_arn }
+  value     = { "TerraformSnapshotAgent" = { arn = module.agent_core_runtime.agent_core_runtime_arn, session = { storage = "s3", bucketName = aws_s3_bucket.session.bucket } } }
 
   depends_on = [module.agent_core_runtime]
 }
@@ -1392,6 +1488,7 @@ output "security_group_id" {
 exports[`ts#agent generator > should match snapshot for generated files > agent-agent.ts 1`] = `
 "import { Agent, tool } from '@strands-agents/sdk';
 import { logModelErrors, logToolErrors } from '@proj/agent-connection';
+import { getSessionManager } from './session.js';
 import { z } from 'zod';
 
 const multiply = tool({
@@ -1410,6 +1507,7 @@ export const getAgent = async () => {
   Use your tools for mathematical tasks.
   Refer to tools as your 'spellbook'.\`,
     tools: [multiply],
+    sessionManager: await getSessionManager(),
   });
   logModelErrors(agent);
   logToolErrors(agent);

--- a/packages/nx-plugin/src/ts/agent/a2a-connection/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/agent/a2a-connection/__snapshots__/generator.spec.ts.snap
@@ -5,6 +5,7 @@ exports[`ts#agent#a2a-connection generator > should match snapshot for agent-con
 export * from './core/tool-errors-strands.js';
 export * from './core/model-errors-strands.js';
 export * from './core/with-session-id-strands.js';
+export * from './core/runtime-config.js';
 export * from './core/session-context.js';
 // Export your library code here
 "
@@ -244,7 +245,7 @@ export class RemoteClientStrands {
       });
     }
     const config = await getAgentCoreRuntimeConfig();
-    const agentRuntimeArn = config.agentRuntimes?.['Remote'];
+    const agentRuntimeArn = config.agentRuntimes?.['Remote']?.arn;
     if (!agentRuntimeArn) {
       throw new Error(
         \`No connected agent runtime named 'Remote' found in runtime configuration.\`,

--- a/packages/nx-plugin/src/ts/agent/a2a-connection/files/agent-connection/app/__targetAgentKebabCase__-client-strands.ts.template
+++ b/packages/nx-plugin/src/ts/agent/a2a-connection/files/agent-connection/app/__targetAgentKebabCase__-client-strands.ts.template
@@ -12,7 +12,7 @@ export class <%- targetAgentClassName %>ClientStrands {
     }
     const config = await getAgentCoreRuntimeConfig();
     const agentRuntimeArn =
-      config.agentRuntimes?.['<%- targetAgentClassName %>'];
+      config.agentRuntimes?.['<%- targetAgentClassName %>']?.arn;
     if (!agentRuntimeArn) {
       throw new Error(
         `No connected agent runtime named '<%- targetAgentClassName %>' found in runtime configuration.`,

--- a/packages/nx-plugin/src/ts/agent/files/ag-ui/index.ts.template
+++ b/packages/nx-plugin/src/ts/agent/files/ag-ui/index.ts.template
@@ -7,8 +7,13 @@ import {
 import express, { type Request, type Response, type NextFunction } from 'express';
 import cors from 'cors';
 import { randomUUID } from 'node:crypto';
-import { runWithSessionId } from '<%- agentConnectionImport %>';
+import {
+  ModelErrorLoggingPlugin,
+  ToolErrorLoggingPlugin,
+  runWithSessionId,
+} from '<%- agentConnectionImport %>';
 import { getAgent } from './agent<% if (esm) { %>.js<% } %>';
+import { getSessionManager } from './session<% if (esm) { %>.js<% } %>';
 
 const PORT = parseInt(process.env.PORT || '8080');
 const HOST = '0.0.0.0';
@@ -32,6 +37,10 @@ void (async () => {
     agent,
     name: '<%= agentNameClassName %>',
     description: 'A Strands Agent exposed via the AG-UI protocol.',
+    plugins: [new ModelErrorLoggingPlugin(), new ToolErrorLoggingPlugin()],
+    config: {
+      sessionManagerProvider: getSessionManager,
+    },
   });
 
   // Built up manually (mirroring createStrandsApp's defaults) rather than via createStrandsApp

--- a/packages/nx-plugin/src/ts/agent/files/common/agent.ts.template
+++ b/packages/nx-plugin/src/ts/agent/files/common/agent.ts.template
@@ -1,6 +1,9 @@
 import { Agent, tool } from '@strands-agents/sdk';
 <%_ if (protocol !== 'ag-ui') { _%>
-import { logModelErrors, logToolErrors } from '<%- agentConnectionImport %>';
+import {
+  ModelErrorLoggingPlugin,
+  ToolErrorLoggingPlugin,
+} from '<%- agentConnectionImport %>';
 import { getSessionManager } from './session<% if (esm) { %>.js<% } %>';
 <%_ } _%>
 import { z } from 'zod';
@@ -23,11 +26,8 @@ export const getAgent = async () => {
     tools: [multiply],
 <%_ if (protocol !== 'ag-ui') { _%>
     sessionManager: await getSessionManager(),
+    plugins: [new ModelErrorLoggingPlugin(), new ToolErrorLoggingPlugin()],
 <%_ } _%>
   });
-<%_ if (protocol !== 'ag-ui') { _%>
-  logModelErrors(agent);
-  logToolErrors(agent);
-<%_ } _%>
   return agent;
 };

--- a/packages/nx-plugin/src/ts/agent/files/common/agent.ts.template
+++ b/packages/nx-plugin/src/ts/agent/files/common/agent.ts.template
@@ -1,5 +1,8 @@
 import { Agent, tool } from '@strands-agents/sdk';
+<%_ if (protocol !== 'ag-ui') { _%>
 import { logModelErrors, logToolErrors } from '<%- agentConnectionImport %>';
+import { getSessionManager } from './session<% if (esm) { %>.js<% } %>';
+<%_ } _%>
 import { z } from 'zod';
 
 const multiply = tool({
@@ -18,8 +21,13 @@ export const getAgent = async () => {
   Use your tools for mathematical tasks.
   Refer to tools as your 'spellbook'.`,
     tools: [multiply],
+<%_ if (protocol !== 'ag-ui') { _%>
+    sessionManager: await getSessionManager(),
+<%_ } _%>
   });
+<%_ if (protocol !== 'ag-ui') { _%>
   logModelErrors(agent);
   logToolErrors(agent);
+<%_ } _%>
   return agent;
 };

--- a/packages/nx-plugin/src/ts/agent/files/common/session.ts.template
+++ b/packages/nx-plugin/src/ts/agent/files/common/session.ts.template
@@ -1,0 +1,43 @@
+import { SessionManager } from '@strands-agents/sdk';
+import { LocalFileStorage<% if (session === 's3') { %>, S3Storage<% } else { %>, InMemoryStorage<% } %> } from '@strands-agents/sdk/storage';
+import {
+  getCurrentSessionId,
+<%_ if (session === 's3') { _%>
+  getAgentCoreRuntimeConfig,
+<%_ } _%>
+} from '<%- agentConnectionImport %>';
+
+/**
+ * Returns a SessionManager for persisting conversation state across
+ * invocations. Local development always uses local file storage for
+ * convenience, regardless of the configured session option. Without a
+ * configured session option, conversation state is kept in memory only and
+ * does not survive process restarts.
+ */
+export const getSessionManager = async (): Promise<SessionManager> => {
+  const sessionId = getCurrentSessionId();
+  if (!sessionId) {
+    throw new Error(
+      'No current session id — cannot resolve a SessionManager outside of a request scope.',
+    );
+  }
+  if (process.env.LOCAL_DEV === 'true') {
+    return new SessionManager({
+      sessionId,
+      storage: new LocalFileStorage('<%- localSessionsDir %>'),
+    });
+  }
+<%_ if (session === 's3') { _%>
+  const config = await getAgentCoreRuntimeConfig();
+  const bucketName =
+    config.agentRuntimes?.['<%- agentNameClassName %>']?.session?.bucketName;
+  if (!bucketName) {
+    throw new Error(
+      "No S3 bucket configured for this agent's session in runtime configuration.",
+    );
+  }
+  return new SessionManager({ sessionId, storage: new S3Storage(bucketName) });
+<%_ } else { _%>
+  return new SessionManager({ sessionId, storage: new InMemoryStorage() });
+<%_ } _%>
+};

--- a/packages/nx-plugin/src/ts/agent/gateway-connection/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/agent/gateway-connection/__snapshots__/generator.spec.ts.snap
@@ -5,6 +5,7 @@ exports[`ts#agent#gateway-connection generator > should match snapshot for agent
 export * from './core/tool-errors-strands.js';
 export * from './core/model-errors-strands.js';
 export * from './core/with-session-id-strands.js';
+export * from './core/runtime-config.js';
 export * from './core/session-context.js';
 // Export your library code here
 "

--- a/packages/nx-plugin/src/ts/agent/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/agent/generator.spec.ts
@@ -1307,7 +1307,7 @@ describe('ts#agent generator', () => {
       name: 'no-warn-agent',
       infra: 'none',
       auth: 'iam',
-      session: 'none',
+      session: 'in-memory',
       iac: 'cdk',
     });
 
@@ -1333,14 +1333,14 @@ describe('ts#agent generator', () => {
     warnSpy.mockRestore();
   });
 
-  it('should not warn when session is explicitly none with infra=none', async () => {
+  it('should not warn when session is explicitly in-memory with infra=none', async () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
     await tsAgentGenerator(tree, {
       project: 'test-project',
       name: 'session-none-agent',
       infra: 'none',
-      session: 'none',
+      session: 'in-memory',
       iac: 'cdk',
     });
 

--- a/packages/nx-plugin/src/ts/agent/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/agent/generator.spec.ts
@@ -163,6 +163,12 @@ describe('ts#agent generator', () => {
     expect(projectPackageJson.dependencies['@modelcontextprotocol/sdk']).toBe(
       'catalog:',
     );
+    // Default session is 's3'; S3Storage lazily imports this at runtime, so
+    // it must be declared for the bundler to inline it into the deployed
+    // container.
+    expect(projectPackageJson.dependencies['@aws-sdk/client-s3']).toBe(
+      'catalog:',
+    );
     expect(projectPackageJson.devDependencies['@types/ws']).toBe('catalog:');
     expect(projectPackageJson.devDependencies['@types/cors']).toBe('catalog:');
 
@@ -872,6 +878,7 @@ describe('ts#agent generator', () => {
     expect(projectConfig.metadata.components[0].name).toBe('agent');
     expect(projectConfig.metadata.components[0].port).toBeDefined();
     expect(typeof projectConfig.metadata.components[0].port).toBe('number');
+    expect(projectConfig.metadata.components[0].session).toBe('s3');
   });
 
   it('should add component generator metadata with custom name', async () => {
@@ -1347,6 +1354,87 @@ describe('ts#agent generator', () => {
     expect(warnSpy).not.toHaveBeenCalled();
 
     warnSpy.mockRestore();
+  });
+
+  it('should not add the @aws-sdk/client-s3 dependency when session is in-memory', async () => {
+    await tsAgentGenerator(tree, {
+      project: 'test-project',
+      infra: 'none',
+      session: 'in-memory',
+      iac: 'cdk',
+    });
+
+    const projectPackageJson = JSON.parse(
+      tree.read('apps/test-project/package.json', 'utf-8'),
+    );
+    expect(
+      projectPackageJson.dependencies['@aws-sdk/client-s3'],
+    ).toBeUndefined();
+  });
+
+  it('should generate session.ts using S3 storage by default', async () => {
+    await tsAgentGenerator(tree, {
+      project: 'test-project',
+      infra: 'none',
+      iac: 'cdk',
+    });
+
+    const sessionContent = tree.read(
+      'apps/test-project/src/agent/session.ts',
+      'utf-8',
+    );
+    expect(sessionContent).toMatchSnapshot('session.ts (s3)');
+  });
+
+  it('should generate session.ts using in-memory storage when session is in-memory', async () => {
+    await tsAgentGenerator(tree, {
+      project: 'test-project',
+      infra: 'none',
+      session: 'in-memory',
+      iac: 'cdk',
+    });
+
+    const sessionContent = tree.read(
+      'apps/test-project/src/agent/session.ts',
+      'utf-8',
+    );
+    expect(sessionContent).toMatchSnapshot('session.ts (in-memory)');
+  });
+
+  it('should not create session bucket infrastructure when session is in-memory', async () => {
+    await tsAgentGenerator(tree, {
+      project: 'test-project',
+      name: 'in-memory-agent',
+      infra: 'agentcore',
+      session: 'in-memory',
+      iac: 'cdk',
+    });
+
+    const agentConstructContent = tree.read(
+      'packages/common/constructs/src/app/agents/in-memory-agent/in-memory-agent.ts',
+      'utf-8',
+    );
+    expect(agentConstructContent).toMatchSnapshot(
+      'agent-construct.ts (in-memory)',
+    );
+  });
+
+  it('should not create session bucket infrastructure when session is in-memory (Terraform)', async () => {
+    await tsAgentGenerator(tree, {
+      project: 'test-project',
+      name: 'in-memory-terraform-agent',
+      infra: 'agentcore',
+      session: 'in-memory',
+      iac: 'terraform',
+    });
+
+    const agentTerraformContent = tree.read(
+      'packages/common/terraform/src/app/agents/in-memory-terraform-agent/in-memory-terraform-agent.tf',
+      'utf-8',
+    );
+    expect(agentTerraformContent).toMatchSnapshot(
+      'terraform-agent.tf (in-memory)',
+    );
   });
 
   it('should generate with infra=none then upgrade to infra=agentcore', async () => {

--- a/packages/nx-plugin/src/ts/agent/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/agent/generator.spec.ts
@@ -1307,6 +1307,40 @@ describe('ts#agent generator', () => {
       name: 'no-warn-agent',
       infra: 'none',
       auth: 'iam',
+      session: 'none',
+      iac: 'cdk',
+    });
+
+    expect(warnSpy).not.toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+  });
+
+  it('should warn when session is not explicitly disabled with infra=none', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await tsAgentGenerator(tree, {
+      project: 'test-project',
+      name: 'session-warn-agent',
+      infra: 'none',
+      iac: 'cdk',
+    });
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      'Warning: session is ignored when no infrastructure is configured (no infrastructure is generated)',
+    );
+
+    warnSpy.mockRestore();
+  });
+
+  it('should not warn when session is explicitly none with infra=none', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await tsAgentGenerator(tree, {
+      project: 'test-project',
+      name: 'session-none-agent',
+      infra: 'none',
+      session: 'none',
       iac: 'cdk',
     });
 

--- a/packages/nx-plugin/src/ts/agent/generator.ts
+++ b/packages/nx-plugin/src/ts/agent/generator.ts
@@ -172,14 +172,16 @@ export const tsAgentGenerator = async (
     );
   }
 
-  // Local-dev session storage lives at the workspace root (`tmp/agentCore/agentRuntimes/sessions`),
-  // not inside the project. The `-dev`/`-serve` targets run with cwd={projectRoot}, so
-  // compute that directory relative to the project root here rather than resolving it
-  // at runtime (e.g. via import.meta.url), which would need an extra runtime helper.
+  // Local-dev session storage lives at the workspace root
+  // (`tmp/agents/strands/<agent-name>`), not inside the project, so each agent
+  // gets its own storage directory. The `-dev`/`-serve` targets run with
+  // cwd={projectRoot}, so compute that directory relative to the project root
+  // here rather than resolving it at runtime (e.g. via import.meta.url),
+  // which would need an extra runtime helper.
   const projectDepth = project.root.split('/').filter(Boolean).length;
   const localSessionsDir = joinPathFragments(
     Array(projectDepth).fill('..').join('/'),
-    'tmp/agentCore/agentRuntimes/sessions',
+    `tmp/agents/strands/${name}`,
   );
 
   // Ensure the shared agent-connection project exists so the server entry

--- a/packages/nx-plugin/src/ts/agent/generator.ts
+++ b/packages/nx-plugin/src/ts/agent/generator.ts
@@ -49,6 +49,7 @@ import {
   readProjectConfigurationUnqualified,
 } from '../../utils/nx';
 import { sortObjectKeys } from '../../utils/object';
+import { getRelativePathToRootByDirectory } from '../../utils/paths';
 import { assignPort } from '../../utils/port';
 import {
   SHARED_CONSTRUCTS_DEPENDENCIES,
@@ -178,9 +179,8 @@ export const tsAgentGenerator = async (
   // cwd={projectRoot}, so compute that directory relative to the project root
   // here rather than resolving it at runtime (e.g. via import.meta.url),
   // which would need an extra runtime helper.
-  const projectDepth = project.root.split('/').filter(Boolean).length;
   const localSessionsDir = joinPathFragments(
-    Array(projectDepth).fill('..').join('/'),
+    getRelativePathToRootByDirectory(project.root),
     `tmp/agents/strands/${name}`,
   );
 

--- a/packages/nx-plugin/src/ts/agent/generator.ts
+++ b/packages/nx-plugin/src/ts/agent/generator.ts
@@ -65,6 +65,7 @@ export interface TsAgentMetadata extends IacMetadata {
   readonly rc: string;
   readonly auth: string;
   readonly protocol: string;
+  readonly session: string;
 }
 
 // Each entry names the branch it belongs to, so the same declaration drives both
@@ -77,6 +78,7 @@ export const DEPENDENCIES = declareDependencies<TsAgentMetadata>()({
     { name: '@aws-sdk/client-appconfigdata' },
     { name: '@aws-lambda-powertools/parameters' },
     { name: '@modelcontextprotocol/sdk' },
+    { name: '@aws-sdk/client-s3', when: (m) => m.session === 's3' },
     { name: 'express', when: (m) => m.protocol !== 'http' },
     { name: '@a2a-js/sdk', when: (m) => m.protocol === 'a2a' },
     { name: '@ag-ui/aws-strands', when: (m) => m.protocol === 'ag-ui' },
@@ -333,6 +335,7 @@ export const tsAgentGenerator = async (
     rc: agentNameClassName,
     auth,
     protocol,
+    session,
     ...(iac ? { iac } : {}),
   };
 

--- a/packages/nx-plugin/src/ts/agent/generator.ts
+++ b/packages/nx-plugin/src/ts/agent/generator.ts
@@ -166,7 +166,7 @@ export const tsAgentGenerator = async (
 
   const session = options.session ?? 's3';
 
-  if (infra === 'none' && session !== 'none') {
+  if (infra === 'none' && session !== 'in-memory') {
     console.warn(
       'Warning: session is ignored when no infrastructure is configured (no infrastructure is generated)',
     );

--- a/packages/nx-plugin/src/ts/agent/generator.ts
+++ b/packages/nx-plugin/src/ts/agent/generator.ts
@@ -164,6 +164,24 @@ export const tsAgentGenerator = async (
 
   const auth = options.auth ?? 'iam';
 
+  const session = options.session ?? 's3';
+
+  if (infra === 'none' && session !== 'none') {
+    console.warn(
+      'Warning: session is ignored when no infrastructure is configured (no infrastructure is generated)',
+    );
+  }
+
+  // Local-dev session storage lives at the workspace root (`tmp/agentCore/agentRuntimes/sessions`),
+  // not inside the project. The `-dev`/`-serve` targets run with cwd={projectRoot}, so
+  // compute that directory relative to the project root here rather than resolving it
+  // at runtime (e.g. via import.meta.url), which would need an extra runtime helper.
+  const projectDepth = project.root.split('/').filter(Boolean).length;
+  const localSessionsDir = joinPathFragments(
+    Array(projectDepth).fill('..').join('/'),
+    'tmp/agentCore/agentRuntimes/sessions',
+  );
+
   // Ensure the shared agent-connection project exists so the server entry
   // point can import `runWithSessionId` and propagate the AgentCore session
   // ID to any downstream MCP / A2A clients a later connection generator
@@ -177,6 +195,9 @@ export const tsAgentGenerator = async (
     name,
     agentNameClassName,
     distDir,
+    protocol,
+    session,
+    localSessionsDir,
     agentConnectionImport: `@${getNpmScope(tree)}/agent-connection`,
     ...esmVars(tree),
   };
@@ -290,6 +311,7 @@ export const tsAgentGenerator = async (
       dockerOutputDir,
       iac,
       auth,
+      session,
       serverProtocol: infraProtocol,
       containers,
     });

--- a/packages/nx-plugin/src/ts/agent/generator.ts
+++ b/packages/nx-plugin/src/ts/agent/generator.ts
@@ -56,7 +56,7 @@ import {
   sharedConstructsGenerator,
 } from '../../utils/shared-constructs';
 import type { IacMetadata } from '../../utils/shared-constructs-constants';
-import { BASE_IMAGES, TS_VERSIONS, withVersions } from '../../utils/versions';
+import { BASE_IMAGES, TS_VERSIONS } from '../../utils/versions';
 import type { TsAgentGeneratorSchema } from './schema';
 
 /** The metadata this generator records, which its predicates read. */

--- a/packages/nx-plugin/src/ts/agent/mcp-connection/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/agent/mcp-connection/__snapshots__/generator.spec.ts.snap
@@ -5,6 +5,7 @@ exports[`ts#agent#mcp-connection generator > should match snapshot for agent-con
 export * from './core/tool-errors-strands.js';
 export * from './core/model-errors-strands.js';
 export * from './core/with-session-id-strands.js';
+export * from './core/runtime-config.js';
 export * from './core/session-context.js';
 // Export your library code here
 "
@@ -231,7 +232,7 @@ export class InventoryMcpClientStrands {
       });
     }
     const config = await getAgentCoreRuntimeConfig();
-    const agentRuntimeArn = config.agentRuntimes?.['InventoryMcp'];
+    const agentRuntimeArn = config.agentRuntimes?.['InventoryMcp']?.arn;
     if (!agentRuntimeArn) {
       throw new Error(
         \`No connected MCP server runtime named 'InventoryMcp' found in runtime configuration.\`,

--- a/packages/nx-plugin/src/ts/agent/mcp-connection/files/agent-connection/app/__mcpServerKebabCase__-client-strands.ts.template
+++ b/packages/nx-plugin/src/ts/agent/mcp-connection/files/agent-connection/app/__mcpServerKebabCase__-client-strands.ts.template
@@ -11,7 +11,8 @@ export class <%- mcpServerClassName %>ClientStrands {
       });
     }
     const config = await getAgentCoreRuntimeConfig();
-    const agentRuntimeArn = config.agentRuntimes?.['<%- mcpServerClassName %>'];
+    const agentRuntimeArn =
+      config.agentRuntimes?.['<%- mcpServerClassName %>']?.arn;
     if (!agentRuntimeArn) {
       throw new Error(
         `No connected MCP server runtime named '<%- mcpServerClassName %>' found in runtime configuration.`,

--- a/packages/nx-plugin/src/ts/agent/react-connection/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/agent/react-connection/__snapshots__/generator.spec.ts.snap
@@ -39,12 +39,11 @@ export const TestAgentAgentClientProvider: FC<PropsWithChildren> = ({
   const sigv4Client = useSigV4();
 
   const container = useMemo<TestAgentAgentTRPCContextValue>(() => {
-    // A string value is a local-dev override URL; otherwise it's the deployed
-    // runtime entry, so build a WebSocket URL from its ARN.
-    const wsUrl =
-      typeof agentRuntimeValue === 'string'
-        ? agentRuntimeValue
-        : buildAgentCoreWsUrl(agentRuntimeValue.arn);
+    // A local-dev override is a plain URL; otherwise it's the agent's
+    // runtime ARN, so build a WebSocket URL from it.
+    const wsUrl = agentRuntimeValue.startsWith('arn:')
+      ? buildAgentCoreWsUrl(agentRuntimeValue)
+      : agentRuntimeValue;
 
     const wsClient = createWSClient({
       url: async () => {
@@ -157,12 +156,11 @@ export const TestAgentAgentClientProvider: FC<PropsWithChildren> = ({
   const accessToken = auth?.user?.access_token;
 
   const container = useMemo<TestAgentAgentTRPCContextValue>(() => {
-    // A string value is a local-dev override URL; otherwise it's the deployed
-    // runtime entry, so build a WebSocket URL from its ARN.
-    const wsUrl =
-      typeof agentRuntimeValue === 'string'
-        ? agentRuntimeValue
-        : buildAgentCoreWsUrl(agentRuntimeValue.arn);
+    // A local-dev override is a plain URL; otherwise it's the agent's
+    // runtime ARN, so build a WebSocket URL from it.
+    const wsUrl = agentRuntimeValue.startsWith('arn:')
+      ? buildAgentCoreWsUrl(agentRuntimeValue)
+      : agentRuntimeValue;
 
     const wsClient = createWSClient({
       url: wsUrl,
@@ -249,12 +247,11 @@ export const TestAgentAgentClientProvider: FC<PropsWithChildren> = ({
   const sigv4Client = useSigV4();
 
   const container = useMemo<TestAgentAgentTRPCContextValue>(() => {
-    // A string value is a local-dev override URL; otherwise it's the deployed
-    // runtime entry, so build a WebSocket URL from its ARN.
-    const wsUrl =
-      typeof agentRuntimeValue === 'string'
-        ? agentRuntimeValue
-        : buildAgentCoreWsUrl(agentRuntimeValue.arn);
+    // A local-dev override is a plain URL; otherwise it's the agent's
+    // runtime ARN, so build a WebSocket URL from it.
+    const wsUrl = agentRuntimeValue.startsWith('arn:')
+      ? buildAgentCoreWsUrl(agentRuntimeValue)
+      : agentRuntimeValue;
 
     const wsClient = createWSClient({
       url: async () => {
@@ -326,12 +323,11 @@ export const TestAgentAgentClientProvider: FC<PropsWithChildren> = ({
   const agentRuntimeValue = runtimeConfig.agentRuntimes.TestAgent;
 
   const container = useMemo<TestAgentAgentTRPCContextValue>(() => {
-    // A string value is a local-dev override URL; otherwise it's the deployed
-    // runtime entry, so build a WebSocket URL from its ARN.
-    const wsUrl =
-      typeof agentRuntimeValue === 'string'
-        ? agentRuntimeValue
-        : buildAgentCoreWsUrl(agentRuntimeValue.arn);
+    // A local-dev override is a plain URL; otherwise it's the agent's
+    // runtime ARN, so build a WebSocket URL from it.
+    const wsUrl = agentRuntimeValue.startsWith('arn:')
+      ? buildAgentCoreWsUrl(agentRuntimeValue)
+      : agentRuntimeValue;
 
     const wsClient = createWSClient({
       url: wsUrl,

--- a/packages/nx-plugin/src/ts/agent/react-connection/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/agent/react-connection/__snapshots__/generator.spec.ts.snap
@@ -39,10 +39,12 @@ export const TestAgentAgentClientProvider: FC<PropsWithChildren> = ({
   const sigv4Client = useSigV4();
 
   const container = useMemo<TestAgentAgentTRPCContextValue>(() => {
-    // If the value is an ARN, convert it to a WebSocket URL
-    const wsUrl = agentRuntimeValue.startsWith('arn:')
-      ? buildAgentCoreWsUrl(agentRuntimeValue)
-      : agentRuntimeValue;
+    // A string value is a local-dev override URL; otherwise it's the deployed
+    // runtime entry, so build a WebSocket URL from its ARN.
+    const wsUrl =
+      typeof agentRuntimeValue === 'string'
+        ? agentRuntimeValue
+        : buildAgentCoreWsUrl(agentRuntimeValue.arn);
 
     const wsClient = createWSClient({
       url: async () => {
@@ -155,10 +157,12 @@ export const TestAgentAgentClientProvider: FC<PropsWithChildren> = ({
   const accessToken = auth?.user?.access_token;
 
   const container = useMemo<TestAgentAgentTRPCContextValue>(() => {
-    // If the value is an ARN, convert it to a WebSocket URL
-    const wsUrl = agentRuntimeValue.startsWith('arn:')
-      ? buildAgentCoreWsUrl(agentRuntimeValue)
-      : agentRuntimeValue;
+    // A string value is a local-dev override URL; otherwise it's the deployed
+    // runtime entry, so build a WebSocket URL from its ARN.
+    const wsUrl =
+      typeof agentRuntimeValue === 'string'
+        ? agentRuntimeValue
+        : buildAgentCoreWsUrl(agentRuntimeValue.arn);
 
     const wsClient = createWSClient({
       url: wsUrl,
@@ -245,10 +249,12 @@ export const TestAgentAgentClientProvider: FC<PropsWithChildren> = ({
   const sigv4Client = useSigV4();
 
   const container = useMemo<TestAgentAgentTRPCContextValue>(() => {
-    // If the value is an ARN, convert it to a WebSocket URL
-    const wsUrl = agentRuntimeValue.startsWith('arn:')
-      ? buildAgentCoreWsUrl(agentRuntimeValue)
-      : agentRuntimeValue;
+    // A string value is a local-dev override URL; otherwise it's the deployed
+    // runtime entry, so build a WebSocket URL from its ARN.
+    const wsUrl =
+      typeof agentRuntimeValue === 'string'
+        ? agentRuntimeValue
+        : buildAgentCoreWsUrl(agentRuntimeValue.arn);
 
     const wsClient = createWSClient({
       url: async () => {
@@ -320,10 +326,12 @@ export const TestAgentAgentClientProvider: FC<PropsWithChildren> = ({
   const agentRuntimeValue = runtimeConfig.agentRuntimes.TestAgent;
 
   const container = useMemo<TestAgentAgentTRPCContextValue>(() => {
-    // If the value is an ARN, convert it to a WebSocket URL
-    const wsUrl = agentRuntimeValue.startsWith('arn:')
-      ? buildAgentCoreWsUrl(agentRuntimeValue)
-      : agentRuntimeValue;
+    // A string value is a local-dev override URL; otherwise it's the deployed
+    // runtime entry, so build a WebSocket URL from its ARN.
+    const wsUrl =
+      typeof agentRuntimeValue === 'string'
+        ? agentRuntimeValue
+        : buildAgentCoreWsUrl(agentRuntimeValue.arn);
 
     const wsClient = createWSClient({
       url: wsUrl,

--- a/packages/nx-plugin/src/ts/agent/react-connection/files/src/components/__agentNameClassName__AgentClientProvider.tsx.template
+++ b/packages/nx-plugin/src/ts/agent/react-connection/files/src/components/__agentNameClassName__AgentClientProvider.tsx.template
@@ -51,12 +51,11 @@ export const <%= agentNameClassName %>AgentClientProvider: FC<PropsWithChildren>
   <%_ } _%>
 
   const container = useMemo<<%= agentNameClassName %>AgentTRPCContextValue>(() => {
-    // A string value is a local-dev override URL; otherwise it's the deployed
-    // runtime entry, so build a WebSocket URL from its ARN.
-    const wsUrl =
-      typeof agentRuntimeValue === 'string'
-        ? agentRuntimeValue
-        : buildAgentCoreWsUrl(agentRuntimeValue.arn);
+    // A local-dev override is a plain URL; otherwise it's the agent's
+    // runtime ARN, so build a WebSocket URL from it.
+    const wsUrl = agentRuntimeValue.startsWith('arn:')
+      ? buildAgentCoreWsUrl(agentRuntimeValue)
+      : agentRuntimeValue;
 
     <%_ if (auth === 'iam') { _%>
     const wsClient = createWSClient({

--- a/packages/nx-plugin/src/ts/agent/react-connection/files/src/components/__agentNameClassName__AgentClientProvider.tsx.template
+++ b/packages/nx-plugin/src/ts/agent/react-connection/files/src/components/__agentNameClassName__AgentClientProvider.tsx.template
@@ -51,10 +51,12 @@ export const <%= agentNameClassName %>AgentClientProvider: FC<PropsWithChildren>
   <%_ } _%>
 
   const container = useMemo<<%= agentNameClassName %>AgentTRPCContextValue>(() => {
-    // If the value is an ARN, convert it to a WebSocket URL
-    const wsUrl = agentRuntimeValue.startsWith('arn:')
-      ? buildAgentCoreWsUrl(agentRuntimeValue)
-      : agentRuntimeValue;
+    // A string value is a local-dev override URL; otherwise it's the deployed
+    // runtime entry, so build a WebSocket URL from its ARN.
+    const wsUrl =
+      typeof agentRuntimeValue === 'string'
+        ? agentRuntimeValue
+        : buildAgentCoreWsUrl(agentRuntimeValue.arn);
 
     <%_ if (auth === 'iam') { _%>
     const wsClient = createWSClient({

--- a/packages/nx-plugin/src/ts/agent/react-connection/generator.ts
+++ b/packages/nx-plugin/src/ts/agent/react-connection/generator.ts
@@ -109,7 +109,7 @@ export async function tsAgentReactConnectionGenerator(
   const session = (
     targetComponent?.session ??
     metadata?.session ??
-    'none'
+    'in-memory'
   ).toLowerCase();
   const agentProjectAlias = agentProjectConfig.name;
   const agentPath = targetComponent?.path ?? 'src/agent';

--- a/packages/nx-plugin/src/ts/agent/react-connection/generator.ts
+++ b/packages/nx-plugin/src/ts/agent/react-connection/generator.ts
@@ -106,6 +106,11 @@ export async function tsAgentReactConnectionGenerator(
   const agentNameClassName = targetComponent?.rc ?? toClassName(agentName);
   const agentPort = targetComponent?.port ?? metadata?.ports?.[0] ?? 8081;
   const auth = (targetComponent?.auth ?? metadata?.auth ?? 'iam').toLowerCase();
+  const session = (
+    targetComponent?.session ??
+    metadata?.session ??
+    'none'
+  ).toLowerCase();
   const agentProjectAlias = agentProjectConfig.name;
   const agentPath = targetComponent?.path ?? 'src/agent';
 
@@ -130,6 +135,7 @@ export async function tsAgentReactConnectionGenerator(
       agentName,
       agentNameClassName,
       auth: auth as AgUiAuth,
+      session,
     });
 
     await addTsAgentTargetToLocalDev(
@@ -282,6 +288,7 @@ export async function tsAgentReactConnectionGenerator(
   await addAgentRuntimeToConnectionNamespace(tree, {
     agentNameKebabCase: kebabCase(agentNameClassName),
     agentNameClassName,
+    session,
   });
 
   addTsDependencies(tree, DEPENDENCIES, {

--- a/packages/nx-plugin/src/ts/agent/react-connection/generator.ts
+++ b/packages/nx-plugin/src/ts/agent/react-connection/generator.ts
@@ -106,11 +106,6 @@ export async function tsAgentReactConnectionGenerator(
   const agentNameClassName = targetComponent?.rc ?? toClassName(agentName);
   const agentPort = targetComponent?.port ?? metadata?.ports?.[0] ?? 8081;
   const auth = (targetComponent?.auth ?? metadata?.auth ?? 'iam').toLowerCase();
-  const session = (
-    targetComponent?.session ??
-    metadata?.session ??
-    'in-memory'
-  ).toLowerCase();
   const agentProjectAlias = agentProjectConfig.name;
   const agentPath = targetComponent?.path ?? 'src/agent';
 
@@ -135,7 +130,6 @@ export async function tsAgentReactConnectionGenerator(
       agentName,
       agentNameClassName,
       auth: auth as AgUiAuth,
-      session,
     });
 
     await addTsAgentTargetToLocalDev(
@@ -288,7 +282,6 @@ export async function tsAgentReactConnectionGenerator(
   await addAgentRuntimeToConnectionNamespace(tree, {
     agentNameKebabCase: kebabCase(agentNameClassName),
     agentNameClassName,
-    session,
   });
 
   addTsDependencies(tree, DEPENDENCIES, {

--- a/packages/nx-plugin/src/ts/agent/schema.d.ts
+++ b/packages/nx-plugin/src/ts/agent/schema.d.ts
@@ -11,7 +11,7 @@ export type AgentProtocol = 'http' | 'a2a' | 'ag-ui';
 
 export type TsAgentAuth = 'iam' | 'cognito';
 
-export type TsAgentSession = 's3' | 'none';
+export type TsAgentSession = 's3' | 'in-memory';
 
 export interface TsAgentGeneratorSchema {
   project: string;

--- a/packages/nx-plugin/src/ts/agent/schema.d.ts
+++ b/packages/nx-plugin/src/ts/agent/schema.d.ts
@@ -11,6 +11,8 @@ export type AgentProtocol = 'http' | 'a2a' | 'ag-ui';
 
 export type TsAgentAuth = 'iam' | 'cognito';
 
+export type TsAgentSession = 's3' | 'none';
+
 export interface TsAgentGeneratorSchema {
   project: string;
   framework?: TsAgentFramework;
@@ -18,6 +20,7 @@ export interface TsAgentGeneratorSchema {
   infra?: TsAgentInfra;
   auth?: TsAgentAuth;
   protocol?: AgentProtocol;
+  session?: TsAgentSession;
   iac: IacOption;
   preferInstallDependencies?: boolean;
 }

--- a/packages/nx-plugin/src/ts/agent/schema.json
+++ b/packages/nx-plugin/src/ts/agent/schema.json
@@ -64,7 +64,7 @@
       "type": "string",
       "description": "The storage used to persist session for your Agent.",
       "x-prompt": "How would you like to persist session for your Agent?",
-      "enum": ["s3", "none"],
+      "enum": ["s3", "in-memory"],
       "default": "s3",
       "x-priority": "important"
     },

--- a/packages/nx-plugin/src/ts/agent/schema.json
+++ b/packages/nx-plugin/src/ts/agent/schema.json
@@ -60,6 +60,14 @@
       "default": "agentcore",
       "x-priority": "important"
     },
+    "session": {
+      "type": "string",
+      "description": "The storage used to persist session for your Agent.",
+      "x-prompt": "How would you like to persist session for your Agent?",
+      "enum": ["s3", "none"],
+      "default": "s3",
+      "x-priority": "important"
+    },
     "preferInstallDependencies": {
       "type": "boolean",
       "description": "Whether to prefer installing dependencies after the generator runs. Set to false to defer installing when batching multiple generators (an install still runs if needed so subsequent generators can compute the Nx project graph); install once at the end.",

--- a/packages/nx-plugin/src/ts/mcp-server/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/mcp-server/__snapshots__/generator.spec.ts.snap
@@ -87,9 +87,6 @@ export class SnapshotBedrockServer
       ...rc.get('agentcore').agentRuntimes,
       SnapshotBedrockServer: {
         arn: this.agentCoreRuntime.agentRuntimeArn,
-        session: {
-          storage: 'in-memory',
-        },
       },
     });
   }
@@ -743,7 +740,7 @@ module "add_agent_runtime_to_runtime_config" {
 
   namespace = "agentcore"
   key       = "agentRuntimes"
-  value     = { "TerraformSnapshotServer" = { arn = module.agent_core_runtime.agent_core_runtime_arn, session = { storage = "in-memory" } } }
+  value     = { "TerraformSnapshotServer" = { arn = module.agent_core_runtime.agent_core_runtime_arn } }
 
   depends_on = [module.agent_core_runtime]
 }

--- a/packages/nx-plugin/src/ts/mcp-server/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/mcp-server/__snapshots__/generator.spec.ts.snap
@@ -85,7 +85,12 @@ export class SnapshotBedrockServer
 
     rc.set('agentcore', 'agentRuntimes', {
       ...rc.get('agentcore').agentRuntimes,
-      SnapshotBedrockServer: this.agentCoreRuntime.agentRuntimeArn,
+      SnapshotBedrockServer: {
+        arn: this.agentCoreRuntime.agentRuntimeArn,
+        session: {
+          storage: 'none',
+        },
+      },
     });
   }
 
@@ -738,7 +743,7 @@ module "add_agent_runtime_to_runtime_config" {
 
   namespace = "agentcore"
   key       = "agentRuntimes"
-  value     = { "TerraformSnapshotServer" = module.agent_core_runtime.agent_core_runtime_arn }
+  value     = { "TerraformSnapshotServer" = { arn = module.agent_core_runtime.agent_core_runtime_arn, session = { storage = "none" } } }
 
   depends_on = [module.agent_core_runtime]
 }

--- a/packages/nx-plugin/src/ts/mcp-server/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/mcp-server/__snapshots__/generator.spec.ts.snap
@@ -88,7 +88,7 @@ export class SnapshotBedrockServer
       SnapshotBedrockServer: {
         arn: this.agentCoreRuntime.agentRuntimeArn,
         session: {
-          storage: 'none',
+          storage: 'in-memory',
         },
       },
     });
@@ -743,7 +743,7 @@ module "add_agent_runtime_to_runtime_config" {
 
   namespace = "agentcore"
   key       = "agentRuntimes"
-  value     = { "TerraformSnapshotServer" = { arn = module.agent_core_runtime.agent_core_runtime_arn, session = { storage = "none" } } }
+  value     = { "TerraformSnapshotServer" = { arn = module.agent_core_runtime.agent_core_runtime_arn, session = { storage = "in-memory" } } }
 
   depends_on = [module.agent_core_runtime]
 }

--- a/packages/nx-plugin/src/ts/react-website/agui/files/common/src/hooks/useAgui__agentNameClassName__.tsx.template
+++ b/packages/nx-plugin/src/ts/react-website/agui/files/common/src/hooks/useAgui__agentNameClassName__.tsx.template
@@ -107,8 +107,6 @@ export const useAgui<%= agentNameClassName %> = (): Record<string, AbstractAgent
 
   const url = useMemo(
     () =>
-      // A local-dev override is a plain URL; otherwise it's the agent's
-      // runtime ARN, so build the invocation URL from it.
       agentRuntimeValue.startsWith('arn:')
         ? buildAgentCoreUrl(agentRuntimeValue)
         : agentRuntimeValue,

--- a/packages/nx-plugin/src/ts/react-website/agui/files/common/src/hooks/useAgui__agentNameClassName__.tsx.template
+++ b/packages/nx-plugin/src/ts/react-website/agui/files/common/src/hooks/useAgui__agentNameClassName__.tsx.template
@@ -107,11 +107,11 @@ export const useAgui<%= agentNameClassName %> = (): Record<string, AbstractAgent
 
   const url = useMemo(
     () =>
-      // A string value is a local-dev override URL; otherwise it's the
-      // deployed runtime entry, so build the invocation URL from its ARN.
-      typeof agentRuntimeValue === 'string'
-        ? agentRuntimeValue
-        : buildAgentCoreUrl(agentRuntimeValue.arn),
+      // A local-dev override is a plain URL; otherwise it's the agent's
+      // runtime ARN, so build the invocation URL from it.
+      agentRuntimeValue.startsWith('arn:')
+        ? buildAgentCoreUrl(agentRuntimeValue)
+        : agentRuntimeValue,
     [agentRuntimeValue],
   );
 

--- a/packages/nx-plugin/src/ts/react-website/agui/files/common/src/hooks/useAgui__agentNameClassName__.tsx.template
+++ b/packages/nx-plugin/src/ts/react-website/agui/files/common/src/hooks/useAgui__agentNameClassName__.tsx.template
@@ -107,9 +107,11 @@ export const useAgui<%= agentNameClassName %> = (): Record<string, AbstractAgent
 
   const url = useMemo(
     () =>
-      agentRuntimeValue.startsWith('arn:')
-        ? buildAgentCoreUrl(agentRuntimeValue)
-        : agentRuntimeValue,
+      // A string value is a local-dev override URL; otherwise it's the
+      // deployed runtime entry, so build the invocation URL from its ARN.
+      typeof agentRuntimeValue === 'string'
+        ? agentRuntimeValue
+        : buildAgentCoreUrl(agentRuntimeValue.arn),
     [agentRuntimeValue],
   );
 

--- a/packages/nx-plugin/src/ts/react-website/agui/generator.ts
+++ b/packages/nx-plugin/src/ts/react-website/agui/generator.ts
@@ -79,6 +79,8 @@ export interface AgUiReactConnectionOptions {
   agentNameClassName: string;
   /** Auth scheme used by the agent */
   auth: AgUiAuth;
+  /** How the agent's session is persisted, e.g. 's3' */
+  session: string;
 }
 
 /**
@@ -97,8 +99,13 @@ export const addAgUiReactConnection = async (
   tree: Tree,
   options: AgUiReactConnectionOptions,
 ) => {
-  const { frontendProjectConfig, agentName, agentNameClassName, auth } =
-    options;
+  const {
+    frontendProjectConfig,
+    agentName,
+    agentNameClassName,
+    auth,
+    session,
+  } = options;
 
   const theme = resolveAgUiTheme(frontendProjectConfig);
   // The values the declaration's predicates read. Callers record the same pair,
@@ -189,6 +196,7 @@ export const addAgUiReactConnection = async (
   await addAgentRuntimeToConnectionNamespace(tree, {
     agentNameKebabCase: kebabCase(agentNameClassName),
     agentNameClassName,
+    session,
   });
 };
 

--- a/packages/nx-plugin/src/ts/react-website/agui/generator.ts
+++ b/packages/nx-plugin/src/ts/react-website/agui/generator.ts
@@ -79,8 +79,6 @@ export interface AgUiReactConnectionOptions {
   agentNameClassName: string;
   /** Auth scheme used by the agent */
   auth: AgUiAuth;
-  /** How the agent's session is persisted, e.g. 's3' */
-  session: string;
 }
 
 /**
@@ -99,13 +97,8 @@ export const addAgUiReactConnection = async (
   tree: Tree,
   options: AgUiReactConnectionOptions,
 ) => {
-  const {
-    frontendProjectConfig,
-    agentName,
-    agentNameClassName,
-    auth,
-    session,
-  } = options;
+  const { frontendProjectConfig, agentName, agentNameClassName, auth } =
+    options;
 
   const theme = resolveAgUiTheme(frontendProjectConfig);
   // The values the declaration's predicates read. Callers record the same pair,
@@ -196,7 +189,6 @@ export const addAgUiReactConnection = async (
   await addAgentRuntimeToConnectionNamespace(tree, {
     agentNameKebabCase: kebabCase(agentNameClassName),
     agentNameClassName,
-    session,
   });
 };
 

--- a/packages/nx-plugin/src/utils/agent-chat/files/common/agentcore.ts.template
+++ b/packages/nx-plugin/src/utils/agent-chat/files/common/agentcore.ts.template
@@ -30,8 +30,8 @@ export const resolveRemoteAgent = async (): Promise<
     application,
     environment: 'default',
     transform: 'json',
-  })) as { agentRuntimes?: Record<string, string> };
-  const arn = config?.agentRuntimes?.['<%- agentNameClassName %>'];
+  })) as { agentRuntimes?: Record<string, { arn: string }> };
+  const arn = config?.agentRuntimes?.['<%- agentNameClassName %>']?.arn;
   if (!arn) {
     throw new Error(
       `No deployed agent named '<%- agentNameClassName %>' found in runtime configuration (application ${application}).`,

--- a/packages/nx-plugin/src/utils/agent-connection/agent-connection.ts
+++ b/packages/nx-plugin/src/utils/agent-connection/agent-connection.ts
@@ -366,6 +366,15 @@ export async function ensureTypeScriptAgentConnectionProject<
     joinPathFragments(AGENT_CONNECTION_PROJECT_DIR, 'src', 'index.ts'),
     './core/session-context.js',
   );
+
+  // Re-export the runtime-config loader so agent server entry points can read
+  // their own connected resources (e.g. session storage) without pulling in
+  // internals.
+  await addStarExport(
+    tree,
+    joinPathFragments(AGENT_CONNECTION_PROJECT_DIR, 'src', 'index.ts'),
+    './core/runtime-config.js',
+  );
 }
 
 /**

--- a/packages/nx-plugin/src/utils/agent-connection/files/core-runtime-config/runtime-config.ts.template
+++ b/packages/nx-plugin/src/utils/agent-connection/files/core-runtime-config/runtime-config.ts.template
@@ -1,16 +1,13 @@
 import { getAppConfig } from '@aws-lambda-powertools/parameters/appconfig';
 
-/** How an agent runtime's conversation session is persisted. */
-export interface AgentRuntimeSession {
-  storage: 's3' | 'in-memory';
-  /** Name of the S3 bucket storing session data. Only set when storage is 's3'. */
-  bucketName?: string;
-}
-
 /** An agent or MCP server runtime registered in AppConfig. */
 export interface AgentRuntimeEntry {
   arn: string;
-  session: AgentRuntimeSession;
+  /** Session storage details. Only set when the agent has S3 session storage configured. */
+  session?: {
+    /** Name of the S3 bucket storing session data. */
+    bucketName: string;
+  };
 }
 
 /**

--- a/packages/nx-plugin/src/utils/agent-connection/files/core-runtime-config/runtime-config.ts.template
+++ b/packages/nx-plugin/src/utils/agent-connection/files/core-runtime-config/runtime-config.ts.template
@@ -2,7 +2,7 @@ import { getAppConfig } from '@aws-lambda-powertools/parameters/appconfig';
 
 /** How an agent runtime's conversation session is persisted. */
 export interface AgentRuntimeSession {
-  storage: 's3' | 'none';
+  storage: 's3' | 'in-memory';
   /** Name of the S3 bucket storing session data. Only set when storage is 's3'. */
   bucketName?: string;
 }

--- a/packages/nx-plugin/src/utils/agent-connection/files/core-runtime-config/runtime-config.ts.template
+++ b/packages/nx-plugin/src/utils/agent-connection/files/core-runtime-config/runtime-config.ts.template
@@ -1,11 +1,24 @@
 import { getAppConfig } from '@aws-lambda-powertools/parameters/appconfig';
 
+/** How an agent runtime's conversation session is persisted. */
+export interface AgentRuntimeSession {
+  storage: 's3' | 'none';
+  /** Name of the S3 bucket storing session data. Only set when storage is 's3'. */
+  bucketName?: string;
+}
+
+/** An agent or MCP server runtime registered in AppConfig. */
+export interface AgentRuntimeEntry {
+  arn: string;
+  session: AgentRuntimeSession;
+}
+
 /**
  * Shape of this project's runtime configuration in AppConfig. Keys are the
  * class names of connected target constructs (e.g. `MyAgent`, `MyGateway`).
  */
 export interface AgentCoreRuntimeConfig {
-  agentRuntimes?: Record<string, string>;
+  agentRuntimes?: Record<string, AgentRuntimeEntry>;
   gateways?: Record<string, string>;
 }
 

--- a/packages/nx-plugin/src/utils/agent-connection/files/core-strands/base/model-errors-strands.ts.template
+++ b/packages/nx-plugin/src/utils/agent-connection/files/core-strands/base/model-errors-strands.ts.template
@@ -1,4 +1,8 @@
-import { AfterModelCallEvent, type LocalAgent } from '@strands-agents/sdk';
+import {
+  AfterModelCallEvent,
+  type LocalAgent,
+  type Plugin,
+} from '@strands-agents/sdk';
 
 const NO_CREDENTIALS =
   'Unable to invoke the model: no AWS credentials found. Configure credentials ' +
@@ -20,17 +24,28 @@ const hasErrorNamed = (error: unknown, name: string): boolean => {
   return false;
 };
 
+/**
+ * Plugin that logs model invocation errors, calling out missing credentials or
+ * denied permissions.
+ */
+export class ModelErrorLoggingPlugin implements Plugin {
+  readonly name = 'model-error-logging';
+
+  initAgent(agent: LocalAgent): void {
+    agent.addHook(AfterModelCallEvent, (event) => {
+      const error = event.error;
+      if (!error) return;
+      if (hasErrorNamed(error, 'CredentialsProviderError')) {
+        console.error(NO_CREDENTIALS);
+      } else if (hasErrorNamed(error, 'AccessDeniedException')) {
+        console.error(ACCESS_DENIED);
+      } else {
+        console.error(`Model invocation failed: ${error.message}`);
+      }
+    });
+  }
+}
+
 /** Logs model invocation errors, calling out missing credentials or denied permissions. */
-export const logModelErrors = (agent: LocalAgent): void => {
-  agent.addHook(AfterModelCallEvent, (event) => {
-    const error = event.error;
-    if (!error) return;
-    if (hasErrorNamed(error, 'CredentialsProviderError')) {
-      console.error(NO_CREDENTIALS);
-    } else if (hasErrorNamed(error, 'AccessDeniedException')) {
-      console.error(ACCESS_DENIED);
-    } else {
-      console.error(`Model invocation failed: ${error.message}`);
-    }
-  });
-};
+export const logModelErrors = (agent: LocalAgent): void =>
+  new ModelErrorLoggingPlugin().initAgent(agent);

--- a/packages/nx-plugin/src/utils/agent-connection/files/core-strands/base/model-errors-strands.ts.template
+++ b/packages/nx-plugin/src/utils/agent-connection/files/core-strands/base/model-errors-strands.ts.template
@@ -45,7 +45,3 @@ export class ModelErrorLoggingPlugin implements Plugin {
     });
   }
 }
-
-/** Logs model invocation errors, calling out missing credentials or denied permissions. */
-export const logModelErrors = (agent: LocalAgent): void =>
-  new ModelErrorLoggingPlugin().initAgent(agent);

--- a/packages/nx-plugin/src/utils/agent-connection/files/core-strands/base/tool-errors-strands.ts.template
+++ b/packages/nx-plugin/src/utils/agent-connection/files/core-strands/base/tool-errors-strands.ts.template
@@ -27,7 +27,3 @@ export class ToolErrorLoggingPlugin implements Plugin {
     });
   }
 }
-
-/** Logs tool execution errors, including the tool name and underlying error or message when available. */
-export const logToolErrors = (agent: LocalAgent): void =>
-  new ToolErrorLoggingPlugin().initAgent(agent);

--- a/packages/nx-plugin/src/utils/agent-connection/files/core-strands/base/tool-errors-strands.ts.template
+++ b/packages/nx-plugin/src/utils/agent-connection/files/core-strands/base/tool-errors-strands.ts.template
@@ -1,22 +1,33 @@
 import {
   AfterToolCallEvent,
   type LocalAgent,
+  type Plugin,
   TextBlock,
 } from '@strands-agents/sdk';
 
+/**
+ * Plugin that logs tool execution errors, including the tool name and underlying error or message when available.
+ */
+export class ToolErrorLoggingPlugin implements Plugin {
+  readonly name = 'tool-error-logging';
+
+  initAgent(agent: LocalAgent): void {
+    agent.addHook(AfterToolCallEvent, (event) => {
+      if (event.result.status !== 'error') return;
+      const error = event.result.error ?? event.error;
+      const message =
+        error?.message ??
+        event.result.content
+          .filter((block): block is TextBlock => block instanceof TextBlock)
+          .map((block) => block.text)
+          .join(' ');
+      console.error(
+        `Tool '${event.toolUse.name}' failed${message ? `: ${message}` : ''}`,
+      );
+    });
+  }
+}
+
 /** Logs tool execution errors, including the tool name and underlying error or message when available. */
-export const logToolErrors = (agent: LocalAgent): void => {
-  agent.addHook(AfterToolCallEvent, (event) => {
-    if (event.result.status !== 'error') return;
-    const error = event.result.error ?? event.error;
-    const message =
-      error?.message ??
-      event.result.content
-        .filter((block): block is TextBlock => block instanceof TextBlock)
-        .map((block) => block.text)
-        .join(' ');
-    console.error(
-      `Tool '${event.toolUse.name}' failed${message ? `: ${message}` : ''}`,
-    );
-  });
-};
+export const logToolErrors = (agent: LocalAgent): void =>
+  new ToolErrorLoggingPlugin().initAgent(agent);

--- a/packages/nx-plugin/src/utils/agent-connection/files/py-core-runtime-config/runtime_config.py.template
+++ b/packages/nx-plugin/src/utils/agent-connection/files/py-core-runtime-config/runtime_config.py.template
@@ -8,9 +8,9 @@ from botocore.config import Config
 def get_agentcore_runtime_config() -> dict[str, Any]:
     """Read the runtime-config ``agentcore`` namespace from AppConfig.
 
-    Returns a dict of the shape ``{"agentRuntimes": {name: arn, ...},
-    "gateways": {name: url, ...}}``, where keys are the class names of
-    connected target constructs.
+    Returns a dict of the shape ``{"agentRuntimes": {name: {"arn": arn,
+    "session": {"type": type}}, ...}, "gateways": {name: url, ...}}``, where
+    keys are the class names of connected target constructs.
 
     ``RUNTIME_CONFIG_APP_ID`` is set on the AgentCore runtime by the generated
     CDK/Terraform construct for this project.

--- a/packages/nx-plugin/src/utils/agent-connection/files/py-core-runtime-config/runtime_config.py.template
+++ b/packages/nx-plugin/src/utils/agent-connection/files/py-core-runtime-config/runtime_config.py.template
@@ -9,8 +9,9 @@ def get_agentcore_runtime_config() -> dict[str, Any]:
     """Read the runtime-config ``agentcore`` namespace from AppConfig.
 
     Returns a dict of the shape ``{"agentRuntimes": {name: {"arn": arn,
-    "session": {"type": type}}, ...}, "gateways": {name: url, ...}}``, where
-    keys are the class names of connected target constructs.
+    "session": {"bucketName": bucket}}, ...}, "gateways": {name: url, ...}}``,
+    where keys are the class names of connected target constructs. ``session``
+    is only present when the agent has S3 session storage configured.
 
     ``RUNTIME_CONFIG_APP_ID`` is set on the AgentCore runtime by the generated
     CDK/Terraform construct for this project.

--- a/packages/nx-plugin/src/utils/agent-core-constructs/agent-core-constructs.ts
+++ b/packages/nx-plugin/src/utils/agent-core-constructs/agent-core-constructs.ts
@@ -55,6 +55,8 @@ export const AGENT_CORE_CONSTRUCTS_DEPENDENCIES = [
 
 export type AgentCoreAuth = 'iam' | 'cognito';
 
+export type AgentCoreSession = 's3' | 'none';
+
 export interface AddAgentCoreInfraProps {
   nameClassName: string;
   nameKebabCase: string;
@@ -64,6 +66,8 @@ export interface AddAgentCoreInfraProps {
   appDirectory: string;
   serverProtocol: 'mcp' | 'http' | 'a2a';
   auth: AgentCoreAuth;
+  /** How this runtime's session should be persisted. MCP servers have no session, so pass 'none'. */
+  session: AgentCoreSession;
   containers: Containers;
 }
 
@@ -228,6 +232,8 @@ export const addMcpServerInfra = async (
     serverProtocol: 'mcp',
     iac: options.iac,
     auth: options.auth,
+    // MCP servers are stateless (no conversation session to persist).
+    session: 'none',
     containers: options.containers,
   });
 };
@@ -239,6 +245,7 @@ export interface AddAgentInfraProps {
   dockerImageTag: string;
   dockerOutputDir: string;
   auth: AgentCoreAuth;
+  session: AgentCoreSession;
   serverProtocol?: 'http' | 'a2a';
   containers: Containers;
 }
@@ -257,6 +264,7 @@ export const addAgentInfra = async (
     dockerImageTag: options.dockerImageTag,
     dockerOutputDir: options.dockerOutputDir,
     appDirectory: 'agents',
+    session: options.session,
     serverProtocol: options.serverProtocol ?? 'http',
     iac: options.iac,
     auth: options.auth,

--- a/packages/nx-plugin/src/utils/agent-core-constructs/agent-core-constructs.ts
+++ b/packages/nx-plugin/src/utils/agent-core-constructs/agent-core-constructs.ts
@@ -198,7 +198,7 @@ const addAgentCoreTerraformInfra = (
       'app',
       options.appDirectory,
     ),
-    options,
+    { ...options, ...terraformProviderVersions() },
     {
       overwriteStrategy: OverwriteStrategy.KeepExisting,
     },

--- a/packages/nx-plugin/src/utils/agent-core-constructs/agent-core-constructs.ts
+++ b/packages/nx-plugin/src/utils/agent-core-constructs/agent-core-constructs.ts
@@ -55,7 +55,7 @@ export const AGENT_CORE_CONSTRUCTS_DEPENDENCIES = [
 
 export type AgentCoreAuth = 'iam' | 'cognito';
 
-export type AgentCoreSession = 's3' | 'none';
+export type AgentCoreSession = 's3' | 'in-memory';
 
 export interface AddAgentCoreInfraProps {
   nameClassName: string;
@@ -66,7 +66,7 @@ export interface AddAgentCoreInfraProps {
   appDirectory: string;
   serverProtocol: 'mcp' | 'http' | 'a2a';
   auth: AgentCoreAuth;
-  /** How this runtime's session should be persisted. MCP servers have no session, so pass 'none'. */
+  /** How this runtime's session should be persisted. MCP servers have no session, so pass 'in-memory'. */
   session: AgentCoreSession;
   containers: Containers;
 }
@@ -233,7 +233,7 @@ export const addMcpServerInfra = async (
     iac: options.iac,
     auth: options.auth,
     // MCP servers are stateless (no conversation session to persist).
-    session: 'none',
+    session: 'in-memory',
     containers: options.containers,
   });
 };

--- a/packages/nx-plugin/src/utils/agent-core-constructs/files/cdk/app/agent-core/__nameKebabCase__/__nameKebabCase__.ts.template
+++ b/packages/nx-plugin/src/utils/agent-core-constructs/files/cdk/app/agent-core/__nameKebabCase__/__nameKebabCase__.ts.template
@@ -3,6 +3,14 @@ import { Platform } from 'aws-cdk-lib/aws-ecr-assets';
 import { Connections, IConnectable } from 'aws-cdk-lib/aws-ec2';
 <%_ if (session === 's3') { _%>
 import { BlockPublicAccess, Bucket, BucketEncryption } from 'aws-cdk-lib/aws-s3';
+import { Key } from 'aws-cdk-lib/aws-kms';
+import {
+  CfnDelivery,
+  CfnDeliveryDestination,
+  CfnDeliverySource,
+  LogGroup,
+  RetentionDays,
+} from 'aws-cdk-lib/aws-logs';
 <%_ } _%>
 import { Construct } from 'constructs';
 import * as path from 'path';
@@ -16,7 +24,7 @@ import {
   RuntimeAuthorizerConfiguration,
 <%_ } _%>
 } from 'aws-cdk-lib/aws-bedrockagentcore';
-import { <%_ if (serverProtocol !== 'mcp') { _%>PolicyStatement, <%_ } _%>IGrantable, IPrincipal<%_ if (auth === 'iam') { _%>, Grant<%_ } _%> } from 'aws-cdk-lib/aws-iam';
+import { <%_ if (serverProtocol !== 'mcp') { _%>PolicyStatement, <%_ } _%><%_ if (session === 's3') { _%>Effect, ServicePrincipal, <%_ } _%>IGrantable, IPrincipal<%_ if (auth === 'iam') { _%>, Grant<%_ } _%> } from 'aws-cdk-lib/aws-iam';
 <%_ if (auth === 'cognito') { _%>
 import { IUserPool, IUserPoolClient } from 'aws-cdk-lib/aws-cognito';
 <%_ } _%>
@@ -80,22 +88,49 @@ export class <%- nameClassName %> extends Construct implements IGrantable, IConn
 
 <%_ } _%>
 <%_ if (session === 's3') { _%>
+    const sessionKey = new Key(this, 'SessionKey', {
+      enableKeyRotation: true,
+    });
+
+    // Allow CloudWatch Logs to use the session key for server access log delivery.
+    const stack = Stack.of(this);
+    sessionKey.addToResourcePolicy(
+      new PolicyStatement({
+        effect: Effect.ALLOW,
+        principals: [new ServicePrincipal(`logs.${stack.region}.amazonaws.com`)],
+        actions: [
+          'kms:Encrypt',
+          'kms:Decrypt',
+          'kms:ReEncrypt*',
+          'kms:GenerateDataKey*',
+          'kms:DescribeKey',
+        ],
+        resources: ['*'],
+        conditions: {
+          ArnLike: {
+            'kms:EncryptionContext:aws:logs:arn': `arn:aws:logs:${stack.region}:${stack.account}:log-group:*`,
+          },
+        },
+      }),
+    );
+
+    const sessionAccessLogs = new LogGroup(this, 'SessionAccessLogs', {
+      retention: RetentionDays.ONE_YEAR,
+      encryptionKey: sessionKey,
+      removalPolicy: RemovalPolicy.DESTROY,
+    });
+
     const sessionBucket = new Bucket(this, 'SessionBucket', {
       enforceSSL: true,
-      autoDeleteObjects: true,
-      removalPolicy: RemovalPolicy.DESTROY,
-      encryption: BucketEncryption.S3_MANAGED,
+      removalPolicy: RemovalPolicy.RETAIN,
+      encryption: BucketEncryption.KMS,
+      encryptionKey: sessionKey,
       blockPublicAccess: BlockPublicAccess.BLOCK_ALL,
     });
     suppressRules(
       sessionBucket,
       ['CKV_AWS_21'],
       'Session data does not need versioning enabled',
-    );
-    suppressRules(
-      sessionBucket,
-      ['CKV_AWS_145'],
-      'AES256 (S3-managed) encryption is sufficient for session data',
     );
     suppressRules(
       sessionBucket,
@@ -115,8 +150,45 @@ export class <%- nameClassName %> extends Construct implements IGrantable, IConn
     suppressRules(
       sessionBucket,
       ['CKV_AWS_18'],
-      'Access logging not required for session data',
+      'Server access logs are delivered to CloudWatch Logs',
     );
+
+    const sessionAccessLogsSource = new CfnDeliverySource(
+      this,
+      'SessionAccessLogsSource',
+      {
+        name: Lazy.string({
+          produce: () =>
+            Names.uniqueResourceName(sessionAccessLogsSource, {
+              maxLength: 60,
+            }),
+        }),
+        logType: 'S3_SERVER_ACCESS_LOGS',
+        resourceArn: sessionBucket.bucketArn,
+      },
+    );
+    const sessionAccessLogsDestination = new CfnDeliveryDestination(
+      this,
+      'SessionAccessLogsDestination',
+      {
+        name: Lazy.string({
+          produce: () =>
+            Names.uniqueResourceName(sessionAccessLogsDestination, {
+              maxLength: 60,
+            }),
+        }),
+        destinationResourceArn: sessionAccessLogs.logGroupArn,
+      },
+    );
+    const sessionAccessLogsDelivery = new CfnDelivery(
+      this,
+      'SessionAccessLogsDelivery',
+      {
+        deliverySourceName: sessionAccessLogsSource.name,
+        deliveryDestinationArn: sessionAccessLogsDestination.attrArn,
+      },
+    );
+    sessionAccessLogsDelivery.addDependency(sessionAccessLogsSource);
 
 <%_ } _%>
     this.agentCoreRuntime = new Runtime(this, '<%- nameClassName %>', {
@@ -171,12 +243,9 @@ export class <%- nameClassName %> extends Construct implements IGrantable, IConn
       ...rc.get('agentcore').agentRuntimes,
       <%- nameClassName %>: {
         arn: this.agentCoreRuntime.agentRuntimeArn,
-        session: {
-          storage: '<%- session %>',
 <%_ if (session === 's3') { _%>
-          bucketName: sessionBucket.bucketName,
+        session: { bucketName: sessionBucket.bucketName },
 <%_ } _%>
-        },
       },
     });
   }

--- a/packages/nx-plugin/src/utils/agent-core-constructs/files/cdk/app/agent-core/__nameKebabCase__/__nameKebabCase__.ts.template
+++ b/packages/nx-plugin/src/utils/agent-core-constructs/files/cdk/app/agent-core/__nameKebabCase__/__nameKebabCase__.ts.template
@@ -153,7 +153,7 @@ export class <%- nameClassName %> extends Construct implements IGrantable, IConn
       'Server access logs are delivered to CloudWatch Logs',
     );
 
-    const sessionAccessLogsSource = new CfnDeliverySource(
+    const sessionAccessLogsSource: CfnDeliverySource = new CfnDeliverySource(
       this,
       'SessionAccessLogsSource',
       {
@@ -167,10 +167,8 @@ export class <%- nameClassName %> extends Construct implements IGrantable, IConn
         resourceArn: sessionBucket.bucketArn,
       },
     );
-    const sessionAccessLogsDestination = new CfnDeliveryDestination(
-      this,
-      'SessionAccessLogsDestination',
-      {
+    const sessionAccessLogsDestination: CfnDeliveryDestination =
+      new CfnDeliveryDestination(this, 'SessionAccessLogsDestination', {
         name: Lazy.string({
           produce: () =>
             Names.uniqueResourceName(sessionAccessLogsDestination, {
@@ -178,8 +176,7 @@ export class <%- nameClassName %> extends Construct implements IGrantable, IConn
             }),
         }),
         destinationResourceArn: sessionAccessLogs.logGroupArn,
-      },
-    );
+      });
     const sessionAccessLogsDelivery = new CfnDelivery(
       this,
       'SessionAccessLogsDelivery',

--- a/packages/nx-plugin/src/utils/agent-core-constructs/files/cdk/app/agent-core/__nameKebabCase__/__nameKebabCase__.ts.template
+++ b/packages/nx-plugin/src/utils/agent-core-constructs/files/cdk/app/agent-core/__nameKebabCase__/__nameKebabCase__.ts.template
@@ -1,6 +1,9 @@
-import { Fn, Lazy, Names, Stack } from 'aws-cdk-lib';
+import { Fn, Lazy, Names<%_ if (session === 's3') { _%>, RemovalPolicy<%_ } _%>, Stack } from 'aws-cdk-lib';
 import { Platform } from 'aws-cdk-lib/aws-ecr-assets';
 import { Connections, IConnectable } from 'aws-cdk-lib/aws-ec2';
+<%_ if (session === 's3') { _%>
+import { BlockPublicAccess, Bucket, BucketEncryption } from 'aws-cdk-lib/aws-s3';
+<%_ } _%>
 import { Construct } from 'constructs';
 import * as path from 'path';
 import * as url from 'url';
@@ -16,6 +19,9 @@ import {
 import { <%_ if (serverProtocol !== 'mcp') { _%>PolicyStatement, <%_ } _%>IGrantable, IPrincipal<%_ if (auth === 'iam') { _%>, Grant<%_ } _%> } from 'aws-cdk-lib/aws-iam';
 <%_ if (auth === 'cognito') { _%>
 import { IUserPool, IUserPoolClient } from 'aws-cdk-lib/aws-cognito';
+<%_ } _%>
+<%_ if (session === 's3') { _%>
+import { suppressRules } from '../../../core/checkov<% if (esm) { %>.js<% } %>';
 <%_ } _%>
 import { RuntimeConfig } from '../../../core/runtime-config<% if (esm) { %>.js<% } %>';
 import { findWorkspaceRoot } from '../../../core/workspace<% if (esm) { %>.js<% } %>';
@@ -73,6 +79,46 @@ export class <%- nameClassName %> extends Construct implements IGrantable, IConn
     const { identity, ...restProps } = props;
 
 <%_ } _%>
+<%_ if (session === 's3') { _%>
+    const sessionBucket = new Bucket(this, 'SessionBucket', {
+      enforceSSL: true,
+      autoDeleteObjects: true,
+      removalPolicy: RemovalPolicy.DESTROY,
+      encryption: BucketEncryption.S3_MANAGED,
+      blockPublicAccess: BlockPublicAccess.BLOCK_ALL,
+    });
+    suppressRules(
+      sessionBucket,
+      ['CKV_AWS_21'],
+      'Session data does not need versioning enabled',
+    );
+    suppressRules(
+      sessionBucket,
+      ['CKV_AWS_145'],
+      'AES256 (S3-managed) encryption is sufficient for session data',
+    );
+    suppressRules(
+      sessionBucket,
+      ['CKV2_AWS_61'],
+      'Lifecycle configuration not required for session data',
+    );
+    suppressRules(
+      sessionBucket,
+      ['CKV_AWS_144'],
+      'Cross-region replication not required for session data',
+    );
+    suppressRules(
+      sessionBucket,
+      ['CKV2_AWS_62'],
+      'Event notifications not required for session data',
+    );
+    suppressRules(
+      sessionBucket,
+      ['CKV_AWS_18'],
+      'Access logging not required for session data',
+    );
+
+<%_ } _%>
     this.agentCoreRuntime = new Runtime(this, '<%- nameClassName %>', {
       runtimeName: Lazy.string({
         produce: () =>
@@ -115,11 +161,23 @@ export class <%- nameClassName %> extends Construct implements IGrantable, IConn
     );
 
 <%_ } _%>
+<%_ if (session === 's3') { _%>
+    sessionBucket.grantReadWrite(this.agentCoreRuntime);
+
+<%_ } _%>
     rc.grantReadAppConfig(this.agentCoreRuntime);
 
     rc.set('agentcore', 'agentRuntimes', {
       ...rc.get('agentcore').agentRuntimes,
-      <%- nameClassName %>: this.agentCoreRuntime.agentRuntimeArn,
+      <%- nameClassName %>: {
+        arn: this.agentCoreRuntime.agentRuntimeArn,
+        session: {
+          storage: '<%- session %>',
+<%_ if (session === 's3') { _%>
+          bucketName: sessionBucket.bucketName,
+<%_ } _%>
+        },
+      },
     });
   }
 

--- a/packages/nx-plugin/src/utils/agent-core-constructs/files/cdk/app/agent-core/__nameKebabCase__/__nameKebabCase__.ts.template
+++ b/packages/nx-plugin/src/utils/agent-core-constructs/files/cdk/app/agent-core/__nameKebabCase__/__nameKebabCase__.ts.template
@@ -167,6 +167,10 @@ export class <%- nameClassName %> extends Construct implements IGrantable, IConn
         resourceArn: sessionBucket.bucketArn,
       },
     );
+    const sessionBucketPolicy = sessionBucket.policy;
+    if (sessionBucketPolicy) {
+      sessionAccessLogsSource.node.addDependency(sessionBucketPolicy);
+    }
     const sessionAccessLogsDestination: CfnDeliveryDestination =
       new CfnDeliveryDestination(this, 'SessionAccessLogsDestination', {
         name: Lazy.string({

--- a/packages/nx-plugin/src/utils/agent-core-constructs/files/terraform/app/agent-core/__nameKebabCase__/__nameKebabCase__.tf.template
+++ b/packages/nx-plugin/src/utils/agent-core-constructs/files/terraform/app/agent-core/__nameKebabCase__/__nameKebabCase__.tf.template
@@ -67,6 +67,38 @@ locals {
 }
 
 <%_ } _%>
+<%_ if (session === 's3') { _%>
+# Bucket storing the agent's session data
+resource "aws_s3_bucket" "session" {
+  #checkov:skip=CKV2_AWS_61:Lifecycle configuration not required for session data
+  #checkov:skip=CKV_AWS_144:Cross-region replication not required for session data
+  #checkov:skip=CKV2_AWS_62:Event notifications not required for session data
+  #checkov:skip=CKV_AWS_18:Access logging not required for session data
+  #checkov:skip=CKV_AWS_21:Session data does not need versioning enabled
+  #checkov:skip=CKV_AWS_145:AES256 (S3-managed) encryption is sufficient for session data
+  force_destroy = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "session" {
+  bucket = aws_s3_bucket.session.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "session" {
+  bucket = aws_s3_bucket.session.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+<%_ } _%>
 module "agent_core_runtime" {
   source = "../../../core/agent-core"
   agent_runtime_name = "<%= nameClassName %>"
@@ -107,6 +139,20 @@ module "agent_core_runtime" {
         "arn:aws:bedrock:*:*:foundation-model/*",
         "arn:aws:bedrock:*:*:inference-profile/*"
       ]
+    }<% } %><% if (session === 's3') { %>,
+    # Grant access for the agent to read/write its session data
+    {
+      Effect = "Allow"
+      Action = [
+        "s3:GetObject",
+        "s3:PutObject",
+        "s3:DeleteObject",
+        "s3:ListBucket"
+      ]
+      Resource = [
+        aws_s3_bucket.session.arn,
+        "${aws_s3_bucket.session.arn}/*"
+      ]
     }<% } %>
   ], var.additional_iam_policy_statements)
   tags = var.tags
@@ -118,7 +164,7 @@ module "add_agent_runtime_to_runtime_config" {
 
   namespace = "agentcore"
   key       = "agentRuntimes"
-  value     = { "<%= nameClassName %>" = module.agent_core_runtime.agent_core_runtime_arn }
+  value     = { "<%= nameClassName %>" = { arn = module.agent_core_runtime.agent_core_runtime_arn, session = { storage = "<%= session %>"<% if (session === 's3') { %>, bucketName = aws_s3_bucket.session.bucket<% } %> } } }
 
   depends_on = [module.agent_core_runtime]
 }

--- a/packages/nx-plugin/src/utils/agent-core-constructs/files/terraform/app/agent-core/__nameKebabCase__/__nameKebabCase__.tf.template
+++ b/packages/nx-plugin/src/utils/agent-core-constructs/files/terraform/app/agent-core/__nameKebabCase__/__nameKebabCase__.tf.template
@@ -1,3 +1,14 @@
+<%_ if (session === 's3') { _%>
+terraform {
+  required_providers {
+    random = {
+      source  = "hashicorp/random"
+      version = "<%- randomProviderVersion %>"
+    }
+  }
+}
+
+<%_ } _%>
 variable "env" {
   description = "Environment variables to pass to the agent core runtime"
   type        = map(string)
@@ -60,23 +71,90 @@ variable "user_pool_client_ids" {
   type        = list(string)
 }
 
+<%_ } _%>
+<%_ if (auth === 'cognito' || session === 's3') { _%>
 data "aws_region" "current" {}
+<%_ } _%>
+<%_ if (session === 's3') { _%>
+data "aws_caller_identity" "current" {}
+<%_ } _%>
+<%_ if (auth === 'cognito') { _%>
 
 locals {
   aws_region = data.aws_region.current.id
 }
-
 <%_ } _%>
 <%_ if (session === 's3') { _%>
+
+locals {
+  # Delivery source/destination names have a 60 character maximum. Truncate
+  # the agent name so these stay within the limit.
+  session_access_logs_name_prefix = substr("<%= nameKebabCase %>", 0, 30)
+}
+
+# Uniquifies resource names below so this construct can be deployed more than
+# once (e.g. across stages) within the same account/region.
+resource "random_id" "session_unique_suffix" {
+  byte_length = 4
+}
+
+# KMS key encrypting the session bucket and its server access logs.
+resource "aws_kms_key" "session" {
+  description             = "KMS key for <%= nameKebabCase %> agent session data"
+  enable_key_rotation     = true
+  deletion_window_in_days = 7
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "EnableIAMUserPermissions"
+        Effect    = "Allow"
+        Principal = { AWS = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root" }
+        Action    = "kms:*"
+        Resource  = "*"
+      },
+      {
+        Sid       = "AllowCloudWatchLogs"
+        Effect    = "Allow"
+        Principal = { Service = "logs.${data.aws_region.current.region}.amazonaws.com" }
+        Action = [
+          "kms:Encrypt",
+          "kms:Decrypt",
+          "kms:ReEncrypt*",
+          "kms:GenerateDataKey*",
+          "kms:DescribeKey"
+        ]
+        Resource = "*"
+        Condition = {
+          ArnLike = {
+            "kms:EncryptionContext:aws:logs:arn" = "arn:aws:logs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:log-group:*"
+          }
+        }
+      }
+    ]
+  })
+
+  tags = var.tags
+}
+
+# CloudWatch log group receiving the session bucket's server access logs.
+resource "aws_cloudwatch_log_group" "session_access_logs" {
+  name              = "/aws/s3/<%= nameKebabCase %>-session-access-logs-${random_id.session_unique_suffix.hex}"
+  retention_in_days = 365
+  kms_key_id        = aws_kms_key.session.arn
+
+  tags = var.tags
+}
+
 # Bucket storing the agent's session data
 resource "aws_s3_bucket" "session" {
   #checkov:skip=CKV2_AWS_61:Lifecycle configuration not required for session data
   #checkov:skip=CKV_AWS_144:Cross-region replication not required for session data
   #checkov:skip=CKV2_AWS_62:Event notifications not required for session data
-  #checkov:skip=CKV_AWS_18:Access logging not required for session data
+  #checkov:skip=CKV_AWS_18:Server access logs are delivered to CloudWatch Logs (see aws_cloudwatch_log_delivery.session)
   #checkov:skip=CKV_AWS_21:Session data does not need versioning enabled
-  #checkov:skip=CKV_AWS_145:AES256 (S3-managed) encryption is sufficient for session data
-  force_destroy = true
+  force_destroy = false
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "session" {
@@ -84,7 +162,8 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "session" {
 
   rule {
     apply_server_side_encryption_by_default {
-      sse_algorithm = "AES256"
+      kms_master_key_id = aws_kms_key.session.arn
+      sse_algorithm     = "aws:kms"
     }
   }
 }
@@ -96,6 +175,51 @@ resource "aws_s3_bucket_public_access_block" "session" {
   block_public_policy     = true
   ignore_public_acls      = true
   restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_policy" "session" {
+  bucket = aws_s3_bucket.session.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "DenyInsecureConnections"
+        Effect    = "Deny"
+        Principal = "*"
+        Action    = "s3:*"
+        Resource = [
+          aws_s3_bucket.session.arn,
+          "${aws_s3_bucket.session.arn}/*"
+        ]
+        Condition = {
+          Bool = {
+            "aws:SecureTransport" = "false"
+          }
+        }
+      }
+    ]
+  })
+}
+
+# Deliver the session bucket's server access logs to CloudWatch Logs.
+resource "aws_cloudwatch_log_delivery_source" "session" {
+  name         = "${local.session_access_logs_name_prefix}-access-logs-source-${random_id.session_unique_suffix.hex}"
+  log_type     = "S3_SERVER_ACCESS_LOGS"
+  resource_arn = aws_s3_bucket.session.arn
+}
+
+resource "aws_cloudwatch_log_delivery_destination" "session" {
+  name = "${local.session_access_logs_name_prefix}-access-logs-dest-${random_id.session_unique_suffix.hex}"
+
+  delivery_destination_configuration {
+    destination_resource_arn = aws_cloudwatch_log_group.session_access_logs.arn
+  }
+}
+
+resource "aws_cloudwatch_log_delivery" "session" {
+  delivery_source_name     = aws_cloudwatch_log_delivery_source.session.name
+  delivery_destination_arn = aws_cloudwatch_log_delivery_destination.session.arn
 }
 
 <%_ } _%>
@@ -153,6 +277,15 @@ module "agent_core_runtime" {
         aws_s3_bucket.session.arn,
         "${aws_s3_bucket.session.arn}/*"
       ]
+    },
+    # Grant access for the agent to use the session bucket's KMS key
+    {
+      Effect = "Allow"
+      Action = [
+        "kms:Decrypt",
+        "kms:GenerateDataKey*"
+      ]
+      Resource = [aws_kms_key.session.arn]
     }<% } %>
   ], var.additional_iam_policy_statements)
   tags = var.tags
@@ -164,7 +297,7 @@ module "add_agent_runtime_to_runtime_config" {
 
   namespace = "agentcore"
   key       = "agentRuntimes"
-  value     = { "<%= nameClassName %>" = { arn = module.agent_core_runtime.agent_core_runtime_arn, session = { storage = "<%= session %>"<% if (session === 's3') { %>, bucketName = aws_s3_bucket.session.bucket<% } %> } } }
+  value     = { "<%= nameClassName %>" = { arn = module.agent_core_runtime.agent_core_runtime_arn<% if (session === 's3') { %>, session = { bucketName = aws_s3_bucket.session.bucket }<% } %> } }
 
   depends_on = [module.agent_core_runtime]
 }

--- a/packages/nx-plugin/src/utils/ast.ts
+++ b/packages/nx-plugin/src/utils/ast.ts
@@ -320,6 +320,35 @@ export const captureGritQL = async (
 };
 
 /**
+ * Like `captureGritQL`, but returns one metavariable's binding (e.g. `mod`
+ * for `$mod`) instead of the whole matched node.
+ */
+export const captureGritQLVariable = async (
+  tree: Tree,
+  filePath: string,
+  pattern: string,
+  variableName: string,
+): Promise<string | undefined> => {
+  if (!tree.exists(filePath)) return undefined;
+  ensureGritDir(tree);
+  const source = tree.read(filePath)!.toString();
+  // The underlying binding lookup requires the `$` sigil.
+  const name = variableName.startsWith('$') ? variableName : `$${variableName}`;
+  let captured: string | undefined;
+  try {
+    const query = new QueryBuilder(pattern);
+    query.filter((node) => {
+      captured ??= node.var(name) ?? undefined;
+      return true;
+    });
+    await query.applyToFile({ path: filePath, content: source });
+  } catch {
+    return undefined;
+  }
+  return captured;
+};
+
+/**
  * Return the text of every node matching the GritQL pattern, in document order.
  */
 export const captureAllGritQL = async (

--- a/packages/nx-plugin/src/utils/connection/open-api/files/components/__apiNameClassName__Provider.tsx.template
+++ b/packages/nx-plugin/src/utils/connection/open-api/files/components/__apiNameClassName__Provider.tsx.template
@@ -26,9 +26,12 @@ const useCreate<%- apiNameClassName %>Client = (): <%- apiNameClassName %> => {
   const runtimeConfig = useRuntimeConfig();
 <%_ if (isAgentRuntime) { _%>
   const agentRuntimeValue = runtimeConfig.agentRuntimes.<%- apiNameClassName %>;
-  const apiUrl = agentRuntimeValue.startsWith('arn:')
-    ? buildAgentCoreHttpUrl(agentRuntimeValue)
-    : agentRuntimeValue;
+  // A string value is a local-dev override URL; otherwise it's the deployed
+  // runtime entry, so build the invocation URL from its ARN.
+  const apiUrl =
+    typeof agentRuntimeValue === 'string'
+      ? agentRuntimeValue
+      : buildAgentCoreHttpUrl(agentRuntimeValue.arn);
 <%_ } else { _%>
   const apiUrl = runtimeConfig.apis.<%- apiNameClassName %>;
 <%_ } _%>

--- a/packages/nx-plugin/src/utils/connection/open-api/files/components/__apiNameClassName__Provider.tsx.template
+++ b/packages/nx-plugin/src/utils/connection/open-api/files/components/__apiNameClassName__Provider.tsx.template
@@ -26,12 +26,11 @@ const useCreate<%- apiNameClassName %>Client = (): <%- apiNameClassName %> => {
   const runtimeConfig = useRuntimeConfig();
 <%_ if (isAgentRuntime) { _%>
   const agentRuntimeValue = runtimeConfig.agentRuntimes.<%- apiNameClassName %>;
-  // A string value is a local-dev override URL; otherwise it's the deployed
-  // runtime entry, so build the invocation URL from its ARN.
-  const apiUrl =
-    typeof agentRuntimeValue === 'string'
-      ? agentRuntimeValue
-      : buildAgentCoreHttpUrl(agentRuntimeValue.arn);
+  // A local-dev override is a plain URL; otherwise it's the agent's runtime
+  // ARN, so build the invocation URL from it.
+  const apiUrl = agentRuntimeValue.startsWith('arn:')
+    ? buildAgentCoreHttpUrl(agentRuntimeValue)
+    : agentRuntimeValue;
 <%_ } else { _%>
   const apiUrl = runtimeConfig.apis.<%- apiNameClassName %>;
 <%_ } _%>


### PR DESCRIPTION
### Reason for this change

`ts#agent`-generated agents had no built-in way to persist conversation state (message history, tool state) across invocations. Since Bedrock AgentCore Runtime can scale or restart between requests, this meant conversations couldn't survive beyond a single process lifetime.

### Description of changes

- Add a `session` option to `ts#agent`: `s3` (default) or `in-memory`.
- Generate a `session.ts` exporting `getSessionManager()`, wired into `agent.ts` for HTTP/A2A agents (directly on the `Agent` constructor) and into `index.ts` for AG-UI agents (via `sessionManagerProvider`, since AG-UI clones a template agent per thread).
- When `session: s3`, CDK/Terraform provision a dedicated S3 bucket (encrypted with a dedicated KMS key, all public access blocked, server access logs delivered to CloudWatch) and grant the agent's IAM role read/write access; the bucket name is registered in AppConfig alongside the agent's runtime ARN.
- Local development always uses `LocalFileStorage` under `tmp/agents/strands/<agent-name>` at the workspace root, regardless of the configured `session` option.
- Add `@aws-sdk/client-s3` as an explicit dependency when `session: s3`, so the bundler can resolve the Strands SDK's lazy `import('@aws-sdk/client-s3')` — without it, the deployed container (which ships no `node_modules`) fails at runtime.
- Add a `ts-agent-session-management-support` Nx migration to bring existing (pre-feature) workspaces up to the new shape: reshapes `agentRuntimes` entries to `{ arn, session }`, backfills `session.ts` and wires it into existing agents, and migrates the error-logging hooks (both AG-UI and HTTP/A2A) to `StrandsAgent`/`Agent` constructor plugins.
- `py#agent` also gains the `session` option (schema only, always `in-memory`) for API parity — Python session manager support isn't implemented yet.
- Docs: new "Session Management" section in the `ts#agent` guide; fixed stale `FileTree`/code samples that predated this change.

### Description of how you validated changes

- Unit tests.
- Generated a baseline test project with the pre-session-feature version of `ts#agent`/`py#agent`, including MCP server, A2A, and React website connections, in [this commit](https://github.com/AlexTo/test-ts-agent-session/commit/a9f2422170ab6fa9a7b16cb4fb9a9e3747bbcf72).
- Applied the migration in [this commit](https://github.com/AlexTo/test-ts-agent-session/commit/de3eaf5e32d76eb452b976c3d8d91cc023bb5f57) to verify existing HTTP/A2A/AG-UI agents (TypeScript and Python), along with their MCP/A2A/React connections, were correctly upgraded — `session.ts` backfilled and wired in, error-logging hooks migrated to `StrandsAgent` plugins for the AG-UI agent, `agentRuntimes` reshaped, and connection client/provider code updated to read the new `{ arn, session }` shape.
- Generated new agents with `session: s3`, an A2A connection between them, and wired them to CDK infra in [this commit](https://github.com/AlexTo/test-ts-agent-session/commit/3d8deb03da4f874836d111e71e1deef3acd253c1), deployed to AWS, and verified the sessionId flows through end-to-end — each connected agent persists its session under the same sessionId, in its own dedicated S3 bucket. Also chatted with the agents locally to verify each agent's local session directory (`tmp/agents/strands/<agent-name>`) is created and populated correctly.

### Issue # (if applicable)

Closes #<issue number here>.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

