### PR TITLE
chore(nx-plugin): key an nx bump by the nx version it moves to

### DIFF
--- a/packages/nx-plugin/migrations.json
+++ b/packages/nx-plugin/migrations.json
@@ -33,7 +33,7 @@
     }
   },
   "packageJsonUpdates": {
-    "latest-nx-packages": {
+    "nx-23.1.0-nx-packages": {
       "version": "latest",
       "packages": {
         "nx": {

--- a/packages/nx-plugin/src/utils/migration-versions.spec.ts
+++ b/packages/nx-plugin/src/utils/migration-versions.spec.ts
@@ -97,6 +97,36 @@ describe('migration versions', () => {
         ),
       ).toEqual({});
     });
+
+    // The nx bumps resolve the same way as the migrations and share the walk, so
+    // the release doesn't read tag history twice.
+    it('should resolve packageJsonUpdates from the same release walk', () => {
+      const read = (version: string): MigrationsJson | undefined =>
+        version === '1.2.0'
+          ? {
+              generators: {},
+              packageJsonUpdates: {
+                'nx-23.1.1-nx-packages': { version: '1.2.0' },
+              },
+            }
+          : { generators: {} };
+
+      expect(
+        readShippedMigrationVersions(
+          {
+            generators: {},
+            packageJsonUpdates: {
+              // Released, so datable from history.
+              'nx-23.1.1-nx-packages': { version: 'latest' },
+              // Never published, so left for the release to stamp.
+              'nx-23.2.0-nx-packages': { version: 'latest' },
+            },
+          },
+          VERSIONS,
+          read,
+        ),
+      ).toEqual({ 'nx-23.1.1-nx-packages': '1.2.0' });
+    });
   });
 
   describe('stampMigrationVersions', () => {
@@ -336,20 +366,30 @@ describe('migration versions', () => {
       expect(backfilled).toEqual([]);
     });
 
-    it('should re-key packageJsonUpdates to the release that shipped it', () => {
-      const { migrations } = backfillMigrationVersions(
+    // Dated in place: the key already names what the bump targets, so it stays
+    // put and a bump still waiting for a release can't be written over.
+    it('should date a released packageJsonUpdates entry without re-keying it', () => {
+      const { migrations, backfilled } = backfillMigrationVersions(
         {
           generators: { 'latest-shipped': { description: 'shipped' } },
           packageJsonUpdates: {
-            'latest-nx-packages': { version: 'latest', packages: { nx: {} } },
+            'nx-23.1.0-nx-packages': {
+              version: 'latest',
+              packages: { nx: {} },
+            },
           },
         },
-        { 'latest-shipped': '1.1.0' },
+        {
+          'latest-shipped': '1.1.0',
+          'nx-23.1.0-nx-packages': '1.1.0',
+        },
       );
-      // The nx bump ships with the migration it accompanied, re-keyed with it.
+
       expect(migrations.packageJsonUpdates).toEqual({
-        'v1.1.0-nx-packages': { version: '1.1.0', packages: { nx: {} } },
+        'nx-23.1.0-nx-packages': { version: '1.1.0', packages: { nx: {} } },
       });
+      // Reported, so the weekly PR says the bump was dated.
+      expect(backfilled).toContain('nx-23.1.0-nx-packages');
     });
 
     it('should leave packageJsonUpdates under latest until a release ships it', () => {

--- a/packages/nx-plugin/src/utils/migration-versions.ts
+++ b/packages/nx-plugin/src/utils/migration-versions.ts
@@ -19,7 +19,8 @@ import { compare, valid } from 'semver';
  * - The weekly `update-versions` PR backfills the version of the release that
  *   shipped each migration, moving and re-keying it accordingly
  *   (`scripts/backfill-migration-versions.ts`), so source converges on the
- *   versions of everything already released.
+ *   versions of everything already released. `packageJsonUpdates` entries are
+ *   dated in place there too, since their keys never change.
  *
  * A version already in source always wins, so backfilled entries are stable.
  *
@@ -34,8 +35,9 @@ export interface MigrationsJson {
   >;
   /**
    * Declarative dependency bumps `nx migrate` applies to the root manifest.
-   * Keyed `<dir>-<name>` like the migrations so entries from different releases
-   * can't collide; nx itself gates on the entry's `version`.
+   * Keyed by what the bump targets rather than the release that ships it, so an
+   * entry is unique from the moment it is written and one release's bump can sit
+   * beside the next; nx itself gates on the entry's `version`.
    */
   packageJsonUpdates?: Record<
     string,
@@ -51,14 +53,18 @@ export const isValidVersion = (version: string): boolean =>
   valid(version) !== null;
 
 /**
- * Map of migration key -> version of the earliest release that registers it,
- * resolved only for the entries still missing a `version` (one already recorded
- * in source wins, so its history doesn't need reading). A migration that hasn't
- * been released is absent.
+ * Map of entry key -> version of the earliest release that registers it, across
+ * both `generators` and `packageJsonUpdates`. Resolved only for the entries still
+ * missing a version (one already recorded in source wins, so its history doesn't
+ * need reading). An entry that hasn't been released is absent.
  *
  * Walks releases newest first and stops as soon as every entry is resolved: an
  * entry that has disappeared from a release's `migrations.json` was first
  * registered by the release after it, which is the one that shipped it.
+ *
+ * Both sections resolve the same way and share the walk, so the release doesn't
+ * read tag history twice. Keys can't collide: a migration is keyed by its own
+ * name, an nx bump by the nx version it moves to.
  *
  * @param migrations parsed source migrations.json
  * @param versions released versions in descending semver order
@@ -71,17 +77,26 @@ export const readShippedMigrationVersions = (
   readReleasedMigrations: (version: string) => MigrationsJson | undefined,
 ): Record<string, string> => {
   const shippedVersions: Record<string, string> = {};
-  let unresolved = Object.entries(migrations.generators ?? {})
-    .filter(([, entry]) => !entry.version)
-    .map(([key]) => key);
+  // A `packageJsonUpdates` entry records `latest` rather than omitting its
+  // version, since nx requires the field.
+  let unresolved = [
+    ...Object.entries(migrations.generators ?? {})
+      .filter(([, entry]) => !entry.version)
+      .map(([key]) => key),
+    ...Object.entries(migrations.packageJsonUpdates ?? {})
+      .filter(([, entry]) => entry.version === LATEST_MIGRATIONS_DIR)
+      .map(([key]) => key),
+  ];
 
   for (const version of versions) {
     if (unresolved.length === 0) {
       break;
     }
-    const registered = new Set(
-      Object.keys(readReleasedMigrations(version)?.generators ?? {}),
-    );
+    const released = readReleasedMigrations(version);
+    const registered = new Set([
+      ...Object.keys(released?.generators ?? {}),
+      ...Object.keys(released?.packageJsonUpdates ?? {}),
+    ]);
     // Entries gone at this release keep the version recorded from the release
     // after it (if any) and stop being looked up.
     unresolved = unresolved.filter((key) => registered.has(key));
@@ -95,9 +110,8 @@ export const readShippedMigrationVersions = (
 
 /**
  * Return a copy of the migrations collection with a `version` stamped onto
- * every generator entry, preserving any already present, and any
- * `packageJsonUpdates` entry still keyed `latest` re-keyed to the version it
- * ships under.
+ * every generator entry, preserving any already present, and the pending version
+ * recorded on any `packageJsonUpdates` entry still holding `latest`.
  *
  * @param migrations parsed migrations.json to stamp
  * @param shippedVersions migration key -> version of the earliest release
@@ -139,32 +153,14 @@ export const stampMigrationVersions = (
 });
 
 /**
- * Version any unreleased `packageJsonUpdates` entry and re-key it out of
- * `latest`, so the nx bump ships under the same version as its migrations.
+ * Version any `packageJsonUpdates` entry still holding `latest` with the release
+ * about to publish it, so the nx bump ships under a version `nx migrate` gates on.
  */
 const stampPackageJsonUpdates = (
   packageJsonUpdates: NonNullable<MigrationsJson['packageJsonUpdates']>,
   pendingVersion: string,
 ): NonNullable<MigrationsJson['packageJsonUpdates']> =>
-  Object.fromEntries(
-    Object.entries(packageJsonUpdates).map(([key, entry]) =>
-      entry.version === LATEST_MIGRATIONS_DIR
-        ? [
-            reKeyToVersion(key, pendingVersion),
-            { ...entry, version: pendingVersion },
-          ]
-        : [key, entry],
-    ),
-  );
-
-/** Swap a `latest-<name>` key for the release that ships it. */
-const reKeyToVersion = (key: string, version: string): string =>
-  key.startsWith(LATEST_KEY_PREFIX)
-    ? migrationKey(
-        versionMigrationsDir(version),
-        key.slice(LATEST_KEY_PREFIX.length),
-      )
-    : key;
+  resolvePackageJsonUpdateVersions(packageJsonUpdates, () => pendingVersion);
 
 /** Directory a newly scaffolded migration lands in, before a release claims it. */
 export const LATEST_MIGRATIONS_DIR = 'latest';
@@ -213,6 +209,14 @@ export const backfillMigrationVersions = (
   const generators: NonNullable<MigrationsJson['generators']> = {};
   const backfilled: string[] = [];
   const moves: MigrationDirMove[] = [];
+  // Reported alongside the migrations so the update's PR says an nx bump was
+  // dated, and so the caller knows there is something to commit.
+  const backfilledUpdates = Object.entries(migrations.packageJsonUpdates ?? {})
+    .filter(
+      ([key, entry]) =>
+        entry.version === LATEST_MIGRATIONS_DIR && shippedVersions[key],
+    )
+    .map(([key]) => key);
 
   for (const [key, entry] of Object.entries(migrations.generators ?? {})) {
     const version = shippedVersions[key];
@@ -260,35 +264,34 @@ export const backfillMigrationVersions = (
       ...migrations,
       generators,
       ...(migrations.packageJsonUpdates && {
-        packageJsonUpdates: backfillPackageJsonUpdates(
+        packageJsonUpdates: resolvePackageJsonUpdateVersions(
           migrations.packageJsonUpdates,
-          // Re-keyed with the earliest release it shipped alongside.
-          backfilled
-            .map((key) => shippedVersions[key])
-            .sort(compareVersions)[0],
+          (key) => shippedVersions[key],
         ),
       }),
     },
-    backfilled,
+    backfilled: [...backfilled, ...backfilledUpdates],
     moves,
   };
 };
 
 /**
- * Record the release that shipped an unreleased `packageJsonUpdates` entry,
- * re-keying it out of `latest`, and leave it alone until one has.
+ * Record the version each `packageJsonUpdates` entry ships under, for those still
+ * holding `latest`.
+ *
+ * The key already identifies the entry — an nx bump is named for the nx version
+ * it moves to — so only the `version` field changes. Nothing is re-keyed, which
+ * is what lets one release's bump sit alongside the next without either being
+ * overwritten before it ships.
  */
-const backfillPackageJsonUpdates = (
+const resolvePackageJsonUpdateVersions = (
   packageJsonUpdates: NonNullable<MigrationsJson['packageJsonUpdates']>,
-  shippedVersion: string | undefined,
+  resolve: (key: string) => string | undefined,
 ): NonNullable<MigrationsJson['packageJsonUpdates']> =>
   Object.fromEntries(
-    Object.entries(packageJsonUpdates).map(([key, entry]) =>
-      entry.version === LATEST_MIGRATIONS_DIR && shippedVersion
-        ? [
-            reKeyToVersion(key, shippedVersion),
-            { ...entry, version: shippedVersion },
-          ]
-        : [key, entry],
-    ),
+    Object.entries(packageJsonUpdates).map(([key, entry]) => {
+      const version =
+        entry.version === LATEST_MIGRATIONS_DIR ? resolve(key) : undefined;
+      return [key, version ? { ...entry, version } : entry];
+    }),
   );

--- a/packages/nx-plugin/src/utils/version-upgrade-migration/nx-package-updates.spec.ts
+++ b/packages/nx-plugin/src/utils/version-upgrade-migration/nx-package-updates.spec.ts
@@ -9,7 +9,12 @@ import {
   stampMigrationVersions,
 } from '../migration-versions';
 import { NX_PACKAGES, NX_VERSION } from '../versions';
-import { isNxPackage, nxPackageJsonUpdates } from './nx-package-updates';
+import {
+  isNxPackage,
+  nxPackageJsonUpdates,
+  nxPackageUpdatesKey,
+  type PackageJsonUpdates,
+} from './nx-package-updates';
 
 describe('nx package updates', () => {
   describe('isNxPackage', () => {
@@ -30,13 +35,13 @@ describe('nx package updates', () => {
 
   describe('nxPackageJsonUpdates', () => {
     it('should bump every nx package to the vended version', () => {
-      const updates = nxPackageJsonUpdates('latest', '1.2.3');
+      const updates = nxPackageJsonUpdates(LATEST_MIGRATIONS_DIR);
       const [key] = Object.keys(updates);
 
-      // Keyed by directory, since the entry is written before a version exists
-      // and re-keyed to `v<version>` once a release claims it.
-      expect(key).toBe('latest-nx-packages');
-      expect(updates[key].version).toBe('1.2.3');
+      // Keyed by the nx version it moves to, which is known when the entry is
+      // written — unlike the plugin version, which only a release can supply.
+      expect(key).toBe(nxPackageUpdatesKey(NX_VERSION));
+      expect(updates[key].version).toBe(LATEST_MIGRATIONS_DIR);
       expect(Object.keys(updates[key].packages).sort()).toEqual(
         [...NX_PACKAGES].sort(),
       );
@@ -45,20 +50,25 @@ describe('nx package updates', () => {
       }
     });
 
-    it('should not collide with an entry from another release', () => {
+    // Two bumps can be pending at once — a second update lands before the
+    // release that would ship the first — so the key cannot depend on a plugin
+    // version neither of them has yet.
+    it('should not collide with a bump still waiting for a release', () => {
       const merged = {
-        ...nxPackageJsonUpdates('v1.1.0', '1.1.0'),
-        ...nxPackageJsonUpdates('latest', '1.2.3'),
+        ...nxPackageJsonUpdates(LATEST_MIGRATIONS_DIR, '23.1.0'),
+        ...nxPackageJsonUpdates(LATEST_MIGRATIONS_DIR, '23.1.1'),
       };
+
       expect(Object.keys(merged).sort()).toEqual([
-        'latest-nx-packages',
-        'v1.1.0-nx-packages',
+        'nx-23.1.0-nx-packages',
+        'nx-23.1.1-nx-packages',
       ]);
     });
 
     // Each release's bump stays behind as the next is written, so a workspace
     // several releases behind gets each nx hop rather than only the newest.
     it('should keep every release its bump shipped in', () => {
+      // An update bumps nx, and the release that ships it is tagged 1.1.0.
       const source = {
         generators: {
           'latest-fix-a': {
@@ -67,39 +77,45 @@ describe('nx package updates', () => {
         },
         packageJsonUpdates: nxPackageJsonUpdates(
           LATEST_MIGRATIONS_DIR,
-          LATEST_MIGRATIONS_DIR,
+          '23.1.0',
         ),
       };
 
-      // The weekly backfill re-keys the entry with the release that shipped it.
+      // The next weekly backfill dates it from the release that published it.
       const backfilled = backfillMigrationVersions(source, {
         'latest-fix-a': '1.1.0',
+        [nxPackageUpdatesKey('23.1.0')]: '1.1.0',
       }).migrations;
 
-      // A later release bumps nx again, writing `latest` afresh alongside it.
+      // That update also bumps nx again, writing a second pending entry.
       const next = {
         ...backfilled,
         packageJsonUpdates: {
           ...backfilled.packageJsonUpdates,
-          ...nxPackageJsonUpdates(LATEST_MIGRATIONS_DIR, LATEST_MIGRATIONS_DIR),
+          ...nxPackageJsonUpdates(LATEST_MIGRATIONS_DIR, '23.1.1'),
         },
       };
 
       const published = stampMigrationVersions(next, {}, '1.2.0');
 
+      // Both hops survive: 1.1.0 gets a workspace to nx 23.1.0, 1.2.0 to 23.1.1.
       expect(
-        Object.entries(published.packageJsonUpdates ?? {}).map(
-          ([key, entry]) => [key, entry.version],
-        ),
+        Object.entries(
+          (published.packageJsonUpdates ?? {}) as PackageJsonUpdates,
+        ).map(([key, entry]) => [
+          key,
+          entry.version,
+          entry.packages.nx.version,
+        ]),
       ).toEqual([
-        ['v1.1.0-nx-packages', '1.1.0'],
-        ['v1.2.0-nx-packages', '1.2.0'],
+        [nxPackageUpdatesKey('23.1.0'), '1.1.0', '23.1.0'],
+        [nxPackageUpdatesKey('23.1.1'), '1.2.0', '23.1.1'],
       ]);
     });
 
     it('should not add nx packages a workspace does not already pin', () => {
       // A workspace without e.g. @nx/react must not gain it as a dependency.
-      const updates = nxPackageJsonUpdates('latest', '1.2.3');
+      const updates = nxPackageJsonUpdates(LATEST_MIGRATIONS_DIR);
       for (const { packages } of Object.values(updates)) {
         for (const entry of Object.values(packages)) {
           expect(entry.alwaysAddToPackageJson).toBe(false);
@@ -108,7 +124,7 @@ describe('nx package updates', () => {
     });
 
     it('should accept an explicit nx version', () => {
-      const updates = nxPackageJsonUpdates('latest', '1.2.3', '24.0.0');
+      const updates = nxPackageJsonUpdates(LATEST_MIGRATIONS_DIR, '24.0.0');
       for (const { packages } of Object.values(updates)) {
         for (const entry of Object.values(packages)) {
           expect(entry.version).toBe('24.0.0');

--- a/packages/nx-plugin/src/utils/version-upgrade-migration/nx-package-updates.ts
+++ b/packages/nx-plugin/src/utils/version-upgrade-migration/nx-package-updates.ts
@@ -32,22 +32,33 @@ export interface PackageJsonUpdate extends Record<string, unknown> {
 export type PackageJsonUpdates = Record<string, PackageJsonUpdate>;
 
 /**
+ * Key an nx bump is registered under, named for the nx version it moves to.
+ *
+ * The plugin version the bump ships under isn't known when it is written — the
+ * weekly update writes it, and only the release that publishes it can say which
+ * version that is. The nx version, though, is exactly what the entry is *for*,
+ * and two bumps to the same nx version would be the same bump — so it keys the
+ * entry uniquely from the moment it is written, with no re-keying later.
+ *
+ * That matters because each release's bump has to stay behind as the next is
+ * written: a workspace several releases behind gets every nx hop in turn rather
+ * than only the newest. A key that had to be rewritten once the plugin version
+ * was known would let a second bump land on the first before either shipped.
+ */
+export const nxPackageUpdatesKey = (nxVersion: string) =>
+  `nx-${nxVersion}-${NX_PACKAGE_UPDATES_NAME}`;
+
+/**
  * `alwaysAddToPackageJson: false` so only packages already present are updated.
  *
- * Keyed by directory rather than version, because the key has to exist before
- * the version does: an entry is written under `latest` and only re-keyed to
- * `v<version>` once a release claims it. One release's entry stays behind as the
- * next is written, so a workspace several releases behind gets each nx bump in
- * turn — hence `<dir>-<name>`, which keeps every release's entry distinct.
- *
- * @param version version `nx migrate` gates the bump on
+ * @param version plugin version `nx migrate` gates the bump on, or
+ *   {@link LATEST_MIGRATIONS_DIR} while it is still waiting for a release
  */
 export const nxPackageJsonUpdates = (
-  dir: string,
   version: string,
   nxVersion: string = NX_VERSION,
 ): PackageJsonUpdates => ({
-  [migrationKey(dir, NX_PACKAGE_UPDATES_NAME)]: {
+  [nxPackageUpdatesKey(nxVersion)]: {
     version,
     packages: Object.fromEntries(
       NX_PACKAGES.map((name) => [

--- a/packages/nx-plugin/src/utils/version-upgrade-migration/register.spec.ts
+++ b/packages/nx-plugin/src/utils/version-upgrade-migration/register.spec.ts
@@ -11,10 +11,11 @@ import {
   stampMigrationVersions,
 } from '../migration-versions';
 import { NX_PACKAGES, NX_VERSION } from '../versions';
+import { nxPackageUpdatesKey } from './nx-package-updates';
 import { registerNxPackageUpdates } from './register';
 
 const MIGRATIONS_JSON_PATH = 'packages/nx-plugin/migrations.json';
-const NX_KEY = `${LATEST_MIGRATIONS_DIR}-nx-packages`;
+const NX_KEY = nxPackageUpdatesKey(NX_VERSION);
 
 const readMigrations = (tree: Tree): MigrationsJson =>
   readJson(tree, MIGRATIONS_JSON_PATH);
@@ -36,7 +37,8 @@ describe('registerNxPackageUpdates', () => {
 
     expect(written).toEqual([MIGRATIONS_JSON_PATH]);
     const updates = readMigrations(tree).packageJsonUpdates;
-    // Keyed like the migrations, so a concurrent PR's entry can't overwrite it.
+    // Keyed by the nx version it moves to, so a bump still waiting for a release
+    // can't be overwritten by the next one.
     expect(Object.keys(updates ?? {})).toEqual([NX_KEY]);
     const packages = (
       updates?.[NX_KEY] as
@@ -64,10 +66,9 @@ describe('registerNxPackageUpdates', () => {
       '1.0.0-rc.49',
     );
 
-    // Gated on the version that really ships, and re-keyed out of `latest` so a
-    // later release's entry sits alongside rather than over it.
-    expect(stamped.packageJsonUpdates?.[NX_KEY]).toBeUndefined();
-    expect(stamped.packageJsonUpdates?.['v1.0.0-rc.49-nx-packages']).toEqual(
+    // Gated on the version that really ships, under the key it was written with
+    // — so a later release's bump sits alongside rather than over it.
+    expect(stamped.packageJsonUpdates?.[NX_KEY]).toEqual(
       expect.objectContaining({ version: '1.0.0-rc.49' }),
     );
   });
@@ -81,12 +82,33 @@ describe('registerNxPackageUpdates', () => {
     expect(readMigrations(tree)).toEqual(first);
   });
 
+  // Both would otherwise ship under the same version, leaving which nx a
+  // workspace lands on down to the order nx happens to apply them in.
+  it('should supersede a bump still waiting for a release', () => {
+    writeJson(tree, MIGRATIONS_JSON_PATH, {
+      name: '@aws/nx-plugin',
+      generators: {},
+      packageJsonUpdates: {
+        'nx-22.0.0-nx-packages': {
+          version: LATEST_MIGRATIONS_DIR,
+          packages: { nx: {} },
+        },
+      },
+    });
+
+    registerNxPackageUpdates(tree);
+
+    expect(Object.keys(readMigrations(tree).packageJsonUpdates ?? {})).toEqual([
+      NX_KEY,
+    ]);
+  });
+
   it('should preserve a packageJsonUpdates entry from another release', () => {
     writeJson(tree, MIGRATIONS_JSON_PATH, {
       name: '@aws/nx-plugin',
       generators: {},
       packageJsonUpdates: {
-        'v1.0.0-nx-packages': { version: '1.0.0', packages: { nx: {} } },
+        'nx-22.0.0-nx-packages': { version: '1.0.0', packages: { nx: {} } },
       },
     });
 
@@ -94,6 +116,6 @@ describe('registerNxPackageUpdates', () => {
 
     expect(
       Object.keys(readMigrations(tree).packageJsonUpdates ?? {}).sort(),
-    ).toEqual([NX_KEY, 'v1.0.0-nx-packages']);
+    ).toEqual(['nx-22.0.0-nx-packages', NX_KEY]);
   });
 });

--- a/packages/nx-plugin/src/utils/version-upgrade-migration/register.ts
+++ b/packages/nx-plugin/src/utils/version-upgrade-migration/register.ts
@@ -19,7 +19,12 @@ const MIGRATIONS_JSON_PATH = 'packages/nx-plugin/migrations.json';
  * only the nx packages need registering per update: they go through
  * `packageJsonUpdates` rather than a migration (see `nx-package-updates.ts`).
  *
- * Idempotent: re-running before a release claims the entry refreshes it in place.
+ * A bump already dated by a release stays — a workspace several releases behind
+ * needs each hop in turn. One still waiting for a release is dropped: this bump
+ * supersedes it, and both would otherwise ship under the same version, leaving
+ * which nx a workspace lands on down to the order nx happens to apply them in.
+ *
+ * Idempotent: re-running before a release replaces the pending entry with itself.
  *
  * @returns paths written, for the update report
  */
@@ -28,8 +33,12 @@ export const registerNxPackageUpdates = (tree: Tree): string[] => {
     ...migrations,
     // Recorded under `latest` until stamping resolves the version it ships with.
     packageJsonUpdates: {
-      ...migrations.packageJsonUpdates,
-      ...nxPackageJsonUpdates(LATEST_MIGRATIONS_DIR, LATEST_MIGRATIONS_DIR),
+      ...Object.fromEntries(
+        Object.entries(migrations.packageJsonUpdates ?? {}).filter(
+          ([, entry]) => entry.version !== LATEST_MIGRATIONS_DIR,
+        ),
+      ),
+      ...nxPackageJsonUpdates(LATEST_MIGRATIONS_DIR),
     },
   }));
 


### PR DESCRIPTION
### Reason for this change

The first `update-versions` run after the version sync landed ([run 30788566363](https://github.com/awslabs/nx-plugin-for-aws/actions/runs/30788566363), PR #1021) bumped nx 23.1.0 -> 23.1.1, but the `packageJsonUpdates` entry it produced came out as:

```json
"v1.0.0-rc.50-nx-packages": { "version": "1.0.0-rc.50", "packages": { "nx": { "version": "23.1.1" } } }
```

`nx migrate` only runs an entry whose version is newer than the one installed, so an entry dated to a release published five versions ago is skipped — no workspace would ever have received the nx bump.

The cause is that the weekly update writes the entry under `latest`, because the plugin version it ships under isn't known until a release publishes it. Dating it therefore meant re-keying, and the weekly backfill re-keyed it using the earliest version among the *migrations* backfilled alongside it — which has nothing to do with when the bump ships.

### Description of changes

Key the entry by the nx version it moves to (`nx-23.1.1-nx-packages`) instead of the release that ships it. That version is known when the entry is written, and is what the entry is *for*, so:

- nothing is ever re-keyed, and the backfill records the version **in place**
- one release's bump can sit beside the next, which is what lets a workspace several releases behind take each nx hop in turn rather than only the newest

`readShippedMigrationVersions` now resolves `packageJsonUpdates` from tag history in the same walk as the migrations, so the release doesn't read tag history twice. Keys can't collide across the two sections: a migration is keyed by its name, an nx bump by an nx version.

Two bumps can also be pending at once — a second update lands before the release that would ship the first — and both would then ship under one version, leaving which nx a workspace lands on down to the order nx happens to apply them in. So registering a bump now drops any that is still waiting for a release, since it supersedes it.

The unreleased `latest-nx-packages` entry in source is re-keyed to `nx-23.1.0-nx-packages` so it isn't orphaned by the new scheme.

### Description of how you validated changes

Unit tests, each confirmed to fail without its fix:

- the pending bump is dated in place rather than re-keyed, and is reported so the weekly PR mentions it
- two bumps pending at once don't collide
- both hops survive a release: 1.1.0 takes a workspace to nx 23.1.0, 1.2.0 to 23.1.1 (this is the invariant that caught an earlier, blunter attempt at this fix, which dropped the accumulation entirely)
- `packageJsonUpdates` resolve from the shared release walk
- registering supersedes a bump still waiting for a release

I also replayed the exact failing scenario end to end — main's pending 23.1.0 entry, a weekly update bumping to 23.1.1, the backfill, then the release stamp — and confirmed both entries come out under distinct keys carrying their own nx version, where before the second overwrote the first at an already-released version.

`pnpm nx run @aws/nx-plugin:build`: 3073/3073 pass.

### Issue # (if applicable)

N/A — regression in #1001, found by the first `update-versions` run after it merged.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*