### PR TITLE
fix(ts#react-website): order access log delivery after the bucket policy

### DIFF
--- a/packages/nx-plugin/migrations.json
+++ b/packages/nx-plugin/migrations.json
@@ -17,6 +17,10 @@
     "latest-user-identity-waf-allow-localhost-callback": {
       "description": "Count the EC2MetaDataSSRF_QUERYARGUMENTS WAF rule on the UserIdentity Web ACL so sign-in from a local dev server is not blocked",
       "implementation": "./src/migrations/latest/user-identity-waf-allow-localhost-callback/migration"
+    },
+    "latest-order-access-log-delivery-after-bucket-policy": {
+      "description": "Order the S3 server access log delivery source after the bucket policy to avoid a 409 from concurrent bucket configuration writes",
+      "implementation": "./src/migrations/latest/order-access-log-delivery-after-bucket-policy/migration"
     }
   }
 }

--- a/packages/nx-plugin/src/migrations/latest/order-access-log-delivery-after-bucket-policy/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/latest/order-access-log-delivery-after-bucket-policy/migration.spec.ts
@@ -1,0 +1,344 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import type { Tree } from '@nx/devkit';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test';
+import migration from './migration';
+
+const STATIC_WEBSITE_FILE =
+  'packages/common/constructs/src/core/static-website.ts';
+
+/**
+ * The `deliverAccessLogsToCloudWatch` helper as generated prior to this fix.
+ * `bucketParam` renames the bucket the delivery source targets, and
+ * `bucketImport` controls whether the concrete `Bucket` type is imported, so
+ * tests can vary both independently of the rest of the shape.
+ */
+const oldStaticWebsiteFile = ({
+  bucketParam = 'bucket',
+  bucketImport = "import { Bucket, IBucket } from 'aws-cdk-lib/aws-s3';",
+}: {
+  bucketParam?: string;
+  bucketImport?: string;
+} = {}) =>
+  `import { Lazy, Names } from 'aws-cdk-lib';
+${bucketImport}
+import {
+  CfnDelivery,
+  CfnDeliveryDestination,
+  CfnDeliverySource,
+  LogGroup,
+} from 'aws-cdk-lib/aws-logs';
+import { Construct } from 'constructs';
+
+export class StaticWebsite extends Construct {
+  /**
+   * Delivers a bucket's S3 server access logs to a CloudWatch log group using
+   * CloudWatch Logs vended log delivery.
+   */
+  private deliverAccessLogsToCloudWatch(
+    id: string,
+    ${bucketParam}: IBucket,
+    logGroup: LogGroup,
+  ) {
+    const source: CfnDeliverySource = new CfnDeliverySource(
+      this,
+      \`\${id}AccessLogsSource\`,
+      {
+        name: Lazy.string({
+          produce: () => Names.uniqueResourceName(source, { maxLength: 60 }),
+        }),
+        logType: 'S3_SERVER_ACCESS_LOGS',
+        resourceArn: ${bucketParam}.bucketArn,
+      },
+    );
+    const destination: CfnDeliveryDestination = new CfnDeliveryDestination(
+      this,
+      \`\${id}AccessLogsDestination\`,
+      {
+        name: Lazy.string({
+          produce: () => Names.uniqueResourceName(destination, { maxLength: 60 }),
+        }),
+        destinationResourceArn: logGroup.logGroupArn,
+      },
+    );
+    const delivery = new CfnDelivery(this, \`\${id}AccessLogsDelivery\`, {
+      deliverySourceName: source.name,
+      deliveryDestinationArn: destination.attrArn,
+    });
+    delivery.addDependency(source);
+  }
+}
+`;
+
+const OLD_STATIC_WEBSITE_FILE = oldStaticWebsiteFile();
+
+describe('order-access-log-delivery-after-bucket-policy migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeUsingTsSolutionSetup();
+  });
+
+  it('should be a no-op when the static website construct does not exist', async () => {
+    const result = await migration(tree);
+    expect(result.nextSteps).toEqual([]);
+    expect(tree.exists(STATIC_WEBSITE_FILE)).toBeFalsy();
+  });
+
+  it('should order the delivery source after the bucket policy', async () => {
+    tree.write(STATIC_WEBSITE_FILE, OLD_STATIC_WEBSITE_FILE);
+
+    const result = await migration(tree);
+
+    const contents = tree.read(STATIC_WEBSITE_FILE, 'utf-8') ?? '';
+    expect(contents).toContain(
+      'const bucketPolicy = (bucket as Bucket).policy',
+    );
+    expect(contents).toContain('source.node.addDependency(bucketPolicy)');
+
+    // The dependency must be added after the delivery source is constructed,
+    // and before the delivery is created.
+    const sourceIdx = contents.indexOf('resourceArn: bucket.bucketArn');
+    const depIdx = contents.indexOf('source.node.addDependency(bucketPolicy)');
+    const deliveryIdx = contents.indexOf('new CfnDelivery(');
+    expect(sourceIdx).toBeLessThan(depIdx);
+    expect(depIdx).toBeLessThan(deliveryIdx);
+
+    // The rest of the helper is preserved.
+    expect(contents).toContain('delivery.addDependency(source)');
+    expect(contents).toContain('CfnDeliveryDestination');
+
+    expect(result.nextSteps.length).toBeGreaterThan(0);
+  });
+
+  it('should not add a comment above the dependency', async () => {
+    tree.write(STATIC_WEBSITE_FILE, OLD_STATIC_WEBSITE_FILE);
+
+    await migration(tree);
+
+    const contents = tree.read(STATIC_WEBSITE_FILE, 'utf-8') ?? '';
+    const lines = contents.split('\n');
+    const depLine = lines.findIndex((l) =>
+      l.includes('const bucketPolicy = (bucket as Bucket).policy'),
+    );
+    expect(depLine).toBeGreaterThan(-1);
+    // The statement directly follows the delivery source declaration, with no
+    // explanatory comment introduced above it.
+    expect(lines[depLine - 1].trim()).toEqual(');');
+    expect(contents).not.toContain('OperationAborted');
+  });
+
+  describe('bucket the delivery targets', () => {
+    it('should use the bucket the delivery source targets when renamed', async () => {
+      // A user who renamed the helper's bucket parameter must still get a
+      // dependency on *that* bucket's policy, not a hardcoded `bucket`.
+      tree.write(
+        STATIC_WEBSITE_FILE,
+        oldStaticWebsiteFile({ bucketParam: 'targetBucket' }),
+      );
+
+      const result = await migration(tree);
+
+      const contents = tree.read(STATIC_WEBSITE_FILE, 'utf-8') ?? '';
+      expect(contents).toContain(
+        'const bucketPolicy = (targetBucket as Bucket).policy',
+      );
+      expect(contents).not.toContain('(bucket as Bucket)');
+      expect(contents).toContain('source.node.addDependency(bucketPolicy)');
+      expect(result.nextSteps.length).toBeGreaterThan(0);
+    });
+
+    it('should reference the same bucket the delivery source targets', async () => {
+      tree.write(
+        STATIC_WEBSITE_FILE,
+        oldStaticWebsiteFile({ bucketParam: 'assetsBucket' }),
+      );
+
+      await migration(tree);
+
+      const contents = tree.read(STATIC_WEBSITE_FILE, 'utf-8') ?? '';
+      // The bucket cast in the inserted statement and the bucket whose ARN the
+      // delivery source targets must be one and the same.
+      const target = /resourceArn: (\w+)\.bucketArn/.exec(contents)?.[1];
+      const cast = /const bucketPolicy = \((\w+) as Bucket\)\.policy/.exec(
+        contents,
+      )?.[1];
+      expect(target).toEqual('assetsBucket');
+      expect(cast).toEqual(target);
+    });
+
+    it('should cover every delivery source in the helper', async () => {
+      // The generated helper is called once per bucket (website and
+      // distribution logs), so ordering the single delivery source it builds
+      // covers both. Guard that assumption: if a workspace grew a second
+      // delivery source targeting a different bucket, the migration must not
+      // silently order only the first.
+      tree.write(STATIC_WEBSITE_FILE, OLD_STATIC_WEBSITE_FILE);
+
+      await migration(tree);
+
+      const contents = tree.read(STATIC_WEBSITE_FILE, 'utf-8') ?? '';
+      const sources = contents.match(/new CfnDeliverySource\(/g) ?? [];
+      const deps =
+        contents.match(/source\.node\.addDependency\(bucketPolicy\)/g) ?? [];
+      expect(sources).toHaveLength(1);
+      expect(deps).toHaveLength(sources.length);
+    });
+
+    it('should skip when the targeted bucket is not a declared parameter', async () => {
+      // The delivery source targets a bucket that is not in scope in the
+      // helper, so the migration must not write a reference to it.
+      const diverged = OLD_STATIC_WEBSITE_FILE.replace(
+        'resourceArn: bucket.bucketArn,',
+        'resourceArn: someOtherBucket.bucketArn,',
+      );
+      tree.write(STATIC_WEBSITE_FILE, diverged);
+
+      const result = await migration(tree);
+
+      const contents = tree.read(STATIC_WEBSITE_FILE, 'utf-8') ?? '';
+      expect(contents).not.toContain('source.node.addDependency(bucketPolicy)');
+      expect(contents).not.toContain('someOtherBucket as Bucket');
+      expect(
+        result.nextSteps.some((s) => s.includes(STATIC_WEBSITE_FILE)),
+      ).toBeTruthy();
+    });
+
+    it('should skip when the delivery source targets a member expression', async () => {
+      // `this.websiteBucket.bucketArn` cannot be cast and dereferenced by the
+      // simple statement this migration writes, so leave the file alone.
+      const diverged = OLD_STATIC_WEBSITE_FILE.replace(
+        'resourceArn: bucket.bucketArn,',
+        'resourceArn: this.websiteBucket.bucketArn,',
+      );
+      tree.write(STATIC_WEBSITE_FILE, diverged);
+
+      const result = await migration(tree);
+
+      const contents = tree.read(STATIC_WEBSITE_FILE, 'utf-8') ?? '';
+      expect(contents).not.toContain('source.node.addDependency(bucketPolicy)');
+      expect(
+        result.nextSteps.some((s) => s.includes(STATIC_WEBSITE_FILE)),
+      ).toBeTruthy();
+    });
+
+    it('should skip when the delivery source has no bucket ARN', async () => {
+      const diverged = OLD_STATIC_WEBSITE_FILE.replace(
+        'resourceArn: bucket.bucketArn,',
+        "resourceArn: 'arn:aws:s3:::hardcoded-bucket',",
+      );
+      tree.write(STATIC_WEBSITE_FILE, diverged);
+
+      const result = await migration(tree);
+
+      const contents = tree.read(STATIC_WEBSITE_FILE, 'utf-8') ?? '';
+      expect(contents).not.toContain('source.node.addDependency(bucketPolicy)');
+      expect(
+        result.nextSteps.some((s) => s.includes(STATIC_WEBSITE_FILE)),
+      ).toBeTruthy();
+    });
+  });
+
+  describe('Bucket type import', () => {
+    it('should add the Bucket import when only IBucket is imported', async () => {
+      // The inserted cast needs the concrete Bucket type, which the generated
+      // helper's IBucket parameter does not provide.
+      tree.write(
+        STATIC_WEBSITE_FILE,
+        oldStaticWebsiteFile({
+          bucketImport: "import { IBucket } from 'aws-cdk-lib/aws-s3';",
+        }),
+      );
+
+      await migration(tree);
+
+      const contents = tree.read(STATIC_WEBSITE_FILE, 'utf-8') ?? '';
+      expect(contents).toContain('(bucket as Bucket).policy');
+      expect(contents).toMatch(
+        /import \{[^}]*\bBucket\b[^}]*\} from 'aws-cdk-lib\/aws-s3'/,
+      );
+      // IBucket is still needed by the parameter type.
+      expect(contents).toMatch(
+        /import \{[^}]*\bIBucket\b[^}]*\} from 'aws-cdk-lib\/aws-s3'/,
+      );
+    });
+
+    it('should not duplicate an existing Bucket import', async () => {
+      tree.write(STATIC_WEBSITE_FILE, OLD_STATIC_WEBSITE_FILE);
+
+      await migration(tree);
+
+      const contents = tree.read(STATIC_WEBSITE_FILE, 'utf-8') ?? '';
+      const s3Imports = contents.match(/from 'aws-cdk-lib\/aws-s3'/g) ?? [];
+      expect(s3Imports).toHaveLength(1);
+      const bucketNames =
+        /import \{([^}]*)\} from 'aws-cdk-lib\/aws-s3'/
+          .exec(contents)?.[1]
+          .split(',')
+          .map((n) => n.trim())
+          .filter((n) => n === 'Bucket') ?? [];
+      expect(bucketNames).toHaveLength(1);
+    });
+  });
+
+  it('should be idempotent', async () => {
+    tree.write(STATIC_WEBSITE_FILE, OLD_STATIC_WEBSITE_FILE);
+
+    await migration(tree);
+    const afterFirst = tree.read(STATIC_WEBSITE_FILE, 'utf-8');
+
+    const result = await migration(tree);
+    const afterSecond = tree.read(STATIC_WEBSITE_FILE, 'utf-8');
+
+    expect(afterSecond).toEqual(afterFirst);
+    // The dependency is added exactly once.
+    expect(
+      afterSecond?.match(/source\.node\.addDependency\(bucketPolicy\)/g),
+    ).toHaveLength(1);
+    expect(result.nextSteps).toEqual([]);
+  });
+
+  it('should be idempotent for a renamed bucket parameter', async () => {
+    tree.write(
+      STATIC_WEBSITE_FILE,
+      oldStaticWebsiteFile({ bucketParam: 'targetBucket' }),
+    );
+
+    await migration(tree);
+    const afterFirst = tree.read(STATIC_WEBSITE_FILE, 'utf-8');
+
+    await migration(tree);
+
+    expect(tree.read(STATIC_WEBSITE_FILE, 'utf-8')).toEqual(afterFirst);
+    expect(
+      afterFirst?.match(/const bucketPolicy = \(targetBucket as Bucket\)/g),
+    ).toHaveLength(1);
+  });
+
+  it('should skip and report a customised helper', async () => {
+    // A user who renamed the delivery source variable no longer matches the
+    // generated shape, so the migration must leave the file alone.
+    const customised = OLD_STATIC_WEBSITE_FILE.replace(
+      /const source: CfnDeliverySource = new CfnDeliverySource\(\n {6}this,\n {6}`\$\{id\}AccessLogsSource`,/,
+      [
+        'const logSource: CfnDeliverySource = new CfnDeliverySource(',
+        '      this,',
+        // `${id}` here is CDK source text the construct interpolates at synth
+        // time, so it is assembled rather than written as a literal.
+        `      \`$\{id}CustomAccessLogsSource\`,`,
+      ].join('\n'),
+    );
+    tree.write(STATIC_WEBSITE_FILE, customised);
+
+    const result = await migration(tree);
+
+    const contents = tree.read(STATIC_WEBSITE_FILE, 'utf-8') ?? '';
+    expect(contents).not.toContain('source.node.addDependency(bucketPolicy)');
+    expect(contents).toContain('CustomAccessLogsSource');
+    expect(
+      result.nextSteps.some((s) => s.includes(STATIC_WEBSITE_FILE)),
+    ).toBeTruthy();
+  });
+});

--- a/packages/nx-plugin/src/migrations/latest/order-access-log-delivery-after-bucket-policy/migration.ts
+++ b/packages/nx-plugin/src/migrations/latest/order-access-log-delivery-after-bucket-policy/migration.ts
@@ -1,0 +1,156 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import type { MigrationReturnObject, Tree } from '@nx/devkit';
+import {
+  addDestructuredImport,
+  applyGritQL,
+  captureGritQL,
+  matchGritQL,
+} from '../../../utils/ast';
+import { formatFilesInSubtree } from '../../../utils/format';
+import {
+  PACKAGES_DIR,
+  SHARED_CONSTRUCTS_DIR,
+} from '../../../utils/shared-constructs-constants';
+
+/**
+ * Order the S3 server access log delivery source after the bucket policy.
+ *
+ * S3 rejects concurrent configuration writes against the same bucket with a 409
+ * (OperationAborted). The generated StaticWebsite construct left the delivery
+ * source and the bucket policy unordered, so CloudFormation could submit both at
+ * once and fail the stack.
+ */
+
+const STATIC_WEBSITE_FILE = `${PACKAGES_DIR}/${SHARED_CONSTRUCTS_DIR}/src/core/static-website.ts`;
+
+const BUCKET_ARN_SUFFIX = '.bucketArn';
+
+/**
+ * The bucket whose policy the delivery source must be ordered after is the one
+ * the delivery source itself targets, so read it off `resourceArn` rather than
+ * assuming the generated parameter name. Returns undefined unless exactly one
+ * simple identifier is found, so a diverged helper is left alone.
+ */
+const findDeliverySourceBucket = async (
+  tree: Tree,
+  filePath: string,
+): Promise<string | undefined> => {
+  const captured = await captureGritQL(
+    tree,
+    filePath,
+    '`resourceArn: $bucket.bucketArn`',
+  );
+  if (!captured) return undefined;
+
+  const bucket = captured
+    .slice(captured.indexOf(':') + 1)
+    .replace(BUCKET_ARN_SUFFIX, '')
+    .trim();
+
+  // Only a plain identifier can be cast and dereferenced safely in the
+  // statement this migration writes.
+  return /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(bucket) ? bucket : undefined;
+};
+
+/**
+ * Confirm the bucket the delivery source targets is declared as a parameter of
+ * the enclosing helper, so the statement this migration writes references a
+ * variable that is actually in scope.
+ */
+const isBucketDeclaredParameter = async (
+  tree: Tree,
+  filePath: string,
+  bucket: string,
+): Promise<boolean> =>
+  await matchGritQL(
+    tree,
+    filePath,
+    `\`private deliverAccessLogsToCloudWatch($params) { $_ }\` where {
+      $params <: contains \`${bucket}: $bucketType\`,
+      $bucketType <: or { \`IBucket\`, \`Bucket\` }
+    }`,
+  );
+
+// Inserts the bucket policy dependency between the delivery source and the
+// delivery destination, matching the shape generators produced prior to this
+// fix. Anchored on the destination declaration so the source's own (multi-line,
+// Lazy-valued) arguments don't need to be matched.
+const addDependencyPattern = (bucket: string) =>
+  `\`const $dest: CfnDeliveryDestination = new CfnDeliveryDestination($destArgs)\` as $decl where {
+  $dest <: \`destination\`
+} => \`const bucketPolicy = (${bucket} as Bucket).policy;
+    if (bucketPolicy) {
+      source.node.addDependency(bucketPolicy);
+    }
+    $decl\``;
+
+export default async function migration(
+  tree: Tree,
+): Promise<MigrationReturnObject> {
+  const nextSteps: string[] = [];
+
+  if (!tree.exists(STATIC_WEBSITE_FILE)) {
+    // No vended StaticWebsite construct in this workspace - nothing to migrate.
+    return { nextSteps };
+  }
+
+  const contents = tree.read(STATIC_WEBSITE_FILE, 'utf-8') ?? '';
+  if (contents.includes('source.node.addDependency(bucketPolicy)')) {
+    // Already migrated.
+    return { nextSteps };
+  }
+
+  const divergedMessage = `${STATIC_WEBSITE_FILE}: deliverAccessLogsToCloudWatch has diverged from the generated shape - left untouched. Manually order the S3 server access log delivery source after the bucket policy of the bucket it targets (\`source.node.addDependency(bucketPolicy)\`), avoiding a 409 (OperationAborted) from concurrent bucket configuration writes.`;
+
+  // The rewrite is anchored on the delivery destination but references the
+  // `source` variable, so only apply it when the delivery source still has the
+  // generated shape.
+  const hasGeneratedSource = await matchGritQL(
+    tree,
+    STATIC_WEBSITE_FILE,
+    '`const source: CfnDeliverySource = new CfnDeliverySource($_)`',
+  );
+
+  const bucket = hasGeneratedSource
+    ? await findDeliverySourceBucket(tree, STATIC_WEBSITE_FILE)
+    : undefined;
+
+  if (
+    !bucket ||
+    !(await isBucketDeclaredParameter(tree, STATIC_WEBSITE_FILE, bucket))
+  ) {
+    nextSteps.push(divergedMessage);
+    return { nextSteps };
+  }
+
+  const rewrote = await applyGritQL(
+    tree,
+    STATIC_WEBSITE_FILE,
+    addDependencyPattern(bucket),
+  );
+
+  if (!rewrote) {
+    nextSteps.push(divergedMessage);
+    return { nextSteps };
+  }
+
+  // The inserted statement casts to the concrete Bucket to reach its policy,
+  // which the helper's own `IBucket` parameter type does not expose.
+  await addDestructuredImport(
+    tree,
+    STATIC_WEBSITE_FILE,
+    ['Bucket'],
+    'aws-cdk-lib/aws-s3',
+  );
+
+  nextSteps.push(
+    `${STATIC_WEBSITE_FILE}: the S3 server access log delivery source is now created after the policy of the bucket it targets, avoiding a 409 (OperationAborted) from concurrent bucket configuration writes.`,
+  );
+
+  await formatFilesInSubtree(tree);
+
+  return { nextSteps };
+}

--- a/packages/nx-plugin/src/ts/react-website/app/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/react-website/app/__snapshots__/generator.spec.ts.snap
@@ -1940,6 +1940,10 @@ export class StaticWebsite extends Construct {
         resourceArn: bucket.bucketArn,
       },
     );
+    const bucketPolicy = (bucket as Bucket).policy;
+    if (bucketPolicy) {
+      source.node.addDependency(bucketPolicy);
+    }
     const destination: CfnDeliveryDestination = new CfnDeliveryDestination(
       this,
       \`\${id}AccessLogsDestination\`,
@@ -3750,6 +3754,10 @@ export class StaticWebsite extends Construct {
         resourceArn: bucket.bucketArn,
       },
     );
+    const bucketPolicy = (bucket as Bucket).policy;
+    if (bucketPolicy) {
+      source.node.addDependency(bucketPolicy);
+    }
     const destination: CfnDeliveryDestination = new CfnDeliveryDestination(
       this,
       \`\${id}AccessLogsDestination\`,
@@ -5420,6 +5428,10 @@ export class StaticWebsite extends Construct {
         resourceArn: bucket.bucketArn,
       },
     );
+    const bucketPolicy = (bucket as Bucket).policy;
+    if (bucketPolicy) {
+      source.node.addDependency(bucketPolicy);
+    }
     const destination: CfnDeliveryDestination = new CfnDeliveryDestination(
       this,
       \`\${id}AccessLogsDestination\`,

--- a/packages/nx-plugin/src/utils/website-constructs/files/cdk/core/static-website.ts.template
+++ b/packages/nx-plugin/src/utils/website-constructs/files/cdk/core/static-website.ts.template
@@ -324,6 +324,10 @@ export class StaticWebsite extends Construct {
         resourceArn: bucket.bucketArn,
       },
     );
+    const bucketPolicy = (bucket as Bucket).policy;
+    if (bucketPolicy) {
+      source.node.addDependency(bucketPolicy);
+    }
     const destination: CfnDeliveryDestination = new CfnDeliveryDestination(
       this,
       `${id}AccessLogsDestination`,


### PR DESCRIPTION
### Reason for this change

The `cdk-deploy` smoke test failed on `main` ([run 30748700714](https://github.com/awslabs/nx-plugin-for-aws/actions/runs/30748700714)) with:

```
CREATE_FAILED | AWS::S3::BucketPolicy
  .../Website/DistributionLogBucket/Policy
  Resource handler returned message: "A conflicting conditional operation is
  currently in progress against this resource. Please try again."
  (Service: S3, Status Code: 409, HandlerErrorCode: GeneralServiceException)
```

That single 409 cancelled 17 in-flight resources and rolled the whole `Application` stack back.

S3 serialises configuration writes against a bucket and rejects concurrent ones with a 409 (`OperationAborted`). In the vended `StaticWebsite` construct the `AWS::S3::BucketPolicy` and the `AWS::Logs::DeliverySource` both target the same bucket but had no ordering between them, so CloudFormation submitted both as soon as the bucket reached `CREATE_COMPLETE`. Synthesising the construct confirms it — both resources came out with `DependsOn: null`, for the distribution log bucket *and* the website bucket:

```
DistributionLogBucketPolicy   (AWS::S3::BucketPolicy)     DependsOn: null
DistributionAccessLogsSource  (AWS::Logs::DeliverySource) DependsOn: null
```

The CI timeline matches exactly: bucket `CREATE_COMPLETE` at 1:21:38, both resources submitted at 1:21:40, policy `CREATE_FAILED` at 1:21:41.

### Description of changes

Order the delivery source after the bucket policy in `deliverAccessLogsToCloudWatch`, so the two writes are never in flight together:

```ts
const bucketPolicy = (bucket as Bucket).policy;
if (bucketPolicy) {
  source.node.addDependency(bucketPolicy);
}
```

This applies to both buckets the construct creates. The guard keeps it safe for an `IBucket` with no policy attached.

Includes the deterministic migration `latest-order-access-log-delivery-after-bucket-policy` so existing workspaces converge on the same output. Because the dependency is only correct if it names the bucket the delivery *actually targets*, the migration does not assume the generated parameter name — it reads the bucket off the delivery source's own `resourceArn`, then refuses to write anything unless that bucket:

- is a plain identifier (a member expression like `this.websiteBucket.bucketArn` can't be cast in the statement it writes),
- is declared as a parameter of the enclosing helper, typed `IBucket`/`Bucket`, so the reference is in scope.

It also adds the `Bucket` type import the inserted cast needs, since the helper's own parameter is typed `IBucket`. Anything that doesn't match is left untouched and reported via `nextSteps`.

**Terraform does not need this fix.** Its `static-website` module has the same unordered writes — five concurrent config writes per bucket, and Terraform's default parallelism is 10 — but the AWS provider retries the 409 internally. A `TF_LOG=DEBUG` apply at `-parallelism=30` shows `tf_resource_type=aws_s3_bucket_policy` receiving `http.status_code=409 OperationAborted` **12 times** while the apply still exits 0. Left as-is rather than adding ordering that buys nothing.

### Description of how you validated changes

**Reproduced the underlying race against real S3** (`us-east-1`). Firing the bucket-level config writes concurrently on one bucket hit the failure in **24/24 iterations**, with the error matching CI byte for byte:

```
HTTP 409 | code=OperationAborted
  message=A conflicting conditional operation is currently in progress against this resource.
```

Worth noting: `PutDeliverySource` on its own did *not* contend in 30 attempts, so the contention comes from the bucket-configuration write set as a whole rather than that one API call.

**Deployed the fixed construct to AWS** (`us-west-2`) — 3 independent stacks, each with the full website shape (KMS key, both buckets, both delivery pipelines, CloudFront distribution). All 3 reached `CREATE_COMPLETE` with `rc=0` and zero 409s, and the deployed templates carried the intended ordering:

```
DistributionAccessLogsSource  DependsOn: ["DistributionLogBucketPolicy..."]
WebsiteAccessLogsSource       DependsOn: ["WebsiteBucketPolicy..."]
```

Synth also confirms no dependency cycle, and the emitted helper typechecks under `tsc --strict`. All test stacks and repro resources were torn down; the account is clean.

**Terraform** — 6 apply/destroy cycles of the vended log-bucket shape plus a 6-bucket stress apply at `-parallelism=30`, all exiting 0.

**Unit tests** — full suite green: 150 files / 2910 tests, 3 snapshots updated for the template change. The migration has 14 tests, covering the happy path, statement placement, idempotency (including for a renamed bucket), the `Bucket` import being added when absent and not duplicated when present, and four skip cases — undeclared bucket, member-expression target, no bucket ARN, and a renamed delivery source.

The bucket-resolution tests were mutation-checked: reverting the migration to the earlier hardcoded-`bucket` implementation fails **7 of them**, so they're load-bearing rather than decorative. I also verified out-of-band that the migration's output is byte-identical to the current template, so a migrated workspace matches a freshly generated one.

`pnpm nx run-many --target build --all` passes.

### Issue # (if applicable)

N/A — CI flake on `main`.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*