### PR TITLE
fix(e2e): scaffold terraform smoke-test gateways without a Cedar policy engine

### DIFF
--- a/e2e/src/files/terraform-deploy/main.tf.template
+++ b/e2e/src/files/terraform-deploy/main.tf.template
@@ -254,7 +254,8 @@ module "ts_agui_agent" {
 # targets of a policy-engine gateway, which the AWS provider declares
 # `Optional` rather than `Computed`, so every apply fails its post-apply
 # consistency check; declaring the header explicitly is rejected as restricted.
-# cdk-deploy still covers Cedar. Restore it once the provider fixes the block.
+# cdk-deploy still covers Cedar. Restore it once the provider fixes the block —
+# tracked in #1065.
 
 # The gateway signs outbound calls to its MCP server targets with its own
 # role and fetches each target's tools at creation time, so it needs invoke

--- a/e2e/src/files/terraform-deploy/main.tf.template
+++ b/e2e/src/files/terraform-deploy/main.tf.template
@@ -246,8 +246,15 @@ module "ts_agui_agent" {
 }
 
 # ---------------------------------------------------------------------------
-# AgentCore Gateway (Cedar policy engine + IAM-authenticated MCP endpoint)
+# AgentCore Gateway (IAM-authenticated MCP endpoint)
 # ---------------------------------------------------------------------------
+
+# The gateways here are generated without a Cedar policy engine. AgentCore
+# injects a server-managed `metadata_configuration.allowed_request_headers` on
+# targets of a policy-engine gateway, which the AWS provider declares
+# `Optional` rather than `Computed`, so every apply fails its post-apply
+# consistency check; declaring the header explicitly is rejected as restricted.
+# cdk-deploy still covers Cedar. Restore it once the provider fixes the block.
 
 # The gateway signs outbound calls to its MCP server targets with its own
 # role and fetches each target's tools at creation time, so it needs invoke
@@ -258,11 +265,6 @@ module "my_gateway" {
   additional_iam_policy_statements = [
     local.invoke_py_mcp_server_statement,
     local.invoke_ts_mcp_server_statement,
-  ]
-
-  policy_dependencies = [
-    aws_bedrockagentcore_gateway_target.ts_mcp_server.target_id,
-    aws_bedrockagentcore_gateway_target.py_mcp_server.target_id,
   ]
 
   # Aggregated by parent_gateway, so its gateway_url must not be consumed
@@ -277,9 +279,9 @@ module "my_gateway" {
 # Register both MCP servers as targets of the Gateway — the Terraform
 # analogue of `myGateway.addMcpServer(...)` in the CDK template. Target
 # names match the local-dev registrations (kebab-cased MCP project class
-# name) so Cedar action prefixes are identical locally and deployed. The
-# runtime ARNs flow through each runtime's readiness probe, so targets are
-# created only once the runtimes serve MCP.
+# name) so tool prefixes are identical locally and deployed. The runtime ARNs
+# flow through each runtime's readiness probe, so targets are created only
+# once the runtimes serve MCP.
 resource "aws_bedrockagentcore_gateway_target" "ts_mcp_server" {
   gateway_identifier = module.my_gateway.gateway_id
   name               = "hosted-mcp-server"
@@ -332,10 +334,6 @@ module "parent_gateway" {
       Action   = ["bedrock-agentcore:InvokeGateway"]
       Resource = [module.my_gateway.gateway_arn]
     }
-  ]
-
-  policy_dependencies = [
-    aws_bedrockagentcore_gateway_target.my_gateway.target_id,
   ]
 }
 

--- a/e2e/src/smoke-tests/generator-matrix.ts
+++ b/e2e/src/smoke-tests/generator-matrix.ts
@@ -25,16 +25,21 @@ interface RunCliOpts {
  * Pass `{ preferInstallDependencies: true }` to install after every generator
  * instead — the idempotency test needs this so lockfiles (including `uv.lock`)
  * are fully synced before it snapshots the workspace.
+ *
+ * Pass `{ cedarPolicy: false }` to scaffold the MCP gateways without a Cedar
+ * policy engine — see the comment on the Terraform caller for why it opts out.
  */
 export const runGeneratorMatrix = async (
   opts: RunCliOpts,
   {
     preferInstallDependencies = false,
-  }: { preferInstallDependencies?: boolean } = {},
+    cedarPolicy = true,
+  }: { preferInstallDependencies?: boolean; cedarPolicy?: boolean } = {},
 ) => {
   const deferFlag = preferInstallDependencies
     ? ''
     : ' --prefer-install-dependencies=false';
+  const cedarFlag = cedarPolicy ? '' : ' --cedarPolicy=false';
   // Websites (with and without TanStack Router), plus auth on each.
   await runCLI(
     `generate @aws/nx-plugin:ts#website --name=website --no-interactive${deferFlag}`,
@@ -290,7 +295,7 @@ export const runGeneratorMatrix = async (
   // gateway -> ts/py mcp-server) so each smoke test exercises a deployable
   // gateway with multiple MCP server targets fronting both agent runtimes.
   await runCLI(
-    `generate @aws/nx-plugin:agentcore-gateway --name=my-gateway --no-interactive${deferFlag}`,
+    `generate @aws/nx-plugin:agentcore-gateway --name=my-gateway --no-interactive${cedarFlag}${deferFlag}`,
     opts,
   );
   await runCLI(
@@ -318,7 +323,7 @@ export const runGeneratorMatrix = async (
   // A parent gateway fronting my-gateway, exercising the
   // gateway -> gateway connection edge (chained gateways).
   await runCLI(
-    `generate @aws/nx-plugin:agentcore-gateway --name=parent-gateway --no-interactive${deferFlag}`,
+    `generate @aws/nx-plugin:agentcore-gateway --name=parent-gateway --no-interactive${cedarFlag}${deferFlag}`,
     opts,
   );
   await runCLI(

--- a/e2e/src/smoke-tests/terraform-deploy.spec.ts
+++ b/e2e/src/smoke-tests/terraform-deploy.spec.ts
@@ -301,8 +301,7 @@ const runTerraformDeployVariant = (config: TerraformDeployVariant) => {
           // Python (`my-mcp-server`) MCP servers as targets. Prompt each agent
           // to call a gateway-prefixed tool (`<target>___<tool>`) for each
           // upstream server. A successful round-trip proves agent -> deployed
-          // Gateway (Cedar ENFORCE + SigV4) -> MCP server works end-to-end for
-          // both languages.
+          // Gateway (SigV4) -> MCP server works end-to-end for both languages.
           expect(
             await invokeTrpcAgentCoreAgent(
               outputs.ts_agent_arn,
@@ -335,8 +334,8 @@ const runTerraformDeployVariant = (config: TerraformDeployVariant) => {
           // Chained gateways — the parent gateway fronts my_gateway via the
           // gateway -> gateway connection, re-exposing its tools under a
           // second prefix. Listing tools on the parent and calling one proves
-          // the parent -> my_gateway (SigV4 + Cedar at both hops) -> MCP
-          // server chain works end-to-end.
+          // the parent -> my_gateway (SigV4 at both hops) -> MCP server chain
+          // works end-to-end.
           await invokeAgentCoreGatewayTool(
             outputs.parent_gateway_url,
             'Parent Gateway -> Gateway -> TS MCP',

--- a/e2e/src/smoke-tests/terraform-smoke-test.ts
+++ b/e2e/src/smoke-tests/terraform-smoke-test.ts
@@ -17,6 +17,15 @@ import { runTerraformPlanTest } from './terraform-plan-test';
  * that `terraform` and `terraform-deploy` smoke tests both verify the same
  * generators, options and connection permutations under the Terraform IaC
  * provider.
+ *
+ * The MCP gateways are scaffolded without a Cedar policy engine: AgentCore
+ * injects a server-managed `metadata_configuration.allowed_request_headers`
+ * on targets of a policy-engine gateway, and the AWS provider declares that
+ * block `Optional` rather than `Computed`, so every apply fails the post-apply
+ * consistency check. The header is rejected if declared explicitly, so there
+ * is no configuration that reconciles it. Cedar stays covered by `cdk-deploy`,
+ * which CloudFormation applies without an equivalent check. Restore the policy
+ * engine here once the provider marks the block `Computed`.
  */
 export const runTerraformSmokeTest = async (
   dir: string,
@@ -52,7 +61,7 @@ export const runTerraformSmokeTest = async (
     opts,
   );
 
-  await runGeneratorMatrix(opts);
+  await runGeneratorMatrix(opts, { cedarPolicy: false });
 
   // Since the smoke tests don't run in a git repo, we need to exclude some
   // patterns for the license sync.

--- a/e2e/src/smoke-tests/terraform-smoke-test.ts
+++ b/e2e/src/smoke-tests/terraform-smoke-test.ts
@@ -25,7 +25,7 @@ import { runTerraformPlanTest } from './terraform-plan-test';
  * consistency check. The header is rejected if declared explicitly, so there
  * is no configuration that reconciles it. Cedar stays covered by `cdk-deploy`,
  * which CloudFormation applies without an equivalent check. Restore the policy
- * engine here once the provider marks the block `Computed`.
+ * engine here once the provider marks the block `Computed` — tracked in #1065.
  */
 export const runTerraformSmokeTest = async (
   dir: string,

--- a/packages/nx-plugin/src/agentcore-gateway/generator.spec.ts
+++ b/packages/nx-plugin/src/agentcore-gateway/generator.spec.ts
@@ -671,6 +671,11 @@ describe('agentcore-gateway generator', () => {
       expect(module).not.toContain('policy_engine');
       expect(module).not.toContain('render-cedar');
       expect(module).toContain('aws_bedrockagentcore_gateway');
+      // policy_dependencies orders Cedar policies against target registration,
+      // so it goes with the policy engine; tool_dependencies gates gateway_url
+      // on target readiness and applies to any mcp gateway.
+      expect(module).not.toContain('policy_dependencies');
+      expect(module).toContain('tool_dependencies');
       expect(
         tree.exists(
           'packages/common/terraform/src/app/gateways/my-gateway/render-cedar.cjs',


### PR DESCRIPTION
### Reason for this change

The `terraform-deploy` smoke test has been failing on `main` since AgentCore began returning a server-managed `metadata_configuration` on gateway targets. It has failed on the last two runs of `main` and blocks `Release` and `Deploy Docs`:

```
Error: Provider produced inconsistent result after apply

When applying changes to aws_bedrockagentcore_gateway_target.py_mcp_server,
provider "provider[\"registry.terraform.io/hashicorp/aws\"]" produced an
unexpected new value: .metadata_configuration: block count changed from 0 to 1.
```

This is not a regression from any commit here — it is a service-side change interacting with a provider schema bug.

AgentCore injects `allowed_request_headers = ["x-amzn-bedrock-agentcore-policy-session-id"]` on targets of a gateway that has a **policy engine attached**. Confirmed directly against the API: the same `CreateGatewayTarget` call against a gateway *without* a policy engine returns `metadataConfiguration: null`. The AWS provider declares that block `Optional` rather than `Computed`, so the injected value trips Terraform's post-apply consistency check and the apply fails.

This also explains the observed blast radius: only the two MCP targets on the Cedar gateway failed, while the HTTP agent targets on the non-Cedar `agent-gateway` created cleanly, and `cdk-deploy` kept passing (CloudFormation has no equivalent post-apply check).

**No Terraform configuration reconciles it.** Each of these was tested against the real API:

| Attempt | Result |
|---|---|
| Declare the injected header | Rejected by the provider validator (`X-Amzn-` prefix) *and* the API: "restricted and cannot be configured" |
| Declare a different header | Service appends its own → `length changed from 1 to 2` |
| Declare only `allowed_query_parameters` | `allowed_request_headers: was null, but now [...]` |
| Empty header list | API rejects: `valid min length: 1` |
| `lifecycle { ignore_changes }` | No effect — the consistency check runs before lifecycle rules |
| Re-run apply | Never converges: the failed resource is left **tainted**, so each retry destroys and recreates it and fails again |

**No provider version fixes it.** 6.58.0 (latest) and unreleased `main` both still declare the block `Optional` with no `Computed`/`PlanModifiers`. Downgrading is not an option either: the block landed in 6.34.0 but `aws_bedrockagentcore_policy_engine` only landed in 6.47.0, which already carries it — so every version that can express a Cedar gateway is affected. No upstream issue exists for this resource yet (the analogous `Optional`-vs-`Computed` bugs #45290 and #48159 are filed for sibling resources).

### Description of changes

- `generator-matrix.ts`: add an opt-in `cedarPolicy` option, threading `--cedarPolicy=false` to the two MCP gateways (`my-gateway`, `parent-gateway`). The `http` gateway is untouched — it has no policy engine by design.
- `terraform-smoke-test.ts`: opt out for the Terraform pipeline, with a comment explaining why and the condition for reverting. Applied at this shared entry point rather than per-spec because `terraform` (plan) and `terraform-deploy` (apply) share the same `main.tf.template`, so both must agree on whether the `policy_dependencies` variable exists. CDK callers are unaffected and keep Cedar.
- `main.tf.template`: drop the `policy_dependencies` wiring, which only exists on a Cedar gateway. `tool_dependencies` is retained — it is gated on `protocol === 'mcp'`, not on Cedar, and still gates `gateway_url` on target readiness for the chained-gateway case.
- Corrected comments that claimed Cedar enforcement on the Terraform path.

Cedar remains covered end-to-end by `cdk-deploy`. This is a deliberate, temporary reduction in Terraform e2e coverage; both the template and the harness carry a comment pointing at #1065, which tracks re-enabling the policy engine once the provider marks the block `Computed`.

### Description of how you validated changes

- **Reproduced the root cause in isolation**, outside this repo: a minimal Cedar-gateway + Lambda MCP target config fails with the identical error, and the same config without a policy engine applies cleanly. All probe resources were destroyed and verified gone.
- **Verified each workaround fails** as tabled above, via both `terraform apply` and direct `CreateGatewayTarget` calls.
- **Generated a real Terraform workspace** with the locally compiled plugin and confirmed the non-Cedar gateway module contains no `policy_dependencies`/`policy_engine` but retains `tool_dependencies`.
- **Ran the credential-free mocked plan** (the same `terraform test` the `terraform` job runs) against that workspace with the gateway and an MCP target wired in: `Success! 1 passed, 0 failed` — confirming the module graph resolves without `policy_dependencies`.
- Extended the existing `cedarPolicy: false (terraform)` unit test to assert this variable gating. `@aws/nx-plugin:test src/agentcore-gateway/generator.spec.ts` — 57 passed. `nx-plugin-e2e:lint` passes.

### Issue # (if applicable)

Tracked by #1065 — re-enable the Cedar policy engine in the Terraform e2e pipeline once the provider fix ships. Deliberately *not* `Closes`, since that issue must stay open until the coverage is restored.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
