### PR TITLE
chore(agentcore-harness): correct managed memory ARN in Terraform role policy

### DIFF
--- a/packages/nx-plugin/src/agentcore-harness/generator.spec.ts
+++ b/packages/nx-plugin/src/agentcore-harness/generator.spec.ts
@@ -509,6 +509,16 @@ describe('agentcore-harness generator', () => {
       expect(tf).toMatch(/harness_name_prefix = "[^"$]*"/);
       expect(tf).not.toContain('regexall(');
     });
+
+    it('scopes the managed memory statement to the name the service assigns', () => {
+      // The service names the managed memory `<harness_name>-<10 chars>`, so it
+      // carries neither the runtime's `harness_` prefix nor an `_` separator.
+      // The provider exposes no memory ARN attribute, hence the wildcard.
+      expect(tf).toContain(
+        'Resource = [\n          "arn:${local.partition}:bedrock-agentcore:${local.region}:${local.account_id}:memory/${local.harness_name}-*",',
+      );
+      expect(tf).not.toContain(':memory/harness_');
+    });
   });
 
   describe('idempotency and infra: none', () => {

--- a/packages/nx-plugin/src/utils/agent-core-constructs/files/terraform/app/agentcore-harness/__nameKebabCase__/__nameKebabCase__.tf.template
+++ b/packages/nx-plugin/src/utils/agent-core-constructs/files/terraform/app/agentcore-harness/__nameKebabCase__/__nameKebabCase__.tf.template
@@ -184,8 +184,8 @@ resource "aws_iam_role_policy" "execution_role" {
           "arn:${local.partition}:bedrock-agentcore:${local.region}:${local.account_id}:workload-identity-directory/default/workload-identity/harness_${local.harness_name}-*",
         ]
       },
-      # The service names the managed memory from a truncated harness name plus
-      # a generated suffix, so this scopes to that prefix.
+      # The service names the managed memory from the harness name plus a
+      # generated suffix, so this scopes to that prefix.
       {
         Sid    = "AgentCoreManagedMemory"
         Effect = "Allow"
@@ -197,7 +197,7 @@ resource "aws_iam_role_policy" "execution_role" {
           "bedrock-agentcore:RetrieveMemoryRecords",
         ]
         Resource = [
-          "arn:${local.partition}:bedrock-agentcore:${local.region}:${local.account_id}:memory/harness_${substr(local.harness_name, 0, 34)}_*",
+          "arn:${local.partition}:bedrock-agentcore:${local.region}:${local.account_id}:memory/${local.harness_name}-*",
         ]
       },
       {


### PR DESCRIPTION
### Reason for this change

The `terraform-deploy` smoke test has been failing on `main` since #1005 ([run 31458602128](https://github.com/awslabs/nx-plugin-for-aws/actions/runs/31458602128) — the only failure out of 63 jobs).

The AgentCore Harness Terraform module scoped its managed-memory IAM statement to an ARN pattern that does not match the memory the service actually creates, so the execution role was denied `bedrock-agentcore:ListEvents` on its own memory and every harness invocation failed:

```
RuntimeClientError: AccessDeniedException ... User: .../MyHarness-HarnessRole-ba80d309/BedrockAgentCore-...
is not authorized to perform: bedrock-agentcore:ListEvents
on resource: arn:aws:bedrock-agentcore:us-west-2:...:memory/MyHarness_ba80d309-rSM4MW27qM
```

The policy granted `memory/harness_${substr(local.harness_name, 0, 34)}_*` → `memory/harness_MyHarness_ba80d309_*`, but the real memory is `MyHarness_ba80d309-rSM4MW27qM`. Three separate mismatches: a spurious `harness_` prefix, an `_` separator instead of `-`, and an unnecessary truncation.

The `harness_` prefix and truncation are not arbitrary — the service *does* prefix the **runtime** and **workload identity** that way (so the neighbouring `AgentCoreWorkloadIdentity` statement is correct), which is likely how the pattern was arrived at. The managed memory is named differently.

This is why the `cdk-deploy` equivalent passes: the CDK construct references `harness.attrMemoryManagedMemoryConfigurationArn` directly. `aws_bedrockagentcore_harness` in AWS provider 6.58.0 exports only `harness_id`, `arn` and `tags_all` — no memory ARN — so the Terraform path has to build a wildcard by hand, and the typo went unnoticed.

### Description of changes

Scope the `AgentCoreManagedMemory` statement to `memory/${local.harness_name}-*`, and correct the accompanying comment. The wildcard suffix stays, since the provider exposes no memory ARN attribute to reference.

Also adds a unit test asserting the rendered statement, so a reintroduced `harness_` prefix or `_` separator fails fast rather than only surfacing in a deploy smoke test.

No CDK changes — that path was already correct.

### Description of how you validated changes

**Deployed to AWS at the boundary case.** The `substr(..., 0, 34)` removal is the part worth proving, so this was validated with a real deployment using the longest name the generator can emit, not just by unit test.

Generated a harness named `a-really-long-harness-name-that-exceeds-the-limit`, which the generator caps to the maximum 40-character harness name (31-char prefix + `_` + 8 hex), wired the module into a `terraform#project` infra app, and deployed it with the locally compiled plugin:

```
harness arn:  arn:aws:bedrock-agentcore:us-west-2:...:harness/AReallyLongHarnessNameThatExcee_501e1334-mogVwcJrZm
memory id:    AReallyLongHarnessNameThatExcee_501e1334-JDcLgjDEzF     (51 chars)
policy arn:   .../memory/AReallyLongHarnessNameThatExcee_501e1334-*
```

The service applies **no truncation** — not even at the 48-character limit documented for user-created memories — so the memory is `<harness name>-<10 chars>` at every length the generator can produce.

Confirmed the fix end to end:

1. **Live invocation succeeded on the first attempt**, which is the call that failed in CI:
   ```
   InvokeHarness("what is 3 + 5 - 2?") -> "**3 + 5 - 2 = 6**"
   ```
2. **`iam simulate-principal-policy`** against the deployed role and the real memory ARN — `ListEvents`, `CreateEvent` and `RetrieveMemoryRecords` all `allowed`.
3. **`iam simulate-custom-policy`** with the old pattern against the same ARN — `implicitDeny`, reproducing the CI failure exactly.

All provisioned resources were destroyed afterwards (`nx destroy` clean; harness, execution role and managed memory confirmed gone).

Also:

- `pnpm nx run @aws/nx-plugin:test` — full suite green (44 harness tests)
- Confirmed the new unit test fails against the old pattern before passing against the new one
- `pnpm nx run-many --target lint --all --fix` — clean

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
