### PR TITLE
feat(graph-builder): match command box to docs code block style

### DIFF
--- a/docs/src/components/graph-builder/output.tsx
+++ b/docs/src/components/graph-builder/output.tsx
@@ -18,14 +18,16 @@ const PACKAGE_MANAGERS = ['pnpm', 'npm', 'yarn', 'bun'] as const;
 
 export const Output = ({ graph, issues, options, onOptionsChange }: Props) => {
   const [annotate, setAnnotate] = useState(true);
+  const [createWorkspace, setCreateWorkspace] = useState(true);
   const [copied, setCopied] = useState(false);
 
   const errors = issues.filter((issue) => issue.severity === 'error');
   const warnings = issues.filter((issue) => issue.severity === 'warning');
 
   const script = useMemo(
-    () => toScript(graph, options, { annotate }),
-    [graph, options, annotate],
+    () =>
+      toScript(graph, options, { annotate, skipWorkspace: !createWorkspace }),
+    [graph, options, annotate, createWorkspace],
   );
 
   useEffect(() => {
@@ -92,14 +94,22 @@ export const Output = ({ graph, issues, options, onOptionsChange }: Props) => {
         </div>
 
         <div className="gb-output-actions">
-          <label className="gb-inline-check">
-            <input
-              type="checkbox"
-              checked={annotate}
-              onChange={(event) => setAnnotate(event.target.checked)}
-            />
-            <span>Comments</span>
-          </label>
+          <button
+            type="button"
+            className={`gb-toggle-pill${createWorkspace ? ' is-active' : ''}`}
+            aria-pressed={createWorkspace}
+            onClick={() => setCreateWorkspace((value) => !value)}
+          >
+            Create workspace
+          </button>
+          <button
+            type="button"
+            className={`gb-toggle-pill${annotate ? ' is-active' : ''}`}
+            aria-pressed={annotate}
+            onClick={() => setAnnotate((value) => !value)}
+          >
+            Comments
+          </button>
           <button
             type="button"
             className={`gb-copy-btn${copied ? ' is-copied' : ''}`}
@@ -149,7 +159,11 @@ export const Output = ({ graph, issues, options, onOptionsChange }: Props) => {
         </ul>
       )}
 
-      <section aria-label="Generated commands">
+      <section className="gb-terminal" aria-label="Generated commands">
+        <div className="gb-terminal-titlebar">
+          <span className="gb-terminal-dots" aria-hidden="true" />
+          <span className="sr-only">Terminal window</span>
+        </div>
         <pre className="gb-script">
           <code>
             {graph.nodes.length === 0

--- a/docs/src/lib/graph-builder/graph-builder.spec.ts
+++ b/docs/src/lib/graph-builder/graph-builder.spec.ts
@@ -470,6 +470,25 @@ describe('commands', () => {
     );
   });
 
+  it('should omit the workspace create and cd when skipWorkspace is set', () => {
+    const script = toScript(graph([node('my-api', 'ts#trpc-api')]), EMIT, {
+      skipWorkspace: true,
+    }).split('\n');
+    expect(script[0]).not.toContain('create @aws/nx-workspace');
+    expect(script.some((line) => line === 'cd my-project')).toBe(false);
+    expect(script[0]).toBe(
+      'pnpm nx g @aws/nx-plugin:ts#api my-api --framework=trpc --no-interactive',
+    );
+  });
+
+  it('should not lead with a blank line when annotating without the workspace', () => {
+    const script = toScript(graph([node('my-api', 'ts#trpc-api')]), EMIT, {
+      annotate: true,
+      skipWorkspace: true,
+    }).split('\n');
+    expect(script[0]).toBe('# Create my-api (tRPC API)');
+  });
+
   it('should prefix generator commands per package manager', () => {
     const single = graph([node('my-api', 'ts#trpc-api')]);
     expect(toScript(single, { ...EMIT, packageManager: 'npm' })).toContain(

--- a/docs/src/styles/graph-builder.css
+++ b/docs/src/styles/graph-builder.css
@@ -1227,6 +1227,41 @@
   margin: 0;
 }
 
+/* An on/off pill matching the CDK/Terraform segments: muted when off, accent
+ * fill when on. */
+.gb-toggle-pill {
+  font: inherit;
+  font-size: 0.76rem;
+  line-height: 1.35;
+  padding: 0.3rem 0.7rem;
+  border-radius: 9999px;
+  border: 1px solid var(--gb-border);
+  background: var(--gb-raised);
+  color: var(--gb-muted);
+  cursor: pointer;
+  white-space: nowrap;
+  transition:
+    background-color 120ms ease,
+    color 120ms ease,
+    border-color 120ms ease;
+}
+
+.gb-toggle-pill:hover {
+  color: var(--gb-text);
+}
+
+.gb-toggle-pill.is-active {
+  background: var(--sl-color-accent-low);
+  border-color: var(--sl-color-accent);
+  color: var(--sl-color-accent-high);
+  font-weight: 500;
+}
+
+.gb-toggle-pill:focus-visible {
+  outline: 2px solid var(--gb-accent);
+  outline-offset: 1px;
+}
+
 .gb-copy-btn {
   position: relative;
   display: inline-flex;
@@ -1281,15 +1316,59 @@
   border-bottom: 1px solid var(--gb-border-soft);
 }
 
+/* The command box mirrors the terminal-window frame Expressive Code renders for
+ * the docs' own shell snippets, so the generated commands read like the commands
+ * elsewhere in the guides. The tokens below carry EC's light theme values,
+ * overridden for dark just under here. */
+.gb-terminal {
+  --gb-term-code-bg: #f6f7f9;
+  --gb-term-titlebar-bg: #ededf3;
+  --gb-term-border: color-mix(in srgb, hsl(224, 6%, 77%), transparent 25%);
+  margin: 0.85rem;
+  border: 1px solid var(--gb-term-border);
+  border-radius: var(--gb-radius-sm);
+  overflow: hidden;
+}
+
+:root[data-theme='dark'] .gb-terminal {
+  --gb-term-code-bg: #23262f;
+  --gb-term-titlebar-bg: #17181c;
+  --gb-term-border: color-mix(in srgb, hsl(224, 10%, 23%), transparent 25%);
+}
+
+.gb-terminal-titlebar {
+  position: relative;
+  height: 1.75rem;
+  background: var(--gb-term-titlebar-bg);
+  border-bottom: 1px solid var(--gb-term-border);
+}
+
+/* The three traffic-light dots, drawn as a masked strip exactly as EC does. */
+.gb-terminal-dots {
+  position: absolute;
+  left: 1rem;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 2.1rem;
+  height: 0.56rem;
+  background: var(--gb-term-border);
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20viewBox%3D'0%200%2060%2016'%20preserveAspectRatio%3D'xMidYMid%20meet'%3E%3Ccircle%20cx%3D'8'%20cy%3D'8'%20r%3D'8'%2F%3E%3Ccircle%20cx%3D'30'%20cy%3D'8'%20r%3D'8'%2F%3E%3Ccircle%20cx%3D'52'%20cy%3D'8'%20r%3D'8'%2F%3E%3C%2Fsvg%3E");
+  mask-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20viewBox%3D'0%200%2060%2016'%20preserveAspectRatio%3D'xMidYMid%20meet'%3E%3Ccircle%20cx%3D'8'%20cy%3D'8'%20r%3D'8'%2F%3E%3Ccircle%20cx%3D'30'%20cy%3D'8'%20r%3D'8'%2F%3E%3Ccircle%20cx%3D'52'%20cy%3D'8'%20r%3D'8'%2F%3E%3C%2Fsvg%3E");
+  -webkit-mask-repeat: no-repeat;
+  mask-repeat: no-repeat;
+  -webkit-mask-size: contain;
+  mask-size: contain;
+}
+
 .gb-script {
   margin: 0;
-  padding: 0.9rem 1rem;
+  padding: 0.75rem 1rem;
   max-height: 22rem;
   overflow: auto;
-  background: var(--gb-surface);
+  background: var(--gb-term-code-bg);
   font-family: var(--__sl-font-mono), ui-monospace, monospace;
-  font-size: 0.8rem;
-  line-height: 1.7;
+  font-size: 0.875rem;
+  line-height: 1.75;
   white-space: pre;
   tab-size: 2;
 }


### PR DESCRIPTION
### Reason for this change

The graph builder's generated-commands box rendered as a plain `<pre>` with its own background, font size and line height, so it looked different from the shell command blocks Expressive Code renders throughout the rest of the docs. Users copying commands from the builder saw a box that didn't read like the commands they see in the guides.

### Description of changes

- **Match the docs' code block style.** The command box now mirrors the Expressive Code terminal-window frame used for the docs' own shell snippets: a titlebar with the three traffic-light dots, a rounded bordered frame, and the same code background (`#f6f7f9` / `#23262f`), font size (`0.875rem`) and line height (`1.75`) for both light and dark themes. Because that Expressive Code stylesheet isn't loaded on the graph-builder page (it has no static code blocks), the frame is replicated directly in `graph-builder.css` — including the masked-SVG dots strip and EC's per-theme token values.
- **Comments toggle is now a pill.** Replaced the checkbox with a toggle pill matching the CDK/Terraform segmented controls.
- **Added a "Create workspace" toggle pill, default on.** When switched off, the emitted script drops the `create @aws/nx-workspace` line and the `cd`, so the generator commands run against a workspace that already exists. This reuses the `skipWorkspace` option on `toScript` (introduced for the embedded graphs).

### Screenshots

Command box in the graph builder, matching the docs' Expressive Code terminal frame:

**Light**

![Graph builder command box, light theme](https://raw.githubusercontent.com/awslabs/nx-plugin-for-aws/pr-assets/pr-1051/command-box-light.png)

**Dark**

![Graph builder command box, dark theme](https://raw.githubusercontent.com/awslabs/nx-plugin-for-aws/pr-assets/pr-1051/command-box-dark.png)

### Description of how you validated changes

- Added unit tests covering the `skipWorkspace` behavior for `toScript` (script omits the workspace create and `cd`, and doesn't lead with a blank comment separator when annotating). Full graph-builder suite passes (126 tests).
- Verified end to end in the running docs site with browser automation: populated the builder from presets and confirmed the box matches the docs' Expressive Code terminal frame in both light and dark themes, that both toggle pills work, and that the empty state renders correctly.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*