### PR TITLE
fix(py#agent,py#mcp-server): strip pip from the runtime image to clear HIGH image-scan CVEs

### DIFF
--- a/packages/nx-plugin/src/migrations/latest/strip-pip-from-python-images/__snapshots__/migration.spec.ts.snap
+++ b/packages/nx-plugin/src/migrations/latest/strip-pip-from-python-images/__snapshots__/migration.spec.ts.snap
@@ -1,0 +1,48 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`strip-pip-from-python-images migration > strips pip from a py#agent Dockerfile 1`] = `
+"FROM public.ecr.aws/docker/library/python:3.14-slim
+
+# Remove the base image's pip: the runtime runs from the bundled environment and
+# never needs it, and pip's vendored packages carry known HIGH/CRITICAL
+# vulnerabilities flagged by the image scan.
+RUN python -m pip uninstall -y pip && \\
+    rm -rf /usr/local/lib/python*/site-packages/pip \\
+           /usr/local/lib/python*/site-packages/pip-*.dist-info
+
+WORKDIR /app
+
+# Copy bundled package
+COPY . /app
+
+EXPOSE 8080
+
+ENV PYTHONPATH=/app
+ENV PATH="/app/bin:\${PATH}"
+
+CMD ["python", "bin/opentelemetry-instrument", "python", "-m", "proj_py_project.my_agent.main"]
+"
+`;
+
+exports[`strip-pip-from-python-images migration > strips pip from a py#mcp-server Dockerfile 1`] = `
+"FROM public.ecr.aws/docker/library/python:3.14-slim
+
+# Remove the base image's pip: the runtime runs from the bundled environment and
+# never needs it, and pip's vendored packages carry known HIGH/CRITICAL
+# vulnerabilities flagged by the image scan.
+RUN python -m pip uninstall -y pip && \\
+    rm -rf /usr/local/lib/python*/site-packages/pip \\
+           /usr/local/lib/python*/site-packages/pip-*.dist-info
+
+WORKDIR /app
+
+# Copy bundled package
+COPY . /app
+
+EXPOSE 8000
+
+ENV PYTHONPATH=/app
+
+CMD ["python", "bin/opentelemetry-instrument", "python", "-m", "uvicorn", "proj_py_project.my_mcp.http:app", "--host", "0.0.0.0", "--port", "8000"]
+"
+`;

--- a/packages/nx-plugin/src/migrations/latest/strip-pip-from-python-images/metadata.json
+++ b/packages/nx-plugin/src/migrations/latest/strip-pip-from-python-images/metadata.json
@@ -1,0 +1,3 @@
+{
+  "description": "Remove pip from vended Python agent / MCP server images so its vulnerable vendored packages are not present at runtime"
+}

--- a/packages/nx-plugin/src/migrations/latest/strip-pip-from-python-images/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/latest/strip-pip-from-python-images/migration.spec.ts
@@ -1,0 +1,181 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { addProjectConfiguration, type Tree } from '@nx/devkit';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test';
+import migration from './migration';
+
+const PROJECT_ROOT = 'packages/py-project/proj_py_project';
+const AGENT_DIR = 'my_agent';
+const MCP_DIR = 'my_mcp';
+const AGENT_DOCKERFILE = `${PROJECT_ROOT}/${AGENT_DIR}/Dockerfile`;
+const MCP_DOCKERFILE = `${PROJECT_ROOT}/${MCP_DIR}/Dockerfile`;
+
+const VENDED_AGENT_DOCKERFILE = `FROM public.ecr.aws/docker/library/python:3.14-slim
+
+WORKDIR /app
+
+# Copy bundled package
+COPY . /app
+
+EXPOSE 8080
+
+ENV PYTHONPATH=/app
+ENV PATH="/app/bin:\${PATH}"
+
+CMD ["python", "bin/opentelemetry-instrument", "python", "-m", "proj_py_project.my_agent.main"]
+`;
+
+const VENDED_MCP_DOCKERFILE = `FROM public.ecr.aws/docker/library/python:3.14-slim
+
+WORKDIR /app
+
+# Copy bundled package
+COPY . /app
+
+EXPOSE 8000
+
+ENV PYTHONPATH=/app
+
+CMD ["python", "bin/opentelemetry-instrument", "python", "-m", "uvicorn", "proj_py_project.my_mcp.http:app", "--host", "0.0.0.0", "--port", "8000"]
+`;
+
+/**
+ * Register a py-project whose components point at the given Dockerfile dirs, so
+ * the migration locates them the way it does in a real workspace.
+ */
+const seedProject = (
+  tree: Tree,
+  components: { generator: string; path: string; name: string }[],
+) => {
+  addProjectConfiguration(tree, 'proj.py-project', {
+    name: 'proj.py-project',
+    root: PROJECT_ROOT,
+    sourceRoot: PROJECT_ROOT,
+    projectType: 'application',
+    targets: {},
+    metadata: { components } as any,
+  });
+};
+
+describe('strip-pip-from-python-images migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeUsingTsSolutionSetup();
+  });
+
+  it('does nothing when there are no runtime image components', async () => {
+    const result = await migration(tree);
+    expect(result.nextSteps).toEqual([]);
+  });
+
+  it('strips pip from a py#agent Dockerfile', async () => {
+    seedProject(tree, [
+      { generator: 'py#agent', path: AGENT_DIR, name: 'my-agent' },
+    ]);
+    tree.write(AGENT_DOCKERFILE, VENDED_AGENT_DOCKERFILE);
+
+    const result = await migration(tree);
+    const content = tree.read(AGENT_DOCKERFILE, 'utf-8')!;
+
+    expect(content).toContain('RUN python -m pip uninstall -y pip');
+    expect(content).toContain(
+      'rm -rf /usr/local/lib/python*/site-packages/pip',
+    );
+    // Inserted after FROM, before the COPY.
+    expect(content.indexOf('pip uninstall')).toBeLessThan(
+      content.indexOf('COPY . /app'),
+    );
+    expect(result.nextSteps).toEqual([]);
+    expect(content).toMatchSnapshot();
+  });
+
+  it('strips pip from a py#mcp-server Dockerfile', async () => {
+    seedProject(tree, [
+      { generator: 'py#mcp-server', path: MCP_DIR, name: 'my-mcp' },
+    ]);
+    tree.write(MCP_DOCKERFILE, VENDED_MCP_DOCKERFILE);
+
+    const result = await migration(tree);
+    const content = tree.read(MCP_DOCKERFILE, 'utf-8')!;
+
+    expect(content).toContain('RUN python -m pip uninstall -y pip');
+    expect(result.nextSteps).toEqual([]);
+    expect(content).toMatchSnapshot();
+  });
+
+  it('ignores Dockerfiles not belonging to a runtime image component', async () => {
+    // A py#agent component exists, but a stray Dockerfile in the project (not
+    // the component's) must not be touched.
+    seedProject(tree, [
+      { generator: 'py#agent', path: AGENT_DIR, name: 'my-agent' },
+    ]);
+    tree.write(AGENT_DOCKERFILE, VENDED_AGENT_DOCKERFILE);
+    const strayDockerfile = `${PROJECT_ROOT}/other/Dockerfile`;
+    tree.write(strayDockerfile, VENDED_AGENT_DOCKERFILE);
+
+    await migration(tree);
+
+    expect(tree.read(AGENT_DOCKERFILE, 'utf-8')).toContain('pip uninstall');
+    expect(tree.read(strayDockerfile, 'utf-8')).toEqual(
+      VENDED_AGENT_DOCKERFILE,
+    );
+  });
+
+  it('skips and reports a Dockerfile that installs pip', async () => {
+    seedProject(tree, [
+      { generator: 'py#agent', path: AGENT_DIR, name: 'my-agent' },
+    ]);
+    const customised = VENDED_AGENT_DOCKERFILE.replace(
+      'WORKDIR /app',
+      'RUN pip install --no-cache-dir some-tool\n\nWORKDIR /app',
+    );
+    tree.write(AGENT_DOCKERFILE, customised);
+
+    const result = await migration(tree);
+
+    expect(tree.read(AGENT_DOCKERFILE, 'utf-8')).toEqual(customised);
+    expect(result.nextSteps).toEqual([
+      expect.stringContaining('this image uses pip'),
+    ]);
+  });
+
+  it('skips and reports a Dockerfile with another pip command', async () => {
+    seedProject(tree, [
+      { generator: 'py#agent', path: AGENT_DIR, name: 'my-agent' },
+    ]);
+    const customised = VENDED_AGENT_DOCKERFILE.replace(
+      'WORKDIR /app',
+      'RUN pip config set global.index-url https://example.com\n\nWORKDIR /app',
+    );
+    tree.write(AGENT_DOCKERFILE, customised);
+
+    const result = await migration(tree);
+
+    expect(tree.read(AGENT_DOCKERFILE, 'utf-8')).toEqual(customised);
+    expect(result.nextSteps).toEqual([
+      expect.stringContaining('this image uses pip'),
+    ]);
+  });
+
+  it('is idempotent', async () => {
+    seedProject(tree, [
+      { generator: 'py#agent', path: AGENT_DIR, name: 'my-agent' },
+      { generator: 'py#mcp-server', path: MCP_DIR, name: 'my-mcp' },
+    ]);
+    tree.write(AGENT_DOCKERFILE, VENDED_AGENT_DOCKERFILE);
+    tree.write(MCP_DOCKERFILE, VENDED_MCP_DOCKERFILE);
+
+    await migration(tree);
+    const agentAfterFirst = tree.read(AGENT_DOCKERFILE, 'utf-8');
+    const mcpAfterFirst = tree.read(MCP_DOCKERFILE, 'utf-8');
+
+    const secondRun = await migration(tree);
+
+    expect(tree.read(AGENT_DOCKERFILE, 'utf-8')).toEqual(agentAfterFirst);
+    expect(tree.read(MCP_DOCKERFILE, 'utf-8')).toEqual(mcpAfterFirst);
+    expect(secondRun.nextSteps).toEqual([]);
+  });
+});

--- a/packages/nx-plugin/src/migrations/latest/strip-pip-from-python-images/migration.ts
+++ b/packages/nx-plugin/src/migrations/latest/strip-pip-from-python-images/migration.ts
@@ -1,0 +1,130 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import {
+  getProjects,
+  joinPathFragments,
+  type MigrationReturnObject,
+  type ProjectConfiguration,
+  type Tree,
+} from '@nx/devkit';
+import { formatFilesInSubtree } from '../../../utils/format';
+import type { ComponentMetadata } from '../../../utils/nx';
+
+/**
+ * Remove pip from the vended Python agent / MCP server images.
+ *
+ * The runtime runs entirely from the bundled `/app` environment and never needs
+ * pip, whose vendored packages (setuptools, msgpack) in the base image carry
+ * known HIGH/CRITICAL vulnerabilities the image scan flags. New workspaces get
+ * this from the generator templates; this brings existing ones up to date.
+ *
+ * Only the Dockerfiles of `py#agent` / `py#mcp-server` components are touched,
+ * located from their project metadata. The Dockerfile is generated
+ * `KeepExisting`, so it is edited in place: the pip removal is inserted right
+ * after the `FROM` line. A Dockerfile whose pip usage has been customised (an
+ * added `pip install`, or any pip command other than this removal) is left
+ * untouched and reported via `nextSteps`, since stripping pip could break it.
+ */
+
+/**
+ * The generators whose runtime images vend pip and should have it stripped.
+ * Hardcoded rather than imported from the generators: a migration matches the
+ * ids workspaces recorded at generation time, which must stay fixed even if the
+ * generators' current ids change later.
+ */
+const RUNTIME_IMAGE_GENERATOR_IDS = ['py#agent', 'py#mcp-server'];
+
+const PIP_REMOVAL = `# Remove the base image's pip: the runtime runs from the bundled environment and
+# never needs it, and pip's vendored packages carry known HIGH/CRITICAL
+# vulnerabilities flagged by the image scan.
+RUN python -m pip uninstall -y pip && \\
+    rm -rf /usr/local/lib/python*/site-packages/pip \\
+           /usr/local/lib/python*/site-packages/pip-*.dist-info`;
+
+/** The exact pip command this migration adds; used to detect an applied fix. */
+const PIP_UNINSTALL = 'pip uninstall -y pip';
+
+/** Matches any `pip` invocation in a RUN instruction (python -m pip … or pip …). */
+const PIP_COMMAND = /\b(?:python\s+-m\s+)?pip\s+\S+/g;
+
+/**
+ * The Dockerfiles of every `py#agent` / `py#mcp-server` component, located from
+ * each project's recorded component metadata (`path` is the component directory
+ * relative to the project root).
+ */
+const runtimeImageDockerfiles = (tree: Tree): string[] => {
+  const paths: string[] = [];
+  for (const project of getProjects(tree).values()) {
+    const components = ((
+      project.metadata as { components?: ComponentMetadata[] }
+    )?.components ?? []) as ComponentMetadata[];
+    for (const component of components) {
+      if (
+        !RUNTIME_IMAGE_GENERATOR_IDS.includes(component.generator) ||
+        !component.path
+      ) {
+        continue;
+      }
+      const dockerfile = joinPathFragments(
+        projectRoot(project),
+        component.path,
+        'Dockerfile',
+      );
+      if (tree.exists(dockerfile)) {
+        paths.push(dockerfile);
+      }
+    }
+  }
+  return paths;
+};
+
+/** A project's root, falling back to sourceRoot for the TS-solution layout. */
+const projectRoot = (project: ProjectConfiguration): string =>
+  project.root ?? project.sourceRoot ?? '';
+
+export default async function migration(
+  tree: Tree,
+): Promise<MigrationReturnObject> {
+  const nextSteps: string[] = [];
+
+  for (const filePath of runtimeImageDockerfiles(tree)) {
+    const content = tree.read(filePath, 'utf-8');
+    if (!content) {
+      continue;
+    }
+    if (content.includes(PIP_UNINSTALL)) {
+      continue; // Already stripped (migrated or user-added).
+    }
+
+    // Leave a customised Dockerfile alone: any pip usage other than this
+    // migration's removal (e.g. an added `pip install`) means stripping pip
+    // could break the image, so flag it for the user instead of editing.
+    const pipUsages = content.match(PIP_COMMAND) ?? [];
+    if (pipUsages.length > 0) {
+      nextSteps.push(
+        `In ${filePath}: this image uses pip (${pipUsages.join(', ')}), so it was left unchanged. pip's vendored packages carry known vulnerabilities flagged by the image scan — remove pip once it is no longer needed, e.g. \`RUN python -m pip uninstall -y pip && rm -rf /usr/local/lib/python*/site-packages/pip /usr/local/lib/python*/site-packages/pip-*.dist-info\`.`,
+      );
+      continue;
+    }
+
+    // Insert the pip removal after the FROM line and its trailing blank line,
+    // matching the spacing a freshly generated Dockerfile has.
+    const updated = content.replace(
+      /^(FROM\s+\S*python:.*\n)\n/m,
+      `$1\n${PIP_REMOVAL}\n\n`,
+    );
+    if (updated === content) {
+      nextSteps.push(
+        `In ${filePath}: remove pip from the image so its vulnerable vendored packages are not scanned — add \`RUN python -m pip uninstall -y pip && rm -rf /usr/local/lib/python*/site-packages/pip /usr/local/lib/python*/site-packages/pip-*.dist-info\` after the FROM line (the runtime does not need pip).`,
+      );
+      continue;
+    }
+    tree.write(filePath, updated);
+  }
+
+  await formatFilesInSubtree(tree);
+
+  return { nextSteps };
+}

--- a/packages/nx-plugin/src/py/agent/__snapshots__/generator.constructs.spec.ts.snap
+++ b/packages/nx-plugin/src/py/agent/__snapshots__/generator.constructs.spec.ts.snap
@@ -3,6 +3,13 @@
 exports[`py#agent generator > should match snapshot for BedrockAgentCoreRuntime generated constructs files > agent-Dockerfile 1`] = `
 "FROM public.ecr.aws/docker/library/python:3.14-slim
 
+# Remove the base image's pip: the agent runs from the bundled environment and
+# never needs it at runtime, and pip's vendored packages carry known
+# HIGH/CRITICAL vulnerabilities flagged by the image scan.
+RUN python -m pip uninstall -y pip && \\
+    rm -rf /usr/local/lib/python*/site-packages/pip \\
+           /usr/local/lib/python*/site-packages/pip-*.dist-info
+
 WORKDIR /app
 
 # Copy bundled package

--- a/packages/nx-plugin/src/py/agent/files/deploy/Dockerfile.template
+++ b/packages/nx-plugin/src/py/agent/files/deploy/Dockerfile.template
@@ -1,5 +1,12 @@
 FROM <%- pythonBaseImage %>
 
+# Remove the base image's pip: the agent runs from the bundled environment and
+# never needs it at runtime, and pip's vendored packages carry known
+# HIGH/CRITICAL vulnerabilities flagged by the image scan.
+RUN python -m pip uninstall -y pip && \
+    rm -rf /usr/local/lib/python*/site-packages/pip \
+           /usr/local/lib/python*/site-packages/pip-*.dist-info
+
 WORKDIR /app
 
 # Copy bundled package

--- a/packages/nx-plugin/src/py/mcp-server/files/deploy/Dockerfile.template
+++ b/packages/nx-plugin/src/py/mcp-server/files/deploy/Dockerfile.template
@@ -1,5 +1,12 @@
 FROM <%- pythonBaseImage %>
 
+# Remove the base image's pip: the server runs from the bundled environment and
+# never needs it at runtime, and pip's vendored packages carry known
+# HIGH/CRITICAL vulnerabilities flagged by the image scan.
+RUN python -m pip uninstall -y pip && \
+    rm -rf /usr/local/lib/python*/site-packages/pip \
+           /usr/local/lib/python*/site-packages/pip-*.dist-info
+
 WORKDIR /app
 
 # Copy bundled package


### PR DESCRIPTION
### Reason for this change

The image scan (\`Smoke Tests - trivy\`) flags 2 HIGH vulnerabilities in the generated Python agent / MCP server images:

- **setuptools** — CVE-2025-47273 (path traversal), installed 70.3.0
- **msgpack** — GHSA-6v7p-g79w-8964 (out-of-bounds read), installed 1.1.2

These are **not** application dependencies. They are pip's *vendored* copies (\`pip/_vendor/vendor.txt\`) baked into the \`python:3.14-slim\` base image — the bundled \`/app\` environment already resolves patched versions (setuptools 83.0.0, msgpack 1.2.1). Pinning them as app deps does not clear the finding, because trivy scans pip's vendored copies in the base image's site-packages.

### Description of changes

The agent and MCP server run entirely from the bundled \`/app\` environment and never invoke pip at runtime, so the vended Python Dockerfile templates now remove pip (and its vulnerable vendored packages) from the image:

```dockerfile
RUN python -m pip uninstall -y pip && \
    rm -rf /usr/local/lib/python*/site-packages/pip \
           /usr/local/lib/python*/site-packages/pip-*.dist-info
```

This mirrors the existing "upgrade npm to a version free of known HIGH/CRITICAL vulnerabilities" step already present in the TypeScript agent / MCP server images.

### Description of how you validated changes

- Generated a Python agent, built the image, and ran the exact CI scan (\`trivy image --scanners vuln --severity HIGH,CRITICAL --ignore-unfixed --exit-code 1\`): **before** — 2 HIGH (pip-vendored setuptools/msgpack); **after** stripping pip — **exit 0, no findings**.
- Confirmed the agent still runs from \`/app/bin/opentelemetry-instrument\` (pip is not on the runtime path).
- Updated the affected generator snapshot; \`py#agent\` and \`py#mcp-server\` unit suites pass.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*