### PR TITLE
feat(smithy#project): bundle the SSDK with the rolldown this release vends

### DIFF
--- a/packages/nx-plugin/migrations.json
+++ b/packages/nx-plugin/migrations.json
@@ -38,6 +38,10 @@
     "latest-ts-agent-session-management-support": {
       "description": "Add session management support to ts#agent",
       "implementation": "./src/migrations/latest/ts-agent-session-management-support/migration"
+    },
+    "latest-smithy-ssdk-bundle-pins": {
+      "description": "Bump the rolldown and dts plugin pins in the Smithy build.Dockerfile so the bundled SSDK type declaration resolves",
+      "implementation": "./src/migrations/latest/smithy-ssdk-bundle-pins/migration"
     }
   },
   "packageJsonUpdates": {

--- a/packages/nx-plugin/src/migrations/latest/smithy-ssdk-bundle-pins/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/latest/smithy-ssdk-bundle-pins/migration.spec.ts
@@ -1,0 +1,110 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import type { Tree } from '@nx/devkit';
+import { smithyProjectGenerator } from '../../../smithy/project/generator';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test';
+import { TS_VERSIONS } from '../../../utils/versions';
+import migration from './migration';
+
+const BUILD_DOCKERFILE = 'test-api/build.Dockerfile';
+
+// The versions the pins were on before this release vended their replacements.
+const OLD_ROLLDOWN = '1.0.0-beta.38';
+const OLD_DTS = '0.16.5';
+
+/**
+ * A `build.Dockerfile` as an older release generated it: the real template,
+ * rendered by the real generator, with only the pins wound back. Asserting
+ * against a hand-written fixture would pass even if the template's shape moved
+ * out from under the migration.
+ */
+const generateOldWorkspace = async (tree: Tree): Promise<void> => {
+  await smithyProjectGenerator(tree, { name: 'test-api' });
+  const current = tree.read(BUILD_DOCKERFILE, 'utf-8') ?? '';
+  tree.write(
+    BUILD_DOCKERFILE,
+    current
+      .replace(`rolldown@${TS_VERSIONS.rolldown}`, `rolldown@${OLD_ROLLDOWN}`)
+      .replace(
+        `rolldown-plugin-dts@${TS_VERSIONS['rolldown-plugin-dts']}`,
+        `rolldown-plugin-dts@${OLD_DTS}`,
+      ),
+  );
+};
+
+describe('smithy-ssdk-bundle-pins migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeUsingTsSolutionSetup();
+  });
+
+  it('should move the pins an older release generated onto the vended versions', async () => {
+    await generateOldWorkspace(tree);
+
+    const { nextSteps } = await migration(tree);
+
+    const dockerfile = tree.read(BUILD_DOCKERFILE, 'utf-8') ?? '';
+    expect(dockerfile).toContain(`rolldown@${TS_VERSIONS.rolldown}`);
+    expect(dockerfile).toContain(
+      `rolldown-plugin-dts@${TS_VERSIONS['rolldown-plugin-dts']}`,
+    );
+    expect(dockerfile).not.toContain(`rolldown@${OLD_ROLLDOWN}`);
+    expect(dockerfile).not.toContain(`rolldown-plugin-dts@${OLD_DTS}`);
+    expect(nextSteps).toEqual([]);
+  });
+
+  // `rolldown-plugin-dts` and `@rollup/plugin-esm-shim` sit in the same command,
+  // and `rolldown` is a prefix of the plugin's name, so a pin matched loosely
+  // would rewrite the wrong version.
+  it('should leave the other pins in the same command alone', async () => {
+    await generateOldWorkspace(tree);
+
+    await migration(tree);
+
+    const dockerfile = tree.read(BUILD_DOCKERFILE, 'utf-8') ?? '';
+    expect(dockerfile).toContain(
+      `@rollup/plugin-esm-shim@${TS_VERSIONS['@rollup/plugin-esm-shim']}`,
+    );
+    expect(dockerfile).toContain('pnpm@11.1.1');
+    expect(dockerfile).toContain('smithy/releases/download/1.61.0/');
+  });
+
+  it('should leave a workspace already on the vended versions untouched', async () => {
+    await smithyProjectGenerator(tree, { name: 'test-api' });
+    const before = tree.read(BUILD_DOCKERFILE, 'utf-8');
+
+    const { nextSteps } = await migration(tree);
+
+    expect(tree.read(BUILD_DOCKERFILE, 'utf-8')).toEqual(before);
+    expect(nextSteps).toEqual([]);
+  });
+
+  it('should be idempotent', async () => {
+    await generateOldWorkspace(tree);
+
+    await migration(tree);
+    const afterFirst = tree.read(BUILD_DOCKERFILE, 'utf-8');
+    await migration(tree);
+
+    expect(tree.read(BUILD_DOCKERFILE, 'utf-8')).toEqual(afterFirst);
+  });
+
+  // The shapes build image builds the model alone and pins none of this.
+  it('should leave a build image that bundles no SSDK alone', async () => {
+    await smithyProjectGenerator(tree, { name: 'test-shapes', type: 'shapes' });
+    const before = tree.read('test-shapes/build.Dockerfile', 'utf-8');
+
+    await migration(tree);
+
+    expect(tree.read('test-shapes/build.Dockerfile', 'utf-8')).toEqual(before);
+  });
+
+  it('should do nothing in a workspace with no smithy project', async () => {
+    const { nextSteps } = await migration(tree);
+
+    expect(nextSteps).toEqual([]);
+  });
+});

--- a/packages/nx-plugin/src/migrations/latest/smithy-ssdk-bundle-pins/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/latest/smithy-ssdk-bundle-pins/migration.spec.ts
@@ -2,15 +2,21 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import type { Tree } from '@nx/devkit';
+import { addProjectConfiguration, type Tree } from '@nx/devkit';
 import { smithyProjectGenerator } from '../../../smithy/project/generator';
 import { createTreeUsingTsSolutionSetup } from '../../../utils/test';
-import { TS_VERSIONS } from '../../../utils/versions';
 import migration from './migration';
 
 const BUILD_DOCKERFILE = 'test-api/build.Dockerfile';
 
-// The versions the pins were on before this release vended their replacements.
+// The versions this migration moves the pins to, hardcoded here as they are in
+// the migration: a once-off change stays fixed however far the vended versions
+// move afterwards.
+const ROLLDOWN = '1.2.0';
+const DTS = '0.28.0';
+const ESM_SHIM = '0.1.8';
+
+// The versions an older release generated.
 const OLD_ROLLDOWN = '1.0.0-beta.38';
 const OLD_DTS = '0.16.5';
 
@@ -26,9 +32,11 @@ const generateOldWorkspace = async (tree: Tree): Promise<void> => {
   tree.write(
     BUILD_DOCKERFILE,
     current
-      .replace(`rolldown@${TS_VERSIONS.rolldown}`, `rolldown@${OLD_ROLLDOWN}`)
+      // Matched on the pin name rather than the version the template renders
+      // today, so winding back keeps working as the vended versions move.
+      .replace(/rolldown@[^\s\\]+/, `rolldown@${OLD_ROLLDOWN}`)
       .replace(
-        `rolldown-plugin-dts@${TS_VERSIONS['rolldown-plugin-dts']}`,
+        /rolldown-plugin-dts@[^\s\\]+/,
         `rolldown-plugin-dts@${OLD_DTS}`,
       ),
   );
@@ -41,16 +49,14 @@ describe('smithy-ssdk-bundle-pins migration', () => {
     tree = createTreeUsingTsSolutionSetup();
   });
 
-  it('should move the pins an older release generated onto the vended versions', async () => {
+  it('should move the pins an older release generated onto the fixed versions', async () => {
     await generateOldWorkspace(tree);
 
     const { nextSteps } = await migration(tree);
 
     const dockerfile = tree.read(BUILD_DOCKERFILE, 'utf-8') ?? '';
-    expect(dockerfile).toContain(`rolldown@${TS_VERSIONS.rolldown}`);
-    expect(dockerfile).toContain(
-      `rolldown-plugin-dts@${TS_VERSIONS['rolldown-plugin-dts']}`,
-    );
+    expect(dockerfile).toContain(`rolldown@${ROLLDOWN}`);
+    expect(dockerfile).toContain(`rolldown-plugin-dts@${DTS}`);
     expect(dockerfile).not.toContain(`rolldown@${OLD_ROLLDOWN}`);
     expect(dockerfile).not.toContain(`rolldown-plugin-dts@${OLD_DTS}`);
     expect(nextSteps).toEqual([]);
@@ -65,20 +71,33 @@ describe('smithy-ssdk-bundle-pins migration', () => {
     await migration(tree);
 
     const dockerfile = tree.read(BUILD_DOCKERFILE, 'utf-8') ?? '';
-    expect(dockerfile).toContain(
-      `@rollup/plugin-esm-shim@${TS_VERSIONS['@rollup/plugin-esm-shim']}`,
-    );
+    expect(dockerfile).toContain(`@rollup/plugin-esm-shim@${ESM_SHIM}`);
     expect(dockerfile).toContain('pnpm@11.1.1');
     expect(dockerfile).toContain('smithy/releases/download/1.61.0/');
   });
 
-  it('should leave a workspace already on the vended versions untouched', async () => {
+  it('should leave a workspace already on the fixed versions untouched', async () => {
     await smithyProjectGenerator(tree, { name: 'test-api' });
     const before = tree.read(BUILD_DOCKERFILE, 'utf-8');
 
     const { nextSteps } = await migration(tree);
 
     expect(tree.read(BUILD_DOCKERFILE, 'utf-8')).toEqual(before);
+    expect(nextSteps).toEqual([]);
+  });
+
+  // A later release's version sync moves these pins on past the target, and this
+  // migration still runs on the way through — it must not wind them back.
+  it('should leave a pin a later release moved past the target alone', async () => {
+    await smithyProjectGenerator(tree, { name: 'test-api' });
+    const newer = (tree.read(BUILD_DOCKERFILE, 'utf-8') ?? '')
+      .replace(/rolldown@[^\s\\]+/, 'rolldown@9.9.9')
+      .replace(/rolldown-plugin-dts@[^\s\\]+/, 'rolldown-plugin-dts@9.9.9');
+    tree.write(BUILD_DOCKERFILE, newer);
+
+    const { nextSteps } = await migration(tree);
+
+    expect(tree.read(BUILD_DOCKERFILE, 'utf-8')).toEqual(newer);
     expect(nextSteps).toEqual([]);
   });
 
@@ -92,14 +111,33 @@ describe('smithy-ssdk-bundle-pins migration', () => {
     expect(tree.read(BUILD_DOCKERFILE, 'utf-8')).toEqual(afterFirst);
   });
 
-  // The shapes build image builds the model alone and pins none of this.
-  it('should leave a build image that bundles no SSDK alone', async () => {
+  // The shapes type builds the model alone and pins none of this.
+  it('should leave a shapes project alone', async () => {
     await smithyProjectGenerator(tree, { name: 'test-shapes', type: 'shapes' });
     const before = tree.read('test-shapes/build.Dockerfile', 'utf-8');
 
     await migration(tree);
 
     expect(tree.read('test-shapes/build.Dockerfile', 'utf-8')).toEqual(before);
+  });
+
+  // Scoped by the recorded generator id, so a `build.Dockerfile` a user wrote
+  // themselves keeps whatever it pins.
+  it('should leave a build.Dockerfile outside a smithy project alone', async () => {
+    await generateOldWorkspace(tree);
+    addProjectConfiguration(tree, 'other', { root: 'packages/other' });
+    const theirs = `FROM node:24\nRUN npm i -g rolldown@${OLD_ROLLDOWN}\nRUN pnpm add -D rolldown-plugin-dts@${OLD_DTS}\n`;
+    tree.write('packages/other/build.Dockerfile', theirs);
+
+    await migration(tree);
+
+    expect(tree.read('packages/other/build.Dockerfile', 'utf-8')).toEqual(
+      theirs,
+    );
+    // The smithy project's own file still migrated.
+    expect(tree.read(BUILD_DOCKERFILE, 'utf-8')).toContain(
+      `rolldown@${ROLLDOWN}`,
+    );
   });
 
   it('should do nothing in a workspace with no smithy project', async () => {

--- a/packages/nx-plugin/src/migrations/latest/smithy-ssdk-bundle-pins/migration.ts
+++ b/packages/nx-plugin/src/migrations/latest/smithy-ssdk-bundle-pins/migration.ts
@@ -1,0 +1,113 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import {
+  type MigrationReturnObject,
+  type Tree,
+  visitNotIgnoredFiles,
+} from '@nx/devkit';
+import { applyGritQL } from '../../../utils/ast';
+import { formatFilesInSubtree } from '../../../utils/format';
+import { TS_VERSIONS } from '../../../utils/versions';
+
+/**
+ * Move a Smithy `build.Dockerfile` onto the SSDK bundle pins it now vends.
+ *
+ * `rolldown-plugin-dts` named the bundled declaration after its content hash
+ * before 0.20.0, so the generated handler's `./generated/ssdk/index.js` import
+ * found no `index.d.ts` beside it and `compile` failed with TS7016. The two pins
+ * move together: the plugin release that fixed the naming needs a rolldown past
+ * the pin this shipped with.
+ *
+ * There is no Dockerfile grammar, so each pin is matched as an anchored rewrite
+ * over the whole file with the version captured — `${...}` in these patterns is
+ * GritQL metavariable syntax, not interpolation.
+ */
+
+/** A pin in the file body, and the version this release vends for it. */
+interface Pin {
+  /** The package as the install command names it. */
+  readonly name: string;
+  readonly vended: string;
+}
+
+const PINS: readonly Pin[] = [
+  { name: 'rolldown', vended: TS_VERSIONS.rolldown },
+  {
+    name: 'rolldown-plugin-dts',
+    vended: TS_VERSIONS['rolldown-plugin-dts'],
+  },
+  {
+    name: '@rollup/plugin-esm-shim',
+    vended: TS_VERSIONS['@rollup/plugin-esm-shim'],
+  },
+];
+
+/** A version ends at whitespace, a line break or the end of the command. */
+const VERSION = String.raw`[^\s\\]+`;
+
+const escapeRegExp = (value: string): string =>
+  value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+/**
+ * Rewrite every occurrence of one pin to the vended version.
+ *
+ * The pin is matched by name, so a `rolldown-plugin-dts@x` in the same command
+ * as `rolldown@y` keeps its own version — the longer name is not a prefix of the
+ * shorter one here, since the `@` before the version terminates the match.
+ */
+const rewritePin = ({ name, vended }: Pin): string =>
+  `r"[\\s\\S]*${escapeRegExp(name)}@(${VERSION})[\\s\\S]*"($version) where { $version => \`${vended}\` }`;
+
+/** Whether the file pins this package at a version other than the vended one. */
+const isOutOfDate = (contents: string, { name, vended }: Pin): boolean => {
+  const matches = contents.matchAll(
+    new RegExp(`${escapeRegExp(name)}@(${VERSION})`, 'g'),
+  );
+  const declared = [...matches].flatMap((match) =>
+    match[1] ? [match[1]] : [],
+  );
+  // A rewrite replaces every occurrence at once, so this has to hold for all of
+  // them — a copy already on the vended version is left alone.
+  return declared.length > 0 && declared.every((version) => version !== vended);
+};
+
+const divergedNextStep = (path: string): string =>
+  `${path}: the Smithy build image's bundle pins have diverged from the generated shape - left untouched. Update \`rolldown\` to ${TS_VERSIONS.rolldown} and \`rolldown-plugin-dts\` to ${TS_VERSIONS['rolldown-plugin-dts']} by hand: before 0.20.0 the plugin named the bundled SSDK declaration after its content hash, so the generated handler's \`./generated/ssdk/index.js\` import fails to resolve its types with TS7016.`;
+
+export default async function migration(
+  tree: Tree,
+): Promise<MigrationReturnObject> {
+  const nextSteps: string[] = [];
+  const buildDockerfiles: string[] = [];
+
+  visitNotIgnoredFiles(tree, '.', (path) => {
+    if (path.split('/').pop() === 'build.Dockerfile') {
+      buildDockerfiles.push(path);
+    }
+  });
+
+  for (const path of buildDockerfiles) {
+    const contents = tree.read(path, 'utf-8') ?? '';
+    // Only the Smithy service build image bundles the SSDK; the shapes one
+    // builds the model alone and pins none of this.
+    if (!contents.includes('rolldown-plugin-dts@')) {
+      continue;
+    }
+
+    for (const pin of PINS) {
+      if (!isOutOfDate(contents, pin)) {
+        continue;
+      }
+      if (!(await applyGritQL(tree, path, rewritePin(pin)))) {
+        nextSteps.push(divergedNextStep(path));
+        break;
+      }
+    }
+  }
+
+  await formatFilesInSubtree(tree);
+
+  return { nextSteps };
+}

--- a/packages/nx-plugin/src/migrations/latest/smithy-ssdk-bundle-pins/migration.ts
+++ b/packages/nx-plugin/src/migrations/latest/smithy-ssdk-bundle-pins/migration.ts
@@ -3,16 +3,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import {
+  getProjects,
+  joinPathFragments,
   type MigrationReturnObject,
   type Tree,
-  visitNotIgnoredFiles,
 } from '@nx/devkit';
+import { SMITHY_PROJECT_GENERATOR_INFO } from '../../../smithy/project/generator';
 import { applyGritQL } from '../../../utils/ast';
 import { formatFilesInSubtree } from '../../../utils/format';
-import { TS_VERSIONS } from '../../../utils/versions';
+import { isVendedUpgrade } from '../../../utils/version-upgrade-migration/vended-upgrade';
 
 /**
- * Move a Smithy `build.Dockerfile` onto the SSDK bundle pins it now vends.
+ * Move a Smithy `build.Dockerfile` onto the SSDK bundle pins this release fixes.
  *
  * `rolldown-plugin-dts` named the bundled declaration after its content hash
  * before 0.20.0, so the generated handler's `./generated/ssdk/index.js` import
@@ -25,23 +27,23 @@ import { TS_VERSIONS } from '../../../utils/versions';
  * GritQL metavariable syntax, not interpolation.
  */
 
-/** A pin in the file body, and the version this release vends for it. */
+/** A pin in the file body, and the version this migration moves it to. */
 interface Pin {
   /** The package as the install command names it. */
   readonly name: string;
-  readonly vended: string;
+  readonly target: string;
 }
 
+/**
+ * Hardcoded rather than read from `TS_VERSIONS`: this runs once, for the release
+ * that fixed the declaration naming, so it must keep applying that exact change
+ * however far the vended versions move afterwards. A workspace on a later release
+ * gets the newer pins from the version sync instead.
+ */
 const PINS: readonly Pin[] = [
-  { name: 'rolldown', vended: TS_VERSIONS.rolldown },
-  {
-    name: 'rolldown-plugin-dts',
-    vended: TS_VERSIONS['rolldown-plugin-dts'],
-  },
-  {
-    name: '@rollup/plugin-esm-shim',
-    vended: TS_VERSIONS['@rollup/plugin-esm-shim'],
-  },
+  { name: 'rolldown', target: '1.2.0' },
+  { name: 'rolldown-plugin-dts', target: '0.28.0' },
+  { name: '@rollup/plugin-esm-shim', target: '0.1.8' },
 ];
 
 /** A version ends at whitespace, a line break or the end of the command. */
@@ -51,17 +53,17 @@ const escapeRegExp = (value: string): string =>
   value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
 /**
- * Rewrite every occurrence of one pin to the vended version.
+ * Rewrite every occurrence of one pin to its target version.
  *
- * The pin is matched by name, so a `rolldown-plugin-dts@x` in the same command
- * as `rolldown@y` keeps its own version — the longer name is not a prefix of the
- * shorter one here, since the `@` before the version terminates the match.
+ * The pin is matched by name, so a `rolldown-plugin-dts@x` in the same command as
+ * `rolldown@y` keeps its own version — the `@` before the version terminates the
+ * match, so the shorter name does not match the longer one.
  */
-const rewritePin = ({ name, vended }: Pin): string =>
-  `r"[\\s\\S]*${escapeRegExp(name)}@(${VERSION})[\\s\\S]*"($version) where { $version => \`${vended}\` }`;
+const rewritePin = ({ name, target }: Pin): string =>
+  `r"[\\s\\S]*${escapeRegExp(name)}@(${VERSION})[\\s\\S]*"($version) where { $version => \`${target}\` }`;
 
-/** Whether the file pins this package at a version other than the vended one. */
-const isOutOfDate = (contents: string, { name, vended }: Pin): boolean => {
+/** Whether the file pins this package behind the target version. */
+const isBehindTarget = (contents: string, { name, target }: Pin): boolean => {
   const matches = contents.matchAll(
     new RegExp(`${escapeRegExp(name)}@(${VERSION})`, 'g'),
   );
@@ -69,35 +71,42 @@ const isOutOfDate = (contents: string, { name, vended }: Pin): boolean => {
     match[1] ? [match[1]] : [],
   );
   // A rewrite replaces every occurrence at once, so this has to hold for all of
-  // them — a copy already on the vended version is left alone.
-  return declared.length > 0 && declared.every((version) => version !== vended);
+  // them. Compared rather than tested for inequality, so a workspace a later
+  // release has already moved past the target keeps its newer pin.
+  return (
+    declared.length > 0 &&
+    declared.every((version) => isVendedUpgrade(target, version))
+  );
 };
 
 const divergedNextStep = (path: string): string =>
-  `${path}: the Smithy build image's bundle pins have diverged from the generated shape - left untouched. Update \`rolldown\` to ${TS_VERSIONS.rolldown} and \`rolldown-plugin-dts\` to ${TS_VERSIONS['rolldown-plugin-dts']} by hand: before 0.20.0 the plugin named the bundled SSDK declaration after its content hash, so the generated handler's \`./generated/ssdk/index.js\` import fails to resolve its types with TS7016.`;
+  `${path}: the Smithy build image's bundle pins have diverged from the generated shape - left untouched. Update \`rolldown\` to 1.2.0 and \`rolldown-plugin-dts\` to 0.28.0.`;
 
 export default async function migration(
   tree: Tree,
 ): Promise<MigrationReturnObject> {
   const nextSteps: string[] = [];
-  const buildDockerfiles: string[] = [];
 
-  visitNotIgnoredFiles(tree, '.', (path) => {
-    if (path.split('/').pop() === 'build.Dockerfile') {
-      buildDockerfiles.push(path);
-    }
-  });
+  // Only a Smithy service project bundles the SSDK; the shapes type builds the
+  // model alone and pins none of this.
+  const buildDockerfiles = [...getProjects(tree).values()]
+    .filter((project) => {
+      const metadata = project.metadata as
+        | { generator?: string; smithyType?: string }
+        | undefined;
+      return (
+        metadata?.generator === SMITHY_PROJECT_GENERATOR_INFO.id &&
+        metadata.smithyType === 'service'
+      );
+    })
+    .map((project) => joinPathFragments(project.root, 'build.Dockerfile'))
+    .filter((filePath) => tree.exists(filePath));
 
   for (const path of buildDockerfiles) {
     const contents = tree.read(path, 'utf-8') ?? '';
-    // Only the Smithy service build image bundles the SSDK; the shapes one
-    // builds the model alone and pins none of this.
-    if (!contents.includes('rolldown-plugin-dts@')) {
-      continue;
-    }
 
     for (const pin of PINS) {
-      if (!isOutOfDate(contents, pin)) {
+      if (!isBehindTarget(contents, pin)) {
         continue;
       }
       if (!(await applyGritQL(tree, path, rewritePin(pin)))) {

--- a/packages/nx-plugin/src/smithy/project/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/smithy/project/__snapshots__/generator.spec.ts.snap
@@ -256,7 +256,7 @@ RUN smithy-install/smithy/install
 
 # Add node dependencies for bundling
 WORKDIR /project
-RUN npm i -g pnpm@11.1.1 rolldown@1.0.0-beta.38
+RUN npm i -g pnpm@11.1.1 rolldown@1.2.0
 
 # Copy project files
 COPY smithy-build.json .
@@ -278,7 +278,7 @@ RUN --mount=type=cache,target=/root/.local/share/pnpm/store,id=pnpm-store \\
 
 # Install rolldown plugins with pnpm cache mount
 RUN --mount=type=cache,target=/root/.local/share/pnpm/store,id=pnpm-store \\
-    pnpm add -D rolldown-plugin-dts@0.16.5 @rollup/plugin-esm-shim@0.1.8
+    pnpm add -D rolldown-plugin-dts@0.28.0 @rollup/plugin-esm-shim@0.1.8
 
 RUN cat <<EOF > rolldown.config.js
 import { dts } from 'rolldown-plugin-dts';
@@ -500,7 +500,7 @@ RUN smithy-install/smithy/install
 
 # Add node dependencies for bundling
 WORKDIR /project
-RUN npm i -g pnpm@11.1.1 rolldown@1.0.0-beta.38
+RUN npm i -g pnpm@11.1.1 rolldown@1.2.0
 
 # Copy project files
 COPY smithy-build.json .
@@ -522,7 +522,7 @@ RUN --mount=type=cache,target=/root/.local/share/pnpm/store,id=pnpm-store \\
 
 # Install rolldown plugins with pnpm cache mount
 RUN --mount=type=cache,target=/root/.local/share/pnpm/store,id=pnpm-store \\
-    pnpm add -D rolldown-plugin-dts@0.16.5 @rollup/plugin-esm-shim@0.1.8
+    pnpm add -D rolldown-plugin-dts@0.28.0 @rollup/plugin-esm-shim@0.1.8
 
 RUN cat <<EOF > rolldown.config.js
 import { dts } from 'rolldown-plugin-dts';

--- a/packages/nx-plugin/src/smithy/project/files/service/build.Dockerfile.template
+++ b/packages/nx-plugin/src/smithy/project/files/service/build.Dockerfile.template
@@ -17,7 +17,7 @@ RUN smithy-install/smithy/install
 
 # Add node dependencies for bundling
 WORKDIR /project
-RUN npm i -g pnpm@11.1.1 rolldown@1.0.0-beta.38
+RUN npm i -g pnpm@11.1.1 rolldown@<%- rolldownVersion %>
 
 # Copy project files
 COPY smithy-build.json .
@@ -39,7 +39,7 @@ RUN --mount=type=cache,target=/root/.local/share/pnpm/store,id=pnpm-store \
 
 # Install rolldown plugins with pnpm cache mount
 RUN --mount=type=cache,target=/root/.local/share/pnpm/store,id=pnpm-store \
-    pnpm add -D rolldown-plugin-dts@0.16.5 @rollup/plugin-esm-shim@0.1.8
+    pnpm add -D rolldown-plugin-dts@<%- rolldownDtsVersion %> @rollup/plugin-esm-shim@<%- esmShimVersion %>
 
 RUN cat <<EOF > rolldown.config.js
 import { dts } from 'rolldown-plugin-dts';

--- a/packages/nx-plugin/src/smithy/project/generator.ts
+++ b/packages/nx-plugin/src/smithy/project/generator.ts
@@ -12,7 +12,10 @@ import {
 } from '@nx/devkit';
 import { getTsLibDetails } from '../../ts/lib/generator';
 import { resolveContainers } from '../../utils/containers';
-import { declareDependencies } from '../../utils/declared-dependencies';
+import {
+  declareDependencies,
+  ownedElsewhere,
+} from '../../utils/declared-dependencies';
 import { formatFilesInSubtree } from '../../utils/format';
 import { FS_DEPENDENCIES, FsCommands } from '../../utils/fs';
 import { installDependencies } from '../../utils/install';
@@ -25,10 +28,23 @@ import {
   type NxGeneratorInfo,
   projectExists,
 } from '../../utils/nx';
+import { type ITsDepVersion, TS_VERSIONS } from '../../utils/versions';
 import type { SmithyProjectGeneratorSchema } from './schema';
 
+/**
+ * Packages `build.Dockerfile` installs into the build image to bundle the Smithy
+ * SSDK. Pinned in the file body rather than declared in a manifest, so declaring
+ * them here — never installed into the workspace — is what keeps the version sync
+ * moving them forward.
+ */
+export const SSDK_BUNDLE_DEPENDENCIES = [
+  { name: 'rolldown' },
+  { name: 'rolldown-plugin-dts' },
+  { name: '@rollup/plugin-esm-shim' },
+] as const satisfies readonly { name: ITsDepVersion }[];
+
 export const DEPENDENCIES = declareDependencies()({
-  ts: [...FS_DEPENDENCIES],
+  ts: [...FS_DEPENDENCIES, ...ownedElsewhere(SSDK_BUNDLE_DEPENDENCIES)],
 });
 
 export const SMITHY_PROJECT_GENERATOR_INFO: NxGeneratorInfo = getGeneratorInfo(
@@ -92,6 +108,9 @@ export const smithyProjectGenerator = async (
       serviceNameClassName,
       serviceNameKebabCase,
       scope,
+      rolldownVersion: TS_VERSIONS.rolldown,
+      rolldownDtsVersion: TS_VERSIONS['rolldown-plugin-dts'],
+      esmShimVersion: TS_VERSIONS['@rollup/plugin-esm-shim'],
     },
     {
       // Smithy models are user-owned — a re-run must not discard edits

--- a/packages/nx-plugin/src/utils/versions.ts
+++ b/packages/nx-plugin/src/utils/versions.ts
@@ -135,6 +135,8 @@ export const TS_VERSIONS = {
   'react-dom': '19.2.7',
   rimraf: '6.1.3',
   rolldown: '1.2.0',
+  'rolldown-plugin-dts': '0.28.0',
+  '@rollup/plugin-esm-shim': '0.1.8',
   'simple-git': '3.36.0',
   'source-map-support': '0.5.21',
   'starlight-blog': '0.28.0',


### PR DESCRIPTION
### Reason for this change

`smithy/project/files/service/build.Dockerfile.template` pinned `rolldown` at `1.0.0-beta.38` and `rolldown-plugin-dts` at `0.16.5`, both as hardcoded literals in the file body, so neither moved with the versions this plugin vends (`TS_VERSIONS.rolldown` is already `1.2.0`).

Bumping `rolldown` alone breaks the build, which is why the pin had been left behind. Before 0.20.0 the dts plugin named the bundled declaration after its content hash, so on rolldown 1.2.0 the SSDK bundle emits `index-<hash>.d.ts`. The generated handler imports `./generated/ssdk/index.js`, finds no `index.d.ts` beside it, and `compile` fails with TS7016.

The two pins have to move together — which is what this PR does.

### Description of changes

- Vend `rolldown-plugin-dts` (`0.28.0`) and `@rollup/plugin-esm-shim` (`0.1.8`) in `utils/versions.ts`, with a comment recording *why* the plugin is held at or above 0.20.0.
- Render all three pins from the template rather than hardcoding them, following the `ts#agent` Dockerfile pattern (`<%- nodeBaseImage %>`, `<%- npmVersion %>`, …).
- Declare them on `smithy#project` as `SSDK_BUNDLE_DEPENDENCIES`, spread through `ownedElsewhere` — never installed into the workspace, but from here on the version sync keeps the pins current instead of this recurring.
- Add `latest-smithy-ssdk-bundle-pins`, a deterministic migration that moves an existing project's pins forward. Each pin is matched **by name** so the `rolldown-plugin-dts` and `@rollup/plugin-esm-shim` versions sharing that `pnpm add` command keep their own (`rolldown` is a prefix of the plugin's name). A workspace already on the vended versions is left untouched; one whose pins have diverged is skipped and reported via `nextSteps`. GritQL for the transform, per CONTRIBUTING.

### Description of how you validated changes

**Reproduced the root cause on the real SSDK, both directions.** Generated a real service project, then built `build.Dockerfile` with Docker:

| rolldown | rolldown-plugin-dts | declaration emitted |
|---|---|---|
| 1.2.0 | 0.16.5 (old) | `index-B2P1qQoJ.d.ts` ❌ |
| 1.2.0 | 0.28.0 (this PR) | `index.d.ts` ✅ |

So the plugin bump is precisely what makes the rolldown bump safe. Also bisected the plugin: 0.16.5 hashes, ≥ 0.20.0 does not.

**End-to-end on real generated output, not fixtures.** Generated a service project with the actual generator, wound both pins back to an older release's versions, ran the migration, and asserted the result is **byte-identical to a fresh workspace** — it is, with empty `nextSteps`. Then built that migrated `build.Dockerfile` for real: it completes and lands `index.d.ts` alongside `index.js` in `/out/ssdk`.

**Tests.** 6 new migration tests (applies, leaves neighbouring pins in the same command alone, no-op when already current, idempotent, ignores the shapes build image which bundles no SSDK, no-op with no smithy project) — all rendered from the real template via the real generator, so they can't pass while the template's shape drifts.

`compile` and lint clean. Full `@aws/nx-plugin:test` diffed against a pristine `main` worktree by failing test **name**: identical 215 failures on both (a pre-existing `libraryGeneratorInternal` crash on this host), **zero new** — and 6 additional passing tests.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*