### PR TITLE
fix: stop shipping toolchain warnings and a failing typecheck in generated workspaces

### DIFF
--- a/docs/src/content/docs/en/guides/docker-bundling.mdx
+++ b/docs/src/content/docs/en/guides/docker-bundling.mdx
@@ -109,7 +109,7 @@ export default defineConfig([
     output: {
       file: '../../dist/packages/my-project/bundle/index.js',
       format: 'cjs',
-      inlineDynamicImports: true,
+      codeSplitting: false,
     },
     platform: 'node',
   },

--- a/docs/src/content/docs/en/guides/nx-generator.mdx
+++ b/docs/src/content/docs/en/guides/nx-generator.mdx
@@ -497,7 +497,7 @@ Unit tests for generators are straightforward to implement. Here's a typical pat
 
 ```typescript
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
-import { yourGenerator } from './generator';
+import { yourGenerator } from './generator.js';
 
 describe('your generator', () => {
   let tree;

--- a/docs/src/content/docs/en/guides/nx-migration.mdx
+++ b/docs/src/content/docs/en/guides/nx-migration.mdx
@@ -97,7 +97,7 @@ The scaffolded `migration.spec.ts` uses `createTreeUsingTsSolutionSetup()` to bu
 ```ts
 import type { Tree } from '@nx/devkit';
 import { createTreeUsingTsSolutionSetup } from '@aws/nx-plugin/sdk/utils/test';
-import migration from './migration';
+import migration from './migration.js';
 
 describe('my migration', () => {
   let tree: Tree;

--- a/docs/src/content/docs/en/guides/typescript-project.mdx
+++ b/docs/src/content/docs/en/guides/typescript-project.mdx
@@ -292,7 +292,7 @@ export default defineConfig([
     output: {
       file: '../../dist/packages/my-library/bundle/index.js',
       format: 'cjs',
-      inlineDynamicImports: true,
+      codeSplitting: false,
     },
   },
 ]);

--- a/docs/src/content/docs/es/guides/docker-bundling.mdx
+++ b/docs/src/content/docs/es/guides/docker-bundling.mdx
@@ -109,7 +109,7 @@ export default defineConfig([
     output: {
       file: '../../dist/packages/my-project/bundle/index.js',
       format: 'cjs',
-      inlineDynamicImports: true,
+      codeSplitting: false,
     },
     platform: 'node',
   },

--- a/docs/src/content/docs/es/guides/nx-generator.mdx
+++ b/docs/src/content/docs/es/guides/nx-generator.mdx
@@ -477,7 +477,7 @@ Pruebas unitarias típicas:
 
 ```typescript
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
-import { yourGenerator } from './generator';
+import { yourGenerator } from './generator.js';
 
 describe('tu generador', () => {
   let tree;

--- a/docs/src/content/docs/es/guides/nx-migration.mdx
+++ b/docs/src/content/docs/es/guides/nx-migration.mdx
@@ -95,7 +95,7 @@ El `migration.spec.ts` generado usa `createTreeUsingTsSolutionSetup()` para cons
 ```ts
 import type { Tree } from '@nx/devkit';
 import { createTreeUsingTsSolutionSetup } from '@aws/nx-plugin/sdk/utils/test';
-import migration from './migration';
+import migration from './migration.js';
 
 describe('my migration', () => {
   let tree: Tree;

--- a/docs/src/content/docs/es/guides/typescript-project.mdx
+++ b/docs/src/content/docs/es/guides/typescript-project.mdx
@@ -293,7 +293,7 @@ export default defineConfig([
     output: {
       file: '../../dist/packages/my-library/bundle/index.js',
       format: 'cjs',
-      inlineDynamicImports: true,
+      codeSplitting: false,
     },
   },
 ]);

--- a/docs/src/content/docs/fr/guides/docker-bundling.mdx
+++ b/docs/src/content/docs/fr/guides/docker-bundling.mdx
@@ -109,7 +109,7 @@ export default defineConfig([
     output: {
       file: '../../dist/packages/my-project/bundle/index.js',
       format: 'cjs',
-      inlineDynamicImports: true,
+      codeSplitting: false,
     },
     platform: 'node',
   },

--- a/docs/src/content/docs/fr/guides/nx-generator.mdx
+++ b/docs/src/content/docs/fr/guides/nx-generator.mdx
@@ -497,7 +497,7 @@ Les tests unitaires pour les générateurs sont simples à implémenter. Voici u
 
 ```typescript
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
-import { yourGenerator } from './generator';
+import { yourGenerator } from './generator.js';
 
 describe('your generator', () => {
   let tree;

--- a/docs/src/content/docs/fr/guides/nx-migration.mdx
+++ b/docs/src/content/docs/fr/guides/nx-migration.mdx
@@ -96,7 +96,7 @@ Le fichier `migration.spec.ts` généré utilise `createTreeUsingTsSolutionSetup
 ```ts
 import type { Tree } from '@nx/devkit';
 import { createTreeUsingTsSolutionSetup } from '@aws/nx-plugin/sdk/utils/test';
-import migration from './migration';
+import migration from './migration.js';
 
 describe('my migration', () => {
   let tree: Tree;

--- a/docs/src/content/docs/fr/guides/typescript-project.mdx
+++ b/docs/src/content/docs/fr/guides/typescript-project.mdx
@@ -293,7 +293,7 @@ export default defineConfig([
     output: {
       file: '../../dist/packages/my-library/bundle/index.js',
       format: 'cjs',
-      inlineDynamicImports: true,
+      codeSplitting: false,
     },
   },
 ]);

--- a/docs/src/content/docs/it/guides/docker-bundling.mdx
+++ b/docs/src/content/docs/it/guides/docker-bundling.mdx
@@ -109,7 +109,7 @@ export default defineConfig([
     output: {
       file: '../../dist/packages/my-project/bundle/index.js',
       format: 'cjs',
-      inlineDynamicImports: true,
+      codeSplitting: false,
     },
     platform: 'node',
   },

--- a/docs/src/content/docs/it/guides/nx-generator.mdx
+++ b/docs/src/content/docs/it/guides/nx-generator.mdx
@@ -496,7 +496,7 @@ I test unitari per i generatori sono semplici da implementare. Ecco un pattern t
 
 ```typescript
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
-import { yourGenerator } from './generator';
+import { yourGenerator } from './generator.js';
 
 describe('your generator', () => {
   let tree;

--- a/docs/src/content/docs/it/guides/nx-migration.mdx
+++ b/docs/src/content/docs/it/guides/nx-migration.mdx
@@ -96,7 +96,7 @@ Il `migration.spec.ts` generato utilizza `createTreeUsingTsSolutionSetup()` per 
 ```ts
 import type { Tree } from '@nx/devkit';
 import { createTreeUsingTsSolutionSetup } from '@aws/nx-plugin/sdk/utils/test';
-import migration from './migration';
+import migration from './migration.js';
 
 describe('my migration', () => {
   let tree: Tree;

--- a/docs/src/content/docs/it/guides/typescript-project.mdx
+++ b/docs/src/content/docs/it/guides/typescript-project.mdx
@@ -293,7 +293,7 @@ export default defineConfig([
     output: {
       file: '../../dist/packages/my-library/bundle/index.js',
       format: 'cjs',
-      inlineDynamicImports: true,
+      codeSplitting: false,
     },
   },
 ]);

--- a/docs/src/content/docs/jp/guides/docker-bundling.mdx
+++ b/docs/src/content/docs/jp/guides/docker-bundling.mdx
@@ -109,7 +109,7 @@ export default defineConfig([
     output: {
       file: '../../dist/packages/my-project/bundle/index.js',
       format: 'cjs',
-      inlineDynamicImports: true,
+      codeSplitting: false,
     },
     platform: 'node',
   },

--- a/docs/src/content/docs/jp/guides/nx-generator.mdx
+++ b/docs/src/content/docs/jp/guides/nx-generator.mdx
@@ -478,7 +478,7 @@ VSCodeプラグインUIにジェネレータが表示されない場合：
 
 ```typescript
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
-import { yourGenerator } from './generator';
+import { yourGenerator } from './generator.js';
 
 describe('your generator', () => {
   let tree;

--- a/docs/src/content/docs/jp/guides/nx-migration.mdx
+++ b/docs/src/content/docs/jp/guides/nx-migration.mdx
@@ -96,7 +96,7 @@ export default async function migration(
 ```ts
 import type { Tree } from '@nx/devkit';
 import { createTreeUsingTsSolutionSetup } from '@aws/nx-plugin/sdk/utils/test';
-import migration from './migration';
+import migration from './migration.js';
 
 describe('my migration', () => {
   let tree: Tree;

--- a/docs/src/content/docs/jp/guides/typescript-project.mdx
+++ b/docs/src/content/docs/jp/guides/typescript-project.mdx
@@ -292,7 +292,7 @@ export default defineConfig([
     output: {
       file: '../../dist/packages/my-library/bundle/index.js',
       format: 'cjs',
-      inlineDynamicImports: true,
+      codeSplitting: false,
     },
   },
 ]);

--- a/docs/src/content/docs/ko/guides/docker-bundling.mdx
+++ b/docs/src/content/docs/ko/guides/docker-bundling.mdx
@@ -109,7 +109,7 @@ export default defineConfig([
     output: {
       file: '../../dist/packages/my-project/bundle/index.js',
       format: 'cjs',
-      inlineDynamicImports: true,
+      codeSplitting: false,
     },
     platform: 'node',
   },

--- a/docs/src/content/docs/ko/guides/nx-generator.mdx
+++ b/docs/src/content/docs/ko/guides/nx-generator.mdx
@@ -497,7 +497,7 @@ VSCode 플러그인 UI에 제너레이터가 표시되지 않으면 다음 명�
 
 ```typescript
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
-import { yourGenerator } from './generator';
+import { yourGenerator } from './generator.js';
 
 describe('your generator', () => {
   let tree;

--- a/docs/src/content/docs/ko/guides/nx-migration.mdx
+++ b/docs/src/content/docs/ko/guides/nx-migration.mdx
@@ -96,7 +96,7 @@ export default async function migration(
 ```ts
 import type { Tree } from '@nx/devkit';
 import { createTreeUsingTsSolutionSetup } from '@aws/nx-plugin/sdk/utils/test';
-import migration from './migration';
+import migration from './migration.js';
 
 describe('my migration', () => {
   let tree: Tree;

--- a/docs/src/content/docs/ko/guides/typescript-project.mdx
+++ b/docs/src/content/docs/ko/guides/typescript-project.mdx
@@ -292,7 +292,7 @@ export default defineConfig([
     output: {
       file: '../../dist/packages/my-library/bundle/index.js',
       format: 'cjs',
-      inlineDynamicImports: true,
+      codeSplitting: false,
     },
   },
 ]);

--- a/docs/src/content/docs/pt/guides/docker-bundling.mdx
+++ b/docs/src/content/docs/pt/guides/docker-bundling.mdx
@@ -109,7 +109,7 @@ export default defineConfig([
     output: {
       file: '../../dist/packages/my-project/bundle/index.js',
       format: 'cjs',
-      inlineDynamicImports: true,
+      codeSplitting: false,
     },
     platform: 'node',
   },

--- a/docs/src/content/docs/pt/guides/nx-generator.mdx
+++ b/docs/src/content/docs/pt/guides/nx-generator.mdx
@@ -494,7 +494,7 @@ Testes unitários seguem este padrão:
 
 ```typescript
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
-import { yourGenerator } from './generator';
+import { yourGenerator } from './generator.js';
 
 describe('your generator', () => {
   let tree;

--- a/docs/src/content/docs/pt/guides/nx-migration.mdx
+++ b/docs/src/content/docs/pt/guides/nx-migration.mdx
@@ -95,7 +95,7 @@ O `migration.spec.ts` gerado usa `createTreeUsingTsSolutionSetup()` para constru
 ```ts
 import type { Tree } from '@nx/devkit';
 import { createTreeUsingTsSolutionSetup } from '@aws/nx-plugin/sdk/utils/test';
-import migration from './migration';
+import migration from './migration.js';
 
 describe('my migration', () => {
   let tree: Tree;

--- a/docs/src/content/docs/pt/guides/typescript-project.mdx
+++ b/docs/src/content/docs/pt/guides/typescript-project.mdx
@@ -293,7 +293,7 @@ export default defineConfig([
     output: {
       file: '../../dist/packages/my-library/bundle/index.js',
       format: 'cjs',
-      inlineDynamicImports: true,
+      codeSplitting: false,
     },
   },
 ]);

--- a/docs/src/content/docs/vi/guides/docker-bundling.mdx
+++ b/docs/src/content/docs/vi/guides/docker-bundling.mdx
@@ -109,7 +109,7 @@ export default defineConfig([
     output: {
       file: '../../dist/packages/my-project/bundle/index.js',
       format: 'cjs',
-      inlineDynamicImports: true,
+      codeSplitting: false,
     },
     platform: 'node',
   },

--- a/docs/src/content/docs/vi/guides/nx-generator.mdx
+++ b/docs/src/content/docs/vi/guides/nx-generator.mdx
@@ -497,7 +497,7 @@ Các bài kiểm tra đơn vị cho generators rất đơn giản để triển 
 
 ```typescript
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
-import { yourGenerator } from './generator';
+import { yourGenerator } from './generator.js';
 
 describe('your generator', () => {
   let tree;

--- a/docs/src/content/docs/vi/guides/nx-migration.mdx
+++ b/docs/src/content/docs/vi/guides/nx-migration.mdx
@@ -95,7 +95,7 @@ Migrations chạy trên các workspace mà bạn không kiểm soát, vì vậy 
 ```ts
 import type { Tree } from '@nx/devkit';
 import { createTreeUsingTsSolutionSetup } from '@aws/nx-plugin/sdk/utils/test';
-import migration from './migration';
+import migration from './migration.js';
 
 describe('my migration', () => {
   let tree: Tree;

--- a/docs/src/content/docs/vi/guides/typescript-project.mdx
+++ b/docs/src/content/docs/vi/guides/typescript-project.mdx
@@ -293,7 +293,7 @@ export default defineConfig([
     output: {
       file: '../../dist/packages/my-library/bundle/index.js',
       format: 'cjs',
-      inlineDynamicImports: true,
+      codeSplitting: false,
     },
   },
 ]);

--- a/docs/src/content/docs/zh/guides/docker-bundling.mdx
+++ b/docs/src/content/docs/zh/guides/docker-bundling.mdx
@@ -109,7 +109,7 @@ export default defineConfig([
     output: {
       file: '../../dist/packages/my-project/bundle/index.js',
       format: 'cjs',
-      inlineDynamicImports: true,
+      codeSplitting: false,
     },
     platform: 'node',
   },

--- a/docs/src/content/docs/zh/guides/nx-generator.mdx
+++ b/docs/src/content/docs/zh/guides/nx-generator.mdx
@@ -497,7 +497,7 @@ export const myOperationNames = [
 
 ```typescript
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
-import { yourGenerator } from './generator';
+import { yourGenerator } from './generator.js';
 
 describe('生成器测试', () => {
   let tree;

--- a/docs/src/content/docs/zh/guides/nx-migration.mdx
+++ b/docs/src/content/docs/zh/guides/nx-migration.mdx
@@ -96,7 +96,7 @@ export default async function migration(
 ```ts
 import type { Tree } from '@nx/devkit';
 import { createTreeUsingTsSolutionSetup } from '@aws/nx-plugin/sdk/utils/test';
-import migration from './migration';
+import migration from './migration.js';
 
 describe('my migration', () => {
   let tree: Tree;

--- a/docs/src/content/docs/zh/guides/typescript-project.mdx
+++ b/docs/src/content/docs/zh/guides/typescript-project.mdx
@@ -293,7 +293,7 @@ export default defineConfig([
     output: {
       file: '../../dist/packages/my-library/bundle/index.js',
       format: 'cjs',
-      inlineDynamicImports: true,
+      codeSplitting: false,
     },
   },
 ]);

--- a/packages/nx-plugin-mcp/rolldown.config.mjs
+++ b/packages/nx-plugin-mcp/rolldown.config.mjs
@@ -15,7 +15,6 @@ export default defineConfig({
     entryFileNames: 'aws-nx-mcp.js',
     format: 'cjs',
     // Keep the bundle self-contained — the published binary ships alone.
-    inlineDynamicImports: true,
     codeSplitting: false,
   },
   platform: 'node',

--- a/packages/nx-plugin/src/mcp-server/guide-pipeline.ts
+++ b/packages/nx-plugin/src/mcp-server/guide-pipeline.ts
@@ -56,7 +56,7 @@ export interface PipelineOptions {
 }
 
 // unified v11 is ESM-only and this package is CJS; dynamic import + rolldown's
-// inlineDynamicImports bundles everything into the published MCP binary.
+// `codeSplitting: false` bundles everything into the published MCP binary.
 interface RemarkDeps {
   unified: typeof import('unified').unified;
   remarkParse: typeof import('remark-parse').default;

--- a/packages/nx-plugin/src/migrations/latest/rolldown-code-splitting/metadata.json
+++ b/packages/nx-plugin/src/migrations/latest/rolldown-code-splitting/metadata.json
@@ -1,0 +1,3 @@
+{
+  "description": "Replace the deprecated inlineDynamicImports rolldown output option with codeSplitting"
+}

--- a/packages/nx-plugin/src/migrations/latest/rolldown-code-splitting/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/latest/rolldown-code-splitting/migration.spec.ts
@@ -1,0 +1,141 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { addProjectConfiguration, type Tree } from '@nx/devkit';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test';
+import migration from './migration';
+
+const CONFIG = 'apps/test-project/rolldown.config.ts';
+
+/**
+ * A `rolldown.config.ts` as an older release generated it, with two bundle
+ * entries. Hardcoded rather than produced by the bundle helper: a migration has
+ * to keep applying to the shape that shipped, however far the generator's output
+ * moves afterwards.
+ */
+const OLD_CONFIG = `import { defineConfig } from 'rolldown';
+
+export default defineConfig([
+  {
+    tsconfig: 'tsconfig.lib.json',
+    input: 'src/index.ts',
+    output: {
+      file: '../../dist/apps/test-project/bundle/index.js',
+      format: 'cjs',
+      inlineDynamicImports: true,
+    },
+    platform: 'node',
+  },
+  {
+    tsconfig: 'tsconfig.lib.json',
+    input: 'src/handler.ts',
+    output: {
+      file: '../../dist/apps/test-project/bundle/handler/index.js',
+      format: 'cjs',
+      inlineDynamicImports: true,
+    },
+    platform: 'node',
+    external: [/@aws-sdk\\/.*/],
+  },
+]);
+`;
+
+const read = (tree: Tree, path: string): string =>
+  tree.read(path, 'utf-8') ?? '';
+
+const givenConfig = (tree: Tree, contents: string): void => {
+  addProjectConfiguration(tree, 'test-project', {
+    root: 'apps/test-project',
+    sourceRoot: 'apps/test-project/src',
+  });
+  tree.write(CONFIG, contents);
+};
+
+describe('rolldown-code-splitting migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeUsingTsSolutionSetup();
+  });
+
+  it('should rewrite every entry an older release generated', async () => {
+    givenConfig(tree, OLD_CONFIG);
+
+    await migration(tree);
+
+    const config = read(tree, CONFIG);
+    expect(config).not.toContain('inlineDynamicImports');
+    // Both bundle entries, so the option is rewritten wherever it appears.
+    expect(config.match(/codeSplitting: false/g)).toHaveLength(2);
+  });
+
+  it('should drop the deprecated option where codeSplitting is already set', async () => {
+    givenConfig(
+      tree,
+      OLD_CONFIG.replaceAll(
+        'inlineDynamicImports: true,',
+        'inlineDynamicImports: true,\n      codeSplitting: false,',
+      ),
+    );
+
+    await migration(tree);
+
+    const config = read(tree, CONFIG);
+    // Renaming rather than dropping would leave the key in twice.
+    expect(config).not.toContain('inlineDynamicImports');
+    expect(config.match(/codeSplitting: false/g)).toHaveLength(2);
+  });
+
+  it('should leave inlineDynamicImports: false alone', async () => {
+    // The opposite request — a user who set this deliberately keeps it.
+    givenConfig(
+      tree,
+      OLD_CONFIG.replaceAll(
+        'inlineDynamicImports: true',
+        'inlineDynamicImports: false',
+      ),
+    );
+
+    await migration(tree);
+
+    const config = read(tree, CONFIG);
+    expect(config).toContain('inlineDynamicImports: false');
+    expect(config).not.toContain('codeSplitting');
+  });
+
+  it('should leave an object of the user own that carries the same key alone', async () => {
+    givenConfig(
+      tree,
+      `const buildOptions = { inlineDynamicImports: true };\n${OLD_CONFIG.replaceAll(
+        '      inlineDynamicImports: true,\n',
+        '',
+      )}`,
+    );
+
+    await migration(tree);
+
+    // Only a rolldown `output` block is rewritten.
+    expect(read(tree, CONFIG)).toContain(
+      'const buildOptions = { inlineDynamicImports: true }',
+    );
+  });
+
+  it('should not produce a doubled comma', async () => {
+    givenConfig(tree, OLD_CONFIG);
+
+    await migration(tree);
+
+    expect(read(tree, CONFIG)).not.toMatch(/,\s*,/);
+  });
+
+  it('should be idempotent', async () => {
+    givenConfig(tree, OLD_CONFIG);
+
+    await migration(tree);
+    const afterFirst = read(tree, CONFIG);
+    await migration(tree);
+
+    expect(read(tree, CONFIG)).toBe(afterFirst);
+  });
+});

--- a/packages/nx-plugin/src/migrations/latest/rolldown-code-splitting/migration.ts
+++ b/packages/nx-plugin/src/migrations/latest/rolldown-code-splitting/migration.ts
@@ -1,0 +1,69 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import {
+  getProjects,
+  joinPathFragments,
+  type MigrationReturnObject,
+  type Tree,
+} from '@nx/devkit';
+import { applyGritQL } from '../../../utils/ast';
+import { formatFilesInSubtree } from '../../../utils/format';
+
+/**
+ * Move generated rolldown configs onto `codeSplitting: false`.
+ *
+ * rolldown deprecated the `inlineDynamicImports` output option in favour of
+ * `codeSplitting`, and warns once per bundle entry — so a workspace with several
+ * bundled projects printed the warning many times over on every build. Both
+ * spellings ask for the same thing: the whole bundle in a single file, which is
+ * what the vended Lambda and container bundles need.
+ *
+ * Guardrails:
+ * - Both patterns are anchored to a rolldown `output` object and scoped with
+ *   `some` to its direct properties, so an object of the user's own that happens
+ *   to carry the same key is left alone. `inlineDynamicImports: false` is also
+ *   left alone: it means the opposite, so a user who set it deliberately keeps it.
+ * - Where an output already carries `codeSplitting`, the deprecated option is
+ *   dropped rather than renamed, so the rewrite can't produce a duplicate key.
+ * - Idempotent: neither pattern matches once the option is gone.
+ */
+
+/**
+ * Rename the deprecated option, where the output does not already set
+ * `codeSplitting`.
+ */
+const RENAME_PATTERN = `\`output: { $props }\` where {
+  $props <: some \`inlineDynamicImports: true\` as $deprecated,
+  $props <: not some \`codeSplitting: $_\`,
+  $deprecated => \`codeSplitting: false\`
+}`;
+
+/**
+ * Drop the deprecated option where `codeSplitting` is already set — renaming it
+ * would leave the output with the key twice.
+ */
+const DROP_PATTERN = `\`output: { $props }\` where {
+  $props <: some \`codeSplitting: $_\`,
+  $props <: some \`inlineDynamicImports: true\` as $deprecated,
+  $deprecated => .
+}`;
+
+export default async function migration(
+  tree: Tree,
+): Promise<MigrationReturnObject> {
+  for (const project of getProjects(tree).values()) {
+    const configPath = joinPathFragments(project.root, 'rolldown.config.ts');
+    if (!tree.exists(configPath)) {
+      continue;
+    }
+    for (const pattern of [RENAME_PATTERN, DROP_PATTERN]) {
+      await applyGritQL(tree, configPath, pattern);
+    }
+  }
+
+  await formatFilesInSubtree(tree);
+
+  return {};
+}

--- a/packages/nx-plugin/src/migrations/latest/vite-config-import-meta-dirname/metadata.json
+++ b/packages/nx-plugin/src/migrations/latest/vite-config-import-meta-dirname/metadata.json
@@ -1,0 +1,3 @@
+{
+  "description": "Resolve vite and vitest config paths from import.meta.dirname rather than __dirname"
+}

--- a/packages/nx-plugin/src/migrations/latest/vite-config-import-meta-dirname/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/latest/vite-config-import-meta-dirname/migration.spec.ts
@@ -1,0 +1,188 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { addProjectConfiguration, type Tree } from '@nx/devkit';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test';
+import migration from './migration';
+
+const LIB_CONFIG = 'packages/lib/vitest.config.mts';
+const WEBSITE_CONFIG = 'packages/website/vite.config.mts';
+
+/**
+ * A library's `vitest.config.mts` as an older release generated it. Hardcoded
+ * rather than produced by the generator: a migration has to keep applying to the
+ * shape that shipped, however far the generator's output moves afterwards.
+ */
+const OLD_LIB_CONFIG = `import { defineConfig } from 'vitest/config';
+
+export default defineConfig(() => ({
+  root: __dirname,
+  cacheDir: '../../node_modules/.vite/packages/lib',
+  test: {
+    passWithNoTests: true,
+    name: '@proj/lib',
+    watch: false,
+    globals: true,
+    environment: 'jsdom',
+    reporters: ['default'],
+    coverage: {
+      reportsDirectory: './test-output/vitest/coverage',
+      provider: 'v8' as const,
+    },
+  },
+}));
+`;
+
+/** A website's `vite.config.mts` as an older release generated it. */
+const OLD_WEBSITE_CONFIG = `import tailwindcss from '@tailwindcss/vite';
+import { resolve } from 'path';
+import { tanstackRouter } from '@tanstack/router-plugin/vite';
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig(() => ({
+  root: __dirname,
+  cacheDir: '../../node_modules/.vite/packages/website',
+  plugins: [
+    tanstackRouter({
+      routesDirectory: resolve(__dirname, 'src/routes'),
+      generatedRouteTree: resolve(__dirname, 'src/routeTree.gen.ts'),
+    }),
+    react(),
+    tailwindcss(),
+  ],
+  build: {
+    outDir: '../../dist/packages/website/bundle',
+  },
+}));
+`;
+
+const read = (tree: Tree, path: string): string =>
+  tree.read(path, 'utf-8') ?? '';
+
+/** Register a project and write the given config into it. */
+const givenProject = (tree: Tree, name: string, config: string): void => {
+  const root = `packages/${name}`;
+  addProjectConfiguration(tree, `@proj/${name}`, {
+    root,
+    sourceRoot: `${root}/src`,
+  });
+  const configFile =
+    name === 'website' ? 'vite.config.mts' : 'vitest.config.mts';
+  tree.write(`${root}/${configFile}`, config);
+};
+
+const givenOldWorkspace = (tree: Tree): void => {
+  givenProject(tree, 'lib', OLD_LIB_CONFIG);
+  givenProject(tree, 'website', OLD_WEBSITE_CONFIG);
+};
+
+describe('vite-config-import-meta-dirname migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeUsingTsSolutionSetup();
+  });
+
+  it('should rewrite the config root an older release generated', async () => {
+    givenOldWorkspace(tree);
+
+    await migration(tree);
+
+    expect(read(tree, LIB_CONFIG)).toContain('root: import.meta.dirname');
+    expect(read(tree, LIB_CONFIG)).not.toContain('__dirname,');
+  });
+
+  it('should rewrite the router paths the website resolves', async () => {
+    givenOldWorkspace(tree);
+
+    await migration(tree);
+
+    const config = read(tree, WEBSITE_CONFIG);
+    expect(config).toContain(`resolve(import.meta.dirname, 'src/routes')`);
+    expect(config).toContain(
+      `resolve(import.meta.dirname, 'src/routeTree.gen.ts')`,
+    );
+    expect(config).not.toContain('__dirname');
+  });
+
+  it('should leave a root nested inside another option alone', async () => {
+    givenProject(
+      tree,
+      'lib',
+      OLD_LIB_CONFIG.replace(
+        `    reporters: ['default'],`,
+        `    reporters: ['default'],\n    alias: { root: __dirname },`,
+      ),
+    );
+
+    await migration(tree);
+
+    const config = read(tree, LIB_CONFIG);
+    // Only the config object's own `root` is the one Vite reads.
+    expect(config).toContain('root: import.meta.dirname');
+    expect(config).toContain('alias: { root: __dirname }');
+  });
+
+  it('should leave a __dirname the user resolves elsewhere alone', async () => {
+    givenProject(
+      tree,
+      'website',
+      OLD_WEBSITE_CONFIG.replace(
+        `  build: {`,
+        `  test: { setupFiles: resolve(__dirname, 'test/setup.ts') },\n  build: {`,
+      ),
+    );
+
+    await migration(tree);
+
+    const config = read(tree, WEBSITE_CONFIG);
+    expect(config).toContain(`resolve(__dirname, 'test/setup.ts')`);
+    expect(config).toContain(`resolve(import.meta.dirname, 'src/routes')`);
+  });
+
+  it('should leave a router path the user repointed alone', async () => {
+    givenProject(
+      tree,
+      'website',
+      OLD_WEBSITE_CONFIG.replace(`'src/routes'`, `'src/my-routes'`),
+    );
+
+    await migration(tree);
+
+    const config = read(tree, WEBSITE_CONFIG);
+    expect(config).toContain(`resolve(__dirname, 'src/my-routes')`);
+    // The option they left alone still gets the fix.
+    expect(config).toContain(
+      `resolve(import.meta.dirname, 'src/routeTree.gen.ts')`,
+    );
+  });
+
+  it('should leave a config without the generated shape alone', async () => {
+    givenProject(
+      tree,
+      'lib',
+      OLD_LIB_CONFIG.replace('root: __dirname', 'root: process.cwd()'),
+    );
+
+    await migration(tree);
+
+    expect(read(tree, LIB_CONFIG)).toContain('root: process.cwd()');
+    expect(read(tree, LIB_CONFIG)).not.toContain('import.meta.dirname');
+  });
+
+  it('should be idempotent', async () => {
+    givenOldWorkspace(tree);
+
+    await migration(tree);
+    const afterFirst = [LIB_CONFIG, WEBSITE_CONFIG].map((path) =>
+      read(tree, path),
+    );
+    await migration(tree);
+
+    expect(
+      [LIB_CONFIG, WEBSITE_CONFIG].map((path) => read(tree, path)),
+    ).toEqual(afterFirst);
+  });
+});

--- a/packages/nx-plugin/src/migrations/latest/vite-config-import-meta-dirname/migration.ts
+++ b/packages/nx-plugin/src/migrations/latest/vite-config-import-meta-dirname/migration.ts
@@ -1,0 +1,85 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import {
+  getProjects,
+  joinPathFragments,
+  type MigrationReturnObject,
+  type Tree,
+} from '@nx/devkit';
+import { applyGritQL } from '../../../utils/ast';
+import { formatFilesInSubtree } from '../../../utils/format';
+
+/**
+ * Resolve the vended vite and vitest config paths from `import.meta.dirname`
+ * rather than `__dirname`.
+ *
+ * `__dirname` is unavailable to Vite's native config loader, so every generated
+ * TypeScript project's config warned that it "uses features that are unsupported
+ * by `configLoader: 'native'`". That loader is slated to become the default, at
+ * which point the config breaks rather than warns.
+ *
+ * Two shapes are rewritten: the `root` that `@nx/js` writes into every project's
+ * config, and the two paths `ts#react-website` passes to the TanStack Router
+ * plugin.
+ *
+ * Guardrails:
+ * - Every pattern is anchored to the exact shape the generators produce, and
+ *   scoped with `some` so it only matches a direct property of the object it
+ *   names. A `root` nested inside another option, or a `resolve(__dirname, ...)`
+ *   the user wrote anywhere else in the config, is left alone.
+ * - The router paths are matched by option name *and* path literal, so a user who
+ *   pointed one somewhere else keeps their value.
+ * - Idempotent: no pattern matches once rewritten.
+ */
+
+/**
+ * The `root` of the object the config factory returns. `some` matches a direct
+ * property only, so a nested `root` (a `test.alias` entry, say) is not touched.
+ */
+const ROOT_PATTERN = `\`defineConfig(() => ({ $props }))\` where {
+  $props <: some \`root: __dirname\` as $root,
+  $root => \`root: import.meta.dirname\`
+}`;
+
+/**
+ * One of the TanStack Router plugin's path options, matched by name and by the
+ * path the generator passes — so a user who repointed it keeps their value.
+ * Scoped to the plugin's own option object rather than the file, so a
+ * `resolve(__dirname, ...)` elsewhere in the config is left alone.
+ */
+const routerPathPattern = (option: string, path: string): string =>
+  `\`tanstackRouter({ $opts })\` where {
+     $opts <: some \`${option}: resolve(__dirname, '${path}')\` as $path,
+     $path => \`${option}: resolve(import.meta.dirname, '${path}')\`
+   }`;
+
+/** The paths `ts#react-website` gives the TanStack Router plugin. */
+const ROUTER_PATTERNS = [
+  routerPathPattern('routesDirectory', 'src/routes'),
+  routerPathPattern('generatedRouteTree', 'src/routeTree.gen.ts'),
+];
+
+/** The config filenames a generated project may carry. */
+const CONFIG_FILES = ['vitest.config.mts', 'vite.config.mts'];
+
+export default async function migration(
+  tree: Tree,
+): Promise<MigrationReturnObject> {
+  for (const project of getProjects(tree).values()) {
+    for (const configFile of CONFIG_FILES) {
+      const configPath = joinPathFragments(project.root, configFile);
+      if (!tree.exists(configPath)) {
+        continue;
+      }
+      for (const pattern of [ROOT_PATTERN, ...ROUTER_PATTERNS]) {
+        await applyGritQL(tree, configPath, pattern);
+      }
+    }
+  }
+
+  await formatFilesInSubtree(tree);
+
+  return {};
+}

--- a/packages/nx-plugin/src/py/rdb/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/rdb/__snapshots__/generator.spec.ts.snap
@@ -947,7 +947,7 @@ from sqlalchemy.ext.asyncio import create_async_engine
 from sqlmodel import SQLModel
 
 # Import all models to register them in SQLModel.metadata
-from proj_db.models import *  # noqa: F401, F403
+from proj_db.models import *  # noqa: F403
 
 config = context.config
 

--- a/packages/nx-plugin/src/py/rdb/files/migrations/env.py.template
+++ b/packages/nx-plugin/src/py/rdb/files/migrations/env.py.template
@@ -9,7 +9,7 @@ from sqlalchemy.ext.asyncio import create_async_engine
 from sqlmodel import SQLModel
 
 # Import all models to register them in SQLModel.metadata
-from <%= name %>.models import *  # noqa: F401, F403
+from <%= name %>.models import *  # noqa: F403
 
 config = context.config
 

--- a/packages/nx-plugin/src/py/rdb/generator.spec.ts
+++ b/packages/nx-plugin/src/py/rdb/generator.spec.ts
@@ -63,6 +63,13 @@ describe('py#rdb generator', () => {
     expect(pyproject).toContain(withPyVersions(DEPENDENCIES, ['alembic'])[0]);
     expect(pyproject).toContain(withPyVersions(DEPENDENCIES, ['asyncpg'])[0]);
     expect(pyproject).not.toContain('psycopg');
+
+    // A wildcard import raises F403, not F401, so suppressing F401 as well is
+    // dead — and ruff's own RUF100 rule reports it as unused.
+    expect(tree.read('packages/db/migrations/env.py', 'utf-8')).toContain(
+      'import *  # noqa: F403',
+    );
+
     expect(projectConfig.targets['bundle-arm']).toEqual({
       cache: true,
       inputs: ['default', '^production'],

--- a/packages/nx-plugin/src/ts/lib/__snapshots__/vitest.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/lib/__snapshots__/vitest.spec.ts.snap
@@ -4,7 +4,7 @@ exports[`vitest utils > should generate a valid vitest.config.mts without a doub
 "import { defineConfig } from 'vitest/config';
 
 export default defineConfig(() => ({
-  root: __dirname,
+  root: import.meta.dirname,
   cacheDir: '../node_modules/.vite/test',
   test: {
     passWithNoTests: true,

--- a/packages/nx-plugin/src/ts/lib/vitest.spec.ts
+++ b/packages/nx-plugin/src/ts/lib/vitest.spec.ts
@@ -46,6 +46,22 @@ describe('vitest utils', () => {
     expect(content).toContain('passWithNoTests: true');
   });
 
+  it('should resolve the config root from import.meta.dirname', async () => {
+    await configureVitest(
+      tree,
+      {
+        dir: 'test',
+        fullyQualifiedName: 'test',
+      },
+      declaration,
+    );
+    const content = tree.read('test/vitest.config.mts', 'utf8');
+    // `@nx/js` writes `root: __dirname`, which Vite warns about under
+    // `configLoader: 'native'` and will reject once that becomes the default.
+    expect(content).toContain('root: import.meta.dirname');
+    expect(content).not.toContain('root: __dirname');
+  });
+
   it('should generate a valid vitest.config.mts without a double comma', () => {
     const content = tree.read('test/vitest.config.mts', 'utf8');
     // Guards against the grit transform emitting `},,` when the matched

--- a/packages/nx-plugin/src/ts/lib/vitest.ts
+++ b/packages/nx-plugin/src/ts/lib/vitest.ts
@@ -21,6 +21,19 @@ const readGritPattern = (name: string): string =>
     'utf-8',
   ).trim();
 
+/**
+ * Resolve the config's `root` from `import.meta.dirname`.
+ *
+ * `@nx/js` writes `root: __dirname`, which Vite's native config loader does not
+ * provide — it warns today and will reject once `configLoader: 'native'` becomes
+ * the default. Scoped with `some` to a direct property of the object the config
+ * factory returns, so a nested `root` (a `test.alias` entry, say) is untouched.
+ */
+const ROOT_IMPORT_META_DIRNAME = `\`defineConfig(() => ({ $props }))\` where {
+  $props <: some \`root: __dirname\` as $root,
+  $root => \`root: import.meta.dirname\`
+}`;
+
 /** Dependencies a caller must declare to configure vitest. */
 export const VITEST_DEPENDENCIES = [
   { name: 'vite' },
@@ -45,6 +58,8 @@ export const configureVitest = async <const D extends DependencyDeclaration>(
       configPath,
       readGritPattern('vitest-pass-with-no-tests'),
     );
+
+    await applyGritQL(tree, configPath, ROOT_IMPORT_META_DIRNAME);
 
     const nxJson = readNxJson(tree);
     updateNxJson(tree, {

--- a/packages/nx-plugin/src/ts/nx-generator/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/nx-generator/__snapshots__/generator.spec.ts.snap
@@ -206,7 +206,7 @@ exports[`nx-generator generator > within @aws/nx-plugin > should update generato
 exports[`nx-generator generator > within another workspace > should generate an example schema, generator and test > local-generator.spec.ts 1`] = `
 "import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import { Tree } from '@nx/devkit';
-import { fooBarGenerator } from './generator';
+import { fooBarGenerator } from './generator.js';
 
 describe('foo#bar generator', () => {
   let tree: Tree;

--- a/packages/nx-plugin/src/ts/nx-generator/files/local/generator.spec.ts.template
+++ b/packages/nx-plugin/src/ts/nx-generator/files/local/generator.spec.ts.template
@@ -1,6 +1,6 @@
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import { Tree } from '@nx/devkit';
-import { <%- nameCamelCase %>Generator } from './generator';
+import { <%- nameCamelCase %>Generator } from './generator<% if (esm) { %>.js<% } %>';
 
 describe('<%- name %> generator', () => {
   let tree: Tree;

--- a/packages/nx-plugin/src/ts/nx-generator/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/nx-generator/generator.spec.ts
@@ -572,6 +572,37 @@ describe('nx-generator generator', () => {
       ).toMatchSnapshot('local-generator.spec.ts');
     });
 
+    it('should import the generator with a .js extension in an ESM workspace', async () => {
+      await tsNxGeneratorGenerator(tree, {
+        project: '@test/plugin',
+        name: 'foo#bar',
+        description: 'Some description',
+      });
+
+      // `nodenext` resolution requires the explicit extension, so an
+      // extensionless relative import fails `typecheck` with TS2835.
+      expect(
+        tree.read('tools/plugin/src/foo-bar/generator.spec.ts', 'utf-8'),
+      ).toContain(`from './generator.js'`);
+    });
+
+    it('should import the generator without an extension in a CommonJS workspace', async () => {
+      writeJson(tree, 'package.json', {
+        name: '@myorg/monorepo',
+        type: 'commonjs',
+      });
+
+      await tsNxGeneratorGenerator(tree, {
+        project: '@test/plugin',
+        name: 'foo#bar',
+        description: 'Some description',
+      });
+
+      expect(
+        tree.read('tools/plugin/src/foo-bar/generator.spec.ts', 'utf-8'),
+      ).toContain(`from './generator'`);
+    });
+
     it('should support a nested directory', async () => {
       await tsNxGeneratorGenerator(tree, {
         project: '@test/plugin',

--- a/packages/nx-plugin/src/ts/nx-migration/files/migration.spec.ts.template
+++ b/packages/nx-plugin/src/ts/nx-migration/files/migration.spec.ts.template
@@ -1,6 +1,6 @@
 import type { Tree } from '@nx/devkit';
 import { createTreeUsingTsSolutionSetup } from '<%- testImportPath %>';
-import migration from './migration';
+import migration from './migration<% if (esm) { %>.js<% } %>';
 
 describe('<%= name %> migration', () => {
   let tree: Tree;

--- a/packages/nx-plugin/src/ts/nx-migration/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/nx-migration/generator.spec.ts
@@ -436,6 +436,39 @@ describe('nx-migration generator', () => {
       );
     });
 
+    it('should import the migration with a .js extension in an ESM workspace', async () => {
+      await tsNxMigrationGenerator(tree, {
+        project: PROJECT,
+        name: 'rename-foo-target',
+        description: 'Rename the foo target to bar',
+        preferInstallDependencies: false,
+      });
+
+      // `nodenext` resolution requires the explicit extension, so an
+      // extensionless relative import fails `typecheck` with TS2835.
+      expect(tree.read(dir('migration.spec.ts'), 'utf-8')).toContain(
+        "import migration from './migration.js';",
+      );
+    });
+
+    it('should import the migration without an extension in a CommonJS workspace', async () => {
+      writeJson(tree, 'package.json', {
+        name: '@myorg/monorepo',
+        type: 'commonjs',
+      });
+
+      await tsNxMigrationGenerator(tree, {
+        project: PROJECT,
+        name: 'rename-foo-target',
+        description: 'Rename the foo target to bar',
+        preferInstallDependencies: false,
+      });
+
+      expect(tree.read(dir('migration.spec.ts'), 'utf-8')).toContain(
+        "import migration from './migration';",
+      );
+    });
+
     it('should add @aws/nx-plugin so the SDK format util resolves', async () => {
       await tsNxMigrationGenerator(tree, {
         project: PROJECT,

--- a/packages/nx-plugin/src/ts/nx-migration/generator.ts
+++ b/packages/nx-plugin/src/ts/nx-migration/generator.ts
@@ -20,6 +20,7 @@ import {
   LATEST_MIGRATIONS_DIR,
   migrationKey,
 } from '../../utils/migration-versions';
+import { isEsmWorkspace } from '../../utils/module-format';
 import { kebabCase } from '../../utils/names';
 import {
   getGeneratorInfo,
@@ -104,6 +105,10 @@ export const tsNxMigrationGenerator = async (
   const testImportPath = isNxPluginForAws
     ? '../../../utils/test'
     : `${PackageJson.name}/sdk/utils/test`;
+  // A generated workspace resolves with `nodenext`, which needs the explicit
+  // extension on the spec's sibling import; this repo resolves with `bundler`,
+  // which takes it extensionless.
+  const esm = !isNxPluginForAws && isEsmWorkspace(tree);
 
   // One template set covers all kinds — scaffold it, then prune what this kind
   // doesn't use.
@@ -111,7 +116,14 @@ export const tsNxMigrationGenerator = async (
     tree,
     joinPathFragments(import.meta.dirname, 'files'),
     migrationDir,
-    { name, description, isHybrid, formatImportPath, testImportPath },
+    {
+      name,
+      description,
+      isHybrid,
+      formatImportPath,
+      testImportPath,
+      esm,
+    },
     { overwriteStrategy: OverwriteStrategy.KeepExisting },
   );
   if (!hasImplementation) {

--- a/packages/nx-plugin/src/ts/rdb/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/rdb/__snapshots__/generator.spec.ts.snap
@@ -4714,7 +4714,7 @@ export default defineConfig([
     output: {
       file: '../../dist/packages/db/bundle/migration/index.js',
       format: 'cjs',
-      inlineDynamicImports: true,
+      codeSplitting: false,
     },
     platform: 'node',
   },
@@ -4724,7 +4724,7 @@ export default defineConfig([
     output: {
       file: '../../dist/packages/db/bundle/create-db-user/index.js',
       format: 'cjs',
-      inlineDynamicImports: true,
+      codeSplitting: false,
     },
     platform: 'node',
   },

--- a/packages/nx-plugin/src/ts/react-website/app/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/react-website/app/__snapshots__/generator.spec.ts.snap
@@ -21,8 +21,8 @@ export default defineConfig(() => ({
   },
   plugins: [
     tanstackRouter({
-      routesDirectory: resolve(__dirname, 'src/routes'),
-      generatedRouteTree: resolve(__dirname, 'src/routeTree.gen.ts'),
+      routesDirectory: resolve(import.meta.dirname, 'src/routes'),
+      generatedRouteTree: resolve(import.meta.dirname, 'src/routeTree.gen.ts'),
     }),
     react(),
     tailwindcss(),
@@ -78,8 +78,8 @@ export default defineConfig(() => ({
   },
   plugins: [
     tanstackRouter({
-      routesDirectory: resolve(__dirname, 'src/routes'),
-      generatedRouteTree: resolve(__dirname, 'src/routeTree.gen.ts'),
+      routesDirectory: resolve(import.meta.dirname, 'src/routes'),
+      generatedRouteTree: resolve(import.meta.dirname, 'src/routeTree.gen.ts'),
     }),
     react(),
   ],
@@ -2152,7 +2152,7 @@ exports[`react-website generator > Tanstack router integration > should generate
 "import { defineConfig } from 'vitest/config';
 
 export default defineConfig(() => ({
-  root: __dirname,
+  root: import.meta.dirname,
   cacheDir: '../../../node_modules/.vite/packages/common/constructs',
   test: {
     passWithNoTests: true,
@@ -3977,7 +3977,7 @@ exports[`react-website generator > Tanstack router integration > should generate
 "import { defineConfig } from 'vitest/config';
 
 export default defineConfig(() => ({
-  root: __dirname,
+  root: import.meta.dirname,
   cacheDir: '../../../node_modules/.vite/packages/common/constructs',
   test: {
     passWithNoTests: true,
@@ -4706,8 +4706,8 @@ export default defineConfig(() => ({
   },
   plugins: [
     tanstackRouter({
-      routesDirectory: resolve(__dirname, 'src/routes'),
-      generatedRouteTree: resolve(__dirname, 'src/routeTree.gen.ts'),
+      routesDirectory: resolve(import.meta.dirname, 'src/routes'),
+      generatedRouteTree: resolve(import.meta.dirname, 'src/routeTree.gen.ts'),
     }),
     react(),
     tailwindcss(),
@@ -4835,8 +4835,8 @@ export default defineConfig(() => ({
   },
   plugins: [
     tanstackRouter({
-      routesDirectory: resolve(__dirname, 'src/routes'),
-      generatedRouteTree: resolve(__dirname, 'src/routeTree.gen.ts'),
+      routesDirectory: resolve(import.meta.dirname, 'src/routes'),
+      generatedRouteTree: resolve(import.meta.dirname, 'src/routeTree.gen.ts'),
     }),
     react(),
     tailwindcss(),

--- a/packages/nx-plugin/src/ts/react-website/app/generator.ts
+++ b/packages/nx-plugin/src/ts/react-website/app/generator.ts
@@ -519,7 +519,7 @@ export async function tsReactWebsiteGenerator(
       await applyGritQL(
         tree,
         viteConfigPath,
-        "`plugins: [$items]` => `plugins: [tanstackRouter({ routesDirectory: resolve(__dirname, 'src/routes'), generatedRouteTree: resolve(__dirname, 'src/routeTree.gen.ts') }), $items]` where { $items <: within `defineConfig($_)`, $items <: not contains `tanstackRouter` }",
+        "`plugins: [$items]` => `plugins: [tanstackRouter({ routesDirectory: resolve(import.meta.dirname, 'src/routes'), generatedRouteTree: resolve(import.meta.dirname, 'src/routeTree.gen.ts') }), $items]` where { $items <: within `defineConfig($_)`, $items <: not contains `tanstackRouter` }",
       );
     }
 

--- a/packages/nx-plugin/src/utils/bundle/bundle.spec.ts
+++ b/packages/nx-plugin/src/utils/bundle/bundle.spec.ts
@@ -324,7 +324,9 @@ export default defineConfig([
       );
 
       expect(configContent).toContain("format: 'cjs'");
-      expect(configContent).toContain('inlineDynamicImports: true');
+      // A single-file bundle, which rolldown asks for as `codeSplitting: false`
+      // — the `inlineDynamicImports` spelling is deprecated and warns.
+      expect(configContent).toContain('codeSplitting: false');
     });
 
     it('should work with nested project structure', async () => {

--- a/packages/nx-plugin/src/utils/bundle/bundle.ts
+++ b/packages/nx-plugin/src/utils/bundle/bundle.ts
@@ -198,7 +198,7 @@ export const addTypeScriptBundleTarget = async <
   const entry = `{
     tsconfig: 'tsconfig.lib.json',
     input: '${opts.targetFilePath}',
-    output: { file: '${outputFile}', format: 'cjs', inlineDynamicImports: true },
+    output: { file: '${outputFile}', format: 'cjs', codeSplitting: false },
     platform: '${opts.platform ?? 'node'}',
     ${external ? `external: [${external}],` : ''}
   }`;


### PR DESCRIPTION
### Reason for this change

Auditing a workspace scaffolded with the full generator matrix (`internal#test-matrix`, 36 projects) surfaced 43 warnings printed on every build, plus three `typecheck` errors, all originating in code we vend rather than in anything the user wrote:

| Finding | Count | Cause | Migration |
|---|---|---|---|
| `inlineDynamicImports` deprecated | 23 warnings | rolldown renamed the option to `codeSplitting` | yes |
| `__dirname` in vite/vitest configs | 20 warnings | unavailable to Vite's native config loader | yes |
| `TS2835` on scaffolded spec files | 3 **errors** | extensionless sibling import under `nodenext` | no — see below |
| Redundant `noqa: F401` | latent | `import *` raises `F403`, not `F401` | no — see below |

Two are worth calling out:

- **The typecheck failures are errors, not warnings.** `nx run-many --target typecheck --all` was red on a freshly generated workspace. It went unnoticed because `compile` builds `tsconfig.lib.json`, which excludes spec files, and no TypeScript project lists `typecheck` in its `build.dependsOn` (Python projects do) — so the only target that sees them is one nothing depends on. The plugin repo itself never hits it either, because it resolves with `bundler` while generated workspaces use `nodenext`.
- **The `__dirname` warning is a forward-compatibility one.** When Vite makes `configLoader: 'native'` the default, those configs break rather than warn.

### Description of changes

Four commits, one per fix. The two that change what every build prints ship a migration; the other two don't, because the leftover state is inert:

1. **`fix(ts#project)`** — `import.meta.dirname` in vite/vitest configs. A GritQL post-process in `configureVitest` rewrites the `root` that `@nx/js` writes, alongside the existing `passWithNoTests` one; the `ts#react-website` pattern that injects the TanStack Router plugin now emits `resolve(import.meta.dirname, ...)`. Ships **`vite-config-import-meta-dirname`**.
2. **`fix(ts#project)`** — `codeSplitting: false` in place of the deprecated `inlineDynamicImports`, and drops the now-redundant option from this repo's own MCP bundle config which already set `codeSplitting`. Ships **`rolldown-code-splitting`**.
3. **`fix(ts#nx-plugin)`** — `.js` extension on the sibling import in the specs `ts#nx-generator` and `ts#nx-migration` scaffold, conditional on module format via the existing `<% if (esm) { %>.js<% } %>` idiom. CommonJS workspaces resolve with `node16` and keep the extensionless form; `ts#nx-migration` also scaffolds into this repo, which resolves with `bundler`, so that stays extensionless too. **No migration** — the leftover import is a one-line edit in a file the user owns, in a target nothing depends on.
4. **`fix(py#rdb)`** — drops `F401` from the Alembic `env.py` wildcard import, keeping the `F403` it actually needs. **No migration** — the leftover directive is inert, so an existing workspace keeps passing its vended lint either way.

Both migrations are self-contained (they import only `@nx/devkit` and the shared GritQL/format utils — no reaching into generator modules or generator IDs), and every GritQL pattern is anchored to the exact shape the generators produce and scoped with `some` so it matches a *direct* property only:

- **`vite-config-import-meta-dirname`** rewrites `root` only as a direct property of the object the config factory returns, so a `root` nested inside another option (a `test.alias` entry, say) is untouched. The router paths are matched by option name *and* path literal, scoped to the plugin's own option object — so a user who repointed `routesDirectory` keeps their value, and a `resolve(__dirname, ...)` they wrote elsewhere in the config is left alone.
- **`rolldown-code-splitting`** is anchored to a rolldown `output` object, so an object of the user's own carrying the same key is untouched. Where an output already sets `codeSplitting` the deprecated option is *dropped* rather than renamed, so the rewrite cannot produce a duplicate key, and `inlineDynamicImports: false` is left alone since it means the opposite.

Docs and the affected snapshots are updated alongside.

### Description of how you validated changes

**Unit tests** — 20 new tests. Each migration spec builds its "before" state from a **hardcoded fixture** of the config as it shipped, not by invoking the generators: a migration has to keep applying to the shape that shipped however far the generator's output moves afterwards. Both migrations are covered for: applies to the vended shape, leaves each customised/diverged variant alone, no doubled commas, and idempotent. The generator fixes add assertions for both ESM and CommonJS module formats. Full suite green: **179 test files passed**.

**End-to-end** — against a workspace created on the published `1.0.0-rc.63` and scaffolded with the full matrix (36 projects), i.e. the exact state users upgrade from, driven through the real `nx migrate --run-migrations` cycle:

- The two migrations touch exactly the expected 28 files and nothing else — 19 vite/vitest configs, 9 rolldown configs.
- **43 → 0 warnings.** `build --all` (32 projects, 204 tasks) green; `test --all` green.
- **Both idempotent** — a second `nx migrate --run-migrations` reports "No changes were made".
- Bundle outputs verified still single-file, so Lambda packaging is unaffected.
- For the two template-only fixes, verified on the same workspace that newly generated projects come out correct: a fresh `ts#nx-plugin` + `ts#nx-generator` + `ts#nx-migration` scaffolds `.js` imports and passes `typecheck`, and a fresh `py#rdb` is `ruff check --extend-select RUF100` clean while still passing its vended ruff config (`F403` remains necessary).

**Parity with fresh generation** — generated a second workspace with the same matrix using today's generators and diffed it against the migrated one: **all migration-touched files are byte-identical** (modulo workspace name and license headers). This is the bar CONTRIBUTING sets — a migrated workspace reaching the state it would be in had it been generated today.

**CI** — the previous revision of this branch (same fixes, plus two migrations since removed as overkill) went fully green across all 63 checks, including all five `migrate` smoke-test shards and the Windows suites.

One pre-existing, unrelated finding turned up while getting the build green: `mariadb@3.5.3` is LGPL-2.1-or-later and not on `DEFAULT_LICENSE_ALLOWLIST`, so `py#rdb --engine=mysql` fails `license-check` out of the box. Not touched here; it deserves its own issue.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*