### PR TITLE
feat(docs): let the graph builder flow top to bottom as well as left to right

### DIFF
--- a/docs/src/components/graph-builder/canvas.tsx
+++ b/docs/src/components/graph-builder/canvas.tsx
@@ -13,9 +13,11 @@ import {
 import {
   edgeMidpoint,
   edgePath,
+  loopMidpoint,
   loopPath,
   NODE_HEIGHT,
   NODE_WIDTH,
+  type Orientation,
   type Point,
   snap,
   sourceAnchor,
@@ -32,6 +34,8 @@ interface Props {
   selectedEdgeId: string | undefined;
   /** The palette type being dragged in, so drop targets can be previewed. */
   pendingType: string | undefined;
+  /** Which way the graph flows, which decides where the ports sit. */
+  orientation: Orientation;
   onSelect: (id: string | undefined, options?: { additive?: boolean }) => void;
   onSelectEdge: (id: string | undefined) => void;
   onMoveNodes: (moves: readonly { id: string; x: number; y: number }[]) => void;
@@ -91,6 +95,7 @@ export const Canvas = ({
   selectedIds,
   selectedEdgeId,
   pendingType,
+  orientation,
   onSelect,
   onSelectEdge,
   onMoveNodes,
@@ -432,9 +437,11 @@ export const Canvas = ({
             if (!source || !target) return null;
 
             const isLoop = source.id === target.id;
-            const from = sourceAnchor(source);
-            const to = targetAnchor(target);
-            const path = isLoop ? loopPath(source) : edgePath(from, to);
+            const from = sourceAnchor(source, orientation);
+            const to = targetAnchor(target, orientation);
+            const path = isLoop
+              ? loopPath(source, orientation)
+              : edgePath(from, to, orientation);
             const severity = edgeIssueSeverity(edge.id);
             const active =
               selectedIds.has(edge.source) || selectedIds.has(edge.target);
@@ -467,11 +474,17 @@ export const Canvas = ({
               const target = edgeDraft.hoverTargetId
                 ? nodeById.get(edgeDraft.hoverTargetId)
                 : undefined;
-              const to = target ? targetAnchor(target) : edgeDraft.to;
+              const to = target
+                ? targetAnchor(target, orientation)
+                : edgeDraft.to;
               return (
                 <path
                   className={`gb-edge-draft${edgeDraft.hoverTargetId ? ' is-valid' : ''}`}
-                  d={edgePath(sourceAnchor(source), to)}
+                  d={edgePath(
+                    sourceAnchor(source, orientation),
+                    to,
+                    orientation,
+                  )}
                   markerEnd="url(#gb-arrow)"
                 />
               );
@@ -486,8 +499,11 @@ export const Canvas = ({
           if (!source || !target) return null;
           const midpoint =
             source.id === target.id
-              ? { x: source.x + NODE_WIDTH / 2, y: source.y - 34 }
-              : edgeMidpoint(sourceAnchor(source), targetAnchor(target));
+              ? loopMidpoint(source, orientation)
+              : edgeMidpoint(
+                  sourceAnchor(source, orientation),
+                  targetAnchor(target, orientation),
+                );
           return (
             <button
               key={`remove-${edge.id}`}
@@ -618,19 +634,22 @@ export const Canvas = ({
               </span>
 
               {type.roles.includes('target') && (
-                <span className="gb-port gb-port--in" aria-hidden="true" />
+                <span
+                  className={`gb-port gb-port--in gb-port--in-${orientation}`}
+                  aria-hidden="true"
+                />
               )}
               {type.roles.includes('source') && (
                 <button
                   type="button"
-                  className="gb-port gb-port--out"
+                  className={`gb-port gb-port--out gb-port--out-${orientation}`}
                   aria-label={`Draw a connection from ${node.name || type.label}`}
                   onPointerDown={(event) => {
                     event.stopPropagation();
                     event.preventDefault();
                     setEdgeDraft({
                       sourceId: node.id,
-                      to: sourceAnchor(node),
+                      to: sourceAnchor(node, orientation),
                     });
                   }}
                 />

--- a/docs/src/components/graph-builder/geometry.ts
+++ b/docs/src/components/graph-builder/geometry.ts
@@ -12,6 +12,12 @@ export const NODE_HEIGHT = 76;
 
 export const GRID = 24;
 
+/**
+ * Which way the graph flows. `horizontal` runs left to right with ports on the
+ * side edges; `vertical` runs top to bottom with ports on the top and bottom.
+ */
+export type Orientation = 'horizontal' | 'vertical';
+
 export interface Point {
   x: number;
   y: number;
@@ -19,44 +25,79 @@ export interface Point {
 
 /**
  * Half the port dot's overhang past the node edge, so an edge meets the centre
- * of the port it comes out of rather than the node's border. Mirrors the
- * `--gb-port-offset` the stylesheet positions the ports with.
+ * of the port it comes out of rather than the node's border. Mirrors the offset
+ * the stylesheet positions the ports with.
  */
 const PORT_OVERHANG = 1;
 
 /** Where an edge leaves its source node: the centre of its output port. */
-export const sourceAnchor = (node: Point): Point => ({
-  x: node.x + NODE_WIDTH - PORT_OVERHANG,
-  y: node.y + NODE_HEIGHT / 2,
-});
+export const sourceAnchor = (
+  node: Point,
+  orientation: Orientation = 'horizontal',
+): Point =>
+  orientation === 'vertical'
+    ? {
+        x: node.x + NODE_WIDTH / 2,
+        y: node.y + NODE_HEIGHT - PORT_OVERHANG,
+      }
+    : {
+        x: node.x + NODE_WIDTH - PORT_OVERHANG,
+        y: node.y + NODE_HEIGHT / 2,
+      };
 
 /** Where an edge meets its target node: the centre of its input port. */
-export const targetAnchor = (node: Point): Point => ({
-  x: node.x + PORT_OVERHANG,
-  y: node.y + NODE_HEIGHT / 2,
-});
+export const targetAnchor = (
+  node: Point,
+  orientation: Orientation = 'horizontal',
+): Point =>
+  orientation === 'vertical'
+    ? { x: node.x + NODE_WIDTH / 2, y: node.y + PORT_OVERHANG }
+    : { x: node.x + PORT_OVERHANG, y: node.y + NODE_HEIGHT / 2 };
 
 /**
- * A cubic bezier between two anchors, with horizontal control points so edges
- * leave and enter nodes flat. The control offset grows with the horizontal gap
- * so short hops stay tight and long ones sweep.
+ * A cubic bezier between two anchors, with control points along the flow axis so
+ * edges leave and enter nodes square to the edge they attach to. The control
+ * offset grows with the gap, so short hops stay tight and long ones sweep.
  */
-export const edgePath = (from: Point, to: Point): string => {
+export const edgePath = (
+  from: Point,
+  to: Point,
+  orientation: Orientation = 'horizontal',
+): string => {
+  if (orientation === 'vertical') {
+    const dy = Math.abs(to.y - from.y);
+    const curve = Math.max(40, Math.min(dy * 0.6, 160));
+    return `M ${from.x} ${from.y} C ${from.x} ${from.y + curve}, ${to.x} ${to.y - curve}, ${to.x} ${to.y}`;
+  }
   const dx = Math.abs(to.x - from.x);
   const curve = Math.max(40, Math.min(dx * 0.6, 160));
   return `M ${from.x} ${from.y} C ${from.x + curve} ${from.y}, ${to.x - curve} ${to.y}, ${to.x} ${to.y}`;
 };
 
 /**
- * A self-edge, drawn as a loop out of the right side and back into the left.
- * Used where a node connects to another of its own type placed at the same spot
- * is impossible — a loop keeps the edge visible rather than degenerate.
+ * A self-edge, looping out of the node's output port and back into its input.
+ * Bows out to the side of the flow axis so the loop stays clear of the node.
  */
-export const loopPath = (node: Point): string => {
-  const from = sourceAnchor(node);
-  const to = targetAnchor(node);
+export const loopPath = (
+  node: Point,
+  orientation: Orientation = 'horizontal',
+): string => {
+  const from = sourceAnchor(node, orientation);
+  const to = targetAnchor(node, orientation);
+  if (orientation === 'vertical') {
+    return `M ${from.x} ${from.y} C ${from.x + 70} ${from.y + 90}, ${to.x + 70} ${to.y - 90}, ${to.x} ${to.y}`;
+  }
   return `M ${from.x} ${from.y} C ${from.x + 90} ${from.y - 70}, ${to.x - 90} ${to.y - 70}, ${to.x} ${to.y}`;
 };
+
+/** Where a self-edge's delete affordance sits, clear of the node it loops around. */
+export const loopMidpoint = (
+  node: Point,
+  orientation: Orientation = 'horizontal',
+): Point =>
+  orientation === 'vertical'
+    ? { x: node.x + NODE_WIDTH + 34, y: node.y + NODE_HEIGHT / 2 }
+    : { x: node.x + NODE_WIDTH / 2, y: node.y - 34 };
 
 /** The midpoint of an edge path, where its delete affordance sits. */
 export const edgeMidpoint = (from: Point, to: Point): Point => ({
@@ -65,3 +106,110 @@ export const edgeMidpoint = (from: Point, to: Point): Point => ({
 });
 
 export const snap = (value: number): number => Math.round(value / GRID) * GRID;
+
+/**
+ * Re-lay a set of node positions for a new orientation by transposing the flow
+ * and cross axes.
+ *
+ * Positions are normalised to lanes first — nodes sharing a position along the
+ * old flow axis form a lane, and lanes become steps along the new one. That way a
+ * graph laid out by hand or by a preset comes back tidy on every swap, rather
+ * than accumulating drift from repeatedly transposing raw pixel values.
+ */
+export const transposePositions = <
+  T extends { id: string; x: number; y: number },
+>(
+  nodes: readonly T[],
+  to: Orientation,
+  /**
+   * The canvas's visible width. Horizontal lanes are tightened, and wrapped if
+   * even that will not fit, so a graph coming back from vertical lands in view
+   * rather than off the right edge.
+   */
+  availableWidth?: number,
+): { id: string; x: number; y: number }[] => {
+  if (nodes.length === 0) return [];
+
+  // Grouping tolerance: nodes within half a node's extent along the flow axis
+  // count as the same lane, so a hand-nudged layout still groups sensibly.
+  const from: Orientation = to === 'vertical' ? 'horizontal' : 'vertical';
+  const flowOf = (node: T) => (from === 'horizontal' ? node.x : node.y);
+  const crossOf = (node: T) => (from === 'horizontal' ? node.y : node.x);
+  const tolerance = (from === 'horizontal' ? NODE_WIDTH : NODE_HEIGHT) / 2;
+
+  // Lanes in flow order, each holding its nodes in cross order.
+  const lanes: T[][] = [];
+  for (const node of [...nodes].sort((a, b) => flowOf(a) - flowOf(b))) {
+    const lane = lanes.at(-1);
+    if (lane && Math.abs(flowOf(node) - flowOf(lane[0])) <= tolerance) {
+      lane.push(node);
+    } else {
+      lanes.push([node]);
+    }
+  }
+  for (const lane of lanes) lane.sort((a, b) => crossOf(a) - crossOf(b));
+
+  const ORIGIN = 24;
+  const crossStep = to === 'vertical' ? NODE_WIDTH + 48 : NODE_HEIGHT + 60;
+
+  // Flowing left to right consumes width per lane, so the step is tightened to
+  // fit the canvas — and where even the tightest step will not fit, lanes wrap
+  // onto further rows. Flowing top to bottom the width is per *lane member*, and
+  // graphs are rarely deep enough for height to bind, so it keeps its spacing.
+  if (to === 'vertical') {
+    const flowStep = NODE_HEIGHT + 60;
+    return lanes.flatMap((lane, laneIndex) =>
+      lane.map((node, indexInLane) => ({
+        id: node.id,
+        x: ORIGIN + indexInLane * crossStep,
+        y: ORIGIN + laneIndex * flowStep,
+      })),
+    );
+  }
+
+  const { perRow, step } = fitLanes(lanes.length, availableWidth);
+  // Rows the lanes themselves occupy, so a wrapped row clears the one above it.
+  const deepestLane = Math.max(...lanes.map((lane) => lane.length));
+  return lanes.flatMap((lane, laneIndex) =>
+    lane.map((node, indexInLane) => ({
+      id: node.id,
+      x: ORIGIN + (laneIndex % perRow) * step,
+      y:
+        ORIGIN +
+        (indexInLane + Math.floor(laneIndex / perRow) * deepestLane) *
+          crossStep,
+    })),
+  );
+};
+
+/** Comfortable horizontal lane spacing, when the canvas is wide enough. */
+const PREFERRED_LANE_STEP = NODE_WIDTH + 120;
+/** The tightest lane spacing still leaving a visible gap between nodes. */
+const MIN_LANE_STEP = NODE_WIDTH + 32;
+
+/**
+ * How many horizontal lanes fit side by side in the available width, and the
+ * step to use. Mirrors how presets are laid out, so a transposed graph and a
+ * freshly loaded preset agree.
+ */
+const fitLanes = (
+  lanes: number,
+  availableWidth?: number,
+): { perRow: number; step: number } => {
+  if (!availableWidth || lanes < 2) {
+    return { perRow: Math.max(1, lanes), step: PREFERRED_LANE_STEP };
+  }
+  const usable = availableWidth - 24 - NODE_WIDTH - 24;
+  const perRow = Math.max(
+    1,
+    Math.min(lanes, Math.floor(usable / MIN_LANE_STEP) + 1),
+  );
+  const step =
+    perRow < 2
+      ? PREFERRED_LANE_STEP
+      : Math.max(
+          MIN_LANE_STEP,
+          Math.min(PREFERRED_LANE_STEP, Math.floor(usable / (perRow - 1))),
+        );
+  return { perRow, step };
+};

--- a/docs/src/components/graph-builder/graph-builder.tsx
+++ b/docs/src/components/graph-builder/graph-builder.tsx
@@ -18,7 +18,13 @@ import {
   validate,
 } from '../../lib/graph-builder/model';
 import { Canvas } from './canvas';
-import { NODE_HEIGHT, NODE_WIDTH, snap } from './geometry';
+import {
+  NODE_HEIGHT,
+  NODE_WIDTH,
+  type Orientation,
+  snap,
+  transposePositions,
+} from './geometry';
 import { Inspector } from './inspector';
 import { Output } from './output';
 import { Palette } from './palette';
@@ -82,6 +88,9 @@ export const GraphBuilder = () => {
   // delete semantics, and selecting one clears the other.
   const [selectedEdgeId, setSelectedEdgeId] = useState<string | undefined>();
   const [pendingType, setPendingType] = useState<string | undefined>();
+  // Which way the graph flows. Swapping it re-lays the nodes rather than just
+  // moving the ports, so the graph still reads along its new axis.
+  const [orientation, setOrientation] = useState<Orientation>('horizontal');
   const [emitOptions, setEmitOptions] =
     useState<EmitOptions>(DEFAULT_EMIT_OPTIONS);
 
@@ -314,11 +323,30 @@ export const GraphBuilder = () => {
       if (!preset) return;
       // Lay the preset out for the canvas as it is now, so its widest row lands
       // fully in view rather than running off the right edge.
-      commit(() => buildPresetGraph(preset, canvasWidthRef.current));
+      commit(() => {
+        const built = buildPresetGraph(preset, canvasWidthRef.current);
+        if (orientation === 'horizontal') return built;
+        // Presets are authored on a left-to-right grid, so transpose one loaded
+        // while the canvas is running top-to-bottom.
+        const moves = new Map(
+          transposePositions(
+            built.nodes,
+            orientation,
+            canvasWidthRef.current,
+          ).map((m) => [m.id, m]),
+        );
+        return {
+          ...built,
+          nodes: built.nodes.map((node) => {
+            const move = moves.get(node.id);
+            return move ? { ...node, x: move.x, y: move.y } : node;
+          }),
+        };
+      });
       setSelection([]);
       setSelectedEdgeId(undefined);
     },
-    [commit],
+    [commit, orientation],
   );
 
   // Stable identity, so the canvas's resize observer isn't torn down and
@@ -326,6 +354,34 @@ export const GraphBuilder = () => {
   const handleCanvasResize = useCallback((width: number) => {
     canvasWidthRef.current = width;
   }, []);
+
+  /**
+   * Flip the flow axis, transposing the layout so the graph reads along it. The
+   * transpose normalises to lanes rather than swapping raw coordinates, so
+   * swapping back and forth stays tidy instead of drifting.
+   */
+  const toggleOrientation = useCallback(() => {
+    setOrientation((current) => {
+      const next: Orientation =
+        current === 'horizontal' ? 'vertical' : 'horizontal';
+      commit((graph) => {
+        if (graph.nodes.length === 0) return graph;
+        const moves = new Map(
+          transposePositions(graph.nodes, next, canvasWidthRef.current).map(
+            (move) => [move.id, move],
+          ),
+        );
+        return {
+          ...graph,
+          nodes: graph.nodes.map((node) => {
+            const move = moves.get(node.id);
+            return move ? { ...node, x: move.x, y: move.y } : node;
+          }),
+        };
+      });
+      return next;
+    });
+  }, [commit]);
 
   const clear = useCallback(() => {
     commit(() => EMPTY_GRAPH);
@@ -453,6 +509,47 @@ export const GraphBuilder = () => {
           )}
           <button
             type="button"
+            className="gb-chip gb-chip--icon"
+            onClick={toggleOrientation}
+            aria-label={
+              orientation === 'horizontal'
+                ? 'Lay the graph out top to bottom'
+                : 'Lay the graph out left to right'
+            }
+            title={
+              orientation === 'horizontal'
+                ? 'Lay out top to bottom'
+                : 'Lay out left to right'
+            }
+          >
+            <svg
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.75"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              {orientation === 'horizontal' ? (
+                // Two stacked boxes joined vertically: what pressing this gives.
+                <>
+                  <rect x="7" y="2.5" width="10" height="6" rx="1.5" />
+                  <rect x="7" y="15.5" width="10" height="6" rx="1.5" />
+                  <line x1="12" y1="8.5" x2="12" y2="15.5" />
+                </>
+              ) : (
+                <>
+                  <rect x="2.5" y="9" width="6" height="6" rx="1.5" />
+                  <rect x="15.5" y="9" width="6" height="6" rx="1.5" />
+                  <line x1="8.5" y1="12" x2="15.5" y2="12" />
+                </>
+              )}
+            </svg>
+            {orientation === 'horizontal' ? 'Vertical' : 'Horizontal'}
+          </button>
+          <button
+            type="button"
             className="gb-chip"
             onClick={undo}
             aria-label="Undo"
@@ -499,6 +596,7 @@ export const GraphBuilder = () => {
           selectedIds={selectedIds}
           selectedEdgeId={selectedEdgeId}
           pendingType={pendingType}
+          orientation={orientation}
           onSelect={selectNode}
           onSelectEdge={selectEdge}
           onMoveNodes={moveNodes}

--- a/docs/src/components/graph-builder/graph-builder.tsx
+++ b/docs/src/components/graph-builder/graph-builder.tsx
@@ -477,18 +477,30 @@ export const GraphBuilder = () => {
     <div className="gb-root" data-graph-builder>
       <div className="gb-toolbar">
         <div className="gb-toolbar-presets">
-          <span className="gb-toolbar-label">Start from</span>
-          {PRESETS.map((preset) => (
-            <button
-              key={preset.id}
-              type="button"
-              className="gb-chip"
-              onClick={() => loadPreset(preset.id)}
-              title={preset.description}
-            >
-              {preset.label}
-            </button>
-          ))}
+          <label className="gb-toolbar-label" htmlFor="gb-preset">
+            Start from
+          </label>
+          <select
+            id="gb-preset"
+            className="gb-select"
+            // Held at the placeholder rather than the last choice, so picking the
+            // same preset again reloads it instead of being a no-op.
+            value=""
+            onChange={(event) => {
+              if (event.target.value) loadPreset(event.target.value);
+            }}
+          >
+            <option value="">Choose an example…</option>
+            {PRESETS.map((preset) => (
+              <option
+                key={preset.id}
+                value={preset.id}
+                title={preset.description}
+              >
+                {preset.label}
+              </option>
+            ))}
+          </select>
         </div>
         <div className="gb-toolbar-actions">
           <span className="gb-stat">

--- a/docs/src/components/graph-builder/graph-builder.tsx
+++ b/docs/src/components/graph-builder/graph-builder.tsx
@@ -28,6 +28,7 @@ import {
 import { Inspector } from './inspector';
 import { Output } from './output';
 import { Palette } from './palette';
+import { PresetPicker } from './preset-picker';
 import { buildPresetGraph, PRESETS } from './presets';
 
 const EMPTY_GRAPH: Graph = { nodes: [], edges: [] };
@@ -480,27 +481,7 @@ export const GraphBuilder = () => {
           <label className="gb-toolbar-label" htmlFor="gb-preset">
             Start from
           </label>
-          <select
-            id="gb-preset"
-            className="gb-select"
-            // Held at the placeholder rather than the last choice, so picking the
-            // same preset again reloads it instead of being a no-op.
-            value=""
-            onChange={(event) => {
-              if (event.target.value) loadPreset(event.target.value);
-            }}
-          >
-            <option value="">Choose an example…</option>
-            {PRESETS.map((preset) => (
-              <option
-                key={preset.id}
-                value={preset.id}
-                title={preset.description}
-              >
-                {preset.label}
-              </option>
-            ))}
-          </select>
+          <PresetPicker options={PRESETS} onPick={loadPreset} />
         </div>
         <div className="gb-toolbar-actions">
           <span className="gb-stat">

--- a/docs/src/components/graph-builder/preset-picker.tsx
+++ b/docs/src/components/graph-builder/preset-picker.tsx
@@ -1,0 +1,163 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { useEffect, useId, useRef, useState } from 'react';
+
+interface PresetOption {
+  readonly id: string;
+  readonly label: string;
+  readonly description: string;
+}
+
+interface Props {
+  options: readonly PresetOption[];
+  onPick: (id: string) => void;
+}
+
+/**
+ * The "start from" picker.
+ *
+ * A listbox rather than a `<select>` because a native select's popup is drawn by
+ * the platform — white and square-cornered whatever the page's theme — and the
+ * builder's open menu should match the docs' surfaces like every other panel
+ * here. It keeps a select's keyboard behaviour: arrows move, Enter picks, Escape
+ * closes, Home/End jump to the ends.
+ *
+ * There is no selected value to display: picking an example loads it, and the
+ * button goes back to reading as a prompt so the same one can be picked again.
+ */
+export const PresetPicker = ({ options, onPick }: Props) => {
+  const [isOpen, setIsOpen] = useState(false);
+  // Which option the keyboard is on. -1 while the pointer is driving, so no
+  // option is highlighted until an arrow key is pressed.
+  const [activeIndex, setActiveIndex] = useState(-1);
+  const wrapRef = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const listboxId = useId();
+
+  const close = ({ refocus = false } = {}) => {
+    setIsOpen(false);
+    setActiveIndex(-1);
+    if (refocus) buttonRef.current?.focus();
+  };
+
+  const choose = (id: string) => {
+    onPick(id);
+    close({ refocus: true });
+  };
+
+  // A press outside, or the page scrolling away beneath it, dismisses the menu —
+  // the behaviour a native popup has.
+  useEffect(() => {
+    if (!isOpen) return;
+    const onPointerDown = (event: PointerEvent) => {
+      if (wrapRef.current?.contains(event.target as Node)) return;
+      setIsOpen(false);
+      setActiveIndex(-1);
+    };
+    window.addEventListener('pointerdown', onPointerDown);
+    return () => window.removeEventListener('pointerdown', onPointerDown);
+  }, [isOpen]);
+
+  const onKeyDown = (event: React.KeyboardEvent) => {
+    if (event.key === 'Escape') {
+      if (isOpen) {
+        event.preventDefault();
+        close({ refocus: true });
+      }
+      return;
+    }
+
+    if (!isOpen) {
+      if (['ArrowDown', 'ArrowUp', 'Enter', ' '].includes(event.key)) {
+        event.preventDefault();
+        setIsOpen(true);
+        setActiveIndex(event.key === 'ArrowUp' ? options.length - 1 : 0);
+      }
+      return;
+    }
+
+    const moves: Record<string, number> = {
+      ArrowDown: activeIndex + 1,
+      ArrowUp: activeIndex - 1,
+      Home: 0,
+      End: options.length - 1,
+    };
+    if (event.key in moves) {
+      event.preventDefault();
+      // Wraps, so holding an arrow cycles rather than sticking at an end.
+      const next = (moves[event.key] + options.length) % options.length;
+      setActiveIndex(next);
+      return;
+    }
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      if (activeIndex >= 0) choose(options[activeIndex].id);
+    }
+  };
+
+  return (
+    <div className="gb-picker" ref={wrapRef}>
+      <button
+        ref={buttonRef}
+        type="button"
+        className={`gb-picker-button${isOpen ? ' is-open' : ''}`}
+        // `combobox` is the role that pairs a control with a popup listbox, and
+        // the role that accepts aria-activedescendant.
+        role="combobox"
+        aria-haspopup="listbox"
+        aria-expanded={isOpen}
+        aria-controls={isOpen ? listboxId : undefined}
+        // On the button, since that is what holds focus while the menu is open.
+        aria-activedescendant={
+          isOpen && activeIndex >= 0 ? `${listboxId}-${activeIndex}` : undefined
+        }
+        onClick={() => (isOpen ? close() : setIsOpen(true))}
+        onKeyDown={onKeyDown}
+      >
+        <span>Choose an example…</span>
+        <svg
+          className="gb-picker-chevron"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.75"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <polyline points="6 9 12 15 18 9" />
+        </svg>
+      </button>
+
+      {isOpen && (
+        <div
+          className="gb-picker-menu"
+          id={listboxId}
+          role="listbox"
+          aria-label="Examples to start from"
+        >
+          {options.map((option, index) => (
+            <div
+              key={option.id}
+              id={`${listboxId}-${index}`}
+              className={`gb-picker-option${index === activeIndex ? ' is-active' : ''}`}
+              role="option"
+              aria-selected={index === activeIndex}
+              // Focus stays on the button, which owns the key handling — the way
+              // a native select behaves — so the options are not tab stops.
+              tabIndex={-1}
+              title={option.description}
+              onPointerEnter={() => setActiveIndex(index)}
+              onClick={() => choose(option.id)}
+              onKeyDown={onKeyDown}
+            >
+              {option.label}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/docs/src/content/docs/en/get_started/graph-builder.mdx
+++ b/docs/src/content/docs/en/get_started/graph-builder.mdx
@@ -22,6 +22,8 @@ A website always gets <Link path="guides/react-website-auth">Cognito authenticat
 
 An `infra` project is added at the end — <Link path="guides/typescript-infrastructure">`ts#infra`</Link> or <Link path="guides/terraform-project">`terraform#project`</Link>, matching your IaC choice. Every generated project vends constructs for it to instantiate, so this is what you deploy. Because it owns that name, no component on the canvas can be called `infra`.
 
+Use **Vertical** / **Horizontal** in the toolbar to swap which way the graph flows — the connection points move to the top and bottom edges of each component, and the layout is transposed to match.
+
 Drag the canvas background to pan around, and drag a component to reposition it. Shift-click to select several components and move them as a group. Click a connection to select it, then press <kbd>Delete</kbd> to remove it (or use the ✕ on the connection itself).
 
 The palette lists every project and component type that can take part in a connection, and you can only draw the connections the plugin supports — so a graph that validates is a graph that scaffolds.

--- a/docs/src/content/docs/es/get_started/graph-builder.mdx
+++ b/docs/src/content/docs/es/get_started/graph-builder.mdx
@@ -18,7 +18,11 @@ Arrastra componentes desde la paleta al lienzo, arrastra desde el borde derecho 
 
 Cada componente en el lienzo se mapea a un generador, y cada conexión al <Link path="guides/connection">generador de conexiones</Link>. Los comandos se emiten en orden de dependencia: primero el espacio de trabajo, luego los proyectos, luego los componentes que alojan, luego las conexiones que los conectan.
 
+Un sitio web siempre obtiene <Link path="guides/react-website-auth">autenticación Cognito</Link> agregada justo después, ya que `ts#website` deja eso a un generador de seguimiento.
+
 Un proyecto `infra` se agrega al final — <Link path="guides/typescript-infrastructure">`ts#infra`</Link> o <Link path="guides/terraform-project">`terraform#project`</Link>, según tu elección de IaC. Cada proyecto generado proporciona constructos para que este los instancie, así que esto es lo que despliegas. Debido a que posee ese nombre, ningún componente en el lienzo puede llamarse `infra`.
+
+Usa **Vertical** / **Horizontal** en la barra de herramientas para cambiar la dirección del flujo del grafo — los puntos de conexión se mueven a los bordes superior e inferior de cada componente, y el diseño se transpone para coincidir.
 
 Arrastra el fondo del lienzo para desplazarte, y arrastra un componente para reposicionarlo. Shift-clic para seleccionar varios componentes y moverlos como un grupo. Haz clic en una conexión para seleccionarla, luego presiona <kbd>Delete</kbd> para eliminarla (o usa la ✕ en la conexión misma).
 

--- a/docs/src/content/docs/fr/get_started/graph-builder.mdx
+++ b/docs/src/content/docs/fr/get_started/graph-builder.mdx
@@ -22,6 +22,8 @@ Un site web reçoit toujours une <Link path="guides/react-website-auth">authenti
 
 Un projet `infra` est ajouté à la fin — <Link path="guides/typescript-infrastructure">`ts#infra`</Link> ou <Link path="guides/terraform-project">`terraform#project`</Link>, correspondant à votre choix d'IaC. Chaque projet généré fournit des constructions pour qu'il puisse les instancier, c'est donc ce que vous déployez. Parce qu'il possède ce nom, aucun composant sur le canevas ne peut s'appeler `infra`.
 
+Utilisez **Vertical** / **Horizontal** dans la barre d'outils pour inverser le sens de circulation du graphe — les points de connexion se déplacent vers les bords supérieur et inférieur de chaque composant, et la disposition est transposée en conséquence.
+
 Faites glisser l'arrière-plan du canevas pour vous déplacer, et faites glisser un composant pour le repositionner. Shift-clic pour sélectionner plusieurs composants et les déplacer en groupe. Cliquez sur une connexion pour la sélectionner, puis appuyez sur <kbd>Delete</kbd> pour la supprimer (ou utilisez le ✕ sur la connexion elle-même).
 
 La palette répertorie tous les types de projets et de composants qui peuvent participer à une connexion, et vous ne pouvez dessiner que les connexions prises en charge par le plugin — donc un graphe qui valide est un graphe qui se génère.

--- a/docs/src/content/docs/it/get_started/graph-builder.mdx
+++ b/docs/src/content/docs/it/get_started/graph-builder.mdx
@@ -18,7 +18,11 @@ Trascina i componenti dalla palette sulla tela, trascina dal bordo destro di un 
 
 Ogni componente sulla tela corrisponde a un generatore, e ogni connessione al <Link path="guides/connection">generatore di connessioni</Link>. I comandi vengono emessi in ordine di dipendenza: prima il workspace, poi i progetti, poi i componenti che ospitano, infine le connessioni che li collegano.
 
+Un sito web riceve sempre l'<Link path="guides/react-website-auth">autenticazione Cognito</Link> aggiunta subito dopo, poiché `ts#website` lascia questo a un generatore successivo.
+
 Un progetto `infra` viene aggiunto alla fine — <Link path="guides/typescript-infrastructure">`ts#infra`</Link> o <Link path="guides/terraform-project">`terraform#project`</Link>, in base alla tua scelta di IaC. Ogni progetto generato fornisce costrutti da istanziare, quindi questo è ciò che distribuisci. Poiché possiede quel nome, nessun componente sulla tela può chiamarsi `infra`.
+
+Usa **Vertical** / **Horizontal** nella barra degli strumenti per cambiare la direzione del flusso del grafo — i punti di connessione si spostano sui bordi superiore e inferiore di ciascun componente, e il layout viene trasposto di conseguenza.
 
 Trascina lo sfondo della tela per spostarti, e trascina un componente per riposizionarlo. Shift-click per selezionare più componenti e spostarli come gruppo. Clicca su una connessione per selezionarla, poi premi <kbd>Delete</kbd> per rimuoverla (o usa la ✕ sulla connessione stessa).
 
@@ -31,8 +35,5 @@ Tre regole da conoscere:
 - **Disegnare una connessione può modificare il target.** Connettere un sito web a un agent cambia quell'agent al protocollo `ag-ui`, e connettere un agent a un altro agent cambia il target a `a2a` — i protocolli su cui si basano quelle connessioni. Una proprietà che hai impostato tu stesso non viene mai modificata.
 
 :::tip[Preferisci costruire con l'AI?]
-Il plugin include un server MCP, quindi il tuo agente di codifica può generare e connettere progetti per te. Vedi <Link path="get_started/building-with-ai">Costruire con l'AI</Link>.
-:::
-I?]
 Il plugin include un server MCP, quindi il tuo agente di codifica può generare e connettere progetti per te. Vedi <Link path="get_started/building-with-ai">Costruire con l'AI</Link>.
 :::

--- a/docs/src/content/docs/jp/get_started/graph-builder.mdx
+++ b/docs/src/content/docs/jp/get_started/graph-builder.mdx
@@ -18,7 +18,11 @@ import GraphBuilder from '@components/graph-builder.astro';
 
 キャンバス上の各コンポーネントはジェネレーターにマッピングされ、各接続は<Link path="guides/connection">接続ジェネレーター</Link>にマッピングされます。コマンドは依存関係の順序で出力されます：最初にワークスペース、次にプロジェクト、それらがホストするコンポーネント、そしてそれらを結び付ける接続の順です。
 
+ウェブサイトには常に<Link path="guides/react-website-auth">Cognito 認証</Link>が直後に追加されます。`ts#website` はそれをフォローアップジェネレーターに任せているためです。
+
 最後に `infra` プロジェクトが追加されます — <Link path="guides/typescript-infrastructure">`ts#infra`</Link> または <Link path="guides/terraform-project">`terraform#project`</Link> のいずれかで、IaC の選択に応じて決まります。生成されたすべてのプロジェクトは、このプロジェクトがインスタンス化するためのコンストラクトを提供するため、これがデプロイするものになります。この名前を所有しているため、キャンバス上のコンポーネントは `infra` という名前を使用できません。
+
+ツールバーの **Vertical** / **Horizontal** を使用して、グラフの流れる方向を切り替えます — 接続ポイントが各コンポーネントの上下の端に移動し、レイアウトがそれに合わせて転置されます。
 
 キャンバスの背景をドラッグしてパンし、コンポーネントをドラッグして位置を変更します。Shift キーを押しながらクリックすると、複数のコンポーネントを選択してグループとして移動できます。接続をクリックして選択し、<kbd>Delete</kbd> キーを押すと削除できます（または接続自体の ✕ を使用します）。
 

--- a/docs/src/content/docs/ko/get_started/graph-builder.mdx
+++ b/docs/src/content/docs/ko/get_started/graph-builder.mdx
@@ -22,6 +22,8 @@ import GraphBuilder from '@components/graph-builder.astro';
 
 마지막에 `infra` 프로젝트가 추가됩니다 — IaC 선택에 따라 <Link path="guides/typescript-infrastructure">`ts#infra`</Link> 또는 <Link path="guides/terraform-project">`terraform#project`</Link>입니다. 생성된 모든 프로젝트는 인스턴스화할 구성 요소를 제공하므로, 이것이 배포하는 대상입니다. 이 이름을 소유하기 때문에 캔버스의 어떤 컴포넌트도 `infra`라고 부를 수 없습니다.
 
+툴바에서 **Vertical** / **Horizontal**을 사용하여 그래프가 흐르는 방향을 전환하세요 — 연결 지점이 각 컴포넌트의 상단과 하단 가장자리로 이동하고, 레이아웃이 이에 맞게 전환됩니다.
+
 캔버스 배경을 드래그하여 이동하고, 컴포넌트를 드래그하여 위치를 변경하세요. Shift-클릭으로 여러 컴포넌트를 선택하고 그룹으로 이동할 수 있습니다. 연결을 클릭하여 선택한 다음 <kbd>Delete</kbd>를 눌러 제거하세요 (또는 연결 자체의 ✕를 사용하세요).
 
 팔레트는 연결에 참여할 수 있는 모든 프로젝트 및 컴포넌트 유형을 나열하며, 플러그인이 지원하는 연결만 그릴 수 있습니다 — 따라서 유효성 검사를 통과한 그래프는 스캐폴딩 가능한 그래프입니다.

--- a/docs/src/content/docs/pt/get_started/graph-builder.mdx
+++ b/docs/src/content/docs/pt/get_started/graph-builder.mdx
@@ -22,6 +22,8 @@ Um website sempre recebe <Link path="guides/react-website-auth">autenticação C
 
 Um projeto `infra` é adicionado no final — <Link path="guides/typescript-infrastructure">`ts#infra`</Link> ou <Link path="guides/terraform-project">`terraform#project`</Link>, correspondendo à sua escolha de IaC. Cada projeto gerado fornece construtos para ele instanciar, então é isso que você implanta. Como ele possui esse nome, nenhum componente na tela pode ser chamado de `infra`.
 
+Use **Vertical** / **Horizontal** na barra de ferramentas para alternar a direção do fluxo do grafo — os pontos de conexão se movem para as bordas superior e inferior de cada componente, e o layout é transposto para corresponder.
+
 Arraste o fundo da tela para navegar e arraste um componente para reposicioná-lo. Shift-clique para selecionar vários componentes e movê-los como um grupo. Clique em uma conexão para selecioná-la e pressione <kbd>Delete</kbd> para removê-la (ou use o ✕ na própria conexão).
 
 A paleta lista todos os tipos de projeto e componente que podem participar de uma conexão, e você só pode desenhar as conexões que o plugin suporta — então um grafo que valida é um grafo que estrutura.

--- a/docs/src/content/docs/vi/get_started/graph-builder.mdx
+++ b/docs/src/content/docs/vi/get_started/graph-builder.mdx
@@ -18,7 +18,11 @@ Kéo các thành phần từ bảng chọn lên canvas, kéo từ cạnh phải 
 
 Mỗi thành phần trên canvas ánh xạ tới một generator, và mỗi kết nối tới <Link path="guides/connection">connection generator</Link>. Các lệnh được phát ra theo thứ tự phụ thuộc: workspace trước, sau đó là các dự án, rồi các thành phần mà chúng chứa, sau đó là các kết nối nối chúng lại với nhau.
 
+Một website luôn được thêm <Link path="guides/react-website-auth">xác thực Cognito</Link> ngay sau nó, vì `ts#website` để lại điều đó cho một generator tiếp theo.
+
 Một dự án `infra` được thêm vào ở cuối — <Link path="guides/typescript-infrastructure">`ts#infra`</Link> hoặc <Link path="guides/terraform-project">`terraform#project`</Link>, phù hợp với lựa chọn IaC của bạn. Mọi dự án được tạo ra đều cung cấp các construct để nó khởi tạo, vì vậy đây là thứ bạn triển khai. Vì nó sở hữu tên đó, không có thành phần nào trên canvas có thể được gọi là `infra`.
+
+Sử dụng **Vertical** / **Horizontal** trong thanh công cụ để chuyển đổi hướng luồng của đồ thị — các điểm kết nối sẽ di chuyển đến các cạnh trên và dưới của mỗi thành phần, và bố cục sẽ được chuyển vị để phù hợp.
 
 Kéo nền canvas để di chuyển xung quanh, và kéo một thành phần để định vị lại nó. Shift-click để chọn nhiều thành phần và di chuyển chúng như một nhóm. Nhấp vào một kết nối để chọn nó, sau đó nhấn <kbd>Delete</kbd> để xóa nó (hoặc sử dụng ✕ trên chính kết nối đó).
 

--- a/docs/src/content/docs/zh/get_started/graph-builder.mdx
+++ b/docs/src/content/docs/zh/get_started/graph-builder.mdx
@@ -18,7 +18,11 @@ import GraphBuilder from '@components/graph-builder.astro';
 
 画布上的每个组件都映射到一个生成器，每个连接都映射到<Link path="guides/connection">连接生成器</Link>。命令按依赖顺序发出：首先是工作空间，然后是项目，然后是它们托管的组件，最后是将它们连接在一起的连接。
 
+网站总是会在其后立即添加 <Link path="guides/react-website-auth">Cognito 身份验证</Link>，因为 `ts#website` 将其留给后续生成器处理。
+
 最后会添加一个 `infra` 项目——<Link path="guides/typescript-infrastructure">`ts#infra`</Link> 或 <Link path="guides/terraform-project">`terraform#project`</Link>，与您的 IaC 选择相匹配。每个生成的项目都会为它提供要实例化的构造，因此这就是您要部署的内容。因为它拥有该名称，所以画布上的任何组件都不能被称为 `infra`。
+
+使用工具栏中的 **Vertical** / **Horizontal** 来切换图的流向——连接点会移动到每个组件的顶部和底部边缘，布局也会相应转置。
 
 拖动画布背景来平移，拖动组件来重新定位它。按住 Shift 键单击可选择多个组件并将它们作为一组移动。单击连接以选中它，然后按 <kbd>Delete</kbd> 键将其删除（或使用连接本身上的 ✕）。
 

--- a/docs/src/lib/graph-builder/graph-builder.spec.ts
+++ b/docs/src/lib/graph-builder/graph-builder.spec.ts
@@ -5,8 +5,12 @@
 import { describe, expect, it } from 'vitest';
 import { SUPPORTED_CONNECTIONS } from '../../../../packages/nx-plugin/src/connection/supported-connections';
 import {
+  edgePath,
   NODE_HEIGHT,
   NODE_WIDTH,
+  sourceAnchor,
+  targetAnchor,
+  transposePositions,
 } from '../../components/graph-builder/geometry';
 import {
   buildPresetGraph,
@@ -126,6 +130,140 @@ describe('catalog', () => {
       if (type.kind !== 'component') continue;
       expect(type.host, `${type.id} has no host`).toBeDefined();
     }
+  });
+});
+
+describe('orientation', () => {
+  const at = (id: string, x: number, y: number) => ({ id, x, y });
+
+  it('should put the ports on the side edges when flowing horizontally', () => {
+    const node = { x: 100, y: 200 };
+    expect(sourceAnchor(node, 'horizontal').y).toBe(200 + NODE_HEIGHT / 2);
+    // Anchors sit on the port's centre, 1px inside the node's edge.
+    expect(sourceAnchor(node, 'horizontal').x).toBe(100 + NODE_WIDTH - 1);
+    expect(targetAnchor(node, 'horizontal').x).toBe(101);
+  });
+
+  it('should put the ports on the top and bottom edges when flowing vertically', () => {
+    const node = { x: 100, y: 200 };
+    expect(sourceAnchor(node, 'vertical').x).toBe(100 + NODE_WIDTH / 2);
+    expect(sourceAnchor(node, 'vertical').y).toBe(200 + NODE_HEIGHT - 1);
+    expect(targetAnchor(node, 'vertical').x).toBe(100 + NODE_WIDTH / 2);
+    expect(targetAnchor(node, 'vertical').y).toBe(201);
+  });
+
+  it('should curve along the flow axis', () => {
+    // Horizontal control points share the endpoints' y; vertical ones share x.
+    // The control offset is 60% of the gap, capped at 160 — here 300 * 0.6 = 180
+    // clamps to 160.
+    const from = { x: 0, y: 50 };
+    const to = { x: 300, y: 50 };
+    expect(edgePath(from, to, 'horizontal')).toBe(
+      'M 0 50 C 160 50, 140 50, 300 50',
+    );
+
+    const down = { x: 50, y: 0 };
+    const below = { x: 50, y: 300 };
+    expect(edgePath(down, below, 'vertical')).toBe(
+      'M 50 0 C 50 160, 50 140, 50 300',
+    );
+  });
+
+  it('should transpose a horizontal chain into a vertical one', () => {
+    const nodes = [at('a', 24, 24), at('b', 352, 24), at('c', 680, 24)];
+    const moved = transposePositions(nodes, 'vertical');
+    // One lane each, so they stack: same x, increasing y.
+    expect(new Set(moved.map((m) => m.x)).size).toBe(1);
+    expect(moved.map((m) => m.y)).toEqual(
+      [...moved.map((m) => m.y)].sort((p, q) => p - q),
+    );
+  });
+
+  it('should transpose a vertical chain back into a horizontal one', () => {
+    const nodes = [at('a', 24, 24), at('b', 24, 160), at('c', 24, 296)];
+    const moved = transposePositions(nodes, 'horizontal', 900);
+    expect(new Set(moved.map((m) => m.y)).size).toBe(1);
+    expect(moved.map((m) => m.x)).toEqual(
+      [...moved.map((m) => m.x)].sort((p, q) => p - q),
+    );
+  });
+
+  it('should be stable across repeated swaps', () => {
+    // The point of normalising to lanes: swapping back and forth must not drift.
+    let nodes = [at('a', 24, 24), at('b', 352, 24), at('c', 680, 24)];
+    const firstVertical = transposePositions(nodes, 'vertical', 900);
+    nodes = firstVertical.map((m) => at(m.id, m.x, m.y));
+    const firstHorizontal = transposePositions(nodes, 'horizontal', 900);
+    nodes = firstHorizontal.map((m) => at(m.id, m.x, m.y));
+    const secondVertical = transposePositions(nodes, 'vertical', 900);
+    expect(secondVertical).toEqual(firstVertical);
+
+    nodes = secondVertical.map((m) => at(m.id, m.x, m.y));
+    expect(transposePositions(nodes, 'horizontal', 900)).toEqual(
+      firstHorizontal,
+    );
+  });
+
+  it('should keep a branching graph on separate lanes', () => {
+    // `a` feeds both `b` and `c`, which sit in one lane together.
+    const nodes = [at('a', 24, 24), at('b', 352, 24), at('c', 352, 160)];
+    const moved = transposePositions(nodes, 'vertical', 900);
+    const byId = new Map(moved.map((m) => [m.id, m]));
+    // b and c share a row below a, at different x.
+    expect(byId.get('b')!.y).toBe(byId.get('c')!.y);
+    expect(byId.get('b')!.x).not.toBe(byId.get('c')!.x);
+    expect(byId.get('a')!.y).toBeLessThan(byId.get('b')!.y);
+  });
+
+  it('should never place a node at a negative coordinate', () => {
+    const nodes = [at('a', 24, 24), at('b', 352, 160)];
+    for (const to of ['vertical', 'horizontal'] as const) {
+      for (const move of transposePositions(nodes, to, 900)) {
+        expect(move.x).toBeGreaterThanOrEqual(0);
+        expect(move.y).toBeGreaterThanOrEqual(0);
+      }
+    }
+  });
+
+  it('should not overlap nodes in either orientation', () => {
+    const nodes = [
+      at('a', 24, 24),
+      at('b', 352, 24),
+      at('c', 352, 160),
+      at('d', 680, 24),
+    ];
+    for (const to of ['vertical', 'horizontal'] as const) {
+      const moved = transposePositions(nodes, to, 900);
+      for (let i = 0; i < moved.length; i += 1) {
+        for (let j = i + 1; j < moved.length; j += 1) {
+          const overlapping =
+            Math.abs(moved[i].x - moved[j].x) < NODE_WIDTH &&
+            Math.abs(moved[i].y - moved[j].y) < NODE_HEIGHT;
+          expect(
+            overlapping,
+            `${to}: ${moved[i].id} overlaps ${moved[j].id}`,
+          ).toBe(false);
+        }
+      }
+    }
+  });
+
+  it('should fit a horizontal layout in the width it is given', () => {
+    // Five lanes cannot fit 400px at any spacing, so they wrap rather than
+    // running off the edge.
+    const nodes = [0, 1, 2, 3, 4].map((i) => at(`n${i}`, 24 + i * 328, 24));
+    for (const width of [900, 560, 400]) {
+      for (const move of transposePositions(nodes, 'horizontal', width)) {
+        expect(
+          move.x + NODE_WIDTH,
+          `a node overflows a ${width}px canvas`,
+        ).toBeLessThanOrEqual(width);
+      }
+    }
+  });
+
+  it('should handle an empty graph', () => {
+    expect(transposePositions([], 'vertical')).toEqual([]);
   });
 });
 

--- a/docs/src/styles/graph-builder.css
+++ b/docs/src/styles/graph-builder.css
@@ -147,32 +147,85 @@
   cursor: default;
 }
 
-/* The preset picker. Matches the chips beside it rather than the inspector's
- * fields, since it sits in the toolbar. */
-.gb-select {
+/* The preset picker. A listbox rather than a native select, so the open menu is
+ * one of the builder's own surfaces rather than the platform's white popup. The
+ * button matches .gb-chip so it sits level with the toolbar's other controls. */
+.gb-picker {
+  position: relative;
+  display: inline-flex;
+}
+
+.gb-picker-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
   font: inherit;
-  font-size: 0.875rem;
   line-height: 1;
-  padding: 0.4rem 0.6rem;
+  height: 2rem;
+  padding: 0 0.75rem 0 0.85rem;
   border-radius: 9999px;
   border: 1px solid var(--gb-border);
-  background: var(--gb-raised);
-  color: var(--gb-text);
+  background: transparent;
+  color: var(--gb-muted);
   cursor: pointer;
-  max-width: 14rem;
   transition:
+    color 150ms ease,
     border-color 150ms ease,
-    box-shadow 150ms ease;
+    background-color 150ms ease;
 }
 
-.gb-select:hover {
+.gb-picker-button:hover,
+.gb-picker-button.is-open {
+  color: var(--gb-text);
   border-color: var(--gb-accent);
+  background: var(--gb-accent-soft);
 }
 
-.gb-select:focus-visible {
+.gb-picker-button:focus-visible {
   outline: none;
   border-color: var(--gb-accent);
   box-shadow: 0 0 0 3px var(--gb-accent-soft);
+}
+
+.gb-picker-chevron {
+  width: 0.85rem;
+  height: 0.85rem;
+  flex-shrink: 0;
+  transition: transform 150ms ease;
+}
+
+.gb-picker-button.is-open .gb-picker-chevron {
+  transform: rotate(180deg);
+}
+
+.gb-picker-menu {
+  position: absolute;
+  top: calc(100% + 0.35rem);
+  left: 0;
+  z-index: 10;
+  min-width: 100%;
+  width: max-content;
+  max-width: 18rem;
+  margin: 0;
+  padding: 0.3rem;
+  list-style: none;
+  border-radius: var(--gb-radius-sm);
+  border: 1px solid var(--gb-border);
+  background: var(--gb-panel);
+  box-shadow: 0 12px 28px -12px rgb(0 0 0 / 0.45);
+}
+
+.gb-picker-option {
+  padding: 0.4rem 0.6rem;
+  border-radius: 6px;
+  color: var(--gb-text);
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.gb-picker-option.is-active {
+  background: var(--sl-color-accent-low);
+  color: var(--sl-color-accent-high);
 }
 
 /* A chip pairing a glyph with its label, for actions whose direction is easier

--- a/docs/src/styles/graph-builder.css
+++ b/docs/src/styles/graph-builder.css
@@ -147,6 +147,34 @@
   cursor: default;
 }
 
+/* The preset picker. Matches the chips beside it rather than the inspector's
+ * fields, since it sits in the toolbar. */
+.gb-select {
+  font: inherit;
+  font-size: 0.875rem;
+  line-height: 1;
+  padding: 0.4rem 0.6rem;
+  border-radius: 9999px;
+  border: 1px solid var(--gb-border);
+  background: var(--gb-raised);
+  color: var(--gb-text);
+  cursor: pointer;
+  max-width: 14rem;
+  transition:
+    border-color 150ms ease,
+    box-shadow 150ms ease;
+}
+
+.gb-select:hover {
+  border-color: var(--gb-accent);
+}
+
+.gb-select:focus-visible {
+  outline: none;
+  border-color: var(--gb-accent);
+  box-shadow: 0 0 0 3px var(--gb-accent-soft);
+}
+
 /* A chip pairing a glyph with its label, for actions whose direction is easier
  * to read as a picture than as words. */
 .gb-chip--icon {

--- a/docs/src/styles/graph-builder.css
+++ b/docs/src/styles/graph-builder.css
@@ -147,6 +147,19 @@
   cursor: default;
 }
 
+/* A chip pairing a glyph with its label, for actions whose direction is easier
+ * to read as a picture than as words. */
+.gb-chip--icon {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.gb-chip--icon svg {
+  width: 0.95rem;
+  height: 0.95rem;
+}
+
 .gb-chip--danger:hover:not(:disabled) {
   color: var(--gb-danger);
   border-color: var(--gb-danger);
@@ -688,12 +701,33 @@
     transform 120ms ease;
 }
 
-.gb-port--in {
+/* Horizontal flow: ports on the side edges, centred vertically. */
+.gb-port--in-horizontal {
   left: -0.35rem;
 }
 
-.gb-port--out {
+.gb-port--out-horizontal {
   right: -0.35rem;
+}
+
+/* Vertical flow: ports on the top and bottom edges, centred horizontally. The
+ * base rule centres vertically via translateY, so that is overridden here. */
+.gb-port--in-vertical,
+.gb-port--out-vertical {
+  top: auto;
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.gb-port--in-vertical {
+  top: -0.35rem;
+}
+
+.gb-port--out-vertical {
+  bottom: -0.35rem;
+}
+
+.gb-port--out {
   cursor: crosshair;
 }
 
@@ -702,10 +736,16 @@
   border-color: var(--gb-accent);
 }
 
-.gb-port--out:hover {
+.gb-port--out-horizontal:hover {
   border-color: var(--gb-accent);
   background: var(--gb-accent);
   transform: translateY(-50%) scale(1.35);
+}
+
+.gb-port--out-vertical:hover {
+  border-color: var(--gb-accent);
+  background: var(--gb-accent);
+  transform: translateX(-50%) scale(1.35);
 }
 
 .gb-port--out:focus-visible {


### PR DESCRIPTION
### Reason for this change

The graph builder only laid graphs out left to right. A deep graph — a website into an agent into an MCP server into a table — runs off the right edge long before it runs out of vertical room, and the canvas is wider than it is tall only by a little. Flowing top to bottom suits those shapes much better, and it is the direction most architecture diagrams are drawn in.

### Description of changes

A toolbar toggle swaps the flow axis. In vertical mode each component's connection points move to its **top and bottom edges**, edges curve downward rather than across, and a self-edge loops out to the side instead of over the top.

Swapping **transposes the layout**, not just the ports — otherwise the nodes would still be strung out along the old axis with the edges now leaving their sides. The transpose normalises positions into lanes first: nodes sharing a position on the old flow axis become one lane, and lanes become steps along the new one. That has two useful consequences:

- **Repeated swapping is idempotent.** Transposing raw pixel values would accumulate drift; normalising means the third swap looks exactly like the first.
- **A hand-nudged layout still groups sensibly**, because lane grouping has a tolerance of half a node rather than needing exact equality.

Horizontal lanes are tightened to the canvas width and wrap onto further rows when even the tightest spacing will not fit — the same rule presets already use, so a transposed graph and a freshly loaded preset agree. A preset loaded while the canvas is vertical arrives transposed too.

Also in this PR: the five "Start from" preset buttons become a single picker. The row of them was competing with the canvas actions beside it, and it only gets longer as examples are added.

It is a listbox rather than a native `<select>`, because a select's popup is drawn by the platform — white, square-cornered, blue highlight — whatever the page's theme. The menu here is one of the builder's own surfaces instead, and correct in both light and dark. It keeps a select's keyboard behaviour: arrows move (wrapping at the ends), Enter picks, Escape closes, Home/End jump, with focus staying on the button and `aria-activedescendant` tracking the highlighted option. There is no selected value to show — picking an example loads it and the button goes back to reading as a prompt, so the same one can be picked again.

### Screenshots

**Horizontal** (the default) — ports on the side edges:

![Graph builder flowing left to right, with connection points on the left and right edges of each component](https://gist.githubusercontent.com/nx-plugin-for-aws/e9aaf774d54eaa08a4f7776fce4434b0/raw/gb-horizontal.png)

**Vertical** — ports on the top and bottom edges, edges running straight down, and the branch to `my-table` curving out to the side:

![Graph builder flowing top to bottom, with connection points on the top and bottom edges of each component](https://gist.githubusercontent.com/nx-plugin-for-aws/e9aaf774d54eaa08a4f7776fce4434b0/raw/gb-vertical.png)

The button label and icon show what pressing it will do, so it reads as an action rather than a state.

**The example picker, open** — the menu uses the builder's panel surface and the brand accent for the highlighted option, rather than the platform's white popup:

![The graph builder's example picker open, showing five examples with one highlighted in the brand accent colour](https://gist.githubusercontent.com/nx-plugin-for-aws/e9aaf774d54eaa08a4f7776fce4434b0/raw/gb-dropdown-open.png)

The same picker in dark mode:

![The example picker open in dark mode, with a dark panel and a deep purple highlight](https://gist.githubusercontent.com/nx-plugin-for-aws/e9aaf774d54eaa08a4f7776fce4434b0/raw/gb-dropdown-dark.png)

### Description of how you validated changes

**Measured in a real browser**, not just eyeballed — for each of three presets, in both orientations, and across repeated swaps:

- **Ports and edges line up exactly.** In vertical mode all three nodes' ports sit at x=128 and the edge endpoints land on them precisely (`128,99 → 128,161` and `128,235 → 128,297`).
- **Swapping is stable.** Three round trips gave byte-identical positions each time (v1 = v2 = v3, h1 = h2 = h3).
- **A round trip returns the original layout** — the horizontal screenshot before and after a swap out and back are pixel-identical.
- **Nothing overflows or overlaps** in either orientation, for the tRPC, Agentic and Multi-agent presets.

This caught a real bug: the first version used full spacing when coming back to horizontal, putting the rightmost node at 888px in an 799px canvas. Hence the width-aware lane fitting.

**Unit tests** — 114 docs tests, 13 new: anchor positions per orientation, that the bezier control points follow the flow axis, transpose in both directions, idempotence across repeated swaps, branch lanes staying grouped, no negative coordinates, no overlap, and fitting a given width at 900/560/400px.

Lint and the docs build with link validation pass.

### Issue # (if applicable)

N/A — follows #1037 and #1039.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
