### PR TITLE
ci: delete leftover e2e stacks stuck in DELETE_FAILED

### DIFF
--- a/e2e/src/smoke-tests/cdk-deploy.spec.ts
+++ b/e2e/src/smoke-tests/cdk-deploy.spec.ts
@@ -81,6 +81,7 @@ async function deleteLeftoverStacks(cdkStageName: string): Promise<void> {
           StackStatus.CREATE_COMPLETE,
           StackStatus.UPDATE_COMPLETE,
           StackStatus.ROLLBACK_COMPLETE,
+          StackStatus.DELETE_FAILED,
         ],
       });
       const leftoverStacks = (stacks.StackSummaries ?? []).filter((s) =>


### PR DESCRIPTION
### Reason for this change

`deleteLeftoverStacks` filters `listStacks` to `CREATE_COMPLETE`, `UPDATE_COMPLETE` and `ROLLBACK_COMPLETE` — so it never sees `DELETE_FAILED`, which is exactly the state a stack lands in when `cdk destroy` hits a resource that won't go. CloudFormation never retries a failed delete on its own, so those stacks accumulate indefinitely.

**27 had built up in the e2e account since mid-July**, holding 3 NAT gateways (billed hourly), 10 AgentCore runtimes, 37 non-empty S3 buckets and 103 orphaned Lambda ENIs. The WAF WebACLs they hold also count against `NUM_WEBACLS_BY_ACCOUNT`, so left unchecked this eventually fails the `cdk-deploy` lane outright.

### Description of changes

Add `StackStatus.DELETE_FAILED` to the status filter, so a stack whose teardown failed is retried by the next run's cleanup instead of being left behind for good.

### Description of how you validated changes

- Cleared the existing 27-stack backlog manually to confirm the failure modes: non-empty agent session buckets, orphaned Lambda ENIs pinning security groups (which is what kept the VPCs and their NAT gateways alive), and AgentCore runtimes timing out. All 27 deleted, all 3 NAT gateways gone, AgentCore runtimes 10 → 0. Protected stacks (`CDKToolkit`, `nx-plugin-for-aws-integ-test`, `shopping-list-infra-sandbox-*`) verified untouched.
- Confirmed the filter is the gap: a real `DELETE_FAILED` stack in the account is invisible to the current filter and picked up with `DELETE_FAILED` added.
- `biome check` clean.

> Uses the `ci:` prefix so merging this does not cut a release.

### Issue # (if applicable)

N/A.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
