### PR TITLE
feat(agentcore-gateway): front cognito agents via JWT passthrough

### DIFF
--- a/docs/src/content/docs/en/guides/connection/agentcore-gateway-agent.mdx
+++ b/docs/src/content/docs/en/guides/connection/agentcore-gateway-agent.mdx
@@ -23,7 +23,7 @@ Once connected, the Gateway proxies requests for the agent under `<gatewayUrl>/<
 Before using this generator, ensure you have:
 
 1. An <Link path="guides/agentcore-gateway">`agentcore-gateway`</Link> project generated with `protocol: http`
-2. An agent component (<Link path="guides/ts-agent">`ts#agent`</Link> or <Link path="guides/py-agent">`py#agent`</Link>) created with `infra: agentcore` and `auth: iam`
+2. An agent component (<Link path="guides/ts-agent">`ts#agent`</Link> or <Link path="guides/py-agent">`py#agent`</Link>) created with `infra: agentcore`. Either `auth: iam` (the Gateway invokes it with its own role) or `auth: cognito` (the Gateway forwards the caller's JWT — see [Forwarding caller identity](#forwarding-caller-identity-to-the-runtime)) works.
 
 :::caution[TypeScript HTTP agents]
 A TypeScript `http` agent serves tRPC over WebSocket, and AgentCore Gateway does not support WebSocket or bidirectional streaming — the generator rejects this combination. Generate the agent with the `ag-ui` protocol instead.
@@ -177,13 +177,19 @@ To connect a website to the Gateway's agents, use the <Link path="guides/connect
 
 ## Forwarding caller identity to the runtime
 
-By default the Gateway signs outbound calls with its own IAM role (the `GATEWAY_IAM_ROLE` credential provider), so the runtime sees the _Gateway's_ identity, not the caller's. If you want the agent to authorize on the caller — for example to read the user's `sub` or `scope` claims — the Gateway can instead forward the caller's JWT to the runtime unchanged. This requires three changes:
+By default the Gateway signs outbound calls with its own IAM role (the `GATEWAY_IAM_ROLE` credential provider), so the runtime sees the _Gateway's_ identity, not the caller's. If instead you want the agent to authorize on the caller — for example to read the user's `sub` or `scope` claims — front a **Cognito** agent with a **Cognito** Gateway. The Gateway then forwards the caller's JWT to the runtime unchanged (the `JWT_PASSTHROUGH` credential provider), and the runtime revalidates it.
 
-1. **The Gateway accepts JWTs.** Generate the Gateway with `auth: cognito` so its inbound authorizer validates a Cognito (or other OIDC) bearer token.
-2. **The runtime accepts the same JWTs.** Generate the agent with `auth: cognito` (same user pool) so the runtime revalidates the forwarded token.
-3. **The target uses the `JWT_PASSTHROUGH` credential provider** instead of `GATEWAY_IAM_ROLE`, and the **runtime allowlists the `Authorization` header** so it reaches your agent code. Without the allowlist, AgentCore validates the token but strips the header before your container.
+Generate both ends with `auth: cognito` and connect them as above:
 
-Callers then invoke the Gateway with `Authorization: Bearer <jwt>` (no SigV4), and the agent reads the claims from the `Authorization` header — skipping signature validation, since the runtime's inbound authorizer has already verified the token:
+- an agent (<Link path="guides/ts-agent">`ts#agent`</Link> or <Link path="guides/py-agent">`py#agent`</Link>) created with `auth: cognito`, and
+- a Gateway created with `auth: cognito` fronting the **same** Cognito user pool.
+
+Everything else is automatic — `gateway.addAgent(agent)` (CDK) and the generated Terraform runtime module handle the wiring for you based on the agent's `auth`:
+
+- the target is created with the `JWT_PASSTHROUGH` credential provider (rather than `GATEWAY_IAM_ROLE`), and
+- the runtime allowlists the `Authorization` header so the forwarded token reaches your agent code. Without this allowlist AgentCore validates the token but strips the header before your container.
+
+Callers invoke the Gateway with `Authorization: Bearer <jwt>` (no SigV4), and the agent reads the claims from the `Authorization` header — skipping signature validation, since the runtime's inbound authorizer has already verified the token:
 
 ```python title="packages/py_project/.../my_agent/main.py"
 import jwt  # PyJWT
@@ -195,82 +201,8 @@ async def invoke(input: InvokeInput, request: Request):
     # authorize on claims['sub'], claims['scope'], ...
 ```
 
-<Infrastructure>
-<Fragment slot="cdk">
-Pass `requestHeaderConfiguration` to the agent so the runtime receives the header, and create the target yourself (instead of `gateway.addAgent(agent)`) with the `JWT_PASSTHROUGH` credential provider:
-
-```ts title="packages/infra/src/stacks/application-stack.ts" {5-7,17-19}
-import { CfnGatewayTarget } from 'aws-cdk-lib/aws-bedrockagentcore';
-import { PolicyStatement } from 'aws-cdk-lib/aws-iam';
-
-const myAgent = new MyAgent(this, 'MyAgent', {
-  identity,
-  // Let the runtime receive the forwarded Authorization header.
-  requestHeaderConfiguration: { allowlistedHeaders: ['Authorization'] },
-});
-const myGateway = new MyGateway(this, 'MyGateway', { identity });
-
-const target = new CfnGatewayTarget(this, 'Target-my-agent', {
-  gatewayIdentifier: myGateway.gateway.gatewayId,
-  name: myAgent.agentName,
-  targetConfiguration: {
-    http: { agentcoreRuntime: { arn: myAgent.agentCoreRuntime.agentRuntimeArn } },
-  },
-  // Forward the caller's validated JWT to the runtime unchanged.
-  credentialProviderConfigurations: [
-    { credentialProviderType: 'JWT_PASSTHROUGH' },
-  ],
-});
-
-// The Gateway role still needs invoke access to the runtime.
-myGateway.gateway.role.addToPrincipalPolicy(
-  new PolicyStatement({
-    actions: ['bedrock-agentcore:InvokeAgentRuntime'],
-    resources: [
-      myAgent.agentCoreRuntime.agentRuntimeArn,
-      `${myAgent.agentCoreRuntime.agentRuntimeArn}/*`,
-    ],
-  }),
-);
-```
-</Fragment>
-<Fragment slot="terraform">
-Add a `request_header_configuration` block to the runtime so it receives the header, and configure the target with the `JWT_PASSTHROUGH` credential provider (instead of `gateway_iam_role {}`):
-
-```hcl title="packages/infra/src/main.tf" {5-7,20-22}
-# Let the runtime receive the forwarded Authorization header. Add this block
-# to the runtime resource in the agent module (packages/common/terraform/...).
-resource "aws_bedrockagentcore_agent_runtime" "agent_runtime" {
-  # ...
-  request_header_configuration {
-    request_header_allowlist = ["Authorization"]
-  }
-}
-
-resource "aws_bedrockagentcore_gateway_target" "my_agent" {
-  gateway_identifier = module.my_gateway.gateway_id
-  name               = "my-agent"
-  description        = "Agent runtime target my-agent"
-
-  target_configuration {
-    http {
-      agentcore_runtime {
-        arn = module.my_agent.agent_core_runtime_arn
-      }
-    }
-  }
-
-  # Forward the caller's validated JWT to the runtime unchanged.
-  credential_provider_configuration {
-    credential_provider_type = "JWT_PASSTHROUGH"
-  }
-}
-```
-</Fragment>
-</Infrastructure>
-
 :::note
-`JWT_PASSTHROUGH` suits a single identity provider whose token audience already covers the runtime. If one Gateway fronts agents across multiple tenants or audiences, use OAuth [on-behalf-of token exchange](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/gateway-building-adding-targets-authorization.html) instead.
+JWT passthrough suits a single identity provider whose token audience already covers the runtime. If one Gateway fronts agents across multiple tenants or audiences, use OAuth [on-behalf-of token exchange](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/gateway-building-adding-targets-authorization.html) instead.
 :::
 
 ## Local Development

--- a/docs/src/content/docs/es/guides/connection/agentcore-gateway-agent.mdx
+++ b/docs/src/content/docs/es/guides/connection/agentcore-gateway-agent.mdx
@@ -23,7 +23,7 @@ Una vez conectado, el Gateway redirige las solicitudes para el agente bajo `<gat
 Antes de usar este generador, asegúrate de tener:
 
 1. Un proyecto <Link path="guides/agentcore-gateway">`agentcore-gateway`</Link> generado con `protocol: http`
-2. Un componente de agente (<Link path="guides/ts-agent">`ts#agent`</Link> o <Link path="guides/py-agent">`py#agent`</Link>) creado con `infra: agentcore` y `auth: iam`
+2. Un componente de agente (<Link path="guides/ts-agent">`ts#agent`</Link> o <Link path="guides/py-agent">`py#agent`</Link>) creado con `infra: agentcore`. Funciona tanto `auth: iam` (el Gateway lo invoca con su propio rol) como `auth: cognito` (el Gateway reenvía el JWT del llamador — ver [Reenvío de identidad del llamador al tiempo de ejecución](#forwarding-caller-identity-to-the-runtime)).
 
 :::caution[Agentes HTTP de TypeScript]
 Un agente `http` de TypeScript sirve tRPC sobre WebSocket, y AgentCore Gateway no soporta WebSocket o streaming bidireccional — el generador rechaza esta combinación. Genera el agente con el protocolo `ag-ui` en su lugar.
@@ -177,13 +177,19 @@ Para conectar un sitio web a los agentes del Gateway, usa el <Link path="guides/
 
 ## Reenvío de identidad del llamador al tiempo de ejecución
 
-Por defecto, el Gateway firma las llamadas salientes con su propio rol de IAM (el proveedor de credenciales `GATEWAY_IAM_ROLE`), por lo que el tiempo de ejecución ve la identidad del _Gateway_, no la del llamador. Si deseas que el agente autorice en función del llamador — por ejemplo, para leer las reclamaciones `sub` o `scope` del usuario — el Gateway puede en su lugar reenviar el JWT del llamador al tiempo de ejecución sin cambios. Esto requiere tres cambios:
+Por defecto, el Gateway firma las llamadas salientes con su propio rol de IAM (el proveedor de credenciales `GATEWAY_IAM_ROLE`), por lo que el tiempo de ejecución ve la identidad del _Gateway_, no la del llamador. Si en cambio deseas que el agente autorice en función del llamador — por ejemplo, para leer las reclamaciones `sub` o `scope` del usuario — antepón un Gateway **Cognito** a un agente **Cognito**. El Gateway entonces reenvía el JWT del llamador al tiempo de ejecución sin cambios (el proveedor de credenciales `JWT_PASSTHROUGH`), y el tiempo de ejecución lo revalida.
 
-1. **El Gateway acepta JWTs.** Genera el Gateway con `auth: cognito` para que su autorizador de entrada valide un token bearer de Cognito (u otro OIDC).
-2. **El tiempo de ejecución acepta los mismos JWTs.** Genera el agente con `auth: cognito` (mismo grupo de usuarios) para que el tiempo de ejecución revalide el token reenviado.
-3. **El destino usa el proveedor de credenciales `JWT_PASSTHROUGH`** en lugar de `GATEWAY_IAM_ROLE`, y **el tiempo de ejecución incluye en la lista permitida el encabezado `Authorization`** para que llegue a tu código de agente. Sin la lista permitida, AgentCore valida el token pero elimina el encabezado antes de tu contenedor.
+Genera ambos extremos con `auth: cognito` y conéctalos como se indicó anteriormente:
 
-Los llamadores luego invocan el Gateway con `Authorization: Bearer <jwt>` (sin SigV4), y el agente lee las reclamaciones del encabezado `Authorization` — omitiendo la validación de firma, ya que el autorizador de entrada del tiempo de ejecución ya ha verificado el token:
+- un agente (<Link path="guides/ts-agent">`ts#agent`</Link> o <Link path="guides/py-agent">`py#agent`</Link>) creado con `auth: cognito`, y
+- un Gateway creado con `auth: cognito` que frontaliza el **mismo** grupo de usuarios de Cognito.
+
+Todo lo demás es automático — `gateway.addAgent(agent)` (CDK) y el módulo de tiempo de ejecución de Terraform generado manejan el cableado por ti según el `auth` del agente:
+
+- el destino se crea con el proveedor de credenciales `JWT_PASSTHROUGH` (en lugar de `GATEWAY_IAM_ROLE`), y
+- el tiempo de ejecución incluye en la lista permitida el encabezado `Authorization` para que el token reenviado llegue a tu código de agente. Sin esta lista permitida, AgentCore valida el token pero elimina el encabezado antes de tu contenedor.
+
+Los llamadores invocan el Gateway con `Authorization: Bearer <jwt>` (sin SigV4), y el agente lee las reclamaciones del encabezado `Authorization` — omitiendo la validación de firma, ya que el autorizador de entrada del tiempo de ejecución ya ha verificado el token:
 
 ```python title="packages/py_project/.../my_agent/main.py"
 import jwt  # PyJWT
@@ -195,82 +201,8 @@ async def invoke(input: InvokeInput, request: Request):
     # authorize on claims['sub'], claims['scope'], ...
 ```
 
-<Infrastructure>
-<Fragment slot="cdk">
-Pasa `requestHeaderConfiguration` al agente para que el tiempo de ejecución reciba el encabezado, y crea el destino tú mismo (en lugar de `gateway.addAgent(agent)`) con el proveedor de credenciales `JWT_PASSTHROUGH`:
-
-```ts title="packages/infra/src/stacks/application-stack.ts" {5-7,17-19}
-import { CfnGatewayTarget } from 'aws-cdk-lib/aws-bedrockagentcore';
-import { PolicyStatement } from 'aws-cdk-lib/aws-iam';
-
-const myAgent = new MyAgent(this, 'MyAgent', {
-  identity,
-  // Let the runtime receive the forwarded Authorization header.
-  requestHeaderConfiguration: { allowlistedHeaders: ['Authorization'] },
-});
-const myGateway = new MyGateway(this, 'MyGateway', { identity });
-
-const target = new CfnGatewayTarget(this, 'Target-my-agent', {
-  gatewayIdentifier: myGateway.gateway.gatewayId,
-  name: myAgent.agentName,
-  targetConfiguration: {
-    http: { agentcoreRuntime: { arn: myAgent.agentCoreRuntime.agentRuntimeArn } },
-  },
-  // Forward the caller's validated JWT to the runtime unchanged.
-  credentialProviderConfigurations: [
-    { credentialProviderType: 'JWT_PASSTHROUGH' },
-  ],
-});
-
-// The Gateway role still needs invoke access to the runtime.
-myGateway.gateway.role.addToPrincipalPolicy(
-  new PolicyStatement({
-    actions: ['bedrock-agentcore:InvokeAgentRuntime'],
-    resources: [
-      myAgent.agentCoreRuntime.agentRuntimeArn,
-      `${myAgent.agentCoreRuntime.agentRuntimeArn}/*`,
-    ],
-  }),
-);
-```
-</Fragment>
-<Fragment slot="terraform">
-Agrega un bloque `request_header_configuration` al tiempo de ejecución para que reciba el encabezado, y configura el destino con el proveedor de credenciales `JWT_PASSTHROUGH` (en lugar de `gateway_iam_role {}`):
-
-```hcl title="packages/infra/src/main.tf" {5-7,20-22}
-# Let the runtime receive the forwarded Authorization header. Add this block
-# to the runtime resource in the agent module (packages/common/terraform/...).
-resource "aws_bedrockagentcore_agent_runtime" "agent_runtime" {
-  # ...
-  request_header_configuration {
-    request_header_allowlist = ["Authorization"]
-  }
-}
-
-resource "aws_bedrockagentcore_gateway_target" "my_agent" {
-  gateway_identifier = module.my_gateway.gateway_id
-  name               = "my-agent"
-  description        = "Agent runtime target my-agent"
-
-  target_configuration {
-    http {
-      agentcore_runtime {
-        arn = module.my_agent.agent_core_runtime_arn
-      }
-    }
-  }
-
-  # Forward the caller's validated JWT to the runtime unchanged.
-  credential_provider_configuration {
-    credential_provider_type = "JWT_PASSTHROUGH"
-  }
-}
-```
-</Fragment>
-</Infrastructure>
-
 :::note
-`JWT_PASSTHROUGH` es adecuado para un único proveedor de identidad cuya audiencia de token ya cubre el tiempo de ejecución. Si un Gateway frontaliza agentes a través de múltiples inquilinos o audiencias, usa en su lugar el [intercambio de tokens en nombre de](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/gateway-building-adding-targets-authorization.html) de OAuth.
+El paso de JWT es adecuado para un único proveedor de identidad cuya audiencia de token ya cubre el tiempo de ejecución. Si un Gateway frontaliza agentes a través de múltiples inquilinos o audiencias, usa en su lugar el [intercambio de tokens en nombre de](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/gateway-building-adding-targets-authorization.html) de OAuth.
 :::
 
 ## Desarrollo local

--- a/docs/src/content/docs/fr/guides/connection/agentcore-gateway-agent.mdx
+++ b/docs/src/content/docs/fr/guides/connection/agentcore-gateway-agent.mdx
@@ -23,7 +23,7 @@ Une fois connectée, la Gateway proxifie les requêtes pour l'agent sous `<gatew
 Avant d'utiliser ce générateur, assurez-vous d'avoir :
 
 1. Un projet <Link path="guides/agentcore-gateway">`agentcore-gateway`</Link> généré avec `protocol: http`
-2. Un composant agent (<Link path="guides/ts-agent">`ts#agent`</Link> ou <Link path="guides/py-agent">`py#agent`</Link>) créé avec `infra: agentcore` et `auth: iam`
+2. Un composant agent (<Link path="guides/ts-agent">`ts#agent`</Link> ou <Link path="guides/py-agent">`py#agent`</Link>) créé avec `infra: agentcore`. Soit `auth: iam` (la Gateway l'invoque avec son propre rôle) ou `auth: cognito` (la Gateway transfère le JWT de l'appelant — voir [Transférer l'identité de l'appelant vers l'exécution](#transférer-lidentité-de-lapelant-vers-lexécution)) fonctionne.
 
 :::caution[Agents HTTP TypeScript]
 Un agent `http` TypeScript sert tRPC sur WebSocket, et AgentCore Gateway ne prend pas en charge WebSocket ou le streaming bidirectionnel — le générateur rejette cette combinaison. Générez l'agent avec le protocole `ag-ui` à la place.
@@ -177,13 +177,19 @@ Pour connecter un site web aux agents de la Gateway, utilisez le <Link path="gui
 
 ## Transférer l'identité de l'appelant vers l'exécution
 
-Par défaut, la Gateway signe les appels sortants avec son propre rôle IAM (le fournisseur d'identifiants `GATEWAY_IAM_ROLE`), de sorte que l'exécution voit l'identité de la _Gateway_, et non celle de l'appelant. Si vous souhaitez que l'agent autorise sur l'appelant — par exemple pour lire les revendications `sub` ou `scope` de l'utilisateur — la Gateway peut à la place transférer le JWT de l'appelant vers l'exécution sans modification. Cela nécessite trois changements :
+Par défaut, la Gateway signe les appels sortants avec son propre rôle IAM (le fournisseur d'identifiants `GATEWAY_IAM_ROLE`), de sorte que l'exécution voit l'identité de la _Gateway_, et non celle de l'appelant. Si au contraire vous souhaitez que l'agent autorise sur l'appelant — par exemple pour lire les revendications `sub` ou `scope` de l'utilisateur — placez un agent **Cognito** derrière une Gateway **Cognito**. La Gateway transfère alors le JWT de l'appelant vers l'exécution sans modification (le fournisseur d'identifiants `JWT_PASSTHROUGH`), et l'exécution le revalide.
 
-1. **La Gateway accepte les JWT.** Générez la Gateway avec `auth: cognito` afin que son autorisateur entrant valide un jeton bearer Cognito (ou autre OIDC).
-2. **L'exécution accepte les mêmes JWT.** Générez l'agent avec `auth: cognito` (même pool d'utilisateurs) afin que l'exécution revalide le jeton transféré.
-3. **La cible utilise le fournisseur d'identifiants `JWT_PASSTHROUGH`** au lieu de `GATEWAY_IAM_ROLE`, et **l'exécution met en liste blanche l'en-tête `Authorization`** afin qu'il atteigne votre code d'agent. Sans la liste blanche, AgentCore valide le jeton mais supprime l'en-tête avant votre conteneur.
+Générez les deux extrémités avec `auth: cognito` et connectez-les comme ci-dessus :
 
-Les appelants invoquent alors la Gateway avec `Authorization: Bearer <jwt>` (pas de SigV4), et l'agent lit les revendications depuis l'en-tête `Authorization` — en sautant la validation de signature, puisque l'autorisateur entrant de l'exécution a déjà vérifié le jeton :
+- un agent (<Link path="guides/ts-agent">`ts#agent`</Link> ou <Link path="guides/py-agent">`py#agent`</Link>) créé avec `auth: cognito`, et
+- une Gateway créée avec `auth: cognito` faisant face au **même** pool d'utilisateurs Cognito.
+
+Tout le reste est automatique — `gateway.addAgent(agent)` (CDK) et le module d'exécution Terraform généré gèrent le câblage pour vous en fonction de l'`auth` de l'agent :
+
+- la cible est créée avec le fournisseur d'identifiants `JWT_PASSTHROUGH` (plutôt que `GATEWAY_IAM_ROLE`), et
+- l'exécution met en liste blanche l'en-tête `Authorization` afin que le jeton transféré atteigne votre code d'agent. Sans cette liste blanche, AgentCore valide le jeton mais supprime l'en-tête avant votre conteneur.
+
+Les appelants invoquent la Gateway avec `Authorization: Bearer <jwt>` (pas de SigV4), et l'agent lit les revendications depuis l'en-tête `Authorization` — en sautant la validation de signature, puisque l'autorisateur entrant de l'exécution a déjà vérifié le jeton :
 
 ```python title="packages/py_project/.../my_agent/main.py"
 import jwt  # PyJWT
@@ -195,82 +201,8 @@ async def invoke(input: InvokeInput, request: Request):
     # authorize on claims['sub'], claims['scope'], ...
 ```
 
-<Infrastructure>
-<Fragment slot="cdk">
-Passez `requestHeaderConfiguration` à l'agent afin que l'exécution reçoive l'en-tête, et créez la cible vous-même (au lieu de `gateway.addAgent(agent)`) avec le fournisseur d'identifiants `JWT_PASSTHROUGH` :
-
-```ts title="packages/infra/src/stacks/application-stack.ts" {5-7,17-19}
-import { CfnGatewayTarget } from 'aws-cdk-lib/aws-bedrockagentcore';
-import { PolicyStatement } from 'aws-cdk-lib/aws-iam';
-
-const myAgent = new MyAgent(this, 'MyAgent', {
-  identity,
-  // Let the runtime receive the forwarded Authorization header.
-  requestHeaderConfiguration: { allowlistedHeaders: ['Authorization'] },
-});
-const myGateway = new MyGateway(this, 'MyGateway', { identity });
-
-const target = new CfnGatewayTarget(this, 'Target-my-agent', {
-  gatewayIdentifier: myGateway.gateway.gatewayId,
-  name: myAgent.agentName,
-  targetConfiguration: {
-    http: { agentcoreRuntime: { arn: myAgent.agentCoreRuntime.agentRuntimeArn } },
-  },
-  // Forward the caller's validated JWT to the runtime unchanged.
-  credentialProviderConfigurations: [
-    { credentialProviderType: 'JWT_PASSTHROUGH' },
-  ],
-});
-
-// The Gateway role still needs invoke access to the runtime.
-myGateway.gateway.role.addToPrincipalPolicy(
-  new PolicyStatement({
-    actions: ['bedrock-agentcore:InvokeAgentRuntime'],
-    resources: [
-      myAgent.agentCoreRuntime.agentRuntimeArn,
-      `${myAgent.agentCoreRuntime.agentRuntimeArn}/*`,
-    ],
-  }),
-);
-```
-</Fragment>
-<Fragment slot="terraform">
-Ajoutez un bloc `request_header_configuration` à l'exécution afin qu'elle reçoive l'en-tête, et configurez la cible avec le fournisseur d'identifiants `JWT_PASSTHROUGH` (au lieu de `gateway_iam_role {}`) :
-
-```hcl title="packages/infra/src/main.tf" {5-7,20-22}
-# Let the runtime receive the forwarded Authorization header. Add this block
-# to the runtime resource in the agent module (packages/common/terraform/...).
-resource "aws_bedrockagentcore_agent_runtime" "agent_runtime" {
-  # ...
-  request_header_configuration {
-    request_header_allowlist = ["Authorization"]
-  }
-}
-
-resource "aws_bedrockagentcore_gateway_target" "my_agent" {
-  gateway_identifier = module.my_gateway.gateway_id
-  name               = "my-agent"
-  description        = "Agent runtime target my-agent"
-
-  target_configuration {
-    http {
-      agentcore_runtime {
-        arn = module.my_agent.agent_core_runtime_arn
-      }
-    }
-  }
-
-  # Forward the caller's validated JWT to the runtime unchanged.
-  credential_provider_configuration {
-    credential_provider_type = "JWT_PASSTHROUGH"
-  }
-}
-```
-</Fragment>
-</Infrastructure>
-
 :::note
-`JWT_PASSTHROUGH` convient à un seul fournisseur d'identité dont l'audience de jeton couvre déjà l'exécution. Si une Gateway fait face à des agents sur plusieurs locataires ou audiences, utilisez plutôt l'[échange de jetons on-behalf-of](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/gateway-building-adding-targets-authorization.html) OAuth.
+Le passage JWT convient à un seul fournisseur d'identité dont l'audience de jeton couvre déjà l'exécution. Si une Gateway fait face à des agents sur plusieurs locataires ou audiences, utilisez plutôt l'[échange de jetons on-behalf-of](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/gateway-building-adding-targets-authorization.html) OAuth.
 :::
 
 ## Développement local

--- a/docs/src/content/docs/it/guides/connection/agentcore-gateway-agent.mdx
+++ b/docs/src/content/docs/it/guides/connection/agentcore-gateway-agent.mdx
@@ -23,7 +23,7 @@ Una volta connesso, il Gateway inoltra le richieste per l'agent sotto `<gatewayU
 Prima di utilizzare questo generatore, assicurati di avere:
 
 1. Un progetto <Link path="guides/agentcore-gateway">`agentcore-gateway`</Link> generato con `protocol: http`
-2. Un componente agent (<Link path="guides/ts-agent">`ts#agent`</Link> o <Link path="guides/py-agent">`py#agent`</Link>) creato con `infra: agentcore` e `auth: iam`
+2. Un componente agent (<Link path="guides/ts-agent">`ts#agent`</Link> o <Link path="guides/py-agent">`py#agent`</Link>) creato con `infra: agentcore`. Funziona sia `auth: iam` (il Gateway lo invoca con il proprio ruolo) che `auth: cognito` (il Gateway inoltra il JWT del chiamante — vedi [Inoltrare l'identità del chiamante al runtime](#forwarding-caller-identity-to-the-runtime)).
 
 :::caution[Agent HTTP TypeScript]
 Un agent TypeScript `http` serve tRPC su WebSocket, e AgentCore Gateway non supporta WebSocket o streaming bidirezionale — il generatore rifiuta questa combinazione. Genera invece l'agent con il protocollo `ag-ui`.
@@ -177,13 +177,19 @@ Per connettere un sito web agli agent del Gateway, utilizza il <Link path="guide
 
 ## Inoltrare l'identità del chiamante al runtime
 
-Per impostazione predefinita, il Gateway firma le chiamate in uscita con il proprio ruolo IAM (il provider di credenziali `GATEWAY_IAM_ROLE`), quindi il runtime vede l'identità del _Gateway_, non quella del chiamante. Se vuoi che l'agent autorizzi in base al chiamante — ad esempio per leggere i claim `sub` o `scope` dell'utente — il Gateway può invece inoltrare il JWT del chiamante al runtime senza modifiche. Questo richiede tre modifiche:
+Per impostazione predefinita, il Gateway firma le chiamate in uscita con il proprio ruolo IAM (il provider di credenziali `GATEWAY_IAM_ROLE`), quindi il runtime vede l'identità del _Gateway_, non quella del chiamante. Se invece vuoi che l'agent autorizzi in base al chiamante — ad esempio per leggere i claim `sub` o `scope` dell'utente — metti un agent **Cognito** dietro un Gateway **Cognito**. Il Gateway inoltra quindi il JWT del chiamante al runtime senza modifiche (il provider di credenziali `JWT_PASSTHROUGH`), e il runtime lo rivalidata.
 
-1. **Il Gateway accetta JWT.** Genera il Gateway con `auth: cognito` in modo che il suo authorizer in ingresso validi un token bearer Cognito (o altro OIDC).
-2. **Il runtime accetta gli stessi JWT.** Genera l'agent con `auth: cognito` (stesso user pool) in modo che il runtime rivalidati il token inoltrato.
-3. **Il target utilizza il provider di credenziali `JWT_PASSTHROUGH`** invece di `GATEWAY_IAM_ROLE`, e il **runtime inserisce l'header `Authorization` nella allowlist** in modo che raggiunga il codice del tuo agent. Senza l'allowlist, AgentCore valida il token ma rimuove l'header prima del tuo container.
+Genera entrambe le estremità con `auth: cognito` e collegale come sopra:
 
-I chiamanti invocano quindi il Gateway con `Authorization: Bearer <jwt>` (senza SigV4), e l'agent legge i claim dall'header `Authorization` — saltando la validazione della firma, poiché l'authorizer in ingresso del runtime ha già verificato il token:
+- un agent (<Link path="guides/ts-agent">`ts#agent`</Link> o <Link path="guides/py-agent">`py#agent`</Link>) creato con `auth: cognito`, e
+- un Gateway creato con `auth: cognito` che si trova davanti allo **stesso** user pool Cognito.
+
+Tutto il resto è automatico — `gateway.addAgent(agent)` (CDK) e il modulo runtime Terraform generato gestiscono il cablaggio per te in base all'`auth` dell'agent:
+
+- il target viene creato con il provider di credenziali `JWT_PASSTHROUGH` (anziché `GATEWAY_IAM_ROLE`), e
+- il runtime inserisce l'header `Authorization` nella allowlist in modo che il token inoltrato raggiunga il codice del tuo agent. Senza questa allowlist AgentCore valida il token ma rimuove l'header prima del tuo container.
+
+I chiamanti invocano il Gateway con `Authorization: Bearer <jwt>` (senza SigV4), e l'agent legge i claim dall'header `Authorization` — saltando la validazione della firma, poiché l'authorizer in ingresso del runtime ha già verificato il token:
 
 ```python title="packages/py_project/.../my_agent/main.py"
 import jwt  # PyJWT
@@ -195,82 +201,8 @@ async def invoke(input: InvokeInput, request: Request):
     # authorize on claims['sub'], claims['scope'], ...
 ```
 
-<Infrastructure>
-<Fragment slot="cdk">
-Passa `requestHeaderConfiguration` all'agent in modo che il runtime riceva l'header, e crea il target tu stesso (invece di `gateway.addAgent(agent)`) con il provider di credenziali `JWT_PASSTHROUGH`:
-
-```ts title="packages/infra/src/stacks/application-stack.ts" {5-7,17-19}
-import { CfnGatewayTarget } from 'aws-cdk-lib/aws-bedrockagentcore';
-import { PolicyStatement } from 'aws-cdk-lib/aws-iam';
-
-const myAgent = new MyAgent(this, 'MyAgent', {
-  identity,
-  // Let the runtime receive the forwarded Authorization header.
-  requestHeaderConfiguration: { allowlistedHeaders: ['Authorization'] },
-});
-const myGateway = new MyGateway(this, 'MyGateway', { identity });
-
-const target = new CfnGatewayTarget(this, 'Target-my-agent', {
-  gatewayIdentifier: myGateway.gateway.gatewayId,
-  name: myAgent.agentName,
-  targetConfiguration: {
-    http: { agentcoreRuntime: { arn: myAgent.agentCoreRuntime.agentRuntimeArn } },
-  },
-  // Forward the caller's validated JWT to the runtime unchanged.
-  credentialProviderConfigurations: [
-    { credentialProviderType: 'JWT_PASSTHROUGH' },
-  ],
-});
-
-// The Gateway role still needs invoke access to the runtime.
-myGateway.gateway.role.addToPrincipalPolicy(
-  new PolicyStatement({
-    actions: ['bedrock-agentcore:InvokeAgentRuntime'],
-    resources: [
-      myAgent.agentCoreRuntime.agentRuntimeArn,
-      `${myAgent.agentCoreRuntime.agentRuntimeArn}/*`,
-    ],
-  }),
-);
-```
-</Fragment>
-<Fragment slot="terraform">
-Aggiungi un blocco `request_header_configuration` al runtime in modo che riceva l'header, e configura il target con il provider di credenziali `JWT_PASSTHROUGH` (invece di `gateway_iam_role {}`):
-
-```hcl title="packages/infra/src/main.tf" {5-7,20-22}
-# Let the runtime receive the forwarded Authorization header. Add this block
-# to the runtime resource in the agent module (packages/common/terraform/...).
-resource "aws_bedrockagentcore_agent_runtime" "agent_runtime" {
-  # ...
-  request_header_configuration {
-    request_header_allowlist = ["Authorization"]
-  }
-}
-
-resource "aws_bedrockagentcore_gateway_target" "my_agent" {
-  gateway_identifier = module.my_gateway.gateway_id
-  name               = "my-agent"
-  description        = "Agent runtime target my-agent"
-
-  target_configuration {
-    http {
-      agentcore_runtime {
-        arn = module.my_agent.agent_core_runtime_arn
-      }
-    }
-  }
-
-  # Forward the caller's validated JWT to the runtime unchanged.
-  credential_provider_configuration {
-    credential_provider_type = "JWT_PASSTHROUGH"
-  }
-}
-```
-</Fragment>
-</Infrastructure>
-
 :::note
-`JWT_PASSTHROUGH` è adatto per un singolo provider di identità il cui audience del token copre già il runtime. Se un Gateway si trova davanti ad agent su più tenant o audience, utilizza invece lo [scambio di token on-behalf-of](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/gateway-building-adding-targets-authorization.html) OAuth.
+Il passthrough JWT è adatto per un singolo provider di identità il cui audience del token copre già il runtime. Se un Gateway si trova davanti ad agent su più tenant o audience, utilizza invece lo [scambio di token on-behalf-of](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/gateway-building-adding-targets-authorization.html) OAuth.
 :::
 
 ## Sviluppo Locale

--- a/docs/src/content/docs/jp/guides/connection/agentcore-gateway-agent.mdx
+++ b/docs/src/content/docs/jp/guides/connection/agentcore-gateway-agent.mdx
@@ -23,7 +23,7 @@ import Infrastructure from '@components/infrastructure.astro';
 このジェネレーターを使用する前に、以下を確認してください：
 
 1. `protocol: http` で生成された <Link path="guides/agentcore-gateway">`agentcore-gateway`</Link> プロジェクト
-2. `infra: agentcore` および `auth: iam` で作成されたエージェントコンポーネント（<Link path="guides/ts-agent">`ts#agent`</Link> または <Link path="guides/py-agent">`py#agent`</Link>）
+2. `infra: agentcore` で作成されたエージェントコンポーネント（<Link path="guides/ts-agent">`ts#agent`</Link> または <Link path="guides/py-agent">`py#agent`</Link>）。`auth: iam`（Gateway が自身のロールで呼び出す）または `auth: cognito`（Gateway が呼び出し元の JWT を転送する — [呼び出し元の ID をランタイムに転送する](#forwarding-caller-identity-to-the-runtime)を参照）のいずれかが機能します。
 
 :::caution[TypeScript HTTP エージェント]
 TypeScript の `http` エージェントは WebSocket 上で tRPC を提供しますが、AgentCore Gateway は WebSocket や双方向ストリーミングをサポートしていません。ジェネレーターはこの組み合わせを拒否します。代わりに `ag-ui` プロトコルでエージェントを生成してください。
@@ -177,13 +177,19 @@ Web サイトを Gateway のエージェントに接続するには、<Link path
 
 ## 呼び出し元の ID をランタイムに転送する
 
-デフォルトでは、Gateway は自身の IAM ロール（`GATEWAY_IAM_ROLE` 認証情報プロバイダー）でアウトバウンド呼び出しに署名するため、ランタイムは呼び出し元の ID ではなく _Gateway の_ ID を認識します。エージェントが呼び出し元に基づいて認可を行いたい場合（例えば、ユーザーの `sub` や `scope` クレームを読み取る場合）、Gateway は代わりに呼び出し元の JWT を変更せずにランタイムに転送できます。これには 3 つの変更が必要です：
+デフォルトでは、Gateway は自身の IAM ロール（`GATEWAY_IAM_ROLE` 認証情報プロバイダー）でアウトバウンド呼び出しに署名するため、ランタイムは呼び出し元の ID ではなく _Gateway の_ ID を認識します。代わりにエージェントが呼び出し元に基づいて認可を行いたい場合（例えば、ユーザーの `sub` や `scope` クレームを読み取る場合）、**Cognito** エージェントの前段に **Cognito** Gateway を配置します。Gateway は呼び出し元の JWT を変更せずにランタイムに転送し（`JWT_PASSTHROUGH` 認証情報プロバイダー）、ランタイムはそれを再検証します。
 
-1. **Gateway が JWT を受け入れる。** Gateway を `auth: cognito` で生成し、インバウンドオーソライザーが Cognito（または他の OIDC）ベアラートークンを検証するようにします。
-2. **ランタイムが同じ JWT を受け入れる。** エージェントを `auth: cognito`（同じユーザープール）で生成し、ランタイムが転送されたトークンを再検証するようにします。
-3. **ターゲットが `GATEWAY_IAM_ROLE` の代わりに `JWT_PASSTHROUGH` 認証情報プロバイダーを使用する**、そして**ランタイムが `Authorization` ヘッダーを許可リストに追加**して、エージェントコードに到達するようにします。許可リストがない場合、AgentCore はトークンを検証しますが、コンテナに到達する前にヘッダーを削除します。
+両端を `auth: cognito` で生成し、上記のように接続します：
 
-その後、呼び出し元は `Authorization: Bearer <jwt>`（SigV4 なし）で Gateway を呼び出し、エージェントは `Authorization` ヘッダーからクレームを読み取ります。ランタイムのインバウンドオーソライザーがすでにトークンを検証しているため、署名検証はスキップします：
+- `auth: cognito` で作成されたエージェント（<Link path="guides/ts-agent">`ts#agent`</Link> または <Link path="guides/py-agent">`py#agent`</Link>）、および
+- **同じ** Cognito ユーザープールを前段に配置する `auth: cognito` で作成された Gateway。
+
+それ以外はすべて自動です — `gateway.addAgent(agent)`（CDK）と生成された Terraform ランタイムモジュールが、エージェントの `auth` に基づいて配線を処理します：
+
+- ターゲットは（`GATEWAY_IAM_ROLE` ではなく）`JWT_PASSTHROUGH` 認証情報プロバイダーで作成され、
+- ランタイムは `Authorization` ヘッダーを許可リストに追加して、転送されたトークンがエージェントコードに到達するようにします。この許可リストがない場合、AgentCore はトークンを検証しますが、コンテナに到達する前にヘッダーを削除します。
+
+呼び出し元は `Authorization: Bearer <jwt>`（SigV4 なし）で Gateway を呼び出し、エージェントは `Authorization` ヘッダーからクレームを読み取ります。ランタイムのインバウンドオーソライザーがすでにトークンを検証しているため、署名検証はスキップします：
 
 ```python title="packages/py_project/.../my_agent/main.py"
 import jwt  # PyJWT
@@ -195,82 +201,8 @@ async def invoke(input: InvokeInput, request: Request):
     # authorize on claims['sub'], claims['scope'], ...
 ```
 
-<Infrastructure>
-<Fragment slot="cdk">
-`requestHeaderConfiguration` をエージェントに渡してランタイムがヘッダーを受信できるようにし、（`gateway.addAgent(agent)` の代わりに）`JWT_PASSTHROUGH` 認証情報プロバイダーでターゲットを自分で作成します：
-
-```ts title="packages/infra/src/stacks/application-stack.ts" {5-7,17-19}
-import { CfnGatewayTarget } from 'aws-cdk-lib/aws-bedrockagentcore';
-import { PolicyStatement } from 'aws-cdk-lib/aws-iam';
-
-const myAgent = new MyAgent(this, 'MyAgent', {
-  identity,
-  // ランタイムが転送された Authorization ヘッダーを受信できるようにします。
-  requestHeaderConfiguration: { allowlistedHeaders: ['Authorization'] },
-});
-const myGateway = new MyGateway(this, 'MyGateway', { identity });
-
-const target = new CfnGatewayTarget(this, 'Target-my-agent', {
-  gatewayIdentifier: myGateway.gateway.gatewayId,
-  name: myAgent.agentName,
-  targetConfiguration: {
-    http: { agentcoreRuntime: { arn: myAgent.agentCoreRuntime.agentRuntimeArn } },
-  },
-  // 呼び出し元の検証済み JWT を変更せずにランタイムに転送します。
-  credentialProviderConfigurations: [
-    { credentialProviderType: 'JWT_PASSTHROUGH' },
-  ],
-});
-
-// Gateway ロールには引き続きランタイムへの呼び出しアクセスが必要です。
-myGateway.gateway.role.addToPrincipalPolicy(
-  new PolicyStatement({
-    actions: ['bedrock-agentcore:InvokeAgentRuntime'],
-    resources: [
-      myAgent.agentCoreRuntime.agentRuntimeArn,
-      `${myAgent.agentCoreRuntime.agentRuntimeArn}/*`,
-    ],
-  }),
-);
-```
-</Fragment>
-<Fragment slot="terraform">
-ランタイムがヘッダーを受信できるように `request_header_configuration` ブロックをランタイムに追加し、（`gateway_iam_role {}` の代わりに）`JWT_PASSTHROUGH` 認証情報プロバイダーでターゲットを構成します：
-
-```hcl title="packages/infra/src/main.tf" {5-7,20-22}
-# ランタイムが転送された Authorization ヘッダーを受信できるようにします。このブロックを
-# エージェントモジュール（packages/common/terraform/...）のランタイムリソースに追加します。
-resource "aws_bedrockagentcore_agent_runtime" "agent_runtime" {
-  # ...
-  request_header_configuration {
-    request_header_allowlist = ["Authorization"]
-  }
-}
-
-resource "aws_bedrockagentcore_gateway_target" "my_agent" {
-  gateway_identifier = module.my_gateway.gateway_id
-  name               = "my-agent"
-  description        = "Agent runtime target my-agent"
-
-  target_configuration {
-    http {
-      agentcore_runtime {
-        arn = module.my_agent.agent_core_runtime_arn
-      }
-    }
-  }
-
-  # 呼び出し元の検証済み JWT を変更せずにランタイムに転送します。
-  credential_provider_configuration {
-    credential_provider_type = "JWT_PASSTHROUGH"
-  }
-}
-```
-</Fragment>
-</Infrastructure>
-
 :::note
-`JWT_PASSTHROUGH` は、トークンオーディエンスがすでにランタイムをカバーしている単一の ID プロバイダーに適しています。1 つの Gateway が複数のテナントやオーディエンスにまたがるエージェントを前段に配置する場合は、代わりに OAuth [on-behalf-of トークン交換](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/gateway-building-adding-targets-authorization.html)を使用してください。
+JWT パススルーは、トークンオーディエンスがすでにランタイムをカバーしている単一の ID プロバイダーに適しています。1 つの Gateway が複数のテナントやオーディエンスにまたがるエージェントを前段に配置する場合は、代わりに OAuth [on-behalf-of トークン交換](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/gateway-building-adding-targets-authorization.html)を使用してください。
 :::
 
 ## ローカル開発

--- a/docs/src/content/docs/ko/guides/connection/agentcore-gateway-agent.mdx
+++ b/docs/src/content/docs/ko/guides/connection/agentcore-gateway-agent.mdx
@@ -23,7 +23,7 @@ import Infrastructure from '@components/infrastructure.astro';
 이 제너레이터를 사용하기 전에 다음을 확인하세요:
 
 1. `protocol: http`로 생성된 <Link path="guides/agentcore-gateway">`agentcore-gateway`</Link> 프로젝트
-2. `infra: agentcore` 및 `auth: iam`으로 생성된 에이전트 컴포넌트(<Link path="guides/ts-agent">`ts#agent`</Link> 또는 <Link path="guides/py-agent">`py#agent`</Link>)
+2. `infra: agentcore`로 생성된 에이전트 컴포넌트(<Link path="guides/ts-agent">`ts#agent`</Link> 또는 <Link path="guides/py-agent">`py#agent`</Link>). `auth: iam`(Gateway가 자체 역할로 호출) 또는 `auth: cognito`(Gateway가 호출자의 JWT를 전달 — [호출자 신원을 런타임으로 전달하기](#forwarding-caller-identity-to-the-runtime) 참조) 모두 작동합니다.
 
 :::caution[TypeScript HTTP 에이전트]
 TypeScript `http` 에이전트는 WebSocket을 통해 tRPC를 제공하며, AgentCore Gateway는 WebSocket 또는 양방향 스트리밍을 지원하지 않습니다. 제너레이터는 이 조합을 거부합니다. 대신 `ag-ui` 프로토콜로 에이전트를 생성하세요.
@@ -176,13 +176,19 @@ egress가 있는 프라이빗 서브넷(NAT 게이트웨이로의 라우트)을 
 
 ## 호출자 신원을 런타임으로 전달하기
 
-기본적으로 Gateway는 자체 IAM 역할(`GATEWAY_IAM_ROLE` 자격 증명 공급자)로 아웃바운드 호출에 서명하므로 런타임은 호출자가 아닌 _Gateway의_ 신원을 봅니다. 에이전트가 호출자를 기반으로 권한을 부여하도록 하려면(예: 사용자의 `sub` 또는 `scope` 클레임을 읽기 위해) Gateway는 대신 호출자의 JWT를 변경하지 않고 런타임으로 전달할 수 있습니다. 이를 위해서는 세 가지 변경이 필요합니다:
+기본적으로 Gateway는 자체 IAM 역할(`GATEWAY_IAM_ROLE` 자격 증명 공급자)로 아웃바운드 호출에 서명하므로 런타임은 호출자가 아닌 _Gateway의_ 신원을 봅니다. 대신 에이전트가 호출자를 기반으로 권한을 부여하도록 하려면(예: 사용자의 `sub` 또는 `scope` 클레임을 읽기 위해) **Cognito** 에이전트를 **Cognito** Gateway로 프론트하세요. 그러면 Gateway가 호출자의 JWT를 변경하지 않고 런타임으로 전달하고(`JWT_PASSTHROUGH` 자격 증명 공급자), 런타임이 이를 재검증합니다.
 
-1. **Gateway가 JWT를 수락합니다.** Gateway를 `auth: cognito`로 생성하여 인바운드 권한 부여자가 Cognito(또는 다른 OIDC) 베어러 토큰을 검증하도록 합니다.
-2. **런타임이 동일한 JWT를 수락합니다.** 에이전트를 `auth: cognito`(동일한 사용자 풀)로 생성하여 런타임이 전달된 토큰을 재검증하도록 합니다.
-3. **대상이 `GATEWAY_IAM_ROLE` 대신 `JWT_PASSTHROUGH` 자격 증명 공급자를 사용하고**, **런타임이 `Authorization` 헤더를 허용 목록에 추가**하여 에이전트 코드에 도달하도록 합니다. 허용 목록이 없으면 AgentCore는 토큰을 검증하지만 컨테이너 이전에 헤더를 제거합니다.
+위와 같이 양쪽 끝을 `auth: cognito`로 생성하고 연결합니다:
 
-그러면 호출자는 `Authorization: Bearer <jwt>`(SigV4 없음)로 Gateway를 호출하고, 에이전트는 `Authorization` 헤더에서 클레임을 읽습니다. 런타임의 인바운드 권한 부여자가 이미 토큰을 검증했으므로 서명 검증을 건너뜁니다:
+- `auth: cognito`로 생성된 에이전트(<Link path="guides/ts-agent">`ts#agent`</Link> 또는 <Link path="guides/py-agent">`py#agent`</Link>), 그리고
+- **동일한** Cognito 사용자 풀을 프론트하는 `auth: cognito`로 생성된 Gateway.
+
+나머지는 모두 자동입니다 — `gateway.addAgent(agent)`(CDK) 및 생성된 Terraform 런타임 모듈이 에이전트의 `auth`를 기반으로 연결을 처리합니다:
+
+- 대상은 `JWT_PASSTHROUGH` 자격 증명 공급자(`GATEWAY_IAM_ROLE` 대신)로 생성되고,
+- 런타임은 `Authorization` 헤더를 허용 목록에 추가하여 전달된 토큰이 에이전트 코드에 도달하도록 합니다. 이 허용 목록이 없으면 AgentCore는 토큰을 검증하지만 컨테이너 이전에 헤더를 제거합니다.
+
+호출자는 `Authorization: Bearer <jwt>`(SigV4 없음)로 Gateway를 호출하고, 에이전트는 `Authorization` 헤더에서 클레임을 읽습니다. 런타임의 인바운드 권한 부여자가 이미 토큰을 검증했으므로 서명 검증을 건너뜁니다:
 
 ```python title="packages/py_project/.../my_agent/main.py"
 import jwt  # PyJWT
@@ -194,82 +200,8 @@ async def invoke(input: InvokeInput, request: Request):
     # authorize on claims['sub'], claims['scope'], ...
 ```
 
-<Infrastructure>
-<Fragment slot="cdk">
-에이전트에 `requestHeaderConfiguration`을 전달하여 런타임이 헤더를 수신하도록 하고, `JWT_PASSTHROUGH` 자격 증명 공급자로 대상을 직접 생성합니다(`gateway.addAgent(agent)` 대신):
-
-```ts title="packages/infra/src/stacks/application-stack.ts" {5-7,17-19}
-import { CfnGatewayTarget } from 'aws-cdk-lib/aws-bedrockagentcore';
-import { PolicyStatement } from 'aws-cdk-lib/aws-iam';
-
-const myAgent = new MyAgent(this, 'MyAgent', {
-  identity,
-  // 런타임이 전달된 Authorization 헤더를 수신하도록 합니다.
-  requestHeaderConfiguration: { allowlistedHeaders: ['Authorization'] },
-});
-const myGateway = new MyGateway(this, 'MyGateway', { identity });
-
-const target = new CfnGatewayTarget(this, 'Target-my-agent', {
-  gatewayIdentifier: myGateway.gateway.gatewayId,
-  name: myAgent.agentName,
-  targetConfiguration: {
-    http: { agentcoreRuntime: { arn: myAgent.agentCoreRuntime.agentRuntimeArn } },
-  },
-  // 호출자의 검증된 JWT를 변경하지 않고 런타임으로 전달합니다.
-  credentialProviderConfigurations: [
-    { credentialProviderType: 'JWT_PASSTHROUGH' },
-  ],
-});
-
-// Gateway 역할은 여전히 런타임에 대한 호출 액세스가 필요합니다.
-myGateway.gateway.role.addToPrincipalPolicy(
-  new PolicyStatement({
-    actions: ['bedrock-agentcore:InvokeAgentRuntime'],
-    resources: [
-      myAgent.agentCoreRuntime.agentRuntimeArn,
-      `${myAgent.agentCoreRuntime.agentRuntimeArn}/*`,
-    ],
-  }),
-);
-```
-</Fragment>
-<Fragment slot="terraform">
-런타임이 헤더를 수신하도록 런타임에 `request_header_configuration` 블록을 추가하고, `JWT_PASSTHROUGH` 자격 증명 공급자로 대상을 구성합니다(`gateway_iam_role {}` 대신):
-
-```hcl title="packages/infra/src/main.tf" {5-7,20-22}
-# 런타임이 전달된 Authorization 헤더를 수신하도록 합니다. 이 블록을
-# 에이전트 모듈의 런타임 리소스에 추가합니다(packages/common/terraform/...).
-resource "aws_bedrockagentcore_agent_runtime" "agent_runtime" {
-  # ...
-  request_header_configuration {
-    request_header_allowlist = ["Authorization"]
-  }
-}
-
-resource "aws_bedrockagentcore_gateway_target" "my_agent" {
-  gateway_identifier = module.my_gateway.gateway_id
-  name               = "my-agent"
-  description        = "Agent runtime target my-agent"
-
-  target_configuration {
-    http {
-      agentcore_runtime {
-        arn = module.my_agent.agent_core_runtime_arn
-      }
-    }
-  }
-
-  # 호출자의 검증된 JWT를 변경하지 않고 런타임으로 전달합니다.
-  credential_provider_configuration {
-    credential_provider_type = "JWT_PASSTHROUGH"
-  }
-}
-```
-</Fragment>
-</Infrastructure>
-
 :::note
-`JWT_PASSTHROUGH`는 토큰 대상이 이미 런타임을 포함하는 단일 신원 공급자에 적합합니다. 하나의 Gateway가 여러 테넌트 또는 대상에 걸쳐 에이전트를 프론트하는 경우 대신 OAuth [on-behalf-of 토큰 교환](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/gateway-building-adding-targets-authorization.html)을 사용하세요.
+JWT 패스스루는 토큰 대상이 이미 런타임을 포함하는 단일 신원 공급자에 적합합니다. 하나의 Gateway가 여러 테넌트 또는 대상에 걸쳐 에이전트를 프론트하는 경우 대신 OAuth [on-behalf-of 토큰 교환](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/gateway-building-adding-targets-authorization.html)을 사용하세요.
 :::
 
 ## 로컬 개발

--- a/docs/src/content/docs/pt/guides/connection/agentcore-gateway-agent.mdx
+++ b/docs/src/content/docs/pt/guides/connection/agentcore-gateway-agent.mdx
@@ -23,7 +23,7 @@ Uma vez conectado, o Gateway faz proxy das requisições para o agente em `<gate
 Antes de usar este gerador, certifique-se de ter:
 
 1. Um projeto <Link path="guides/agentcore-gateway">`agentcore-gateway`</Link> gerado com `protocol: http`
-2. Um componente de agente (<Link path="guides/ts-agent">`ts#agent`</Link> ou <Link path="guides/py-agent">`py#agent`</Link>) criado com `infra: agentcore` e `auth: iam`
+2. Um componente de agente (<Link path="guides/ts-agent">`ts#agent`</Link> ou <Link path="guides/py-agent">`py#agent`</Link>) criado com `infra: agentcore`. Tanto `auth: iam` (o Gateway o invoca com sua própria função) quanto `auth: cognito` (o Gateway encaminha o JWT do chamador — veja [Encaminhando a identidade do chamador para o runtime](#encaminhando-a-identidade-do-chamador-para-o-runtime)) funcionam.
 
 :::caution[Agentes HTTP TypeScript]
 Um agente `http` TypeScript serve tRPC sobre WebSocket, e o AgentCore Gateway não suporta WebSocket ou streaming bidirecional — o gerador rejeita essa combinação. Gere o agente com o protocolo `ag-ui` em vez disso.
@@ -177,13 +177,19 @@ Para conectar um website aos agentes do Gateway, use o <Link path="guides/connec
 
 ## Encaminhando a identidade do chamador para o runtime
 
-Por padrão, o Gateway assina chamadas de saída com sua própria função IAM (o provedor de credenciais `GATEWAY_IAM_ROLE`), então o runtime vê a identidade do _Gateway_, não a do chamador. Se você quiser que o agente autorize com base no chamador — por exemplo, para ler as claims `sub` ou `scope` do usuário — o Gateway pode, em vez disso, encaminhar o JWT do chamador para o runtime sem alterações. Isso requer três mudanças:
+Por padrão, o Gateway assina chamadas de saída com sua própria função IAM (o provedor de credenciais `GATEWAY_IAM_ROLE`), então o runtime vê a identidade do _Gateway_, não a do chamador. Se, em vez disso, você quiser que o agente autorize com base no chamador — por exemplo, para ler as claims `sub` ou `scope` do usuário — coloque um agente **Cognito** atrás de um Gateway **Cognito**. O Gateway então encaminha o JWT do chamador para o runtime sem alterações (o provedor de credenciais `JWT_PASSTHROUGH`), e o runtime o revalida.
 
-1. **O Gateway aceita JWTs.** Gere o Gateway com `auth: cognito` para que seu autorizador de entrada valide um token bearer do Cognito (ou outro OIDC).
-2. **O runtime aceita os mesmos JWTs.** Gere o agente com `auth: cognito` (mesmo user pool) para que o runtime revalide o token encaminhado.
-3. **O destino usa o provedor de credenciais `JWT_PASSTHROUGH`** em vez de `GATEWAY_IAM_ROLE`, e o **runtime coloca o cabeçalho `Authorization` na lista de permissões** para que ele chegue ao código do seu agente. Sem a lista de permissões, o AgentCore valida o token mas remove o cabeçalho antes do seu contêiner.
+Gere ambas as extremidades com `auth: cognito` e conecte-as como acima:
 
-Os chamadores então invocam o Gateway com `Authorization: Bearer <jwt>` (sem SigV4), e o agente lê as claims do cabeçalho `Authorization` — pulando a validação de assinatura, já que o autorizador de entrada do runtime já verificou o token:
+- um agente (<Link path="guides/ts-agent">`ts#agent`</Link> ou <Link path="guides/py-agent">`py#agent`</Link>) criado com `auth: cognito`, e
+- um Gateway criado com `auth: cognito` fronteando o **mesmo** user pool do Cognito.
+
+Todo o resto é automático — `gateway.addAgent(agent)` (CDK) e o módulo de runtime Terraform gerado cuidam da conexão para você com base no `auth` do agente:
+
+- o destino é criado com o provedor de credenciais `JWT_PASSTHROUGH` (em vez de `GATEWAY_IAM_ROLE`), e
+- o runtime coloca o cabeçalho `Authorization` na lista de permissões para que o token encaminhado chegue ao código do seu agente. Sem essa lista de permissões, o AgentCore valida o token mas remove o cabeçalho antes do seu contêiner.
+
+Os chamadores invocam o Gateway com `Authorization: Bearer <jwt>` (sem SigV4), e o agente lê as claims do cabeçalho `Authorization` — pulando a validação de assinatura, já que o autorizador de entrada do runtime já verificou o token:
 
 ```python title="packages/py_project/.../my_agent/main.py"
 import jwt  # PyJWT
@@ -195,82 +201,8 @@ async def invoke(input: InvokeInput, request: Request):
     # authorize on claims['sub'], claims['scope'], ...
 ```
 
-<Infrastructure>
-<Fragment slot="cdk">
-Passe `requestHeaderConfiguration` para o agente para que o runtime receba o cabeçalho, e crie o destino você mesmo (em vez de `gateway.addAgent(agent)`) com o provedor de credenciais `JWT_PASSTHROUGH`:
-
-```ts title="packages/infra/src/stacks/application-stack.ts" {5-7,17-19}
-import { CfnGatewayTarget } from 'aws-cdk-lib/aws-bedrockagentcore';
-import { PolicyStatement } from 'aws-cdk-lib/aws-iam';
-
-const myAgent = new MyAgent(this, 'MyAgent', {
-  identity,
-  // Let the runtime receive the forwarded Authorization header.
-  requestHeaderConfiguration: { allowlistedHeaders: ['Authorization'] },
-});
-const myGateway = new MyGateway(this, 'MyGateway', { identity });
-
-const target = new CfnGatewayTarget(this, 'Target-my-agent', {
-  gatewayIdentifier: myGateway.gateway.gatewayId,
-  name: myAgent.agentName,
-  targetConfiguration: {
-    http: { agentcoreRuntime: { arn: myAgent.agentCoreRuntime.agentRuntimeArn } },
-  },
-  // Forward the caller's validated JWT to the runtime unchanged.
-  credentialProviderConfigurations: [
-    { credentialProviderType: 'JWT_PASSTHROUGH' },
-  ],
-});
-
-// The Gateway role still needs invoke access to the runtime.
-myGateway.gateway.role.addToPrincipalPolicy(
-  new PolicyStatement({
-    actions: ['bedrock-agentcore:InvokeAgentRuntime'],
-    resources: [
-      myAgent.agentCoreRuntime.agentRuntimeArn,
-      `${myAgent.agentCoreRuntime.agentRuntimeArn}/*`,
-    ],
-  }),
-);
-```
-</Fragment>
-<Fragment slot="terraform">
-Adicione um bloco `request_header_configuration` ao runtime para que ele receba o cabeçalho, e configure o destino com o provedor de credenciais `JWT_PASSTHROUGH` (em vez de `gateway_iam_role {}`):
-
-```hcl title="packages/infra/src/main.tf" {5-7,20-22}
-# Let the runtime receive the forwarded Authorization header. Add this block
-# to the runtime resource in the agent module (packages/common/terraform/...).
-resource "aws_bedrockagentcore_agent_runtime" "agent_runtime" {
-  # ...
-  request_header_configuration {
-    request_header_allowlist = ["Authorization"]
-  }
-}
-
-resource "aws_bedrockagentcore_gateway_target" "my_agent" {
-  gateway_identifier = module.my_gateway.gateway_id
-  name               = "my-agent"
-  description        = "Agent runtime target my-agent"
-
-  target_configuration {
-    http {
-      agentcore_runtime {
-        arn = module.my_agent.agent_core_runtime_arn
-      }
-    }
-  }
-
-  # Forward the caller's validated JWT to the runtime unchanged.
-  credential_provider_configuration {
-    credential_provider_type = "JWT_PASSTHROUGH"
-  }
-}
-```
-</Fragment>
-</Infrastructure>
-
 :::note
-`JWT_PASSTHROUGH` é adequado para um único provedor de identidade cujo audience do token já cobre o runtime. Se um Gateway frontaliza agentes em múltiplos tenants ou audiences, use a [troca de token on-behalf-of](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/gateway-building-adding-targets-authorization.html) do OAuth em vez disso.
+O passthrough de JWT é adequado para um único provedor de identidade cujo audience do token já cobre o runtime. Se um Gateway frontaliza agentes em múltiplos tenants ou audiences, use a [troca de token on-behalf-of](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/gateway-building-adding-targets-authorization.html) do OAuth em vez disso.
 :::
 
 ## Desenvolvimento Local

--- a/docs/src/content/docs/vi/guides/connection/agentcore-gateway-agent.mdx
+++ b/docs/src/content/docs/vi/guides/connection/agentcore-gateway-agent.mdx
@@ -23,7 +23,7 @@ Sau khi kết nối, Gateway sẽ proxy các yêu cầu cho agent dưới đư�
 Trước khi sử dụng generator này, hãy đảm bảo bạn có:
 
 1. Một dự án <Link path="guides/agentcore-gateway">`agentcore-gateway`</Link> được tạo với `protocol: http`
-2. Một agent component (<Link path="guides/ts-agent">`ts#agent`</Link> hoặc <Link path="guides/py-agent">`py#agent`</Link>) được tạo với `infra: agentcore` và `auth: iam`
+2. Một agent component (<Link path="guides/ts-agent">`ts#agent`</Link> hoặc <Link path="guides/py-agent">`py#agent`</Link>) được tạo với `infra: agentcore`. Cả `auth: iam` (Gateway gọi nó bằng role của chính nó) hoặc `auth: cognito` (Gateway chuyển tiếp JWT của người gọi — xem [Chuyển tiếp danh tính người gọi đến runtime](#forwarding-caller-identity-to-the-runtime)) đều hoạt động.
 
 :::caution[TypeScript HTTP agents]
 Một agent TypeScript `http` phục vụ tRPC qua WebSocket, và AgentCore Gateway không hỗ trợ WebSocket hoặc bidirectional streaming — generator sẽ từ chối kết hợp này. Hãy tạo agent với giao thức `ag-ui` thay thế.
@@ -177,13 +177,19 @@ Các yêu cầu đến `<gatewayUrl origin>/<targetName>/invocations` được c
 
 ## Chuyển tiếp danh tính người gọi đến runtime
 
-Theo mặc định, Gateway ký các lệnh gọi đi ra bằng IAM role của chính nó (credential provider `GATEWAY_IAM_ROLE`), do đó runtime thấy danh tính của _Gateway_, không phải của người gọi. Nếu bạn muốn agent ủy quyền dựa trên người gọi — ví dụ để đọc các claim `sub` hoặc `scope` của người dùng — Gateway có thể chuyển tiếp JWT của người gọi đến runtime mà không thay đổi. Điều này yêu cầu ba thay đổi:
+Theo mặc định, Gateway ký các lệnh gọi đi ra bằng IAM role của chính nó (credential provider `GATEWAY_IAM_ROLE`), do đó runtime thấy danh tính của _Gateway_, không phải của người gọi. Nếu thay vào đó bạn muốn agent ủy quyền dựa trên người gọi — ví dụ để đọc các claim `sub` hoặc `scope` của người dùng — hãy đặt một agent **Cognito** phía sau một Gateway **Cognito**. Gateway sau đó sẽ chuyển tiếp JWT của người gọi đến runtime mà không thay đổi (credential provider `JWT_PASSTHROUGH`), và runtime xác thực lại nó.
 
-1. **Gateway chấp nhận JWT.** Tạo Gateway với `auth: cognito` để inbound authorizer của nó xác thực bearer token Cognito (hoặc OIDC khác).
-2. **Runtime chấp nhận cùng JWT.** Tạo agent với `auth: cognito` (cùng user pool) để runtime xác thực lại token được chuyển tiếp.
-3. **Target sử dụng credential provider `JWT_PASSTHROUGH`** thay vì `GATEWAY_IAM_ROLE`, và **runtime cho phép header `Authorization`** để nó đến được mã agent của bạn. Không có allowlist, AgentCore xác thực token nhưng loại bỏ header trước khi đến container của bạn.
+Tạo cả hai đầu với `auth: cognito` và kết nối chúng như trên:
 
-Sau đó người gọi invoke Gateway với `Authorization: Bearer <jwt>` (không có SigV4), và agent đọc các claim từ header `Authorization` — bỏ qua xác thực chữ ký, vì inbound authorizer của runtime đã xác minh token:
+- một agent (<Link path="guides/ts-agent">`ts#agent`</Link> hoặc <Link path="guides/py-agent">`py#agent`</Link>) được tạo với `auth: cognito`, và
+- một Gateway được tạo với `auth: cognito` đứng trước **cùng** Cognito user pool.
+
+Mọi thứ khác đều tự động — `gateway.addAgent(agent)` (CDK) và module runtime Terraform được tạo sẽ xử lý việc kết nối cho bạn dựa trên `auth` của agent:
+
+- target được tạo với credential provider `JWT_PASSTHROUGH` (thay vì `GATEWAY_IAM_ROLE`), và
+- runtime cho phép header `Authorization` để token được chuyển tiếp đến được mã agent của bạn. Không có allowlist này, AgentCore xác thực token nhưng loại bỏ header trước khi đến container của bạn.
+
+Người gọi invoke Gateway với `Authorization: Bearer <jwt>` (không có SigV4), và agent đọc các claim từ header `Authorization` — bỏ qua xác thực chữ ký, vì inbound authorizer của runtime đã xác minh token:
 
 ```python title="packages/py_project/.../my_agent/main.py"
 import jwt  # PyJWT
@@ -195,82 +201,8 @@ async def invoke(input: InvokeInput, request: Request):
     # authorize on claims['sub'], claims['scope'], ...
 ```
 
-<Infrastructure>
-<Fragment slot="cdk">
-Truyền `requestHeaderConfiguration` cho agent để runtime nhận được header, và tự tạo target (thay vì `gateway.addAgent(agent)`) với credential provider `JWT_PASSTHROUGH`:
-
-```ts title="packages/infra/src/stacks/application-stack.ts" {5-7,17-19}
-import { CfnGatewayTarget } from 'aws-cdk-lib/aws-bedrockagentcore';
-import { PolicyStatement } from 'aws-cdk-lib/aws-iam';
-
-const myAgent = new MyAgent(this, 'MyAgent', {
-  identity,
-  // Let the runtime receive the forwarded Authorization header.
-  requestHeaderConfiguration: { allowlistedHeaders: ['Authorization'] },
-});
-const myGateway = new MyGateway(this, 'MyGateway', { identity });
-
-const target = new CfnGatewayTarget(this, 'Target-my-agent', {
-  gatewayIdentifier: myGateway.gateway.gatewayId,
-  name: myAgent.agentName,
-  targetConfiguration: {
-    http: { agentcoreRuntime: { arn: myAgent.agentCoreRuntime.agentRuntimeArn } },
-  },
-  // Forward the caller's validated JWT to the runtime unchanged.
-  credentialProviderConfigurations: [
-    { credentialProviderType: 'JWT_PASSTHROUGH' },
-  ],
-});
-
-// The Gateway role still needs invoke access to the runtime.
-myGateway.gateway.role.addToPrincipalPolicy(
-  new PolicyStatement({
-    actions: ['bedrock-agentcore:InvokeAgentRuntime'],
-    resources: [
-      myAgent.agentCoreRuntime.agentRuntimeArn,
-      `${myAgent.agentCoreRuntime.agentRuntimeArn}/*`,
-    ],
-  }),
-);
-```
-</Fragment>
-<Fragment slot="terraform">
-Thêm block `request_header_configuration` vào runtime để nó nhận được header, và cấu hình target với credential provider `JWT_PASSTHROUGH` (thay vì `gateway_iam_role {}`):
-
-```hcl title="packages/infra/src/main.tf" {5-7,20-22}
-# Let the runtime receive the forwarded Authorization header. Add this block
-# to the runtime resource in the agent module (packages/common/terraform/...).
-resource "aws_bedrockagentcore_agent_runtime" "agent_runtime" {
-  # ...
-  request_header_configuration {
-    request_header_allowlist = ["Authorization"]
-  }
-}
-
-resource "aws_bedrockagentcore_gateway_target" "my_agent" {
-  gateway_identifier = module.my_gateway.gateway_id
-  name               = "my-agent"
-  description        = "Agent runtime target my-agent"
-
-  target_configuration {
-    http {
-      agentcore_runtime {
-        arn = module.my_agent.agent_core_runtime_arn
-      }
-    }
-  }
-
-  # Forward the caller's validated JWT to the runtime unchanged.
-  credential_provider_configuration {
-    credential_provider_type = "JWT_PASSTHROUGH"
-  }
-}
-```
-</Fragment>
-</Infrastructure>
-
 :::note
-`JWT_PASSTHROUGH` phù hợp với một identity provider duy nhất có token audience đã bao phủ runtime. Nếu một Gateway đứng trước các agent trên nhiều tenant hoặc audience, hãy sử dụng OAuth [on-behalf-of token exchange](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/gateway-building-adding-targets-authorization.html) thay thế.
+JWT passthrough phù hợp với một identity provider duy nhất có token audience đã bao phủ runtime. Nếu một Gateway đứng trước các agent trên nhiều tenant hoặc audience, hãy sử dụng OAuth [on-behalf-of token exchange](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/gateway-building-adding-targets-authorization.html) thay thế.
 :::
 
 ## Phát triển cục bộ

--- a/docs/src/content/docs/zh/guides/connection/agentcore-gateway-agent.mdx
+++ b/docs/src/content/docs/zh/guides/connection/agentcore-gateway-agent.mdx
@@ -23,7 +23,7 @@ import Infrastructure from '@components/infrastructure.astro';
 在使用此生成器之前，请确保您具备：
 
 1. 使用 `protocol: http` 生成的 <Link path="guides/agentcore-gateway">`agentcore-gateway`</Link> 项目
-2. 使用 `infra: agentcore` 和 `auth: iam` 创建的代理组件（<Link path="guides/ts-agent">`ts#agent`</Link> 或 <Link path="guides/py-agent">`py#agent`</Link>）
+2. 使用 `infra: agentcore` 创建的代理组件（<Link path="guides/ts-agent">`ts#agent`</Link> 或 <Link path="guides/py-agent">`py#agent`</Link>）。`auth: iam`（Gateway 使用自己的角色调用它）或 `auth: cognito`（Gateway 转发调用者的 JWT——参见[将调用者身份转发到运行时](#forwarding-caller-identity-to-the-runtime)）都可以使用。
 
 :::caution[TypeScript HTTP 代理]
 TypeScript `http` 代理通过 WebSocket 提供 tRPC 服务，而 AgentCore Gateway 不支持 WebSocket 或双向流——生成器会拒绝此组合。请改用 `ag-ui` 协议生成代理。
@@ -177,13 +177,19 @@ module "my_agent" {
 
 ## 将调用者身份转发到运行时
 
-默认情况下，Gateway 使用自己的 IAM 角色（`GATEWAY_IAM_ROLE` 凭证提供程序）对出站调用进行签名，因此运行时看到的是 _Gateway 的_身份，而不是调用者的身份。如果您希望代理基于调用者进行授权——例如读取用户的 `sub` 或 `scope` 声明——Gateway 可以将调用者的 JWT 原封不动地转发到运行时。这需要三个更改：
+默认情况下，Gateway 使用自己的 IAM 角色（`GATEWAY_IAM_ROLE` 凭证提供程序）对出站调用进行签名，因此运行时看到的是 _Gateway 的_身份，而不是调用者的身份。如果您希望代理基于调用者进行授权——例如读取用户的 `sub` 或 `scope` 声明——请使用 **Cognito** Gateway 前置 **Cognito** 代理。然后 Gateway 会将调用者的 JWT 原封不动地转发到运行时（`JWT_PASSTHROUGH` 凭证提供程序），运行时会重新验证它。
 
-1. **Gateway 接受 JWT。** 使用 `auth: cognito` 生成 Gateway，以便其入站授权器验证 Cognito（或其他 OIDC）bearer 令牌。
-2. **运行时接受相同的 JWT。** 使用 `auth: cognito`（相同的用户池）生成代理，以便运行时重新验证转发的令牌。
-3. **目标使用 `JWT_PASSTHROUGH` 凭证提供程序**而不是 `GATEWAY_IAM_ROLE`，并且**运行时将 `Authorization` 标头列入允许列表**，以便它到达您的代理代码。如果没有允许列表，AgentCore 会验证令牌但在到达您的容器之前剥离标头。
+使用 `auth: cognito` 生成两端并按上述方式连接它们：
 
-然后，调用者使用 `Authorization: Bearer <jwt>`（无 SigV4）调用 Gateway，代理从 `Authorization` 标头读取声明——跳过签名验证，因为运行时的入站授权器已经验证了令牌：
+- 使用 `auth: cognito` 创建的代理（<Link path="guides/ts-agent">`ts#agent`</Link> 或 <Link path="guides/py-agent">`py#agent`</Link>），以及
+- 使用 `auth: cognito` 创建的 Gateway，前置**相同的** Cognito 用户池。
+
+其他一切都是自动的——`gateway.addAgent(agent)`（CDK）和生成的 Terraform 运行时模块会根据代理的 `auth` 为您处理连接：
+
+- 目标使用 `JWT_PASSTHROUGH` 凭证提供程序（而不是 `GATEWAY_IAM_ROLE`）创建，并且
+- 运行时将 `Authorization` 标头列入允许列表，以便转发的令牌到达您的代理代码。如果没有此允许列表，AgentCore 会验证令牌但在到达您的容器之前剥离标头。
+
+调用者使用 `Authorization: Bearer <jwt>`（无 SigV4）调用 Gateway，代理从 `Authorization` 标头读取声明——跳过签名验证，因为运行时的入站授权器已经验证了令牌：
 
 ```python title="packages/py_project/.../my_agent/main.py"
 import jwt  # PyJWT
@@ -195,82 +201,8 @@ async def invoke(input: InvokeInput, request: Request):
     # authorize on claims['sub'], claims['scope'], ...
 ```
 
-<Infrastructure>
-<Fragment slot="cdk">
-将 `requestHeaderConfiguration` 传递给代理，以便运行时接收标头，并自己创建目标（而不是 `gateway.addAgent(agent)`），使用 `JWT_PASSTHROUGH` 凭证提供程序：
-
-```ts title="packages/infra/src/stacks/application-stack.ts" {5-7,17-19}
-import { CfnGatewayTarget } from 'aws-cdk-lib/aws-bedrockagentcore';
-import { PolicyStatement } from 'aws-cdk-lib/aws-iam';
-
-const myAgent = new MyAgent(this, 'MyAgent', {
-  identity,
-  // Let the runtime receive the forwarded Authorization header.
-  requestHeaderConfiguration: { allowlistedHeaders: ['Authorization'] },
-});
-const myGateway = new MyGateway(this, 'MyGateway', { identity });
-
-const target = new CfnGatewayTarget(this, 'Target-my-agent', {
-  gatewayIdentifier: myGateway.gateway.gatewayId,
-  name: myAgent.agentName,
-  targetConfiguration: {
-    http: { agentcoreRuntime: { arn: myAgent.agentCoreRuntime.agentRuntimeArn } },
-  },
-  // Forward the caller's validated JWT to the runtime unchanged.
-  credentialProviderConfigurations: [
-    { credentialProviderType: 'JWT_PASSTHROUGH' },
-  ],
-});
-
-// The Gateway role still needs invoke access to the runtime.
-myGateway.gateway.role.addToPrincipalPolicy(
-  new PolicyStatement({
-    actions: ['bedrock-agentcore:InvokeAgentRuntime'],
-    resources: [
-      myAgent.agentCoreRuntime.agentRuntimeArn,
-      `${myAgent.agentCoreRuntime.agentRuntimeArn}/*`,
-    ],
-  }),
-);
-```
-</Fragment>
-<Fragment slot="terraform">
-将 `request_header_configuration` 块添加到运行时，以便它接收标头，并使用 `JWT_PASSTHROUGH` 凭证提供程序配置目标（而不是 `gateway_iam_role {}`）：
-
-```hcl title="packages/infra/src/main.tf" {5-7,20-22}
-# Let the runtime receive the forwarded Authorization header. Add this block
-# to the runtime resource in the agent module (packages/common/terraform/...).
-resource "aws_bedrockagentcore_agent_runtime" "agent_runtime" {
-  # ...
-  request_header_configuration {
-    request_header_allowlist = ["Authorization"]
-  }
-}
-
-resource "aws_bedrockagentcore_gateway_target" "my_agent" {
-  gateway_identifier = module.my_gateway.gateway_id
-  name               = "my-agent"
-  description        = "Agent runtime target my-agent"
-
-  target_configuration {
-    http {
-      agentcore_runtime {
-        arn = module.my_agent.agent_core_runtime_arn
-      }
-    }
-  }
-
-  # Forward the caller's validated JWT to the runtime unchanged.
-  credential_provider_configuration {
-    credential_provider_type = "JWT_PASSTHROUGH"
-  }
-}
-```
-</Fragment>
-</Infrastructure>
-
 :::note
-`JWT_PASSTHROUGH` 适用于单个身份提供程序，其令牌受众已经覆盖运行时。如果一个 Gateway 前置跨多个租户或受众的代理，请改用 OAuth [代表令牌交换](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/gateway-building-adding-targets-authorization.html)。
+JWT 透传适用于单个身份提供程序，其令牌受众已经覆盖运行时。如果一个 Gateway 前置跨多个租户或受众的代理，请改用 OAuth [代表令牌交换](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/gateway-building-adding-targets-authorization.html)。
 :::
 
 ## 本地开发

--- a/packages/nx-plugin/src/agentcore-gateway/agent-connection/generator.spec.ts
+++ b/packages/nx-plugin/src/agentcore-gateway/agent-connection/generator.spec.ts
@@ -229,7 +229,7 @@ describe('agentcore-gateway#agent-connection generator', () => {
     ).resolves.toBeDefined();
   });
 
-  it('throws for a non-iam agent', async () => {
+  it('connects a cognito agent (fronted via JWT passthrough)', async () => {
     const gw = addGateway();
     const project = addAgentProject();
 
@@ -239,7 +239,20 @@ describe('agentcore-gateway#agent-connection generator', () => {
         targetProject: project,
         targetComponent: agentComponent({ auth: 'cognito' }) as any,
       }),
-    ).rejects.toThrow(/IAM authentication/);
+    ).resolves.toBeDefined();
+  });
+
+  it('throws for an agent whose auth a gateway cannot front', async () => {
+    const gw = addGateway();
+    const project = addAgentProject();
+
+    await expect(
+      agentcoreGatewayAgentConnectionGenerator(tree, {
+        sourceProject: `@proj/${gw.name}`,
+        targetProject: project,
+        targetComponent: agentComponent({ auth: 'apikey' }) as any,
+      }),
+    ).rejects.toThrow(/gateway cannot front/);
   });
 
   it('throws when the target has no agent component metadata', async () => {

--- a/packages/nx-plugin/src/agentcore-gateway/agent-connection/generator.ts
+++ b/packages/nx-plugin/src/agentcore-gateway/agent-connection/generator.ts
@@ -86,9 +86,14 @@ export const agentcoreGatewayAgentConnectionGenerator = async (
           : `. Supported protocols: ${supportedProtocols.join(', ')}.`),
     );
   }
-  if (agentComponent.auth && agentComponent.auth !== 'iam') {
+  // Both IAM and Cognito agents can be fronted. An IAM agent is invoked with
+  // the gateway's own role (GATEWAY_IAM_ROLE); a Cognito agent has the caller's
+  // JWT forwarded to it (JWT_PASSTHROUGH) so it authorizes on the token. The
+  // vended `addAgent` picks the credential from the agent's `auth`.
+  const agentAuth = (agentComponent.auth as string | undefined) ?? 'iam';
+  if (agentAuth !== 'iam' && agentAuth !== 'cognito') {
     throw new Error(
-      `Agent '${agentComponent.name}' uses auth='${agentComponent.auth}'. Gateway->agent connections currently require the agent to use IAM authentication.`,
+      `Agent '${agentComponent.name}' uses auth='${agentAuth}', which a gateway cannot front. Supported: iam, cognito.`,
     );
   }
 

--- a/packages/nx-plugin/src/migrations/latest/gateway-cognito-passthrough/__snapshots__/migration.spec.ts.snap
+++ b/packages/nx-plugin/src/migrations/latest/gateway-cognito-passthrough/__snapshots__/migration.spec.ts.snap
@@ -1,0 +1,149 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`gateway-cognito-passthrough migration > adds auth=cognito and the Authorization allowlist to a Cognito agent 1`] = `
+"import {
+  Runtime,
+  RuntimeAuthorizerConfiguration,
+} from 'aws-cdk-lib/aws-bedrockagentcore';
+import { Construct } from 'constructs';
+
+export class MyCognitoAgent extends Construct {
+  public readonly agentCoreRuntime: Runtime;
+  /** Default Gateway target name for this agent. */
+  public readonly agentName = 'my-cognito-agent';
+  /** Inbound auth — a fronting Gateway uses this to pick its outbound credential. */
+  public readonly auth = 'cognito';
+
+  constructor(scope: Construct, id: string, props: MyCognitoAgentProps) {
+    super(scope, id);
+    const { identity } = props;
+    this.agentCoreRuntime = new Runtime(this, 'MyCognitoAgent', {
+      authorizerConfiguration: RuntimeAuthorizerConfiguration.usingCognito(
+        identity.userPool,
+        [identity.userPoolClient],
+      ),
+      // Receive the caller's Authorization header (validated by the authorizer).
+      requestHeaderConfiguration: {
+        allowlistedHeaders: ['Authorization'],
+      },
+    });
+  }
+}
+"
+`;
+
+exports[`gateway-cognito-passthrough migration > adds the request_header_configuration block to the terraform runtime 1`] = `
+"resource "aws_bedrockagentcore_agent_runtime" "agent_runtime" {
+  agent_runtime_name = "test"
+
+  dynamic "authorizer_configuration" {
+    for_each = var.authorizer_configuration != null && try(var.authorizer_configuration.custom_jwt_authorizer, null) != null ? [var.authorizer_configuration.custom_jwt_authorizer] : []
+    content {
+      custom_jwt_authorizer {
+        discovery_url    = authorizer_configuration.value.discovery_url
+        allowed_audience = authorizer_configuration.value.allowed_audience
+        allowed_clients  = authorizer_configuration.value.allowed_clients
+      }
+    }
+  }
+
+  # Receive the caller's Authorization header (validated by the JWT authorizer).
+  dynamic "request_header_configuration" {
+    for_each = var.authorizer_configuration != null && try(var.authorizer_configuration.custom_jwt_authorizer, null) != null ? [1] : []
+    content {
+      request_header_allowlist = ["Authorization"]
+    }
+  }
+
+  network_configuration {
+    network_mode = "PUBLIC"
+  }
+}
+"
+`;
+
+exports[`gateway-cognito-passthrough migration > makes the gateway pick the target credential from the agent auth 1`] = `
+"import * as agentcore from 'aws-cdk-lib/aws-bedrockagentcore';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import { Construct } from 'constructs';
+
+export class AgentCoreGateway extends Construct implements iam.IGrantable {
+  public addAgent(
+    agent: Construct & {
+      readonly agentCoreRuntime: agentcore.Runtime;
+      readonly agentName: string;
+      readonly auth?: 'iam' | 'cognito';
+    },
+    props?: {
+      gatewayTargetName?: string;
+    },
+  ): agentcore.CfnGatewayTarget {
+    return this.addAgentTarget({
+      gatewayTargetName: props?.gatewayTargetName ?? agent.agentName,
+      agentRuntimeArn: agent.agentCoreRuntime.agentRuntimeArn,
+      credentials: agent.auth === 'cognito' ? 'jwt-passthrough' : 'gateway-iam',
+    });
+  }
+
+  public addAgentTarget(props: {
+    gatewayTargetName: string;
+    agentRuntimeArn: string;
+    credentials?: 'gateway-iam' | 'jwt-passthrough';
+  }): agentcore.CfnGatewayTarget {
+    const target = new agentcore.CfnGatewayTarget(
+      this,
+      \`Target-\${props.gatewayTargetName}\`,
+      {
+        gatewayIdentifier: this.gateway.gatewayId,
+        name: props.gatewayTargetName,
+        targetConfiguration: {
+          http: {
+            agentcoreRuntime: {
+              arn: props.agentRuntimeArn,
+              qualifier: 'DEFAULT',
+            },
+          },
+        },
+        // The bare gateway IAM role credential: runtime targets reject the
+        // iamCredentialProvider detail MCP targets carry.
+        credentialProviderConfigurations: [
+          {
+            credentialProviderType:
+              props.credentials === 'jwt-passthrough'
+                ? 'JWT_PASSTHROUGH'
+                : 'GATEWAY_IAM_ROLE',
+          },
+        ],
+      },
+    );
+    return target;
+  }
+
+  public addMcpServerTarget(props: {
+    gatewayTargetName: string;
+    mcpServerRuntimeArn: string;
+  }): agentcore.CfnGatewayTarget {
+    const target = new agentcore.CfnGatewayTarget(
+      this,
+      \`Target-\${props.gatewayTargetName}\`,
+      {
+        gatewayIdentifier: this.gateway.gatewayId,
+        name: props.gatewayTargetName,
+        targetConfiguration: {
+          mcp: { openApiSchema: { inlinePayload: 'x' } },
+        },
+        credentialProviderConfigurations: [
+          {
+            credentialProviderType: 'GATEWAY_IAM_ROLE',
+            credentialProvider: {
+              iamCredentialProvider: { service: 'bedrock-agentcore' },
+            },
+          },
+        ],
+      },
+    );
+    return target;
+  }
+}
+"
+`;

--- a/packages/nx-plugin/src/migrations/latest/gateway-cognito-passthrough/metadata.json
+++ b/packages/nx-plugin/src/migrations/latest/gateway-cognito-passthrough/metadata.json
@@ -1,0 +1,3 @@
+{
+  "description": "Front Cognito agents with an AgentCore Gateway via JWT passthrough: addAgent picks the target credential from the agent's auth, agent constructs gain an auth member, and Cognito runtimes allowlist the Authorization header"
+}

--- a/packages/nx-plugin/src/migrations/latest/gateway-cognito-passthrough/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/latest/gateway-cognito-passthrough/migration.spec.ts
@@ -1,0 +1,288 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import type { Tree } from '@nx/devkit';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test';
+import migration from './migration';
+
+const GATEWAY_CONSTRUCT_FILE =
+  'packages/common/constructs/src/core/agentcore-gateway/agentcore-gateway.ts';
+const COGNITO_AGENT_FILE =
+  'packages/common/constructs/src/app/agents/my-cognito-agent/my-cognito-agent.ts';
+const IAM_AGENT_FILE =
+  'packages/common/constructs/src/app/agents/my-iam-agent/my-iam-agent.ts';
+const TF_RUNTIME_FILE =
+  'packages/common/terraform/src/core/agent-core/runtime.tf';
+
+/**
+ * The `AgentCoreGateway` construct as generated with agent-target support but
+ * before Cognito JWT passthrough — condensed to the shapes the migration edits:
+ * the addAgent param, the addAgent->addAgentTarget call, the addAgentTarget
+ * signature, and the target credential provider.
+ */
+const OLD_GATEWAY_CONSTRUCT = `import * as agentcore from 'aws-cdk-lib/aws-bedrockagentcore';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import { Construct } from 'constructs';
+
+export class AgentCoreGateway extends Construct implements iam.IGrantable {
+  public addAgent(
+    agent: Construct & {
+      readonly agentCoreRuntime: agentcore.Runtime;
+      readonly agentName: string;
+    },
+    props?: {
+      gatewayTargetName?: string;
+    },
+  ): agentcore.CfnGatewayTarget {
+    return this.addAgentTarget({
+      gatewayTargetName: props?.gatewayTargetName ?? agent.agentName,
+      agentRuntimeArn: agent.agentCoreRuntime.agentRuntimeArn,
+    });
+  }
+
+  public addAgentTarget(props: {
+    gatewayTargetName: string;
+    agentRuntimeArn: string;
+  }): agentcore.CfnGatewayTarget {
+    const target = new agentcore.CfnGatewayTarget(this, \`Target-\${props.gatewayTargetName}\`, {
+      gatewayIdentifier: this.gateway.gatewayId,
+      name: props.gatewayTargetName,
+      targetConfiguration: {
+        http: { agentcoreRuntime: { arn: props.agentRuntimeArn, qualifier: 'DEFAULT' } },
+      },
+        // The bare gateway IAM role credential: runtime targets reject the
+        // iamCredentialProvider detail MCP targets carry.
+        credentialProviderConfigurations: [
+          {
+            credentialProviderType: 'GATEWAY_IAM_ROLE',
+          },
+        ],
+    });
+    return target;
+  }
+
+  public addMcpServerTarget(props: {
+    gatewayTargetName: string;
+    mcpServerRuntimeArn: string;
+  }): agentcore.CfnGatewayTarget {
+    const target = new agentcore.CfnGatewayTarget(this, \`Target-\${props.gatewayTargetName}\`, {
+      gatewayIdentifier: this.gateway.gatewayId,
+      name: props.gatewayTargetName,
+      targetConfiguration: {
+        mcp: { openApiSchema: { inlinePayload: 'x' } },
+      },
+        credentialProviderConfigurations: [
+          {
+            credentialProviderType: 'GATEWAY_IAM_ROLE',
+            credentialProvider: {
+              iamCredentialProvider: { service: 'bedrock-agentcore' },
+            },
+          },
+        ],
+    });
+    return target;
+  }
+}
+`;
+
+/** A Cognito agent construct before the migration: no `auth`, no header allowlist. */
+const OLD_COGNITO_AGENT = `import { Runtime, RuntimeAuthorizerConfiguration } from 'aws-cdk-lib/aws-bedrockagentcore';
+import { Construct } from 'constructs';
+
+export class MyCognitoAgent extends Construct {
+  public readonly agentCoreRuntime: Runtime;
+  /** Default Gateway target name for this agent. */
+  public readonly agentName = 'my-cognito-agent';
+
+  constructor(scope: Construct, id: string, props: MyCognitoAgentProps) {
+    super(scope, id);
+    const { identity } = props;
+    this.agentCoreRuntime = new Runtime(this, 'MyCognitoAgent', {
+      authorizerConfiguration: RuntimeAuthorizerConfiguration.usingCognito(
+        identity.userPool,
+        [identity.userPoolClient],
+      ),
+    });
+  }
+}
+`;
+
+/** An IAM agent construct before the migration: no `auth` member. */
+const OLD_IAM_AGENT = `import { Runtime } from 'aws-cdk-lib/aws-bedrockagentcore';
+import { Construct } from 'constructs';
+
+export class MyIamAgent extends Construct {
+  public readonly agentCoreRuntime: Runtime;
+  /** Default Gateway target name for this agent. */
+  public readonly agentName = 'my-iam-agent';
+
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+    this.agentCoreRuntime = new Runtime(this, 'MyIamAgent', {});
+  }
+}
+`;
+
+/** The Terraform runtime module before the migration: JWT authorizer, no header config. */
+const OLD_TF_RUNTIME = `resource "aws_bedrockagentcore_agent_runtime" "agent_runtime" {
+  agent_runtime_name = "test"
+
+  dynamic "authorizer_configuration" {
+    for_each = var.authorizer_configuration != null && try(var.authorizer_configuration.custom_jwt_authorizer, null) != null ? [var.authorizer_configuration.custom_jwt_authorizer] : []
+    content {
+      custom_jwt_authorizer {
+        discovery_url    = authorizer_configuration.value.discovery_url
+        allowed_audience = authorizer_configuration.value.allowed_audience
+        allowed_clients  = authorizer_configuration.value.allowed_clients
+      }
+    }
+  }
+
+  network_configuration {
+    network_mode = "PUBLIC"
+  }
+}
+`;
+
+describe('gateway-cognito-passthrough migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeUsingTsSolutionSetup();
+  });
+
+  const seedGateway = () =>
+    tree.write(GATEWAY_CONSTRUCT_FILE, OLD_GATEWAY_CONSTRUCT);
+  const seedCognitoAgent = () =>
+    tree.write(COGNITO_AGENT_FILE, OLD_COGNITO_AGENT);
+  const seedIamAgent = () => tree.write(IAM_AGENT_FILE, OLD_IAM_AGENT);
+  const seedTfRuntime = () => tree.write(TF_RUNTIME_FILE, OLD_TF_RUNTIME);
+
+  it('does nothing when no gateway, agent or terraform runtime is vended', async () => {
+    const result = await migration(tree);
+    expect(result.nextSteps).toEqual([]);
+  });
+
+  it('makes the gateway pick the target credential from the agent auth', async () => {
+    seedGateway();
+    const result = await migration(tree);
+    const contents = tree.read(GATEWAY_CONSTRUCT_FILE, 'utf-8')!;
+
+    expect(contents).toContain(`readonly auth?: 'iam' | 'cognito';`);
+    expect(contents).toContain(
+      `credentials: agent.auth === 'cognito' ? 'jwt-passthrough' : 'gateway-iam',`,
+    );
+    expect(contents).toContain(
+      `credentials?: 'gateway-iam' | 'jwt-passthrough';`,
+    );
+    expect(contents).toContain(`? 'JWT_PASSTHROUGH'`);
+    expect(contents).toContain(`: 'GATEWAY_IAM_ROLE'`);
+    // Only the agent target's credential becomes conditional — the MCP server
+    // target keeps its unconditional GATEWAY_IAM_ROLE.
+    expect(contents).toContain(`credentialProviderType: 'GATEWAY_IAM_ROLE',
+            credentialProvider: {`);
+    // Exactly one conditional (agent) credential provider.
+    expect(
+      contents.match(/props\.credentials === 'jwt-passthrough'/g),
+    ).toHaveLength(1);
+    expect(result.nextSteps).toEqual([]);
+    expect(contents).toMatchSnapshot();
+  });
+
+  it('adds auth=cognito and the Authorization allowlist to a Cognito agent', async () => {
+    seedCognitoAgent();
+    const result = await migration(tree);
+    const contents = tree.read(COGNITO_AGENT_FILE, 'utf-8')!;
+
+    expect(contents).toContain(`public readonly auth = 'cognito';`);
+    expect(contents).toContain(`allowlistedHeaders: ['Authorization'],`);
+    expect(result.nextSteps).toEqual([]);
+    expect(contents).toMatchSnapshot();
+  });
+
+  it('adds auth=iam (no header allowlist) to an IAM agent', async () => {
+    seedIamAgent();
+    const result = await migration(tree);
+    const contents = tree.read(IAM_AGENT_FILE, 'utf-8')!;
+
+    expect(contents).toContain(`public readonly auth = 'iam';`);
+    expect(contents).not.toContain('requestHeaderConfiguration');
+    expect(result.nextSteps).toEqual([]);
+  });
+
+  it('adds the request_header_configuration block to the terraform runtime', async () => {
+    seedTfRuntime();
+    const result = await migration(tree);
+    const contents = tree.read(TF_RUNTIME_FILE, 'utf-8')!;
+
+    expect(contents).toContain('dynamic "request_header_configuration"');
+    expect(contents).toContain('request_header_allowlist = ["Authorization"]');
+    expect(result.nextSteps).toEqual([]);
+    expect(contents).toMatchSnapshot();
+  });
+
+  it('is idempotent', async () => {
+    seedGateway();
+    seedCognitoAgent();
+    seedIamAgent();
+    seedTfRuntime();
+
+    await migration(tree);
+    const gatewayAfterFirst = tree.read(GATEWAY_CONSTRUCT_FILE, 'utf-8');
+    const cognitoAfterFirst = tree.read(COGNITO_AGENT_FILE, 'utf-8');
+    const tfAfterFirst = tree.read(TF_RUNTIME_FILE, 'utf-8');
+
+    const secondRun = await migration(tree);
+
+    expect(tree.read(GATEWAY_CONSTRUCT_FILE, 'utf-8')).toEqual(
+      gatewayAfterFirst,
+    );
+    expect(tree.read(COGNITO_AGENT_FILE, 'utf-8')).toEqual(cognitoAfterFirst);
+    expect(tree.read(TF_RUNTIME_FILE, 'utf-8')).toEqual(tfAfterFirst);
+    expect(secondRun.nextSteps).toEqual([]);
+  });
+
+  it('skips and reports a diverged gateway construct', async () => {
+    // A real addAgentTarget method (so agent-target support is detected), but
+    // the user has customised the body away from the generated shape — the
+    // credential-provider anchor is gone — so the migration must not touch it.
+    tree.write(
+      GATEWAY_CONSTRUCT_FILE,
+      `import * as agentcore from 'aws-cdk-lib/aws-bedrockagentcore';
+
+export class AgentCoreGateway {
+  public addAgentTarget(props: {
+    gatewayTargetName: string;
+    agentRuntimeArn: string;
+  }): agentcore.CfnGatewayTarget {
+    // diverged: custom implementation, no recognisable credential block
+    return this.buildCustomTarget(props);
+  }
+}
+`,
+    );
+    const before = tree.read(GATEWAY_CONSTRUCT_FILE, 'utf-8');
+    const result = await migration(tree);
+    // Left untouched, with a single actionable next step.
+    expect(tree.read(GATEWAY_CONSTRUCT_FILE, 'utf-8')).toEqual(before);
+    expect(result.nextSteps).toEqual([
+      expect.stringContaining("pass `credentials: 'jwt-passthrough'`"),
+    ]);
+  });
+
+  it('leaves an agent construct with a user-added auth member alone', async () => {
+    tree.write(
+      IAM_AGENT_FILE,
+      OLD_IAM_AGENT.replace(
+        `  public readonly agentName = 'my-iam-agent';`,
+        `  public readonly agentName = 'my-iam-agent';
+  public readonly auth = 'iam';`,
+      ),
+    );
+    const before = tree.read(IAM_AGENT_FILE, 'utf-8');
+    const result = await migration(tree);
+    expect(tree.read(IAM_AGENT_FILE, 'utf-8')).toEqual(before);
+    expect(result.nextSteps).toEqual([]);
+  });
+});

--- a/packages/nx-plugin/src/migrations/latest/gateway-cognito-passthrough/migration.ts
+++ b/packages/nx-plugin/src/migrations/latest/gateway-cognito-passthrough/migration.ts
@@ -1,0 +1,287 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import type { MigrationReturnObject, Tree } from '@nx/devkit';
+import {
+  applyGritQL,
+  GRIT_INSERT_PLACEHOLDER,
+  insertViaGritQL,
+  matchGritQL,
+} from '../../../utils/ast';
+import { formatFilesInSubtree } from '../../../utils/format';
+import {
+  PACKAGES_DIR,
+  SHARED_CONSTRUCTS_DIR,
+  SHARED_TERRAFORM_DIR,
+} from '../../../utils/shared-constructs-constants';
+
+/**
+ * Bring existing workspaces up to the generators' current gateway->agent
+ * support for Cognito agents, which forward the caller's JWT to the runtime:
+ *
+ * - The vended `AgentCoreGateway` construct's `addAgent`/`addAgentTarget` pick
+ *   the outbound credential from the agent's `auth`: a `cognito` agent uses
+ *   `JWT_PASSTHROUGH` (the caller's token reaches the runtime), an `iam` agent
+ *   the gateway role (`GATEWAY_IAM_ROLE`, the previous behaviour).
+ * - Vended agent constructs gain an `auth` member `addAgent` reads, and Cognito
+ *   agents allowlist the `Authorization` header (CDK + Terraform runtime) so the
+ *   runtime receives the forwarded token.
+ *
+ * These files are generated with `KeepExisting`, so without this an upgraded
+ * workspace pairs new app-level constructs with stale core ones. Diverged files
+ * are left untouched and reported via `nextSteps`.
+ */
+
+const GATEWAY_CONSTRUCT_FILE = `${PACKAGES_DIR}/${SHARED_CONSTRUCTS_DIR}/src/core/agentcore-gateway/agentcore-gateway.ts`;
+const AGENTS_DIR = `${PACKAGES_DIR}/${SHARED_CONSTRUCTS_DIR}/src/app/agents`;
+const TF_RUNTIME_FILE = `${PACKAGES_DIR}/${SHARED_TERRAFORM_DIR}/src/core/agent-core/runtime.tf`;
+
+/**
+ * Teach the vended `AgentCoreGateway` construct to pick the target credential
+ * from the agent's `auth` (JWT passthrough for Cognito, gateway role for IAM).
+ */
+const migrateGatewayConstruct = async (
+  tree: Tree,
+  nextSteps: string[],
+): Promise<void> => {
+  if (!tree.exists(GATEWAY_CONSTRUCT_FILE)) {
+    return; // No vended gateway construct.
+  }
+  // Predates agent-target support (the gateway-agent-targets migration adds
+  // addAgentTarget first) — match the method, not a bare identifier.
+  if (
+    !(await matchGritQL(
+      tree,
+      GATEWAY_CONSTRUCT_FILE,
+      '`addAgentTarget(props: { $_ }): agentcore.CfnGatewayTarget { $_ }`',
+    ))
+  ) {
+    return;
+  }
+  // Already migrated: the credentials member is on addAgentTarget's props.
+  if (
+    await matchGritQL(
+      tree,
+      GATEWAY_CONSTRUCT_FILE,
+      "`credentials?: 'gateway-iam' | 'jwt-passthrough'`",
+    )
+  ) {
+    return;
+  }
+
+  const divergedMessage = `In ${GATEWAY_CONSTRUCT_FILE}: have addAgent read the agent's \`auth\` and pass \`credentials: 'jwt-passthrough'\` to addAgentTarget, so the target's credentialProviderType becomes 'JWT_PASSTHROUGH' for Cognito agents.`;
+
+  // GritQL patterns for each of the four edits. Verified against the tree
+  // up-front so the transform is all-or-nothing: a construct missing any
+  // anchor is left untouched with a single actionable next step, rather than
+  // half-migrated.
+  const authParamPattern = `\`readonly agentName: string\` as $sig where {
+  $program <: not contains \`readonly auth?\`
+} => \`$sig;
+      readonly auth?: 'iam' | 'cognito'\``;
+
+  const callPattern = `\`agentRuntimeArn: agent.agentCoreRuntime.agentRuntimeArn\` as $prop where {
+  $program <: not contains \`credentials:\`
+} => \`$prop,
+      credentials: agent.auth === 'cognito' ? 'jwt-passthrough' : 'gateway-iam'\``;
+
+  // The addAgentTarget props type: matched on its `agentRuntimeArn: string`
+  // member signature (without trailing semicolon), which the rewrite re-adds
+  // followed by the credentials member. The `: string` type distinguishes it
+  // from the `agentRuntimeArn:` value in the addAgent call.
+  const paramPattern = `\`agentRuntimeArn: string\` as $sig where {
+  $program <: not contains \`credentials?\`
+} => \`$sig;
+    credentials?: 'gateway-iam' | 'jwt-passthrough'\``;
+
+  // Scoped to the agent target's own CfnGatewayTarget (the one configured with
+  // an agentcoreRuntime), so the MCP server target's GATEWAY_IAM_ROLE — a
+  // sibling method with its own credential block — is left untouched.
+  const credentialPattern = `\`credentialProviderType: 'GATEWAY_IAM_ROLE'\` as $cred where {
+  $cred <: within \`new agentcore.CfnGatewayTarget($_, $_, $config)\`,
+  $config <: contains \`agentcoreRuntime\`
+} => \`credentialProviderType:
+              props.credentials === 'jwt-passthrough'
+                ? 'JWT_PASSTHROUGH'
+                : 'GATEWAY_IAM_ROLE'\``;
+
+  // Verify every anchor matches before mutating anything (matchGritQL is
+  // read-only), so a diverged construct is never left partially migrated.
+  for (const pattern of [
+    authParamPattern,
+    callPattern,
+    paramPattern,
+    credentialPattern,
+  ]) {
+    if (!(await matchGritQL(tree, GATEWAY_CONSTRUCT_FILE, pattern))) {
+      nextSteps.push(divergedMessage);
+      return;
+    }
+  }
+
+  await applyGritQL(tree, GATEWAY_CONSTRUCT_FILE, authParamPattern);
+  await applyGritQL(tree, GATEWAY_CONSTRUCT_FILE, callPattern);
+  await applyGritQL(tree, GATEWAY_CONSTRUCT_FILE, paramPattern);
+  await applyGritQL(tree, GATEWAY_CONSTRUCT_FILE, credentialPattern);
+};
+
+/**
+ * Add the `auth` member to each vended agent construct, and for Cognito agents
+ * allowlist the Authorization header so the runtime receives the forwarded JWT.
+ */
+const migrateAgentConstructs = async (
+  tree: Tree,
+  nextSteps: string[],
+): Promise<void> => {
+  if (!tree.exists(AGENTS_DIR)) {
+    return;
+  }
+  for (const dir of tree.children(AGENTS_DIR)) {
+    const constructFile = `${AGENTS_DIR}/${dir}/${dir}.ts`;
+    if (!tree.exists(constructFile)) {
+      continue;
+    }
+    // Only agents (which carry a gateway target name), not MCP servers.
+    if (
+      !(await matchGritQL(
+        tree,
+        constructFile,
+        '`public readonly agentName = $_`',
+      ))
+    ) {
+      continue;
+    }
+    if (await matchGritQL(tree, constructFile, '`public readonly auth = $_`')) {
+      continue; // Already migrated (or user-added).
+    }
+
+    // Cognito agents configure the runtime's inbound authorizer with a Cognito
+    // JWT — match that authorizerConfiguration property specifically.
+    const isCognito = await matchGritQL(
+      tree,
+      constructFile,
+      '`authorizerConfiguration: RuntimeAuthorizerConfiguration.usingCognito($_)`',
+    );
+    const authValue = isCognito ? 'cognito' : 'iam';
+
+    // The `auth` member, after the agentName member. Matched without the
+    // trailing semicolon — GritQL parses the field's initializer as its AST
+    // node, so the semicolon is appended by the rewrite.
+    const authPattern = `\`public readonly agentName = $name\` as $field => \`$field;
+  /** Inbound auth — a fronting Gateway uses this to pick its outbound credential. */
+  public readonly auth = '${authValue}'\``;
+
+    // Cognito agents allowlist the Authorization header so the runtime (and a
+    // fronting gateway, via passthrough) receives the caller's token.
+    const headerNeeded =
+      isCognito &&
+      !(await matchGritQL(
+        tree,
+        constructFile,
+        '`requestHeaderConfiguration: $_`',
+      ));
+    const headerPattern = `\`authorizerConfiguration: RuntimeAuthorizerConfiguration.usingCognito($args)\` as $authz where {
+  $program <: not contains \`requestHeaderConfiguration\`
+} => \`$authz,
+      ${GRIT_INSERT_PLACEHOLDER}\``;
+    const headerText = `// Receive the caller's Authorization header (validated by the authorizer).
+      requestHeaderConfiguration: {
+        allowlistedHeaders: ['Authorization'],
+      }`;
+
+    // Verify every anchor up-front so the construct is never half-migrated:
+    // if any edit can't be applied, leave the file untouched with one
+    // actionable next step.
+    const authOk = await matchGritQL(tree, constructFile, authPattern);
+    const headerOk =
+      !headerNeeded || (await matchGritQL(tree, constructFile, headerPattern));
+    if (!authOk || !headerOk) {
+      const actions = [
+        `add a \`public readonly auth = '${authValue}';\` member`,
+      ];
+      if (headerNeeded) {
+        actions.push(
+          `add \`requestHeaderConfiguration: { allowlistedHeaders: ['Authorization'] }\` to its Runtime so a gateway can pass the caller's JWT through`,
+        );
+      }
+      nextSteps.push(`In ${constructFile}: ${actions.join('; and ')}.`);
+      continue;
+    }
+
+    await applyGritQL(tree, constructFile, authPattern);
+    if (headerNeeded) {
+      await insertViaGritQL(tree, constructFile, headerPattern, headerText);
+    }
+  }
+};
+
+/**
+ * Add the `request_header_configuration` block to the vended Terraform runtime
+ * module so a JWT-authorized runtime receives the forwarded Authorization
+ * header (the analogue of the CDK requestHeaderConfiguration).
+ */
+const migrateTerraformRuntime = async (
+  tree: Tree,
+  nextSteps: string[],
+): Promise<void> => {
+  if (!tree.exists(TF_RUNTIME_FILE)) {
+    return;
+  }
+  if (
+    await matchGritQL(
+      tree,
+      TF_RUNTIME_FILE,
+      'language hcl\n`dynamic "request_header_configuration" { $_ }`',
+    )
+  ) {
+    return; // Already migrated.
+  }
+
+  const tfActionMessage = `In ${TF_RUNTIME_FILE}: add a \`request_header_configuration { request_header_allowlist = ["Authorization"] }\` block (guarded by the JWT authorizer) to the aws_bedrockagentcore_agent_runtime resource so a gateway can pass the caller's JWT through.`;
+
+  const hasAuthorizerBlock = await matchGritQL(
+    tree,
+    TF_RUNTIME_FILE,
+    'language hcl\n`dynamic "authorizer_configuration" { $_ }`',
+  );
+  if (!hasAuthorizerBlock) {
+    nextSteps.push(tfActionMessage);
+    return;
+  }
+
+  const added = await insertViaGritQL(
+    tree,
+    TF_RUNTIME_FILE,
+    `language hcl
+\`dynamic "authorizer_configuration" { $body }\` as $block where {
+  $block <: within \`resource "aws_bedrockagentcore_agent_runtime" $_ { $_ }\`
+} => \`$block
+
+  ${GRIT_INSERT_PLACEHOLDER}\``,
+    `# Receive the caller's Authorization header (validated by the JWT authorizer).
+  dynamic "request_header_configuration" {
+    for_each = var.authorizer_configuration != null && try(var.authorizer_configuration.custom_jwt_authorizer, null) != null ? [1] : []
+    content {
+      request_header_allowlist = ["Authorization"]
+    }
+  }`,
+  );
+  if (!added) {
+    nextSteps.push(tfActionMessage);
+  }
+};
+
+export default async function migration(
+  tree: Tree,
+): Promise<MigrationReturnObject> {
+  const nextSteps: string[] = [];
+
+  await migrateGatewayConstruct(tree, nextSteps);
+  await migrateAgentConstructs(tree, nextSteps);
+  await migrateTerraformRuntime(tree, nextSteps);
+
+  await formatFilesInSubtree(tree);
+
+  return { nextSteps };
+}

--- a/packages/nx-plugin/src/py/agent/__snapshots__/generator.constructs.spec.ts.snap
+++ b/packages/nx-plugin/src/py/agent/__snapshots__/generator.constructs.spec.ts.snap
@@ -57,6 +57,8 @@ export class SnapshotBedrockAgent
   public readonly agentCoreRuntime: Runtime;
   /** Default Gateway target name for this agent. */
   public readonly agentName = 'snapshot-bedrock-agent';
+  /** Inbound auth — a fronting Gateway uses this to pick its outbound credential. */
+  public readonly auth = 'iam';
 
   constructor(scope: Construct, id: string, props?: SnapshotBedrockAgentProps) {
     super(scope, id);

--- a/packages/nx-plugin/src/py/agent/__snapshots__/generator.protocols.spec.ts.snap
+++ b/packages/nx-plugin/src/py/agent/__snapshots__/generator.protocols.spec.ts.snap
@@ -506,6 +506,14 @@ resource "aws_bedrockagentcore_agent_runtime" "agent_runtime" {
     }
   }
 
+  # Receive the caller's Authorization header (validated by the JWT authorizer).
+  dynamic "request_header_configuration" {
+    for_each = var.authorizer_configuration != null && try(var.authorizer_configuration.custom_jwt_authorizer, null) != null ? [1] : []
+    content {
+      request_header_allowlist = ["Authorization"]
+    }
+  }
+
   network_configuration {
     network_mode = var.enable_vpc ? "VPC" : "PUBLIC"
 

--- a/packages/nx-plugin/src/py/mcp-server/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/mcp-server/__snapshots__/generator.spec.ts.snap
@@ -527,6 +527,14 @@ resource "aws_bedrockagentcore_agent_runtime" "agent_runtime" {
     }
   }
 
+  # Receive the caller's Authorization header (validated by the JWT authorizer).
+  dynamic "request_header_configuration" {
+    for_each = var.authorizer_configuration != null && try(var.authorizer_configuration.custom_jwt_authorizer, null) != null ? [1] : []
+    content {
+      request_header_allowlist = ["Authorization"]
+    }
+  }
+
   network_configuration {
     network_mode = var.enable_vpc ? "VPC" : "PUBLIC"
 

--- a/packages/nx-plugin/src/ts/agent/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/agent/__snapshots__/generator.spec.ts.snap
@@ -724,6 +724,8 @@ export class SnapshotBedrockAgent
   public readonly agentCoreRuntime: Runtime;
   /** Default Gateway target name for this agent. */
   public readonly agentName = 'snapshot-bedrock-agent';
+  /** Inbound auth — a fronting Gateway uses this to pick its outbound credential. */
+  public readonly auth = 'iam';
 
   constructor(scope: Construct, id: string, props?: SnapshotBedrockAgentProps) {
     super(scope, id);
@@ -1633,6 +1635,14 @@ resource "aws_bedrockagentcore_agent_runtime" "agent_runtime" {
     }
   }
 
+  # Receive the caller's Authorization header (validated by the JWT authorizer).
+  dynamic "request_header_configuration" {
+    for_each = var.authorizer_configuration != null && try(var.authorizer_configuration.custom_jwt_authorizer, null) != null ? [1] : []
+    content {
+      request_header_allowlist = ["Authorization"]
+    }
+  }
+
   network_configuration {
     network_mode = var.enable_vpc ? "VPC" : "PUBLIC"
 
@@ -2359,6 +2369,8 @@ export class InMemoryAgent
   public readonly agentCoreRuntime: Runtime;
   /** Default Gateway target name for this agent. */
   public readonly agentName = 'in-memory-agent';
+  /** Inbound auth — a fronting Gateway uses this to pick its outbound credential. */
+  public readonly auth = 'iam';
 
   constructor(scope: Construct, id: string, props?: InMemoryAgentProps) {
     super(scope, id);

--- a/packages/nx-plugin/src/ts/mcp-server/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/mcp-server/__snapshots__/generator.spec.ts.snap
@@ -527,6 +527,14 @@ resource "aws_bedrockagentcore_agent_runtime" "agent_runtime" {
     }
   }
 
+  # Receive the caller's Authorization header (validated by the JWT authorizer).
+  dynamic "request_header_configuration" {
+    for_each = var.authorizer_configuration != null && try(var.authorizer_configuration.custom_jwt_authorizer, null) != null ? [1] : []
+    content {
+      request_header_allowlist = ["Authorization"]
+    }
+  }
+
   network_configuration {
     network_mode = var.enable_vpc ? "VPC" : "PUBLIC"
 

--- a/packages/nx-plugin/src/utils/agent-core-constructs/files/cdk/app/agent-core/__nameKebabCase__/__nameKebabCase__.ts.template
+++ b/packages/nx-plugin/src/utils/agent-core-constructs/files/cdk/app/agent-core/__nameKebabCase__/__nameKebabCase__.ts.template
@@ -69,6 +69,8 @@ export class <%- nameClassName %> extends Construct implements IGrantable, IConn
 <%_ } else { _%>
   /** Default Gateway target name for this agent. */
   public readonly agentName = '<%- nameKebabCase %>';
+  /** Inbound auth — a fronting Gateway uses this to pick its outbound credential. */
+  public readonly auth = '<%- auth %>';
 <%_ } _%>
 
   constructor(scope: Construct, id: string, props<%_ if (auth !== 'cognito') { _%>?<%_ } _%>: <%- nameClassName %>Props) {
@@ -207,6 +209,10 @@ export class <%- nameClassName %> extends Construct implements IGrantable, IConn
         identity.userPool,
         [identity.userPoolClient],
       ),
+      // Receive the caller's Authorization header (validated by the authorizer).
+      requestHeaderConfiguration: {
+        allowlistedHeaders: ['Authorization'],
+      },
       ...restProps,
 <%_ } else { _%>
       ...props,

--- a/packages/nx-plugin/src/utils/agent-core-constructs/files/cdk/core/agentcore-gateway/agentcore-gateway.ts.template
+++ b/packages/nx-plugin/src/utils/agent-core-constructs/files/cdk/core/agentcore-gateway/agentcore-gateway.ts.template
@@ -458,6 +458,7 @@ export class AgentCoreGateway extends Construct implements iam.IGrantable {
     agent: Construct & {
       readonly agentCoreRuntime: agentcore.Runtime;
       readonly agentName: string;
+      readonly auth?: 'iam' | 'cognito';
     },
     props?: {
       gatewayTargetName?: string;
@@ -466,16 +467,22 @@ export class AgentCoreGateway extends Construct implements iam.IGrantable {
     return this.addAgentTarget({
       gatewayTargetName: props?.gatewayTargetName ?? agent.agentName,
       agentRuntimeArn: agent.agentCoreRuntime.agentRuntimeArn,
+      credentials: agent.auth === 'cognito' ? 'jwt-passthrough' : 'gateway-iam',
     });
   }
 
   /**
    * Register an agent runtime ARN as a Gateway target. Prefer
    * {@link addAgent} when the construct is in scope.
+   *
+   * `credentials` selects the outbound authorization to the runtime:
+   * `gateway-iam` (default) signs with the gateway role; `jwt-passthrough`
+   * forwards the caller's JWT so the runtime authorizes on it.
    */
   public addAgentTarget(props: {
     gatewayTargetName: string;
     agentRuntimeArn: string;
+    credentials?: 'gateway-iam' | 'jwt-passthrough';
   }): agentcore.CfnGatewayTarget {
     if (this.protocol !== 'http') {
       throw new Error(
@@ -500,11 +507,12 @@ export class AgentCoreGateway extends Construct implements iam.IGrantable {
             },
           },
         },
-        // The bare gateway IAM role credential: runtime targets reject the
-        // iamCredentialProvider detail MCP targets carry.
         credentialProviderConfigurations: [
           {
-            credentialProviderType: 'GATEWAY_IAM_ROLE',
+            credentialProviderType:
+              props.credentials === 'jwt-passthrough'
+                ? 'JWT_PASSTHROUGH'
+                : 'GATEWAY_IAM_ROLE',
           },
         ],
       },

--- a/packages/nx-plugin/src/utils/agent-core-constructs/files/terraform/core/agent-core/runtime.tf.template
+++ b/packages/nx-plugin/src/utils/agent-core-constructs/files/terraform/core/agent-core/runtime.tf.template
@@ -376,6 +376,14 @@ resource "aws_bedrockagentcore_agent_runtime" "agent_runtime" {
     }
   }
 
+  # Receive the caller's Authorization header (validated by the JWT authorizer).
+  dynamic "request_header_configuration" {
+    for_each = var.authorizer_configuration != null && try(var.authorizer_configuration.custom_jwt_authorizer, null) != null ? [1] : []
+    content {
+      request_header_allowlist = ["Authorization"]
+    }
+  }
+
   network_configuration {
     network_mode = var.enable_vpc ? "VPC" : "PUBLIC"
 


### PR DESCRIPTION
### Reason for this change

An http AgentCore Gateway could only front IAM-authenticated agents — the `agent-connection` generator rejected Cognito agents. But a common need is to let the **downstream runtime authorize on the original caller** (its `sub`, `scope`, etc.) rather than on the gateway's identity. AgentCore supports this via the `JWT_PASSTHROUGH` outbound credential (the gateway forwards the caller's validated JWT to the runtime unchanged), which the plugin did not yet vend.

### Description of changes

Front a **Cognito** agent with a **Cognito** http gateway and the caller's JWT is forwarded to the runtime automatically:

- **Agent constructs** expose a `readonly auth` member. Cognito agents also allowlist the `Authorization` header on their runtime (CDK `requestHeaderConfiguration` / Terraform `request_header_configuration`) — without it AgentCore validates the JWT but strips the header before the container.
- **The `AgentCoreGateway` construct**'s `addAgent`/`addAgentTarget` pick the target credential from the agent's `auth`: `cognito` → `JWT_PASSTHROUGH`, `iam` → `GATEWAY_IAM_ROLE` (unchanged default). A `credentials` option is also exposed on `addAgentTarget` for explicit control.
- **The `agentcore-gateway#agent-connection` generator** now accepts Cognito agents (previously errored).
- **New `latest` migration** (`gateway-cognito-passthrough`) upgrades existing workspaces' vended constructs/modules. It is GritQL-based and **all-or-nothing** per file: every anchor is verified before any edit, so a diverged construct is left untouched with a single actionable next step rather than half-migrated.

### Description of how you validated changes

- Unit tests for the generator (accepts cognito, rejects unsupported auth), the construct/module snapshots, and the migration (apply / cognito+iam / terraform / idempotency / diverged / user-modified).
- **Deployed end-to-end in both CDK and Terraform** against the real service: a Cognito http gateway fronting a Cognito agent. Minted a Cognito access token, invoked the gateway with `Authorization: Bearer <jwt>` and **no SigV4** → `200` with the agent's streamed response; an unsigned request → `401`. Confirmed separately that the runtime receives the caller's claims (`sub`/`scope`) once the `Authorization` header is allowlisted. All resources destroyed afterwards.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*