### PR TITLE
docs(skill): include recommended prerequisites in the skill and power

### DIFF
--- a/docs/src/content/docs/en/snippets/prerequisites.mdx
+++ b/docs/src/content/docs/en/snippets/prerequisites.mdx
@@ -10,13 +10,7 @@ import Snippet from '@components/snippet.astro';
 
 ### Recommended
 
-- [PNPM >= 11](https://pnpm.io/installation#using-npm) (you can also use [Yarn >= 4](https://yarnpkg.com/getting-started/install), [Bun >= 1](https://bun.sh/docs/installation), or [NPM >= 10](https://nodejs.org/en/learn/getting-started/an-introduction-to-the-npm-package-manager) if you prefer)
-  - verify by running `pnpm --version`, `yarn --version`, `bun --version` or `npm --version`
-- [AWS Credentials](https://docs.aws.amazon.com/sdkref/latest/guide/access.html) configured to your target AWS account are required to deploy your application (as well as for some local development workflows).
-- [Docker](https://www.docker.com/) or [Finch >= 1.6.0](https://runfinch.com/) is required for some generators. For Docker, [multi-platform builds](https://docs.docker.com/build/building/multi-platform/) must be set up; Finch supports [multi-platform builds](https://runfinch.com/docs/getting-started/building-images/#building-a-multi-architecture-container-image) out of the box.
-- [Terraform >= 1.12](https://developer.hashicorp.com/terraform/install) is required if you choose to use this for infrastructure as code instead of CDK
-  - verify by running `terraform --version`
-- If you are using [VSCode](https://code.visualstudio.com/), we recommend installing the [Nx Console VSCode Plugin](https://marketplace.visualstudio.com/items?itemName=nrwl.angular-console).
+<Snippet name="recommended-prerequisites" parentHeading="Recommended" />
 
 :::tip[AI Assistant Setup]
 If you use an AI Assistant such as Kiro, Kiro CLI, Cursor, Claude Code or Cline, you may also wish to <Link path="/get_started/building-with-ai">install the Nx Plugin for AWS MCP server.</Link>

--- a/docs/src/content/docs/en/snippets/recommended-prerequisites.mdx
+++ b/docs/src/content/docs/en/snippets/recommended-prerequisites.mdx
@@ -1,0 +1,10 @@
+---
+title: Recommended Prerequisites
+---
+- [PNPM >= 11](https://pnpm.io/installation#using-npm) (you can also use [Yarn >= 4](https://yarnpkg.com/getting-started/install), [Bun >= 1](https://bun.sh/docs/installation), or [NPM >= 10](https://nodejs.org/en/learn/getting-started/an-introduction-to-the-npm-package-manager) if you prefer)
+  - verify by running `pnpm --version`, `yarn --version`, `bun --version` or `npm --version`
+- [AWS Credentials](https://docs.aws.amazon.com/sdkref/latest/guide/access.html) configured to your target AWS account are required to deploy your application (as well as for some local development workflows).
+- [Docker](https://www.docker.com/) or [Finch >= 1.6.0](https://runfinch.com/) is required for some generators. For Docker, [multi-platform builds](https://docs.docker.com/build/building/multi-platform/) must be set up; Finch supports [multi-platform builds](https://runfinch.com/docs/getting-started/building-images/#building-a-multi-architecture-container-image) out of the box.
+- [Terraform >= 1.12](https://developer.hashicorp.com/terraform/install) is required if you choose to use this for infrastructure as code instead of CDK
+  - verify by running `terraform --version`
+- If you are using [VSCode](https://code.visualstudio.com/), we recommend installing the [Nx Console VSCode Plugin](https://marketplace.visualstudio.com/items?itemName=nrwl.angular-console).

--- a/docs/src/content/docs/es/snippets/prerequisites.mdx
+++ b/docs/src/content/docs/es/snippets/prerequisites.mdx
@@ -13,11 +13,7 @@ import Snippet from '@components/snippet.astro';
 
 ### Recomendados
 
-- [AWS Credentials](https://docs.aws.amazon.com/sdkref/latest/guide/access.html) configuradas para tu cuenta de AWS de destino son necesarias para desplegar tu aplicación (así como para algunos flujos de trabajo de desarrollo local).
-- [Docker](https://www.docker.com/) o [Finch >= 1.6.0](https://runfinch.com/) es necesario para algunos generadores. Para Docker, las [compilaciones multiplataforma](https://docs.docker.com/build/building/multi-platform/) deben estar configuradas; Finch admite [compilaciones multiplataforma](https://runfinch.com/docs/getting-started/building-images/#building-a-multi-architecture-container-image) de forma predeterminada.
-- [Terraform >= 1.12](https://developer.hashicorp.com/terraform/install) es necesario si eliges usar esta herramienta para infraestructura como código en lugar de CDK
-  - verifica ejecutando `terraform --version`
-- Si usas [VSCode](https://code.visualstudio.com/), recomendamos instalar el [Nx Console VSCode Plugin](https://marketplace.visualstudio.com/items?itemName=nrwl.angular-console).
+<Snippet name="recommended-prerequisites" parentHeading="Recomendados" />
 
 :::tip[Configuración del asistente IA]
 Si utilizas un Asistente de IA como Kiro, Kiro CLI, Cursor, Claude Code o Cline, también puedes <Link path="/get_started/building-with-ai">instalar el complemento NX para AWS MCP server.</Link>

--- a/docs/src/content/docs/es/snippets/recommended-prerequisites.mdx
+++ b/docs/src/content/docs/es/snippets/recommended-prerequisites.mdx
@@ -1,0 +1,10 @@
+---
+title: Requisitos Previos Recomendados
+---
+- [PNPM >= 11](https://pnpm.io/installation#using-npm) (también puedes usar [Yarn >= 4](https://yarnpkg.com/getting-started/install), [Bun >= 1](https://bun.sh/docs/installation), o [NPM >= 10](https://nodejs.org/en/learn/getting-started/an-introduction-to-the-npm-package-manager) si lo prefieres)
+  - verifica ejecutando `pnpm --version`, `yarn --version`, `bun --version` o `npm --version`
+- [Credenciales de AWS](https://docs.aws.amazon.com/sdkref/latest/guide/access.html) configuradas para tu cuenta de AWS de destino son necesarias para desplegar tu aplicación (así como para algunos flujos de trabajo de desarrollo local).
+- [Docker](https://www.docker.com/) o [Finch >= 1.6.0](https://runfinch.com/) es necesario para algunos generadores. Para Docker, las [compilaciones multiplataforma](https://docs.docker.com/build/building/multi-platform/) deben estar configuradas; Finch soporta [compilaciones multiplataforma](https://runfinch.com/docs/getting-started/building-images/#building-a-multi-architecture-container-image) de forma nativa.
+- [Terraform >= 1.12](https://developer.hashicorp.com/terraform/install) es necesario si eliges usar esto para infraestructura como código en lugar de CDK
+  - verifica ejecutando `terraform --version`
+- Si estás usando [VSCode](https://code.visualstudio.com/), recomendamos instalar el [Plugin Nx Console para VSCode](https://marketplace.visualstudio.com/items?itemName=nrwl.angular-console).

--- a/docs/src/content/docs/fr/snippets/prerequisites.mdx
+++ b/docs/src/content/docs/fr/snippets/prerequisites.mdx
@@ -13,11 +13,7 @@ import Snippet from '@components/snippet.astro';
 
 ### Recommandé
 
-- [AWS Credentials](https://docs.aws.amazon.com/sdkref/latest/guide/access.html) configurées pour votre compte AWS cible sont requises pour déployer votre application (ainsi que pour certains flux de travail de développement local).
-- [Docker](https://www.docker.com/) ou [Finch >= 1.6.0](https://runfinch.com/) est requis pour certains générateurs. Pour Docker, les [builds multi-plateformes](https://docs.docker.com/build/building/multi-platform/) doivent être configurés ; Finch prend en charge les [builds multi-plateformes](https://runfinch.com/docs/getting-started/building-images/#building-a-multi-architecture-container-image) nativement.
-- [Terraform >= 1.12](https://developer.hashicorp.com/terraform/install) est requis si vous choisissez de l'utiliser pour l'infrastructure as code au lieu de CDK
-  - vérifiez en exécutant `terraform --version`
-- Si vous utilisez [VSCode](https://code.visualstudio.com/), nous recommandons d'installer le [Nx Console VSCode Plugin](https://marketplace.visualstudio.com/items?itemName=nrwl.angular-console).
+<Snippet name="recommended-prerequisites" parentHeading="Recommended" />
 
 :::tip[Configuration de l'assistant IA]
 Si vous utilisez un assistant d'IA tel que Kiro, Kiro CLI, Cursor, Claude Code ou Cline, vous pouvez également <Link path="/get_started/building-with-ai">installer le Nx Plugin pour AWS MCP server.</Link>

--- a/docs/src/content/docs/fr/snippets/recommended-prerequisites.mdx
+++ b/docs/src/content/docs/fr/snippets/recommended-prerequisites.mdx
@@ -1,0 +1,10 @@
+---
+title: Prérequis recommandés
+---
+- [PNPM >= 11](https://pnpm.io/installation#using-npm) (vous pouvez également utiliser [Yarn >= 4](https://yarnpkg.com/getting-started/install), [Bun >= 1](https://bun.sh/docs/installation), ou [NPM >= 10](https://nodejs.org/en/learn/getting-started/an-introduction-to-the-npm-package-manager) si vous préférez)
+  - vérifiez en exécutant `pnpm --version`, `yarn --version`, `bun --version` ou `npm --version`
+- [AWS Credentials](https://docs.aws.amazon.com/sdkref/latest/guide/access.html) configurées pour votre compte AWS cible sont nécessaires pour déployer votre application (ainsi que pour certains workflows de développement local).
+- [Docker](https://www.docker.com/) ou [Finch >= 1.6.0](https://runfinch.com/) est requis pour certains générateurs. Pour Docker, les [compilations multi-plateformes](https://docs.docker.com/build/building/multi-platform/) doivent être configurées ; Finch prend en charge les [compilations multi-plateformes](https://runfinch.com/docs/getting-started/building-images/#building-a-multi-architecture-container-image) dès le départ.
+- [Terraform >= 1.12](https://developer.hashicorp.com/terraform/install) est requis si vous choisissez d'utiliser ceci pour l'infrastructure en tant que code au lieu de CDK
+  - vérifiez en exécutant `terraform --version`
+- Si vous utilisez [VSCode](https://code.visualstudio.com/), nous recommandons d'installer le [Nx Console VSCode Plugin](https://marketplace.visualstudio.com/items?itemName=nrwl.angular-console).

--- a/docs/src/content/docs/it/snippets/prerequisites.mdx
+++ b/docs/src/content/docs/it/snippets/prerequisites.mdx
@@ -13,11 +13,7 @@ import Snippet from '@components/snippet.astro';
 
 ### Consigliati
 
-- [AWS Credentials](https://docs.aws.amazon.com/sdkref/latest/guide/access.html) configurate per il tuo account AWS di destinazione sono necessarie per distribuire la tua applicazione (così come per alcuni flussi di lavoro di sviluppo locale).
-- [Docker](https://www.docker.com/) o [Finch >= 1.6.0](https://runfinch.com/) è necessario per alcuni generatori. Per Docker, le [build multi-piattaforma](https://docs.docker.com/build/building/multi-platform/) devono essere configurate; Finch supporta le [build multi-piattaforma](https://runfinch.com/docs/getting-started/building-images/#building-a-multi-architecture-container-image) di default.
-- [Terraform >= 1.12](https://developer.hashicorp.com/terraform/install) è richiesto se scegli di utilizzarlo per l'infrastructure as code invece di CDK
-  - verifica eseguendo `terraform --version`
-- Se utilizzi [VSCode](https://code.visualstudio.com/), consigliamo di installare il [Nx Console VSCode Plugin](https://marketplace.visualstudio.com/items?itemName=nrwl.angular-console).
+<Snippet name="recommended-prerequisites" parentHeading="Consigliati" />
 
 :::tip[Configurazione dell'assistente IA]
 Se utilizzi un Assistente AI come Kiro, Kiro CLI, Cursor, Claude Code o Cline, potresti voler <Link path="/get_started/building-with-ai">installare il Plugin Nx per AWS MCP server.</Link>

--- a/docs/src/content/docs/it/snippets/recommended-prerequisites.mdx
+++ b/docs/src/content/docs/it/snippets/recommended-prerequisites.mdx
@@ -1,0 +1,10 @@
+---
+title: Prerequisiti Consigliati
+---
+- [PNPM >= 11](https://pnpm.io/installation#using-npm) (puoi anche usare [Yarn >= 4](https://yarnpkg.com/getting-started/install), [Bun >= 1](https://bun.sh/docs/installation), o [NPM >= 10](https://nodejs.org/en/learn/getting-started/an-introduction-to-the-npm-package-manager) se preferisci)
+  - verifica eseguendo `pnpm --version`, `yarn --version`, `bun --version` o `npm --version`
+- [AWS Credentials](https://docs.aws.amazon.com/sdkref/latest/guide/access.html) configurate per il tuo account AWS di destinazione sono necessarie per distribuire la tua applicazione (così come per alcuni flussi di lavoro di sviluppo locale).
+- [Docker](https://www.docker.com/) o [Finch >= 1.6.0](https://runfinch.com/) è richiesto per alcuni generatori. Per Docker, le [build multi-piattaforma](https://docs.docker.com/build/building/multi-platform/) devono essere configurate; Finch supporta le [build multi-piattaforma](https://runfinch.com/docs/getting-started/building-images/#building-a-multi-architecture-container-image) nativamente.
+- [Terraform >= 1.12](https://developer.hashicorp.com/terraform/install) è richiesto se scegli di utilizzarlo per l'infrastruttura come codice invece di CDK
+  - verifica eseguendo `terraform --version`
+- Se stai usando [VSCode](https://code.visualstudio.com/), consigliamo di installare il [Nx Console VSCode Plugin](https://marketplace.visualstudio.com/items?itemName=nrwl.angular-console).

--- a/docs/src/content/docs/jp/snippets/prerequisites.mdx
+++ b/docs/src/content/docs/jp/snippets/prerequisites.mdx
@@ -10,11 +10,7 @@ import Snippet from '@components/snippet.astro';
 
 ### 推奨
 
-- ターゲットAWSアカウントに設定された[AWS Credentials](https://docs.aws.amazon.com/sdkref/latest/guide/access.html)は、アプリケーションのデプロイ（および一部のローカル開発ワークフロー）に必要です。
-- [Docker](https://www.docker.com/)または[Finch >= 1.6.0](https://runfinch.com/)は一部のジェネレーターで必要です。Dockerの場合、[マルチプラットフォームビルド](https://docs.docker.com/build/building/multi-platform/)をセットアップする必要があります。Finchは[マルチプラットフォームビルド](https://runfinch.com/docs/getting-started/building-images/#building-a-multi-architecture-container-image)を標準でサポートしています。
-- CDKの代わりにインフラストラクチャー・アズ・コードでTerraformを使用する場合、[Terraform >= 1.12](https://developer.hashicorp.com/terraform/install)が必要です
-  - `terraform --version` を実行して確認してください
-- [VSCode](https://code.visualstudio.com/)を使用する場合、[Nx Console VSCode Plugin](https://marketplace.visualstudio.com/items?itemName=nrwl.angular-console)のインストールを推奨します
+<Snippet name="recommended-prerequisites" parentHeading="推奨" />
 
 :::tip[AIアシスタントのセットアップ]
 Kiro、Kiro CLI、Cursor、Claude Code、ClineなどのAIアシスタントを使用する場合、<Link path="/get_started/building-with-ai">Nx Plugin for AWS MCP serverのインストール</Link>も推奨します

--- a/docs/src/content/docs/jp/snippets/recommended-prerequisites.mdx
+++ b/docs/src/content/docs/jp/snippets/recommended-prerequisites.mdx
@@ -1,0 +1,10 @@
+---
+title: 推奨される前提条件
+---
+- [PNPM >= 11](https://pnpm.io/installation#using-npm)（お好みに応じて [Yarn >= 4](https://yarnpkg.com/getting-started/install)、[Bun >= 1](https://bun.sh/docs/installation)、または [NPM >= 10](https://nodejs.org/en/learn/getting-started/an-introduction-to-the-npm-package-manager) も使用できます）
+  - `pnpm --version`、`yarn --version`、`bun --version`、または `npm --version` を実行して確認してください
+- アプリケーションをデプロイするには、ターゲットのAWSアカウントに設定された [AWS Credentials](https://docs.aws.amazon.com/sdkref/latest/guide/access.html) が必要です（一部のローカル開発ワークフローにも必要です）。
+- 一部のジェネレーターには [Docker](https://www.docker.com/) または [Finch >= 1.6.0](https://runfinch.com/) が必要です。Dockerの場合、[マルチプラットフォームビルド](https://docs.docker.com/build/building/multi-platform/)を設定する必要があります。Finchは[マルチプラットフォームビルド](https://runfinch.com/docs/getting-started/building-images/#building-a-multi-architecture-container-image)を標準でサポートしています。
+- CDKの代わりにインフラストラクチャをコードとして使用する場合は、[Terraform >= 1.12](https://developer.hashicorp.com/terraform/install) が必要です
+  - `terraform --version` を実行して確認してください
+- [VSCode](https://code.visualstudio.com/) を使用している場合は、[Nx Console VSCode Plugin](https://marketplace.visualstudio.com/items?itemName=nrwl.angular-console) のインストールをお勧めします。

--- a/docs/src/content/docs/ko/snippets/prerequisites.mdx
+++ b/docs/src/content/docs/ko/snippets/prerequisites.mdx
@@ -13,11 +13,7 @@ import Snippet from '@components/snippet.astro';
 
 ### 권장 사항
 
-- 대상 AWS 계정에 구성된 [AWS Credentials](https://docs.aws.amazon.com/sdkref/latest/guide/access.html)는 애플리케이션 배포(및 일부 로컬 개발 워크플로)에 필요합니다.
-- 일부 생성기에는 [Docker](https://www.docker.com/) 또는 [Finch >= 1.6.0](https://runfinch.com/)가 필요합니다. Docker의 경우 [멀티 플랫폼 빌드](https://docs.docker.com/build/building/multi-platform/)가 설정되어 있어야 하며, Finch는 [멀티 플랫폼 빌드](https://runfinch.com/docs/getting-started/building-images/#building-a-multi-architecture-container-image)를 기본적으로 지원합니다.
-- CDK 대신 인프라스트럭처 코드로 Terraform을 사용할 경우 [Terraform >= 1.12](https://developer.hashicorp.com/terraform/install) 설치 필요
-  - `terraform --version` 명령어로 버전 확인
-- [VSCode](https://code.visualstudio.com/) 사용 시 [Nx Console VSCode Plugin](https://marketplace.visualstudio.com/items?itemName=nrwl.angular-console) 설치 권장
+<Snippet name="recommended-prerequisites" parentHeading="Recommended" />
 
 :::tip[AI 어시스턴트 설정]
 Kiro, Amazon Q Developer, Cursor, Claude Code, Cline과 같은 AI 어시스턴트를 사용하는 경우 <Link path="/get_started/building-with-ai">AWS MCP 서버용 Nx 플러그인 설치</Link>를 고려해 보세요

--- a/docs/src/content/docs/ko/snippets/recommended-prerequisites.mdx
+++ b/docs/src/content/docs/ko/snippets/recommended-prerequisites.mdx
@@ -1,0 +1,10 @@
+---
+title: 권장 사전 요구사항
+---
+- [PNPM >= 11](https://pnpm.io/installation#using-npm) (원하시는 경우 [Yarn >= 4](https://yarnpkg.com/getting-started/install), [Bun >= 1](https://bun.sh/docs/installation), 또는 [NPM >= 10](https://nodejs.org/en/learn/getting-started/an-introduction-to-the-npm-package-manager)을 사용할 수도 있습니다)
+  - `pnpm --version`, `yarn --version`, `bun --version` 또는 `npm --version`을 실행하여 확인하세요
+- 애플리케이션을 배포하려면 대상 AWS 계정에 구성된 [AWS Credentials](https://docs.aws.amazon.com/sdkref/latest/guide/access.html)가 필요합니다 (일부 로컬 개발 워크플로우에도 필요합니다).
+- 일부 생성기에는 [Docker](https://www.docker.com/) 또는 [Finch >= 1.6.0](https://runfinch.com/)이 필요합니다. Docker의 경우 [멀티 플랫폼 빌드](https://docs.docker.com/build/building/multi-platform/)를 설정해야 합니다. Finch는 기본적으로 [멀티 플랫폼 빌드](https://runfinch.com/docs/getting-started/building-images/#building-a-multi-architecture-container-image)를 지원합니다.
+- CDK 대신 인프라를 코드로 관리하기 위해 이것을 사용하려면 [Terraform >= 1.12](https://developer.hashicorp.com/terraform/install)가 필요합니다
+  - `terraform --version`을 실행하여 확인하세요
+- [VSCode](https://code.visualstudio.com/)를 사용하는 경우 [Nx Console VSCode Plugin](https://marketplace.visualstudio.com/items?itemName=nrwl.angular-console) 설치를 권장합니다.

--- a/docs/src/content/docs/pt/snippets/prerequisites.mdx
+++ b/docs/src/content/docs/pt/snippets/prerequisites.mdx
@@ -13,11 +13,7 @@ import Snippet from '@components/snippet.astro';
 
 ### Recomendados
 
-- [AWS Credentials](https://docs.aws.amazon.com/sdkref/latest/guide/access.html) configuradas para sua conta AWS de destino são necessárias para implantar sua aplicação (assim como para alguns fluxos de trabalho de desenvolvimento local).
-- [Docker](https://www.docker.com/) ou [Finch >= 1.6.0](https://runfinch.com/) é necessário para alguns geradores. Para Docker, [compilações multi-plataforma](https://docs.docker.com/build/building/multi-platform/) devem ser configuradas; Finch suporta [compilações multi-plataforma](https://runfinch.com/docs/getting-started/building-images/#building-a-multi-architecture-container-image) pronto para uso.
-- [Terraform >= 1.12](https://developer.hashicorp.com/terraform/install) é necessário se você optar por usar isso para infraestrutura como código em vez do CDK
-  - verifique executando `terraform --version`
-- Se você usa [VSCode](https://code.visualstudio.com/), recomendamos instalar o [Nx Console VSCode Plugin](https://marketplace.visualstudio.com/items?itemName=nrwl.angular-console).
+<Snippet name="recommended-prerequisites" parentHeading="Recommended" />
 
 :::tip[Configuração do assistente IA]
 Se você usa um Assistente de IA como Kiro, Amazon Q Developer, Cursor, Claude Code ou Cline, você também pode querer <Link path="/get_started/building-with-ai">instalar o Nx Plugin para AWS MCP server.</Link>

--- a/docs/src/content/docs/pt/snippets/recommended-prerequisites.mdx
+++ b/docs/src/content/docs/pt/snippets/recommended-prerequisites.mdx
@@ -1,0 +1,10 @@
+---
+title: Pré-requisitos Recomendados
+---
+- [PNPM >= 11](https://pnpm.io/installation#using-npm) (você também pode usar [Yarn >= 4](https://yarnpkg.com/getting-started/install), [Bun >= 1](https://bun.sh/docs/installation), ou [NPM >= 10](https://nodejs.org/en/learn/getting-started/an-introduction-to-the-npm-package-manager) se preferir)
+  - verifique executando `pnpm --version`, `yarn --version`, `bun --version` ou `npm --version`
+- [AWS Credentials](https://docs.aws.amazon.com/sdkref/latest/guide/access.html) configuradas para sua conta AWS de destino são necessárias para implantar sua aplicação (assim como para alguns fluxos de trabalho de desenvolvimento local).
+- [Docker](https://www.docker.com/) ou [Finch >= 1.6.0](https://runfinch.com/) é necessário para alguns geradores. Para Docker, [multi-platform builds](https://docs.docker.com/build/building/multi-platform/) devem ser configuradas; Finch suporta [multi-platform builds](https://runfinch.com/docs/getting-started/building-images/#building-a-multi-architecture-container-image) nativamente.
+- [Terraform >= 1.12](https://developer.hashicorp.com/terraform/install) é necessário se você optar por usar isso para infraestrutura como código em vez de CDK
+  - verifique executando `terraform --version`
+- Se você está usando [VSCode](https://code.visualstudio.com/), recomendamos instalar o [Nx Console VSCode Plugin](https://marketplace.visualstudio.com/items?itemName=nrwl.angular-console).

--- a/docs/src/content/docs/vi/snippets/prerequisites.mdx
+++ b/docs/src/content/docs/vi/snippets/prerequisites.mdx
@@ -11,11 +11,7 @@ import Snippet from '@components/snippet.astro';
 
 ### Khuyến nghị
 
-- [AWS Credentials](https://docs.aws.amazon.com/sdkref/latest/guide/access.html) được cấu hình cho tài khoản AWS mục tiêu của bạn là bắt buộc để triển khai ứng dụng của bạn (cũng như cho một số quy trình phát triển cục bộ).
-- [Docker](https://www.docker.com/) hoặc [Finch >= 1.6.0](https://runfinch.com/) là bắt buộc đối với một số trình tạo. Đối với Docker, [multi-platform builds](https://docs.docker.com/build/building/multi-platform/) phải được thiết lập; Finch hỗ trợ [multi-platform builds](https://runfinch.com/docs/getting-started/building-images/#building-a-multi-architecture-container-image) ngay từ đầu.
-- [Terraform >= 1.12](https://developer.hashicorp.com/terraform/install) là bắt buộc nếu bạn chọn sử dụng công cụ này cho cơ sở hạ tầng dưới dạng mã thay vì CDK
-  - xác minh bằng cách chạy `terraform --version`
-- Nếu bạn đang sử dụng [VSCode](https://code.visualstudio.com/), chúng tôi khuyến nghị cài đặt [Nx Console VSCode Plugin](https://marketplace.visualstudio.com/items?itemName=nrwl.angular-console).
+<Snippet name="recommended-prerequisites" parentHeading="Khuyến nghị" />
 
 :::tip[Thiết lập trợ lý AI]
 Nếu bạn sử dụng AI Assistant như Kiro, Amazon Q Developer, Cursor, Claude Code hoặc Cline, bạn cũng có thể muốn <Link path="/get_started/building-with-ai">cài đặt Nx Plugin cho AWS MCP server.</Link>

--- a/docs/src/content/docs/vi/snippets/recommended-prerequisites.mdx
+++ b/docs/src/content/docs/vi/snippets/recommended-prerequisites.mdx
@@ -1,0 +1,10 @@
+---
+title: Các Yêu Cầu Được Khuyến Nghị
+---
+- [PNPM >= 11](https://pnpm.io/installation#using-npm) (bạn cũng có thể sử dụng [Yarn >= 4](https://yarnpkg.com/getting-started/install), [Bun >= 1](https://bun.sh/docs/installation), hoặc [NPM >= 10](https://nodejs.org/en/learn/getting-started/an-introduction-to-the-npm-package-manager) nếu bạn muốn)
+  - xác minh bằng cách chạy `pnpm --version`, `yarn --version`, `bun --version` hoặc `npm --version`
+- [AWS Credentials](https://docs.aws.amazon.com/sdkref/latest/guide/access.html) được cấu hình cho tài khoản AWS đích của bạn là bắt buộc để triển khai ứng dụng của bạn (cũng như cho một số quy trình phát triển cục bộ).
+- [Docker](https://www.docker.com/) hoặc [Finch >= 1.6.0](https://runfinch.com/) là bắt buộc cho một số trình tạo. Đối với Docker, [multi-platform builds](https://docs.docker.com/build/building/multi-platform/) phải được thiết lập; Finch hỗ trợ [multi-platform builds](https://runfinch.com/docs/getting-started/building-images/#building-a-multi-architecture-container-image) ngay từ đầu.
+- [Terraform >= 1.12](https://developer.hashicorp.com/terraform/install) là bắt buộc nếu bạn chọn sử dụng công cụ này cho cơ sở hạ tầng dưới dạng mã thay vì CDK
+  - xác minh bằng cách chạy `terraform --version`
+- Nếu bạn đang sử dụng [VSCode](https://code.visualstudio.com/), chúng tôi khuyến nghị cài đặt [Nx Console VSCode Plugin](https://marketplace.visualstudio.com/items?itemName=nrwl.angular-console).

--- a/docs/src/content/docs/zh/snippets/prerequisites.mdx
+++ b/docs/src/content/docs/zh/snippets/prerequisites.mdx
@@ -13,11 +13,7 @@ import Snippet from '@components/snippet.astro';
 
 ### 推荐
 
-- 需要配置到目标 AWS 账户的 [AWS 凭证](https://docs.aws.amazon.com/sdkref/latest/guide/access.html)才能部署应用程序（以及用于某些本地开发工作流）。
-- 某些生成器需要 [Docker](https://www.docker.com/) 或 [Finch >= 1.6.0](https://runfinch.com/)。对于 Docker，必须设置[多平台构建](https://docs.docker.com/build/building/multi-platform/)；Finch 开箱即支持[多平台构建](https://runfinch.com/docs/getting-started/building-images/#building-a-multi-architecture-container-image)。
-- [Terraform >= 1.12](https://developer.hashicorp.com/terraform/install)：如果选择使用 Terraform 替代 CDK 进行基础设施即代码时需要
-  - 可通过运行 `terraform --version` 验证版本
-- 如果使用 [VSCode](https://code.visualstudio.com/)，推荐安装 [Nx Console VSCode 插件](https://marketplace.visualstudio.com/items?itemName=nrwl.angular-console)
+<Snippet name="recommended-prerequisites" parentHeading="Recommended" />
 
 :::tip[AI助手设置]
 如果使用 Kiro、Amazon Q Developer、Cursor、Claude Code 或 Cline 等 AI 助手，您可能还需要<Link path="/get_started/building-with-ai">安装适用于 AWS MCP 服务器的 Nx 插件</Link>

--- a/docs/src/content/docs/zh/snippets/recommended-prerequisites.mdx
+++ b/docs/src/content/docs/zh/snippets/recommended-prerequisites.mdx
@@ -1,0 +1,10 @@
+---
+title: 推荐的前置条件
+---
+- [PNPM >= 11](https://pnpm.io/installation#using-npm)（如果您愿意，也可以使用 [Yarn >= 4](https://yarnpkg.com/getting-started/install)、[Bun >= 1](https://bun.sh/docs/installation) 或 [NPM >= 10](https://nodejs.org/en/learn/getting-started/an-introduction-to-the-npm-package-manager)）
+  - 通过运行 `pnpm --version`、`yarn --version`、`bun --version` 或 `npm --version` 来验证
+- 需要配置到目标 AWS 账户的 [AWS Credentials](https://docs.aws.amazon.com/sdkref/latest/guide/access.html) 来部署您的应用程序（以及用于某些本地开发工作流）。
+- 某些生成器需要 [Docker](https://www.docker.com/) 或 [Finch >= 1.6.0](https://runfinch.com/)。对于 Docker，必须设置[多平台构建](https://docs.docker.com/build/building/multi-platform/)；Finch 开箱即支持[多平台构建](https://runfinch.com/docs/getting-started/building-images/#building-a-multi-architecture-container-image)。
+- 如果您选择使用 [Terraform >= 1.12](https://developer.hashicorp.com/terraform/install) 作为基础设施即代码工具而不是 CDK，则需要安装它
+  - 通过运行 `terraform --version` 来验证
+- 如果您使用 [VSCode](https://code.visualstudio.com/)，我们建议安装 [Nx Console VSCode Plugin](https://marketplace.visualstudio.com/items?itemName=nrwl.angular-console)。

--- a/powers/nx-plugin-for-aws/POWER.md
+++ b/powers/nx-plugin-for-aws/POWER.md
@@ -26,13 +26,24 @@ Key capabilities:
 
 ### Prerequisites
 
+#### Required
+
 - [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
 - [Node >= 22](https://nodejs.org/en/download) (We recommend using something like [NVM](https://github.com/nvm-sh/nvm) to manage your node versions)
   - verify by running `node --version`
 - [UV >= 0.5.29](https://docs.astral.sh/uv/getting-started/installation/)
   1. install Python 3.14 by running: `uv python install 3.14.0`
   2. verify with `uv python list --only-installed`
-- [AWS Credentials](https://docs.aws.amazon.com/sdkref/latest/guide/access.html) configured to your target AWS account are required to deploy, and for some local development workflows
+
+#### Recommended
+
+- [PNPM >= 11](https://pnpm.io/installation#using-npm) (you can also use [Yarn >= 4](https://yarnpkg.com/getting-started/install), [Bun >= 1](https://bun.sh/docs/installation), or [NPM >= 10](https://nodejs.org/en/learn/getting-started/an-introduction-to-the-npm-package-manager) if you prefer)
+  - verify by running `pnpm --version`, `yarn --version`, `bun --version` or `npm --version`
+- [AWS Credentials](https://docs.aws.amazon.com/sdkref/latest/guide/access.html) configured to your target AWS account are required to deploy your application (as well as for some local development workflows).
+- [Docker](https://www.docker.com/) or [Finch >= 1.6.0](https://runfinch.com/) is required for some generators. For Docker, [multi-platform builds](https://docs.docker.com/build/building/multi-platform/) must be set up; Finch supports [multi-platform builds](https://runfinch.com/docs/getting-started/building-images/#building-a-multi-architecture-container-image) out of the box.
+- [Terraform >= 1.12](https://developer.hashicorp.com/terraform/install) is required if you choose to use this for infrastructure as code instead of CDK
+  - verify by running `terraform --version`
+- If you are using [VSCode](https://code.visualstudio.com/), we recommend installing the [Nx Console VSCode Plugin](https://marketplace.visualstudio.com/items?itemName=nrwl.angular-console).
 
 ### Getting Started
 

--- a/scripts/make-skills.ts
+++ b/scripts/make-skills.ts
@@ -21,16 +21,23 @@ interface GeneratorsJsonSchema {
 const ROOT = join(__dirname, '..');
 
 /**
- * Read required-prerequisites.mdx and strip frontmatter
+ * Read a prerequisites snippet and strip its frontmatter, so its bullets can be
+ * inlined into the generated skill.
  */
-const getPrerequisites = (): string => {
+const readPrerequisites = (snippet: string): string => {
   const content = readFileSync(
-    join(ROOT, 'docs/src/content/docs/en/snippets/required-prerequisites.mdx'),
+    join(ROOT, `docs/src/content/docs/en/snippets/${snippet}.mdx`),
     'utf-8',
   );
   // Remove YAML frontmatter (--- ... ---)
   return content.replace(/^---[\s\S]*?---\n/, '').trim();
 };
+
+const getRequiredPrerequisites = (): string =>
+  readPrerequisites('required-prerequisites');
+
+const getRecommendedPrerequisites = (): string =>
+  readPrerequisites('recommended-prerequisites');
 
 /**
  * Build the create workspace command using pnpm as the default
@@ -86,7 +93,8 @@ const tree = new FsTree(ROOT, false);
 const templateDir = joinPathFragments(__dirname, 'skill-templates');
 
 const sharedVariables = {
-  prerequisites: getPrerequisites(),
+  requiredPrerequisites: getRequiredPrerequisites(),
+  recommendedPrerequisites: getRecommendedPrerequisites(),
   createNxWorkspaceCommand: getCreateNxWorkspaceCommand(),
   generators: getGeneratorsTable(),
 };

--- a/scripts/skill-templates/__fileName__.template
+++ b/scripts/skill-templates/__fileName__.template
@@ -20,8 +20,13 @@ Key capabilities:
 
 ### Prerequisites
 
-<%- prerequisites %>
-- [AWS Credentials](https://docs.aws.amazon.com/sdkref/latest/guide/access.html) configured to your target AWS account are required to deploy, and for some local development workflows
+#### Required
+
+<%- requiredPrerequisites %>
+
+#### Recommended
+
+<%- recommendedPrerequisites %>
 
 ### Getting Started
 

--- a/skills/nx-plugin-for-aws/SKILL.md
+++ b/skills/nx-plugin-for-aws/SKILL.md
@@ -25,13 +25,24 @@ Key capabilities:
 
 ### Prerequisites
 
+#### Required
+
 - [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
 - [Node >= 22](https://nodejs.org/en/download) (We recommend using something like [NVM](https://github.com/nvm-sh/nvm) to manage your node versions)
   - verify by running `node --version`
 - [UV >= 0.5.29](https://docs.astral.sh/uv/getting-started/installation/)
   1. install Python 3.14 by running: `uv python install 3.14.0`
   2. verify with `uv python list --only-installed`
-- [AWS Credentials](https://docs.aws.amazon.com/sdkref/latest/guide/access.html) configured to your target AWS account are required to deploy, and for some local development workflows
+
+#### Recommended
+
+- [PNPM >= 11](https://pnpm.io/installation#using-npm) (you can also use [Yarn >= 4](https://yarnpkg.com/getting-started/install), [Bun >= 1](https://bun.sh/docs/installation), or [NPM >= 10](https://nodejs.org/en/learn/getting-started/an-introduction-to-the-npm-package-manager) if you prefer)
+  - verify by running `pnpm --version`, `yarn --version`, `bun --version` or `npm --version`
+- [AWS Credentials](https://docs.aws.amazon.com/sdkref/latest/guide/access.html) configured to your target AWS account are required to deploy your application (as well as for some local development workflows).
+- [Docker](https://www.docker.com/) or [Finch >= 1.6.0](https://runfinch.com/) is required for some generators. For Docker, [multi-platform builds](https://docs.docker.com/build/building/multi-platform/) must be set up; Finch supports [multi-platform builds](https://runfinch.com/docs/getting-started/building-images/#building-a-multi-architecture-container-image) out of the box.
+- [Terraform >= 1.12](https://developer.hashicorp.com/terraform/install) is required if you choose to use this for infrastructure as code instead of CDK
+  - verify by running `terraform --version`
+- If you are using [VSCode](https://code.visualstudio.com/), we recommend installing the [Nx Console VSCode Plugin](https://marketplace.visualstudio.com/items?itemName=nrwl.angular-console).
 
 ### Getting Started
 


### PR DESCRIPTION
### Reason for this change

The generated `POWER.md` / `SKILL.md` (the Nx Plugin for AWS skill/power used by AI coding agents) only listed the **required** prerequisites. An agent onboarding through the skill therefore missed the recommended ones — a package manager, AWS credentials, Docker/Finch, Terraform, and the Nx Console plugin — which it needs for most real workflows.

### Description of changes

- Extracted the recommended prerequisites into a plain-markdown `recommended-prerequisites.mdx` snippet, mirroring the existing `required-prerequisites.mdx`, so it can be inlined into the skill.
- `prerequisites.mdx` (the docs page) now consumes that snippet instead of listing the bullets inline — no change to what the docs render.
- `scripts/make-skills.ts` and the skill template now render **Required** and **Recommended** subsections under Prerequisites. The previously hardcoded "AWS Credentials" line is dropped from the template since it now comes from the recommended snippet.
- Regenerated `POWER.md` and `SKILL.md`.

### Description of how you validated changes

- Ran `tsx scripts/make-skills.ts` and confirmed both generated files now show Required + Recommended sections with the full list.
- `nx build docs` passes with all internal links valid; verified the recommended bullets still render on the pages that use the `prerequisites` snippet (Quick Start, Add to an existing project).

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
