### PR TITLE
feat(agentcore-harness): implement IConnectable for VPC deployments

### DIFF
--- a/docs/src/content/docs/en/guides/agentcore-harness.mdx
+++ b/docs/src/content/docs/en/guides/agentcore-harness.mdx
@@ -97,8 +97,9 @@ The construct also accepts:
 - `allowedTools` — the tools the Harness may use. The Harness deploys with none unless you supply them, see <a href="#configuring-tools">Configuring tools</a>.
 - `executionRole` — an existing IAM role to use instead of the generated role. A supplied role is used as-is: the baseline permissions are not added to it, and its ARN always feeds the Harness (the raw `executionRoleArn` string cannot be overridden).
 - `modelResourceArns` — the Bedrock model and inference-profile ARNs the generated execution role may invoke, replacing the default list.
+- `vpc`, `vpcSubnets` and `securityGroups` — run the Harness in a VPC so it can reach private resources, see <a href="#running-in-a-vpc">Running in a VPC</a>.
 
-Its public members are `harness` (the `CfnHarness`), `executionRole`, `grantPrincipal`, the `harnessArn` getter, `addToRolePolicy(statement)` for execution role extensions, and `grantInvokeAccess(grantee)` for authorizing callers.
+Its public members are `harness` (the `CfnHarness`), `executionRole`, `grantPrincipal`, the `harnessArn` getter, `connections` (in a VPC), `addToRolePolicy(statement)` for execution role extensions, and `grantInvokeAccess(grantee)` for authorizing callers.
 
 Deploy the stack with your infrastructure project as usual — see the <Link path="guides/typescript-infrastructure">CDK infrastructure guide</Link>.
   </Fragment>
@@ -224,6 +225,46 @@ Add an `allowed_tools` variable to the module if you would rather set it as a mo
 </Infrastructure>
 
 Narrow `@builtin` to specific patterns such as `@builtin/file_operations` to restrict what the agent loop can do. See [Harness tools](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/harness-tools.html) for the built-in tools you can add.
+
+### Running in a VPC
+
+<Infrastructure>
+  <Fragment slot="cdk">
+Supply a `vpc` to run the Harness inside it, so it can reach private resources such as a database. The construct implements `IConnectable`, so those resources grant it access the same way they would any other:
+
+```ts
+const harness = new MyHarness(this, 'MyHarness', { vpc });
+
+database.connections.allowDefaultPortFrom(harness, 'Harness to database');
+```
+
+The Harness is placed in the VPC's private subnets with egress, in a security group created for it. Override either with `vpcSubnets` and `securityGroups`. Both require `vpc`, and `connections` is only available when the Harness runs in a VPC.
+  </Fragment>
+  <Fragment slot="terraform">
+Add a `network_configuration` block to the generated `aws_bedrockagentcore_harness` resource's `environment.agent_core_runtime_environment`, then reference the security group you place it in from your other resources' rules:
+
+```hcl title="packages/common/terraform/src/app/harnesses/my-harness/my-harness.tf"
+resource "aws_security_group" "harness" {
+  vpc_id = var.vpc_id
+}
+
+resource "aws_bedrockagentcore_harness" "this" {
+  # ...
+  environment {
+    agent_core_runtime_environment {
+      network_configuration {
+        network_mode = "VPC"
+        network_mode_config {
+          security_groups = [aws_security_group.harness.id]
+          subnets         = var.subnet_ids
+        }
+      }
+    }
+  }
+}
+```
+  </Fragment>
+</Infrastructure>
 
 ### Per-invocation overrides
 

--- a/docs/src/content/docs/es/guides/agentcore-harness.mdx
+++ b/docs/src/content/docs/es/guides/agentcore-harness.mdx
@@ -97,8 +97,9 @@ El constructo también acepta:
 - `allowedTools` — las herramientas que el Harness puede usar. El Harness se implementa sin ninguna a menos que las proporciones, consulta <a href="#configurar-herramientas">Configurar herramientas</a>.
 - `executionRole` — un rol IAM existente para usar en lugar del rol generado. Un rol proporcionado se usa tal cual: los permisos básicos no se le agregan, y su ARN siempre alimenta el Harness (la cadena `executionRoleArn` sin procesar no se puede anular).
 - `modelResourceArns` — los ARN del modelo de Bedrock y del perfil de inferencia que el rol de ejecución generado puede invocar, reemplazando la lista predeterminada.
+- `vpc`, `vpcSubnets` y `securityGroups` — ejecuta el Harness en una VPC para que pueda alcanzar recursos privados, consulta <a href="#ejecutar-en-una-vpc">Ejecutar en una VPC</a>.
 
-Sus miembros públicos son `harness` (el `CfnHarness`), `executionRole`, `grantPrincipal`, el getter `harnessArn`, `addToRolePolicy(statement)` para extensiones del rol de ejecución, y `grantInvokeAccess(grantee)` para autorizar llamadores.
+Sus miembros públicos son `harness` (el `CfnHarness`), `executionRole`, `grantPrincipal`, el getter `harnessArn`, `connections` (en una VPC), `addToRolePolicy(statement)` para extensiones del rol de ejecución, y `grantInvokeAccess(grantee)` para autorizar llamadores.
 
 Implementa el stack con tu proyecto de infraestructura como de costumbre — consulta la <Link path="guides/typescript-infrastructure">guía de infraestructura CDK</Link>.
   </Fragment>
@@ -224,6 +225,46 @@ Agrega una variable `allowed_tools` al módulo si prefieres establecerla como un
 </Infrastructure>
 
 Reduce `@builtin` a patrones específicos como `@builtin/file_operations` para restringir lo que el bucle de agente puede hacer. Consulta [Herramientas de Harness](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/harness-tools.html) para las herramientas integradas que puedes agregar.
+
+### Ejecutar en una VPC
+
+<Infrastructure>
+  <Fragment slot="cdk">
+Proporciona una `vpc` para ejecutar el Harness dentro de ella, de modo que pueda alcanzar recursos privados como una base de datos. El constructo implementa `IConnectable`, por lo que esos recursos le otorgan acceso de la misma manera que lo harían con cualquier otro:
+
+```ts
+const harness = new MyHarness(this, 'MyHarness', { vpc });
+
+database.connections.allowDefaultPortFrom(harness, 'Harness to database');
+```
+
+El Harness se coloca en las subredes privadas de la VPC con salida, en un grupo de seguridad creado para él. Anula cualquiera de los dos con `vpcSubnets` y `securityGroups`. Ambos requieren `vpc`, y `connections` solo está disponible cuando el Harness se ejecuta en una VPC.
+  </Fragment>
+  <Fragment slot="terraform">
+Agrega un bloque `network_configuration` al `environment.agent_core_runtime_environment` del recurso `aws_bedrockagentcore_harness` generado, luego referencia el grupo de seguridad en el que lo colocas desde las reglas de tus otros recursos:
+
+```hcl title="packages/common/terraform/src/app/harnesses/my-harness/my-harness.tf"
+resource "aws_security_group" "harness" {
+  vpc_id = var.vpc_id
+}
+
+resource "aws_bedrockagentcore_harness" "this" {
+  # ...
+  environment {
+    agent_core_runtime_environment {
+      network_configuration {
+        network_mode = "VPC"
+        network_mode_config {
+          security_groups = [aws_security_group.harness.id]
+          subnets         = var.subnet_ids
+        }
+      }
+    }
+  }
+}
+```
+  </Fragment>
+</Infrastructure>
 
 ### Anulaciones por invocación
 

--- a/docs/src/content/docs/fr/guides/agentcore-harness.mdx
+++ b/docs/src/content/docs/fr/guides/agentcore-harness.mdx
@@ -97,8 +97,9 @@ Le construct accepte également :
 - `allowedTools` — les outils que le Harness peut utiliser. Le Harness se déploie sans aucun outil sauf si vous les fournissez, voir <a href="#configuring-tools">Configuration des outils</a>.
 - `executionRole` — un rôle IAM existant à utiliser au lieu du rôle généré. Un rôle fourni est utilisé tel quel : les permissions de base ne lui sont pas ajoutées, et son ARN alimente toujours le Harness (la chaîne brute `executionRoleArn` ne peut pas être remplacée).
 - `modelResourceArns` — les ARN de modèle Bedrock et de profil d'inférence que le rôle d'exécution généré peut invoquer, remplaçant la liste par défaut.
+- `vpc`, `vpcSubnets` et `securityGroups` — exécutez le Harness dans un VPC afin qu'il puisse atteindre des ressources privées, voir <a href="#running-in-a-vpc">Exécution dans un VPC</a>.
 
-Ses membres publics sont `harness` (le `CfnHarness`), `executionRole`, `grantPrincipal`, le getter `harnessArn`, `addToRolePolicy(statement)` pour les extensions de rôle d'exécution, et `grantInvokeAccess(grantee)` pour autoriser les appelants.
+Ses membres publics sont `harness` (le `CfnHarness`), `executionRole`, `grantPrincipal`, le getter `harnessArn`, `connections` (dans un VPC), `addToRolePolicy(statement)` pour les extensions de rôle d'exécution, et `grantInvokeAccess(grantee)` pour autoriser les appelants.
 
 Déployez la pile avec votre projet d'infrastructure comme d'habitude — voir le <Link path="guides/typescript-infrastructure">guide d'infrastructure CDK</Link>.
   </Fragment>
@@ -224,6 +225,46 @@ Ajoutez une variable `allowed_tools` au module si vous préférez la définir co
 </Infrastructure>
 
 Restreignez `@builtin` à des modèles spécifiques tels que `@builtin/file_operations` pour limiter ce que la boucle d'agent peut faire. Voir [Outils Harness](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/harness-tools.html) pour les outils intégrés que vous pouvez ajouter.
+
+### Exécution dans un VPC
+
+<Infrastructure>
+  <Fragment slot="cdk">
+Fournissez un `vpc` pour exécuter le Harness à l'intérieur, afin qu'il puisse atteindre des ressources privées telles qu'une base de données. Le construct implémente `IConnectable`, donc ces ressources lui accordent l'accès de la même manière qu'elles le feraient pour n'importe quelle autre :
+
+```ts
+const harness = new MyHarness(this, 'MyHarness', { vpc });
+
+database.connections.allowDefaultPortFrom(harness, 'Harness to database');
+```
+
+Le Harness est placé dans les sous-réseaux privés du VPC avec sortie, dans un groupe de sécurité créé pour lui. Remplacez l'un ou l'autre avec `vpcSubnets` et `securityGroups`. Les deux nécessitent `vpc`, et `connections` n'est disponible que lorsque le Harness s'exécute dans un VPC.
+  </Fragment>
+  <Fragment slot="terraform">
+Ajoutez un bloc `network_configuration` à l'`environment.agent_core_runtime_environment` de la ressource `aws_bedrockagentcore_harness` générée, puis référencez le groupe de sécurité dans lequel vous le placez depuis les règles de vos autres ressources :
+
+```hcl title="packages/common/terraform/src/app/harnesses/my-harness/my-harness.tf"
+resource "aws_security_group" "harness" {
+  vpc_id = var.vpc_id
+}
+
+resource "aws_bedrockagentcore_harness" "this" {
+  # ...
+  environment {
+    agent_core_runtime_environment {
+      network_configuration {
+        network_mode = "VPC"
+        network_mode_config {
+          security_groups = [aws_security_group.harness.id]
+          subnets         = var.subnet_ids
+        }
+      }
+    }
+  }
+}
+```
+  </Fragment>
+</Infrastructure>
 
 ### Remplacements par invocation
 

--- a/docs/src/content/docs/it/guides/agentcore-harness.mdx
+++ b/docs/src/content/docs/it/guides/agentcore-harness.mdx
@@ -97,8 +97,9 @@ Il costrutto accetta anche:
 - `allowedTools` — gli strumenti che l'Harness può utilizzare. L'Harness viene distribuito senza strumenti a meno che tu non li fornisca, vedi <a href="#configuring-tools">Configurazione degli strumenti</a>.
 - `executionRole` — un ruolo IAM esistente da utilizzare al posto del ruolo generato. Un ruolo fornito viene utilizzato così com'è: le autorizzazioni di base non vengono aggiunte ad esso e il suo ARN alimenta sempre l'Harness (la stringa `executionRoleArn` grezza non può essere sovrascritta).
 - `modelResourceArns` — gli ARN del modello Bedrock e del profilo di inferenza che il ruolo di esecuzione generato può invocare, sostituendo l'elenco predefinito.
+- `vpc`, `vpcSubnets` e `securityGroups` — esegui l'Harness in un VPC in modo che possa raggiungere risorse private, vedi <a href="#running-in-a-vpc">Esecuzione in un VPC</a>.
 
-I suoi membri pubblici sono `harness` (il `CfnHarness`), `executionRole`, `grantPrincipal`, il getter `harnessArn`, `addToRolePolicy(statement)` per le estensioni del ruolo di esecuzione e `grantInvokeAccess(grantee)` per autorizzare i chiamanti.
+I suoi membri pubblici sono `harness` (il `CfnHarness`), `executionRole`, `grantPrincipal`, il getter `harnessArn`, `connections` (in un VPC), `addToRolePolicy(statement)` per le estensioni del ruolo di esecuzione e `grantInvokeAccess(grantee)` per autorizzare i chiamanti.
 
 Distribuisci lo stack con il tuo progetto di infrastruttura come al solito — vedi la <Link path="guides/typescript-infrastructure">guida all'infrastruttura CDK</Link>.
   </Fragment>
@@ -224,6 +225,46 @@ Aggiungi una variabile `allowed_tools` al modulo se preferisci impostarla come a
 </Infrastructure>
 
 Restringi `@builtin` a pattern specifici come `@builtin/file_operations` per limitare ciò che il ciclo dell'agente può fare. Vedi [Strumenti Harness](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/harness-tools.html) per gli strumenti integrati che puoi aggiungere.
+
+### Esecuzione in un VPC
+
+<Infrastructure>
+  <Fragment slot="cdk">
+Fornisci un `vpc` per eseguire l'Harness al suo interno, in modo che possa raggiungere risorse private come un database. Il costrutto implementa `IConnectable`, quindi quelle risorse gli concedono l'accesso nello stesso modo in cui lo farebbero con qualsiasi altro:
+
+```ts
+const harness = new MyHarness(this, 'MyHarness', { vpc });
+
+database.connections.allowDefaultPortFrom(harness, 'Harness to database');
+```
+
+L'Harness viene posizionato nelle subnet private del VPC con egress, in un gruppo di sicurezza creato per esso. Sovrascrivi uno dei due con `vpcSubnets` e `securityGroups`. Entrambi richiedono `vpc`, e `connections` è disponibile solo quando l'Harness viene eseguito in un VPC.
+  </Fragment>
+  <Fragment slot="terraform">
+Aggiungi un blocco `network_configuration` all'`environment.agent_core_runtime_environment` della risorsa `aws_bedrockagentcore_harness` generata, quindi fai riferimento al gruppo di sicurezza in cui lo posizioni dalle regole delle tue altre risorse:
+
+```hcl title="packages/common/terraform/src/app/harnesses/my-harness/my-harness.tf"
+resource "aws_security_group" "harness" {
+  vpc_id = var.vpc_id
+}
+
+resource "aws_bedrockagentcore_harness" "this" {
+  # ...
+  environment {
+    agent_core_runtime_environment {
+      network_configuration {
+        network_mode = "VPC"
+        network_mode_config {
+          security_groups = [aws_security_group.harness.id]
+          subnets         = var.subnet_ids
+        }
+      }
+    }
+  }
+}
+```
+  </Fragment>
+</Infrastructure>
 
 ### Override per invocazione
 

--- a/docs/src/content/docs/jp/guides/agentcore-harness.mdx
+++ b/docs/src/content/docs/jp/guides/agentcore-harness.mdx
@@ -97,8 +97,9 @@ const harness = new MyHarness(this, 'MyHarness', {
 - `allowedTools` — Harnessが使用できるツール。指定しない限り、Harnessはツールなしでデプロイされます。<a href="#configuring-tools">ツールの構成</a>を参照してください。
 - `executionRole` — 生成されたロールの代わりに使用する既存のIAMロール。指定されたロールはそのまま使用されます。ベースライン権限は追加されず、そのARNは常にHarnessに供給されます（生の`executionRoleArn`文字列はオーバーライドできません）。
 - `modelResourceArns` — 生成された実行ロールが呼び出せるBedrockモデルおよび推論プロファイルARN。デフォルトリストを置き換えます。
+- `vpc`、`vpcSubnets`、`securityGroups` — HarnessをVPC内で実行し、プライベートリソースに到達できるようにします。<a href="#running-in-a-vpc">VPCでの実行</a>を参照してください。
 
-パブリックメンバーは、`harness`（`CfnHarness`）、`executionRole`、`grantPrincipal`、`harnessArn`ゲッター、実行ロール拡張用の`addToRolePolicy(statement)`、呼び出し元を認証するための`grantInvokeAccess(grantee)`です。
+パブリックメンバーは、`harness`（`CfnHarness`）、`executionRole`、`grantPrincipal`、`harnessArn`ゲッター、`connections`（VPC内）、実行ロール拡張用の`addToRolePolicy(statement)`、呼び出し元を認証するための`grantInvokeAccess(grantee)`です。
 
 通常どおりインフラストラクチャプロジェクトでスタックをデプロイします。<Link path="guides/typescript-infrastructure">CDKインフラストラクチャガイド</Link>を参照してください。
   </Fragment>
@@ -224,6 +225,46 @@ resource "aws_bedrockagentcore_harness" "this" {
 </Infrastructure>
 
 `@builtin`を`@builtin/file_operations`などの特定のパターンに絞り込んで、エージェントループができることを制限します。追加できる組み込みツールについては、[Harnessツール](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/harness-tools.html)を参照してください。
+
+### VPCでの実行
+
+<Infrastructure>
+  <Fragment slot="cdk">
+`vpc`を指定してHarnessをその中で実行すると、データベースなどのプライベートリソースに到達できるようになります。コンストラクトは`IConnectable`を実装しているため、これらのリソースは他のリソースと同じ方法でアクセスを許可します。
+
+```ts
+const harness = new MyHarness(this, 'MyHarness', { vpc });
+
+database.connections.allowDefaultPortFrom(harness, 'Harness to database');
+```
+
+Harnessは、VPCのプライベートサブネット（エグレス付き）に配置され、専用のセキュリティグループに入れられます。`vpcSubnets`と`securityGroups`でいずれかをオーバーライドできます。両方とも`vpc`が必要で、`connections`はHarnessがVPC内で実行されている場合にのみ利用可能です。
+  </Fragment>
+  <Fragment slot="terraform">
+生成された`aws_bedrockagentcore_harness`リソースの`environment.agent_core_runtime_environment`に`network_configuration`ブロックを追加し、配置したセキュリティグループを他のリソースのルールから参照します。
+
+```hcl title="packages/common/terraform/src/app/harnesses/my-harness/my-harness.tf"
+resource "aws_security_group" "harness" {
+  vpc_id = var.vpc_id
+}
+
+resource "aws_bedrockagentcore_harness" "this" {
+  # ...
+  environment {
+    agent_core_runtime_environment {
+      network_configuration {
+        network_mode = "VPC"
+        network_mode_config {
+          security_groups = [aws_security_group.harness.id]
+          subnets         = var.subnet_ids
+        }
+      }
+    }
+  }
+}
+```
+  </Fragment>
+</Infrastructure>
 
 ### 呼び出しごとのオーバーライド
 

--- a/docs/src/content/docs/ko/guides/agentcore-harness.mdx
+++ b/docs/src/content/docs/ko/guides/agentcore-harness.mdx
@@ -97,8 +97,9 @@ const harness = new MyHarness(this, 'MyHarness', {
 - `allowedTools` — Harness가 사용할 수 있는 도구. 제공하지 않으면 Harness는 도구 없이 배포됩니다. <a href="#configuring-tools">도구 구성</a>을 참조하세요.
 - `executionRole` — 생성된 역할 대신 사용할 기존 IAM 역할. 제공된 역할은 있는 그대로 사용됩니다: 기본 권한이 추가되지 않으며, 해당 ARN은 항상 Harness에 제공됩니다(원시 `executionRoleArn` 문자열은 재정의할 수 없음).
 - `modelResourceArns` — 생성된 실행 역할이 호출할 수 있는 Bedrock 모델 및 추론 프로필 ARN으로, 기본 목록을 대체합니다.
+- `vpc`, `vpcSubnets` 및 `securityGroups` — VPC에서 Harness를 실행하여 프라이빗 리소스에 도달할 수 있도록 합니다. <a href="#running-in-a-vpc">VPC에서 실행</a>을 참조하세요.
 
-공개 멤버는 `harness`(`CfnHarness`), `executionRole`, `grantPrincipal`, `harnessArn` getter, 실행 역할 확장을 위한 `addToRolePolicy(statement)`, 호출자 권한 부여를 위한 `grantInvokeAccess(grantee)`입니다.
+공개 멤버는 `harness`(`CfnHarness`), `executionRole`, `grantPrincipal`, `harnessArn` getter, `connections`(VPC에서), 실행 역할 확장을 위한 `addToRolePolicy(statement)`, 호출자 권한 부여를 위한 `grantInvokeAccess(grantee)`입니다.
 
 평소와 같이 인프라 프로젝트로 스택을 배포하세요 — <Link path="guides/typescript-infrastructure">CDK 인프라 가이드</Link>를 참조하세요.
   </Fragment>
@@ -224,6 +225,46 @@ resource "aws_bedrockagentcore_harness" "this" {
 </Infrastructure>
 
 `@builtin`을 `@builtin/file_operations`와 같은 특정 패턴으로 좁혀 에이전트 루프가 수행할 수 있는 작업을 제한하세요. 추가할 수 있는 내장 도구는 [Harness tools](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/harness-tools.html)를 참조하세요.
+
+### VPC에서 실행
+
+<Infrastructure>
+  <Fragment slot="cdk">
+`vpc`를 제공하여 Harness를 그 안에서 실행하면 데이터베이스와 같은 프라이빗 리소스에 도달할 수 있습니다. 구성은 `IConnectable`을 구현하므로 해당 리소스는 다른 리소스와 동일한 방식으로 액세스 권한을 부여합니다:
+
+```ts
+const harness = new MyHarness(this, 'MyHarness', { vpc });
+
+database.connections.allowDefaultPortFrom(harness, 'Harness to database');
+```
+
+Harness는 VPC의 프라이빗 서브넷에 배치되며, 이를 위해 생성된 보안 그룹에 배치됩니다. `vpcSubnets` 및 `securityGroups`로 둘 중 하나를 재정의할 수 있습니다. 둘 다 `vpc`가 필요하며, `connections`는 Harness가 VPC에서 실행될 때만 사용할 수 있습니다.
+  </Fragment>
+  <Fragment slot="terraform">
+생성된 `aws_bedrockagentcore_harness` 리소스의 `environment.agent_core_runtime_environment`에 `network_configuration` 블록을 추가한 다음, 다른 리소스의 규칙에서 배치한 보안 그룹을 참조하세요:
+
+```hcl title="packages/common/terraform/src/app/harnesses/my-harness/my-harness.tf"
+resource "aws_security_group" "harness" {
+  vpc_id = var.vpc_id
+}
+
+resource "aws_bedrockagentcore_harness" "this" {
+  # ...
+  environment {
+    agent_core_runtime_environment {
+      network_configuration {
+        network_mode = "VPC"
+        network_mode_config {
+          security_groups = [aws_security_group.harness.id]
+          subnets         = var.subnet_ids
+        }
+      }
+    }
+  }
+}
+```
+  </Fragment>
+</Infrastructure>
 
 ### 호출별 재정의
 

--- a/docs/src/content/docs/pt/guides/agentcore-harness.mdx
+++ b/docs/src/content/docs/pt/guides/agentcore-harness.mdx
@@ -97,8 +97,9 @@ O construto também aceita:
 - `allowedTools` — as ferramentas que o Harness pode usar. O Harness é implantado sem nenhuma a menos que você as forneça, veja <a href="#configuring-tools">Configurando ferramentas</a>.
 - `executionRole` — uma função IAM existente para usar em vez da função gerada. Uma função fornecida é usada como está: as permissões básicas não são adicionadas a ela, e seu ARN sempre alimenta o Harness (a string bruta `executionRoleArn` não pode ser substituída).
 - `modelResourceArns` — os ARNs de modelo e perfil de inferência do Bedrock que a função de execução gerada pode invocar, substituindo a lista padrão.
+- `vpc`, `vpcSubnets` e `securityGroups` — execute o Harness em uma VPC para que ele possa alcançar recursos privados, veja <a href="#running-in-a-vpc">Executando em uma VPC</a>.
 
-Seus membros públicos são `harness` (o `CfnHarness`), `executionRole`, `grantPrincipal`, o getter `harnessArn`, `addToRolePolicy(statement)` para extensões da função de execução, e `grantInvokeAccess(grantee)` para autorizar chamadores.
+Seus membros públicos são `harness` (o `CfnHarness`), `executionRole`, `grantPrincipal`, o getter `harnessArn`, `connections` (em uma VPC), `addToRolePolicy(statement)` para extensões da função de execução, e `grantInvokeAccess(grantee)` para autorizar chamadores.
 
 Implante a stack com seu projeto de infraestrutura como de costume — veja o <Link path="guides/typescript-infrastructure">guia de infraestrutura CDK</Link>.
   </Fragment>
@@ -224,6 +225,46 @@ Adicione uma variável `allowed_tools` ao módulo se você preferir defini-la co
 </Infrastructure>
 
 Restrinja `@builtin` a padrões específicos como `@builtin/file_operations` para restringir o que o loop do agente pode fazer. Veja [Harness tools](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/harness-tools.html) para as ferramentas integradas que você pode adicionar.
+
+### Executando em uma VPC
+
+<Infrastructure>
+  <Fragment slot="cdk">
+Forneça uma `vpc` para executar o Harness dentro dela, para que ele possa alcançar recursos privados como um banco de dados. O construto implementa `IConnectable`, então esses recursos concedem acesso a ele da mesma forma que fariam com qualquer outro:
+
+```ts
+const harness = new MyHarness(this, 'MyHarness', { vpc });
+
+database.connections.allowDefaultPortFrom(harness, 'Harness to database');
+```
+
+O Harness é colocado nas sub-redes privadas da VPC com saída, em um grupo de segurança criado para ele. Substitua qualquer um com `vpcSubnets` e `securityGroups`. Ambos requerem `vpc`, e `connections` está disponível apenas quando o Harness é executado em uma VPC.
+  </Fragment>
+  <Fragment slot="terraform">
+Adicione um bloco `network_configuration` ao `environment.agent_core_runtime_environment` do recurso `aws_bedrockagentcore_harness` gerado, então referencie o grupo de segurança no qual você o coloca a partir das regras de seus outros recursos:
+
+```hcl title="packages/common/terraform/src/app/harnesses/my-harness/my-harness.tf"
+resource "aws_security_group" "harness" {
+  vpc_id = var.vpc_id
+}
+
+resource "aws_bedrockagentcore_harness" "this" {
+  # ...
+  environment {
+    agent_core_runtime_environment {
+      network_configuration {
+        network_mode = "VPC"
+        network_mode_config {
+          security_groups = [aws_security_group.harness.id]
+          subnets         = var.subnet_ids
+        }
+      }
+    }
+  }
+}
+```
+  </Fragment>
+</Infrastructure>
 
 ### Substituições por invocação
 

--- a/docs/src/content/docs/vi/guides/agentcore-harness.mdx
+++ b/docs/src/content/docs/vi/guides/agentcore-harness.mdx
@@ -97,8 +97,9 @@ Construct cũng chấp nhận:
 - `allowedTools` — các công cụ mà Harness có thể sử dụng. Harness triển khai mà không có công cụ nào trừ khi bạn cung cấp chúng, xem <a href="#configuring-tools">Configuring tools</a>.
 - `executionRole` — một IAM role hiện có để sử dụng thay vì role được tạo. Một role được cung cấp được sử dụng nguyên trạng: các quyền cơ bản không được thêm vào nó, và ARN của nó luôn cung cấp cho Harness (chuỗi `executionRoleArn` thô không thể bị ghi đè).
 - `modelResourceArns` — các ARN của Bedrock model và inference-profile mà execution role được tạo có thể gọi, thay thế danh sách mặc định.
+- `vpc`, `vpcSubnets` và `securityGroups` — chạy Harness trong một VPC để nó có thể tiếp cận các tài nguyên riêng tư, xem <a href="#running-in-a-vpc">Running in a VPC</a>.
 
-Các thành viên công khai của nó là `harness` (`CfnHarness`), `executionRole`, `grantPrincipal`, getter `harnessArn`, `addToRolePolicy(statement)` cho các mở rộng execution role, và `grantInvokeAccess(grantee)` để ủy quyền cho người gọi.
+Các thành viên công khai của nó là `harness` (`CfnHarness`), `executionRole`, `grantPrincipal`, getter `harnessArn`, `connections` (trong một VPC), `addToRolePolicy(statement)` cho các mở rộng execution role, và `grantInvokeAccess(grantee)` để ủy quyền cho người gọi.
 
 Triển khai stack với dự án hạ tầng của bạn như thường lệ — xem <Link path="guides/typescript-infrastructure">hướng dẫn hạ tầng CDK</Link>.
   </Fragment>
@@ -224,6 +225,46 @@ Thêm một biến `allowed_tools` vào module nếu bạn muốn đặt nó là
 </Infrastructure>
 
 Thu hẹp `@builtin` thành các mẫu cụ thể như `@builtin/file_operations` để hạn chế những gì vòng lặp agent có thể làm. Xem [Harness tools](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/harness-tools.html) cho các công cụ tích hợp sẵn mà bạn có thể thêm.
+
+### Chạy trong một VPC
+
+<Infrastructure>
+  <Fragment slot="cdk">
+Cung cấp một `vpc` để chạy Harness bên trong nó, để nó có thể tiếp cận các tài nguyên riêng tư như cơ sở dữ liệu. Construct triển khai `IConnectable`, vì vậy các tài nguyên đó cấp quyền truy cập cho nó theo cách tương tự như bất kỳ tài nguyên nào khác:
+
+```ts
+const harness = new MyHarness(this, 'MyHarness', { vpc });
+
+database.connections.allowDefaultPortFrom(harness, 'Harness to database');
+```
+
+Harness được đặt trong các subnet riêng tư của VPC với egress, trong một security group được tạo cho nó. Ghi đè một trong hai với `vpcSubnets` và `securityGroups`. Cả hai đều yêu cầu `vpc`, và `connections` chỉ khả dụng khi Harness chạy trong một VPC.
+  </Fragment>
+  <Fragment slot="terraform">
+Thêm một khối `network_configuration` vào `environment.agent_core_runtime_environment` của tài nguyên `aws_bedrockagentcore_harness` được tạo, sau đó tham chiếu security group mà bạn đặt nó vào từ các quy tắc của các tài nguyên khác của bạn:
+
+```hcl title="packages/common/terraform/src/app/harnesses/my-harness/my-harness.tf"
+resource "aws_security_group" "harness" {
+  vpc_id = var.vpc_id
+}
+
+resource "aws_bedrockagentcore_harness" "this" {
+  # ...
+  environment {
+    agent_core_runtime_environment {
+      network_configuration {
+        network_mode = "VPC"
+        network_mode_config {
+          security_groups = [aws_security_group.harness.id]
+          subnets         = var.subnet_ids
+        }
+      }
+    }
+  }
+}
+```
+  </Fragment>
+</Infrastructure>
 
 ### Ghi đè theo từng lần gọi
 

--- a/docs/src/content/docs/zh/guides/agentcore-harness.mdx
+++ b/docs/src/content/docs/zh/guides/agentcore-harness.mdx
@@ -97,8 +97,9 @@ const harness = new MyHarness(this, 'MyHarness', {
 - `allowedTools` — Harness 可以使用的工具。除非您提供工具，否则 Harness 部署时不带任何工具，请参阅<a href="#configuring-tools">配置工具</a>。
 - `executionRole` — 要使用的现有 IAM 角色，而不是生成的角色。提供的角色按原样使用：不会向其添加基线权限，其 ARN 始终提供给 Harness（原始 `executionRoleArn` 字符串无法被覆盖）。
 - `modelResourceArns` — 生成的执行角色可以调用的 Bedrock 模型和推理配置文件 ARN，替换默认列表。
+- `vpc`、`vpcSubnets` 和 `securityGroups` — 在 VPC 中运行 Harness，以便它可以访问私有资源，请参阅<a href="#running-in-a-vpc">在 VPC 中运行</a>。
 
-其公共成员包括 `harness`（`CfnHarness`）、`executionRole`、`grantPrincipal`、`harnessArn` getter、用于执行角色扩展的 `addToRolePolicy(statement)` 以及用于授权调用者的 `grantInvokeAccess(grantee)`。
+其公共成员包括 `harness`（`CfnHarness`）、`executionRole`、`grantPrincipal`、`harnessArn` getter、`connections`（在 VPC 中）、用于执行角色扩展的 `addToRolePolicy(statement)` 以及用于授权调用者的 `grantInvokeAccess(grantee)`。
 
 像往常一样使用您的基础设施项目部署堆栈 — 请参阅 <Link path="guides/typescript-infrastructure">CDK 基础设施指南</Link>。
   </Fragment>
@@ -224,6 +225,46 @@ resource "aws_bedrockagentcore_harness" "this" {
 </Infrastructure>
 
 将 `@builtin` 缩小到特定模式（如 `@builtin/file_operations`）以限制代理循环可以执行的操作。有关可以添加的内置工具，请参阅 [Harness 工具](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/harness-tools.html)。
+
+### 在 VPC 中运行
+
+<Infrastructure>
+  <Fragment slot="cdk">
+提供 `vpc` 以在其中运行 Harness，以便它可以访问私有资源（如数据库）。该构造实现了 `IConnectable`，因此这些资源以与其他资源相同的方式授予它访问权限：
+
+```ts
+const harness = new MyHarness(this, 'MyHarness', { vpc });
+
+database.connections.allowDefaultPortFrom(harness, 'Harness to database');
+```
+
+Harness 被放置在 VPC 的具有出口的私有子网中，位于为其创建的安全组中。使用 `vpcSubnets` 和 `securityGroups` 覆盖任一项。两者都需要 `vpc`，并且 `connections` 仅在 Harness 在 VPC 中运行时可用。
+  </Fragment>
+  <Fragment slot="terraform">
+将 `network_configuration` 块添加到生成的 `aws_bedrockagentcore_harness` 资源的 `environment.agent_core_runtime_environment`，然后从其他资源的规则中引用您放置它的安全组：
+
+```hcl title="packages/common/terraform/src/app/harnesses/my-harness/my-harness.tf"
+resource "aws_security_group" "harness" {
+  vpc_id = var.vpc_id
+}
+
+resource "aws_bedrockagentcore_harness" "this" {
+  # ...
+  environment {
+    agent_core_runtime_environment {
+      network_configuration {
+        network_mode = "VPC"
+        network_mode_config {
+          security_groups = [aws_security_group.harness.id]
+          subnets         = var.subnet_ids
+        }
+      }
+    }
+  }
+}
+```
+  </Fragment>
+</Infrastructure>
 
 ### 每次调用覆盖
 

--- a/packages/nx-plugin/src/agentcore-harness/generator.spec.ts
+++ b/packages/nx-plugin/src/agentcore-harness/generator.spec.ts
@@ -355,7 +355,8 @@ describe('agentcore-harness generator', () => {
     });
 
     it('emits the construct, exports it, and inlines the model id and prompt read', () => {
-      expect(construct).toContain('export class MyHarness extends Construct');
+      expect(construct).toContain('export class MyHarness');
+      expect(construct).toContain('extends Construct');
       // ESM workspace, so addStarExport keeps the `.js` specifier suffix.
       expect(tree.read(CDK_HARNESSES_INDEX_PATH, 'utf-8')).toContain(
         "export * from './my-harness/my-harness.js';",
@@ -413,6 +414,39 @@ describe('agentcore-harness generator', () => {
       expect(construct).toContain(
         "allowedTools?: agentcore.CfnHarnessProps['allowedTools'];",
       );
+    });
+
+    // IConnectable, so a VPC resource can grant the Harness port access with
+    // the same `connections` idiom every other construct uses.
+    it('implements IConnectable for a Harness placed in a VPC', () => {
+      expect(construct).toContain(
+        "import * as ec2 from 'aws-cdk-lib/aws-ec2';",
+      );
+      expect(construct).toContain(
+        'implements iam.IGrantable, ec2.IConnectable',
+      );
+      expect(construct).toContain(
+        'public get connections(): ec2.Connections {',
+      );
+
+      // The three placement props, and a security group created only when the
+      // caller does not bring their own.
+      for (const prop of [
+        'vpc?: ec2.IVpc;',
+        'vpcSubnets?: ec2.SubnetSelection;',
+        'securityGroups?: ec2.ISecurityGroup[];',
+      ]) {
+        expect(construct, prop).toContain(prop);
+      }
+      expect(construct).toContain(
+        "new ec2.SecurityGroup(this, 'SecurityGroup'",
+      );
+      expect(construct).toContain('ec2.SubnetType.PRIVATE_WITH_EGRESS');
+
+      // Rendered lazily, so a security group added through `connections` after
+      // construction still reaches the resource.
+      expect(construct).toContain('Lazy.any({');
+      expect(construct).toContain("networkMode: 'VPC',");
     });
   });
 

--- a/packages/nx-plugin/src/utils/agent-core-constructs/files/cdk/app/agentcore-harness/__nameKebabCase__/__nameKebabCase__.ts.template
+++ b/packages/nx-plugin/src/utils/agent-core-constructs/files/cdk/app/agentcore-harness/__nameKebabCase__/__nameKebabCase__.ts.template
@@ -1,8 +1,9 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as url from 'node:url';
-import { CfnOutput, Names, Stack } from 'aws-cdk-lib';
+import { CfnOutput, Lazy, Names, Stack } from 'aws-cdk-lib';
 import * as agentcore from 'aws-cdk-lib/aws-bedrockagentcore';
+import * as ec2 from 'aws-cdk-lib/aws-ec2';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import { Construct, IConstruct } from 'constructs';
 import { suppressRules } from '../../../core/checkov<% if (esm) { %>.js<% } %>';
@@ -36,12 +37,26 @@ export interface <%- nameClassName %>Props
   modelResourceArns?: string[];
   /** Tools the Harness may use. Deploys with none unless supplied here. */
   allowedTools?: agentcore.CfnHarnessProps['allowedTools'];
+  /**
+   * Run the Harness in a VPC so it can reach private resources. Selects private
+   * subnets with egress unless `vpcSubnets` narrows it, and creates a security
+   * group unless `securityGroups` supplies them.
+   */
+  vpc?: ec2.IVpc;
+  /** Subnets to place the Harness in. Requires `vpc`. */
+  vpcSubnets?: ec2.SubnetSelection;
+  /** Security groups for the Harness. Requires `vpc`. */
+  securityGroups?: ec2.ISecurityGroup[];
 }
 
 /** A managed Amazon Bedrock AgentCore Harness, using IAM inbound auth. */
-export class <%- nameClassName %> extends Construct implements iam.IGrantable {
+export class <%- nameClassName %>
+  extends Construct
+  implements iam.IGrantable, ec2.IConnectable
+{
   public readonly harness: agentcore.CfnHarness;
   public readonly executionRole: iam.IRole;
+  private readonly _connections?: ec2.Connections;
 
   constructor(scope: Construct, id: string, props?: <%- nameClassName %>Props) {
     super(scope, id);
@@ -53,8 +68,28 @@ export class <%- nameClassName %> extends Construct implements iam.IGrantable {
         `arn:${stack.partition}:bedrock:*::foundation-model/*`,
         `arn:${stack.partition}:bedrock:${stack.region}:${stack.account}:*`,
       ],
+      vpc,
+      vpcSubnets,
+      securityGroups,
       ...harnessProps
     } = props ?? {};
+
+    if (!vpc && (vpcSubnets || securityGroups)) {
+      throw new Error(
+        'vpcSubnets and securityGroups require vpc to be supplied.',
+      );
+    }
+
+    if (vpc) {
+      this._connections = new ec2.Connections({
+        securityGroups: securityGroups ?? [
+          new ec2.SecurityGroup(this, 'SecurityGroup', {
+            vpc,
+            description: `Harness ${id}`,
+          }),
+        ],
+      });
+    }
 
     // Harness names allow ASCII letters, digits and underscores, must start
     // with a letter, and are at most 40 characters.
@@ -206,6 +241,38 @@ export class <%- nameClassName %> extends Construct implements iam.IGrantable {
       );
     }
 
+    // Rendered lazily so security groups added through `connections` after
+    // construction are still picked up.
+    const environment: agentcore.CfnHarnessProps['environment'] | undefined = vpc
+      ? Lazy.any({
+          produce: () => ({
+            ...(harnessProps.environment as
+              | agentcore.CfnHarness.HarnessEnvironmentProviderProperty
+              | undefined),
+            agentCoreRuntimeEnvironment: {
+              ...(
+                harnessProps.environment as
+                  | agentcore.CfnHarness.HarnessEnvironmentProviderProperty
+                  | undefined
+              )?.agentCoreRuntimeEnvironment,
+              networkConfiguration: {
+                networkMode: 'VPC',
+                networkModeConfig: {
+                  subnets: vpc.selectSubnets(
+                    vpcSubnets ?? {
+                      subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS,
+                    },
+                  ).subnetIds,
+                  securityGroups: this._connections!.securityGroups.map(
+                    (group) => group.securityGroupId,
+                  ),
+                },
+              },
+            },
+          }),
+        })
+      : harnessProps.environment;
+
     this.harness = new agentcore.CfnHarness(this, 'Harness', {
       model: {
         bedrockModelConfig: {
@@ -218,6 +285,9 @@ export class <%- nameClassName %> extends Construct implements iam.IGrantable {
       // execution role's workload-identity resource pattern.
       harnessName,
       executionRoleArn: this.executionRole.roleArn,
+      // Carries the VPC network configuration when `vpc` is supplied, and is
+      // the caller's own `environment` otherwise.
+      environment,
     });
 
     // The Harness provisions managed memory unless `memory` is supplied, and
@@ -255,6 +325,19 @@ export class <%- nameClassName %> extends Construct implements iam.IGrantable {
 
   public get grantPrincipal(): iam.IPrincipal {
     return this.executionRole.grantPrincipal;
+  }
+
+  /**
+   * Network connections for this Harness, for granting access to resources such
+   * as a database. Only available when the Harness runs in a VPC.
+   */
+  public get connections(): ec2.Connections {
+    if (!this._connections) {
+      throw new Error(
+        'Connections are only available when the Harness runs in a VPC. Supply the vpc prop.',
+      );
+    }
+    return this._connections;
   }
 
   /** The deployed Harness ARN. */


### PR DESCRIPTION
### Reason for this change

A generated Harness had no way to reach private resources: the construct exposed no network configuration, so it always ran on the public network. That rules out the common case of an agent talking to a database or any other resource in a VPC.

Closes #1072.

### Description of changes

Adds `vpc`, `vpcSubnets` and `securityGroups` props to the generated CDK construct, and implements `ec2.IConnectable` so a VPC resource can grant the Harness port access with the usual idiom:

```ts
const harness = new MyHarness(this, 'MyHarness', { vpc });

database.connections.allowDefaultPortFrom(harness, 'Harness to database');
```

- Placement defaults to the VPC's private subnets with egress, in a security group created for the Harness. `vpcSubnets` and `securityGroups` override either, and both require `vpc`.
- The service reads network configuration from `environment.agentCoreRuntimeEnvironment.networkConfiguration`. That is rendered with `Lazy` so a security group added through `connections` *after* construction is still picked up, and it merges into any `environment` the caller supplies rather than replacing it.
- `connections` throws a named error when the Harness is not in a VPC, rather than returning an empty `Connections`.
- Purely additive: the non-VPC path emits no `Environment` at all, so an existing Harness synthesizes exactly as before.

No IAM changes are needed — AgentCore manages the ENIs service-side, so the execution role takes no `ec2:*` permissions.

Terraform is unchanged. The module keeps the native `aws_bedrockagentcore_harness` resource directly editable, so a VPC is configured by adding the `network_configuration` block; the guide now documents that.

### Description of how you validated changes

- **Unit tests** — a test pinning the interface, the three props, the created security group, the private-with-egress default, and the lazy render. Full suite passes (3458 tests).
- **End to end in a real workspace**, verified against the synthesized template:
  - the issue's motivating case — a VPC Harness plus an Aurora cluster granting it access — compiles and synths, with the ingress rule correctly referencing the Harness security group
  - BYO `securityGroups` and explicit `vpcSubnets` are both honoured
  - a security group added via `connections.addSecurityGroup()` after construction appears in the rendered template, confirming the lazy render
  - a caller-supplied `environment` is preserved rather than clobbered
  - a Harness with no `vpc` emits no network configuration
- **Docs** — `docs:build` passes with all internal links valid.

Note for reviewers: destroying a stack containing a VPC Harness can need a retry. AgentCore leaves service-managed ENIs (`ela-attach-*`, which cannot be force-detached) behind after the Harness is deleted, and they block deletion of the security group, subnets and VPC until the service releases them. That is service behaviour rather than something this change introduces, but worth knowing.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*