### PR TITLE
feat(ts#infra): add deploy-sandbox target for the sandbox stage

### DIFF
--- a/docs/src/content/docs/en/get_started/quick-start.mdx
+++ b/docs/src/content/docs/en/get_started/quick-start.mdx
@@ -248,10 +248,6 @@ Deploy your project:
 <Infrastructure>
 <Fragment slot="cdk">
 <NxCommands commands={['deploy-sandbox infra']} />
-
-:::tip[Sandbox Stage]
-`deploy-sandbox` deploys the sandbox stage defined in `packages/infra/src/main.ts`. To deploy a different stage, use the `deploy` target and name it, for example `deploy infra "my-project-infra-beta/*"`.
-:::
 </Fragment>
 <Fragment slot="terraform">
 <NxCommands commands={['apply infra']} />

--- a/docs/src/content/docs/en/get_started/quick-start.mdx
+++ b/docs/src/content/docs/en/get_started/quick-start.mdx
@@ -247,7 +247,11 @@ Deploy your project:
 
 <Infrastructure>
 <Fragment slot="cdk">
-<NxCommands commands={['deploy infra "my-project-infra-sandbox/*"']} />
+<NxCommands commands={['deploy-sandbox infra']} />
+
+:::tip[Sandbox Stage]
+`deploy-sandbox` deploys the sandbox stage defined in `packages/infra/src/main.ts`. To deploy a different stage, use the `deploy` target and name it, for example `deploy infra "my-project-infra-beta/*"`.
+:::
 </Fragment>
 <Fragment slot="terraform">
 <NxCommands commands={['apply infra']} />

--- a/docs/src/content/docs/en/get_started/tutorials/dungeon-game/4.mdx
+++ b/docs/src/content/docs/en/get_started/tutorials/dungeon-game/4.mdx
@@ -107,13 +107,15 @@ Your game is complete and you've tested every piece locally. Now let's deploy it
 
 ### Deploy your application
 
-<NxCommands commands={['deploy infra "dungeon-adventure-infra-sandbox/*"']} />
+<NxCommands commands={['deploy-sandbox infra']} />
 
 :::caution[Bootstrap Required]
 If this is the first CDK deployment in your AWS account/region, bootstrap it first:
 
 <NxCommands commands={['bootstrap infra']} />
 :::
+
+The `deploy-sandbox` target deploys the sandbox stage defined in `packages/infra/src/main.ts` — `dungeon-adventure-infra-sandbox` — so you don't need to name it yourself.
 
 Your first deployment will take around 6 minutes to complete as it waits for all resources to fully stabilize. Subsequent deployments are faster. To speed up iteration during development you can opt into [CloudFormation express mode](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-express-mode.html) by passing the `--express` flag, which completes each resource operation as soon as its configuration is applied rather than waiting for full stabilization.
 

--- a/docs/src/content/docs/en/get_started/tutorials/dungeon-game/4.mdx
+++ b/docs/src/content/docs/en/get_started/tutorials/dungeon-game/4.mdx
@@ -115,7 +115,7 @@ If this is the first CDK deployment in your AWS account/region, bootstrap it fir
 <NxCommands commands={['bootstrap infra']} />
 :::
 
-The `deploy-sandbox` target deploys the sandbox stage defined in `packages/infra/src/main.ts` — `dungeon-adventure-infra-sandbox` — so you don't need to name it yourself.
+The `deploy-sandbox` target deploys the sandbox stage defined in `packages/infra/src/main.ts`.
 
 Your first deployment will take around 6 minutes to complete as it waits for all resources to fully stabilize. Subsequent deployments are faster. To speed up iteration during development you can opt into [CloudFormation express mode](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-express-mode.html) by passing the `--express` flag, which completes each resource operation as soon as its configuration is applied rather than waiting for full stabilization.
 

--- a/docs/src/content/docs/en/guides/typescript-infrastructure.mdx
+++ b/docs/src/content/docs/en/guides/typescript-infrastructure.mdx
@@ -393,6 +393,14 @@ The `deploy-sandbox` target deploys the sandbox stage that `main.ts` declares, s
 
 This is the quickest way to get your own copy of the application running in AWS while you develop.
 
+:::tip[Express Mode for Faster Deployments]
+The deploy targets wait for full resource stabilization by default, favouring consistency over speed. To speed up iteration during development, opt into [CloudFormation express mode](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-express-mode.html) by passing CDK's `--express` flag:
+
+<NxCommands commands={['deploy-sandbox <my-infra> --express']} />
+
+Express mode finishes once resource configuration is confirmed applied rather than waiting for full stabilization, with propagation continuing in the background, for significantly faster iteration cycles. It is intended for development and iteration.
+:::
+
 ### Deploying a Specific Stage
 
 The `deploy` target deploys whichever stage or stacks you name. Use it for stages other than your sandbox, or to deploy a single stack:
@@ -402,14 +410,6 @@ The `deploy` target deploys whichever stage or stacks you name. Use it for stage
 You can specify any stage so long as it is defined in `main.ts`. To deploy an individual stack, give the full stack name:
 
 <NxCommands commands={['deploy <my-infra> <my-infra>-sandbox/Application']} />
-
-:::tip[Express Mode for Faster Deployments]
-The deploy targets wait for full resource stabilization by default, favouring consistency over speed. To speed up iteration during development, opt into [CloudFormation express mode](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-express-mode.html) by passing CDK's `--express` flag:
-
-<NxCommands commands={['deploy-sandbox <my-infra> --express']} />
-
-Express mode finishes once resource configuration is confirmed applied rather than waiting for full stabilization, with propagation continuing in the background, for significantly faster iteration cycles. It is intended for development and iteration.
-:::
 
 ## Deploying to AWS in a CI/CD Pipeline
 

--- a/docs/src/content/docs/en/guides/typescript-infrastructure.mdx
+++ b/docs/src/content/docs/en/guides/typescript-infrastructure.mdx
@@ -96,9 +96,13 @@ new ApplicationStage(app, 'my-app-sandbox', {
     region: process.env.CDK_DEFAULT_REGION,
   },
 });
+
+// Define other instances of stages, such as beta and prod, below
 ```
 
 The `env` property tells CDK which AWS account and region to deploy to. `CDK_DEFAULT_ACCOUNT` and `CDK_DEFAULT_REGION` are resolved automatically by the CDK CLI from your active AWS credentials. See the [CDK environments documentation](https://docs.aws.amazon.com/cdk/v2/guide/environments.html) for more details.
+
+The sandbox stage is the one the <Link path="guides/typescript-infrastructure#deploying-your-sandbox-stage">`deploy-sandbox` target</Link> deploys.
 
 If you generated with `stageConfig`, the `main.ts` reads account and region from a centralized config file instead, falling back to environment variables when no config is set:
 
@@ -371,32 +375,40 @@ For more details, please refer to the [CDK bootstrapping documentation](https://
 
 ## Deploying to AWS
 
-After a build, you can deploy your infrastructure to AWS using the `deploy` target.
+Your project has three deploy targets, each suited to a different situation:
 
-:::caution[CI Deployment]
-Use the `deploy-ci` target if deploying in a CI/CD pipeline. See below for more details.
-:::
+| Target           | Use it for                                                                       |
+| ---------------- | -------------------------------------------------------------------------------- |
+| `deploy-sandbox` | Deploying your own sandbox stage during development. No stage argument needed.    |
+| `deploy`         | Deploying any stage, by naming the stage or stacks you want.                      |
+| `deploy-ci`      | Deploying from a CI/CD pipeline, using a pre-synthesized cloud assembly.          |
 
 First, make sure you have AWS credentials configured. If you generated with `stageConfig` and have configured stage credentials in `packages/common/infra-config/src/stages.config.ts`, the deploy command will automatically resolve and apply the correct credentials for the target stage. Otherwise, ensure your AWS credentials are set in your environment (e.g., via `AWS_PROFILE` or environment variables). See the [AWS credentials documentation](https://docs.aws.amazon.com/sdkref/latest/guide/access.html) for the available options.
 
-Then run the deploy target:
+### Deploying your Sandbox Stage
+
+The `deploy-sandbox` target deploys the sandbox stage that `main.ts` declares, so you don't need to remember its stage name:
+
+<NxCommands commands={['deploy-sandbox <my-infra>']} />
+
+This is the quickest way to get your own copy of the application running in AWS while you develop.
+
+### Deploying a Specific Stage
+
+The `deploy` target deploys whichever stage or stacks you name. Use it for stages other than your sandbox, or to deploy a single stack:
 
 <NxCommands commands={['deploy <my-infra> <my-infra>-sandbox/*']} />
 
-:::tip[Express Mode for Faster Deployments]
-The `deploy` target waits for full resource stabilization by default, favouring consistency over speed. To speed up iteration during development, opt into [CloudFormation express mode](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-express-mode.html) by passing CDK's `--express` flag:
-
-<NxCommands commands={['deploy <my-infra> <my-infra>-sandbox/* --express']} />
-
-Express mode finishes once resource configuration is confirmed applied rather than waiting for full stabilization, with propagation continuing in the background, for significantly faster iteration cycles. It is intended for development and iteration.
-:::
-
-:::tip[Selective Stack Deployment]
-The above command deploys _all_ stacks for the `<my-infra>-sandbox` stage. You can specify other stages so long as they are defined in `main.ts`.
-
-You can also deploy individual stacks by specifying the full stack name, for example:
+You can specify any stage so long as it is defined in `main.ts`. To deploy an individual stack, give the full stack name:
 
 <NxCommands commands={['deploy <my-infra> <my-infra>-sandbox/Application']} />
+
+:::tip[Express Mode for Faster Deployments]
+The deploy targets wait for full resource stabilization by default, favouring consistency over speed. To speed up iteration during development, opt into [CloudFormation express mode](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-express-mode.html) by passing CDK's `--express` flag:
+
+<NxCommands commands={['deploy-sandbox <my-infra> --express']} />
+
+Express mode finishes once resource configuration is confirmed applied rather than waiting for full stabilization, with propagation continuing in the background, for significantly faster iteration cycles. It is intended for development and iteration.
 :::
 
 ## Deploying to AWS in a CI/CD Pipeline

--- a/docs/src/content/docs/es/get_started/quick-start.mdx
+++ b/docs/src/content/docs/es/get_started/quick-start.mdx
@@ -247,7 +247,11 @@ Despliega tu proyecto:
 
 <Infrastructure>
 <Fragment slot="cdk">
-<NxCommands commands={['deploy infra "my-project-infra-sandbox/*"']} />
+<NxCommands commands={['deploy-sandbox infra']} />
+
+:::tip[Etapa Sandbox]
+`deploy-sandbox` despliega la etapa sandbox definida en `packages/infra/src/main.ts`. Para desplegar una etapa diferente, usa el objetivo `deploy` y nómbralo, por ejemplo `deploy infra "my-project-infra-beta/*"`.
+:::
 </Fragment>
 <Fragment slot="terraform">
 <NxCommands commands={['apply infra']} />

--- a/docs/src/content/docs/es/get_started/quick-start.mdx
+++ b/docs/src/content/docs/es/get_started/quick-start.mdx
@@ -248,10 +248,6 @@ Despliega tu proyecto:
 <Infrastructure>
 <Fragment slot="cdk">
 <NxCommands commands={['deploy-sandbox infra']} />
-
-:::tip[Etapa Sandbox]
-`deploy-sandbox` despliega la etapa sandbox definida en `packages/infra/src/main.ts`. Para desplegar una etapa diferente, usa el objetivo `deploy` y nómbralo, por ejemplo `deploy infra "my-project-infra-beta/*"`.
-:::
 </Fragment>
 <Fragment slot="terraform">
 <NxCommands commands={['apply infra']} />

--- a/docs/src/content/docs/es/get_started/tutorials/dungeon-game/4.mdx
+++ b/docs/src/content/docs/es/get_started/tutorials/dungeon-game/4.mdx
@@ -115,7 +115,7 @@ Si este es el primer despliegue de CDK en tu cuenta/región de AWS, primero haz 
 <NxCommands commands={['bootstrap infra']} />
 :::
 
-El target `deploy-sandbox` despliega el stage sandbox definido en `packages/infra/src/main.ts` — `dungeon-adventure-infra-sandbox` — por lo que no necesitas nombrarlo tú mismo.
+El target `deploy-sandbox` despliega el stage sandbox definido en `packages/infra/src/main.ts`.
 
 Tu primer despliegue tomará alrededor de 6 minutos en completarse ya que espera a que todos los recursos se estabilicen completamente. Los despliegues posteriores son más rápidos. Para acelerar la iteración durante el desarrollo, puedes optar por el [modo express de CloudFormation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-express-mode.html) pasando la bandera `--express`, que completa cada operación de recurso tan pronto como se aplica su configuración en lugar de esperar la estabilización completa.
 

--- a/docs/src/content/docs/es/get_started/tutorials/dungeon-game/4.mdx
+++ b/docs/src/content/docs/es/get_started/tutorials/dungeon-game/4.mdx
@@ -107,13 +107,15 @@ Tu juego está completo y has probado cada pieza localmente. Ahora vamos a despl
 
 ### Implementar tu aplicación
 
-<NxCommands commands={['deploy infra "dungeon-adventure-infra-sandbox/*"']} />
+<NxCommands commands={['deploy-sandbox infra']} />
 
 :::caution[Bootstrap requerido]
 Si este es el primer despliegue de CDK en tu cuenta/región de AWS, primero haz bootstrap:
 
 <NxCommands commands={['bootstrap infra']} />
 :::
+
+El target `deploy-sandbox` despliega el stage sandbox definido en `packages/infra/src/main.ts` — `dungeon-adventure-infra-sandbox` — por lo que no necesitas nombrarlo tú mismo.
 
 Tu primer despliegue tomará alrededor de 6 minutos en completarse ya que espera a que todos los recursos se estabilicen completamente. Los despliegues posteriores son más rápidos. Para acelerar la iteración durante el desarrollo, puedes optar por el [modo express de CloudFormation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-express-mode.html) pasando la bandera `--express`, que completa cada operación de recurso tan pronto como se aplica su configuración en lugar de esperar la estabilización completa.
 

--- a/docs/src/content/docs/es/guides/typescript-infrastructure.mdx
+++ b/docs/src/content/docs/es/guides/typescript-infrastructure.mdx
@@ -394,6 +394,14 @@ El objetivo `deploy-sandbox` despliega la etapa sandbox que `main.ts` declara, p
 
 Esta es la forma más rápida de obtener tu propia copia de la aplicación ejecutándose en AWS mientras desarrollas.
 
+:::tip[Modo Express para despliegues más rápidos]
+Los objetivos de despliegue esperan la estabilización completa de los recursos por defecto, favoreciendo la consistencia sobre la velocidad. Para acelerar la iteración durante el desarrollo, opta por el [modo express de CloudFormation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-express-mode.html) pasando la bandera `--express` de CDK:
+
+<NxCommands commands={['deploy-sandbox <my-infra> --express']} />
+
+El modo express finaliza una vez que se confirma que la configuración de recursos se ha aplicado en lugar de esperar la estabilización completa, con la propagación continuando en segundo plano, para ciclos de iteración significativamente más rápidos. Está destinado al desarrollo y la iteración.
+:::
+
 ### Desplegando una etapa específica
 
 El objetivo `deploy` despliega cualquier etapa o stacks que nombres. Úsalo para etapas distintas a tu sandbox, o para desplegar un solo stack:
@@ -403,14 +411,6 @@ El objetivo `deploy` despliega cualquier etapa o stacks que nombres. Úsalo para
 Puedes especificar cualquier etapa siempre que esté definida en `main.ts`. Para desplegar un stack individual, proporciona el nombre completo del stack:
 
 <NxCommands commands={['deploy <my-infra> <my-infra>-sandbox/Application']} />
-
-:::tip[Modo Express para despliegues más rápidos]
-Los objetivos de despliegue esperan la estabilización completa de los recursos por defecto, favoreciendo la consistencia sobre la velocidad. Para acelerar la iteración durante el desarrollo, opta por el [modo express de CloudFormation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-express-mode.html) pasando la bandera `--express` de CDK:
-
-<NxCommands commands={['deploy-sandbox <my-infra> --express']} />
-
-El modo express finaliza una vez que se confirma que la configuración de recursos se ha aplicado en lugar de esperar la estabilización completa, con la propagación continuando en segundo plano, para ciclos de iteración significativamente más rápidos. Está destinado al desarrollo y la iteración.
-:::
 
 ## Desplegando en AWS en un pipeline CI/CD
 

--- a/docs/src/content/docs/es/guides/typescript-infrastructure.mdx
+++ b/docs/src/content/docs/es/guides/typescript-infrastructure.mdx
@@ -97,9 +97,13 @@ new ApplicationStage(app, 'my-app-sandbox', {
     region: process.env.CDK_DEFAULT_REGION,
   },
 });
+
+// Define other instances of stages, such as beta and prod, below
 ```
 
 La propiedad `env` indica a CDK en qué cuenta y región de AWS desplegar. `CDK_DEFAULT_ACCOUNT` y `CDK_DEFAULT_REGION` son resueltos automáticamente por el CLI de CDK desde tus credenciales AWS activas. Consulta la [documentación de entornos CDK](https://docs.aws.amazon.com/cdk/v2/guide/environments.html) para más detalles.
+
+La etapa sandbox es la que despliega el <Link path="guides/typescript-infrastructure#deploying-your-sandbox-stage">objetivo `deploy-sandbox`</Link>.
 
 Si generaste con `stageConfig`, el `main.ts` lee la cuenta y región desde un archivo de configuración centralizado, recurriendo a variables de entorno cuando no hay configuración establecida:
 
@@ -372,32 +376,40 @@ Para más detalles, consulta la [documentación de preparación de CDK](https://
 
 ## Desplegando en AWS
 
-Después de una compilación, puedes desplegar tu infraestructura en AWS usando el objetivo `deploy`.
+Tu proyecto tiene tres objetivos de despliegue, cada uno adecuado para una situación diferente:
 
-:::caution[Despliegue CI]
-Usa el objetivo `deploy-ci` si despliegas en un pipeline CI/CD. Ver más abajo para más detalles.
-:::
+| Objetivo         | Úsalo para                                                                       |
+| ---------------- | -------------------------------------------------------------------------------- |
+| `deploy-sandbox` | Desplegar tu propia etapa sandbox durante el desarrollo. No se necesita argumento de etapa. |
+| `deploy`         | Desplegar cualquier etapa, nombrando la etapa o stacks que desees.              |
+| `deploy-ci`      | Desplegar desde un pipeline CI/CD, usando un cloud assembly pre-sintetizado.    |
 
 Primero, asegúrate de tener credenciales AWS configuradas. Si generaste con `stageConfig` y has configurado credenciales de etapas en `packages/common/infra-config/src/stages.config.ts`, el comando de despliegue resolverá y aplicará automáticamente las credenciales correctas para la etapa objetivo. De lo contrario, asegúrate de que tus credenciales AWS estén establecidas en tu entorno (por ejemplo, mediante `AWS_PROFILE` o variables de entorno). Consulta la [documentación de credenciales AWS](https://docs.aws.amazon.com/sdkref/latest/guide/access.html) para las opciones disponibles.
 
-Luego ejecuta el objetivo de despliegue:
+### Desplegando tu etapa Sandbox
+
+El objetivo `deploy-sandbox` despliega la etapa sandbox que `main.ts` declara, por lo que no necesitas recordar su nombre de etapa:
+
+<NxCommands commands={['deploy-sandbox <my-infra>']} />
+
+Esta es la forma más rápida de obtener tu propia copia de la aplicación ejecutándose en AWS mientras desarrollas.
+
+### Desplegando una etapa específica
+
+El objetivo `deploy` despliega cualquier etapa o stacks que nombres. Úsalo para etapas distintas a tu sandbox, o para desplegar un solo stack:
 
 <NxCommands commands={['deploy <my-infra> <my-infra>-sandbox/*']} />
 
-:::tip[Modo Express para despliegues más rápidos]
-El objetivo `deploy` espera la estabilización completa de los recursos por defecto, favoreciendo la consistencia sobre la velocidad. Para acelerar la iteración durante el desarrollo, opta por el [modo express de CloudFormation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-express-mode.html) pasando la bandera `--express` de CDK:
-
-<NxCommands commands={['deploy <my-infra> <my-infra>-sandbox/* --express']} />
-
-El modo express finaliza una vez que se confirma que la configuración de recursos se ha aplicado en lugar de esperar la estabilización completa, con la propagación continuando en segundo plano, para ciclos de iteración significativamente más rápidos. Está destinado al desarrollo y la iteración.
-:::
-
-:::tip[Despliegue selectivo de stacks]
-El comando anterior despliega _todos_ los stacks de la etapa `<my-infra>-sandbox`. Puedes especificar otras etapas siempre que estén definidas en `main.ts`.
-
-También puedes desplegar stacks individuales especificando el nombre completo del stack, por ejemplo:
+Puedes especificar cualquier etapa siempre que esté definida en `main.ts`. Para desplegar un stack individual, proporciona el nombre completo del stack:
 
 <NxCommands commands={['deploy <my-infra> <my-infra>-sandbox/Application']} />
+
+:::tip[Modo Express para despliegues más rápidos]
+Los objetivos de despliegue esperan la estabilización completa de los recursos por defecto, favoreciendo la consistencia sobre la velocidad. Para acelerar la iteración durante el desarrollo, opta por el [modo express de CloudFormation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-express-mode.html) pasando la bandera `--express` de CDK:
+
+<NxCommands commands={['deploy-sandbox <my-infra> --express']} />
+
+El modo express finaliza una vez que se confirma que la configuración de recursos se ha aplicado en lugar de esperar la estabilización completa, con la propagación continuando en segundo plano, para ciclos de iteración significativamente más rápidos. Está destinado al desarrollo y la iteración.
 :::
 
 ## Desplegando en AWS en un pipeline CI/CD

--- a/docs/src/content/docs/fr/get_started/quick-start.mdx
+++ b/docs/src/content/docs/fr/get_started/quick-start.mdx
@@ -247,7 +247,11 @@ Déployez votre projet :
 
 <Infrastructure>
 <Fragment slot="cdk">
-<NxCommands commands={['deploy infra "my-project-infra-sandbox/*"']} />
+<NxCommands commands={['deploy-sandbox infra']} />
+
+:::tip[Étape Sandbox]
+`deploy-sandbox` déploie l'étape sandbox définie dans `packages/infra/src/main.ts`. Pour déployer une étape différente, utilisez la cible `deploy` et nommez-la, par exemple `deploy infra "my-project-infra-beta/*"`.
+:::
 </Fragment>
 <Fragment slot="terraform">
 <NxCommands commands={['apply infra']} />

--- a/docs/src/content/docs/fr/get_started/quick-start.mdx
+++ b/docs/src/content/docs/fr/get_started/quick-start.mdx
@@ -248,10 +248,6 @@ Déployez votre projet :
 <Infrastructure>
 <Fragment slot="cdk">
 <NxCommands commands={['deploy-sandbox infra']} />
-
-:::tip[Étape Sandbox]
-`deploy-sandbox` déploie l'étape sandbox définie dans `packages/infra/src/main.ts`. Pour déployer une étape différente, utilisez la cible `deploy` et nommez-la, par exemple `deploy infra "my-project-infra-beta/*"`.
-:::
 </Fragment>
 <Fragment slot="terraform">
 <NxCommands commands={['apply infra']} />

--- a/docs/src/content/docs/fr/get_started/tutorials/dungeon-game/4.mdx
+++ b/docs/src/content/docs/fr/get_started/tutorials/dungeon-game/4.mdx
@@ -107,7 +107,7 @@ Votre jeu est complet et vous avez testé chaque élément localement. Maintenan
 
 ### Déployer votre application
 
-<NxCommands commands={['deploy infra "dungeon-adventure-infra-sandbox/*"']} />
+<NxCommands commands={['deploy-sandbox infra']} />
 
 :::caution[Bootstrap requis]
 S'il s'agit du premier déploiement CDK dans votre compte/région AWS, effectuez d'abord le bootstrap :

--- a/docs/src/content/docs/fr/get_started/tutorials/dungeon-game/4.mdx
+++ b/docs/src/content/docs/fr/get_started/tutorials/dungeon-game/4.mdx
@@ -115,6 +115,8 @@ S'il s'agit du premier déploiement CDK dans votre compte/région AWS, effectuez
 <NxCommands commands={['bootstrap infra']} />
 :::
 
+La cible `deploy-sandbox` déploie l'étape sandbox définie dans `packages/infra/src/main.ts` — `dungeon-adventure-infra-sandbox` — vous n'avez donc pas besoin de la nommer vous-même.
+
 Votre premier déploiement prendra environ 6 minutes pour se terminer car il attend que toutes les ressources se stabilisent complètement. Les déploiements suivants sont plus rapides. Pour accélérer l'itération pendant le développement, vous pouvez opter pour le [mode express CloudFormation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-express-mode.html) en passant le flag `--express`, qui termine chaque opération de ressource dès que sa configuration est appliquée plutôt que d'attendre la stabilisation complète.
 
 Une fois le déploiement terminé, vous verrez des sorties similaires aux suivantes :

--- a/docs/src/content/docs/fr/guides/typescript-infrastructure.mdx
+++ b/docs/src/content/docs/fr/guides/typescript-infrastructure.mdx
@@ -97,13 +97,17 @@ new ApplicationStage(app, 'my-app-sandbox', {
     region: process.env.CDK_DEFAULT_REGION,
   },
 });
+
+// Define other instances of stages, such as beta and prod, below
 ```
 
 La propriété `env` indique à CDK vers quel compte AWS et quelle région déployer. `CDK_DEFAULT_ACCOUNT` et `CDK_DEFAULT_REGION` sont résolus automatiquement par la CLI CDK à partir de vos credentials AWS actifs. Consultez la [documentation CDK sur les environnements](https://docs.aws.amazon.com/cdk/v2/guide/environments.html) pour plus de détails.
 
-Si vous avez généré avec `enableStageConfig`, le `main.ts` lit le compte et la région depuis un fichier de configuration centralisé, avec un repli sur les variables d'environnement lorsqu'aucune config n'est définie :
+Le stage sandbox est celui que la <Link path="guides/typescript-infrastructure#deploying-your-sandbox-stage">cible `deploy-sandbox`</Link> déploie.
 
-```ts title="src/main.ts (avec enableStageConfig)"
+Si vous avez généré avec `stageConfig`, le `main.ts` lit le compte et la région depuis un fichier de configuration centralisé, avec un repli sur les variables d'environnement lorsqu'aucune config n'est définie :
+
+```ts title="src/main.ts (avec stageConfig)"
 import stagesConfig from ':my-scope/common-infra-config';
 
 const projectStages = stagesConfig.projects?.['packages/infra']?.stages ?? {};
@@ -371,32 +375,40 @@ Pour plus de détails, veuillez vous référer à la [documentation CDK sur le b
 
 ## Déploiement sur AWS
 
-Après un build, vous pouvez déployer votre infrastructure sur AWS en utilisant la cible `deploy`.
+Votre projet dispose de trois cibles de déploiement, chacune adaptée à une situation différente :
 
-:::caution[Déploiement CI]
-Utilisez la cible `deploy-ci` si vous déployez dans un pipeline CI/CD. Voir ci-dessous pour plus de détails.
-:::
+| Cible            | À utiliser pour                                                                                  |
+| ---------------- | ------------------------------------------------------------------------------------------------ |
+| `deploy-sandbox` | Déployer votre propre stage sandbox pendant le développement. Aucun argument de stage nécessaire. |
+| `deploy`         | Déployer n'importe quel stage, en nommant le stage ou les stacks que vous souhaitez.             |
+| `deploy-ci`      | Déployer depuis un pipeline CI/CD, en utilisant une assembly cloud pré-synthétisée.              |
 
 Tout d'abord, assurez-vous d'avoir configuré les credentials AWS. Si vous avez généré avec `stageConfig` et avez configuré les credentials de stage dans `packages/common/infra-config/src/stages.config.ts`, la commande de déploiement résoudra et appliquera automatiquement les credentials corrects pour le stage cible. Sinon, assurez-vous que vos credentials AWS sont définis dans votre environnement (par exemple, via `AWS_PROFILE` ou des variables d'environnement). Consultez la [documentation AWS sur les credentials](https://docs.aws.amazon.com/sdkref/latest/guide/access.html) pour les options disponibles.
 
-Ensuite, exécutez la cible de déploiement :
+### Déploiement de votre Stage Sandbox
+
+La cible `deploy-sandbox` déploie le stage sandbox que `main.ts` déclare, vous n'avez donc pas besoin de vous souvenir de son nom de stage :
+
+<NxCommands commands={['deploy-sandbox <my-infra>']} />
+
+C'est le moyen le plus rapide d'obtenir votre propre copie de l'application fonctionnant dans AWS pendant que vous développez.
+
+### Déploiement d'un Stage Spécifique
+
+La cible `deploy` déploie le stage ou les stacks que vous nommez. Utilisez-la pour des stages autres que votre sandbox, ou pour déployer une seule stack :
 
 <NxCommands commands={['deploy <my-infra> <my-infra>-sandbox/*']} />
 
-:::tip[Mode Express pour des déploiements plus rapides]
-La cible `deploy` attend la stabilisation complète des ressources par défaut, privilégiant la cohérence à la vitesse. Pour accélérer l'itération pendant le développement, optez pour le [mode express CloudFormation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-express-mode.html) en passant le flag `--express` de CDK :
-
-<NxCommands commands={['deploy <my-infra> <my-infra>-sandbox/* --express']} />
-
-Le mode express se termine une fois que la configuration des ressources est confirmée comme appliquée plutôt que d'attendre la stabilisation complète, la propagation se poursuivant en arrière-plan, pour des cycles d'itération nettement plus rapides. Il est destiné au développement et à l'itération.
-:::
-
-:::tip[Déploiement sélectif de stacks]
-La commande ci-dessus déploie _toutes_ les stacks du stage `<my-infra>-sandbox`. Vous pouvez spécifier d'autres stages tant qu'ils sont définis dans `main.ts`.
-
-Vous pouvez également déployer des stacks individuelles en spécifiant le nom complet de la stack, par exemple :
+Vous pouvez spécifier n'importe quel stage tant qu'il est défini dans `main.ts`. Pour déployer une stack individuelle, donnez le nom complet de la stack :
 
 <NxCommands commands={['deploy <my-infra> <my-infra>-sandbox/Application']} />
+
+:::tip[Mode Express pour des déploiements plus rapides]
+Les cibles de déploiement attendent la stabilisation complète des ressources par défaut, privilégiant la cohérence à la vitesse. Pour accélérer l'itération pendant le développement, optez pour le [mode express CloudFormation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-express-mode.html) en passant le flag `--express` de CDK :
+
+<NxCommands commands={['deploy-sandbox <my-infra> --express']} />
+
+Le mode express se termine une fois que la configuration des ressources est confirmée comme appliquée plutôt que d'attendre la stabilisation complète, la propagation se poursuivant en arrière-plan, pour des cycles d'itération nettement plus rapides. Il est destiné au développement et à l'itération.
 :::
 
 ## Déploiement sur AWS dans un pipeline CI/CD

--- a/docs/src/content/docs/fr/guides/typescript-infrastructure.mdx
+++ b/docs/src/content/docs/fr/guides/typescript-infrastructure.mdx
@@ -393,6 +393,14 @@ La cible `deploy-sandbox` déploie le stage sandbox que `main.ts` déclare, vous
 
 C'est le moyen le plus rapide d'obtenir votre propre copie de l'application fonctionnant dans AWS pendant que vous développez.
 
+:::tip[Mode Express pour des déploiements plus rapides]
+Les cibles de déploiement attendent la stabilisation complète des ressources par défaut, privilégiant la cohérence à la vitesse. Pour accélérer l'itération pendant le développement, optez pour le [mode express CloudFormation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-express-mode.html) en passant le flag `--express` de CDK :
+
+<NxCommands commands={['deploy-sandbox <my-infra> --express']} />
+
+Le mode express se termine une fois que la configuration des ressources est confirmée comme appliquée plutôt que d'attendre la stabilisation complète, la propagation se poursuivant en arrière-plan, pour des cycles d'itération nettement plus rapides. Il est destiné au développement et à l'itération.
+:::
+
 ### Déploiement d'un Stage Spécifique
 
 La cible `deploy` déploie le stage ou les stacks que vous nommez. Utilisez-la pour des stages autres que votre sandbox, ou pour déployer une seule stack :
@@ -402,14 +410,6 @@ La cible `deploy` déploie le stage ou les stacks que vous nommez. Utilisez-la p
 Vous pouvez spécifier n'importe quel stage tant qu'il est défini dans `main.ts`. Pour déployer une stack individuelle, donnez le nom complet de la stack :
 
 <NxCommands commands={['deploy <my-infra> <my-infra>-sandbox/Application']} />
-
-:::tip[Mode Express pour des déploiements plus rapides]
-Les cibles de déploiement attendent la stabilisation complète des ressources par défaut, privilégiant la cohérence à la vitesse. Pour accélérer l'itération pendant le développement, optez pour le [mode express CloudFormation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-express-mode.html) en passant le flag `--express` de CDK :
-
-<NxCommands commands={['deploy-sandbox <my-infra> --express']} />
-
-Le mode express se termine une fois que la configuration des ressources est confirmée comme appliquée plutôt que d'attendre la stabilisation complète, la propagation se poursuivant en arrière-plan, pour des cycles d'itération nettement plus rapides. Il est destiné au développement et à l'itération.
-:::
 
 ## Déploiement sur AWS dans un pipeline CI/CD
 

--- a/docs/src/content/docs/it/get_started/quick-start.mdx
+++ b/docs/src/content/docs/it/get_started/quick-start.mdx
@@ -248,10 +248,6 @@ Distribuisci il tuo progetto:
 <Infrastructure>
 <Fragment slot="cdk">
 <NxCommands commands={['deploy-sandbox infra']} />
-
-:::tip[Stage Sandbox]
-`deploy-sandbox` distribuisce lo stage sandbox definito in `packages/infra/src/main.ts`. Per distribuire uno stage diverso, utilizza il target `deploy` e nominalo, ad esempio `deploy infra "my-project-infra-beta/*"`.
-:::
 </Fragment>
 <Fragment slot="terraform">
 <NxCommands commands={['apply infra']} />

--- a/docs/src/content/docs/it/get_started/quick-start.mdx
+++ b/docs/src/content/docs/it/get_started/quick-start.mdx
@@ -247,7 +247,11 @@ Distribuisci il tuo progetto:
 
 <Infrastructure>
 <Fragment slot="cdk">
-<NxCommands commands={['deploy infra "my-project-infra-sandbox/*"']} />
+<NxCommands commands={['deploy-sandbox infra']} />
+
+:::tip[Stage Sandbox]
+`deploy-sandbox` distribuisce lo stage sandbox definito in `packages/infra/src/main.ts`. Per distribuire uno stage diverso, utilizza il target `deploy` e nominalo, ad esempio `deploy infra "my-project-infra-beta/*"`.
+:::
 </Fragment>
 <Fragment slot="terraform">
 <NxCommands commands={['apply infra']} />

--- a/docs/src/content/docs/it/get_started/tutorials/dungeon-game/4.mdx
+++ b/docs/src/content/docs/it/get_started/tutorials/dungeon-game/4.mdx
@@ -115,7 +115,7 @@ Se questa è la prima distribuzione CDK nel tuo account/regione AWS, esegui prim
 <NxCommands commands={['bootstrap infra']} />
 :::
 
-Il target `deploy-sandbox` distribuisce lo stage sandbox definito in `packages/infra/src/main.ts` — `dungeon-adventure-infra-sandbox` — quindi non è necessario nominarlo tu stesso.
+Il target `deploy-sandbox` distribuisce lo stage sandbox definito in `packages/infra/src/main.ts`.
 
 La tua prima distribuzione richiederà circa 6 minuti per completarsi poiché attende che tutte le risorse si stabilizzino completamente. Le distribuzioni successive sono più veloci. Per accelerare l'iterazione durante lo sviluppo puoi optare per la [modalità express di CloudFormation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-express-mode.html) passando il flag `--express`, che completa ogni operazione di risorsa non appena viene applicata la sua configurazione anziché attendere la stabilizzazione completa.
 

--- a/docs/src/content/docs/it/get_started/tutorials/dungeon-game/4.mdx
+++ b/docs/src/content/docs/it/get_started/tutorials/dungeon-game/4.mdx
@@ -30,7 +30,7 @@ Avvia lo stack locale completo — il server di sviluppo game-ui insieme a una G
 Il target `dev` su `game-ui` ha `dependsOn` su `game-api:dev` e `dungeon_adventure.story:agent-dev`, quindi Nx avvia il server locale di ogni progetto in parallelo. Attraverso le connessioni che abbiamo configurato nel Modulo 1, questi a loro volta avviano il server MCP Inventory e DynamoDB Local. Assicurati che il tuo motore di container sia in esecuzione, quindi apri il server di sviluppo in un browser.
 
 <Aside type="tip" title="Nessun login localmente">
-In modalità `serve-local` il componente `CognitoAuth` salta il flusso di login Cognito (non c'è un user pool in esecuzione localmente), quindi atterrerai direttamente sul gioco senza effettuare l'accesso. Creerai un account reale quando distribuiremo su AWS alla fine di questo modulo.
+In modalità `local-dev` il componente `CognitoAuth` salta il flusso di login Cognito (non c'è un user pool in esecuzione localmente), quindi atterrerai direttamente sul gioco senza effettuare l'accesso. Creerai un account reale quando distribuiremo su AWS alla fine di questo modulo.
 </Aside>
 
 <Aside type="caution" title="Mantieni il server di sviluppo attivo">
@@ -107,7 +107,7 @@ Il tuo gioco è completo e hai testato ogni componente localmente. Ora distribui
 
 ### Distribuisci l'applicazione
 
-<NxCommands commands={['deploy infra "dungeon-adventure-infra-sandbox/*"']} />
+<NxCommands commands={['deploy-sandbox infra']} />
 
 :::caution[Bootstrap Richiesto]
 Se questa è la prima distribuzione CDK nel tuo account/regione AWS, esegui prima il bootstrap:
@@ -115,7 +115,9 @@ Se questa è la prima distribuzione CDK nel tuo account/regione AWS, esegui prim
 <NxCommands commands={['bootstrap infra']} />
 :::
 
-La tua prima distribuzione richiederà circa 8 minuti per completarsi. Le distribuzioni successive sono più veloci.
+Il target `deploy-sandbox` distribuisce lo stage sandbox definito in `packages/infra/src/main.ts` — `dungeon-adventure-infra-sandbox` — quindi non è necessario nominarlo tu stesso.
+
+La tua prima distribuzione richiederà circa 6 minuti per completarsi poiché attende che tutte le risorse si stabilizzino completamente. Le distribuzioni successive sono più veloci. Per accelerare l'iterazione durante lo sviluppo puoi optare per la [modalità express di CloudFormation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-express-mode.html) passando il flag `--express`, che completa ogni operazione di risorsa non appena viene applicata la sua configurazione anziché attendere la stabilizzazione completa.
 
 Una volta completata la distribuzione, vedrai output simili ai seguenti:
 
@@ -142,9 +144,9 @@ Naviga verso l'URL di CloudFront (`GameUIDistributionDomainName` dagli output CD
 
 ## Task 6: Combinare componenti locali e distribuiti
 
-Hai visto i due estremi dello spettro: tutto locale (`serve-local`) e tutto distribuito. Durante lo sviluppo quotidiano è spesso utile combinare i due — ad esempio, iterare sul codice del sito web contro l'API e l'agente *reali* distribuiti, o eseguire l'API localmente contro la tabella DynamoDB *reale*.
+Hai visto i due estremi dello spettro: tutto locale (`dev`) e tutto distribuito. Durante lo sviluppo quotidiano è spesso utile combinare i due — ad esempio, iterare sul codice del sito web contro l'API e l'agente *reali* distribuiti, o eseguire l'API localmente contro la tabella DynamoDB *reale*.
 
-La chiave è la variabile d'ambiente `RUNTIME_CONFIG_APP_ID`. Quando un progetto viene eseguito **senza** `SERVE_LOCAL=true`, le ricerche della configurazione runtime recuperano la loro configurazione da AWS AppConfig utilizzando questo id applicazione — il valore `RuntimeConfigApplicationId` dagli output CDK.
+La chiave è la variabile d'ambiente `RUNTIME_CONFIG_APP_ID`. Quando un progetto viene eseguito **senza** `LOCAL_DEV=true`, le ricerche della configurazione runtime recuperano la loro configurazione da AWS AppConfig utilizzando questo id applicazione — il valore `RuntimeConfigApplicationId` dagli output CDK.
 
 Ogni sito web ha un target `load-runtime-config` che scarica il `runtime-config.json` distribuito (pool Cognito, endpoint API, ARN agente) nel server di sviluppo locale. Alcune combinazioni utili:
 
@@ -160,7 +162,6 @@ Ogni sito web ha un target `load-runtime-config` che scarica il `runtime-config.
 Questa flessibilità ti permette di testare esattamente la porzione su cui stai lavorando, contro qualsiasi componente — locale o distribuito — abbia senso.
 
 Complimenti. Hai costruito, testato e distribuito il tuo Gioco di Avventura Agentico nel Dungeon!  🎉🎉🎉
-stato sull'id applicazione distribuito:
 
   <NxCommands env={{RUNTIME_CONFIG_APP_ID:"<RuntimeConfigApplicationId dagli output CDK>"}} commands={["serve game-api"]} />
 

--- a/docs/src/content/docs/it/guides/typescript-infrastructure.mdx
+++ b/docs/src/content/docs/it/guides/typescript-infrastructure.mdx
@@ -97,9 +97,13 @@ new ApplicationStage(app, 'my-app-sandbox', {
     region: process.env.CDK_DEFAULT_REGION,
   },
 });
+
+// Define other instances of stages, such as beta and prod, below
 ```
 
 La proprietà `env` indica a CDK su quale account AWS e regione eseguire il deploy. `CDK_DEFAULT_ACCOUNT` e `CDK_DEFAULT_REGION` vengono risolti automaticamente dalla CLI di CDK dalle tue credenziali AWS attive. Consulta la [documentazione sugli ambienti CDK](https://docs.aws.amazon.com/cdk/v2/guide/environments.html) per maggiori dettagli.
+
+Lo stage sandbox è quello che il <Link path="guides/typescript-infrastructure#deploying-your-sandbox-stage">target `deploy-sandbox`</Link> deploya.
 
 Se hai generato con `stageConfig`, il `main.ts` legge account e regione da un file di configurazione centralizzato, con fallback alle variabili d'ambiente quando non è impostata alcuna configurazione:
 
@@ -371,32 +375,40 @@ Per maggiori dettagli, consulta la [documentazione sul bootstrap di CDK](https:/
 
 ## Deploy su AWS
 
-Dopo una build, puoi deployare la tua infrastruttura su AWS usando il target `deploy`.
+Il tuo progetto ha tre target di deploy, ciascuno adatto a una situazione diversa:
 
-:::caution[Deploy CI]
-Usa il target `deploy-ci` se stai deployando in una pipeline CI/CD. Vedi sotto per maggiori dettagli.
-:::
+| Target           | Usalo per                                                                        |
+| ---------------- | -------------------------------------------------------------------------------- |
+| `deploy-sandbox` | Deployare il tuo stage sandbox personale durante lo sviluppo. Non serve specificare lo stage. |
+| `deploy`         | Deployare qualsiasi stage, specificando lo stage o gli stack che desideri.      |
+| `deploy-ci`      | Deployare da una pipeline CI/CD, usando un cloud assembly pre-sintetizzato.     |
 
 Prima, assicurati di avere le credenziali AWS configurate. Se hai generato con `stageConfig` e hai configurato le credenziali degli stage in `packages/common/infra-config/src/stages.config.ts`, il comando deploy risolverà e applicherà automaticamente le credenziali corrette per lo stage target. Altrimenti, assicurati che le tue credenziali AWS siano impostate nel tuo ambiente (ad esempio, tramite `AWS_PROFILE` o variabili d'ambiente). Consulta la [documentazione sulle credenziali AWS](https://docs.aws.amazon.com/sdkref/latest/guide/access.html) per le opzioni disponibili.
 
-Poi esegui il target deploy:
+### Deployare il tuo Stage Sandbox
+
+Il target `deploy-sandbox` deploya lo stage sandbox che `main.ts` dichiara, quindi non devi ricordare il nome dello stage:
+
+<NxCommands commands={['deploy-sandbox <my-infra>']} />
+
+Questo è il modo più veloce per ottenere la tua copia dell'applicazione in esecuzione su AWS mentre sviluppi.
+
+### Deployare uno Stage Specifico
+
+Il target `deploy` deploya qualsiasi stage o stack tu specifichi. Usalo per stage diversi dal tuo sandbox, o per deployare un singolo stack:
 
 <NxCommands commands={['deploy <my-infra> <my-infra>-sandbox/*']} />
 
-:::tip[Modalità Express per Deploy più Veloci]
-Il target `deploy` attende la completa stabilizzazione delle risorse per impostazione predefinita, favorendo la coerenza rispetto alla velocità. Per velocizzare l'iterazione durante lo sviluppo, opta per la [modalità express di CloudFormation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-express-mode.html) passando il flag `--express` di CDK:
-
-<NxCommands commands={['deploy <my-infra> <my-infra>-sandbox/* --express']} />
-
-La modalità express termina una volta che la configurazione delle risorse è confermata applicata anziché attendere la completa stabilizzazione, con la propagazione che continua in background, per cicli di iterazione significativamente più veloci. È pensata per lo sviluppo e l'iterazione.
-:::
-
-:::tip[Deploy selettivo degli stack]
-Il comando sopra deploya _tutti_ gli stack per lo stage `<my-infra>-sandbox`. Puoi specificare altri stage purché siano definiti in `main.ts`.
-
-Puoi anche deployare singoli stack specificando il nome completo dello stack, ad esempio:
+Puoi specificare qualsiasi stage purché sia definito in `main.ts`. Per deployare un singolo stack, fornisci il nome completo dello stack:
 
 <NxCommands commands={['deploy <my-infra> <my-infra>-sandbox/Application']} />
+
+:::tip[Modalità Express per Deploy più Veloci]
+I target di deploy attendono la completa stabilizzazione delle risorse per impostazione predefinita, favorendo la coerenza rispetto alla velocità. Per velocizzare l'iterazione durante lo sviluppo, opta per la [modalità express di CloudFormation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-express-mode.html) passando il flag `--express` di CDK:
+
+<NxCommands commands={['deploy-sandbox <my-infra> --express']} />
+
+La modalità express termina una volta che la configurazione delle risorse è confermata applicata anziché attendere la completa stabilizzazione, con la propagazione che continua in background, per cicli di iterazione significativamente più veloci. È pensata per lo sviluppo e l'iterazione.
 :::
 
 ## Deploy su AWS in pipeline CI/CD

--- a/docs/src/content/docs/it/guides/typescript-infrastructure.mdx
+++ b/docs/src/content/docs/it/guides/typescript-infrastructure.mdx
@@ -393,6 +393,14 @@ Il target `deploy-sandbox` deploya lo stage sandbox che `main.ts` dichiara, quin
 
 Questo è il modo più veloce per ottenere la tua copia dell'applicazione in esecuzione su AWS mentre sviluppi.
 
+:::tip[Modalità Express per Deploy più Veloci]
+I target di deploy attendono la completa stabilizzazione delle risorse per impostazione predefinita, favorendo la coerenza rispetto alla velocità. Per velocizzare l'iterazione durante lo sviluppo, opta per la [modalità express di CloudFormation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-express-mode.html) passando il flag `--express` di CDK:
+
+<NxCommands commands={['deploy-sandbox <my-infra> --express']} />
+
+La modalità express termina una volta che la configurazione delle risorse è confermata applicata anziché attendere la completa stabilizzazione, con la propagazione che continua in background, per cicli di iterazione significativamente più veloci. È pensata per lo sviluppo e l'iterazione.
+:::
+
 ### Deployare uno Stage Specifico
 
 Il target `deploy` deploya qualsiasi stage o stack tu specifichi. Usalo per stage diversi dal tuo sandbox, o per deployare un singolo stack:
@@ -402,14 +410,6 @@ Il target `deploy` deploya qualsiasi stage o stack tu specifichi. Usalo per stag
 Puoi specificare qualsiasi stage purché sia definito in `main.ts`. Per deployare un singolo stack, fornisci il nome completo dello stack:
 
 <NxCommands commands={['deploy <my-infra> <my-infra>-sandbox/Application']} />
-
-:::tip[Modalità Express per Deploy più Veloci]
-I target di deploy attendono la completa stabilizzazione delle risorse per impostazione predefinita, favorendo la coerenza rispetto alla velocità. Per velocizzare l'iterazione durante lo sviluppo, opta per la [modalità express di CloudFormation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-express-mode.html) passando il flag `--express` di CDK:
-
-<NxCommands commands={['deploy-sandbox <my-infra> --express']} />
-
-La modalità express termina una volta che la configurazione delle risorse è confermata applicata anziché attendere la completa stabilizzazione, con la propagazione che continua in background, per cicli di iterazione significativamente più veloci. È pensata per lo sviluppo e l'iterazione.
-:::
 
 ## Deploy su AWS in pipeline CI/CD
 

--- a/docs/src/content/docs/jp/get_started/quick-start.mdx
+++ b/docs/src/content/docs/jp/get_started/quick-start.mdx
@@ -247,7 +247,11 @@ Terraformブートストラップは、Terraformステートファイルを保�
 
 <Infrastructure>
 <Fragment slot="cdk">
-<NxCommands commands={['deploy infra "my-project-infra-sandbox/*"']} />
+<NxCommands commands={['deploy-sandbox infra']} />
+
+:::tip[Sandboxステージ]
+`deploy-sandbox`は、`packages/infra/src/main.ts`で定義されたsandboxステージをデプロイします。別のステージをデプロイするには、`deploy`ターゲットを使用して名前を指定します。例：`deploy infra "my-project-infra-beta/*"`。
+:::
 </Fragment>
 <Fragment slot="terraform">
 <NxCommands commands={['apply infra']} />

--- a/docs/src/content/docs/jp/get_started/quick-start.mdx
+++ b/docs/src/content/docs/jp/get_started/quick-start.mdx
@@ -248,10 +248,6 @@ Terraformブートストラップは、Terraformステートファイルを保�
 <Infrastructure>
 <Fragment slot="cdk">
 <NxCommands commands={['deploy-sandbox infra']} />
-
-:::tip[Sandboxステージ]
-`deploy-sandbox`は、`packages/infra/src/main.ts`で定義されたsandboxステージをデプロイします。別のステージをデプロイするには、`deploy`ターゲットを使用して名前を指定します。例：`deploy infra "my-project-infra-beta/*"`。
-:::
 </Fragment>
 <Fragment slot="terraform">
 <NxCommands commands={['apply infra']} />

--- a/docs/src/content/docs/jp/get_started/tutorials/dungeon-game/4.mdx
+++ b/docs/src/content/docs/jp/get_started/tutorials/dungeon-game/4.mdx
@@ -107,7 +107,7 @@ React Queryのデフォルトキャッシュは最初の結果を5分間保持�
 
 ### アプリケーションをデプロイする
 
-<NxCommands commands={['deploy infra "dungeon-adventure-infra-sandbox/*"']} />
+<NxCommands commands={['deploy-sandbox infra']} />
 
 :::caution[ブートストラップが必要]
 AWSアカウント/リージョンで初めてCDKデプロイを行う場合は、まずブートストラップしてください：
@@ -115,7 +115,9 @@ AWSアカウント/リージョンで初めてCDKデプロイを行う場合は�
 <NxCommands commands={['bootstrap infra']} />
 :::
 
-`deploy`ターゲットはデフォルトで[CloudFormation expressモード](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-express-mode.html)を使用します。これは、完全な安定化を待つのではなく、各リソースの設定が適用されるとすぐにリソース操作を完了します。最初のデプロイは完了まで約4分かかり、一部のリソース（CloudFrontディストリビューションなど）はその後しばらくの間バックグラウンドでプロビジョニングを続ける場合があります。その後のデプロイはより高速です。
+`deploy-sandbox`ターゲットは、`packages/infra/src/main.ts`で定義されたsandboxステージ — `dungeon-adventure-infra-sandbox` — をデプロイするため、自分で名前を指定する必要はありません。
+
+最初のデプロイは、すべてのリソースが完全に安定化するのを待つため、完了まで約6分かかります。その後のデプロイはより高速です。開発中の反復を高速化するには、`--express`フラグを渡すことで[CloudFormation expressモード](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-express-mode.html)を選択できます。これにより、完全な安定化を待つのではなく、設定が適用されるとすぐに各リソース操作が完了します。
 
 デプロイが完了すると、次のような出力が表示されます：
 
@@ -146,7 +148,7 @@ CloudFront URL（CDK出力の`GameUIDistributionDomainName`）に移動し、新
 
 鍵は`RUNTIME_CONFIG_APP_ID`環境変数です。プロジェクトが`LOCAL_DEV=true`**なし**で実行される場合、ランタイム設定ルックアップは、このアプリケーションIDを使用してAWS AppConfigから設定を取得します — CDK出力の`RuntimeConfigApplicationId`値です。
 
-各ウェブサイトには、デプロイされた`runtime-config.json`（Cognitoプール、APIエンドポイント、エージェントARN）をローカル開発サーバーにダウンロードする`load:runtime-config`ターゲットがあります。いくつかの便利な組み合わせ：
+各ウェブサイトには、デプロイされた`runtime-config.json`（Cognitoプール、APIエンドポイント、エージェントARN）をローカル開発サーバーにダウンロードする`load-runtime-config`ターゲットがあります。いくつかの便利な組み合わせ：
 
 - **ローカルウェブサイト → デプロイされたバックエンド。** デプロイされた設定を一度プルしてから、プレーンな`serve`ターゲットを実行して、UIがデプロイされたAPIとエージェントと通信するようにします：
 
@@ -159,4 +161,4 @@ CloudFront URL（CDK出力の`GameUIDistributionDomainName`）に移動し、新
 
 この柔軟性により、作業している正確なスライスを、意味のあるコンポーネント — ローカルまたはデプロイ済み — に対してテストできます。
 
-おめでとうございます。エージェント型ダンジョンアドベンチャーゲームを構築、テスト、デプロイしました！ 🎉🎉🎉🎉
+おめでとうございます。エージェント型ダンジョンアドベンチャーゲームを構築、テスト、デプロイしました！ 🎉🎉🎉🎉うございます。エージェント型ダンジョンアドベンチャーゲームを構築、テスト、デプロイしました！ 🎉🎉🎉🎉

--- a/docs/src/content/docs/jp/get_started/tutorials/dungeon-game/4.mdx
+++ b/docs/src/content/docs/jp/get_started/tutorials/dungeon-game/4.mdx
@@ -115,7 +115,7 @@ AWSアカウント/リージョンで初めてCDKデプロイを行う場合は�
 <NxCommands commands={['bootstrap infra']} />
 :::
 
-`deploy-sandbox`ターゲットは、`packages/infra/src/main.ts`で定義されたsandboxステージ — `dungeon-adventure-infra-sandbox` — をデプロイするため、自分で名前を指定する必要はありません。
+`deploy-sandbox`ターゲットは、`packages/infra/src/main.ts`で定義されたsandboxステージをデプロイします。
 
 最初のデプロイは、すべてのリソースが完全に安定化するのを待つため、完了まで約6分かかります。その後のデプロイはより高速です。開発中の反復を高速化するには、`--express`フラグを渡すことで[CloudFormation expressモード](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-express-mode.html)を選択できます。これにより、完全な安定化を待つのではなく、設定が適用されるとすぐに各リソース操作が完了します。
 

--- a/docs/src/content/docs/jp/guides/typescript-infrastructure.mdx
+++ b/docs/src/content/docs/jp/guides/typescript-infrastructure.mdx
@@ -394,6 +394,14 @@ npx cdk bootstrap aws://<account-id>/<region>
 
 これは、開発中にアプリケーションの自分用のコピーをAWSで実行する最も迅速な方法です。
 
+:::tip[より高速なデプロイのためのExpressモード]
+デプロイターゲットは、デフォルトで完全なリソース安定化を待機し、速度よりも一貫性を優先します。開発中のイテレーションを高速化するには、CDKの`--express`フラグを渡して[CloudFormation expressモード](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-express-mode.html)をオプトインしてください:
+
+<NxCommands commands={['deploy-sandbox <my-infra> --express']} />
+
+Expressモードは、完全な安定化を待つのではなく、リソース設定が適用されたことが確認されると終了し、伝播はバックグラウンドで継続されるため、イテレーションサイクルが大幅に高速化されます。これは開発とイテレーションを目的としています。
+:::
+
 ### 特定のステージのデプロイ
 
 `deploy`ターゲットは、指定したステージまたはスタックをデプロイします。sandbox以外のステージや、単一のスタックをデプロイする場合に使用します:
@@ -403,14 +411,6 @@ npx cdk bootstrap aws://<account-id>/<region>
 `main.ts`で定義されている任意のステージを指定できます。個別のスタックをデプロイするには、完全なスタック名を指定します:
 
 <NxCommands commands={['deploy <my-infra> <my-infra>-sandbox/Application']} />
-
-:::tip[より高速なデプロイのためのExpressモード]
-デプロイターゲットは、デフォルトで完全なリソース安定化を待機し、速度よりも一貫性を優先します。開発中のイテレーションを高速化するには、CDKの`--express`フラグを渡して[CloudFormation expressモード](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-express-mode.html)をオプトインしてください:
-
-<NxCommands commands={['deploy-sandbox <my-infra> --express']} />
-
-Expressモードは、完全な安定化を待つのではなく、リソース設定が適用されたことが確認されると終了し、伝播はバックグラウンドで継続されるため、イテレーションサイクルが大幅に高速化されます。これは開発とイテレーションを目的としています。
-:::
 
 ## CI/CDパイプラインでのAWSデプロイ
 

--- a/docs/src/content/docs/jp/guides/typescript-infrastructure.mdx
+++ b/docs/src/content/docs/jp/guides/typescript-infrastructure.mdx
@@ -97,17 +97,22 @@ new ApplicationStage(app, 'my-app-sandbox', {
     region: process.env.CDK_DEFAULT_REGION,
   },
 });
+
+// betaやprodなど、他のステージのインスタンスを以下に定義
 ```
 
 `env`プロパティは、デプロイ先のAWSアカウントとリージョンをCDKに指示します。`CDK_DEFAULT_ACCOUNT`と`CDK_DEFAULT_REGION`は、アクティブなAWS認証情報からCDK CLIによって自動的に解決されます。詳細は[CDK環境ドキュメント](https://docs.aws.amazon.com/cdk/v2/guide/environments.html)を参照してください。
 
+sandboxステージは<Link path="guides/typescript-infrastructure#deploying-your-sandbox-stage">`deploy-sandbox`ターゲット</Link>がデプロイするステージです。
+
 `stageConfig`で生成した場合、`main.ts`は集中設定ファイルからアカウントとリージョンを読み取り、設定がない場合は環境変数にフォールバックします:
 
 ```ts title="src/main.ts (stageConfigの場合)"
-import stagesConfig from ':my-scope/common-infra-config';
+import { resolveStage } from '@my-scope/common-infra-config';
 
-const projectStages = stagesConfig.projects?.['packages/infra']?.stages ?? {};
-const sandboxConfig = projectStages['my-app-sandbox'];
+// このプロジェクト（packages/infra）配下のステージを検索し、
+// 共有ステージにフォールバックします。ステージの設定が存在しない場合はundefinedを返します。
+const sandboxConfig = resolveStage('packages/infra', 'my-app-sandbox');
 
 new ApplicationStage(app, 'my-app-sandbox', {
   env: {
@@ -371,32 +376,40 @@ npx cdk bootstrap aws://<account-id>/<region>
 
 ## AWSへのデプロイ
 
-ビルド後、`deploy`ターゲットを使用してインフラストラクチャをAWSにデプロイできます。
+プロジェクトには3つのデプロイターゲットがあり、それぞれ異なる状況に適しています:
 
-:::caution[CIデプロイ]
-CI/CDパイプラインでのデプロイには`deploy-ci`ターゲットを使用してください。詳細は後述します。
-:::
+| ターゲット       | 用途                                                                             |
+| ---------------- | -------------------------------------------------------------------------------- |
+| `deploy-sandbox` | 開発中に自分のsandboxステージをデプロイ。ステージ引数は不要。                     |
+| `deploy`         | 任意のステージをデプロイ。デプロイしたいステージまたはスタックを指定。             |
+| `deploy-ci`      | CI/CDパイプラインからのデプロイ。事前合成済みのクラウドアセンブリを使用。         |
 
 まず、AWS認証情報が設定されていることを確認してください。`stageConfig`で生成し、`packages/common/infra-config/src/stages.config.ts`でステージ認証情報を設定している場合、デプロイコマンドはターゲットステージに対して正しい認証情報を自動的に解決して適用します。それ以外の場合は、環境にAWS認証情報が設定されていることを確認してください（例: `AWS_PROFILE`または環境変数経由）。利用可能なオプションについては、[AWS認証情報ドキュメント](https://docs.aws.amazon.com/sdkref/latest/guide/access.html)を参照してください。
 
-次にデプロイターゲットを実行します:
+### Sandboxステージのデプロイ
+
+`deploy-sandbox`ターゲットは`main.ts`で宣言されているsandboxステージをデプロイするため、ステージ名を覚えておく必要はありません:
+
+<NxCommands commands={['deploy-sandbox <my-infra>']} />
+
+これは、開発中にアプリケーションの自分用のコピーをAWSで実行する最も迅速な方法です。
+
+### 特定のステージのデプロイ
+
+`deploy`ターゲットは、指定したステージまたはスタックをデプロイします。sandbox以外のステージや、単一のスタックをデプロイする場合に使用します:
 
 <NxCommands commands={['deploy <my-infra> <my-infra>-sandbox/*']} />
 
-:::tip[より高速なデプロイのためのExpressモード]
-`deploy`ターゲットは、デフォルトで完全なリソース安定化を待機し、速度よりも一貫性を優先します。開発中のイテレーションを高速化するには、CDKの`--express`フラグを渡して[CloudFormation expressモード](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-express-mode.html)をオプトインしてください:
-
-<NxCommands commands={['deploy <my-infra> <my-infra>-sandbox/* --express']} />
-
-Expressモードは、完全な安定化を待つのではなく、リソース設定が適用されたことが確認されると終了し、伝播はバックグラウンドで継続されるため、イテレーションサイクルが大幅に高速化されます。これは開発とイテレーションを目的としています。
-:::
-
-:::tip[選択的スタックデプロイ]
-上記のコマンドは`<my-infra>-sandbox`ステージの*すべて*のスタックをデプロイします。`main.ts`で定義されている他のステージを指定できます。
-
-完全なスタック名を指定して個別のスタックをデプロイすることも可能です:
+`main.ts`で定義されている任意のステージを指定できます。個別のスタックをデプロイするには、完全なスタック名を指定します:
 
 <NxCommands commands={['deploy <my-infra> <my-infra>-sandbox/Application']} />
+
+:::tip[より高速なデプロイのためのExpressモード]
+デプロイターゲットは、デフォルトで完全なリソース安定化を待機し、速度よりも一貫性を優先します。開発中のイテレーションを高速化するには、CDKの`--express`フラグを渡して[CloudFormation expressモード](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-express-mode.html)をオプトインしてください:
+
+<NxCommands commands={['deploy-sandbox <my-infra> --express']} />
+
+Expressモードは、完全な安定化を待つのではなく、リソース設定が適用されたことが確認されると終了し、伝播はバックグラウンドで継続されるため、イテレーションサイクルが大幅に高速化されます。これは開発とイテレーションを目的としています。
 :::
 
 ## CI/CDパイプラインでのAWSデプロイ

--- a/docs/src/content/docs/ko/get_started/quick-start.mdx
+++ b/docs/src/content/docs/ko/get_started/quick-start.mdx
@@ -247,7 +247,11 @@ Terraform 부트스트래핑은 Terraform 상태 파일을 저장할 S3 버킷�
 
 <Infrastructure>
 <Fragment slot="cdk">
-<NxCommands commands={['deploy infra "my-project-infra-sandbox/*"']} />
+<NxCommands commands={['deploy-sandbox infra']} />
+
+:::tip[샌드박스 스테이지]
+`deploy-sandbox`는 `packages/infra/src/main.ts`에 정의된 샌드박스 스테이지를 배포합니다. 다른 스테이지를 배포하려면 `deploy` 타겟을 사용하고 이름을 지정하세요. 예: `deploy infra "my-project-infra-beta/*"`.
+:::
 </Fragment>
 <Fragment slot="terraform">
 <NxCommands commands={['apply infra']} />

--- a/docs/src/content/docs/ko/get_started/quick-start.mdx
+++ b/docs/src/content/docs/ko/get_started/quick-start.mdx
@@ -248,10 +248,6 @@ Terraform 부트스트래핑은 Terraform 상태 파일을 저장할 S3 버킷�
 <Infrastructure>
 <Fragment slot="cdk">
 <NxCommands commands={['deploy-sandbox infra']} />
-
-:::tip[샌드박스 스테이지]
-`deploy-sandbox`는 `packages/infra/src/main.ts`에 정의된 샌드박스 스테이지를 배포합니다. 다른 스테이지를 배포하려면 `deploy` 타겟을 사용하고 이름을 지정하세요. 예: `deploy infra "my-project-infra-beta/*"`.
-:::
 </Fragment>
 <Fragment slot="terraform">
 <NxCommands commands={['apply infra']} />

--- a/docs/src/content/docs/ko/get_started/tutorials/dungeon-game/4.mdx
+++ b/docs/src/content/docs/ko/get_started/tutorials/dungeon-game/4.mdx
@@ -115,6 +115,8 @@ AWS 계정/리전에서 처음으로 CDK를 배포하는 경우, 먼저 부트�
 <NxCommands commands={['bootstrap infra']} />
 :::
 
+`deploy-sandbox` 타겟은 `packages/infra/src/main.ts`에 정의된 샌드박스 스테이지 — `dungeon-adventure-infra-sandbox` — 를 배포하므로 직접 이름을 지정할 필요가 없습니다.
+
 첫 번째 배포는 모든 리소스가 완전히 안정화될 때까지 기다리므로 완료하는 데 약 6분이 걸립니다. 이후 배포는 더 빠릅니다. 개발 중 반복 속도를 높이려면 `--express` 플래그를 전달하여 [CloudFormation express mode](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-express-mode.html)를 선택할 수 있습니다. 이 모드는 완전한 안정화를 기다리지 않고 구성이 적용되는 즉시 각 리소스 작업을 완료합니다.
 
 배포가 완료되면 다음과 유사한 출력이 표시됩니다:

--- a/docs/src/content/docs/ko/get_started/tutorials/dungeon-game/4.mdx
+++ b/docs/src/content/docs/ko/get_started/tutorials/dungeon-game/4.mdx
@@ -107,7 +107,7 @@ React Query의 기본 캐시는 첫 번째 결과를 5분 동안 유지하므로
 
 ### 애플리케이션 배포
 
-<NxCommands commands={['deploy infra "dungeon-adventure-infra-sandbox/*"']} />
+<NxCommands commands={['deploy-sandbox infra']} />
 
 :::caution[부트스트랩 필요]
 AWS 계정/리전에서 처음으로 CDK를 배포하는 경우, 먼저 부트스트랩하세요:
@@ -161,4 +161,4 @@ CloudFront URL(CDK 출력의 `GameUIDistributionDomainName`)로 이동하여 새
 
 이러한 유연성을 통해 작업 중인 정확한 부분을 로컬 또는 배포된 컴포넌트 중 적합한 것에 대해 테스트할 수 있습니다.
 
-축하합니다. 에이전트 기반 던전 어드벤처 게임을 성공적으로 구축, 테스트 및 배포하셨습니다! 🎉🎉🎉�으로 구축, 테스트 및 배포하셨습니다! 🎉🎉🎉
+축하합니다. 에이전트 기반 던전 어드벤처 게임을 성공적으로 구축, 테스트 및 배포하셨습니다! 🎉🎉🎉

--- a/docs/src/content/docs/ko/get_started/tutorials/dungeon-game/4.mdx
+++ b/docs/src/content/docs/ko/get_started/tutorials/dungeon-game/4.mdx
@@ -115,7 +115,7 @@ AWS 계정/리전에서 처음으로 CDK를 배포하는 경우, 먼저 부트�
 <NxCommands commands={['bootstrap infra']} />
 :::
 
-`deploy-sandbox` 타겟은 `packages/infra/src/main.ts`에 정의된 샌드박스 스테이지 — `dungeon-adventure-infra-sandbox` — 를 배포하므로 직접 이름을 지정할 필요가 없습니다.
+`deploy-sandbox` 타겟은 `packages/infra/src/main.ts`에 정의된 샌드박스 스테이지를 배포합니다.
 
 첫 번째 배포는 모든 리소스가 완전히 안정화될 때까지 기다리므로 완료하는 데 약 6분이 걸립니다. 이후 배포는 더 빠릅니다. 개발 중 반복 속도를 높이려면 `--express` 플래그를 전달하여 [CloudFormation express mode](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-express-mode.html)를 선택할 수 있습니다. 이 모드는 완전한 안정화를 기다리지 않고 구성이 적용되는 즉시 각 리소스 작업을 완료합니다.
 
@@ -161,4 +161,4 @@ CloudFront URL(CDK 출력의 `GameUIDistributionDomainName`)로 이동하여 새
 
 이러한 유연성을 통해 작업 중인 정확한 부분을 로컬 또는 배포된 컴포넌트 중 적합한 것에 대해 테스트할 수 있습니다.
 
-축하합니다. 에이전트 기반 던전 어드벤처 게임을 성공적으로 구축, 테스트 및 배포하셨습니다! 🎉🎉🎉
+축하합니다. 에이전트 기반 던전 어드벤처 게임을 성공적으로 구축, 테스트 및 배포하셨습니다! 🎉🎉🎉�으로 구축, 테스트 및 배포하셨습니다! 🎉🎉🎉

--- a/docs/src/content/docs/ko/guides/typescript-infrastructure.mdx
+++ b/docs/src/content/docs/ko/guides/typescript-infrastructure.mdx
@@ -97,9 +97,13 @@ new ApplicationStage(app, 'my-app-sandbox', {
     region: process.env.CDK_DEFAULT_REGION,
   },
 });
+
+// Define other instances of stages, such as beta and prod, below
 ```
 
 `env` 속성은 CDK에게 배포할 AWS 계정과 리전을 알려줍니다. `CDK_DEFAULT_ACCOUNT`와 `CDK_DEFAULT_REGION`은 활성 AWS 자격 증명에서 CDK CLI에 의해 자동으로 확인됩니다. 자세한 내용은 [CDK 환경 문서](https://docs.aws.amazon.com/cdk/v2/guide/environments.html)를 참조하세요.
+
+샌드박스 스테이지는 <Link path="guides/typescript-infrastructure#deploying-your-sandbox-stage">`deploy-sandbox` 타겟</Link>이 배포하는 스테이지입니다.
 
 `stageConfig`로 생성한 경우, `main.ts`는 중앙 집중식 구성 파일에서 계정과 리전을 읽으며, 구성이 설정되지 않은 경우 환경 변수로 폴백합니다:
 
@@ -371,32 +375,40 @@ npx cdk bootstrap aws://<account-id>/<region>
 
 ## AWS에 배포하기
 
-빌드 후 `deploy` 타겟을 사용하여 인프라를 AWS에 배포할 수 있습니다.
+프로젝트에는 각각 다른 상황에 적합한 세 가지 배포 타겟이 있습니다:
 
-:::caution[CI 배포]
-CI/CD 파이프라인 배포 시 `deploy-ci` 타겟을 사용하세요. 자세한 내용은 아래를 참조하세요.
-:::
+| 타겟             | 사용 용도                                                                        |
+| ---------------- | -------------------------------------------------------------------------------- |
+| `deploy-sandbox` | 개발 중 자신의 샌드박스 스테이지를 배포합니다. 스테이지 인수가 필요하지 않습니다.    |
+| `deploy`         | 원하는 스테이지 또는 스택의 이름을 지정하여 모든 스테이지를 배포합니다.              |
+| `deploy-ci`      | 사전 합성된 클라우드 어셈블리를 사용하여 CI/CD 파이프라인에서 배포합니다.            |
 
 먼저 AWS 자격 증명이 구성되어 있는지 확인하세요. `stageConfig`로 생성하고 `packages/common/infra-config/src/stages.config.ts`에 스테이지 자격 증명을 구성한 경우, 배포 명령이 대상 스테이지에 대한 올바른 자격 증명을 자동으로 확인하고 적용합니다. 그렇지 않으면 환경에 AWS 자격 증명이 설정되어 있는지 확인하세요(예: `AWS_PROFILE` 또는 환경 변수를 통해). 사용 가능한 옵션은 [AWS 자격 증명 문서](https://docs.aws.amazon.com/sdkref/latest/guide/access.html)를 참조하세요.
 
-그런 다음 배포 타겟을 실행합니다:
+### 샌드박스 스테이지 배포하기
+
+`deploy-sandbox` 타겟은 `main.ts`가 선언하는 샌드박스 스테이지를 배포하므로 스테이지 이름을 기억할 필요가 없습니다:
+
+<NxCommands commands={['deploy-sandbox <my-infra>']} />
+
+이것은 개발하는 동안 AWS에서 애플리케이션의 자체 복사본을 실행하는 가장 빠른 방법입니다.
+
+### 특정 스테이지 배포하기
+
+`deploy` 타겟은 지정한 스테이지 또는 스택을 배포합니다. 샌드박스 이외의 스테이지나 단일 스택을 배포하는 데 사용하세요:
 
 <NxCommands commands={['deploy <my-infra> <my-infra>-sandbox/*']} />
 
-:::tip[더 빠른 배포를 위한 Express 모드]
-`deploy` 타겟은 기본적으로 전체 리소스 안정화를 기다리며, 속도보다 일관성을 우선시합니다. 개발 중 반복 속도를 높이려면 CDK의 `--express` 플래그를 전달하여 [CloudFormation express 모드](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-express-mode.html)를 선택할 수 있습니다:
-
-<NxCommands commands={['deploy <my-infra> <my-infra>-sandbox/* --express']} />
-
-Express 모드는 전체 안정화를 기다리지 않고 리소스 구성이 적용된 것으로 확인되면 완료되며, 전파는 백그라운드에서 계속 진행되어 반복 주기가 훨씬 빨라집니다. 이는 개발 및 반복 작업을 위한 것입니다.
-:::
-
-:::tip[선택적 스택 배포]
-위 명령은 `<my-infra>-sandbox` 스테이지의 _모든_ 스택을 배포합니다. `main.ts`에 정의된 다른 스테이지를 지정할 수 있습니다.
-
-전체 스택 이름을 지정하여 개별 스택을 배포할 수도 있습니다. 예시:
+`main.ts`에 정의된 모든 스테이지를 지정할 수 있습니다. 개별 스택을 배포하려면 전체 스택 이름을 제공하세요:
 
 <NxCommands commands={['deploy <my-infra> <my-infra>-sandbox/Application']} />
+
+:::tip[더 빠른 배포를 위한 Express 모드]
+배포 타겟은 기본적으로 전체 리소스 안정화를 기다리며, 속도보다 일관성을 우선시합니다. 개발 중 반복 속도를 높이려면 CDK의 `--express` 플래그를 전달하여 [CloudFormation express 모드](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-express-mode.html)를 선택할 수 있습니다:
+
+<NxCommands commands={['deploy-sandbox <my-infra> --express']} />
+
+Express 모드는 전체 안정화를 기다리지 않고 리소스 구성이 적용된 것으로 확인되면 완료되며, 전파는 백그라운드에서 계속 진행되어 반복 주기가 훨씬 빨라집니다. 이는 개발 및 반복 작업을 위한 것입니다.
 :::
 
 ## CI/CD 파이프라인에서 AWS 배포

--- a/docs/src/content/docs/ko/guides/typescript-infrastructure.mdx
+++ b/docs/src/content/docs/ko/guides/typescript-infrastructure.mdx
@@ -393,6 +393,14 @@ npx cdk bootstrap aws://<account-id>/<region>
 
 이것은 개발하는 동안 AWS에서 애플리케이션의 자체 복사본을 실행하는 가장 빠른 방법입니다.
 
+:::tip[더 빠른 배포를 위한 Express 모드]
+배포 타겟은 기본적으로 전체 리소스 안정화를 기다리며, 속도보다 일관성을 우선시합니다. 개발 중 반복 속도를 높이려면 CDK의 `--express` 플래그를 전달하여 [CloudFormation express 모드](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-express-mode.html)를 선택할 수 있습니다:
+
+<NxCommands commands={['deploy-sandbox <my-infra> --express']} />
+
+Express 모드는 전체 안정화를 기다리지 않고 리소스 구성이 적용된 것으로 확인되면 완료되며, 전파는 백그라운드에서 계속 진행되어 반복 주기가 훨씬 빨라집니다. 이는 개발 및 반복 작업을 위한 것입니다.
+:::
+
 ### 특정 스테이지 배포하기
 
 `deploy` 타겟은 지정한 스테이지 또는 스택을 배포합니다. 샌드박스 이외의 스테이지나 단일 스택을 배포하는 데 사용하세요:
@@ -402,14 +410,6 @@ npx cdk bootstrap aws://<account-id>/<region>
 `main.ts`에 정의된 모든 스테이지를 지정할 수 있습니다. 개별 스택을 배포하려면 전체 스택 이름을 제공하세요:
 
 <NxCommands commands={['deploy <my-infra> <my-infra>-sandbox/Application']} />
-
-:::tip[더 빠른 배포를 위한 Express 모드]
-배포 타겟은 기본적으로 전체 리소스 안정화를 기다리며, 속도보다 일관성을 우선시합니다. 개발 중 반복 속도를 높이려면 CDK의 `--express` 플래그를 전달하여 [CloudFormation express 모드](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-express-mode.html)를 선택할 수 있습니다:
-
-<NxCommands commands={['deploy-sandbox <my-infra> --express']} />
-
-Express 모드는 전체 안정화를 기다리지 않고 리소스 구성이 적용된 것으로 확인되면 완료되며, 전파는 백그라운드에서 계속 진행되어 반복 주기가 훨씬 빨라집니다. 이는 개발 및 반복 작업을 위한 것입니다.
-:::
 
 ## CI/CD 파이프라인에서 AWS 배포
 

--- a/docs/src/content/docs/pt/get_started/quick-start.mdx
+++ b/docs/src/content/docs/pt/get_started/quick-start.mdx
@@ -66,25 +66,25 @@ Caso contrário, siga os passos abaixo para executar cada gerador você mesmo.
 
 ### Adicionar uma API tRPC
 
-<RunGenerator generator="ts#api" requiredParameters={{ name: 'demo-api', framework: 'trpc', auth: 'iam' }} />
+<RunGenerator generator="ts#api" requiredParameters={{ name: 'demo-api', framework: 'trpc', auth: 'iam' }} noInteractive />
 
 Isso criará a API dentro da pasta `packages/demo-api`.
 
 ### Adicionar um Website React
 
-<RunGenerator generator="ts#website" requiredParameters={{ name: 'demo-website' }} />
+<RunGenerator generator="ts#website" requiredParameters={{ name: 'demo-website' }} noInteractive />
 
 Isso cria um novo website React em `packages/demo-website`.
 
 ### Adicionar Autenticação Cognito
 
-<RunGenerator generator="ts#website#auth" requiredParameters={{ project: '@my-project/demo-website', cognitoDomain: 'my-demo' }} />
+<RunGenerator generator="ts#website#auth" requiredParameters={{ project: '@my-project/demo-website', cognitoDomain: 'my-demo' }} noInteractive />
 
 Isso configura a infraestrutura necessária e o código React para adicionar Autenticação Cognito ao seu website.
 
 ### Conectar Frontend ao Backend
 
-<RunGenerator generator="connection" requiredParameters={{ sourceProject: '@my-project/demo-website', targetProject: '@my-project/demo-api' }} />
+<RunGenerator generator="connection" requiredParameters={{ sourceProject: '@my-project/demo-website', targetProject: '@my-project/demo-api' }} noInteractive />
 
 Isso configura os provedores necessários para garantir que seu website possa chamar sua API tRPC.
 
@@ -94,7 +94,7 @@ Adicione o projeto de infraestrutura com base no seu provedor IAC escolhido.
 
 <Infrastructure>
 <Fragment slot="cdk">
-<RunGenerator generator="ts#infra" requiredParameters={{ name: 'infra' }} />
+<RunGenerator generator="ts#infra" requiredParameters={{ name: 'infra' }} noInteractive />
 
 Isso configura uma CDK App que você pode usar para implantar sua infraestrutura na AWS.
 </Fragment>
@@ -248,10 +248,6 @@ Implante seu projeto:
 <Infrastructure>
 <Fragment slot="cdk">
 <NxCommands commands={['deploy-sandbox infra']} />
-
-:::tip[Estágio Sandbox]
-`deploy-sandbox` implanta o estágio sandbox definido em `packages/infra/src/main.ts`. Para implantar um estágio diferente, use o target `deploy` e nomeie-o, por exemplo `deploy infra "my-project-infra-beta/*"`.
-:::
 </Fragment>
 <Fragment slot="terraform">
 <NxCommands commands={['apply infra']} />

--- a/docs/src/content/docs/pt/get_started/quick-start.mdx
+++ b/docs/src/content/docs/pt/get_started/quick-start.mdx
@@ -247,7 +247,11 @@ Implante seu projeto:
 
 <Infrastructure>
 <Fragment slot="cdk">
-<NxCommands commands={['deploy infra "my-project-infra-sandbox/*"']} />
+<NxCommands commands={['deploy-sandbox infra']} />
+
+:::tip[Estágio Sandbox]
+`deploy-sandbox` implanta o estágio sandbox definido em `packages/infra/src/main.ts`. Para implantar um estágio diferente, use o target `deploy` e nomeie-o, por exemplo `deploy infra "my-project-infra-beta/*"`.
+:::
 </Fragment>
 <Fragment slot="terraform">
 <NxCommands commands={['apply infra']} />

--- a/docs/src/content/docs/pt/get_started/tutorials/dungeon-game/4.mdx
+++ b/docs/src/content/docs/pt/get_started/tutorials/dungeon-game/4.mdx
@@ -107,7 +107,7 @@ Seu jogo está completo e você testou cada parte localmente. Agora vamos implan
 
 ### Implantar sua aplicação
 
-<NxCommands commands={['deploy infra "dungeon-adventure-infra-sandbox/*"']} />
+<NxCommands commands={['deploy-sandbox infra']} />
 
 :::caution[Bootstrap Necessário]
 Se esta for a primeira implantação CDK na sua conta/região AWS, faça o bootstrap primeiro:

--- a/docs/src/content/docs/pt/get_started/tutorials/dungeon-game/4.mdx
+++ b/docs/src/content/docs/pt/get_started/tutorials/dungeon-game/4.mdx
@@ -115,7 +115,7 @@ Se esta for a primeira implantação CDK na sua conta/região AWS, faça o boots
 <NxCommands commands={['bootstrap infra']} />
 :::
 
-O target `deploy-sandbox` implanta o estágio sandbox definido em `packages/infra/src/main.ts` — `dungeon-adventure-infra-sandbox` — então você não precisa nomeá-lo você mesmo.
+O target `deploy-sandbox` implanta o estágio sandbox definido em `packages/infra/src/main.ts`.
 
 Sua primeira implantação levará cerca de 6 minutos para ser concluída, pois aguarda a estabilização completa de todos os recursos. Implantações subsequentes são mais rápidas. Para acelerar a iteração durante o desenvolvimento, você pode optar pelo [modo expresso do CloudFormation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-express-mode.html) passando a flag `--express`, que conclui cada operação de recurso assim que sua configuração é aplicada, em vez de aguardar a estabilização completa.
 

--- a/docs/src/content/docs/pt/get_started/tutorials/dungeon-game/4.mdx
+++ b/docs/src/content/docs/pt/get_started/tutorials/dungeon-game/4.mdx
@@ -115,6 +115,8 @@ Se esta for a primeira implantação CDK na sua conta/região AWS, faça o boots
 <NxCommands commands={['bootstrap infra']} />
 :::
 
+O target `deploy-sandbox` implanta o estágio sandbox definido em `packages/infra/src/main.ts` — `dungeon-adventure-infra-sandbox` — então você não precisa nomeá-lo você mesmo.
+
 Sua primeira implantação levará cerca de 6 minutos para ser concluída, pois aguarda a estabilização completa de todos os recursos. Implantações subsequentes são mais rápidas. Para acelerar a iteração durante o desenvolvimento, você pode optar pelo [modo expresso do CloudFormation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-express-mode.html) passando a flag `--express`, que conclui cada operação de recurso assim que sua configuração é aplicada, em vez de aguardar a estabilização completa.
 
 Após a conclusão da implantação, você verá saídas semelhantes às seguintes:

--- a/docs/src/content/docs/pt/guides/typescript-infrastructure.mdx
+++ b/docs/src/content/docs/pt/guides/typescript-infrastructure.mdx
@@ -97,9 +97,13 @@ new ApplicationStage(app, 'my-app-sandbox', {
     region: process.env.CDK_DEFAULT_REGION,
   },
 });
+
+// Define other instances of stages, such as beta and prod, below
 ```
 
 A propriedade `env` informa ao CDK em qual conta AWS e região implantar. `CDK_DEFAULT_ACCOUNT` e `CDK_DEFAULT_REGION` são resolvidos automaticamente pelo CDK CLI a partir de suas credenciais AWS ativas. Consulte a [documentação de ambientes do CDK](https://docs.aws.amazon.com/cdk/v2/guide/environments.html) para mais detalhes.
+
+O estágio sandbox é aquele que o <Link path="guides/typescript-infrastructure#deploying-your-sandbox-stage">target `deploy-sandbox`</Link> implanta.
 
 Se você gerou com `stageConfig`, o `main.ts` lê conta e região de um arquivo de configuração centralizado, recorrendo a variáveis de ambiente quando nenhuma configuração está definida:
 
@@ -371,32 +375,40 @@ Para mais detalhes, consulte a [documentação de bootstrapping do CDK](https://
 
 ## Implantando na AWS
 
-Após um build, você pode implantar sua infraestrutura na AWS usando o target `deploy`.
+Seu projeto tem três targets de implantação, cada um adequado para uma situação diferente:
 
-:::caution[Implantação CI]
-Use o target `deploy-ci` se estiver implantando em um pipeline CI/CD. Veja abaixo para mais detalhes.
-:::
+| Target           | Use para                                                                         |
+| ---------------- | -------------------------------------------------------------------------------- |
+| `deploy-sandbox` | Implantar seu próprio estágio sandbox durante o desenvolvimento. Nenhum argumento de estágio necessário. |
+| `deploy`         | Implantar qualquer estágio, nomeando o estágio ou stacks que você deseja.       |
+| `deploy-ci`      | Implantar a partir de um pipeline CI/CD, usando uma cloud assembly pré-sintetizada. |
 
 Primeiro, certifique-se de ter credenciais AWS configuradas. Se você gerou com `stageConfig` e configurou credenciais de estágio em `packages/common/infra-config/src/stages.config.ts`, o comando deploy resolverá e aplicará automaticamente as credenciais corretas para o estágio alvo. Caso contrário, certifique-se de que suas credenciais AWS estejam definidas no seu ambiente (por exemplo, via `AWS_PROFILE` ou variáveis de ambiente). Consulte a [documentação de credenciais AWS](https://docs.aws.amazon.com/sdkref/latest/guide/access.html) para as opções disponíveis.
 
-Em seguida, execute o target deploy:
+### Implantando seu Estágio Sandbox
+
+O target `deploy-sandbox` implanta o estágio sandbox que `main.ts` declara, então você não precisa lembrar o nome do estágio:
+
+<NxCommands commands={['deploy-sandbox <my-infra>']} />
+
+Esta é a maneira mais rápida de ter sua própria cópia da aplicação rodando na AWS enquanto você desenvolve.
+
+### Implantando um Estágio Específico
+
+O target `deploy` implanta qualquer estágio ou stacks que você nomear. Use-o para estágios diferentes do seu sandbox, ou para implantar uma única stack:
 
 <NxCommands commands={['deploy <my-infra> <my-infra>-sandbox/*']} />
 
-:::tip[Modo Express para Implantações Mais Rápidas]
-O target `deploy` aguarda a estabilização completa dos recursos por padrão, favorecendo consistência em vez de velocidade. Para acelerar a iteração durante o desenvolvimento, opte pelo [modo express do CloudFormation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-express-mode.html) passando a flag `--express` do CDK:
-
-<NxCommands commands={['deploy <my-infra> <my-infra>-sandbox/* --express']} />
-
-O modo express finaliza assim que a configuração do recurso é confirmada como aplicada, em vez de esperar pela estabilização completa, com a propagação continuando em segundo plano, para ciclos de iteração significativamente mais rápidos. Ele é destinado ao desenvolvimento e iteração.
-:::
-
-:::tip[Implantação seletiva de stacks]
-O comando acima implanta _todas_ as stacks do estágio `<my-infra>-sandbox`. Você pode especificar outros estágios desde que estejam definidos em `main.ts`.
-
-Você também pode implantar stacks individuais especificando o nome completo da stack, por exemplo:
+Você pode especificar qualquer estágio desde que esteja definido em `main.ts`. Para implantar uma stack individual, forneça o nome completo da stack:
 
 <NxCommands commands={['deploy <my-infra> <my-infra>-sandbox/Application']} />
+
+:::tip[Modo Express para Implantações Mais Rápidas]
+Os targets de implantação aguardam a estabilização completa dos recursos por padrão, favorecendo consistência em vez de velocidade. Para acelerar a iteração durante o desenvolvimento, opte pelo [modo express do CloudFormation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-express-mode.html) passando a flag `--express` do CDK:
+
+<NxCommands commands={['deploy-sandbox <my-infra> --express']} />
+
+O modo express finaliza assim que a configuração do recurso é confirmada como aplicada, em vez de esperar pela estabilização completa, com a propagação continuando em segundo plano, para ciclos de iteração significativamente mais rápidos. Ele é destinado ao desenvolvimento e iteração.
 :::
 
 ## Implantando na AWS em um Pipeline CI/CD

--- a/docs/src/content/docs/pt/guides/typescript-infrastructure.mdx
+++ b/docs/src/content/docs/pt/guides/typescript-infrastructure.mdx
@@ -393,6 +393,14 @@ O target `deploy-sandbox` implanta o estágio sandbox que `main.ts` declara, ent
 
 Esta é a maneira mais rápida de ter sua própria cópia da aplicação rodando na AWS enquanto você desenvolve.
 
+:::tip[Modo Express para Implantações Mais Rápidas]
+Os targets de implantação aguardam a estabilização completa dos recursos por padrão, favorecendo consistência em vez de velocidade. Para acelerar a iteração durante o desenvolvimento, opte pelo [modo express do CloudFormation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-express-mode.html) passando a flag `--express` do CDK:
+
+<NxCommands commands={['deploy-sandbox <my-infra> --express']} />
+
+O modo express finaliza assim que a configuração do recurso é confirmada como aplicada, em vez de esperar pela estabilização completa, com a propagação continuando em segundo plano, para ciclos de iteração significativamente mais rápidos. Ele é destinado ao desenvolvimento e iteração.
+:::
+
 ### Implantando um Estágio Específico
 
 O target `deploy` implanta qualquer estágio ou stacks que você nomear. Use-o para estágios diferentes do seu sandbox, ou para implantar uma única stack:
@@ -402,14 +410,6 @@ O target `deploy` implanta qualquer estágio ou stacks que você nomear. Use-o p
 Você pode especificar qualquer estágio desde que esteja definido em `main.ts`. Para implantar uma stack individual, forneça o nome completo da stack:
 
 <NxCommands commands={['deploy <my-infra> <my-infra>-sandbox/Application']} />
-
-:::tip[Modo Express para Implantações Mais Rápidas]
-Os targets de implantação aguardam a estabilização completa dos recursos por padrão, favorecendo consistência em vez de velocidade. Para acelerar a iteração durante o desenvolvimento, opte pelo [modo express do CloudFormation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-express-mode.html) passando a flag `--express` do CDK:
-
-<NxCommands commands={['deploy-sandbox <my-infra> --express']} />
-
-O modo express finaliza assim que a configuração do recurso é confirmada como aplicada, em vez de esperar pela estabilização completa, com a propagação continuando em segundo plano, para ciclos de iteração significativamente mais rápidos. Ele é destinado ao desenvolvimento e iteração.
-:::
 
 ## Implantando na AWS em um Pipeline CI/CD
 

--- a/docs/src/content/docs/vi/get_started/quick-start.mdx
+++ b/docs/src/content/docs/vi/get_started/quick-start.mdx
@@ -94,7 +94,7 @@ Thêm dự án infrastructure dựa trên nhà cung cấp IAC bạn đã chọn.
 
 <Infrastructure>
 <Fragment slot="cdk">
-<RunGenerator generator="ts#infra" requiredParameters={{ name: 'infra' }} />
+<RunGenerator generator="ts#infra" requiredParameters={{ name: 'infra' }} noInteractive />
 
 Điều này cấu hình một CDK App mà bạn có thể sử dụng để triển khai cơ sở hạ tầng của mình trên AWS.
 </Fragment>
@@ -247,7 +247,11 @@ Triển khai dự án của bạn:
 
 <Infrastructure>
 <Fragment slot="cdk">
-<NxCommands commands={['deploy infra "my-project-infra-sandbox/*"']} />
+<NxCommands commands={['deploy-sandbox infra']} />
+
+:::tip[Sandbox Stage]
+`deploy-sandbox` triển khai sandbox stage được định nghĩa trong `packages/infra/src/main.ts`. Để triển khai một stage khác, sử dụng target `deploy` và đặt tên cho nó, ví dụ `deploy infra "my-project-infra-beta/*"`.
+:::
 </Fragment>
 <Fragment slot="terraform">
 <NxCommands commands={['apply infra']} />

--- a/docs/src/content/docs/vi/get_started/quick-start.mdx
+++ b/docs/src/content/docs/vi/get_started/quick-start.mdx
@@ -248,10 +248,6 @@ Triển khai dự án của bạn:
 <Infrastructure>
 <Fragment slot="cdk">
 <NxCommands commands={['deploy-sandbox infra']} />
-
-:::tip[Sandbox Stage]
-`deploy-sandbox` triển khai sandbox stage được định nghĩa trong `packages/infra/src/main.ts`. Để triển khai một stage khác, sử dụng target `deploy` và đặt tên cho nó, ví dụ `deploy infra "my-project-infra-beta/*"`.
-:::
 </Fragment>
 <Fragment slot="terraform">
 <NxCommands commands={['apply infra']} />

--- a/docs/src/content/docs/vi/get_started/tutorials/dungeon-game/4.mdx
+++ b/docs/src/content/docs/vi/get_started/tutorials/dungeon-game/4.mdx
@@ -115,7 +115,7 @@ Nếu đây là lần triển khai CDK đầu tiên trong tài khoản/khu vực
 <NxCommands commands={['bootstrap infra']} />
 :::
 
-Target `deploy-sandbox` triển khai stage sandbox được định nghĩa trong `packages/infra/src/main.ts` — `dungeon-adventure-infra-sandbox` — vì vậy bạn không cần tự đặt tên cho nó.
+Target `deploy-sandbox` triển khai stage sandbox được định nghĩa trong `packages/infra/src/main.ts`.
 
 Lần triển khai đầu tiên của bạn sẽ mất khoảng 6 phút để hoàn thành vì nó đợi tất cả các tài nguyên ổn định hoàn toàn. Các lần triển khai tiếp theo sẽ nhanh hơn. Để tăng tốc độ lặp lại trong quá trình phát triển, bạn có thể chọn sử dụng [CloudFormation express mode](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-express-mode.html) bằng cách truyền cờ `--express`, điều này hoàn thành mỗi thao tác tài nguyên ngay khi cấu hình của nó được áp dụng thay vì đợi ổn định hoàn toàn.
 

--- a/docs/src/content/docs/vi/get_started/tutorials/dungeon-game/4.mdx
+++ b/docs/src/content/docs/vi/get_started/tutorials/dungeon-game/4.mdx
@@ -115,6 +115,8 @@ Nếu đây là lần triển khai CDK đầu tiên trong tài khoản/khu vực
 <NxCommands commands={['bootstrap infra']} />
 :::
 
+Target `deploy-sandbox` triển khai stage sandbox được định nghĩa trong `packages/infra/src/main.ts` — `dungeon-adventure-infra-sandbox` — vì vậy bạn không cần tự đặt tên cho nó.
+
 Lần triển khai đầu tiên của bạn sẽ mất khoảng 6 phút để hoàn thành vì nó đợi tất cả các tài nguyên ổn định hoàn toàn. Các lần triển khai tiếp theo sẽ nhanh hơn. Để tăng tốc độ lặp lại trong quá trình phát triển, bạn có thể chọn sử dụng [CloudFormation express mode](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-express-mode.html) bằng cách truyền cờ `--express`, điều này hoàn thành mỗi thao tác tài nguyên ngay khi cấu hình của nó được áp dụng thay vì đợi ổn định hoàn toàn.
 
 Sau khi triển khai hoàn tất, bạn sẽ thấy các đầu ra tương tự như sau:

--- a/docs/src/content/docs/vi/get_started/tutorials/dungeon-game/4.mdx
+++ b/docs/src/content/docs/vi/get_started/tutorials/dungeon-game/4.mdx
@@ -107,7 +107,7 @@ Trò chơi của bạn đã hoàn thành và bạn đã kiểm tra từng phần
 
 ### Triển khai ứng dụng của bạn
 
-<NxCommands commands={['deploy infra "dungeon-adventure-infra-sandbox/*"']} />
+<NxCommands commands={['deploy-sandbox infra']} />
 
 :::caution[Yêu cầu Bootstrap]
 Nếu đây là lần triển khai CDK đầu tiên trong tài khoản/khu vực AWS của bạn, hãy bootstrap nó trước:

--- a/docs/src/content/docs/vi/guides/typescript-infrastructure.mdx
+++ b/docs/src/content/docs/vi/guides/typescript-infrastructure.mdx
@@ -394,6 +394,14 @@ Target `deploy-sandbox` triển khai stage sandbox mà `main.ts` khai báo, vì 
 
 Đây là cách nhanh nhất để có bản sao ứng dụng của riêng bạn chạy trên AWS trong khi bạn phát triển.
 
+:::tip[Chế độ Express để triển khai nhanh hơn]
+Các target triển khai chờ đợi ổn định tài nguyên hoàn toàn theo mặc định, ưu tiên tính nhất quán hơn tốc độ. Để tăng tốc độ lặp trong quá trình phát triển, hãy chọn sử dụng [chế độ express của CloudFormation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-express-mode.html) bằng cách truyền cờ `--express` của CDK:
+
+<NxCommands commands={['deploy-sandbox <my-infra> --express']} />
+
+Chế độ express hoàn thành ngay khi cấu hình tài nguyên được xác nhận đã áp dụng thay vì chờ đợi ổn định hoàn toàn, với việc lan truyền tiếp tục ở chế độ nền, giúp chu kỳ lặp nhanh hơn đáng kể. Nó được thiết kế cho phát triển và lặp lại.
+:::
+
 ### Triển khai một Stage cụ thể
 
 Target `deploy` triển khai bất kỳ stage hoặc stack nào bạn đặt tên. Sử dụng nó cho các stage khác ngoài sandbox của bạn, hoặc để triển khai một stack duy nhất:
@@ -403,14 +411,6 @@ Target `deploy` triển khai bất kỳ stage hoặc stack nào bạn đặt tê
 Bạn có thể chỉ định bất kỳ stage nào miễn là nó được định nghĩa trong `main.ts`. Để triển khai một stack riêng lẻ, hãy cung cấp tên stack đầy đủ:
 
 <NxCommands commands={['deploy <my-infra> <my-infra>-sandbox/Application']} />
-
-:::tip[Chế độ Express để triển khai nhanh hơn]
-Các target triển khai chờ đợi ổn định tài nguyên hoàn toàn theo mặc định, ưu tiên tính nhất quán hơn tốc độ. Để tăng tốc độ lặp trong quá trình phát triển, hãy chọn sử dụng [chế độ express của CloudFormation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-express-mode.html) bằng cách truyền cờ `--express` của CDK:
-
-<NxCommands commands={['deploy-sandbox <my-infra> --express']} />
-
-Chế độ express hoàn thành ngay khi cấu hình tài nguyên được xác nhận đã áp dụng thay vì chờ đợi ổn định hoàn toàn, với việc lan truyền tiếp tục ở chế độ nền, giúp chu kỳ lặp nhanh hơn đáng kể. Nó được thiết kế cho phát triển và lặp lại.
-:::
 
 ## Triển khai lên AWS trong một pipeline CI/CD
 

--- a/docs/src/content/docs/vi/guides/typescript-infrastructure.mdx
+++ b/docs/src/content/docs/vi/guides/typescript-infrastructure.mdx
@@ -97,9 +97,13 @@ new ApplicationStage(app, 'my-app-sandbox', {
     region: process.env.CDK_DEFAULT_REGION,
   },
 });
+
+// Define other instances of stages, such as beta and prod, below
 ```
 
 Thuộc tính `env` cho CDK biết tài khoản AWS và region nào để triển khai. `CDK_DEFAULT_ACCOUNT` và `CDK_DEFAULT_REGION` được CDK CLI tự động phân giải từ thông tin xác thực AWS đang hoạt động của bạn. Xem [tài liệu về môi trường CDK](https://docs.aws.amazon.com/cdk/v2/guide/environments.html) để biết thêm chi tiết.
+
+Stage sandbox là stage mà <Link path="guides/typescript-infrastructure#deploying-your-sandbox-stage">target `deploy-sandbox`</Link> triển khai.
 
 Nếu bạn tạo với `enableStageConfig`, tệp `main.ts` sẽ đọc account và region từ một tệp cấu hình tập trung thay vì vậy, và quay lại sử dụng biến môi trường khi không có cấu hình được đặt:
 
@@ -372,32 +376,40 @@ npx cdk bootstrap aws://<account-id>/<region>
 
 ## Triển khai lên AWS
 
-Sau khi build, bạn có thể triển khai cơ sở hạ tầng của mình lên AWS bằng target `deploy`.
+Dự án của bạn có ba target triển khai, mỗi target phù hợp với một tình huống khác nhau:
 
-:::caution[Triển khai CI]
-Sử dụng target `deploy-ci` nếu triển khai trong một pipeline CI/CD. Xem bên dưới để biết thêm chi tiết.
-:::
+| Target           | Sử dụng cho                                                                       |
+| ---------------- | -------------------------------------------------------------------------------- |
+| `deploy-sandbox` | Triển khai stage sandbox của riêng bạn trong quá trình phát triển. Không cần đối số stage.    |
+| `deploy`         | Triển khai bất kỳ stage nào, bằng cách đặt tên stage hoặc stack bạn muốn.                      |
+| `deploy-ci`      | Triển khai từ pipeline CI/CD, sử dụng cloud assembly đã được tổng hợp trước.          |
 
 Đầu tiên, đảm bảo rằng bạn đã cấu hình thông tin xác thực AWS. Nếu bạn tạo với `stageConfig` và đã cấu hình thông tin xác thực stage trong `packages/common/infra-config/src/stages.config.ts`, lệnh deploy sẽ tự động phân giải và áp dụng thông tin xác thực chính xác cho stage đích. Nếu không, hãy đảm bảo thông tin xác thực AWS của bạn được đặt trong môi trường của bạn (ví dụ: thông qua `AWS_PROFILE` hoặc biến môi trường). Xem [tài liệu thông tin xác thực AWS](https://docs.aws.amazon.com/sdkref/latest/guide/access.html) để biết các tùy chọn có sẵn.
 
-Sau đó chạy target deploy:
+### Triển khai Stage Sandbox của bạn
+
+Target `deploy-sandbox` triển khai stage sandbox mà `main.ts` khai báo, vì vậy bạn không cần nhớ tên stage của nó:
+
+<NxCommands commands={['deploy-sandbox <my-infra>']} />
+
+Đây là cách nhanh nhất để có bản sao ứng dụng của riêng bạn chạy trên AWS trong khi bạn phát triển.
+
+### Triển khai một Stage cụ thể
+
+Target `deploy` triển khai bất kỳ stage hoặc stack nào bạn đặt tên. Sử dụng nó cho các stage khác ngoài sandbox của bạn, hoặc để triển khai một stack duy nhất:
 
 <NxCommands commands={['deploy <my-infra> <my-infra>-sandbox/*']} />
 
-:::tip[Chế độ Express để triển khai nhanh hơn]
-Target `deploy` chờ đợi ổn định tài nguyên hoàn toàn theo mặc định, ưu tiên tính nhất quán hơn tốc độ. Để tăng tốc độ lặp trong quá trình phát triển, hãy chọn sử dụng [chế độ express của CloudFormation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-express-mode.html) bằng cách truyền cờ `--express` của CDK:
-
-<NxCommands commands={['deploy <my-infra> <my-infra>-sandbox/* --express']} />
-
-Chế độ express hoàn thành ngay khi cấu hình tài nguyên được xác nhận đã áp dụng thay vì chờ đợi ổn định hoàn toàn, với việc lan truyền tiếp tục ở chế độ nền, giúp chu kỳ lặp nhanh hơn đáng kể. Nó được thiết kế cho phát triển và lặp lại.
-:::
-
-:::tip[Triển khai stack chọn lọc]
-Lệnh trên triển khai _tất cả_ các stack cho stage `<my-infra>-sandbox`. Bạn có thể chỉ định các stage khác miễn là chúng được định nghĩa trong `main.ts`.
-
-Bạn cũng có thể triển khai các stack riêng lẻ bằng cách chỉ định tên stack đầy đủ, ví dụ:
+Bạn có thể chỉ định bất kỳ stage nào miễn là nó được định nghĩa trong `main.ts`. Để triển khai một stack riêng lẻ, hãy cung cấp tên stack đầy đủ:
 
 <NxCommands commands={['deploy <my-infra> <my-infra>-sandbox/Application']} />
+
+:::tip[Chế độ Express để triển khai nhanh hơn]
+Các target triển khai chờ đợi ổn định tài nguyên hoàn toàn theo mặc định, ưu tiên tính nhất quán hơn tốc độ. Để tăng tốc độ lặp trong quá trình phát triển, hãy chọn sử dụng [chế độ express của CloudFormation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-express-mode.html) bằng cách truyền cờ `--express` của CDK:
+
+<NxCommands commands={['deploy-sandbox <my-infra> --express']} />
+
+Chế độ express hoàn thành ngay khi cấu hình tài nguyên được xác nhận đã áp dụng thay vì chờ đợi ổn định hoàn toàn, với việc lan truyền tiếp tục ở chế độ nền, giúp chu kỳ lặp nhanh hơn đáng kể. Nó được thiết kế cho phát triển và lặp lại.
 :::
 
 ## Triển khai lên AWS trong một pipeline CI/CD

--- a/docs/src/content/docs/zh/get_started/quick-start.mdx
+++ b/docs/src/content/docs/zh/get_started/quick-start.mdx
@@ -248,10 +248,6 @@ Terraform 引导会创建一个 S3 存储桶来存储您的 Terraform 状态文�
 <Infrastructure>
 <Fragment slot="cdk">
 <NxCommands commands={['deploy-sandbox infra']} />
-
-:::tip[沙盒阶段]
-`deploy-sandbox` 部署在 `packages/infra/src/main.ts` 中定义的沙盒阶段。要部署不同的阶段，请使用 `deploy` 目标并为其命名，例如 `deploy infra "my-project-infra-beta/*"`。
-:::
 </Fragment>
 <Fragment slot="terraform">
 <NxCommands commands={['apply infra']} />

--- a/docs/src/content/docs/zh/get_started/quick-start.mdx
+++ b/docs/src/content/docs/zh/get_started/quick-start.mdx
@@ -247,7 +247,11 @@ Terraform 引导会创建一个 S3 存储桶来存储您的 Terraform 状态文�
 
 <Infrastructure>
 <Fragment slot="cdk">
-<NxCommands commands={['deploy infra "my-project-infra-sandbox/*"']} />
+<NxCommands commands={['deploy-sandbox infra']} />
+
+:::tip[沙盒阶段]
+`deploy-sandbox` 部署在 `packages/infra/src/main.ts` 中定义的沙盒阶段。要部署不同的阶段，请使用 `deploy` 目标并为其命名，例如 `deploy infra "my-project-infra-beta/*"`。
+:::
 </Fragment>
 <Fragment slot="terraform">
 <NxCommands commands={['apply infra']} />

--- a/docs/src/content/docs/zh/get_started/tutorials/dungeon-game/4.mdx
+++ b/docs/src/content/docs/zh/get_started/tutorials/dungeon-game/4.mdx
@@ -115,7 +115,7 @@ React Query 的默认缓存会保留第一个结果 5 分钟，因此返回访�
 <NxCommands commands={['bootstrap infra']} />
 :::
 
-`deploy-sandbox` 目标会部署在 `packages/infra/src/main.ts` 中定义的 sandbox 阶段——`dungeon-adventure-infra-sandbox`——因此您无需自己命名它。
+`deploy-sandbox` 目标会部署在 `packages/infra/src/main.ts` 中定义的 sandbox 阶段。
 
 您的第一次部署将需要大约 6 分钟才能完成，因为它会等待所有资源完全稳定。后续部署会更快。为了在开发期间加快迭代速度，您可以通过传递 `--express` 标志来选择使用 [CloudFormation express 模式](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-express-mode.html)，该模式会在应用每个资源的配置后立即完成资源操作，而不是等待完全稳定。
 

--- a/docs/src/content/docs/zh/get_started/tutorials/dungeon-game/4.mdx
+++ b/docs/src/content/docs/zh/get_started/tutorials/dungeon-game/4.mdx
@@ -107,13 +107,15 @@ React Query 的默认缓存会保留第一个结果 5 分钟，因此返回访�
 
 ### 部署应用程序
 
-<NxCommands commands={['deploy infra "dungeon-adventure-infra-sandbox/*"']} />
+<NxCommands commands={['deploy-sandbox infra']} />
 
 :::caution[需要引导]
 如果这是您的 AWS 账户/区域中的第一次 CDK 部署，请先进行引导：
 
 <NxCommands commands={['bootstrap infra']} />
 :::
+
+`deploy-sandbox` 目标会部署在 `packages/infra/src/main.ts` 中定义的 sandbox 阶段——`dungeon-adventure-infra-sandbox`——因此您无需自己命名它。
 
 您的第一次部署将需要大约 6 分钟才能完成，因为它会等待所有资源完全稳定。后续部署会更快。为了在开发期间加快迭代速度，您可以通过传递 `--express` 标志来选择使用 [CloudFormation express 模式](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-express-mode.html)，该模式会在应用每个资源的配置后立即完成资源操作，而不是等待完全稳定。
 

--- a/docs/src/content/docs/zh/guides/typescript-infrastructure.mdx
+++ b/docs/src/content/docs/zh/guides/typescript-infrastructure.mdx
@@ -394,6 +394,14 @@ npx cdk bootstrap aws://<account-id>/<region>
 
 这是在开发时让您自己的应用程序副本在 AWS 中运行的最快方法。
 
+:::tip[快速模式以加快部署速度]
+部署目标默认等待资源完全稳定，优先考虑一致性而非速度。要在开发期间加快迭代速度，可以通过传递 CDK 的 `--express` 标志来选择使用 [CloudFormation 快速模式](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-express-mode.html)：
+
+<NxCommands commands={['deploy-sandbox <my-infra> --express']} />
+
+快速模式在确认资源配置已应用后即完成，而不是等待完全稳定，传播会在后台继续进行，从而显著加快迭代周期。它适用于开发和迭代。
+:::
+
 ### 部署特定阶段
 
 `deploy` 目标部署您命名的任何阶段或堆栈。将其用于沙箱以外的阶段，或部署单个堆栈：
@@ -403,14 +411,6 @@ npx cdk bootstrap aws://<account-id>/<region>
 只要阶段在 `main.ts` 中定义，您就可以指定任何阶段。要部署单个堆栈，请提供完整的堆栈名称：
 
 <NxCommands commands={['deploy <my-infra> <my-infra>-sandbox/Application']} />
-
-:::tip[快速模式以加快部署速度]
-部署目标默认等待资源完全稳定，优先考虑一致性而非速度。要在开发期间加快迭代速度，可以通过传递 CDK 的 `--express` 标志来选择使用 [CloudFormation 快速模式](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-express-mode.html)：
-
-<NxCommands commands={['deploy-sandbox <my-infra> --express']} />
-
-快速模式在确认资源配置已应用后即完成，而不是等待完全稳定，传播会在后台继续进行，从而显著加快迭代周期。它适用于开发和迭代。
-:::
 
 ## 在 CI/CD 流水线中部署到 AWS
 

--- a/docs/src/content/docs/zh/guides/typescript-infrastructure.mdx
+++ b/docs/src/content/docs/zh/guides/typescript-infrastructure.mdx
@@ -97,9 +97,13 @@ new ApplicationStage(app, 'my-app-sandbox', {
     region: process.env.CDK_DEFAULT_REGION,
   },
 });
+
+// Define other instances of stages, such as beta and prod, below
 ```
 
 `env` 属性告诉 CDK 要部署到哪个 AWS 账户和区域。`CDK_DEFAULT_ACCOUNT` 和 `CDK_DEFAULT_REGION` 由 CDK CLI 从您的活动 AWS 凭证中自动解析。有关更多详细信息，请参阅 [CDK 环境文档](https://docs.aws.amazon.com/cdk/v2/guide/environments.html)。
+
+沙箱阶段是 <Link path="guides/typescript-infrastructure#deploying-your-sandbox-stage">`deploy-sandbox` 目标</Link> 部署的阶段。
 
 如果您使用 `stageConfig` 生成，`main.ts` 会从集中式配置文件中读取账户和区域，当未设置配置时会回退到环境变量：
 
@@ -372,32 +376,40 @@ npx cdk bootstrap aws://<account-id>/<region>
 
 ## 部署到 AWS
 
-构建完成后，可通过 `deploy` 目标将基础设施部署到 AWS。
+您的项目有三个部署目标，每个都适用于不同的情况：
 
-:::caution[CI部署]
-在 CI/CD 流水线中部署时，请使用 `deploy-ci` 目标。详见下文。
-:::
+| 目标             | 用途                                                                       |
+| ---------------- | -------------------------------------------------------------------------------- |
+| `deploy-sandbox` | 在开发期间部署您自己的沙箱阶段。无需阶段参数。    |
+| `deploy`         | 通过命名阶段或堆栈来部署任何阶段。                      |
+| `deploy-ci`      | 从 CI/CD 流水线部署，使用预合成的云装配。          |
 
 首先，确保已配置 AWS 凭证。如果您使用 `stageConfig` 生成并在 `packages/common/infra-config/src/stages.config.ts` 中配置了阶段凭证，部署命令将自动解析并应用目标阶段的正确凭证。否则，请确保在您的环境中设置了 AWS 凭证（例如，通过 `AWS_PROFILE` 或环境变量）。有关可用选项，请参阅 [AWS 凭证文档](https://docs.aws.amazon.com/sdkref/latest/guide/access.html)。
 
-然后运行部署目标：
+### 部署您的沙箱阶段
+
+`deploy-sandbox` 目标部署 `main.ts` 声明的沙箱阶段，因此您无需记住其阶段名称：
+
+<NxCommands commands={['deploy-sandbox <my-infra>']} />
+
+这是在开发时让您自己的应用程序副本在 AWS 中运行的最快方法。
+
+### 部署特定阶段
+
+`deploy` 目标部署您命名的任何阶段或堆栈。将其用于沙箱以外的阶段，或部署单个堆栈：
 
 <NxCommands commands={['deploy <my-infra> <my-infra>-sandbox/*']} />
 
-:::tip[快速模式以加快部署速度]
-`deploy` 目标默认等待资源完全稳定，优先考虑一致性而非速度。要在开发期间加快迭代速度，可以通过传递 CDK 的 `--express` 标志来选择使用 [CloudFormation 快速模式](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-express-mode.html)：
-
-<NxCommands commands={['deploy <my-infra> <my-infra>-sandbox/* --express']} />
-
-快速模式在确认资源配置已应用后即完成，而不是等待完全稳定，传播会在后台继续进行，从而显著加快迭代周期。它适用于开发和迭代。
-:::
-
-:::tip[选择性堆栈部署]
-上述命令部署 `<my-infra>-sandbox` 阶段的 _所有_ 堆栈。只要阶段在 `main.ts` 中定义，您也可以指定其他阶段。
-
-您还可以通过指定完整堆栈名称来部署单个堆栈，例如：
+只要阶段在 `main.ts` 中定义，您就可以指定任何阶段。要部署单个堆栈，请提供完整的堆栈名称：
 
 <NxCommands commands={['deploy <my-infra> <my-infra>-sandbox/Application']} />
+
+:::tip[快速模式以加快部署速度]
+部署目标默认等待资源完全稳定，优先考虑一致性而非速度。要在开发期间加快迭代速度，可以通过传递 CDK 的 `--express` 标志来选择使用 [CloudFormation 快速模式](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-express-mode.html)：
+
+<NxCommands commands={['deploy-sandbox <my-infra> --express']} />
+
+快速模式在确认资源配置已应用后即完成，而不是等待完全稳定，传播会在后台继续进行，从而显著加快迭代周期。它适用于开发和迭代。
 :::
 
 ## 在 CI/CD 流水线中部署到 AWS

--- a/packages/nx-plugin/src/infra/app/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/infra/app/__snapshots__/generator.spec.ts.snap
@@ -184,6 +184,17 @@ exports[`infra generator > should configure project.json with correct targets > 
         "cwd": "{projectRoot}",
       },
     },
+    "deploy-sandbox": {
+      "dependsOn": [
+        "^build",
+        "compile",
+      ],
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "cdk deploy --require-approval=never "proj-test-sandbox/*"",
+        "cwd": "{projectRoot}",
+      },
+    },
     "destroy": {
       "dependsOn": [
         "^build",
@@ -410,6 +421,8 @@ new ApplicationStage(app, 'proj-test-sandbox', {
   },
 });
 
+// Define other instances of stages, such as beta and prod, below
+
 app.synth();
 ",
   "src/stacks/application-stack.ts": "import { Stack, StackProps } from 'aws-cdk-lib';
@@ -562,6 +575,8 @@ new ApplicationStage(app, 'proj-test-sandbox', {
   },
 });
 
+// Define other instances of stages, such as beta and prod, below
+
 app.synth();
 "
 `;
@@ -648,6 +663,8 @@ new ApplicationStage(app, 'proj-custom-infra-sandbox', {
     region: process.env.CDK_DEFAULT_REGION,
   },
 });
+
+// Define other instances of stages, such as beta and prod, below
 
 app.synth();
 ",
@@ -759,6 +776,17 @@ exports[`infra generator > should handle custom project names correctly > custom
       "executor": "nx:run-commands",
       "options": {
         "command": "cdk deploy --require-approval=never --app ../../dist/{projectRoot}/cdk.out",
+        "cwd": "{projectRoot}",
+      },
+    },
+    "deploy-sandbox": {
+      "dependsOn": [
+        "^build",
+        "compile",
+      ],
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "cdk deploy --require-approval=never "proj-custom-infra-sandbox/*"",
         "cwd": "{projectRoot}",
       },
     },

--- a/packages/nx-plugin/src/infra/app/files/app/README.md.template
+++ b/packages/nx-plugin/src/infra/app/files/app/README.md.template
@@ -27,6 +27,10 @@ You can also automatically fix some lint errors by running the following command
 
 ## Deploy to AWS
 
+### Deploy your Sandbox Stage
+
+Run `<%= pkgMgrCmd %> nx deploy-sandbox <%= fullyQualifiedName %>`
+
 ### Deploy all Stacks
 
 Run `<%= pkgMgrCmd %> nx deploy <%= fullyQualifiedName %> --all`

--- a/packages/nx-plugin/src/infra/app/files/app/README.md.template
+++ b/packages/nx-plugin/src/infra/app/files/app/README.md.template
@@ -31,13 +31,13 @@ You can also automatically fix some lint errors by running the following command
 
 Run `<%= pkgMgrCmd %> nx deploy-sandbox <%= fullyQualifiedName %>`
 
-### Deploy all Stacks
+### Deploy all Stacks in a Stage
 
-Run `<%= pkgMgrCmd %> nx deploy <%= fullyQualifiedName %> --all`
+Run `<%= pkgMgrCmd %> nx deploy <%= fullyQualifiedName %> "[stageName]/*"`
 
 ### Deploy a single Stack
 
-Run `<%= pkgMgrCmd %> nx deploy <%= fullyQualifiedName %> [stackName]`
+Run `<%= pkgMgrCmd %> nx deploy <%= fullyQualifiedName %> [stageName]/[stackName]`
 
 ### Hotswap deployment
 
@@ -48,7 +48,7 @@ Use the --hotswap flag with the deploy target to attempt to update your AWS reso
 
 Currently hot swapping supports Lambda functions, Step Functions state machines, and Amazon ECS container images. The --hotswap flag also disables rollback (i.e., implies --no-rollback).
 
-Run `<%= pkgMgrCmd %> nx deploy <%= fullyQualifiedName %> --hotswap --all`
+Run `<%= pkgMgrCmd %> nx deploy-sandbox <%= fullyQualifiedName %> --hotswap`
 
 ## Checkov Rule Suppressions
 

--- a/packages/nx-plugin/src/infra/app/files/app/src/main.ts.template
+++ b/packages/nx-plugin/src/infra/app/files/app/src/main.ts.template
@@ -17,6 +17,8 @@ new ApplicationStage(app, '<%= namespace %>-sandbox', {
     region: sandboxConfig?.region ?? process.env.CDK_DEFAULT_REGION,
   },
 });
+
+// Define other instances of stages, such as beta and prod, below
 <% } else { %>
 // Use this to deploy your own sandbox environment (assumes your CLI credentials)
 new ApplicationStage(app, '<%= namespace %>-sandbox', {
@@ -25,5 +27,7 @@ new ApplicationStage(app, '<%= namespace %>-sandbox', {
     region: process.env.CDK_DEFAULT_REGION,
   },
 });
+
+// Define other instances of stages, such as beta and prod, below
 <% } %>
 app.synth();

--- a/packages/nx-plugin/src/infra/app/generator.spec.ts
+++ b/packages/nx-plugin/src/infra/app/generator.spec.ts
@@ -9,6 +9,7 @@ import {
   type Tree,
 } from '@nx/devkit';
 import { expectHasMetricTags } from '../../utils/metrics.spec';
+import { toKebabCase } from '../../utils/names';
 import {
   createTreeUsingTsSolutionSetup,
   snapshotTreeDir,
@@ -85,6 +86,14 @@ describe('infra generator', () => {
       options: {
         cwd: '{projectRoot}',
         command: 'cdk deploy --require-approval=never',
+      },
+      dependsOn: ['^build', 'compile'],
+    });
+    expect(config.targets['deploy-sandbox']).toMatchObject({
+      executor: 'nx:run-commands',
+      options: {
+        cwd: '{projectRoot}',
+        command: 'cdk deploy --require-approval=never "proj-test-sandbox/*"',
       },
       dependsOn: ['^build', 'compile'],
     });
@@ -311,6 +320,71 @@ describe('infra generator', () => {
     expect(mainTs).toContain('process.env.CDK_DEFAULT_REGION');
   });
 
+  it('should invite further stages below the sandbox stage in main.ts', async () => {
+    await tsInfraGenerator(tree, options);
+    const mainTs = tree.read('packages/test/src/main.ts').toString();
+    expect(mainTs).toContain(
+      '// Define other instances of stages, such as beta and prod, below',
+    );
+    // The comment sits after the sandbox stage and before app.synth().
+    expect(
+      mainTs.indexOf('// Define other instances of stages'),
+    ).toBeGreaterThan(
+      mainTs.indexOf("new ApplicationStage(app, 'proj-test-sandbox'"),
+    );
+    expect(mainTs.indexOf('// Define other instances of stages')).toBeLessThan(
+      mainTs.indexOf('app.synth()'),
+    );
+  });
+
+  describe('deploy-sandbox target', () => {
+    // The stage pattern must match the stage main.ts instantiates, otherwise
+    // cdk deploys nothing. Derived from the scope-prefixed project name.
+    it.each([
+      { name: 'test', subDirectory: undefined, stage: 'proj-test-sandbox' },
+      { name: 'infra', subDirectory: undefined, stage: 'proj-infra-sandbox' },
+      {
+        name: 'myInfra',
+        subDirectory: undefined,
+        stage: 'proj-my-infra-sandbox',
+      },
+      { name: 'test', subDirectory: 'nested', stage: 'proj-test-sandbox' },
+    ])(
+      'should target the stage main.ts declares for $name in $subDirectory',
+      async ({ name, subDirectory, stage }) => {
+        await tsInfraGenerator(tree, { ...options, name, subDirectory });
+        // The project name is the kebab-cased name under the workspace scope.
+        const config = readProjectConfiguration(
+          tree,
+          `@proj/${toKebabCase(name)}`,
+        );
+        const mainTs = tree.read(`${config.root}/src/main.ts`).toString();
+
+        expect(mainTs).toContain(`new ApplicationStage(app, '${stage}'`);
+        expect(config.targets['deploy-sandbox'].options.command).toBe(
+          `cdk deploy --require-approval=never "${stage}/*"`,
+        );
+      },
+    );
+
+    it('should quote the stage pattern so the shell does not glob it', async () => {
+      await tsInfraGenerator(tree, options);
+      const config = readProjectConfiguration(tree, '@proj/test');
+      expect(config.targets['deploy-sandbox'].options.command).toContain(
+        '"proj-test-sandbox/*"',
+      );
+    });
+
+    it('should build before deploying, like the deploy target', async () => {
+      await tsInfraGenerator(tree, options);
+      const config = readProjectConfiguration(tree, '@proj/test');
+      expect(config.targets['deploy-sandbox'].dependsOn).toEqual([
+        '^build',
+        'compile',
+      ]);
+    });
+  });
+
   it('should not add infra-config tsconfig reference by default', async () => {
     await tsInfraGenerator(tree, options);
     const tsConfig = readJson(tree, 'packages/test/tsconfig.lib.json');
@@ -335,6 +409,20 @@ describe('infra generator', () => {
       expect(config.targets.destroy.options.command).toBe(
         'tsx packages/common/scripts/src/infra/infra-destroy.ts packages/test',
       );
+    });
+
+    it('should pass the sandbox stage to infra-deploy for deploy-sandbox', async () => {
+      await tsInfraGenerator(tree, stageConfigOptions);
+      const config = readProjectConfiguration(tree, '@proj/test');
+      // The stage is the first positional arg after the project path, which is
+      // where infra-deploy looks it up in stages.config.ts.
+      expect(config.targets['deploy-sandbox'].options.command).toBe(
+        'tsx packages/common/scripts/src/infra/infra-deploy.ts packages/test "proj-test-sandbox/*"',
+      );
+      expect(config.targets['deploy-sandbox'].dependsOn).toEqual([
+        '^build',
+        'compile',
+      ]);
     });
 
     it('should generate infra-config package with stages types and config', async () => {

--- a/packages/nx-plugin/src/infra/app/generator.ts
+++ b/packages/nx-plugin/src/infra/app/generator.ts
@@ -136,6 +136,9 @@ export async function tsInfraGenerator(
   const npmScopePrefix = getNpmScopePrefix(tree);
   const scopeAlias = npmScopePrefix;
   const fullyQualifiedName = `${npmScopePrefix}${schema.name}`;
+  const namespace = kebabCase(fullyQualifiedName);
+  // The stage instantiated in main.ts. Quoted so the shell does not glob `*`.
+  const sandboxStagePattern = `"${namespace}-sandbox/*"`;
   tree.delete(joinPathFragments(libraryRoot, 'src'));
 
   generateFiles(
@@ -145,7 +148,7 @@ export async function tsInfraGenerator(
     {
       synthDir: synthDirFromProject,
       scopeAlias: scopeAlias,
-      namespace: kebabCase(fullyQualifiedName),
+      namespace,
       fullyQualifiedName,
       pkgMgrCmd: getPackageManagerDisplayCommands().exec,
       dir: lib.dir,
@@ -202,6 +205,18 @@ export async function tsInfraGenerator(
           : withCdkEnv({
               cwd: '{projectRoot}',
               command: 'cdk deploy --require-approval=never',
+            }),
+      };
+      config.targets['deploy-sandbox'] = {
+        executor: 'nx:run-commands',
+        dependsOn: ['^build', 'compile'],
+        options: stageConfig
+          ? withCdkEnv({
+              command: `tsx packages/common/scripts/src/infra/infra-deploy.ts ${libraryRoot} ${sandboxStagePattern}`,
+            })
+          : withCdkEnv({
+              cwd: '{projectRoot}',
+              command: `cdk deploy --require-approval=never ${sandboxStagePattern}`,
             }),
       };
       config.targets['deploy-ci'] = {

--- a/packages/nx-plugin/src/mcp-server/tools/general-guidance.ts
+++ b/packages/nx-plugin/src/mcp-server/tools/general-guidance.ts
@@ -78,6 +78,7 @@ ${PACKAGE_MANAGERS.map((pm) => buildNxCommand('<options>', pm)).join(' - \n')}
 - Generate all projects into the \`packages/\` directory
 - After making changes to your projects, fix linting issues, then run a full build
 - When it's time to start testing a project, suggest to the user that infrastructure is deployed to AWS. For websites, if a runtime-config.json is needed, use the load-runtime-config target after a deployment to point a local website at a sandbox stack.
+- For CDK infrastructure projects, deploy the sandbox stage with the \`deploy-sandbox\` target (eg \`nx deploy-sandbox infra\`) rather than passing a stage pattern to \`deploy\` — it already targets the sandbox stage declared in \`main.ts\`.
 
 ## Batching Generators
 

--- a/packages/nx-plugin/src/migrations/latest/add-deploy-sandbox-target/metadata.json
+++ b/packages/nx-plugin/src/migrations/latest/add-deploy-sandbox-target/metadata.json
@@ -1,0 +1,3 @@
+{
+  "description": "Add a deploy-sandbox target to CDK infrastructure projects which deploys the sandbox stage"
+}

--- a/packages/nx-plugin/src/migrations/latest/add-deploy-sandbox-target/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/latest/add-deploy-sandbox-target/migration.spec.ts
@@ -1,0 +1,239 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import {
+  addProjectConfiguration,
+  readProjectConfiguration,
+  type Tree,
+  updateProjectConfiguration,
+} from '@nx/devkit';
+import { INFRA_APP_GENERATOR_INFO } from '../../../infra/app/generator';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test';
+import migration from './migration';
+
+const TARGET = 'deploy-sandbox';
+
+const mainTs = (stages: string[]) =>
+  `import { ApplicationStage } from './stages/application-stage.js';
+import { App } from '@proj/common-constructs';
+
+const app = new App();
+
+${stages
+  .map(
+    (stage) => `new ApplicationStage(app, '${stage}', {
+  env: {
+    account: process.env.CDK_DEFAULT_ACCOUNT,
+    region: process.env.CDK_DEFAULT_REGION,
+  },
+});
+`,
+  )
+  .join('\n')}
+app.synth();
+`;
+
+const cdkDeployTarget = () => ({
+  executor: 'nx:run-commands',
+  dependsOn: ['^build', 'compile'],
+  options: {
+    cwd: '{projectRoot}',
+    command: 'cdk deploy --require-approval=never',
+  },
+});
+
+const stageConfigDeployTarget = () => ({
+  executor: 'nx:run-commands',
+  dependsOn: ['^build', 'compile'],
+  options: {
+    command:
+      'tsx packages/common/scripts/src/infra/infra-deploy.ts packages/infra',
+  },
+});
+
+/**
+ * Seeds a CDK infrastructure project as the generator leaves it: `ts#infra`
+ * metadata, a `deploy` target and a `main.ts` declaring the given stages.
+ */
+const seedInfraProject = (
+  tree: Tree,
+  {
+    name = '@proj/infra',
+    root = 'packages/infra',
+    stages = ['proj-infra-sandbox'],
+    deploy = cdkDeployTarget(),
+    main,
+  }: {
+    name?: string;
+    root?: string;
+    stages?: string[];
+    deploy?: unknown;
+    main?: string;
+  } = {},
+) => {
+  addProjectConfiguration(tree, name, {
+    root,
+    projectType: 'application',
+    metadata: { generator: INFRA_APP_GENERATOR_INFO.id } as never,
+    targets: {
+      build: { executor: 'nx:run-commands' },
+      deploy: deploy as never,
+      'deploy-ci': { executor: 'nx:run-commands' },
+    },
+  });
+  tree.write(`${root}/src/main.ts`, main ?? mainTs(stages));
+};
+
+const sandboxTargetOf = (tree: Tree, project = '@proj/infra') =>
+  readProjectConfiguration(tree, project).targets[TARGET];
+
+describe('add-deploy-sandbox-target migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeUsingTsSolutionSetup();
+  });
+
+  it('should add the target deploying the sandbox stage main.ts declares', async () => {
+    seedInfraProject(tree);
+
+    const result = await migration(tree);
+
+    expect(sandboxTargetOf(tree)).toEqual({
+      executor: 'nx:run-commands',
+      dependsOn: ['^build', 'compile'],
+      options: {
+        cwd: '{projectRoot}',
+        command: 'cdk deploy --require-approval=never "proj-infra-sandbox/*"',
+      },
+    });
+    expect(result.nextSteps).toEqual([]);
+  });
+
+  it('should pass the stage to the credential script under stageConfig', async () => {
+    seedInfraProject(tree, { deploy: stageConfigDeployTarget() });
+
+    await migration(tree);
+
+    expect(sandboxTargetOf(tree).options).toEqual({
+      command:
+        'tsx packages/common/scripts/src/infra/infra-deploy.ts packages/infra "proj-infra-sandbox/*"',
+    });
+  });
+
+  it('should pick the sandbox stage when other stages are declared', async () => {
+    seedInfraProject(tree, {
+      stages: ['proj-infra-beta', 'proj-infra-prod', 'proj-infra-sandbox'],
+    });
+
+    await migration(tree);
+
+    expect(sandboxTargetOf(tree).options.command).toBe(
+      'cdk deploy --require-approval=never "proj-infra-sandbox/*"',
+    );
+  });
+
+  it('should use a renamed sandbox stage rather than the project name', async () => {
+    seedInfraProject(tree, { stages: ['my-own-sandbox'] });
+
+    await migration(tree);
+
+    expect(sandboxTargetOf(tree).options.command).toBe(
+      'cdk deploy --require-approval=never "my-own-sandbox/*"',
+    );
+  });
+
+  it('should read a double-quoted stage id', async () => {
+    seedInfraProject(tree, {
+      main: `const app = new App();
+new ApplicationStage(app, "proj-infra-sandbox", { env: {} });
+app.synth();
+`,
+    });
+
+    await migration(tree);
+
+    expect(sandboxTargetOf(tree).options.command).toBe(
+      'cdk deploy --require-approval=never "proj-infra-sandbox/*"',
+    );
+  });
+
+  it('should leave non-infrastructure projects alone', async () => {
+    addProjectConfiguration(tree, '@proj/website', {
+      root: 'packages/website',
+      targets: { deploy: cdkDeployTarget() },
+    });
+
+    const result = await migration(tree);
+
+    expect(sandboxTargetOf(tree, '@proj/website')).toBeUndefined();
+    expect(result.nextSteps).toEqual([]);
+  });
+
+  it('should skip and report a project with no sandbox stage', async () => {
+    seedInfraProject(tree, { stages: ['proj-infra-beta'] });
+
+    const result = await migration(tree);
+
+    expect(sandboxTargetOf(tree)).toBeUndefined();
+    expect(result.nextSteps).toEqual([
+      expect.stringContaining('no sandbox stage was found'),
+    ]);
+  });
+
+  it('should skip and report a project whose deploy target has diverged', async () => {
+    seedInfraProject(tree, {
+      deploy: { executor: '@my-org/deployer:deploy', options: { stage: 'x' } },
+    });
+
+    const result = await migration(tree);
+
+    expect(sandboxTargetOf(tree)).toBeUndefined();
+    expect(result.nextSteps).toEqual([
+      expect.stringContaining('no longer matches the shape'),
+    ]);
+  });
+
+  it('should not overwrite an existing deploy-sandbox target', async () => {
+    seedInfraProject(tree);
+    const project = readProjectConfiguration(tree, '@proj/infra');
+    const existing = { executor: 'nx:run-commands', options: { command: 'x' } };
+    project.targets[TARGET] = existing;
+    updateProjectConfiguration(tree, '@proj/infra', project);
+
+    await migration(tree);
+
+    expect(sandboxTargetOf(tree)).toEqual(existing);
+  });
+
+  it('should handle multiple infrastructure projects', async () => {
+    seedInfraProject(tree);
+    seedInfraProject(tree, {
+      name: '@proj/other-infra',
+      root: 'packages/other-infra',
+      stages: ['proj-other-infra-sandbox'],
+    });
+
+    await migration(tree);
+
+    expect(sandboxTargetOf(tree).options.command).toBe(
+      'cdk deploy --require-approval=never "proj-infra-sandbox/*"',
+    );
+    expect(sandboxTargetOf(tree, '@proj/other-infra').options.command).toBe(
+      'cdk deploy --require-approval=never "proj-other-infra-sandbox/*"',
+    );
+  });
+
+  it('should be idempotent', async () => {
+    seedInfraProject(tree);
+
+    await migration(tree);
+    const afterFirst = readProjectConfiguration(tree, '@proj/infra');
+
+    await migration(tree);
+    const afterSecond = readProjectConfiguration(tree, '@proj/infra');
+
+    expect(afterSecond).toEqual(afterFirst);
+  });
+});

--- a/packages/nx-plugin/src/migrations/latest/add-deploy-sandbox-target/migration.ts
+++ b/packages/nx-plugin/src/migrations/latest/add-deploy-sandbox-target/migration.ts
@@ -84,13 +84,13 @@ export default async function migration(
 
     if (typeof command !== 'string') {
       nextSteps.push(
-        `Add a '${TARGET}' target to ${projectName} by hand — its 'deploy' target no longer matches the shape the generator produced.`,
+        `Add a '${TARGET}' target to ${projectName} by hand if necessary — its 'deploy' target no longer matches the shape the generator produced.`,
       );
       continue;
     }
     if (!stageId) {
       nextSteps.push(
-        `Add a '${TARGET}' target to ${projectName} by hand — no sandbox stage was found in ${mainPath}.`,
+        `Add a '${TARGET}' target to ${projectName} by hand if necessary — no sandbox stage was found in ${mainPath}.`,
       );
       continue;
     }

--- a/packages/nx-plugin/src/migrations/latest/add-deploy-sandbox-target/migration.ts
+++ b/packages/nx-plugin/src/migrations/latest/add-deploy-sandbox-target/migration.ts
@@ -1,0 +1,113 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import {
+  getProjects,
+  joinPathFragments,
+  type MigrationReturnObject,
+  type Tree,
+  updateProjectConfiguration,
+} from '@nx/devkit';
+import { INFRA_APP_GENERATOR_INFO } from '../../../infra/app/generator';
+import { captureGritQLVariable } from '../../../utils/ast';
+import { formatFilesInSubtree } from '../../../utils/format';
+import { normalizeTargetKeyOrder } from '../../../utils/nx';
+import { sortObjectKeys } from '../../../utils/object';
+
+/**
+ * CDK infrastructure projects gained a `deploy-sandbox` target, which deploys the
+ * sandbox stage without the user having to spell out its stage pattern
+ * (`nx deploy-sandbox infra` rather than `nx deploy infra "my-app-infra-sandbox/*"`).
+ *
+ * The stage id is read from `main.ts` rather than recomputed from the project
+ * name, so a project whose sandbox stage has been renamed gets a target that
+ * deploys the stage it actually declares.
+ *
+ * How to write a migration:
+ * - https://nx.dev/docs/kb/migration-generators
+ * - What `nextSteps` means: https://nx.dev/docs/reference/devkit/MigrationReturnObject
+ */
+
+const TARGET = 'deploy-sandbox';
+
+/**
+ * Matches `new ApplicationStage(app, '<id>-sandbox', { ... })`, binding the
+ * quoted stage id. The regex spans the quotes because it is matched against the
+ * whole string literal node; both quote styles are accepted since the user's
+ * formatter may have rewritten them.
+ *
+ * `main.ts` can declare several stages (beta, prod), so the pattern selects the
+ * sandbox one rather than whichever comes first.
+ */
+const SANDBOX_STAGE_PATTERN =
+  '`new ApplicationStage($app, $id, $props)` where { $id <: r"[\'\\"].*-sandbox[\'\\"]" }';
+
+/** The id of the sandbox stage a project's `main.ts` instantiates. */
+const sandboxStageId = async (
+  tree: Tree,
+  projectRoot: string,
+): Promise<string | undefined> => {
+  const captured = await captureGritQLVariable(
+    tree,
+    joinPathFragments(projectRoot, 'src', 'main.ts'),
+    SANDBOX_STAGE_PATTERN,
+    'id',
+  );
+  // The binding keeps the quotes from the source.
+  return captured?.slice(1, -1);
+};
+
+export default async function migration(
+  tree: Tree,
+): Promise<MigrationReturnObject> {
+  const nextSteps: string[] = [];
+
+  for (const [projectName, project] of getProjects(tree)) {
+    const generator = (project.metadata as { generator?: string } | undefined)
+      ?.generator;
+    if (
+      generator !== INFRA_APP_GENERATOR_INFO.id ||
+      project.targets?.[TARGET]
+    ) {
+      // Not a CDK infrastructure project, or the target is already present.
+      continue;
+    }
+
+    // The new target mirrors `deploy`, so it inherits whatever that resolved to
+    // when the project was generated: the `tsx` credential-resolving script
+    // under `stageConfig`, plain `cdk deploy` otherwise.
+    const deploy = project.targets.deploy;
+    const command = deploy?.options?.command;
+    const mainPath = joinPathFragments(project.root, 'src/main.ts');
+    const stageId = await sandboxStageId(tree, project.root);
+
+    if (typeof command !== 'string') {
+      nextSteps.push(
+        `Add a '${TARGET}' target to ${projectName} by hand — its 'deploy' target no longer matches the shape the generator produced.`,
+      );
+      continue;
+    }
+    if (!stageId) {
+      nextSteps.push(
+        `Add a '${TARGET}' target to ${projectName} by hand — no sandbox stage was found in ${mainPath}.`,
+      );
+      continue;
+    }
+
+    project.targets[TARGET] = normalizeTargetKeyOrder({
+      executor: deploy.executor,
+      ...(deploy.dependsOn ? { dependsOn: [...deploy.dependsOn] } : {}),
+      // Quoted so the shell does not glob the `*`.
+      options: { ...deploy.options, command: `${command} "${stageId}/*"` },
+    });
+    updateProjectConfiguration(tree, projectName, {
+      ...project,
+      targets: sortObjectKeys(project.targets),
+    });
+  }
+
+  await formatFilesInSubtree(tree);
+
+  return { nextSteps };
+}


### PR DESCRIPTION
### Reason for this change

Deploying a sandbox stage previously meant spelling out its stage pattern:

```bash
nx deploy infra "my-project-infra-sandbox/*"
```

That requires knowing how the stage id is derived (workspace scope + project name, kebab-cased, `-sandbox` suffix) and remembering to quote it so the shell doesn't glob the `*`. It's the single most common deploy during development, so it shouldn't need the ceremony.

### Description of changes

**`deploy-sandbox` target** — `ts#infra` now vends a `deploy-sandbox` target that deploys the sandbox stage `main.ts` declares:

```bash
nx deploy-sandbox infra
```

It mirrors the `deploy` target so it behaves consistently:

| | `deploy` command | `deploy-sandbox` command |
| --- | --- | --- |
| default | `cdk deploy --require-approval=never` | `cdk deploy --require-approval=never "<scope>-<name>-sandbox/*"` |
| `stageConfig` | `tsx .../infra-deploy.ts <root>` | `tsx .../infra-deploy.ts <root> "<scope>-<name>-sandbox/*"` |

Under `stageConfig` the stage lands as the first positional arg after the project path, which is exactly where `infra-deploy` looks it up in `stages.config.ts` — so credential resolution works unchanged. `dependsOn` matches `deploy` (`^build`, `compile`), and extra CDK args (`--express`, `--hotswap`, …) still forward.

**`main.ts` comment** — a one-line comment below the sandbox stage marks where further stages go:

```ts
// Define other instances of stages, such as beta and prod, below
```

**Migration** — `add-deploy-sandbox-target` adds the target to existing CDK infrastructure projects. It reads the stage id from `main.ts` via GritQL rather than recomputing it from the project name, so a project whose sandbox stage has been renamed gets a target that deploys the stage it actually declares. It derives the command from the project's existing `deploy` target, so it picks up the `stageConfig` variant automatically. Projects whose `deploy` target has diverged, or which declare no sandbox stage, are skipped and reported via `nextSteps`.

**Vended README deploy commands fixed** — while validating the README against real CDK, both of its existing deploy examples turned out to be broken. Stacks live inside CDK Stages, so they are never in the main cloud assembly and a bare stack name does not resolve:

| Command | Result |
| --- | --- |
| `deploy infra --all` (was in README) | ❌ `No stack found in the main cloud assembly` |
| `deploy infra Application` (was in README) | ❌ `No stacks match the name(s) Application` |
| `deploy infra "<stage>/*"` | ✅ all stacks in that stage |
| `deploy infra <stage>/Application` | ✅ that one stack |

The README now uses the `stage/stack` forms CDK actually resolves, and its hotswap example (which also used `--all`) uses `deploy-sandbox --hotswap`.

**Docs** — the `ts#infra` guide's "Deploying to AWS" section now covers `deploy-sandbox` alongside `deploy` and `deploy-ci` with a table of when to use each; the quick start and dungeon adventure tutorial use `deploy-sandbox`; the MCP server's general guidance mentions it too.

### Description of how you validated changes

**Unit tests** — 18 new tests. The generator tests assert the target's stage pattern matches the stage `main.ts` instantiates across name/scope/subdirectory permutations (this is the invariant that matters — a mismatched pattern deploys nothing), that the pattern is quoted, and that the `stageConfig` variant passes the stage where `infra-deploy` reads it. 11 migration tests cover both deploy variants, multi-stage `main.ts` files, renamed sandbox stages, double-quoted stage ids, skip-and-report paths, and idempotency. Full suite green: 3343 tests.

**Real AWS deployments** — created a workspace named `my-project` with an `infra` project, confirming the vended command is exactly `deploy 'my-project-infra-sandbox/*'` as expected, then deployed for real to AWS:

- **Default variant** — `nx deploy-sandbox infra` deployed `my-project-infra-sandbox-Application`. `main.ts` also declared a `my-project-infra-beta` stage; CDK reported `[1/1]` and only the sandbox stack existed in CloudFormation afterwards, confirming the pattern scopes the deploy to the sandbox stage rather than deploying everything.
- **Arg forwarding** — `nx deploy-sandbox infra --express` and `--hotswap` both forwarded through to CDK.
- **`stageConfig` variant** — deployed in a second workspace. The script logged `No credentials for 'sc-project-infra-sandbox' — using environment`, then with a config entry added, `Using profile '…' for 'sc-project-infra-sandbox' (shared)` — confirming the quoted pattern still parses into a stage name for credential lookup.
- **Nested project** — a project generated into `packages/nested/other-infra` produced a target matching its `sc-project-other-infra-sandbox` stage.
- **README commands** — a third workspace with two stages × two stacks, used to establish the table above; every corrected form was then re-run against AWS from the regenerated README.
- **Migration end-to-end** — removed the target from a real generated workspace, ran the migration against it, and the resulting `project.json` was byte-identical to the generator's own output (verified by re-running the generator and getting an empty diff).

All provisioned AWS resources were torn down and CloudFormation confirmed empty.

**Build and lint** — `nx run-many --target build --all` and `lint --all --fix` both pass.

### Issue # (if applicable)

N/A.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
