### PR TITLE
fix(ts#astro-docs): omit blog schema and card when --noBlog is passed

### DIFF
--- a/packages/nx-plugin/src/ts/astro-docs/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/astro-docs/__snapshots__/generator.spec.ts.snap
@@ -221,3 +221,17 @@ exports[`ts#astro-docs generator > should generate a docs site with default opti
 }
 "
 `;
+
+exports[`ts#astro-docs generator > should omit the blog when --noBlog is passed > content.config.ts 1`] = `
+"import { defineCollection } from 'astro:content';
+import { docsLoader } from '@astrojs/starlight/loaders';
+import { docsSchema } from '@astrojs/starlight/schema';
+
+export const collections = {
+  docs: defineCollection({
+    loader: docsLoader(),
+    schema: docsSchema(),
+  }),
+};
+"
+`;

--- a/packages/nx-plugin/src/ts/astro-docs/files/base/src/content.config.ts.template
+++ b/packages/nx-plugin/src/ts/astro-docs/files/base/src/content.config.ts.template
@@ -1,13 +1,13 @@
 import { defineCollection } from 'astro:content';
 import { docsLoader } from '@astrojs/starlight/loaders';
 import { docsSchema } from '@astrojs/starlight/schema';
-import { blogSchema } from 'starlight-blog/schema';
-
+<% if (includeBlog) { %>import { blogSchema } from 'starlight-blog/schema';
+<% } %>
 export const collections = {
   docs: defineCollection({
     loader: docsLoader(),
-    schema: docsSchema({
+    schema: docsSchema(<% if (includeBlog) { %>{
       extend: (context) => blogSchema(context),
-    }),
+    }<% } %>),
   }),
 };

--- a/packages/nx-plugin/src/ts/astro-docs/files/base/src/content/docs/en/index.mdx.template
+++ b/packages/nx-plugin/src/ts/astro-docs/files/base/src/content/docs/en/index.mdx.template
@@ -17,10 +17,10 @@ import { CardGrid, Card } from '@astrojs/starlight/components';
   <Card title="Guides" icon="open-book">
     Reference documentation for <%= title %>.
   </Card>
-  <Card title="Blog" icon="pencil">
+<% if (includeBlog) { %>  <Card title="Blog" icon="pencil">
     News and updates from the team.
   </Card>
-  <Card title="Snippets" icon="seti:config">
+<% } %>  <Card title="Snippets" icon="seti:config">
     Reusable content fragments used across the docs.
   </Card>
   <Card title="Localised" icon="translate">

--- a/packages/nx-plugin/src/ts/astro-docs/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/astro-docs/generator.spec.ts
@@ -211,6 +211,14 @@ describe('ts#astro-docs generator', () => {
     expect(astroConfig).not.toContain('starlight-blog');
     expect(astroConfig).not.toContain('starlightBlog(');
 
+    const contentConfig = tree.read('docs/src/content.config.ts', 'utf-8');
+    expect(contentConfig).not.toContain('starlight-blog');
+    expect(contentConfig).not.toContain('blogSchema');
+    expect(contentConfig).toMatchSnapshot('content.config.ts');
+
+    const index = tree.read('docs/src/content/docs/en/index.mdx', 'utf-8');
+    expect(index).not.toContain('Blog');
+
     const packageJson = readJson(tree, 'package.json');
     const deps = {
       ...(packageJson.dependencies ?? {}),


### PR DESCRIPTION
### Reason for this change

`ts#docs`/`ts#astro-docs` gated the `starlight-blog` dependency and the `astro.config.mjs` plugin registration on `includeBlog`, but `src/content.config.ts` imported from the package unconditionally:

```ts
import { blogSchema } from 'starlight-blog/schema';
```

Since the dependency is only added `when: (m) => m.includeBlog`, sites generated with `--noBlog` emitted an import with no corresponding dependency and failed to build:

```
[GenerateContentTypesError] `astro sync` command failed to generate content collection types:
Cannot find module 'starlight-blog/schema' imported from '.../docs/src/content.config.ts'
```

A second, related leak: the landing page rendered a **Blog** card advertising content that was never generated under `--noBlog`.

Reported against `@aws/nx-plugin` v1.0.0-rc.59.

### Description of changes

- `files/base/src/content.config.ts.template` — gate the `starlight-blog/schema` import and the `extend` option on `includeBlog`, falling back to a bare `docsSchema()`.
- `files/base/src/content/docs/en/index.mdx.template` — gate the Blog card on `includeBlog`.
- `generator.spec.ts` — extend the existing `--noBlog` test to assert the generated `content.config.ts` contains no `starlight-blog`/`blogSchema` reference and that the landing page has no Blog card, plus a snapshot of the generated file.

### Description of how you validated changes

Extended the existing `--noBlog` unit test with assertions on `content.config.ts` and `index.mdx` (both previously unchecked), and confirmed the full `@aws/nx-plugin` test suite, `build --all` and `lint --all` are green.

End-to-end: compiled the plugin and `pnpm link`ed it into two fresh workspaces, one per branch of the flag.

|                              | `--noBlog`                             | default (blog)                |
| ---------------------------- | -------------------------------------- | ----------------------------- |
| `content.config.ts`          | bare `docsSchema()`, no blog import    | `blogSchema` extension present |
| `docs/package.json`          | no `starlight-blog`                    | `starlight-blog` present      |
| `nx build`                   | passes (4 pages)                       | passes                        |
| `nx start` (dev server)      | serves HTTP 200                        | —                             |
| blog references in `dist/`   | none                                   | present                       |

Also confirmed the reported failure reproduces against the pre-fix template in the same workspace, so the fix is addressing the actual cause.

### Issue # (if applicable)

N/A — reported directly.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*