### PR TITLE
fix(agentcore-gateway): wait for gateway role policy to propagate without Cedar

### DIFF
--- a/packages/nx-plugin/src/agentcore-gateway/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/agentcore-gateway/__snapshots__/generator.spec.ts.snap
@@ -9,6 +9,10 @@ exports[`agentcore-gateway generator > protocol: http > omits protocol_type from
       source  = "hashicorp/aws"
       version = "6.57.1"
     }
+    time = {
+      source  = "hashicorp/time"
+      version = "0.14.0"
+    }
     random = {
       source  = "hashicorp/random"
       version = "3.9.0"
@@ -85,6 +89,22 @@ resource "aws_iam_role_policy" "gateway_role_policy" {
   })
 }
 
+# IAM is eventually consistent, and the gateway assumes this role to reach its
+# targets — an MCP target fetches tools at creation time. Without this wait the
+# fetch intermittently runs before the policy above has propagated and the
+# target lands in FAILED with an authorization error.
+resource "time_sleep" "gateway_role_policy_propagation" {
+  count = length(var.additional_iam_policy_statements) > 0 ? 1 : 0
+
+  depends_on = [aws_iam_role_policy.gateway_role_policy]
+
+  create_duration = "30s"
+
+  triggers = {
+    policy = aws_iam_role_policy.gateway_role_policy[0].policy
+  }
+}
+
 resource "aws_bedrockagentcore_gateway" "this" {
   # Cap the name so the 11-char service suffix keeps the gateway id within its
   # 50-char limit (30 prefix + "-<8 hex>" + 11 = 50).
@@ -97,6 +117,8 @@ resource "aws_bedrockagentcore_gateway" "this" {
   # (\`/<targetName>/invocations\`).
 
   authorizer_type = "AWS_IAM"
+
+  depends_on = [time_sleep.gateway_role_policy_propagation]
 }
 
 # WAFv2 protection for the gateway. AgentCore Gateway requires a REGIONAL web

--- a/packages/nx-plugin/src/utils/agent-core-constructs/files/terraform/app/agentcore-gateway/__nameKebabCase__/__nameKebabCase__.tf.template
+++ b/packages/nx-plugin/src/utils/agent-core-constructs/files/terraform/app/agentcore-gateway/__nameKebabCase__/__nameKebabCase__.tf.template
@@ -11,11 +11,11 @@ terraform {
       source  = "hashicorp/external"
       version = "<%- externalProviderVersion %>"
     }
+<%_ } _%>
     time = {
       source  = "hashicorp/time"
       version = "<%- timeProviderVersion %>"
     }
-<%_ } _%>
     random = {
       source  = "hashicorp/random"
       version = "<%- randomProviderVersion %>"
@@ -168,6 +168,22 @@ resource "aws_iam_role_policy" "gateway_role_policy" {
     Statement = var.additional_iam_policy_statements
   })
 }
+
+# IAM is eventually consistent, and the gateway assumes this role to reach its
+# targets — an MCP target fetches tools at creation time. Without this wait the
+# fetch intermittently runs before the policy above has propagated and the
+# target lands in FAILED with an authorization error.
+resource "time_sleep" "gateway_role_policy_propagation" {
+  count = length(var.additional_iam_policy_statements) > 0 ? 1 : 0
+
+  depends_on = [aws_iam_role_policy.gateway_role_policy]
+
+  create_duration = "30s"
+
+  triggers = {
+    policy = aws_iam_role_policy.gateway_role_policy[0].policy
+  }
+}
 <%_ } _%>
 <%_ if (cedarPolicy) { _%>
 
@@ -215,9 +231,9 @@ resource "aws_bedrockagentcore_gateway" "this" {
     arn  = aws_bedrockagentcore_policy_engine.this.policy_engine_arn
     mode = "ENFORCE"
   }
+<%_ } _%>
 
   depends_on = [time_sleep.gateway_role_policy_propagation]
-<%_ } _%>
 }
 
 # WAFv2 protection for the gateway. AgentCore Gateway requires a REGIONAL web


### PR DESCRIPTION
### Reason for this change

`Smoke Tests - terraform-deploy` is still failing on `main` after #1064, now with a different error:

```
Error: creating Bedrock AgentCore Gateway Target
  with aws_bedrockagentcore_gateway_target.ts_mcp_server,
ID: 0IZ4CDMTGH
Cause: While waiting, unexpected state 'FAILED', wanted target 'READY'.
last error: Failed to connect and fetch tools from the provided MCP target
server. Error - Authorization error when sending message
```

The original `metadata_configuration` inconsistency from #1064 is gone — this is a second, latent bug that #1064 uncovered by generating the Terraform e2e gateways without a policy engine.

The `time_sleep.gateway_role_policy_propagation` resource, which lets the gateway role's inline policy propagate before the gateway is created, lived **inside the `cedarPolicy` branch** of the gateway template. On the non-Cedar branch the `aws_iam_role_policy` carrying the connection generators' `InvokeAgentRuntime*` statements was created with no propagation wait at all. IAM is eventually consistent and an MCP target fetches its tools at creation time, so that fetch could run before the policy was visible to the gateway — leaving the target in `FAILED`.

This is not e2e-only: it affects any user who generates a gateway with `--cedarPolicy=false` and connects an MCP server to it.

### Description of changes

- Add the same 30s propagation wait to the non-Cedar branch, `count`ed on `additional_iam_policy_statements` being non-empty so it is only created when there is a policy to wait for (mirroring the `aws_iam_role_policy` it guards).
- Move `depends_on = [time_sleep.gateway_role_policy_propagation]` on `aws_bedrockagentcore_gateway` out of the Cedar-only block so both branches wait. `depends_on` accepts a counted resource that expands to zero instances, so this is valid when the wait is absent.
- Move the `time` provider requirement out of the Cedar-only `required_providers` block, since both paths now use it. Verified exactly one declaration is emitted per variant (no duplication on the Cedar path).

### Description of how you validated changes

- Generated **both** variants against a real workspace with the locally compiled plugin: the non-Cedar module now contains the `time_sleep`, the `hashicorp/time` requirement and the `depends_on`; the Cedar module is unchanged apart from where the provider requirement is declared.
- Ran the credential-free mocked plan (the same `terraform test` the `terraform` job runs) with **both** gateways wired into one `main.tf`, including `additional_iam_policy_statements` populated so the counted `time_sleep` is actually instantiated: `Success! 1 passed, 0 failed`. Confirmed `terraform init` resolves `hashicorp/time v0.14.0` for the non-Cedar module.
- Full plugin unit suite: **3343 passed (177 files)**. One snapshot updated for the new block, reviewed line by line.

Note: `*-deploy` smoke tests do not run on PRs (the PR workflow excludes them) — they only run on `main` post-merge, so the end-to-end confirmation for this fix will come from the post-merge run.

### Issue # (if applicable)

Follow-up to #1064. Unblocks the same pipeline; #1065 continues to track re-enabling Cedar in the Terraform e2e once the provider bug is fixed.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*