### PR TITLE
feat(ts#smithy-api): move onto the renamed @smithy/server-* packages

### DIFF
--- a/packages/nx-plugin/src/migrations/latest/smithy-server-package-rename/metadata.json
+++ b/packages/nx-plugin/src/migrations/latest/smithy-server-package-rename/metadata.json
@@ -1,0 +1,3 @@
+{
+  "description": "Move Smithy APIs onto the renamed @smithy/server-* packages"
+}

--- a/packages/nx-plugin/src/migrations/latest/smithy-server-package-rename/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/latest/smithy-server-package-rename/migration.spec.ts
@@ -1,0 +1,266 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { addProjectConfiguration, readJson, type Tree } from '@nx/devkit';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test';
+import migration from './migration';
+
+const PROJECT_ROOT = 'packages/test-api/backend';
+const HANDLER = `${PROJECT_ROOT}/src/handler.ts`;
+const LOCAL_SERVER = `${PROJECT_ROOT}/src/local-server.ts`;
+const MANIFEST = `${PROJECT_ROOT}/package.json`;
+
+/**
+ * The handler and local server as the release before the rename generated them,
+ * and the dependencies it declared. Hardcoded rather than produced by running the
+ * generator: a migration has to keep applying to the shape that shipped, however
+ * far the generator's output moves afterwards.
+ */
+const OLD_HANDLER = `import {
+  convertEvent,
+  convertVersion1Response,
+} from '@aws-smithy/server-apigateway';
+import type { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import middy from '@middy/core';
+import { Service } from './service';
+import { getMyApiServiceHandler } from './generated/ssdk/index';
+
+const serviceHandler = getMyApiServiceHandler(Service);
+
+export const lambdaHandler = async (
+  event: APIGatewayProxyEvent,
+): Promise<APIGatewayProxyResult> => {
+  const httpRequest = convertEvent(event);
+  const httpResponse = await serviceHandler.handle(httpRequest, {});
+  return convertVersion1Response(httpResponse);
+};
+
+export const handler = middy().handler(lambdaHandler);
+`;
+
+const OLD_LOCAL_SERVER = `import { IncomingMessage, ServerResponse, createServer } from 'http';
+import { convertRequest, writeResponse } from '@aws-smithy/server-node';
+import { Service } from './service';
+import { getMyApiServiceHandler } from './generated/ssdk/index';
+
+const PORT = 3001;
+
+createServer(async (req: IncomingMessage, res: ServerResponse) => {
+  const httpRequest = await convertRequest(req);
+  const httpResponse = await getMyApiServiceHandler(Service).handle(
+    httpRequest,
+    {},
+  );
+  writeResponse(httpResponse, res);
+}).listen(PORT);
+`;
+
+const OLD_DEPENDENCIES = {
+  '@aws-smithy/server-apigateway': '1.0.0-alpha.10',
+  '@aws-smithy/server-node': '1.0.0-alpha.10',
+  '@middy/core': '7.7.2',
+};
+
+const read = (tree: Tree, path: string): string =>
+  tree.read(path, 'utf-8') ?? '';
+
+/**
+ * A Smithy API project as the release before the rename left it, carrying the
+ * metadata that generator records — which is how the migration finds it.
+ */
+const givenSmithyApi = (
+  tree: Tree,
+  {
+    handler = OLD_HANDLER,
+    localServer = OLD_LOCAL_SERVER,
+    dependencies = OLD_DEPENDENCIES,
+    generator = 'ts#smithy-api',
+  }: {
+    handler?: string;
+    localServer?: string;
+    dependencies?: Record<string, string>;
+    generator?: string;
+  } = {},
+): void => {
+  addProjectConfiguration(tree, 'test-api-backend', {
+    root: PROJECT_ROOT,
+    sourceRoot: `${PROJECT_ROOT}/src`,
+    metadata: { generator } as Record<string, unknown>,
+  });
+  tree.write(HANDLER, handler);
+  tree.write(LOCAL_SERVER, localServer);
+  tree.write(
+    MANIFEST,
+    JSON.stringify({ name: '@test/backend', dependencies }, null, 2),
+  );
+};
+
+describe('smithy-server-package-rename migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeUsingTsSolutionSetup();
+  });
+
+  it('should apply to the shape the generators produce', async () => {
+    givenSmithyApi(tree);
+
+    const result = await migration(tree);
+
+    const handler = read(tree, HANDLER);
+    expect(handler).not.toContain('@aws-smithy/');
+    expect(handler).toContain("from '@smithy/server-apigateway'");
+    // The bindings survive the move.
+    expect(handler).toContain('convertEvent');
+    expect(handler).toContain('convertVersion1Response');
+
+    const localServer = read(tree, LOCAL_SERVER);
+    expect(localServer).not.toContain('@aws-smithy/');
+    expect(localServer).toContain(
+      "import { convertRequest, writeResponse } from '@smithy/server-node'",
+    );
+
+    expect(result.nextSteps).toEqual([]);
+  });
+
+  it('should move the declarations onto the renamed packages', async () => {
+    givenSmithyApi(tree);
+
+    await migration(tree);
+
+    const { dependencies } = readJson(tree, MANIFEST);
+    expect(dependencies).not.toHaveProperty('@aws-smithy/server-apigateway');
+    expect(dependencies).not.toHaveProperty('@aws-smithy/server-node');
+    // The renamed line restarted at 0.x, so carrying the old `1.0.0-alpha.10`
+    // across would resolve nothing.
+    expect(dependencies['@smithy/server-apigateway']).toBe('0.2.0');
+    expect(dependencies['@smithy/server-node']).toBe('0.2.0');
+    // A package the migration does not own keeps its version.
+    expect(dependencies['@middy/core']).toBe('7.7.2');
+  });
+
+  it('should keep bindings a project added of its own', async () => {
+    givenSmithyApi(tree, {
+      handler: OLD_HANDLER.replace(
+        '  convertVersion1Response,\n',
+        '  convertVersion1Response,\n  convertVersion2Response,\n',
+      ),
+    });
+
+    await migration(tree);
+
+    const handler = read(tree, HANDLER);
+    expect(handler).toContain("from '@smithy/server-apigateway'");
+    expect(handler).toContain('convertVersion2Response');
+  });
+
+  it('should rename a declaration hoisted to the workspace root', async () => {
+    givenSmithyApi(tree, { dependencies: {} });
+    tree.write(
+      'package.json',
+      JSON.stringify(
+        {
+          name: 'test-workspace',
+          devDependencies: {
+            '@aws-smithy/server-node': '1.0.0-alpha.10',
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    await migration(tree);
+
+    const { devDependencies } = readJson(tree, 'package.json');
+    expect(devDependencies).not.toHaveProperty('@aws-smithy/server-node');
+    expect(devDependencies['@smithy/server-node']).toBe('0.2.0');
+  });
+
+  it('should skip and report a customised file', async () => {
+    // A namespace import is not the generated shape, so it is reported for the
+    // user to move by hand rather than rewritten.
+    givenSmithyApi(tree, {
+      handler: `import * as apigateway from '@aws-smithy/server-apigateway';\n`,
+    });
+
+    const result = await migration(tree);
+
+    expect(read(tree, HANDLER)).toContain(
+      "import * as apigateway from '@aws-smithy/server-apigateway'",
+    );
+    expect(result.nextSteps).toEqual([
+      expect.stringContaining(`${HANDLER}: still imports a deprecated`),
+    ]);
+  });
+
+  it('should leave a project this plugin did not generate alone', async () => {
+    givenSmithyApi(tree, { generator: 'ts#project' });
+
+    await migration(tree);
+
+    // Scoped to a Smithy API project: a file of the user's own that happens to
+    // import these packages is not this migration's to rewrite.
+    expect(read(tree, HANDLER)).toContain('@aws-smithy/server-apigateway');
+    const { dependencies } = readJson(tree, MANIFEST);
+    expect(dependencies).toHaveProperty('@aws-smithy/server-apigateway');
+  });
+
+  it('should leave a workspace that already moved itself alone', async () => {
+    const migrated = {
+      handler: OLD_HANDLER.replaceAll('@aws-smithy/', '@smithy/'),
+      localServer: OLD_LOCAL_SERVER.replaceAll('@aws-smithy/', '@smithy/'),
+      dependencies: {
+        '@smithy/server-apigateway': '0.2.0',
+        '@smithy/server-node': '0.2.0',
+      },
+    };
+    givenSmithyApi(tree, migrated);
+
+    const result = await migration(tree);
+
+    expect(read(tree, HANDLER)).toContain("from '@smithy/server-apigateway'");
+    expect(readJson(tree, MANIFEST).dependencies).toEqual(
+      migrated.dependencies,
+    );
+    expect(result.nextSteps).toEqual([]);
+  });
+
+  it('should be idempotent', async () => {
+    givenSmithyApi(tree);
+
+    await migration(tree);
+    const afterFirst = {
+      handler: read(tree, HANDLER),
+      localServer: read(tree, LOCAL_SERVER),
+      manifest: readJson(tree, MANIFEST),
+    };
+    const result = await migration(tree);
+
+    expect(read(tree, HANDLER)).toEqual(afterFirst.handler);
+    expect(read(tree, LOCAL_SERVER)).toEqual(afterFirst.localServer);
+    expect(readJson(tree, MANIFEST)).toEqual(afterFirst.manifest);
+    expect(result.nextSteps).toEqual([]);
+  });
+
+  it('should leave a workspace with no Smithy API alone', async () => {
+    const rootManifest = JSON.stringify(
+      {
+        name: 'test-workspace',
+        devDependencies: { '@aws-smithy/server-node': '1.0.0-alpha.10' },
+      },
+      null,
+      2,
+    );
+    tree.write('package.json', rootManifest);
+
+    const result = await migration(tree);
+
+    // Nothing generated these, so the declaration is the user's own.
+    expect(readJson(tree, 'package.json').devDependencies).toHaveProperty(
+      '@aws-smithy/server-node',
+    );
+    expect(result.nextSteps).toEqual([]);
+  });
+});

--- a/packages/nx-plugin/src/migrations/latest/smithy-server-package-rename/migration.ts
+++ b/packages/nx-plugin/src/migrations/latest/smithy-server-package-rename/migration.ts
@@ -1,0 +1,152 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import {
+  getProjects,
+  joinPathFragments,
+  type MigrationReturnObject,
+  readJson,
+  type Tree,
+  updateJson,
+} from '@nx/devkit';
+import { applyGritQL, matchGritQL } from '../../../utils/ast';
+import { formatFilesInSubtree } from '../../../utils/format';
+
+/**
+ * Move a Smithy API onto the renamed `@smithy/server-*` packages.
+ *
+ * The Smithy server runtime was published as `@aws-smithy/server-*`, stopped at
+ * `1.0.0-alpha.10`, and was renamed to `@smithy/server-*`. The Server SDK codegen
+ * this release vends generates against the renamed packages, importing
+ * `AuthScheme` and `ServerInterceptor` — types the deprecated packages never
+ * exported — so a workspace left on them fails to bundle its SSDK.
+ *
+ * Both the imports and the declarations move: the renamed packages are no longer
+ * the same names, so the version sync cannot recognise the old ones and would
+ * leave them installed alongside the new.
+ *
+ * Guardrails:
+ * - Scoped to a Smithy API project this plugin generated, found through the
+ *   metadata the generator records. A file of the user's own that happens to
+ *   import these packages is left alone.
+ * - Imports are rewritten by module specifier, preserving whatever the file
+ *   imports from it, so a project that imports more than the generated shape
+ *   keeps its own bindings. Only the two packages the generators vend are
+ *   matched: `@aws-smithy/server-common` is a transitive dependency of those and
+ *   is never declared or imported directly.
+ * - A manifest is only rewritten where it declares the old package, and the new
+ *   name takes the field the old one occupied. A workspace that already moved
+ *   itself is left alone.
+ * - Idempotent: nothing matches the old names once they are gone.
+ *
+ * Every value here is hardcoded rather than read from the generators: this runs
+ * once, for the release that renamed the packages, so it has to keep applying
+ * that exact change however far the vended versions and generators move
+ * afterwards.
+ */
+
+/** The id the `ts#smithy-api` generator records on the projects it creates. */
+const SMITHY_API_GENERATOR_ID = 'ts#smithy-api';
+
+/** The renamed packages, old name to new, with the version this release vends. */
+const RENAMES = [
+  {
+    old: '@aws-smithy/server-apigateway',
+    renamed: '@smithy/server-apigateway',
+    version: '0.2.0',
+  },
+  {
+    old: '@aws-smithy/server-node',
+    renamed: '@smithy/server-node',
+    version: '0.2.0',
+  },
+] as const;
+
+/** The source files the generators give these imports. */
+const SOURCE_FILES = ['src/handler.ts', 'src/local-server.ts'];
+
+/**
+ * Rewrite an import's module specifier, keeping its bindings — `$bindings` holds
+ * whatever the file imports, so a binding the project added survives the move.
+ */
+const importPattern = (from: string, to: string): string =>
+  `\`import { $bindings } from '${from}'\` => \`import { $bindings } from '${to}'\``;
+
+/** Whether the file still imports the old package under any other form. */
+const hasRemainingImport = (from: string): string =>
+  `\`import $_ from '${from}'\``;
+
+/** Rename the packages a manifest declares, reporting whether anything changed. */
+const renameInManifest = (tree: Tree, path: string): boolean => {
+  if (!tree.exists(path)) {
+    return false;
+  }
+  const json = readJson(tree, path);
+  const fields = (['dependencies', 'devDependencies'] as const).filter(
+    (field) => RENAMES.some(({ old }) => json[field]?.[old]),
+  );
+  if (fields.length === 0) {
+    return false;
+  }
+  updateJson(tree, path, (manifest) => {
+    for (const field of fields) {
+      const declared = manifest[field] as Record<string, string>;
+      for (const { old, renamed, version } of RENAMES) {
+        if (!declared[old]) {
+          continue;
+        }
+        delete declared[old];
+        // The vended pin rather than the old specifier: the renamed line
+        // restarted at 0.x, so carrying `1.0.0-alpha.10` across resolves nothing.
+        declared[renamed] = version;
+      }
+    }
+    return manifest;
+  });
+  return true;
+};
+
+const divergedNextStep = (path: string): string =>
+  `${path}: still imports a deprecated '@aws-smithy/server-*' package in a form this migration does not rewrite - update the import to the matching '@smithy/server-*' package by hand.`;
+
+export default async function migration(
+  tree: Tree,
+): Promise<MigrationReturnObject> {
+  const nextSteps: string[] = [];
+
+  // Only a Smithy API project this plugin generated carries these packages.
+  const projects = [...getProjects(tree).values()].filter(
+    (project) =>
+      (project.metadata as { generator?: string } | undefined)?.generator ===
+      SMITHY_API_GENERATOR_ID,
+  );
+
+  for (const project of projects) {
+    for (const sourceFile of SOURCE_FILES) {
+      const sourcePath = joinPathFragments(project.root, sourceFile);
+      if (!tree.exists(sourcePath)) {
+        continue;
+      }
+      for (const { old, renamed } of RENAMES) {
+        await applyGritQL(tree, sourcePath, importPattern(old, renamed));
+        // A namespace or default import of the same package is left as it is —
+        // reported rather than rewritten, so a diverged file is never clobbered.
+        if (await matchGritQL(tree, sourcePath, hasRemainingImport(old))) {
+          nextSteps.push(divergedNextStep(sourcePath));
+        }
+      }
+    }
+
+    renameInManifest(tree, joinPathFragments(project.root, 'package.json'));
+  }
+
+  // A workspace may hoist these to the root manifest, which is not an nx project.
+  if (projects.length > 0) {
+    renameInManifest(tree, 'package.json');
+  }
+
+  await formatFilesInSubtree(tree);
+
+  return { nextSteps };
+}

--- a/packages/nx-plugin/src/smithy/project/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/smithy/project/__snapshots__/generator.spec.ts.snap
@@ -364,7 +364,7 @@ exports[`smithyProjectGenerator > should generate smithy project with default op
       "software.amazon.smithy:smithy-aws-traits:1.72.1",
       "software.amazon.smithy:smithy-validation-model:1.72.1",
       "software.amazon.smithy:smithy-openapi:1.72.1",
-      "software.amazon.smithy.typescript:smithy-aws-typescript-codegen:0.50.0"
+      "software.amazon.smithy.typescript:smithy-aws-typescript-codegen:0.52.0"
     ]
   }
 }
@@ -550,7 +550,7 @@ exports[`smithyProjectGenerator > should handle kebab-case conversion for servic
       "software.amazon.smithy:smithy-aws-traits:1.72.1",
       "software.amazon.smithy:smithy-validation-model:1.72.1",
       "software.amazon.smithy:smithy-openapi:1.72.1",
-      "software.amazon.smithy.typescript:smithy-aws-typescript-codegen:0.50.0"
+      "software.amazon.smithy.typescript:smithy-aws-typescript-codegen:0.52.0"
     ]
   }
 }

--- a/packages/nx-plugin/src/smithy/ts/api/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/smithy/ts/api/__snapshots__/generator.spec.ts.snap
@@ -1628,7 +1628,7 @@ exports[`tsSmithyApiGenerator > should generate smithy ts api with default optio
 "import {
   convertEvent,
   convertVersion1Response,
-} from '@aws-smithy/server-apigateway';
+} from '@smithy/server-apigateway';
 import type { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
 import middy from '@middy/core';
 import { Tracer } from '@aws-lambda-powertools/tracer';
@@ -1693,7 +1693,7 @@ export const handler = middy<APIGatewayProxyEvent, APIGatewayProxyResult>()
 
 exports[`tsSmithyApiGenerator > should generate smithy ts api with default options > local-server.ts 1`] = `
 "import { IncomingMessage, ServerResponse, createServer } from 'http';
-import { convertRequest, writeResponse } from '@aws-smithy/server-node';
+import { convertRequest, writeResponse } from '@smithy/server-node';
 import { Logger } from '@aws-lambda-powertools/logger';
 import { Metrics } from '@aws-lambda-powertools/metrics';
 import { Tracer } from '@aws-lambda-powertools/tracer';
@@ -1807,7 +1807,7 @@ exports[`tsSmithyApiGenerator > should handle kebab-case API names correctly > k
 "import {
   convertEvent,
   convertVersion1Response,
-} from '@aws-smithy/server-apigateway';
+} from '@smithy/server-apigateway';
 import type { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
 import middy from '@middy/core';
 import { Tracer } from '@aws-lambda-powertools/tracer';

--- a/packages/nx-plugin/src/smithy/ts/api/files/handler.ts.template
+++ b/packages/nx-plugin/src/smithy/ts/api/files/handler.ts.template
@@ -1,7 +1,7 @@
 import {
   convertEvent,
   convertVersion1Response,
-} from '@aws-smithy/server-apigateway';
+} from '@smithy/server-apigateway';
 import type { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
 import middy from '@middy/core';
 import { Tracer } from '@aws-lambda-powertools/tracer';

--- a/packages/nx-plugin/src/smithy/ts/api/files/local-server.ts.template
+++ b/packages/nx-plugin/src/smithy/ts/api/files/local-server.ts.template
@@ -1,5 +1,5 @@
 import { IncomingMessage, ServerResponse, createServer } from 'http';
-import { convertRequest, writeResponse } from '@aws-smithy/server-node';
+import { convertRequest, writeResponse } from '@smithy/server-node';
 import { Logger } from '@aws-lambda-powertools/logger';
 import { Metrics } from '@aws-lambda-powertools/metrics';
 import { Tracer } from '@aws-lambda-powertools/tracer';

--- a/packages/nx-plugin/src/smithy/ts/api/generator.spec.ts
+++ b/packages/nx-plugin/src/smithy/ts/api/generator.spec.ts
@@ -381,9 +381,9 @@ describe('tsSmithyApiGenerator', () => {
 
     // Verify runtime dependencies
     expect(packageJson.dependencies).toHaveProperty(
-      '@aws-smithy/server-apigateway',
+      '@smithy/server-apigateway',
     );
-    expect(packageJson.dependencies).toHaveProperty('@aws-smithy/server-node');
+    expect(packageJson.dependencies).toHaveProperty('@smithy/server-node');
     expect(packageJson.dependencies).toHaveProperty('@middy/core');
 
     // Powertools

--- a/packages/nx-plugin/src/smithy/ts/api/generator.ts
+++ b/packages/nx-plugin/src/smithy/ts/api/generator.ts
@@ -62,8 +62,8 @@ export interface TsSmithyApiMetadata extends IacMetadata {
 // adding and the version sync.
 export const DEPENDENCIES = declareDependencies<TsSmithyApiMetadata>()({
   ts: [
-    { name: '@aws-smithy/server-apigateway' },
-    { name: '@aws-smithy/server-node' },
+    { name: '@smithy/server-apigateway' },
+    { name: '@smithy/server-node' },
     { name: '@middy/core' },
     { name: '@aws-lambda-powertools/logger' },
     { name: '@aws-lambda-powertools/parameters' },

--- a/packages/nx-plugin/src/ts/rdb/smithy-connection/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/rdb/smithy-connection/__snapshots__/generator.spec.ts.snap
@@ -51,7 +51,7 @@ exports[`ts#rdb smithy-connection generator > should be idempotent across contex
 import {
   convertEvent,
   convertVersion1Response,
-} from '@aws-smithy/server-apigateway';
+} from '@smithy/server-apigateway';
 import type { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
 import { Tracer } from '@aws-lambda-powertools/tracer';
 import { Logger } from '@aws-lambda-powertools/logger';
@@ -84,7 +84,7 @@ export const lambdaHandler = async (
 exports[`ts#rdb smithy-connection generator > should be idempotent across context.ts, handler.ts, and local-server.ts 3`] = `
 "import { getPrisma as getDb } from 'db';
 import { IncomingMessage, ServerResponse, createServer } from 'http';
-import { convertRequest, writeResponse } from '@aws-smithy/server-node';
+import { convertRequest, writeResponse } from '@smithy/server-node';
 import { Tracer } from '@aws-lambda-powertools/tracer';
 import { Logger } from '@aws-lambda-powertools/logger';
 import { Metrics } from '@aws-lambda-powertools/metrics';
@@ -136,7 +136,7 @@ exports[`ts#rdb smithy-connection generator > should inject into context.ts, han
 import {
   convertEvent,
   convertVersion1Response,
-} from '@aws-smithy/server-apigateway';
+} from '@smithy/server-apigateway';
 import type { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
 import { Tracer } from '@aws-lambda-powertools/tracer';
 import { Logger } from '@aws-lambda-powertools/logger';
@@ -169,7 +169,7 @@ export const lambdaHandler = async (
 exports[`ts#rdb smithy-connection generator > should inject into context.ts, handler.ts, and local-server.ts 3`] = `
 "import { getPrisma as getDb } from 'db';
 import { IncomingMessage, ServerResponse, createServer } from 'http';
-import { convertRequest, writeResponse } from '@aws-smithy/server-node';
+import { convertRequest, writeResponse } from '@smithy/server-node';
 import { Tracer } from '@aws-lambda-powertools/tracer';
 import { Logger } from '@aws-lambda-powertools/logger';
 import { Metrics } from '@aws-lambda-powertools/metrics';
@@ -224,7 +224,7 @@ import { getPrisma as getPostgresDb } from 'postgres-db';
 import {
   convertEvent,
   convertVersion1Response,
-} from '@aws-smithy/server-apigateway';
+} from '@smithy/server-apigateway';
 import type { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
 import { Tracer } from '@aws-lambda-powertools/tracer';
 import { Logger } from '@aws-lambda-powertools/logger';
@@ -260,7 +260,7 @@ exports[`ts#rdb smithy-connection generator > should support multiple rdb connec
 "import { getPrisma as getMysqlDb } from 'mysql-db';
 import { getPrisma as getPostgresDb } from 'postgres-db';
 import { IncomingMessage, ServerResponse, createServer } from 'http';
-import { convertRequest, writeResponse } from '@aws-smithy/server-node';
+import { convertRequest, writeResponse } from '@smithy/server-node';
 import { Tracer } from '@aws-lambda-powertools/tracer';
 import { Logger } from '@aws-lambda-powertools/logger';
 import { Metrics } from '@aws-lambda-powertools/metrics';

--- a/packages/nx-plugin/src/ts/rdb/smithy-connection/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/rdb/smithy-connection/generator.spec.ts
@@ -50,7 +50,7 @@ export interface ServiceContext {
     tree.write(
       `packages/${name}/src/local-server.ts`,
       `import { IncomingMessage, ServerResponse, createServer } from 'http';
-import { convertRequest, writeResponse } from '@aws-smithy/server-node';
+import { convertRequest, writeResponse } from '@smithy/server-node';
 import { Tracer } from '@aws-lambda-powertools/tracer';
 import { Logger } from '@aws-lambda-powertools/logger';
 import { Metrics } from '@aws-lambda-powertools/metrics';
@@ -78,7 +78,7 @@ server.listen(3000);
     );
     tree.write(
       `packages/${name}/src/handler.ts`,
-      `import { convertEvent, convertVersion1Response } from '@aws-smithy/server-apigateway';
+      `import { convertEvent, convertVersion1Response } from '@smithy/server-apigateway';
 import type { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
 import { Tracer } from '@aws-lambda-powertools/tracer';
 import { Logger } from '@aws-lambda-powertools/logger';

--- a/packages/nx-plugin/src/utils/versions.ts
+++ b/packages/nx-plugin/src/utils/versions.ts
@@ -35,8 +35,8 @@ export const TS_VERSIONS = {
   '@aws-sdk/credential-provider-cognito-identity': '3.972.66',
   '@aws-sdk/client-secrets-manager': '3.1106.0',
   '@aws-sdk/rds-signer': '3.1106.0',
-  '@aws-smithy/server-apigateway': '1.0.0-alpha.10',
-  '@aws-smithy/server-node': '1.0.0-alpha.10',
+  '@smithy/server-apigateway': '0.2.0',
+  '@smithy/server-node': '0.2.0',
   '@aws-lambda-powertools/logger': '2.34.0',
   '@aws-lambda-powertools/metrics': '2.34.0',
   '@aws-lambda-powertools/parameters': '2.34.0',
@@ -283,7 +283,7 @@ export const JAVA_VERSIONS = {
   'software.amazon.smithy:smithy-aws-traits': '1.72.1',
   'software.amazon.smithy:smithy-validation-model': '1.72.1',
   'software.amazon.smithy:smithy-openapi': '1.72.1',
-  'software.amazon.smithy.typescript:smithy-aws-typescript-codegen': '0.50.0',
+  'software.amazon.smithy.typescript:smithy-aws-typescript-codegen': '0.52.0',
 } as const;
 export type IJavaVersion = keyof typeof JAVA_VERSIONS;
 


### PR DESCRIPTION
### Reason for this change

The Smithy server runtime was published as `@aws-smithy/server-*`, stopped at `1.0.0-alpha.10`, and was [renamed to `@smithy/server-*`](https://github.com/smithy-lang/smithy-typescript/commit/3ea2dd40) upstream. The old packages are deprecated on npm ("has been renamed to `@smithy/server-common`. Please install the renamed package.") and the generators were still vending them.

That deprecation turned into a build failure. `smithy-aws-typescript-codegen` 0.51.0 added a server interceptor/auth-scheme feature to `ServerGenerator`, so the generated Server SDK imports `AuthScheme` and `ServerInterceptor` — but 0.51.0 still declared the *old* package, which never exported those types. Every generated SSDK failed to bundle:

```
[MISSING_EXPORT] "AuthScheme" is not exported by ".../@aws-smithy/server-common/dist/types/index.d.ts".
[MISSING_EXPORT] "ServerInterceptor" is not exported by ".../@aws-smithy/server-common/dist/types/index.d.ts".
```

The codegen was held back to 0.50.0 in #1069 to unblock that week's dependency update. This addresses the root cause instead: 0.51.0 was caught mid-rename, and the fix is to go forward.

Comparing the codegen jars' declared dependency:

| | 0.50.0 | 0.51.0 | 0.52.0 |
|---|---|---|---|
| Declared package | `@aws-smithy/server-common` | `@aws-smithy/server-common` | `@smithy/server-common` |
| Pinned version | `1.0.0-alpha.10` | `1.0.0-alpha.10` | `0.2.0` |
| Emits `ServerInterceptor` | no | **yes** | yes |

`@smithy/server-common@0.2.0` exports both types, with signatures matching the generated code exactly (`withAuth(...schemes: AuthScheme<Context>[])`, `addInterceptor`, `addInterceptors`).

Worth noting for future dependency updates: the deprecated line sat at `1.0.0-alpha.10` while the renamed one restarted at `0.x`, so `npm-check-updates` could never surface the rename as an upgrade.

### Description of changes

- **Codegen to 0.52.0** (`JAVA_VERSIONS`), which completes the rename upstream.
- **`@smithy/server-apigateway` and `@smithy/server-node` at `0.2.0`** replace the deprecated `@aws-smithy/*` entries in `TS_VERSIONS` and in the `ts#smithy-api` dependency declaration.
- **Templates** (`handler.ts`, `local-server.ts`) import from the renamed packages. No repository reference to `@aws-smithy/` remains.
- **A migration** (`latest/smithy-server-package-rename`) moves an existing workspace's imports and declarations across. The version sync cannot do this on its own: the renamed packages are different names, so it would leave the deprecated ones installed alongside the new. The migration writes the vended pin rather than carrying `1.0.0-alpha.10` across, since the renamed line restarted at `0.x`.

The migration is scoped to Smithy API projects this plugin generated (via the metadata the generator records) and is deliberately self-contained — no generator constants or generator calls — so it keeps applying the exact change it shipped for however far the generators move afterwards. Imports are rewritten by module specifier with bindings preserved, a namespace/default import is reported via `nextSteps` rather than clobbered, and re-running is a no-op.

### Description of how you validated changes

- `nx test nx-plugin` — 3399 tests pass, including 9 new migration tests covering the generated shape, declaration rename, added bindings, a root-hoisted declaration, a diverged file reported via `nextSteps`, a non-plugin project, an already-migrated workspace, idempotency, and a workspace with no Smithy API.
- `nx run-many --target build --all` passes.
- `nx test nx-plugin-e2e -t 'smoke test - smithy-api'` passes end to end. Inspecting the real generated output confirms codegen 0.52.0 imports `@smithy/server-common`, declares `@smithy/server-common@0.2.0`, and the bundled `index.d.ts` exposes `AuthScheme`, `ServerInterceptor`, `addInterceptor` and `withAuth` — the types that failed to resolve under 0.51.0.

One thing I checked and deliberately left alone: the `dropSelfImports` plugin in `ssdk.rolldown.config.mjs`, which works around the Smithy CLI's Windows codegen writing a module that imports itself. `ImportDeclarations.class` is **byte-identical** across 0.50.0, 0.51.0 and 0.52.0 (sha `c08f07eb046ccf91`), and the upstream source is untouched since December 2025, so the workaround is still required. The generated output on Linux has 19 relative specifiers and no self-references, as expected — that path only triggers on Windows, so Windows CI is the check that matters here.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
