### PR TITLE
chore(nx-plugin): date a released nx bump before the next one supersedes it

### DIFF
--- a/.github/workflows/update-versions.yml
+++ b/.github/workflows/update-versions.yml
@@ -33,11 +33,17 @@ jobs:
           npx -y npm-check-updates@22.2.9 --configFileName .ncurc.cjs
           pnpm i --lockfile-only
           pnpm i
-          pnpm exec tsx ./scripts/update-versions.ts
           # Record the release that shipped each migration, so source converges
           # on the versions of everything already released and the release only
           # has to resolve entries that are still unversioned.
+          #
+          # Runs BEFORE the bump: a release that published since the last run left
+          # source's entry still reading `latest`, and registering a newer nx bump
+          # drops whatever is still pending. Dating that entry first means the bump
+          # supersedes only what has genuinely never shipped, so a workspace on the
+          # released version still gets its hop.
           pnpm exec tsx ./scripts/backfill-migration-versions.ts
+          pnpm exec tsx ./scripts/update-versions.ts
           pnpm nx reset
           pnpm nx test nx-plugin -u
           pnpm lint

--- a/packages/nx-plugin/src/utils/version-upgrade-migration/nx-package-updates.spec.ts
+++ b/packages/nx-plugin/src/utils/version-upgrade-migration/nx-package-updates.spec.ts
@@ -131,5 +131,62 @@ describe('nx package updates', () => {
         }
       }
     });
+
+    // A release stamps `dist` only, so after one publishes, source's entry still
+    // reads `latest` until a backfill dates it. Registering a newer bump drops
+    // whatever is still pending — so the weekly workflow has to backfill *before*
+    // it bumps, or the hop that release just published is lost.
+    it('should keep a released bump when the backfill runs before the next bump', () => {
+      const published = stampMigrationVersions(
+        {
+          generators: {},
+          packageJsonUpdates: nxPackageJsonUpdates(
+            LATEST_MIGRATIONS_DIR,
+            '23.1.0',
+          ),
+        },
+        {},
+        '1.0.0-rc.56',
+      );
+      // Source is untouched by the release, so it still holds `latest`.
+      const source = {
+        generators: {},
+        packageJsonUpdates: nxPackageJsonUpdates(
+          LATEST_MIGRATIONS_DIR,
+          '23.1.0',
+        ),
+      };
+
+      // Backfill first, resolving the version from the release that published it.
+      const dated = backfillMigrationVersions(source, {
+        [nxPackageUpdatesKey('23.1.0')]: '1.0.0-rc.56',
+      }).migrations;
+      // Then the new bump lands, superseding only what is still pending.
+      const next = {
+        ...dated,
+        packageJsonUpdates: {
+          ...Object.fromEntries(
+            Object.entries(dated.packageJsonUpdates ?? {}).filter(
+              ([, entry]) => entry.version !== LATEST_MIGRATIONS_DIR,
+            ),
+          ),
+          ...nxPackageJsonUpdates(LATEST_MIGRATIONS_DIR, '23.1.1'),
+        },
+      };
+
+      expect(
+        published.packageJsonUpdates?.[nxPackageUpdatesKey('23.1.0')],
+      ).toEqual(expect.objectContaining({ version: '1.0.0-rc.56' }));
+      // Both hops survive: the released one keeps its version, the new one pends.
+      expect(
+        Object.entries(next.packageJsonUpdates).map(([key, entry]) => [
+          key,
+          entry.version,
+        ]),
+      ).toEqual([
+        [nxPackageUpdatesKey('23.1.0'), '1.0.0-rc.56'],
+        [nxPackageUpdatesKey('23.1.1'), LATEST_MIGRATIONS_DIR],
+      ]);
+    });
   });
 });


### PR DESCRIPTION
### Reason for this change

`nx release` stamps versions into `dist` only, never source — `stamp-migrations.ts` writes `DIST_MIGRATIONS_PATH`, and `ci.yml` runs it with `--git-tag=false --git-commit=false --stage-changes=false`. So once a release publishes, source's `packageJsonUpdates` entry still reads `version: "latest"` even though that exact nx bump has shipped. Dating it is the weekly backfill's job.

But the weekly workflow ran the steps in this order:

```
update-versions.ts             # registers the new bump → drops anything still `latest`
backfill-migration-versions.ts # too late: the entry it would have dated is gone
```

Registering a bump drops whatever is still pending — deliberately, since two entries on `latest` would ship under the same version and leave which nx a workspace lands on down to the order nx happens to apply them in. The flaw is that "still pending" was being decided *before* the backfill had a chance to say otherwise.

So a release landing between two weekly runs loses its hop:

```
t0 SOURCE:              nx-23.1.0  version=latest
t1 PUBLISHED rc.56:     nx-23.1.0  version=1.0.0-rc.56   ← dist only
t1 SOURCE (unchanged):  nx-23.1.0  version=latest
t2 next weekly bump:    nx-23.1.1  version=latest        ← 23.1.0 hop GONE
```

A workspace on rc.56 would never receive the nx 23.1.0 it shipped with — the multi-hop guarantee the keyed entries exist for.

### Description of changes

Run `backfill-migration-versions.ts` **before** `update-versions.ts`. The backfill dates the released entry from tag history, so it no longer looks pending and the new bump supersedes only what has genuinely never shipped:

```
backfill first → nx-23.1.0  version=1.0.0-rc.56   ← no longer matches the pending filter
then the bump  → nx-23.1.0  version=1.0.0-rc.56   ← survives
                 nx-23.1.1  version=latest
```

### Description of how you validated changes

Added a unit test for the invariant — a released bump survives the next one when the backfill runs first — and confirmed the reverse order really does lose it: simulating bump-first yields only `nx-23.1.1-nx-packages=latest`, with the 23.1.0 entry absent.

Also verified the reordered workflow YAML parses and that both scripts remain, in the new order.

`pnpm nx run @aws/nx-plugin:build`: 3079/3079 pass.

Not yet observed in production — no released version has carried an nx bump so far (`v1.0.0-rc.55` was tagged but never published), so this is a latent bug rather than one that has already dropped a hop.

### Issue # (if applicable)

N/A — found while reviewing how these entries behave if a release lands while a version-update PR is open.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*