### PR TITLE
test(e2e): raise the local-dev beforeAll hook timeout to 30 minutes

### DIFF
--- a/e2e/src/smoke-tests/local-dev.spec.ts
+++ b/e2e/src/smoke-tests/local-dev.spec.ts
@@ -784,7 +784,11 @@ def list_examples_by_category(category: str) -> list[ExampleItem]:
       };
       console.log('Ports discovered:', ports);
     },
-    15 * 60 * 1000,
+    // Scaffolds ~24 projects, installs (npm + uv), pulls the Playwright browser
+    // and its apt system libraries, then lints and builds everything. On a slow
+    // runner or apt mirror this legitimately approaches 20 minutes, so budget
+    // generously to avoid tipping over the hook timeout mid-setup.
+    30 * 60 * 1000,
   );
 
   afterAll(async () => {


### PR DESCRIPTION
### Reason for this change

The `local-dev` smoke test's `beforeAll` hook timed out (`Error: Hook timed out in 900000ms`) on two consecutive CI runs on main, skipping all 21 tests. The hook does a large amount of setup:

- Scaffolds ~24 projects (TS/Python APIs, agents, MCP servers, websites, RDBs, DynamoDB, gateways)
- Installs npm + `uv` dependencies
- Pulls the Playwright browser **and its apt system libraries** via `playwright install --with-deps`
- Lints and builds the entire workspace

This legitimately approaches ~15 minutes, and the apt fetch alone took **3–4 minutes** on a slow mirror (observed at ~104 kB/s). Capped at exactly `15 * 60 * 1000`, the hook had zero margin and tipped over mid-setup on slower runners. On a marginally faster runner the same code's hook completed in ~14 minutes and passed — confirming this is a timing race against the bound, not a code defect.

The sibling deploy smoke tests (`cdk-deploy`, `terraform-deploy`) run equivalent setup **inside the `it()` block**, which inherits the 120-minute global `testTimeout`. Only `local-dev` places the heavy scaffold in a tightly-bounded `beforeAll`.

### Description of changes

Raise the `local-dev` `beforeAll` hook timeout from 15 to 30 minutes, with a comment explaining what the hook does and why the generous budget is warranted. 30 minutes comfortably absorbs slow-runner and slow-apt-mirror variance while staying well under the global test timeout.

### Description of how you validated changes

Verified formatting with biome. The change is a test-infrastructure timeout adjustment; the hook body is unchanged. On the current HEAD CI run the `local-dev` job completed in ~20 minutes wall-clock (hook ~14 min) — comfortably inside the new bound.

### Issue # (if applicable)

N/A — CI flake remediation.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*