### PR TITLE
feat(ts#react-website): rename load:runtime-config target to load-runtime-config

### DIFF
--- a/docs/src/content/docs/en/get_started/quick-start.mdx
+++ b/docs/src/content/docs/en/get_started/quick-start.mdx
@@ -263,7 +263,7 @@ This command will first run `terraform plan` to show you what changes will be ma
 <Steps>
 1. Fetch the `runtime-config.json` file:
 
-    <NxCommands commands={['run demo-website:load:runtime-config']} />
+    <NxCommands commands={['load-runtime-config demo-website']} />
 
 2. Start the local website server
 

--- a/docs/src/content/docs/en/get_started/tutorials/dungeon-game/4.mdx
+++ b/docs/src/content/docs/en/get_started/tutorials/dungeon-game/4.mdx
@@ -146,11 +146,11 @@ You've seen two ends of the spectrum: everything local (`dev`) and everything de
 
 The key is the `RUNTIME_CONFIG_APP_ID` environment variable. When a project runs **without** `LOCAL_DEV=true`, the runtime config lookups fetch their configuration from AWS AppConfig using this application id — the `RuntimeConfigApplicationId` value from your CDK outputs.
 
-Each website has a `load:runtime-config` target that downloads the deployed `runtime-config.json` (Cognito pool, API endpoints, agent ARN) into the local dev server. Some useful combinations:
+Each website has a `load-runtime-config` target that downloads the deployed `runtime-config.json` (Cognito pool, API endpoints, agent ARN) into the local dev server. Some useful combinations:
 
 - **Local website → deployed backend.** Pull the deployed config once, then run the plain `serve` target so the UI talks to the deployed API and agent:
 
-  <NxCommands commands={["run game-ui:load:runtime-config"]} />
+  <NxCommands commands={["load-runtime-config game-ui"]} />
   <NxCommands commands={["serve game-ui"]} />
 
 - **Local API → real DynamoDB table.** Run the plain `serve` target with `RUNTIME_CONFIG_APP_ID` set to the deployed application id:

--- a/docs/src/content/docs/en/guides/react-website.mdx
+++ b/docs/src/content/docs/en/guides/react-website.mdx
@@ -326,19 +326,19 @@ For details on how runtime configuration is stored in AWS AppConfig and how serv
 
 When running the [local development server](#local-development-server), you will need a `runtime-config.json` file in your `public` directory in order for your local website to know the backend URLs, identity configuration, etc.
 
-Your website project is configured with a `load:runtime-config` target which you can use to pull down the `runtime-config.json` file from a deployed application:
+Your website project is configured with a `load-runtime-config` target which you can use to pull down the `runtime-config.json` file from a deployed application:
 
-<NxCommands commands={['run <my-website>:"load:runtime-config"']} />
+<NxCommands commands={['load-runtime-config <my-website>']} />
 
 :::note[Custom Stage Names]
 <Infrastructure>
 <Fragment slot="cdk">
-If you change the prefix for your stage names in your infrastructure project's `src/main.ts`, you will need to update the `load:runtime-config` target in your website's `project.json` file accordingly.
+If you change the prefix for your stage names in your infrastructure project's `src/main.ts`, you will need to update the `load-runtime-config` target in your website's `project.json` file accordingly.
 
-Additionally it's worth noting that the `load:runtime-config` target assumes a single stage of your application is deployed to the environment you have AWS credentials for. You will need to adjust the command if you deploy multiple stages to the same account and region.
+Additionally it's worth noting that the `load-runtime-config` target assumes a single stage of your application is deployed to the environment you have AWS credentials for. You will need to adjust the command if you deploy multiple stages to the same account and region.
 </Fragment>
 <Fragment slot="terraform">
-For Terraform projects, the `load:runtime-config` target copies the `runtime-config.json` file that was created after your most recent local `terraform apply`.
+For Terraform projects, the `load-runtime-config` target copies the `runtime-config.json` file that was created after your most recent local `terraform apply`.
 </Fragment>
 </Infrastructure>
 :::

--- a/docs/src/content/docs/es/get_started/quick-start.mdx
+++ b/docs/src/content/docs/es/get_started/quick-start.mdx
@@ -263,7 +263,7 @@ Este comando primero ejecutará `terraform plan` para mostrarte qué cambios se 
 <Steps>
 1. Obtén el archivo `runtime-config.json`:
 
-    <NxCommands commands={['run demo-website:load:runtime-config']} />
+    <NxCommands commands={['load-runtime-config demo-website']} />
 
 2. Inicia el servidor del sitio web local
 

--- a/docs/src/content/docs/es/get_started/tutorials/dungeon-game/4.mdx
+++ b/docs/src/content/docs/es/get_started/tutorials/dungeon-game/4.mdx
@@ -146,11 +146,11 @@ Has visto dos extremos del espectro: todo local (`serve-local`) y todo desplegad
 
 La clave es la variable de entorno `RUNTIME_CONFIG_APP_ID`. Cuando un proyecto se ejecuta **sin** `SERVE_LOCAL=true`, las búsquedas de configuración en tiempo de ejecución obtienen su configuración de AWS AppConfig usando este id de aplicación — el valor `RuntimeConfigApplicationId` de tus salidas de CDK.
 
-Cada sitio web tiene un target `load:runtime-config` que descarga el `runtime-config.json` desplegado (pool de Cognito, endpoints de API, ARN del agente) en el servidor de desarrollo local. Algunas combinaciones útiles:
+Cada sitio web tiene un target `load-runtime-config` que descarga el `runtime-config.json` desplegado (pool de Cognito, endpoints de API, ARN del agente) en el servidor de desarrollo local. Algunas combinaciones útiles:
 
 - **Sitio web local → backend desplegado.** Descarga la configuración desplegada una vez, luego ejecuta el target `serve` simple para que la UI se comunique con la API y el agente desplegados:
 
-  <NxCommands commands={["run game-ui:load:runtime-config"]} />
+  <NxCommands commands={["load-runtime-config game-ui"]} />
   <NxCommands commands={["serve game-ui"]} />
 
 - **API local → tabla real de DynamoDB.** Ejecuta el target `serve` simple con `RUNTIME_CONFIG_APP_ID` configurado al id de aplicación desplegado:
@@ -160,3 +160,4 @@ Cada sitio web tiene un target `load:runtime-config` que descarga el `runtime-co
 Esta flexibilidad te permite probar exactamente la parte en la que estás trabajando, contra los componentes — locales o desplegados — que tengan sentido.
 
 ¡Felicitaciones! Has construido, probado y desplegado tu Juego de Aventuras de Mazmorra Agéntico. 🎉🎉🎉
+���

--- a/docs/src/content/docs/es/guides/react-website.mdx
+++ b/docs/src/content/docs/es/guides/react-website.mdx
@@ -339,7 +339,7 @@ Si cambias el prefijo de stages en `src/main.ts` de tu infraestructura, debes ac
 Además, este target asume un único stage desplegado en el entorno con credenciales AWS. Debes ajustar el comando si despliegas múltiples stages en la misma cuenta/región.
 </Fragment>
 <Fragment slot="terraform">
-Para proyectos Terraform, el target `load:runtime-config` copia el `runtime-config.json` creado tras el último `terraform apply` local.
+Para proyectos Terraform, el target `load-runtime-config` copia el `runtime-config.json` creado tras el último `terraform apply` local.
 </Fragment>
 </Infrastructure>
 :::

--- a/docs/src/content/docs/fr/get_started/quick-start.mdx
+++ b/docs/src/content/docs/fr/get_started/quick-start.mdx
@@ -263,7 +263,7 @@ Cette commande exécutera d'abord `terraform plan` pour vous montrer quels chang
 <Steps>
 1. Récupérez le fichier `runtime-config.json` :
 
-    <NxCommands commands={['run demo-website:load:runtime-config']} />
+    <NxCommands commands={['load-runtime-config demo-website']} />
 
 2. Démarrez le serveur de site Web local
 

--- a/docs/src/content/docs/fr/get_started/tutorials/dungeon-game/4.mdx
+++ b/docs/src/content/docs/fr/get_started/tutorials/dungeon-game/4.mdx
@@ -146,11 +146,11 @@ Vous avez vu les deux extrêmes du spectre : tout local (`dev`) et tout déploy�
 
 La clé est la variable d'environnement `RUNTIME_CONFIG_APP_ID`. Lorsqu'un projet s'exécute **sans** `LOCAL_DEV=true`, les recherches de configuration d'exécution récupèrent leur configuration depuis AWS AppConfig en utilisant cet identifiant d'application — la valeur `RuntimeConfigApplicationId` de vos sorties CDK.
 
-Chaque site web a une cible `load:runtime-config` qui télécharge le `runtime-config.json` déployé (pool Cognito, points de terminaison API, ARN de l'agent) dans le serveur de développement local. Quelques combinaisons utiles :
+Chaque site web a une cible `load-runtime-config` qui télécharge le `runtime-config.json` déployé (pool Cognito, points de terminaison API, ARN de l'agent) dans le serveur de développement local. Quelques combinaisons utiles :
 
 - **Site web local → backend déployé.** Récupérez la configuration déployée une fois, puis exécutez la cible `serve` simple pour que l'interface utilisateur communique avec l'API et l'agent déployés :
 
-  <NxCommands commands={["run game-ui:load:runtime-config"]} />
+  <NxCommands commands={["load-runtime-config game-ui"]} />
   <NxCommands commands={["serve game-ui"]} />
 
 - **API locale → table DynamoDB réelle.** Exécutez la cible `serve` simple avec `RUNTIME_CONFIG_APP_ID` défini sur l'identifiant d'application déployé :
@@ -159,4 +159,4 @@ Chaque site web a une cible `load:runtime-config` qui télécharge le `runtime-c
 
 Cette flexibilité vous permet de tester exactement la partie sur laquelle vous travaillez, contre les composants — locaux ou déployés — qui ont du sens.
 
-Félicitations. Vous avez construit, testé et déployé votre Jeu d'Aventure en Donjon Agentique ! 🎉🎉🎉
+Félicitations. Vous avez construit, testé et déployé votre Jeu d'Aventure en Donjon Agentique ! 🎉🎉🎉🎉

--- a/docs/src/content/docs/fr/guides/react-website.mdx
+++ b/docs/src/content/docs/fr/guides/react-website.mdx
@@ -339,7 +339,7 @@ Si vous modifiez le préfixe des noms de stage dans le `src/main.ts` de votre pr
 De plus, notez que la cible `load:runtime-config` suppose qu'un seul stage de votre application est déployé dans l'environnement pour lequel vous avez des credentials AWS. Vous devrez ajuster la commande si vous déployez plusieurs stages dans le même compte et région.
 </Fragment>
 <Fragment slot="terraform">
-Pour les projets Terraform, la cible `load:runtime-config` copie le fichier `runtime-config.json` créé après votre dernier `terraform apply` local.
+Pour les projets Terraform, la cible `load-runtime-config` copie le fichier `runtime-config.json` créé après votre dernier `terraform apply` local.
 </Fragment>
 </Infrastructure>
 :::

--- a/docs/src/content/docs/fr/guides/react-website.mdx
+++ b/docs/src/content/docs/fr/guides/react-website.mdx
@@ -543,4 +543,3 @@ Utilisez le générateur <Link path="guides/connection">`connection`</Link> pour
     />
 
 </CardGrid>
-id>

--- a/docs/src/content/docs/it/get_started/quick-start.mdx
+++ b/docs/src/content/docs/it/get_started/quick-start.mdx
@@ -263,7 +263,7 @@ Questo comando eseguirà prima `terraform plan` per mostrarti quali modifiche ve
 <Steps>
 1. Recupera il file `runtime-config.json`:
 
-    <NxCommands commands={['run demo-website:load:runtime-config']} />
+    <NxCommands commands={['load-runtime-config demo-website']} />
 
 2. Avvia il server del sito web locale
 

--- a/docs/src/content/docs/it/get_started/tutorials/dungeon-game/4.mdx
+++ b/docs/src/content/docs/it/get_started/tutorials/dungeon-game/4.mdx
@@ -146,14 +146,21 @@ Hai visto i due estremi dello spettro: tutto locale (`serve-local`) e tutto dist
 
 La chiave è la variabile d'ambiente `RUNTIME_CONFIG_APP_ID`. Quando un progetto viene eseguito **senza** `SERVE_LOCAL=true`, le ricerche della configurazione runtime recuperano la loro configurazione da AWS AppConfig utilizzando questo id applicazione — il valore `RuntimeConfigApplicationId` dagli output CDK.
 
-Ogni sito web ha un target `load:runtime-config` che scarica il `runtime-config.json` distribuito (pool Cognito, endpoint API, ARN agente) nel server di sviluppo locale. Alcune combinazioni utili:
+Ogni sito web ha un target `load-runtime-config` che scarica il `runtime-config.json` distribuito (pool Cognito, endpoint API, ARN agente) nel server di sviluppo locale. Alcune combinazioni utili:
 
 - **Sito web locale → backend distribuito.** Scarica la configurazione distribuita una volta, quindi esegui il target `serve` semplice in modo che l'UI comunichi con l'API e l'agente distribuiti:
 
-  <NxCommands commands={["run game-ui:load:runtime-config"]} />
+  <NxCommands commands={["load-runtime-config game-ui"]} />
   <NxCommands commands={["serve game-ui"]} />
 
 - **API locale → tabella DynamoDB reale.** Esegui il target `serve` semplice con `RUNTIME_CONFIG_APP_ID` impostato sull'id applicazione distribuito:
+
+  <NxCommands env={{RUNTIME_CONFIG_APP_ID:"<RuntimeConfigApplicationId dagli output CDK>"}} commands={["serve game-api"]} />
+
+Questa flessibilità ti permette di testare esattamente la porzione su cui stai lavorando, contro qualsiasi componente — locale o distribuito — abbia senso.
+
+Complimenti. Hai costruito, testato e distribuito il tuo Gioco di Avventura Agentico nel Dungeon!  🎉🎉🎉
+stato sull'id applicazione distribuito:
 
   <NxCommands env={{RUNTIME_CONFIG_APP_ID:"<RuntimeConfigApplicationId dagli output CDK>"}} commands={["serve game-api"]} />
 

--- a/docs/src/content/docs/it/guides/react-website.mdx
+++ b/docs/src/content/docs/it/guides/react-website.mdx
@@ -339,7 +339,7 @@ Se cambi il prefisso per i nomi degli stage in `src/main.ts` del tuo progetto in
 Inoltre, nota che il target `load:runtime-config` assume che un singolo stage della tua applicazione sia distribuito nell'ambiente per cui hai le credenziali AWS. Dovrai modificare il comando se distribuisci più stage nello stesso account e regione.
 </Fragment>
 <Fragment slot="terraform">
-Per progetti Terraform, il target `load:runtime-config` copia il file `runtime-config.json` creato dopo il più recente `terraform apply` locale.
+Per progetti Terraform, il target `load-runtime-config` copia il file `runtime-config.json` creato dopo il più recente `terraform apply` locale.
 </Fragment>
 </Infrastructure>
 :::

--- a/docs/src/content/docs/jp/get_started/quick-start.mdx
+++ b/docs/src/content/docs/jp/get_started/quick-start.mdx
@@ -263,7 +263,7 @@ Terraformブートストラップは、Terraformステートファイルを保�
 <Steps>
 1. `runtime-config.json`ファイルを取得します：
 
-    <NxCommands commands={['run demo-website:load:runtime-config']} />
+    <NxCommands commands={['load-runtime-config demo-website']} />
 
 2. ローカルWebsiteサーバーを起動します
 

--- a/docs/src/content/docs/jp/get_started/tutorials/dungeon-game/4.mdx
+++ b/docs/src/content/docs/jp/get_started/tutorials/dungeon-game/4.mdx
@@ -150,7 +150,7 @@ CloudFront URL（CDK出力の`GameUIDistributionDomainName`）に移動し、新
 
 - **ローカルウェブサイト → デプロイされたバックエンド。** デプロイされた設定を一度プルしてから、プレーンな`serve`ターゲットを実行して、UIがデプロイされたAPIとエージェントと通信するようにします：
 
-  <NxCommands commands={["run game-ui:load:runtime-config"]} />
+  <NxCommands commands={["load-runtime-config game-ui"]} />
   <NxCommands commands={["serve game-ui"]} />
 
 - **ローカルAPI → 実際のDynamoDBテーブル。** デプロイされたアプリケーションIDに設定された`RUNTIME_CONFIG_APP_ID`でプレーンな`serve`ターゲットを実行します：
@@ -159,4 +159,4 @@ CloudFront URL（CDK出力の`GameUIDistributionDomainName`）に移動し、新
 
 この柔軟性により、作業している正確なスライスを、意味のあるコンポーネント — ローカルまたはデプロイ済み — に対してテストできます。
 
-おめでとうございます。エージェント型ダンジョンアドベンチャーゲームを構築、テスト、デプロイしました！ 🎉🎉🎉
+おめでとうございます。エージェント型ダンジョンアドベンチャーゲームを構築、テスト、デプロイしました！ 🎉🎉🎉🎉

--- a/docs/src/content/docs/jp/guides/react-website.mdx
+++ b/docs/src/content/docs/jp/guides/react-website.mdx
@@ -339,7 +339,7 @@ const MyComponent = () => {
 また、このターゲットは単一ステージがAWS認証情報の環境にデプロイされていることを前提としています。同一アカウント/リージョンに複数ステージをデプロイする場合はコマンドを調整してください。
 </Fragment>
 <Fragment slot="terraform">
-Terraformプロジェクトでは、`load:runtime-config`ターゲットは直近のローカル`terraform apply`で作成された`runtime-config.json`をコピーします。
+Terraformプロジェクトでは、`load-runtime-config`ターゲットは直近のローカル`terraform apply`で作成された`runtime-config.json`をコピーします。
 </Fragment>
 </Infrastructure>
 :::
@@ -541,4 +541,6 @@ provider "aws" {
     source="react"
     target="agentcore"
   />
+</CardGrid>
+/>
 </CardGrid>

--- a/docs/src/content/docs/jp/guides/react-website.mdx
+++ b/docs/src/content/docs/jp/guides/react-website.mdx
@@ -542,5 +542,3 @@ provider "aws" {
     target="agentcore"
   />
 </CardGrid>
-/>
-</CardGrid>

--- a/docs/src/content/docs/ko/get_started/quick-start.mdx
+++ b/docs/src/content/docs/ko/get_started/quick-start.mdx
@@ -263,7 +263,7 @@ Terraform 부트스트래핑은 Terraform 상태 파일을 저장할 S3 버킷�
 <Steps>
 1. `runtime-config.json` 파일을 가져옵니다:
 
-    <NxCommands commands={['run demo-website:load:runtime-config']} />
+    <NxCommands commands={['load-runtime-config demo-website']} />
 
 2. 로컬 웹사이트 서버를 시작합니다
 

--- a/docs/src/content/docs/ko/get_started/tutorials/dungeon-game/4.mdx
+++ b/docs/src/content/docs/ko/get_started/tutorials/dungeon-game/4.mdx
@@ -146,11 +146,11 @@ CloudFront URL(CDK 출력의 `GameUIDistributionDomainName`)로 이동하여 새
 
 핵심은 `RUNTIME_CONFIG_APP_ID` 환경 변수입니다. 프로젝트가 `LOCAL_DEV=true` **없이** 실행될 때, 런타임 구성 조회는 이 애플리케이션 ID를 사용하여 AWS AppConfig에서 구성을 가져옵니다 — CDK 출력의 `RuntimeConfigApplicationId` 값입니다.
 
-각 웹사이트에는 배포된 `runtime-config.json`(Cognito 풀, API 엔드포인트, 에이전트 ARN)을 로컬 개발 서버로 다운로드하는 `load:runtime-config` 타겟이 있습니다. 유용한 조합은 다음과 같습니다:
+각 웹사이트에는 배포된 `runtime-config.json`(Cognito 풀, API 엔드포인트, 에이전트 ARN)을 로컬 개발 서버로 다운로드하는 `load-runtime-config` 타겟이 있습니다. 유용한 조합은 다음과 같습니다:
 
 - **로컬 웹사이트 → 배포된 백엔드.** 배포된 구성을 한 번 가져온 다음 일반 `serve` 타겟을 실행하여 UI가 배포된 API 및 에이전트와 통신하도록 합니다:
 
-  <NxCommands commands={["run game-ui:load:runtime-config"]} />
+  <NxCommands commands={["load-runtime-config game-ui"]} />
   <NxCommands commands={["serve game-ui"]} />
 
 - **로컬 API → 실제 DynamoDB 테이블.** `RUNTIME_CONFIG_APP_ID`를 배포된 애플리케이션 ID로 설정하여 일반 `serve` 타겟을 실행합니다:

--- a/docs/src/content/docs/ko/guides/react-website.mdx
+++ b/docs/src/content/docs/ko/guides/react-website.mdx
@@ -339,7 +339,7 @@ const MyComponent = () => {
 또한 `load:runtime-config` 타겟은 단일 스테이지가 AWS 자격 증명 환경에 배포되었다고 가정합니다. 동일 계정/리전에 여러 스테이지를 배포한 경우 명령어를 조정해야 합니다.
 </Fragment>
 <Fragment slot="terraform">
-Terraform 프로젝트의 경우 `load:runtime-config` 타겟은 최근 로컬 `terraform apply`로 생성된 `runtime-config.json` 파일을 복사합니다.
+Terraform 프로젝트의 경우 `load-runtime-config` 타겟은 최근 로컬 `terraform apply`로 생성된 `runtime-config.json` 파일을 복사합니다.
 </Fragment>
 </Infrastructure>
 :::

--- a/docs/src/content/docs/pt/get_started/quick-start.mdx
+++ b/docs/src/content/docs/pt/get_started/quick-start.mdx
@@ -263,7 +263,7 @@ Este comando primeiro executará `terraform plan` para mostrar quais alteraçõe
 <Steps>
 1. Busque o arquivo `runtime-config.json`:
 
-    <NxCommands commands={['run demo-website:load:runtime-config']} />
+    <NxCommands commands={['load-runtime-config demo-website']} />
 
 2. Inicie o servidor de website local
 

--- a/docs/src/content/docs/pt/get_started/tutorials/dungeon-game/4.mdx
+++ b/docs/src/content/docs/pt/get_started/tutorials/dungeon-game/4.mdx
@@ -115,7 +115,7 @@ Se esta for a primeira implantação CDK na sua conta/região AWS, faça o boots
 <NxCommands commands={['bootstrap infra']} />
 :::
 
-Sua primeira implantação levará cerca de 8 minutos para ser concluída. Implantações subsequentes são mais rápidas.
+Sua primeira implantação levará cerca de 6 minutos para ser concluída, pois aguarda a estabilização completa de todos os recursos. Implantações subsequentes são mais rápidas. Para acelerar a iteração durante o desenvolvimento, você pode optar pelo [modo expresso do CloudFormation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-express-mode.html) passando a flag `--express`, que conclui cada operação de recurso assim que sua configuração é aplicada, em vez de aguardar a estabilização completa.
 
 Após a conclusão da implantação, você verá saídas semelhantes às seguintes:
 
@@ -146,11 +146,11 @@ Você viu os dois extremos do espectro: tudo local (`dev`) e tudo implantado. Du
 
 A chave é a variável de ambiente `RUNTIME_CONFIG_APP_ID`. Quando um projeto é executado **sem** `LOCAL_DEV=true`, as buscas de configuração de runtime obtêm sua configuração do AWS AppConfig usando este id de aplicação — o valor `RuntimeConfigApplicationId` das suas saídas do CDK.
 
-Cada site tem um target `load:runtime-config` que baixa o `runtime-config.json` implantado (pool do Cognito, endpoints da API, ARN do agente) para o servidor de desenvolvimento local. Algumas combinações úteis:
+Cada site tem um target `load-runtime-config` que baixa o `runtime-config.json` implantado (pool do Cognito, endpoints da API, ARN do agente) para o servidor de desenvolvimento local. Algumas combinações úteis:
 
 - **Site local → backend implantado.** Baixe a configuração implantada uma vez e então execute o target `serve` simples para que a UI se comunique com a API e agente implantados:
 
-  <NxCommands commands={["run game-ui:load:runtime-config"]} />
+  <NxCommands commands={["load-runtime-config game-ui"]} />
   <NxCommands commands={["serve game-ui"]} />
 
 - **API local → tabela DynamoDB real.** Execute o target `serve` simples com `RUNTIME_CONFIG_APP_ID` definido para o id de aplicação implantado:
@@ -159,4 +159,4 @@ Cada site tem um target `load:runtime-config` que baixa o `runtime-config.json` 
 
 Essa flexibilidade permite que você teste exatamente a parte em que está trabalhando, contra quaisquer componentes — locais ou implantados — que façam sentido.
 
-Parabéns. Você construiu, testou e implantou seu Jogo de Aventura em Masmorra com Agentes!  🎉🎉🎉
+Parabéns. Você construiu, testou e implantou seu Jogo de Aventura em Masmorra com Agentes!  🎉🎉🎉🎉

--- a/docs/src/content/docs/pt/guides/react-website.mdx
+++ b/docs/src/content/docs/pt/guides/react-website.mdx
@@ -327,19 +327,19 @@ Para detalhes sobre como a configuração de runtime é armazenada no AWS AppCon
 
 Ao executar o [servidor de desenvolvimento local](#local-development-server), você precisará de um arquivo `runtime-config.json` em seu diretório `public` para que seu website local conheça as URLs de backend, configuração de identidade, etc.
 
-Seu projeto de website está configurado com um target `load:runtime-config` que você pode usar para baixar o arquivo `runtime-config.json` de uma aplicação implantada:
+Seu projeto de website está configurado com um target `load-runtime-config` que você pode usar para baixar o arquivo `runtime-config.json` de uma aplicação implantada:
 
-<NxCommands commands={['run <my-website>:"load:runtime-config"']} />
+<NxCommands commands={['load-runtime-config <my-website>']} />
 
 :::note[Nomes de estágio personalizados]
 <Infrastructure>
 <Fragment slot="cdk">
-Se você alterar o prefixo dos nomes de stage em `src/main.ts` de seu projeto de infraestrutura, precisará atualizar o target `load:runtime-config` no arquivo `project.json` de seu website.
+Se você alterar o prefixo dos nomes de stage em `src/main.ts` de seu projeto de infraestrutura, precisará atualizar o target `load-runtime-config` no arquivo `project.json` de seu website.
 
-Além disso, é importante notar que o target `load:runtime-config` assume que um único stage de sua aplicação está implantado no ambiente para o qual você tem credenciais AWS. Você precisará ajustar o comando se implantar múltiplos stages na mesma conta e região.
+Além disso, é importante notar que o target `load-runtime-config` assume que um único stage de sua aplicação está implantado no ambiente para o qual você tem credenciais AWS. Você precisará ajustar o comando se implantar múltiplos stages na mesma conta e região.
 </Fragment>
 <Fragment slot="terraform">
-Para projetos Terraform, o target `load:runtime-config` copia o arquivo `runtime-config.json` criado após seu último `terraform apply` local.
+Para projetos Terraform, o target `load-runtime-config` copia o arquivo `runtime-config.json` criado após seu último `terraform apply` local.
 </Fragment>
 </Infrastructure>
 :::

--- a/docs/src/content/docs/vi/get_started/quick-start.mdx
+++ b/docs/src/content/docs/vi/get_started/quick-start.mdx
@@ -263,7 +263,7 @@ Lệnh này sẽ chạy `terraform plan` trước để hiển thị những tha
 <Steps>
 1. Tải tệp `runtime-config.json`:
 
-    <NxCommands commands={['run demo-website:load:runtime-config']} />
+    <NxCommands commands={['load-runtime-config demo-website']} />
 
 2. Khởi động local website server
 

--- a/docs/src/content/docs/vi/get_started/tutorials/dungeon-game/4.mdx
+++ b/docs/src/content/docs/vi/get_started/tutorials/dungeon-game/4.mdx
@@ -146,11 +146,11 @@ Bạn đã thấy hai đầu của phổ: mọi thứ cục bộ (`dev`) và m�
 
 Chìa khóa là biến môi trường `RUNTIME_CONFIG_APP_ID`. Khi một dự án chạy **không có** `LOCAL_DEV=true`, các tra cứu runtime config lấy cấu hình của chúng từ AWS AppConfig sử dụng application id này — giá trị `RuntimeConfigApplicationId` từ các đầu ra CDK của bạn.
 
-Mỗi website có một target `load:runtime-config` tải xuống `runtime-config.json` đã triển khai (Cognito pool, API endpoints, agent ARN) vào máy chủ phát triển cục bộ. Một số kết hợp hữu ích:
+Mỗi website có một target `load-runtime-config` tải xuống `runtime-config.json` đã triển khai (Cognito pool, API endpoints, agent ARN) vào máy chủ phát triển cục bộ. Một số kết hợp hữu ích:
 
 - **Website cục bộ → backend đã triển khai.** Tải config đã triển khai một lần, sau đó chạy target `serve` thông thường để UI giao tiếp với API và agent đã triển khai:
 
-  <NxCommands commands={["run game-ui:load:runtime-config"]} />
+  <NxCommands commands={["load-runtime-config game-ui"]} />
   <NxCommands commands={["serve game-ui"]} />
 
 - **API cục bộ → bảng DynamoDB thực.** Chạy target `serve` thông thường với `RUNTIME_CONFIG_APP_ID` được đặt thành application id đã triển khai:

--- a/docs/src/content/docs/vi/guides/react-website.mdx
+++ b/docs/src/content/docs/vi/guides/react-website.mdx
@@ -339,7 +339,7 @@ Nếu bạn thay đổi tiền tố cho tên stage trong file `src/main.ts` củ
 Ngoài ra, cần lưu ý rằng target `load:runtime-config` giả định một stage duy nhất của ứng dụng của bạn được triển khai vào môi trường mà bạn có thông tin đăng nhập AWS. Bạn sẽ cần điều chỉnh lệnh nếu bạn triển khai nhiều stage vào cùng một tài khoản và khu vực.
 </Fragment>
 <Fragment slot="terraform">
-Đối với các dự án Terraform, target `load:runtime-config` sao chép file `runtime-config.json` được tạo sau lần `terraform apply` local gần nhất của bạn.
+Đối với các dự án Terraform, target `load-runtime-config` sao chép file `runtime-config.json` được tạo sau lần `terraform apply` local gần nhất của bạn.
 </Fragment>
 </Infrastructure>
 :::

--- a/docs/src/content/docs/zh/get_started/quick-start.mdx
+++ b/docs/src/content/docs/zh/get_started/quick-start.mdx
@@ -263,7 +263,7 @@ Terraform 引导会创建一个 S3 存储桶来存储您的 Terraform 状态文�
 <Steps>
 1. 获取 `runtime-config.json` 文件：
 
-    <NxCommands commands={['run demo-website:load:runtime-config']} />
+    <NxCommands commands={['load-runtime-config demo-website']} />
 
 2. 启动本地网站服务器
 

--- a/docs/src/content/docs/zh/get_started/tutorials/dungeon-game/4.mdx
+++ b/docs/src/content/docs/zh/get_started/tutorials/dungeon-game/4.mdx
@@ -146,11 +146,11 @@ dungeon-adventure-infra-sandbox-Application.UserIdentityUserIdentityUserPoolIdXX
 
 关键是 `RUNTIME_CONFIG_APP_ID` 环境变量。当项目运行时**没有** `LOCAL_DEV=true`，运行时配置查找会使用此应用程序 ID 从 AWS AppConfig 获取其配置——即 CDK 输出中的 `RuntimeConfigApplicationId` 值。
 
-每个网站都有一个 `load:runtime-config` 目标，可将已部署的 `runtime-config.json`（Cognito 池、API 端点、代理 ARN）下载到本地开发服务器中。一些有用的组合：
+每个网站都有一个 `load-runtime-config` 目标，可将已部署的 `runtime-config.json`（Cognito 池、API 端点、代理 ARN）下载到本地开发服务器中。一些有用的组合：
 
 - **本地网站 → 已部署后端。** 拉取一次已部署的配置，然后运行普通的 `serve` 目标，以便 UI 与已部署的 API 和代理通信：
 
-  <NxCommands commands={["run game-ui:load:runtime-config"]} />
+  <NxCommands commands={["load-runtime-config game-ui"]} />
   <NxCommands commands={["serve game-ui"]} />
 
 - **本地 API → 真实 DynamoDB 表。** 运行普通的 `serve` 目标，并将 `RUNTIME_CONFIG_APP_ID` 设置为已部署的应用程序 ID：

--- a/docs/src/content/docs/zh/guides/react-website.mdx
+++ b/docs/src/content/docs/zh/guides/react-website.mdx
@@ -542,4 +542,3 @@ provider "aws" {
     target="agentcore"
   />
 </CardGrid>
-Grid>

--- a/docs/src/content/docs/zh/guides/react-website.mdx
+++ b/docs/src/content/docs/zh/guides/react-website.mdx
@@ -327,9 +327,9 @@ const MyComponent = () => {
 
 运行[本地开发服务器](#local-development-server)时，需要在 `public` 目录下放置 `runtime-config.json` 文件以使网站能获取后端 URL 等配置。
 
-网站项目已配置 `load:runtime-config` 目标，用于从已部署环境拉取配置文件：
+网站项目已配置 `load-runtime-config` 目标，用于从已部署环境拉取配置文件：
 
-<NxCommands commands={['run <my-website>:"load:runtime-config"']} />
+<NxCommands commands={['load-runtime-config <my-website>']} />
 
 :::note[自定义阶段名称]
 <Infrastructure>
@@ -542,3 +542,4 @@ provider "aws" {
     target="agentcore"
   />
 </CardGrid>
+Grid>

--- a/packages/nx-plugin/src/mcp-server/tools/general-guidance.ts
+++ b/packages/nx-plugin/src/mcp-server/tools/general-guidance.ts
@@ -77,7 +77,7 @@ ${PACKAGE_MANAGERS.map((pm) => buildNxCommand('<options>', pm)).join(' - \n')}
 - Carefully examine the files that have been generated and always refer back to the generator guide when working in a generated project
 - Generate all projects into the \`packages/\` directory
 - After making changes to your projects, fix linting issues, then run a full build
-- When it's time to start testing a project, suggest to the user that infrastructure is deployed to AWS. For websites, if a runtime-config.json is needed, use the load:runtime-config target after a deployment to point a local website at a sandbox stack.
+- When it's time to start testing a project, suggest to the user that infrastructure is deployed to AWS. For websites, if a runtime-config.json is needed, use the load-runtime-config target after a deployment to point a local website at a sandbox stack.
 
 ## Batching Generators
 

--- a/packages/nx-plugin/src/migrations/latest/rename-load-runtime-config-target/metadata.json
+++ b/packages/nx-plugin/src/migrations/latest/rename-load-runtime-config-target/metadata.json
@@ -1,0 +1,3 @@
+{
+  "description": "Clone the react website 'load:runtime-config' target to a 'load-runtime-config' target so it can be run with the verb syntax (nx load-runtime-config <project>)"
+}

--- a/packages/nx-plugin/src/migrations/latest/rename-load-runtime-config-target/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/latest/rename-load-runtime-config-target/migration.spec.ts
@@ -1,0 +1,175 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import {
+  addProjectConfiguration,
+  readProjectConfiguration,
+  type Tree,
+} from '@nx/devkit';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test';
+import migration from './migration';
+
+const OLD_TARGET = 'load:runtime-config';
+const NEW_TARGET = 'load-runtime-config';
+
+const cdkTarget = () => ({
+  executor: 'nx:run-commands',
+  metadata: {
+    description:
+      "Load runtime config from your deployed stack for dev purposes. You must set your AWS CLI credentials whilst calling 'pnpm exec nx run @my-scope/website:load:runtime-config'",
+  },
+  options: {
+    command:
+      'aws s3 cp s3://`aws cloudformation describe-stacks`/runtime-config.json "{projectRoot}/public/runtime-config.json"',
+  },
+});
+
+const terraformTarget = () => ({
+  executor: 'nx:run-commands',
+  metadata: {
+    description:
+      "Load runtime config from most recently applied terraform env for dev purposes. Copies the runtime config from the Terraform dist directory to the website's public directory.",
+  },
+  options: {
+    command: 'node -e "..."',
+    env: {
+      SRC_FILE: 'dist/packages/common/terraform/runtime-config.json',
+      DEST_DIR: '{projectRoot}/public',
+      DEST_FILE: '{projectRoot}/public/runtime-config.json',
+    },
+  },
+});
+
+describe('rename-load-runtime-config-target migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeUsingTsSolutionSetup();
+  });
+
+  it('should do nothing when no project has the target', async () => {
+    addProjectConfiguration(tree, 'website', {
+      root: 'packages/website',
+      targets: { build: { executor: 'nx:run-commands' } },
+    });
+
+    await migration(tree);
+
+    const project = readProjectConfiguration(tree, 'website');
+    expect(project.targets?.[NEW_TARGET]).toBeUndefined();
+  });
+
+  it('should clone the target, leaving the original in place (CDK)', async () => {
+    addProjectConfiguration(tree, 'website', {
+      root: 'packages/website',
+      targets: { [OLD_TARGET]: cdkTarget() },
+    });
+
+    await migration(tree);
+
+    const project = readProjectConfiguration(tree, 'website');
+    // Original preserved
+    expect(project.targets?.[OLD_TARGET]).toEqual(cdkTarget());
+    // Clone added
+    const cloned = project.targets?.[NEW_TARGET];
+    expect(cloned).toBeDefined();
+    expect(cloned?.executor).toBe('nx:run-commands');
+    expect(cloned?.options).toEqual(cdkTarget().options);
+    // Description uses the verb syntax for the new target
+    expect(cloned?.metadata?.description).toContain(
+      'nx load-runtime-config @my-scope/website',
+    );
+    expect(cloned?.metadata?.description).not.toContain('nx run');
+  });
+
+  it('should clone the target for Terraform projects', async () => {
+    addProjectConfiguration(tree, 'website', {
+      root: 'packages/website',
+      targets: { [OLD_TARGET]: terraformTarget() },
+    });
+
+    await migration(tree);
+
+    const project = readProjectConfiguration(tree, 'website');
+    expect(project.targets?.[OLD_TARGET]).toEqual(terraformTarget());
+    expect(project.targets?.[NEW_TARGET]?.options).toEqual(
+      terraformTarget().options,
+    );
+  });
+
+  it('should be a deep clone independent of the original', async () => {
+    addProjectConfiguration(tree, 'website', {
+      root: 'packages/website',
+      targets: { [OLD_TARGET]: terraformTarget() },
+    });
+
+    await migration(tree);
+
+    const project = readProjectConfiguration(tree, 'website');
+    expect(project.targets?.[NEW_TARGET]?.options?.env).not.toBe(
+      project.targets?.[OLD_TARGET]?.options?.env,
+    );
+  });
+
+  it('should not overwrite an existing new target', async () => {
+    const existingNew = {
+      executor: 'nx:run-commands',
+      options: { command: 'echo custom' },
+    };
+    addProjectConfiguration(tree, 'website', {
+      root: 'packages/website',
+      targets: {
+        [OLD_TARGET]: cdkTarget(),
+        [NEW_TARGET]: existingNew,
+      },
+    });
+
+    await migration(tree);
+
+    const project = readProjectConfiguration(tree, 'website');
+    expect(project.targets?.[NEW_TARGET]).toEqual(existingNew);
+  });
+
+  it('should be idempotent', async () => {
+    addProjectConfiguration(tree, 'website', {
+      root: 'packages/website',
+      targets: { [OLD_TARGET]: cdkTarget() },
+    });
+
+    await migration(tree);
+    const afterFirst = readProjectConfiguration(tree, 'website');
+
+    await migration(tree);
+    const afterSecond = readProjectConfiguration(tree, 'website');
+
+    expect(afterSecond).toEqual(afterFirst);
+  });
+
+  it('should handle multiple projects', async () => {
+    addProjectConfiguration(tree, 'website-a', {
+      root: 'packages/website-a',
+      targets: { [OLD_TARGET]: cdkTarget() },
+    });
+    addProjectConfiguration(tree, 'website-b', {
+      root: 'packages/website-b',
+      targets: { [OLD_TARGET]: terraformTarget() },
+    });
+    addProjectConfiguration(tree, 'api', {
+      root: 'packages/api',
+      targets: { build: { executor: 'nx:run-commands' } },
+    });
+
+    await migration(tree);
+
+    expect(
+      readProjectConfiguration(tree, 'website-a').targets?.[NEW_TARGET],
+    ).toBeDefined();
+    expect(
+      readProjectConfiguration(tree, 'website-b').targets?.[NEW_TARGET],
+    ).toBeDefined();
+    expect(
+      readProjectConfiguration(tree, 'api').targets?.[NEW_TARGET],
+    ).toBeUndefined();
+  });
+});

--- a/packages/nx-plugin/src/migrations/latest/rename-load-runtime-config-target/migration.ts
+++ b/packages/nx-plugin/src/migrations/latest/rename-load-runtime-config-target/migration.ts
@@ -1,0 +1,51 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import {
+  getProjects,
+  type MigrationReturnObject,
+  type Tree,
+  updateProjectConfiguration,
+} from '@nx/devkit';
+import { formatFilesInSubtree } from '../../../utils/format';
+
+/**
+ * React website projects gained a `load-runtime-config` target so the config
+ * can be loaded with the verb syntax (`nx load-runtime-config <project>`),
+ * replacing the colon-separated `load:runtime-config` that had to be quoted on
+ * the CLI. This clones the existing target under the new name in workspaces
+ * generated before the rename, leaving the original in place so any scripts
+ * still referencing it keep working.
+ */
+
+const OLD_TARGET = 'load:runtime-config';
+const NEW_TARGET = 'load-runtime-config';
+
+export default async function migration(
+  tree: Tree,
+): Promise<MigrationReturnObject> {
+  for (const [projectName, project] of getProjects(tree)) {
+    const targets = project.targets;
+    if (!targets?.[OLD_TARGET] || targets[NEW_TARGET]) {
+      // No target to clone, or the new target already exists.
+      continue;
+    }
+
+    const cloned = structuredClone(targets[OLD_TARGET]);
+    // Point the description at the verb syntax for the new target.
+    if (cloned.metadata?.description) {
+      cloned.metadata.description = cloned.metadata.description.replace(
+        new RegExp(`nx run (\\S+):${OLD_TARGET}`, 'g'),
+        `nx ${NEW_TARGET} $1`,
+      );
+    }
+    targets[NEW_TARGET] = cloned;
+
+    updateProjectConfiguration(tree, projectName, project);
+  }
+
+  await formatFilesInSubtree(tree);
+
+  return {};
+}

--- a/packages/nx-plugin/src/ts/react-website/app/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/react-website/app/__snapshots__/generator.spec.ts.snap
@@ -2231,7 +2231,7 @@ You can also automatically fix some lint errors by running the following command
 
 In order to integrate with cognito or trpc backends, you need to have a \`runtime-config.json\` file in your \`/public\` website directory. You can fetch this is follows:
 
-\`pnpm nx run @proj/test-app:load:runtime-config\`
+\`pnpm nx load-runtime-config @proj/test-app\`
 
 > [!IMPORTANT]
 > Ensure you have AWS CLI and curl installed
@@ -2354,10 +2354,10 @@ exports[`react-website generator > Tanstack router integration > should generate
       },
       "dependsOn": ["format"]
     },
-    "load:runtime-config": {
+    "load-runtime-config": {
       "executor": "nx:run-commands",
       "metadata": {
-        "description": "Load runtime config from your deployed stack for dev purposes. You must set your AWS CLI credentials whilst calling 'pnpm nx run @proj/test-app:load:runtime-config'"
+        "description": "Load runtime config from your deployed stack for dev purposes. You must set your AWS CLI credentials whilst calling 'pnpm nx load-runtime-config @proj/test-app'"
       },
       "options": {
         "command": "aws s3 cp s3://\`aws cloudformation describe-stacks --query \\"Stacks[?starts_with(StackName, 'proj-')][].Outputs[] | [?contains(OutputKey, 'TestAppWebsiteBucketName')].OutputValue\\" --output text\`/runtime-config.json \\"{projectRoot}/public/runtime-config.json\\""
@@ -4061,7 +4061,7 @@ You can also automatically fix some lint errors by running the following command
 
 In order to integrate with cognito or trpc backends, you need to have a \`runtime-config.json\` file in your \`/public\` website directory. You can fetch this is follows:
 
-\`pnpm nx run @proj/test-app:load:runtime-config\`
+\`pnpm nx load-runtime-config @proj/test-app\`
 
 > [!IMPORTANT]
 > Ensure you have AWS CLI and curl installed
@@ -4185,10 +4185,10 @@ exports[`react-website generator > Tanstack router integration > should generate
       },
       "dependsOn": ["format"]
     },
-    "load:runtime-config": {
+    "load-runtime-config": {
       "executor": "nx:run-commands",
       "metadata": {
-        "description": "Load runtime config from your deployed stack for dev purposes. You must set your AWS CLI credentials whilst calling 'pnpm nx run @proj/test-app:load:runtime-config'"
+        "description": "Load runtime config from your deployed stack for dev purposes. You must set your AWS CLI credentials whilst calling 'pnpm nx load-runtime-config @proj/test-app'"
       },
       "options": {
         "command": "aws s3 cp s3://\`aws cloudformation describe-stacks --query \\"Stacks[?starts_with(StackName, 'proj-')][].Outputs[] | [?contains(OutputKey, 'TestAppWebsiteBucketName')].OutputValue\\" --output text\`/runtime-config.json \\"{projectRoot}/public/runtime-config.json\\""

--- a/packages/nx-plugin/src/ts/react-website/app/files/app/common/README.md.template
+++ b/packages/nx-plugin/src/ts/react-website/app/files/app/common/README.md.template
@@ -33,7 +33,7 @@ You can also automatically fix some lint errors by running the following command
 
 In order to integrate with cognito or trpc backends, you need to have a `runtime-config.json` file in your `/public` website directory. You can fetch this is follows:
 
-`<%= pkgMgrCmd %> nx run <%= fullyQualifiedName %>:load:runtime-config`
+`<%= pkgMgrCmd %> nx load-runtime-config <%= fullyQualifiedName %>`
 
 > [!IMPORTANT]
 > Ensure you have AWS CLI and curl installed

--- a/packages/nx-plugin/src/ts/react-website/app/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/react-website/app/generator.spec.ts
@@ -602,8 +602,8 @@ describe('react-website generator', () => {
     });
   });
 
-  describe('load:runtime-config target', () => {
-    it('should configure load:runtime-config target for CDK provider', async () => {
+  describe('load-runtime-config target', () => {
+    it('should configure load-runtime-config target for CDK provider', async () => {
       await tsReactWebsiteGenerator(tree, {
         ...options,
         iac: 'cdk',
@@ -611,7 +611,7 @@ describe('react-website generator', () => {
 
       const projectConfig = readJson(tree, 'test-app/project.json');
       const loadRuntimeConfigTarget =
-        projectConfig.targets['load:runtime-config'];
+        projectConfig.targets['load-runtime-config'];
 
       expect(loadRuntimeConfigTarget).toBeDefined();
       expect(loadRuntimeConfigTarget.executor).toBe('nx:run-commands');
@@ -627,7 +627,7 @@ describe('react-website generator', () => {
       );
     });
 
-    it('should configure load:runtime-config target for Terraform provider', async () => {
+    it('should configure load-runtime-config target for Terraform provider', async () => {
       await tsReactWebsiteGenerator(tree, {
         ...options,
         iac: 'terraform',
@@ -635,7 +635,7 @@ describe('react-website generator', () => {
 
       const projectConfig = readJson(tree, 'test-app/project.json');
       const loadRuntimeConfigTarget =
-        projectConfig.targets['load:runtime-config'];
+        projectConfig.targets['load-runtime-config'];
 
       expect(loadRuntimeConfigTarget).toBeDefined();
       expect(loadRuntimeConfigTarget.executor).toBe('nx:run-commands');
@@ -659,7 +659,7 @@ describe('react-website generator', () => {
       ).rejects.toThrow('Unsupported iac UnknownProvider');
     });
 
-    it('should configure load:runtime-config target with custom directory for Terraform', async () => {
+    it('should configure load-runtime-config target with custom directory for Terraform', async () => {
       await tsReactWebsiteGenerator(tree, {
         ...options,
         directory: 'custom-dir',
@@ -668,7 +668,7 @@ describe('react-website generator', () => {
 
       const projectConfig = readJson(tree, 'custom-dir/test-app/project.json');
       const loadRuntimeConfigTarget =
-        projectConfig.targets['load:runtime-config'];
+        projectConfig.targets['load-runtime-config'];
 
       expect(loadRuntimeConfigTarget).toBeDefined();
       expect(loadRuntimeConfigTarget.options.env.SRC_FILE).toBe(
@@ -682,7 +682,7 @@ describe('react-website generator', () => {
       );
     });
 
-    it('should configure load:runtime-config target with scoped npm prefix for CDK', async () => {
+    it('should configure load-runtime-config target with scoped npm prefix for CDK', async () => {
       // Set up package.json with a scope
       tree.write(
         'package.json',
@@ -699,7 +699,7 @@ describe('react-website generator', () => {
 
       const projectConfig = readJson(tree, 'test-app/project.json');
       const loadRuntimeConfigTarget =
-        projectConfig.targets['load:runtime-config'];
+        projectConfig.targets['load-runtime-config'];
 
       expect(loadRuntimeConfigTarget.options.command).toContain('test-scope-');
       expect(loadRuntimeConfigTarget.options.command).toContain(
@@ -789,7 +789,7 @@ describe('react-website generator', () => {
       const projectJson = JSON.parse(
         tree.read('test-app/project.json', 'utf-8'),
       );
-      expect(projectJson.targets['load:runtime-config']).toBeUndefined();
+      expect(projectJson.targets['load-runtime-config']).toBeUndefined();
       expect(tree.exists('packages/common/constructs')).toBeFalsy();
 
       await tsReactWebsiteGenerator(tree, {
@@ -800,7 +800,7 @@ describe('react-website generator', () => {
       const updatedProjectJson = JSON.parse(
         tree.read('test-app/project.json', 'utf-8'),
       );
-      expect(updatedProjectJson.targets['load:runtime-config']).toBeDefined();
+      expect(updatedProjectJson.targets['load-runtime-config']).toBeDefined();
       expect(tree.exists('packages/common/constructs')).toBeTruthy();
     });
   });

--- a/packages/nx-plugin/src/ts/react-website/app/generator.ts
+++ b/packages/nx-plugin/src/ts/react-website/app/generator.ts
@@ -237,21 +237,21 @@ export async function tsReactWebsiteGenerator(
 
   const infra = schema.infra ?? 'cloudfront-s3';
 
-  // Configure load:runtime-config target based on IaC provider (only when infra is not none)
+  // Configure load-runtime-config target based on IaC provider (only when infra is not none)
   const iac = infra !== 'none' ? await resolveIac(tree, schema.iac) : undefined;
 
   if (iac === 'cdk') {
-    targets['load:runtime-config'] = {
+    targets['load-runtime-config'] = {
       executor: 'nx:run-commands',
       metadata: {
-        description: `Load runtime config from your deployed stack for dev purposes. You must set your AWS CLI credentials whilst calling '${getPackageManagerDisplayCommands().exec} nx run ${fullyQualifiedName}:load:runtime-config'`,
+        description: `Load runtime config from your deployed stack for dev purposes. You must set your AWS CLI credentials whilst calling '${getPackageManagerDisplayCommands().exec} nx load-runtime-config ${fullyQualifiedName}'`,
       },
       options: {
         command: `aws s3 cp s3://\`aws cloudformation describe-stacks --query "Stacks[?starts_with(StackName, '${kebabCase(npmScopePrefix)}-')][].Outputs[] | [?contains(OutputKey, '${websiteNameClassName}WebsiteBucketName')].OutputValue" --output text\`/runtime-config.json "{projectRoot}/public/runtime-config.json"`,
       },
     };
   } else if (iac === 'terraform') {
-    targets['load:runtime-config'] = {
+    targets['load-runtime-config'] = {
       executor: 'nx:run-commands',
       metadata: {
         description:


### PR DESCRIPTION

### Reason for this change

The react website's runtime config target was named `load:runtime-config`. The colon in the target name forces it to be quoted on the CLI (e.g. `nx run <project>:"load:runtime-config"`), which is awkward. Renaming it to `load-runtime-config` allows it to be run with Nx's cleaner verb syntax: `nx load-runtime-config <project>`.

### Description of changes

- Renamed the `load:runtime-config` target vended by the `ts#react-website` generator to `load-runtime-config` (both the CDK and Terraform variants), and updated the CDK target's description to reference the verb syntax.
- Updated the generated project README template and the MCP `general-guidance` tool to reference the new target name / verb syntax.
- Updated documentation (quick start, react-website guide, dungeon adventure tutorial) to use the verb syntax: `pnpm nx load-runtime-config <project>`.
- Added a migration (`rename-load-runtime-config-target`) which clones any existing react website project's `load:runtime-config` target to an additional `load-runtime-config` target, leaving the original in place so existing scripts keep working. The clone's description is rewritten to reference the verb syntax.

### Description of how you validated changes

- Updated and ran the `ts#react-website` generator unit tests (including the `load-runtime-config` target tests and project.json snapshots).
- Added unit tests for the new migration covering: no-op when the target is absent, cloning for CDK and Terraform projects, leaving the original in place, deep-clone independence, not overwriting an existing new target, idempotency, and multiple projects.
- Confirmed the plugin compiles and the migration is assembled into `migrations.json`.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
