### PR TITLE
fix(dynamodb): drop -optimizeDbBeforeStartup from local container script

### DIFF
--- a/packages/nx-plugin/migrations.json
+++ b/packages/nx-plugin/migrations.json
@@ -30,6 +30,10 @@
     "latest-backfill-generator-metadata": {
       "description": "Backfill the project metadata the version sync reads, recovered from the files the generators left behind",
       "implementation": "./src/migrations/latest/backfill-generator-metadata/migration"
+    },
+    "latest-dynamodb-local-remove-optimize-flag": {
+      "description": "Drop -optimizeDbBeforeStartup from the vended DynamoDB Local container script, which can corrupt shared-local-instance.db",
+      "implementation": "./src/migrations/latest/dynamodb-local-remove-optimize-flag/migration"
     }
   },
   "packageJsonUpdates": {

--- a/packages/nx-plugin/src/migrations/latest/dynamodb-local-remove-optimize-flag/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/latest/dynamodb-local-remove-optimize-flag/migration.spec.ts
@@ -1,0 +1,105 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import type { Tree } from '@nx/devkit';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test';
+import migration from './migration';
+
+const START_CONTAINER_FILE =
+  'packages/common/scripts/src/dynamodb/start-container.ts';
+
+const oldStartContainerFile = ({
+  tail = "    '-port', `${port}`,\n    '-optimizeDbBeforeStartup',\n  ];",
+} = {}) =>
+  `import { spawn, spawnSync } from 'child_process';
+
+const { containerEngine, containerName, image, port } = JSON.parse(
+  require('fs').readFileSync('config.json', 'utf-8'),
+).localDev;
+
+const runArgs = [
+    'run',
+    ...(containerEngine === 'docker' ? ['--rm'] : []),
+    '--name', containerName,
+    '-u', 'root',
+    '-w', '/home/dynamodblocal',
+    \`-p\`, \`\${port}:\${port}\`,
+    '-v', \`\${containerName}-data:/home/dynamodblocal/data\`,
+    '-d', image,
+    '-jar', 'DynamoDBLocal.jar',
+    '-sharedDb',
+    '-dbPath', './data',
+${tail}
+const create = spawnSync(containerEngine, runArgs, { stdio: 'pipe' });
+`;
+
+const OLD_START_CONTAINER_FILE = oldStartContainerFile();
+
+describe('dynamodb-local-remove-optimize-flag migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeUsingTsSolutionSetup();
+  });
+
+  it('should be a no-op when the shared dynamodb scripts do not exist', async () => {
+    const result = await migration(tree);
+    expect(result.nextSteps).toEqual([]);
+    expect(tree.exists(START_CONTAINER_FILE)).toBeFalsy();
+  });
+
+  it('should drop -optimizeDbBeforeStartup from the container args', async () => {
+    tree.write(START_CONTAINER_FILE, OLD_START_CONTAINER_FILE);
+
+    const result = await migration(tree);
+
+    const contents = tree.read(START_CONTAINER_FILE, 'utf-8') ?? '';
+    expect(contents).not.toContain('-optimizeDbBeforeStartup');
+    // The rest of the args are preserved.
+    expect(contents).toContain("'-port'");
+    expect(contents).toContain('`${port}`');
+    expect(contents).toContain("'-sharedDb'");
+    // A successful automatic fix needs no manual action, so nothing is reported.
+    expect(result.nextSteps).toEqual([]);
+  });
+
+  it('should skip and report a diverged file', async () => {
+    const diverged = oldStartContainerFile({
+      tail: "    '-port', `${port}`,\n    '-optimizeDbBeforeStartup',\n    '-extraCustomFlag',\n  ];",
+    });
+    tree.write(START_CONTAINER_FILE, diverged);
+
+    const result = await migration(tree);
+
+    const contents = tree.read(START_CONTAINER_FILE, 'utf-8') ?? '';
+    expect(contents).toContain('-optimizeDbBeforeStartup');
+    expect(
+      result.nextSteps.some((s) => s.includes(START_CONTAINER_FILE)),
+    ).toBeTruthy();
+  });
+
+  it('should be a no-op when the flag is already absent', async () => {
+    const alreadyFixed = oldStartContainerFile({
+      tail: "    '-port', `${port}`,\n  ];",
+    });
+    tree.write(START_CONTAINER_FILE, alreadyFixed);
+
+    const result = await migration(tree);
+
+    expect(tree.read(START_CONTAINER_FILE, 'utf-8')).toEqual(alreadyFixed);
+    expect(result.nextSteps).toEqual([]);
+  });
+
+  it('should be idempotent', async () => {
+    tree.write(START_CONTAINER_FILE, OLD_START_CONTAINER_FILE);
+
+    await migration(tree);
+    const afterFirst = tree.read(START_CONTAINER_FILE, 'utf-8');
+
+    const secondResult = await migration(tree);
+
+    expect(tree.read(START_CONTAINER_FILE, 'utf-8')).toEqual(afterFirst);
+    expect(secondResult.nextSteps).toEqual([]);
+  });
+});

--- a/packages/nx-plugin/src/migrations/latest/dynamodb-local-remove-optimize-flag/migration.ts
+++ b/packages/nx-plugin/src/migrations/latest/dynamodb-local-remove-optimize-flag/migration.ts
@@ -15,9 +15,7 @@ import {
  *
  * DynamoDB Local's startup vacuum drops primary key / GSI uniqueness on the
  * underlying sqlite file, letting PutItem/UpdateItem write duplicate rows for
- * the same key:
- * - https://github.com/aaronshaf/dynamodb-admin/issues/105
- * - https://github.com/awslabs/amazon-dynamodb-local-samples/issues/36
+ * the same key.
  *
  * The edit is expressed as a GritQL rewrite so the script is matched on its
  * AST rather than its formatting. The rewrite matches the whole `runArgs`
@@ -71,7 +69,7 @@ const REMOVE_FLAG_PATTERN = `\`[
     '-port', $portArg,
   ]\``;
 
-const divergedNextStep = `${START_CONTAINER_FILE}: the container script has diverged from the generated shape - left untouched. Manually drop ${FLAG} from the DynamoDB Local container run args - its startup vacuum can drop primary key / GSI uniqueness on the sqlite file, letting PutItem/UpdateItem write duplicate rows for the same key (aaronshaf/dynamodb-admin#105, awslabs/amazon-dynamodb-local-samples#36).`;
+const divergedNextStep = `${START_CONTAINER_FILE}: the container script has diverged from the generated shape - left untouched. Manually drop ${FLAG} from the DynamoDB Local container run args - its startup vacuum can drop primary key / GSI uniqueness on the sqlite file, letting PutItem/UpdateItem write duplicate rows for the same key.`;
 
 export default async function migration(
   tree: Tree,

--- a/packages/nx-plugin/src/migrations/latest/dynamodb-local-remove-optimize-flag/migration.ts
+++ b/packages/nx-plugin/src/migrations/latest/dynamodb-local-remove-optimize-flag/migration.ts
@@ -1,0 +1,105 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import type { MigrationReturnObject, Tree } from '@nx/devkit';
+import { applyGritQL } from '../../../utils/ast';
+import { formatFilesInSubtree } from '../../../utils/format';
+import {
+  PACKAGES_DIR,
+  SHARED_SCRIPTS_DIR,
+} from '../../../utils/shared-constructs-constants';
+
+/**
+ * Drop -optimizeDbBeforeStartup from the vended DynamoDB Local container script
+ *
+ * DynamoDB Local's startup vacuum drops primary key / GSI uniqueness on the
+ * underlying sqlite file, letting PutItem/UpdateItem write duplicate rows for
+ * the same key:
+ * - https://github.com/aaronshaf/dynamodb-admin/issues/105
+ * - https://github.com/awslabs/amazon-dynamodb-local-samples/issues/36
+ *
+ * The edit is expressed as a GritQL rewrite so the script is matched on its
+ * AST rather than its formatting. The rewrite matches the whole `runArgs`
+ * array rather than just the flag, because this GritQL/tree-sitter grammar
+ * can't match a partial slice of array elements, and a literal backtick
+ * template string breaks matching anywhere it appears alongside other
+ * elements - so every templated element (the port/volume args) is matched via
+ * a metavariable instead of being spelled out.
+ *
+ * How to write a migration:
+ * - https://nx.dev/docs/kb/migration-generators
+ * - What `nextSteps` means: https://nx.dev/docs/reference/devkit/MigrationReturnObject
+ *
+ * Guardrails:
+ * - Pattern-match before writing: skip files that have diverged from the shape
+ *   the generator produces and report them via `nextSteps`.
+ * - Idempotent: re-running must be a no-op.
+ * - Format what you write: finish with `formatFilesInSubtree`.
+ */
+
+const START_CONTAINER_FILE = `${PACKAGES_DIR}/${SHARED_SCRIPTS_DIR}/src/dynamodb/start-container.ts`;
+
+const FLAG = "'-optimizeDbBeforeStartup'";
+
+const REMOVE_FLAG_PATTERN = `\`[
+    'run',
+    ...(containerEngine === 'docker' ? ['--rm'] : []),
+    '--name', containerName,
+    '-u', 'root',
+    '-w', '/home/dynamodblocal',
+    $flagP, $portColonPort,
+    '-v', $volume,
+    '-d', image,
+    '-jar', 'DynamoDBLocal.jar',
+    '-sharedDb',
+    '-dbPath', './data',
+    '-port', $portArg,
+    ${FLAG},
+  ]\` => \`[
+    'run',
+    ...(containerEngine === 'docker' ? ['--rm'] : []),
+    '--name', containerName,
+    '-u', 'root',
+    '-w', '/home/dynamodblocal',
+    $flagP, $portColonPort,
+    '-v', $volume,
+    '-d', image,
+    '-jar', 'DynamoDBLocal.jar',
+    '-sharedDb',
+    '-dbPath', './data',
+    '-port', $portArg,
+  ]\``;
+
+const divergedNextStep = `${START_CONTAINER_FILE}: the container script has diverged from the generated shape - left untouched. Manually drop ${FLAG} from the DynamoDB Local container run args - its startup vacuum can drop primary key / GSI uniqueness on the sqlite file, letting PutItem/UpdateItem write duplicate rows for the same key (aaronshaf/dynamodb-admin#105, awslabs/amazon-dynamodb-local-samples#36).`;
+
+export default async function migration(
+  tree: Tree,
+): Promise<MigrationReturnObject> {
+  const nextSteps: string[] = [];
+
+  if (!tree.exists(START_CONTAINER_FILE)) {
+    return { nextSteps };
+  }
+
+  const contents = tree.read(START_CONTAINER_FILE, 'utf-8') ?? '';
+  if (!contents.includes(FLAG)) {
+    // Already migrated, or doesn't use this shape.
+    return { nextSteps };
+  }
+
+  const rewrote = await applyGritQL(
+    tree,
+    START_CONTAINER_FILE,
+    REMOVE_FLAG_PATTERN,
+  );
+
+  if (!rewrote) {
+    nextSteps.push(divergedNextStep);
+    return { nextSteps };
+  }
+
+  await formatFilesInSubtree(tree);
+
+  return { nextSteps };
+}

--- a/packages/nx-plugin/src/py/dynamodb/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/dynamodb/__snapshots__/generator.spec.ts.snap
@@ -565,7 +565,6 @@ for (;;) {
     './data',
     '-port',
     \`\${port}\`,
-    '-optimizeDbBeforeStartup',
   ];
   const create = spawnSync(containerEngine, runArgs, { stdio: 'pipe' });
   if (create.status === 0) {
@@ -1281,7 +1280,6 @@ for (;;) {
     './data',
     '-port',
     \`\${port}\`,
-    '-optimizeDbBeforeStartup',
   ];
   const create = spawnSync(containerEngine, runArgs, { stdio: 'pipe' });
   if (create.status === 0) {

--- a/packages/nx-plugin/src/ts/dynamodb/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/dynamodb/__snapshots__/generator.spec.ts.snap
@@ -565,7 +565,6 @@ for (;;) {
     './data',
     '-port',
     \`\${port}\`,
-    '-optimizeDbBeforeStartup',
   ];
   const create = spawnSync(containerEngine, runArgs, { stdio: 'pipe' });
   if (create.status === 0) {
@@ -1213,7 +1212,6 @@ for (;;) {
     './data',
     '-port',
     \`\${port}\`,
-    '-optimizeDbBeforeStartup',
   ];
   const create = spawnSync(containerEngine, runArgs, { stdio: 'pipe' });
   if (create.status === 0) {

--- a/packages/nx-plugin/src/utils/files/common/scripts/src/dynamodb/start-container.ts.template
+++ b/packages/nx-plugin/src/utils/files/common/scripts/src/dynamodb/start-container.ts.template
@@ -64,7 +64,6 @@ for (;;) {
     '-sharedDb',
     '-dbPath', './data',
     '-port', `${port}`,
-    '-optimizeDbBeforeStartup',
   ];
   const create = spawnSync(containerEngine, runArgs, { stdio: 'pipe' });
   if (create.status === 0) {


### PR DESCRIPTION
### Reason for this change

`-optimizeDbBeforeStartup` on the vended DynamoDB Local container script causes DynamoDB Local's startup vacuum to drop primary key / GSI uniqueness on the underlying sqlite file, letting PutItem/UpdateItem write duplicate rows for the same key. Reported upstream:
- https://github.com/aaronshaf/dynamodb-admin/issues/105
- https://github.com/awslabs/amazon-dynamodb-local-samples/issues/36

### Description of changes

- Removed `-optimizeDbBeforeStartup` from the shared `start-container.ts.template`, used by both `ts#dynamodb` and `py#dynamodb`.
- Updated the `ts#dynamodb`/`py#dynamodb` generator snapshots to match.
- Added an Nx migration (`latest-dynamodb-local-remove-optimize-flag`) so workspaces that already generated this vended script get the fix via `nx migrate` — it's copied with `OverwriteStrategy.KeepExisting`, so the template fix alone wouldn't reach already-generated workspaces. The rewrite is a GritQL pattern matching the full `runArgs` array (metavariables stand in for the template-literal port/volume args, since this GritQL/tree-sitter grammar can't match array elements piecemeal or spell out backtick template strings inline).

### Description of how you validated changes

- Added a migration spec covering: no shared scripts present (no-op), successful rewrite, a diverged/customised file (reported via `nextSteps`, left untouched), already-fixed file (no-op), and idempotency.
- Ran the `ts#dynamodb`/`py#dynamodb` generator specs to confirm the updated snapshots pass.
- Ran the full migrations test suite to confirm no regressions.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*