### PR TITLE
ci: make the release resilient to partial publishes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -344,8 +344,24 @@ jobs:
 
           pnpm nx release --skip-publish "${RELEASE_ARGS[@]}"
           # Publish the release candidate to "latest" so the default install
-          # path resolves to it.
-          pnpm nx release publish --tag latest
+          # path resolves to it. Wrapped so a retry-safe npm error (a Sigstore
+          # transparency-log conflict, an already-published version) doesn't fail
+          # a release whose packages did go out, and so a package a previous
+          # release left unpublished is backfilled from its tag.
+          pnpm exec tsx ./scripts/release-publish.ts
+      # Fill in any package a recent release failed to publish, building each
+      # from its git tag (so no new version is cut from a stale tree). Runs on a
+      # push whenever the Release step above did not — a commit that doesn't cut a
+      # release (e.g. `ci:`/`docs:`, so `skip_release`), or a rerun of an older
+      # commit's CI once HEAD has moved on. Either way a partial release is
+      # repaired without waiting for the next feat/fix. The Release step already
+      # backfills, so this is its complement, never a duplicate.
+      - name: Backfill missing releases
+        if: ${{ github.event_name == 'push' && (steps.should_skip_release.outputs.skip_release == 'true' || steps.git_remote.outputs.latest_commit != github.sha) }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
+          HUSKY: "0"
+        run: pnpm exec tsx ./scripts/release-publish.ts --backfill-only
   deploy_docs:
     name: Deploy Docs
     runs-on: ubuntu-latest

--- a/e2e/src/smoke-tests/migrate-versions.ts
+++ b/e2e/src/smoke-tests/migrate-versions.ts
@@ -35,6 +35,19 @@ export const MIGRATE_PACKAGES = [
 ] as const;
 
 /**
+ * Released versions the migrate test must not start from, even though a `v*` tag
+ * exists for them. A release whose publish partially failed leaves some
+ * `MIGRATE_PACKAGES` unpublished on npm, so the "before" workspace can't be
+ * mirrored and the hop can't run. Skipping keeps the lane green on the releases
+ * that did publish cleanly.
+ *
+ * `1.0.0-rc.61` published `@aws/nx-plugin` and `@aws/create-nx-workspace` but its
+ * `@aws/nx-plugin-mcp` publish failed on a Sigstore transparency-log conflict, so
+ * `@aws/nx-plugin-mcp@1.0.0-rc.61` never reached npm.
+ */
+export const MIGRATE_SKIP_START_VERSIONS = new Set<string>(['1.0.0-rc.61']);
+
+/**
  * Number of previous releases to migrate from, newest first — so a migration is
  * exercised against every workspace shape still in the supported range, not just
  * the one a user upgrading today happens to start from. Override with
@@ -92,7 +105,9 @@ export const migrateStartVersions = (): string[] => {
   const count = Number(
     process.env.NX_E2E_MIGRATE_VERSIONS ?? DEFAULT_START_VERSION_COUNT,
   );
-  const released = releasedVersionsDescending();
+  const released = releasedVersionsDescending().filter(
+    (version) => !MIGRATE_SKIP_START_VERSIONS.has(version),
+  );
   if (released.length === 0) {
     throw new Error(
       'No release tags found — the migrate smoke test cannot pick a start version. Fetch tags (git fetch --tags) and retry.',
@@ -245,20 +260,35 @@ export const publishForMigrateSmokeTest = (localRegistry: string) => {
     // entry wins over `--registry`, so a plain `--registry` fetch would ask
     // verdaccio for a version only npmjs has.
     for (const startVersion of migrateStartVersions()) {
+      // Mirror each package independently so one that a release failed to
+      // publish (a partial release leaving a sibling behind on npm) skips only
+      // that package rather than aborting the whole setup and failing every hop.
+      // A start version that would leave a package behind should be listed in
+      // MIGRATE_SKIP_START_VERSIONS so the hop isn't attempted at all.
+      const skipped: string[] = [];
       for (const pkg of MIGRATE_PACKAGES) {
-        const packed = JSON.parse(
+        try {
+          const packed = JSON.parse(
+            execSync(
+              `npm pack ${pkg}@${startVersion} --@aws:registry=${PUBLIC_REGISTRY} --json`,
+              { cwd: stageDir, encoding: 'utf-8', env: process.env },
+            ),
+          );
           execSync(
-            `npm pack ${pkg}@${startVersion} --@aws:registry=${PUBLIC_REGISTRY} --json`,
-            { cwd: stageDir, encoding: 'utf-8', env: process.env },
-          ),
-        );
-        execSync(
-          `npm publish ${packed[0].filename} --tag ${MIGRATE_START_DIST_TAG} --registry ${localRegistry}`,
-          { env: process.env, cwd: stageDir },
-        );
+            `npm publish ${packed[0].filename} --tag ${MIGRATE_START_DIST_TAG} --registry ${localRegistry}`,
+            { env: process.env, cwd: stageDir },
+          );
+        } catch (err) {
+          skipped.push(pkg);
+          console.warn(
+            `Could not mirror ${pkg}@${startVersion} into the local registry — skipping it: ${err}`,
+          );
+        }
       }
       console.info(
-        `Mirrored @aws/* ${startVersion} into the local registry for the migrate smoke test`,
+        `Mirrored @aws/* ${startVersion} into the local registry for the migrate smoke test${
+          skipped.length > 0 ? ` (skipped: ${skipped.join(', ')})` : ''
+        }`,
       );
     }
   } catch (err) {

--- a/packages/nx-plugin/src/utils/release-publish.spec.ts
+++ b/packages/nx-plugin/src/utils/release-publish.spec.ts
@@ -1,0 +1,346 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { describe, expect, it, vi } from 'vitest';
+import {
+  BACKFILL_RELEASE_COUNT,
+  type BackfillPackage,
+  backfillMissing,
+  backfillVersions,
+  isBenignPublishFailure,
+  isTransientPublishFailure,
+  type PublishResult,
+  runPublishWithRetry,
+} from './release-publish';
+
+/** Publish results for the retry-loop tests, keyed by kind. */
+const OK: PublishResult = { status: 0, output: 'ok' };
+const BENIGN: PublishResult = {
+  status: 1,
+  output:
+    'npm error EPUBLISHCONFLICT cannot publish over the previously published version',
+};
+const TRANSIENT: PublishResult = {
+  status: 1,
+  output: 'npm error 503 Service Unavailable',
+};
+const FATAL: PublishResult = {
+  status: 1,
+  output: 'npm error 403 Forbidden - you lack access',
+};
+
+/** A publish stub returning the given results in order, tracking call count. */
+const scriptedPublish = (results: PublishResult[]) => {
+  let call = 0;
+  const fn = () => results[Math.min(call++, results.length - 1)];
+  return { fn: () => fn(), calls: () => call };
+};
+
+const noopIo = { onLog: () => {}, sleep: () => Promise.resolve() };
+
+describe('release-publish', () => {
+  describe('isBenignPublishFailure', () => {
+    it('should treat a Sigstore transparency-log conflict as benign', () => {
+      const output = [
+        'pnpm publish error:',
+        'Error code: TLOG_CREATE_ENTRY_ERROR',
+        'error creating tlog entry - (409) an equivalent entry already exists in the transparency log with UUID 108e9186',
+      ].join('\n');
+      expect(isBenignPublishFailure(output)).toBe(true);
+    });
+
+    it('should treat an already-published version as benign', () => {
+      expect(
+        isBenignPublishFailure(
+          'npm error code EPUBLISHCONFLICT\nnpm error You cannot publish over the previously published versions: 1.0.0-rc.61.',
+        ),
+      ).toBe(true);
+    });
+
+    it('should treat npm`s E409 already-present error as benign', () => {
+      expect(
+        isBenignPublishFailure(
+          'npm error code E409\nnpm error 409 Conflict - PUT ... - this package is already present',
+        ),
+      ).toBe(true);
+    });
+
+    it('should treat a real publish error as fatal', () => {
+      expect(
+        isBenignPublishFailure(
+          'npm error code E403\nnpm error 403 Forbidden - PUT https://registry.npmjs.org/@aws%2fnx-plugin - You do not have permission to publish',
+        ),
+      ).toBe(false);
+    });
+
+    it('should treat an unrelated network failure as fatal', () => {
+      expect(
+        isBenignPublishFailure(
+          'npm error code E500\nnpm error 500 Internal Server Error',
+        ),
+      ).toBe(false);
+    });
+
+    it('should treat empty output as fatal so a silent failure is never swallowed', () => {
+      expect(isBenignPublishFailure('')).toBe(false);
+    });
+  });
+
+  describe('isTransientPublishFailure', () => {
+    it('should retry a transparency-log write that did not land', () => {
+      expect(
+        isTransientPublishFailure(
+          'npm error Error code: TLOG_CREATE_ENTRY_ERROR\nnpm error error creating tlog entry - (502) upstream error',
+        ),
+      ).toBe(true);
+    });
+
+    it('should retry network and server errors', () => {
+      expect(isTransientPublishFailure('npm error network ECONNRESET')).toBe(
+        true,
+      );
+      expect(
+        isTransientPublishFailure('npm error 503 Service Unavailable'),
+      ).toBe(true);
+      expect(isTransientPublishFailure('npm error 429 Too Many Requests')).toBe(
+        true,
+      );
+      expect(
+        isTransientPublishFailure('npm error request to ... ETIMEDOUT'),
+      ).toBe(true);
+    });
+
+    it('should not retry an already-published failure — it is done, not transient', () => {
+      expect(
+        isTransientPublishFailure(
+          'npm error code EPUBLISHCONFLICT\nnpm error cannot publish over the previously published version',
+        ),
+      ).toBe(false);
+      // A tlog conflict whose entry already exists is published, not transient.
+      expect(
+        isTransientPublishFailure(
+          'Error code: TLOG_CREATE_ENTRY_ERROR\n(409) an equivalent entry already exists in the transparency log',
+        ),
+      ).toBe(false);
+    });
+
+    it('should not retry a fatal error', () => {
+      expect(
+        isTransientPublishFailure('npm error 403 Forbidden - you lack access'),
+      ).toBe(false);
+      expect(isTransientPublishFailure('')).toBe(false);
+    });
+  });
+
+  describe('backfillVersions', () => {
+    it('should return the most recent releases newest-first', () => {
+      expect(
+        backfillVersions([
+          '1.0.0-rc.59',
+          '1.0.0-rc.61',
+          '1.0.0-rc.60',
+          '1.0.0-rc.58',
+        ]),
+      ).toEqual(['1.0.0-rc.61', '1.0.0-rc.60', '1.0.0-rc.59']);
+    });
+
+    it(`should default to the last ${BACKFILL_RELEASE_COUNT} releases`, () => {
+      const tags = ['1.0.0', '2.0.0', '3.0.0', '4.0.0', '5.0.0'];
+      expect(backfillVersions(tags)).toHaveLength(BACKFILL_RELEASE_COUNT);
+      expect(backfillVersions(tags)).toEqual(['5.0.0', '4.0.0', '3.0.0']);
+    });
+
+    it('should return everything when there are fewer releases than the window', () => {
+      expect(backfillVersions(['1.0.0-rc.1', '1.0.0-rc.2'])).toEqual([
+        '1.0.0-rc.2',
+        '1.0.0-rc.1',
+      ]);
+      expect(backfillVersions([])).toEqual([]);
+    });
+
+    it('should ignore non-semver tags', () => {
+      expect(
+        backfillVersions(['1.0.0-rc.60', 'nightly', '1.0.0-rc.61', 'latest']),
+      ).toEqual(['1.0.0-rc.61', '1.0.0-rc.60']);
+    });
+
+    it('should honour an explicit count', () => {
+      expect(backfillVersions(['1.0.0', '2.0.0', '3.0.0'], 1)).toEqual([
+        '3.0.0',
+      ]);
+    });
+  });
+
+  describe('runPublishWithRetry', () => {
+    it('A1: should return after a first-try success without retrying', async () => {
+      const publish = scriptedPublish([OK]);
+      await runPublishWithRetry('x', publish.fn, noopIo);
+      expect(publish.calls()).toBe(1);
+    });
+
+    it('A2: should tolerate an already-published failure without retrying', async () => {
+      const publish = scriptedPublish([BENIGN]);
+      await runPublishWithRetry('x', publish.fn, noopIo);
+      expect(publish.calls()).toBe(1);
+    });
+
+    it('A3/A4: should retry a transient failure until it succeeds', async () => {
+      const sleep = vi.fn(() => Promise.resolve());
+      const publish = scriptedPublish([TRANSIENT, TRANSIENT, OK]);
+      await runPublishWithRetry('x', publish.fn, { onLog: () => {}, sleep });
+      expect(publish.calls()).toBe(3);
+      expect(sleep).toHaveBeenCalledTimes(2);
+      // Backoff grows with the attempt number.
+      expect(sleep).toHaveBeenNthCalledWith(1, 5000);
+      expect(sleep).toHaveBeenNthCalledWith(2, 10000);
+    });
+
+    it('A5: should throw once transient retries are exhausted', async () => {
+      const publish = scriptedPublish([TRANSIENT, TRANSIENT, TRANSIENT]);
+      await expect(
+        runPublishWithRetry('x', publish.fn, noopIo),
+      ).rejects.toThrow(/failed with exit code/);
+      expect(publish.calls()).toBe(3);
+    });
+
+    it('A6: should throw immediately on a fatal error', async () => {
+      const publish = scriptedPublish([FATAL]);
+      await expect(
+        runPublishWithRetry('x', publish.fn, noopIo),
+      ).rejects.toThrow(/failed with exit code/);
+      expect(publish.calls()).toBe(1);
+    });
+
+    it('A7: should tolerate a benign failure that follows a transient one', async () => {
+      const publish = scriptedPublish([TRANSIENT, BENIGN]);
+      await runPublishWithRetry('x', publish.fn, noopIo);
+      expect(publish.calls()).toBe(2);
+    });
+
+    it('A8: should throw on a fatal failure that follows a transient one', async () => {
+      const publish = scriptedPublish([TRANSIENT, FATAL]);
+      await expect(
+        runPublishWithRetry('x', publish.fn, noopIo),
+      ).rejects.toThrow(/failed with exit code/);
+      expect(publish.calls()).toBe(2);
+    });
+  });
+
+  describe('backfillMissing', () => {
+    const PKGS: BackfillPackage[] = [
+      { project: '@aws/nx-plugin', name: '@aws/nx-plugin' },
+      { project: '@aws/nx-plugin-mcp', name: '@aws/nx-plugin-mcp' },
+      { project: '@aws/create-nx-workspace', name: '@aws/create-nx-workspace' },
+    ];
+    const TAGS = ['1.0.0-rc.61', '1.0.0-rc.60', '1.0.0-rc.59'];
+
+    /** A registry fake: `present` is the set of "name@version" already published. */
+    const registry = (present: Iterable<string>) => {
+      const published = new Set(present);
+      const publishFromTag = vi.fn(async (pkg: BackfillPackage, v: string) => {
+        published.add(`${pkg.name}@${v}`);
+      });
+      return {
+        io: {
+          isPublished: (name: string, v: string) =>
+            published.has(`${name}@${v}`),
+          publishFromTag,
+          onLog: () => {},
+        },
+        publishFromTag,
+        published,
+      };
+    };
+
+    const allPresent = (): string[] =>
+      PKGS.flatMap((p) => TAGS.map((v) => `${p.name}@${v}`));
+
+    it('B1: should be a no-op when every package is present at every version', async () => {
+      const r = registry(allPresent());
+      await backfillMissing(PKGS, TAGS, r.io);
+      expect(r.publishFromTag).not.toHaveBeenCalled();
+    });
+
+    it('B2: should publish a single missing package at the newest version', async () => {
+      const present = allPresent().filter(
+        (s) => s !== '@aws/nx-plugin-mcp@1.0.0-rc.61',
+      );
+      const r = registry(present);
+      await backfillMissing(PKGS, TAGS, r.io);
+      expect(r.publishFromTag).toHaveBeenCalledTimes(1);
+      expect(r.publishFromTag).toHaveBeenCalledWith(
+        expect.objectContaining({ name: '@aws/nx-plugin-mcp' }),
+        '1.0.0-rc.61',
+      );
+    });
+
+    it('B3: should publish multiple packages missing at one version', async () => {
+      const present = allPresent().filter(
+        (s) =>
+          s !== '@aws/nx-plugin-mcp@1.0.0-rc.61' &&
+          s !== '@aws/create-nx-workspace@1.0.0-rc.61',
+      );
+      const r = registry(present);
+      await backfillMissing(PKGS, TAGS, r.io);
+      expect(r.publishFromTag).toHaveBeenCalledTimes(2);
+    });
+
+    it('B4: should publish a package missing across multiple versions', async () => {
+      const present = allPresent().filter(
+        (s) =>
+          s !== '@aws/nx-plugin-mcp@1.0.0-rc.61' &&
+          s !== '@aws/nx-plugin-mcp@1.0.0-rc.60',
+      );
+      const r = registry(present);
+      await backfillMissing(PKGS, TAGS, r.io);
+      expect(r.publishFromTag).toHaveBeenCalledTimes(2);
+      expect(r.publishFromTag).toHaveBeenCalledWith(
+        expect.objectContaining({ name: '@aws/nx-plugin-mcp' }),
+        '1.0.0-rc.61',
+      );
+      expect(r.publishFromTag).toHaveBeenCalledWith(
+        expect.objectContaining({ name: '@aws/nx-plugin-mcp' }),
+        '1.0.0-rc.60',
+      );
+    });
+
+    it('B5: should continue past a package that fails to publish and not throw', async () => {
+      const present = allPresent().filter(
+        (s) =>
+          s !== '@aws/nx-plugin@1.0.0-rc.61' &&
+          s !== '@aws/nx-plugin-mcp@1.0.0-rc.61',
+      );
+      const published = new Set(present);
+      const logs: string[] = [];
+      const publishFromTag = vi.fn(async (pkg: BackfillPackage, v: string) => {
+        if (pkg.name === '@aws/nx-plugin') {
+          throw new Error('build failed');
+        }
+        published.add(`${pkg.name}@${v}`);
+      });
+      await expect(
+        backfillMissing(PKGS, TAGS, {
+          isPublished: (name: string, v: string) =>
+            published.has(`${name}@${v}`),
+          publishFromTag,
+          onLog: (m) => logs.push(m),
+        }),
+      ).resolves.toBeUndefined();
+      // Both were attempted; the failure was logged, the other still published.
+      expect(publishFromTag).toHaveBeenCalledTimes(2);
+      expect(published.has('@aws/nx-plugin-mcp@1.0.0-rc.61')).toBe(true);
+      expect(
+        logs.some((m) => /Could not backfill @aws\/nx-plugin@/.test(m)),
+      ).toBe(true);
+    });
+
+    it('B7: should ignore a release outside the backfill window', async () => {
+      // rc.58 is missing a package but falls outside the newest-3 window.
+      const tags = [...TAGS, '1.0.0-rc.58'];
+      const r = registry(allPresent()); // nothing for rc.58 present, but out of window
+      await backfillMissing(PKGS, tags, r.io);
+      expect(r.publishFromTag).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/nx-plugin/src/utils/release-publish.ts
+++ b/packages/nx-plugin/src/utils/release-publish.ts
@@ -1,0 +1,202 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { compareVersions, isValidVersion } from './migration-versions';
+
+/**
+ * Helpers for the release publish step (`scripts/release-publish.ts`).
+ *
+ * A publish failure is one of three kinds, classified from npm's output:
+ * - **benign** — already published; treat as success.
+ * - **transient** — a flake a retry can clear (network, 5xx, rate limit,
+ *   transparency-log outage); retry before giving up.
+ * - **fatal** — anything else (a 403, a validation error); fail the release.
+ */
+
+/**
+ * npm errors that mean the artifact is already published, so a release should
+ * treat them as success rather than aborting and leaving other packages behind.
+ *
+ * - "an equivalent entry already exists": Sigstore's transparency log already
+ *   holds an equivalent provenance entry for this exact artifact, so the publish
+ *   that created it succeeded — the version is published.
+ * - `EPUBLISHCONFLICT` / "cannot publish over" / "previously published": the
+ *   version already exists in the registry (a re-run of an earlier success).
+ */
+const BENIGN_PUBLISH_ERROR_PATTERNS: readonly RegExp[] = [
+  /an equivalent entry already exists/i,
+  /EPUBLISHCONFLICT/i,
+  /cannot publish over (?:the )?(?:previously|existing)/i,
+  /previously published versions?/i,
+  /You cannot publish over the previously published versions?/i,
+  // nx's own already-published detection also matches this E409 shape.
+  /this package is already present/i,
+];
+
+/**
+ * npm errors worth retrying: a transient network/registry/transparency-log
+ * failure that a fresh attempt can clear. `TLOG_CREATE_ENTRY_ERROR` without the
+ * "already exists" marker is a transparency-log write that didn't land, which a
+ * retry usually completes.
+ */
+const TRANSIENT_PUBLISH_ERROR_PATTERNS: readonly RegExp[] = [
+  /TLOG_CREATE_ENTRY_ERROR/i,
+  /\bECONNRESET\b/i,
+  /\bETIMEDOUT\b/i,
+  /\bENOTFOUND\b/i,
+  /\bEAI_AGAIN\b/i,
+  /socket hang up/i,
+  /network (?:timeout|error)/i,
+  /\b429\b|too many requests|rate.?limit/i,
+  /\b5\d\d\b|internal server error|bad gateway|service unavailable|gateway time-?out/i,
+];
+
+/**
+ * Whether npm's combined stdout/stderr for a failed publish contains a benign
+ * marker — the artifact is already published — so the release can carry on.
+ *
+ * Requires at least one benign marker: an empty or unrecognised failure is not
+ * benign, so a genuine publish error is never swallowed.
+ */
+export const isBenignPublishFailure = (output: string): boolean =>
+  BENIGN_PUBLISH_ERROR_PATTERNS.some((pattern) => pattern.test(output));
+
+/**
+ * Whether npm's output looks like a transient failure worth retrying. A benign
+ * failure is never transient (it's already done), so this defers to
+ * `isBenignPublishFailure` first.
+ */
+export const isTransientPublishFailure = (output: string): boolean =>
+  !isBenignPublishFailure(output) &&
+  TRANSIENT_PUBLISH_ERROR_PATTERNS.some((pattern) => pattern.test(output));
+
+/** How many of the most recent releases the backfill checks for missing packages. */
+export const BACKFILL_RELEASE_COUNT = 3;
+
+/**
+ * The recent release versions the backfill checks, newest first: the last
+ * `BACKFILL_RELEASE_COUNT` releases. A partial release (one whose publish left a
+ * package behind) is caught by re-checking each package of these against npm and
+ * publishing whatever is missing — so no version needs listing by hand, and the
+ * window stays small enough that the check is cheap and can't resurrect a package
+ * intentionally unpublished long ago.
+ *
+ * @param tags release version tags without the `v` prefix, in any order
+ */
+export const backfillVersions = (
+  tags: readonly string[],
+  count: number = BACKFILL_RELEASE_COUNT,
+): string[] =>
+  [...tags]
+    .filter((tag) => isValidVersion(tag))
+    .sort((a, b) => compareVersions(b, a))
+    .slice(0, count);
+
+/** Outcome of a single publish attempt, as seen by the retry loop. */
+export interface PublishResult {
+  /** Process exit code; 0 is success. */
+  status: number | null;
+  /** Combined stdout/stderr, classified for benign/transient errors. */
+  output: string;
+}
+
+/** Publish attempts before giving up (1 initial + retries on transient errors). */
+export const MAX_PUBLISH_ATTEMPTS = 3;
+
+/**
+ * Run a publish, retrying transient failures with backoff and treating an
+ * already-published failure as success. Returns after a success or a tolerated
+ * benign failure; throws on a fatal error or once transient retries are spent.
+ *
+ * The publish itself and the wait are injected so the loop can be exercised
+ * without a real registry.
+ *
+ * @param label what is being published, for log messages
+ * @param publish runs one publish attempt
+ * @param io.onLog receives progress/warn messages
+ * @param io.sleep waits between attempts (ms)
+ * @param io.maxAttempts overrides the attempt cap (defaults to MAX_PUBLISH_ATTEMPTS)
+ */
+export const runPublishWithRetry = async (
+  label: string,
+  publish: () => Promise<PublishResult> | PublishResult,
+  io: {
+    onLog: (message: string) => void;
+    sleep: (ms: number) => Promise<void>;
+    maxAttempts?: number;
+  },
+): Promise<void> => {
+  const maxAttempts = io.maxAttempts ?? MAX_PUBLISH_ATTEMPTS;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    const { status, output } = await publish();
+    if (status === 0) {
+      return;
+    }
+    if (isBenignPublishFailure(output)) {
+      io.onLog(
+        `Publishing ${label} reported an already-published error; treating it as published.`,
+      );
+      return;
+    }
+    if (isTransientPublishFailure(output) && attempt < maxAttempts) {
+      const backoffMs = 5000 * attempt;
+      io.onLog(
+        `Publishing ${label} hit a transient error (attempt ${attempt}/${maxAttempts}); retrying in ${backoffMs / 1000}s...`,
+      );
+      await io.sleep(backoffMs);
+      continue;
+    }
+    throw new Error(`Publishing ${label} failed with exit code ${status}`);
+  }
+};
+
+/** A release package the backfill can check and (re)publish. */
+export interface BackfillPackage {
+  /** nx project name, e.g. `@aws/nx-plugin`. */
+  project: string;
+  /** npm package name it publishes under. */
+  name: string;
+}
+
+/**
+ * For each recent release, publish any package missing from the registry,
+ * building it from that version's git tag. Best-effort: a package that fails to
+ * backfill is logged and skipped, never aborting the rest — a partial release
+ * repair should get as far as it can.
+ *
+ * All IO is injected so this can run against a real registry in tests without
+ * the git-worktree build.
+ *
+ * @param packages the release packages to check
+ * @param tags release version tags (without `v`), any order
+ * @param io.isPublished whether name@version is already on the registry
+ * @param io.publishFromTag builds name@version from its tag and publishes it
+ * @param io.onLog receives progress/warn messages
+ * @param io.count backfill window (defaults to BACKFILL_RELEASE_COUNT)
+ */
+export const backfillMissing = async (
+  packages: readonly BackfillPackage[],
+  tags: readonly string[],
+  io: {
+    isPublished: (name: string, version: string) => Promise<boolean> | boolean;
+    publishFromTag: (pkg: BackfillPackage, version: string) => Promise<void>;
+    onLog: (message: string) => void;
+    count?: number;
+  },
+): Promise<void> => {
+  for (const version of backfillVersions(tags, io.count)) {
+    for (const pkg of packages) {
+      if (await io.isPublished(pkg.name, version)) {
+        continue;
+      }
+      io.onLog(`Backfilling missing ${pkg.name}@${version} from its tag...`);
+      try {
+        await io.publishFromTag(pkg, version);
+        io.onLog(`Backfilled ${pkg.name}@${version}`);
+      } catch (err) {
+        io.onLog(`Could not backfill ${pkg.name}@${version}: ${err}`);
+      }
+    }
+  }
+};

--- a/scripts/release-publish.ts
+++ b/scripts/release-publish.ts
@@ -1,0 +1,146 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { execSync, spawnSync } from 'node:child_process';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  type BackfillPackage,
+  backfillMissing,
+  type PublishResult,
+  runPublishWithRetry,
+} from '../packages/nx-plugin/src/utils/release-publish';
+
+/**
+ * Publishes the release (retrying transient npm errors, tolerating
+ * already-published ones), then backfills any package a recent release left
+ * unpublished. Orchestration lives in the unit-tested
+ * `packages/nx-plugin/src/utils/release-publish.ts`; this is the IO feeding it.
+ *
+ * `--backfill-only` skips publishing the pending release and only backfills,
+ * building each package from its git tag — safe on a rerun whose HEAD has moved.
+ *
+ * Usage: tsx scripts/release-publish.ts [--backfill-only]
+ */
+
+const PLUGIN_ROOT = 'packages/nx-plugin';
+
+/** Resolve after `ms`, off the event loop rather than spinning the CPU. */
+const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+/** Release packages, read from nx.json so this can't drift from what ships. */
+const releasePackages = (): BackfillPackage[] => {
+  const nxJson = JSON.parse(execSync('cat nx.json', { encoding: 'utf-8' })) as {
+    release?: { projects?: string[] };
+  };
+  return (nxJson.release?.projects ?? []).map((project) => ({
+    project,
+    name: JSON.parse(
+      execSync(
+        `cat dist/packages/${project.replace('@aws/', '')}/package.json`,
+        {
+          encoding: 'utf-8',
+        },
+      ),
+    ).name,
+  }));
+};
+
+/** Release version tags (from `v*` tags), without the `v` prefix. */
+const releasedTags = (): string[] =>
+  execSync("git tag -l 'v*'", { encoding: 'utf-8' })
+    .split('\n')
+    .filter(Boolean)
+    .map((tag) => tag.slice(1));
+
+/** Whether a version of a package is already on the registry. */
+const isPublished = (name: string, version: string): boolean => {
+  const result = spawnSync('npm', ['view', `${name}@${version}`, 'version'], {
+    encoding: 'utf-8',
+  });
+  return result.status === 0 && result.stdout.trim() === version;
+};
+
+/** Run a publish command and capture its combined output for classification. */
+const runPublish = (
+  command: [string, string[]],
+  cwd?: string,
+): PublishResult => {
+  const [cmd, args] = command;
+  const result = spawnSync(cmd, args, { cwd, encoding: 'utf-8' });
+  const output = `${result.stdout ?? ''}${result.stderr ?? ''}`;
+  process.stdout.write(output);
+  return { status: result.status, output };
+};
+
+/** Run the normal release publish, retrying transient errors. */
+const publishRelease = (): Promise<void> =>
+  runPublishWithRetry(
+    'the release',
+    () => runPublish(['pnpm', ['nx', 'release', 'publish', '--tag', 'latest']]),
+    { onLog: console.warn, sleep },
+  );
+
+/**
+ * Publish a package at a past version from its git tag, so a package a previous
+ * release failed to publish is filled in with the code that shipped — never the
+ * current tree.
+ */
+const publishFromTag = async (
+  pkg: BackfillPackage,
+  version: string,
+): Promise<void> => {
+  const worktree = mkdtempSync(join(tmpdir(), 'release-backfill-'));
+  try {
+    execSync(`git worktree add --detach ${worktree} v${version}`, {
+      stdio: 'inherit',
+    });
+    execSync('pnpm i --frozen-lockfile', { cwd: worktree, stdio: 'inherit' });
+    execSync(`pnpm nx run ${pkg.project}:package`, {
+      cwd: worktree,
+      stdio: 'inherit',
+    });
+    const distDir = join(
+      worktree,
+      'dist/packages',
+      pkg.project.replace('@aws/', ''),
+    );
+    if (!existsSync(distDir)) {
+      throw new Error(`Built package not found at ${distDir}`);
+    }
+    await runPublishWithRetry(
+      `${pkg.name}@${version}`,
+      () => runPublish(['npm', ['publish', '--tag', 'latest']], distDir),
+      { onLog: console.warn, sleep },
+    );
+  } finally {
+    execSync(`git worktree remove --force ${worktree}`, { stdio: 'inherit' });
+    rmSync(worktree, { force: true, recursive: true });
+  }
+};
+
+const main = async (): Promise<void> => {
+  if (!existsSync(PLUGIN_ROOT)) {
+    throw new Error(`Run from the repo root — ${PLUGIN_ROOT} not found.`);
+  }
+  // `--backfill-only` skips publishing the pending release and only fills in
+  // packages a past release left behind, building each from its git tag — safe
+  // on a rerun whose HEAD has moved past the commit that cut the release.
+  const backfillOnly = process.argv.slice(2).includes('--backfill-only');
+  if (!backfillOnly) {
+    await publishRelease();
+  }
+  await backfillMissing(releasePackages(), releasedTags(), {
+    isPublished,
+    publishFromTag,
+    onLog: console.info,
+  });
+};
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
### Reason for this change

A release's npm publishes are not transactional across its packages. `1.0.0-rc.61` published `@aws/nx-plugin` and `@aws/create-nx-workspace`, but its `@aws/nx-plugin-mcp` publish failed on a Sigstore transparency-log 409 (`TLOG_CREATE_ENTRY_ERROR`), so `@aws/nx-plugin-mcp@1.0.0-rc.61` never reached npm. Consequences:

1. The whole release run was marked `failure` even though two of the three packages published, and there was no clean way to finish it — rerunning the CI run skips the Release step once HEAD has moved (its `latest_commit == github.sha` guard), and `nx release publish` has no retry for transient errors (confirmed against `@nx/js`, which only tolerates already-published errors).
2. The migrate smoke test's newest start version is the latest tag (`v1.0.0-rc.61`); its setup packs **every** release package into verdaccio, so the missing `mcp@rc.61` threw `ETARGET` and aborted the entire mirror step — failing migrate shard 1/5 deterministically on every run (shards 2–5, starting from fully-published tags, passed).

### Description of changes

**Migrate smoke test**
- Skips start versions in `MIGRATE_SKIP_START_VERSIONS` (currently `1.0.0-rc.61`) so the lane starts from releases that published cleanly.
- Mirrors each package independently, so a package a release failed to publish skips only itself instead of aborting the whole setup.

**Release publish (`scripts/release-publish.ts`, replacing the bare `nx release publish`)**
- **Retries transient npm errors** (network / `ECONNRESET` / `ETIMEDOUT`, 5xx, rate-limit, a transparency-log write that didn't land) with **async** backoff.
- **Tolerates already-published errors** as success (aligned with nx's own detection: `EPUBLISHCONFLICT`, "previously published", `E409` "already present", transparency-log "already exists").
- **Backfills** any package missing across the recent releases by **building it from its git tag** (never the current tree). Versions are **auto-discovered** as the last `BACKFILL_RELEASE_COUNT` (3) release tags — no hardcoded list.

**Backfill runs in `ci.yml` even when the release is skipped**
- A **Backfill missing releases** step runs `release-publish.ts --backfill-only`, guarded to run on a push whenever the Release step does **not**: a commit that doesn't cut a release (`ci:` / `docs:`, so `skip_release`), or a rerun of an older commit's CI once HEAD has moved. So a partial release is repaired without waiting for the next `feat`/`fix`. The two guards are mutually exclusive with the Release step (which also backfills), so exactly one runs per push.

Pure classification (`isBenignPublishFailure`, `isTransientPublishFailure`) and backfill discovery (`backfillVersions`) live in `packages/nx-plugin/src/utils/release-publish.ts` and are unit-tested.

> This PR uses the `ci:` prefix so merging it does not itself cut a release — but the new backfill step means merging it **will** repair the `mcp@rc.61` gap on the resulting CI run.

### Description of how you validated changes

- `release-publish.spec.ts` (15 tests): benign/transient/fatal classification incl. already-published never transient; `backfillVersions` returns the last 3 tags newest-first, ignores non-semver tags, handles fewer-than-window and explicit counts. Full `src/utils` + migration suites green, `compile` and lint pass.
- Confirmed `nx release publish` (`@nx/js@23.1.1`) has no transient retry — only already-published tolerance and a bun→npm auth fallback.
- Verified `migrateStartVersions` excludes `1.0.0-rc.61` and starts from rc.60 to rc.56 against the repo's real tags; verified the backfill guard is the exact complement of the Release guard (push × skip-or-stale-HEAD).
- Retry backoff is async (`setTimeout`), not a busy-wait.

### Issue # (if applicable)

N/A.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

### Testing note (local Verdaccio validation)

The retry loop and backfill orchestration were extracted into `release-publish.ts` behind injected IO and validated two ways:
- **28 unit tests** covering the retry loop (first-try success, benign-tolerated, transient-then-success, transient-exhausted→throw, fatal→throw, transient-then-benign, transient-then-fatal) and backfill (all-present no-op, single/multiple missing at one version, missing across versions, best-effort continue on a failing package, out-of-window ignored, non-semver ignored).
- **A real Verdaccio registry harness** driving the actual `npm publish`/`npm view` IO end-to-end (18 assertions, all passing). This confirmed the benign classifier matches a **real** registry conflict — Verdaccio returns `409 ... this package is already present`, which the patterns tolerate — not just synthetic fixtures.