### PR TITLE
fix(ts#nx-migration): share the unranked-migration sentinel between stamping and backfill

### DIFF
--- a/packages/nx-plugin/src/utils/migration-versions.ts
+++ b/packages/nx-plugin/src/utils/migration-versions.ts
@@ -113,9 +113,15 @@ export const readShippedMigrationVersions = (
 /**
  * Rank a migration ships under, lower running first. Unranked entries (no commit
  * history for them, or an every-migration entry with no folder) sort after every
- * ranked one, so a ranked migration always precedes an unranked peer.
+ * ranked one, so a ranked migration always precedes an unranked peer. Shared by
+ * stamping and backfill so the two order unranked entries the same way.
  */
 const UNRANKED = Number.MAX_SAFE_INTEGER;
+
+/** Commit-rank comparator, ordering unranked entries last (see `UNRANKED`). */
+const byCommitRank =
+  (commitRanks: Record<string, number>) => (keyA: string, keyB: string) =>
+    (commitRanks[keyA] ?? UNRANKED) - (commitRanks[keyB] ?? UNRANKED);
 
 /**
  * Return a copy of the migrations collection with a `version` stamped onto
@@ -158,9 +164,7 @@ export const stampMigrationVersions = (
         }
         // Equal ranks (same commit, or both unranked) fall through to a stable
         // sort, keeping the manifest's key order the assembly already imposed.
-        return (
-          (commitRanks[keyA] ?? UNRANKED) - (commitRanks[keyB] ?? UNRANKED)
-        );
+        return byCommitRank(commitRanks)(keyA, keyB);
       })
       .map(([name, entry]) => {
         // Source-only marker, stripped from what nx reads.
@@ -292,9 +296,7 @@ export const backfillMigrationVersions = (
   }
   for (const keys of byVersion.values()) {
     const ordered = keys.sort((a, b) => {
-      const rankDiff =
-        (commitRanks[a] ?? Number.MAX_SAFE_INTEGER) -
-        (commitRanks[b] ?? Number.MAX_SAFE_INTEGER);
+      const rankDiff = byCommitRank(commitRanks)(a, b);
       return rankDiff !== 0
         ? rankDiff
         : latestKeyName(a).localeCompare(latestKeyName(b));


### PR DESCRIPTION
### Reason for this change

`stampMigrationVersions` and `backfillMigrationVersions` both order migrations by commit rank, treating an entry with no rank as sorting last. Stamping referenced the named `UNRANKED` constant, while backfill duplicated the same sentinel inline as `Number.MAX_SAFE_INTEGER`. The two paths implement the same ordering semantics, so a change to how unranked entries sort in one would silently diverge from the other.

### Description of changes

Extract a shared `byCommitRank` comparator built on the `UNRANKED` constant and use it in both `stampMigrationVersions` and `backfillMigrationVersions`, so the two order unranked entries identically by construction. No behavioural change — purely deduplicates the sentinel.

### Description of how you validated changes

- Existing unit tests for both functions pass (`migration-versions` + `migration-manifest`, 44 tests), including the ranked-before-unranked and equal-rank-fallback cases that exercise the sentinel.
- `compile` and lint pass.

### Issue # (if applicable)

N/A.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*