### PR TITLE
test(e2e): settle the lock file before the migrate idempotency check

### DIFF
--- a/e2e/src/smoke-tests/migrate.ts
+++ b/e2e/src/smoke-tests/migrate.ts
@@ -249,6 +249,13 @@ export const runMigrateTest = async (
 
   // 5. Idempotency: re-running the migrations must not change the workspace.
   if (migrations?.length) {
+    // Settle the lock file first. A migration that moves a dependency version
+    // leaves it stale by design — it reports the install as a next step rather
+    // than running one — and `nx migrate --run-migrations` installs when the root
+    // manifest changed. So the *second* run's install would write the lock file
+    // the first run left behind, which is the install landing, not a migration
+    // being non-idempotent.
+    await runInstall(opts);
     commitAll('after migrations');
     await runCLI('migrate --run-migrations --if-exists --no-interactive', {
       ...opts,


### PR DESCRIPTION
### Reason for this change

The `migrate` smoke lane fails on every version-update PR that moves a dependency version, e.g. [#1026](https://github.com/awslabs/nx-plugin-for-aws/pull/1026):

```
Error: Migrations were not idempotent — re-running changed the workspace:

M pnpm-lock.yaml
@@ -43,35 +43,35 @@ catalogs:
-      specifier: 3.1090.0
+      specifier: 3.1101.0
```

Only `pnpm-lock.yaml` differs, and the migrations themselves report `No changes were made` on the re-run — so they *are* idempotent. The check is attributing an install to them.

The version sync leaves the lock file stale on purpose: it moves manifest and catalog specifiers and reports the install as a next step (`Run \`pnpm install\` to update the lock file`) rather than running one, because `nx migrate` installs itself. It installs when the root manifest changed — so the **second** `migrate --run-migrations` performed the install for the **first** run's version bumps, and the snapshot taken between them caught the difference.

### Description of changes

Run the install before snapshotting, so the lock file is settled by the time the second run happens. That attributes the write to the install rather than to a migration, and leaves the check judging what it is named for.

Deliberately not excluding `pnpm-lock.yaml` from the check: a migration that really did rewrite the lock file non-idempotently should still fail this lane.

### Description of how you validated changes

Diagnosed from the failing lane's log on #1026: every hop failed with `M pnpm-lock.yaml` alone, while each migration printed `No changes were made` on the re-run, and the sync's own next-step output (`Run \`pnpm install\` to update the lock file`) names the install it defers.

This changes only the e2e harness, so the plugin's unit tests are unaffected; the `migrate` lane in this PR's own CI is the test. Note that lane self-skips hops whose start version predates `internal#test-matrix`, so its log needs checking for `migrate smoke test: migrated from …` to confirm it actually asserted something.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*