### PR TITLE
docs(quick-start): correct infra stack name in deploy command

### DIFF
--- a/docs/src/content/docs/en/get_started/quick-start.mdx
+++ b/docs/src/content/docs/en/get_started/quick-start.mdx
@@ -247,7 +247,7 @@ Deploy your project:
 
 <Infrastructure>
 <Fragment slot="cdk">
-<NxCommands commands={['deploy infra "my-project-sandbox/*"']} />
+<NxCommands commands={['deploy infra "my-project-infra-sandbox/*"']} />
 </Fragment>
 <Fragment slot="terraform">
 <NxCommands commands={['apply infra']} />

--- a/docs/src/content/docs/es/get_started/quick-start.mdx
+++ b/docs/src/content/docs/es/get_started/quick-start.mdx
@@ -247,7 +247,7 @@ Despliega tu proyecto:
 
 <Infrastructure>
 <Fragment slot="cdk">
-<NxCommands commands={['deploy infra "my-project-sandbox/*"']} />
+<NxCommands commands={['deploy infra "my-project-infra-sandbox/*"']} />
 </Fragment>
 <Fragment slot="terraform">
 <NxCommands commands={['apply infra']} />

--- a/docs/src/content/docs/fr/get_started/quick-start.mdx
+++ b/docs/src/content/docs/fr/get_started/quick-start.mdx
@@ -247,7 +247,7 @@ Déployez votre projet :
 
 <Infrastructure>
 <Fragment slot="cdk">
-<NxCommands commands={['deploy infra "my-project-sandbox/*"']} />
+<NxCommands commands={['deploy infra "my-project-infra-sandbox/*"']} />
 </Fragment>
 <Fragment slot="terraform">
 <NxCommands commands={['apply infra']} />

--- a/docs/src/content/docs/it/get_started/quick-start.mdx
+++ b/docs/src/content/docs/it/get_started/quick-start.mdx
@@ -247,7 +247,7 @@ Distribuisci il tuo progetto:
 
 <Infrastructure>
 <Fragment slot="cdk">
-<NxCommands commands={['deploy infra "my-project-sandbox/*"']} />
+<NxCommands commands={['deploy infra "my-project-infra-sandbox/*"']} />
 </Fragment>
 <Fragment slot="terraform">
 <NxCommands commands={['apply infra']} />

--- a/docs/src/content/docs/jp/get_started/quick-start.mdx
+++ b/docs/src/content/docs/jp/get_started/quick-start.mdx
@@ -247,7 +247,7 @@ Terraformブートストラップは、Terraformステートファイルを保�
 
 <Infrastructure>
 <Fragment slot="cdk">
-<NxCommands commands={['deploy infra "my-project-sandbox/*"']} />
+<NxCommands commands={['deploy infra "my-project-infra-sandbox/*"']} />
 </Fragment>
 <Fragment slot="terraform">
 <NxCommands commands={['apply infra']} />

--- a/docs/src/content/docs/ko/get_started/quick-start.mdx
+++ b/docs/src/content/docs/ko/get_started/quick-start.mdx
@@ -247,7 +247,7 @@ Terraform 부트스트래핑은 Terraform 상태 파일을 저장할 S3 버킷�
 
 <Infrastructure>
 <Fragment slot="cdk">
-<NxCommands commands={['deploy infra "my-project-sandbox/*"']} />
+<NxCommands commands={['deploy infra "my-project-infra-sandbox/*"']} />
 </Fragment>
 <Fragment slot="terraform">
 <NxCommands commands={['apply infra']} />

--- a/docs/src/content/docs/pt/get_started/quick-start.mdx
+++ b/docs/src/content/docs/pt/get_started/quick-start.mdx
@@ -247,7 +247,7 @@ Implante seu projeto:
 
 <Infrastructure>
 <Fragment slot="cdk">
-<NxCommands commands={['deploy infra "my-project-sandbox/*"']} />
+<NxCommands commands={['deploy infra "my-project-infra-sandbox/*"']} />
 </Fragment>
 <Fragment slot="terraform">
 <NxCommands commands={['apply infra']} />

--- a/docs/src/content/docs/vi/get_started/quick-start.mdx
+++ b/docs/src/content/docs/vi/get_started/quick-start.mdx
@@ -247,7 +247,7 @@ Triển khai dự án của bạn:
 
 <Infrastructure>
 <Fragment slot="cdk">
-<NxCommands commands={['deploy infra "my-project-sandbox/*"']} />
+<NxCommands commands={['deploy infra "my-project-infra-sandbox/*"']} />
 </Fragment>
 <Fragment slot="terraform">
 <NxCommands commands={['apply infra']} />

--- a/docs/src/content/docs/zh/get_started/quick-start.mdx
+++ b/docs/src/content/docs/zh/get_started/quick-start.mdx
@@ -247,7 +247,7 @@ Terraform 引导会创建一个 S3 存储桶来存储您的 Terraform 状态文�
 
 <Infrastructure>
 <Fragment slot="cdk">
-<NxCommands commands={['deploy infra "my-project-sandbox/*"']} />
+<NxCommands commands={['deploy infra "my-project-infra-sandbox/*"']} />
 </Fragment>
 <Fragment slot="terraform">
 <NxCommands commands={['apply infra']} />


### PR DESCRIPTION
### Reason for this change

The Quick Start deployment instructions told users to deploy with:

```
pnpm nx deploy infra "my-project-sandbox/*"
```

However the actual CloudFormation stack name follows the infra project naming, so the correct command is:

```
pnpm nx deploy infra "my-project-infra-sandbox/*"
```

This matches the pattern used elsewhere in the docs (e.g. the dungeon adventure tutorial uses `dungeon-adventure-infra-sandbox/*`).

### Description of changes

Updated the deploy command in `docs/src/content/docs/en/get_started/quick-start.mdx` to reference `my-project-infra-sandbox/*` instead of `my-project-sandbox/*`.

### Description of how you validated changes

Documentation-only change. Verified against the naming convention used in other tutorial docs and the infra project name generated in the same guide.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*