### PR TITLE
fix(ts#nx-migration): order migrations within a release by commit order

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -193,6 +193,10 @@ Do not add a `version` field to `migrations.json` entries — versions arrive on
 
 A version already recorded in source always wins, so the backfilled values are stable and the release only has to reason about entries that are still unversioned.
 
+##### Order within a release
+
+Migrations shipped together share a version — a batch stamped with the same pending release, or a whole `v<x.y.z>/` folder replayed on a big version jump. `nx migrate` sorts the run ascending by version and keeps the manifest's order among equal versions, so **within a version, migrations run in the order they were committed**: stamping ranks each by the commit that added its folder (`scripts/utils/migration-commit-order.ts`) and emits them in that order. An earlier-authored migration therefore runs before a later one in the same release, so you can land a batch of dependent changes across separate commits without worrying about ordering — commit the migration a later one relies on first. Two migrations added in the same commit (a squashed PR) share a rank and fall back to alphabetical order, so if one depends on the other, split them across commits. The `everyMigration` sync entry always runs last regardless (see below). Ordering follows the folder through the `latest/` → `v<x.y.z>/` move — `git log --follow` walks the rename back to the original add — so a migration keeps its place once a release claims it.
+
 #### Vended dependency versions
 
 Version bumps ship themselves, and everything that makes that work lives in `utils/version-upgrade-migration/`. The weekly `update-versions` PR rewrites the vended versions in `utils/versions.ts` and nothing else needs authoring or generating per bump: `migrations.json` carries one committed `sync-vended-versions` entry marked `everyMigration: true`, pointing at `migration.ts`. That delegates to `syncVendedVersions` (`sync-vended-versions.ts`), which syncs TypeScript dependencies (catalogs and direct ranges), Python `pyproject.toml` pins, Terraform provider versions and the plugin version the metrics files report.

--- a/packages/nx-plugin/src/utils/migration-versions.spec.ts
+++ b/packages/nx-plugin/src/utils/migration-versions.spec.ts
@@ -224,6 +224,86 @@ describe('migration versions', () => {
       ]);
     });
 
+    it('should order migrations sharing a version by commit rank', () => {
+      const stamped = stampMigrationVersions(
+        {
+          generators: {
+            'latest-authored-second': { description: 'second' },
+            'latest-authored-first': { description: 'first' },
+          },
+        },
+        {},
+        '1.3.0',
+        // Keys aren't in commit order — the ranks are what orders them.
+        { 'latest-authored-first': 1, 'latest-authored-second': 2 },
+      );
+      expect(Object.keys(stamped.generators ?? {})).toEqual([
+        'latest-authored-first',
+        'latest-authored-second',
+      ]);
+    });
+
+    it('should keep every-migration entries last regardless of commit rank', () => {
+      const stamped = stampMigrationVersions(
+        {
+          generators: {
+            'sync-vended-versions': {
+              description: 'runs every migration',
+              everyMigration: true,
+            },
+            'latest-code-change': { description: 'a code migration' },
+          },
+        },
+        {},
+        '1.3.0',
+        // A high rank on the code migration must not float it past the
+        // every-migration entry, which carries no rank.
+        { 'latest-code-change': 99 },
+      );
+      expect(Object.keys(stamped.generators ?? {})).toEqual([
+        'latest-code-change',
+        'sync-vended-versions',
+      ]);
+    });
+
+    it('should sort ranked migrations ahead of unranked ones', () => {
+      const stamped = stampMigrationVersions(
+        {
+          generators: {
+            'latest-unranked': { description: 'no history' },
+            'latest-ranked': { description: 'has history' },
+          },
+        },
+        {},
+        '1.3.0',
+        { 'latest-ranked': 5 },
+      );
+      expect(Object.keys(stamped.generators ?? {})).toEqual([
+        'latest-ranked',
+        'latest-unranked',
+      ]);
+    });
+
+    it('should fall back to manifest key order for equal ranks', () => {
+      const stamped = stampMigrationVersions(
+        {
+          generators: {
+            'latest-alpha': { description: 'alpha' },
+            'latest-bravo': { description: 'bravo' },
+          },
+        },
+        {},
+        '1.3.0',
+        // Added in the same commit (squash merge), so the same rank — the stable
+        // sort leaves the manifest's key order in place.
+        { 'latest-alpha': 3, 'latest-bravo': 3 },
+      );
+      expect(Object.keys(stamped.generators ?? {})).toEqual([
+        'latest-alpha',
+        'latest-bravo',
+      ]);
+    });
+
     it('should strip the source-only everyMigration flag', () => {
       const stamped = stampMigrationVersions(
         {

--- a/packages/nx-plugin/src/utils/migration-versions.ts
+++ b/packages/nx-plugin/src/utils/migration-versions.ts
@@ -111,31 +111,57 @@ export const readShippedMigrationVersions = (
 };
 
 /**
+ * Rank a migration ships under, lower running first. Unranked entries (no commit
+ * history for them, or an every-migration entry with no folder) sort after every
+ * ranked one, so a ranked migration always precedes an unranked peer.
+ */
+const UNRANKED = Number.MAX_SAFE_INTEGER;
+
+/**
  * Return a copy of the migrations collection with a `version` stamped onto
  * every generator entry, preserving any already present, and the pending version
  * recorded on any `packageJsonUpdates` entry still holding `latest`.
+ *
+ * `nx migrate` sorts the run ascending by version and keeps the manifest's order
+ * among equal versions, so the order entries are emitted in is the run order
+ * within a release. Migrations sharing a version (a batch shipped together, or a
+ * whole `v<x.y.z>` folder replayed on a big version jump) are therefore ordered
+ * here by the commit that added them — an earlier-committed migration runs
+ * first — so a later migration can depend on an earlier one in the same batch.
+ * Every-migration entries are emitted last regardless, so they run after the
+ * release's own migrations (letting one add a dependency this then brings up to
+ * date). Entries with no rank fall back to the manifest's order, which
+ * `assembleMigrations` already sorts by key.
  *
  * @param migrations parsed migrations.json to stamp
  * @param shippedVersions migration key -> version of the earliest release
  *   tag that registers it (absent for migrations that haven't shipped)
  * @param pendingVersion version the release is about to publish, stamped onto
  *   unshipped migrations so their version is one that really shipped
+ * @param commitRanks migration key -> rank of the commit that added it (lower is
+ *   earlier); absent entries fall back to the manifest's order
  */
 export const stampMigrationVersions = (
   migrations: MigrationsJson,
   shippedVersions: Record<string, string>,
   pendingVersion: string,
+  commitRanks: Record<string, number> = {},
 ): MigrationsJson => ({
   ...migrations,
   generators: Object.fromEntries(
-    // `nx migrate` sorts the run ascending by version and preserves the
-    // manifest's order among equal versions, so emitting the every-migration
-    // entries last is what makes them run after the release's own migrations.
     Object.entries(migrations.generators ?? {})
-      .sort(
-        ([, a], [, b]) =>
-          Number(a.everyMigration ?? false) - Number(b.everyMigration ?? false),
-      )
+      .sort(([keyA, a], [keyB, b]) => {
+        const everyDiff =
+          Number(a.everyMigration ?? false) - Number(b.everyMigration ?? false);
+        if (everyDiff !== 0) {
+          return everyDiff;
+        }
+        // Equal ranks (same commit, or both unranked) fall through to a stable
+        // sort, keeping the manifest's key order the assembly already imposed.
+        return (
+          (commitRanks[keyA] ?? UNRANKED) - (commitRanks[keyB] ?? UNRANKED)
+        );
+      })
       .map(([name, entry]) => {
         // Source-only marker, stripped from what nx reads.
         const { everyMigration, version: sourceVersion, ...published } = entry;

--- a/scripts/stamp-migrations.ts
+++ b/scripts/stamp-migrations.ts
@@ -9,6 +9,7 @@ import {
   readShippedMigrationVersions,
   stampMigrationVersions,
 } from '../packages/nx-plugin/src/utils/migration-versions';
+import { readMigrationCommitRanks } from './utils/migration-commit-order';
 import {
   discoverMigrations,
   readPackageJsonUpdates,
@@ -78,9 +79,10 @@ const main = () => {
   const { name } = JSON.parse(
     readFileSync('packages/nx-plugin/package.json', 'utf-8'),
   );
+  const discovered = discoverMigrations();
   const migrations = assembleMigrations(
     name,
-    discoverMigrations(),
+    discovered,
     readPackageJsonUpdates(),
   );
 
@@ -95,6 +97,10 @@ const main = () => {
     migrations,
     readShippedMigrationVersions(migrations, versions, readReleasedMigrations),
     pendingVersion,
+    // Order migrations sharing a version by the commit that added them, so an
+    // earlier-committed one runs first and a later one in the same batch can
+    // depend on it.
+    readMigrationCommitRanks(discovered),
   );
 
   writeFileSync(outPath, `${JSON.stringify(stamped, null, 2)}\n`, 'utf-8');

--- a/scripts/utils/migration-commit-order.ts
+++ b/scripts/utils/migration-commit-order.ts
@@ -1,0 +1,95 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { execFileSync } from 'node:child_process';
+import { join } from 'node:path';
+import type { DiscoveredMigration } from '../../packages/nx-plugin/src/utils/migration-manifest';
+import { migrationKey } from '../../packages/nx-plugin/src/utils/migration-versions';
+import { MIGRATIONS_DIR } from './migration-folders';
+
+/**
+ * Resolves the commit order of the migration folders, so release-time stamping
+ * can order migrations sharing a version by when they were committed (see
+ * `migration-versions.ts` for how that order becomes the `nx migrate` run order).
+ *
+ * `main` is linear (the repo squash- and rebase-merges), so a migration's rank
+ * is the position on `main` of the commit that first added its folder. A later
+ * `git mv` into a `v<x.y.z>` folder at release time doesn't reset that — `git log
+ * --follow` walks through the rename back to the original add — so a migration
+ * keeps its rank once a release claims it.
+ *
+ * Requires full history; the release job and the migrate smoke test that call
+ * the stamping script both check out `fetch-depth: 0`.
+ */
+
+/** Run a git command from the repo root, returning trimmed stdout or undefined. */
+const tryGit = (args: string[]): string | undefined => {
+  try {
+    return execFileSync('git', args, {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'ignore'],
+    }).trim();
+  } catch {
+    return undefined;
+  }
+};
+
+/**
+ * The commit that first added a path, following it through renames. `git log`
+ * lists newest first and `--follow` is incompatible with `--reverse`, so the
+ * oldest (the add) is the last line.
+ */
+const addCommit = (path: string): string | undefined => {
+  const log = tryGit([
+    'log',
+    '--follow',
+    '--diff-filter=A',
+    '--format=%H',
+    '--',
+    path,
+  ]);
+  if (!log) {
+    return undefined;
+  }
+  const commits = log.split('\n').filter(Boolean);
+  return commits[commits.length - 1];
+};
+
+/** Position of a commit on the current linear branch (older commits rank lower). */
+const commitRank = (commit: string): number | undefined => {
+  const count = tryGit(['rev-list', '--count', commit]);
+  return count ? Number(count) : undefined;
+};
+
+/**
+ * Map of migration key -> rank of the commit that added its folder, for the
+ * migrations that resolve to one. A migration with no history (unlikely outside
+ * a shallow checkout) is absent, and stamping falls back to the manifest order
+ * for it.
+ *
+ * @param migrations migration folders discovered under `src/migrations`
+ * @param migrationsDir where those folders live, relative to the repo root
+ */
+export const readMigrationCommitRanks = (
+  migrations: DiscoveredMigration[],
+  migrationsDir: string = MIGRATIONS_DIR,
+): Record<string, number> => {
+  const ranks: Record<string, number> = {};
+  for (const migration of migrations) {
+    // metadata.json is present for every migration and moves with the folder,
+    // so it is a stable anchor for the folder's history across the release move.
+    const metadataPath = join(
+      migrationsDir,
+      migration.dir,
+      migration.name,
+      'metadata.json',
+    );
+    const commit = addCommit(metadataPath);
+    const rank = commit ? commitRank(commit) : undefined;
+    if (rank !== undefined) {
+      ranks[migrationKey(migration.dir, migration.name)] = rank;
+    }
+  }
+  return ranks;
+};


### PR DESCRIPTION
### Reason for this change

Migrations shipped under the same version — a batch stamped with one pending release, or a whole `v<x.y.z>/` folder replayed on a big version jump — had no ordering guarantee. The assembled `migrations.json` sorts entries alphabetically by key, and `nx migrate` preserves the manifest's order among equal versions, so within a release migrations ran in alphabetical order. That meant an earlier-authored migration was not guaranteed to run before a later one in the same batch, so a release containing dependent migrations could run them out of order.

### Description of changes

Release-time stamping now orders migrations sharing a version by the commit that added them, so an earlier-committed migration runs first and a later one in the same batch can depend on it.

- `stampMigrationVersions` takes an optional `commitRanks` map and sorts equal-version entries by rank (every-migration entries still emitted last; entries with no resolvable rank fall back to the manifest's key order via a stable sort).
- New `scripts/utils/migration-commit-order.ts` resolves each migration's rank from `git log --follow --diff-filter=A` on its `metadata.json` (which survives the `latest/` → `v<x.y.z>/` `git mv`) plus `git rev-list --count`. Requires full history — the release job and the migrate smoke test that stamp both check out `fetch-depth: 0`.
- `scripts/stamp-migrations.ts` passes the ranks in.
- Assembly and backfill are unchanged: assembly stays git-free and deterministic (it runs on every build, including shallow checkouts), and the stamped manifest remains the single authoritative ordering point — mirroring how the every-migration-last ordering already worked.
- Two migrations added in the same commit (a squashed PR) share a rank and fall back to alphabetical order; documented in CONTRIBUTING so authors split dependent migrations across commits.

### Description of how you validated changes

- Added unit tests to `migration-versions.spec.ts` covering: commit-rank ordering, every-migration entries staying last regardless of rank, ranked-before-unranked, and the stable fallback for equal ranks. Full plugin test suite (82 tests) and `compile` pass.
- Validated end-to-end against a **deep clone** with full history by running the real `stamp-migrations.ts`: the pending batch now orders `waf-log-group-removal` (committed first) before `strip-pip-from-python-images`, reversing the previous alphabetical order, with `sync-vended-versions` last.
- Validated the **shallow clone** path degrades gracefully — ranks collapse and stamping falls back to manifest order.
- Verified `git log --follow` recovers a migration's original add-commit across a `git mv` into a version folder, and that nx preserves equal-version manifest order (brute-force checked against the nx 23.1.1 comparator).

### Issue # (if applicable)

N/A.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*