### PR TITLE
fix(py#agent): construct A2A agents in a FastAPI lifespan instead of at import time

### DIFF
--- a/packages/nx-plugin/src/migrations/latest/py-agent-a2a-lifespan-construction/metadata.json
+++ b/packages/nx-plugin/src/migrations/latest/py-agent-a2a-lifespan-construction/metadata.json
@@ -1,0 +1,3 @@
+{
+  "description": "Move py#agent A2A agent construction (Strands and LangChain) out of module import time and into a FastAPI lifespan handler, stored on app.state; also updates with_session_id/session_id_context to use Generator instead of the deprecated Iterator return type"
+}

--- a/packages/nx-plugin/src/migrations/latest/py-agent-a2a-lifespan-construction/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/latest/py-agent-a2a-lifespan-construction/migration.spec.ts
@@ -1,0 +1,363 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { addProjectConfiguration, type Tree } from '@nx/devkit';
+import { PY_AGENT_GENERATOR_INFO } from '../../../py/agent/generator';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test';
+import migration from './migration';
+
+const PROJECT_ROOT = 'apps/test-project';
+const AGENT_DIR = `${PROJECT_ROOT}/proj_test_project/agent`;
+
+const OLD_STRANDS_MAIN = `import logging
+
+from fastapi import FastAPI
+from strands.multiagent.a2a import A2AServer
+from proj_agent_connection import session_id_context, with_session_id
+
+from .agent import get_agent
+
+_agent_ctx = with_session_id(
+    get_agent,
+    name="SnapshotAgent",
+    description="A Strands Agent exposed via the Agent-to-Agent (A2A) protocol.",
+)
+_agent = _agent_ctx.__enter__()
+
+a2a_server = A2AServer(agent=_agent, port=9000)
+
+app = FastAPI()
+
+app.mount("/", a2a_server.to_fastapi_app())
+`;
+
+const OLD_LANGCHAIN_MAIN = `from fastapi import FastAPI
+
+from .agent import get_agent
+
+_graph = get_agent()
+
+
+async def handle(context):
+    result = await _graph.ainvoke(
+        {"messages": [{"role": "user", "content": context.get_user_input()}]},
+        {"configurable": {"thread_id": "abc"}},
+    )
+    return result
+
+
+app = FastAPI(title="SnapshotAgent")
+`;
+
+const AC_DIR = 'packages/common/agent_connection/proj_agent_connection/core';
+const WITH_SESSION_ID_PATH = `${AC_DIR}/with_session_id_strands.py`;
+const SESSION_CONTEXT_PATH = `${AC_DIR}/session_context.py`;
+
+const OLD_WITH_SESSION_ID = `from collections.abc import Callable, Iterator
+from contextlib import AbstractContextManager, ExitStack, contextmanager
+from typing import Any
+
+from .session_context import get_current_session_id
+
+
+@contextmanager
+def with_session_id(
+    agent_factory: Callable[[], AbstractContextManager[Any]],
+    *,
+    name: str,
+    description: str,
+) -> Iterator[Any]:
+    """Wrap an agent factory so each session gets its own cached Agent."""
+    stack = ExitStack()
+    agents: dict[str, Any] = {}
+
+    def _for_session() -> Any:
+        sid = get_current_session_id() or "default"
+        if sid not in agents:
+            agents[sid] = stack.enter_context(agent_factory())
+        return agents[sid]
+
+    try:
+        yield _for_session()
+    finally:
+        stack.close()
+`;
+
+const OLD_SESSION_CONTEXT = `from collections.abc import Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
+
+_session_id_var: ContextVar[str | None] = ContextVar(
+    "agentcore_session_id", default=None
+)
+
+
+def get_current_session_id() -> str | None:
+    """The session ID for the current async scope, or \`\`None\`\`."""
+    return _session_id_var.get()
+
+
+@contextmanager
+def session_id_context(session_id: str) -> Iterator[None]:
+    """Bind *session_id* as the current session for the scope of the block."""
+    token = _session_id_var.set(session_id)
+    try:
+        yield
+    finally:
+        _session_id_var.reset(token)
+`;
+
+const setUpProject = (
+  tree: Tree,
+  options: {
+    path?: string;
+    protocol?: 'a2a' | 'http';
+    framework?: 'strands' | 'langchain';
+  } = {},
+) => {
+  addProjectConfiguration(tree, 'test-project', {
+    root: PROJECT_ROOT,
+    sourceRoot: `${PROJECT_ROOT}/proj_test_project`,
+    targets: {},
+    metadata: {
+      components: [
+        {
+          generator: PY_AGENT_GENERATOR_INFO.id,
+          path: options.path ?? 'proj_test_project/agent',
+          protocol: options.protocol ?? 'a2a',
+          framework: options.framework ?? 'strands',
+          rc: 'SnapshotAgent',
+        },
+      ],
+    } as any,
+  });
+};
+
+describe('py-agent-a2a-lifespan-construction migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeUsingTsSolutionSetup();
+  });
+
+  it('should do nothing when no projects contain Python agents', async () => {
+    await expect(migration(tree)).resolves.toEqual({ nextSteps: [] });
+  });
+
+  describe('Strands A2A', () => {
+    it('should migrate a Strands A2A agent to a lifespan-scoped agent factory', async () => {
+      setUpProject(tree);
+      tree.write(`${AGENT_DIR}/main.py`, OLD_STRANDS_MAIN);
+
+      const result = await migration(tree);
+      const migrated = tree.read(`${AGENT_DIR}/main.py`, 'utf-8') ?? '';
+
+      expect(result.nextSteps).toEqual([]);
+      expect(migrated).toContain('asynccontextmanager');
+      expect(migrated).toContain('SimpleNamespace');
+      expect(migrated).toContain('from typing import cast');
+      expect(migrated).toContain('from strands import Agent');
+      expect(migrated).toContain('AGENT_NAME = "SnapshotAgent"');
+      expect(migrated).toContain(
+        '_card_placeholder = cast(\n    Agent, SimpleNamespace(name=AGENT_NAME, description=AGENT_DESCRIPTION)\n)',
+      );
+      expect(migrated).toContain('async def lifespan(app: FastAPI):');
+      expect(migrated).toContain('with_session_id(');
+      expect(migrated).toContain('app.state.agent = agent');
+      expect(migrated).toContain('app = FastAPI(lifespan=lifespan)');
+      expect(migrated).toContain('a2a_server = A2AServer(');
+      expect(migrated).toContain(
+        'agent_factory=lambda _context_id: getattr(app.state, "agent", _card_placeholder)',
+      );
+      expect(migrated).toContain('port=9000');
+      expect(migrated).not.toContain('agent=_agent');
+      expect(migrated).not.toContain('_agent_ctx');
+      expect(migrated).not.toContain('__enter__()');
+    });
+
+    it('should support legacy component paths ending in agent.py', async () => {
+      setUpProject(tree, { path: 'proj_test_project/agent/agent.py' });
+      tree.write(`${AGENT_DIR}/main.py`, OLD_STRANDS_MAIN);
+
+      await migration(tree);
+
+      expect(tree.read(`${AGENT_DIR}/main.py`, 'utf-8')).toContain(
+        'agent_factory=lambda _context_id: getattr(app.state, "agent", _card_placeholder)',
+      );
+    });
+
+    it('should report a diverged generated shape without partially rewriting it', async () => {
+      setUpProject(tree);
+      const diverged = OLD_STRANDS_MAIN.replace(
+        'description="A Strands Agent exposed via the Agent-to-Agent (A2A) protocol.",',
+        'description="Custom description",',
+      );
+      tree.write(`${AGENT_DIR}/main.py`, diverged);
+
+      const result = await migration(tree);
+      const contents = tree.read(`${AGENT_DIR}/main.py`, 'utf-8') ?? '';
+
+      expect(result.nextSteps).toHaveLength(1);
+      expect(result.nextSteps[0]).toContain(`${AGENT_DIR}/main.py`);
+      expect(contents).toContain('_agent_ctx = with_session_id(');
+      expect(contents).toContain('_agent = _agent_ctx.__enter__()');
+      expect(contents).not.toContain('async def lifespan');
+      expect(contents).not.toContain('asynccontextmanager');
+    });
+
+    it('should be idempotent', async () => {
+      setUpProject(tree);
+      tree.write(`${AGENT_DIR}/main.py`, OLD_STRANDS_MAIN);
+
+      await migration(tree);
+      const once = tree.read(`${AGENT_DIR}/main.py`, 'utf-8');
+      const result = await migration(tree);
+
+      expect(result.nextSteps).toEqual([]);
+      expect(tree.read(`${AGENT_DIR}/main.py`, 'utf-8')).toEqual(once);
+    });
+  });
+
+  describe('LangChain A2A', () => {
+    it('should migrate a LangChain A2A agent to lifespan-scoped construction', async () => {
+      setUpProject(tree, { framework: 'langchain' });
+      tree.write(`${AGENT_DIR}/main.py`, OLD_LANGCHAIN_MAIN);
+
+      const result = await migration(tree);
+      const migrated = tree.read(`${AGENT_DIR}/main.py`, 'utf-8') ?? '';
+
+      expect(result.nextSteps).toEqual([]);
+      expect(migrated).toContain('asynccontextmanager');
+      expect(migrated).toContain('async def lifespan(app: FastAPI):');
+      expect(migrated).toContain('app.state.agent = get_agent()');
+      expect(migrated).toContain('app.state.agent.ainvoke(');
+      expect(migrated).toContain(
+        'app = FastAPI(title="SnapshotAgent", lifespan=lifespan)',
+      );
+      expect(migrated).not.toContain('_graph');
+    });
+
+    it('should report a diverged generated shape without partially rewriting it', async () => {
+      setUpProject(tree, { framework: 'langchain' });
+      const diverged = OLD_LANGCHAIN_MAIN.replace(
+        'app = FastAPI(title="SnapshotAgent")',
+        'app = FastAPI(title="SnapshotAgent", debug=True)',
+      );
+      tree.write(`${AGENT_DIR}/main.py`, diverged);
+
+      const result = await migration(tree);
+      const contents = tree.read(`${AGENT_DIR}/main.py`, 'utf-8') ?? '';
+
+      expect(result.nextSteps).toHaveLength(1);
+      expect(result.nextSteps[0]).toContain(`${AGENT_DIR}/main.py`);
+      expect(contents).toContain('_graph = get_agent()');
+      expect(contents).not.toContain('async def lifespan');
+    });
+
+    it('should be idempotent', async () => {
+      setUpProject(tree, { framework: 'langchain' });
+      tree.write(`${AGENT_DIR}/main.py`, OLD_LANGCHAIN_MAIN);
+
+      await migration(tree);
+      const once = tree.read(`${AGENT_DIR}/main.py`, 'utf-8');
+      const result = await migration(tree);
+
+      expect(result.nextSteps).toEqual([]);
+      expect(tree.read(`${AGENT_DIR}/main.py`, 'utf-8')).toEqual(once);
+    });
+  });
+
+  it('should leave Strands HTTP agents untouched', async () => {
+    setUpProject(tree, { protocol: 'http' });
+    tree.write(`${AGENT_DIR}/main.py`, OLD_STRANDS_MAIN);
+
+    const result = await migration(tree);
+    const contents = tree.read(`${AGENT_DIR}/main.py`, 'utf-8') ?? '';
+
+    expect(result.nextSteps).toEqual([]);
+    expect(contents).toContain('_agent_ctx = with_session_id(');
+    expect(contents).toContain('_agent = _agent_ctx.__enter__()');
+    expect(contents).toContain('agent=_agent');
+    expect(contents).not.toContain('async def lifespan');
+  });
+
+  describe('Iterator -> Generator (agent-connection)', () => {
+    it('should migrate with_session_id_strands.py', async () => {
+      tree.write(WITH_SESSION_ID_PATH, OLD_WITH_SESSION_ID);
+
+      const result = await migration(tree);
+      const migrated = tree.read(WITH_SESSION_ID_PATH, 'utf-8') ?? '';
+
+      expect(result.nextSteps).toEqual([]);
+      expect(migrated).toContain(
+        'from collections.abc import Callable, Generator',
+      );
+      expect(migrated).toContain('-> Generator[Any]:');
+      expect(migrated).not.toContain('Iterator');
+    });
+
+    it('should migrate session_context.py', async () => {
+      tree.write(SESSION_CONTEXT_PATH, OLD_SESSION_CONTEXT);
+
+      const result = await migration(tree);
+      const migrated = tree.read(SESSION_CONTEXT_PATH, 'utf-8') ?? '';
+
+      expect(result.nextSteps).toEqual([]);
+      expect(migrated).toContain('from collections.abc import Generator');
+      expect(migrated).toContain('-> Generator[None]:');
+      expect(migrated).not.toContain('Iterator');
+    });
+
+    it('should migrate both files together', async () => {
+      tree.write(WITH_SESSION_ID_PATH, OLD_WITH_SESSION_ID);
+      tree.write(SESSION_CONTEXT_PATH, OLD_SESSION_CONTEXT);
+
+      const result = await migration(tree);
+
+      expect(result.nextSteps).toEqual([]);
+      expect(tree.read(WITH_SESSION_ID_PATH, 'utf-8')).not.toContain(
+        'Iterator',
+      );
+      expect(tree.read(SESSION_CONTEXT_PATH, 'utf-8')).not.toContain(
+        'Iterator',
+      );
+    });
+
+    it('should report a diverged with_session_id_strands.py without partially rewriting it', async () => {
+      const diverged = OLD_WITH_SESSION_ID.replace(
+        'from collections.abc import Callable, Iterator',
+        'from collections.abc import Iterator\nfrom my_custom_module import Callable',
+      );
+      tree.write(WITH_SESSION_ID_PATH, diverged);
+
+      const result = await migration(tree);
+      const contents = tree.read(WITH_SESSION_ID_PATH, 'utf-8') ?? '';
+
+      expect(result.nextSteps).toHaveLength(1);
+      expect(result.nextSteps[0]).toContain(WITH_SESSION_ID_PATH);
+      expect(contents).toContain('from my_custom_module import Callable');
+      expect(contents).toContain('Iterator[Any]');
+    });
+
+    it('should be idempotent', async () => {
+      tree.write(WITH_SESSION_ID_PATH, OLD_WITH_SESSION_ID);
+      tree.write(SESSION_CONTEXT_PATH, OLD_SESSION_CONTEXT);
+
+      await migration(tree);
+      const once = {
+        withSessionId: tree.read(WITH_SESSION_ID_PATH, 'utf-8'),
+        sessionContext: tree.read(SESSION_CONTEXT_PATH, 'utf-8'),
+      };
+      const result = await migration(tree);
+
+      expect(result.nextSteps).toEqual([]);
+      expect(tree.read(WITH_SESSION_ID_PATH, 'utf-8')).toEqual(
+        once.withSessionId,
+      );
+      expect(tree.read(SESSION_CONTEXT_PATH, 'utf-8')).toEqual(
+        once.sessionContext,
+      );
+    });
+  });
+});

--- a/packages/nx-plugin/src/migrations/latest/py-agent-a2a-lifespan-construction/migration.ts
+++ b/packages/nx-plugin/src/migrations/latest/py-agent-a2a-lifespan-construction/migration.ts
@@ -1,0 +1,399 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import {
+  getProjects,
+  joinPathFragments,
+  type MigrationReturnObject,
+  type Tree,
+  visitNotIgnoredFiles,
+} from '@nx/devkit';
+import { PY_AGENT_GENERATOR_INFO } from '../../../py/agent/generator';
+import {
+  addPythonDestructuredImport,
+  applyGritQL,
+  captureGritQLVariable,
+  matchGritQL,
+} from '../../../utils/ast';
+import { formatFilesInSubtree } from '../../../utils/format';
+import type { ComponentMetadata } from '../../../utils/nx';
+
+/**
+ * Move py#agent A2A agent construction (Strands and LangChain) out of module
+ * import time and into a FastAPI `lifespan` handler, stored on `app.state`.
+ *
+ * The `v1.0.0-rc.61/0001-py-agent-lifespan-construction` migration (HTTP/AG-UI)
+ * deliberately left A2A alone, reasoning that `with_session_id` only touches
+ * its agent factory lazily on first use, so the eager `_agent_ctx.__enter__()`
+ * was never actually eager in practice. That held for `with_session_id`'s own
+ * laziness, but missed a separate trigger: `strands.multiagent.a2a.executor
+ * .StrandsA2AExecutor.__init__`, in its deprecated single-`agent=` mode, does
+ * `getattr(agent, "_session_manager", None)` - which the session-routing
+ * proxy's `__getattr__` happily serves by building the real underlying Agent
+ * right then, under a bogus "default" session, since no request has bound a
+ * real session id yet. That call happens inside `A2AServer.__init__`, which
+ * the old template constructed at plain module import time - so the "lazy"
+ * proxy was forced eager anyway, just one layer further down than the
+ * previous migration checked.
+ *
+ * Strands: `agent_factory=` mode sidesteps this - `StrandsA2AExecutor` takes
+ * an entirely different branch when given a factory (no `_session_manager`
+ * probe at all), and the one placeholder call `A2AServer.__init__` makes
+ * before `lifespan` has run returns a bare `SimpleNamespace` with just
+ * `name`/`description` - no `__getattr__`, nothing to force construction.
+ *
+ * LangChain: the compiled graph from `get_agent()` has no such trap, but was
+ * still built eagerly at import time (`_graph = get_agent()`). Moved into
+ * `lifespan` for the same reason HTTP/AG-UI were: it can require env vars
+ * (model id, region) or do network setup that isn't guaranteed available at
+ * import - e.g. under test collection or OpenAPI spec generation tooling.
+ *
+ * Also folds in an unrelated but adjacent fix: Pylance (Pyright) deprecates
+ * annotating a `@contextmanager`-decorated function's return type as
+ * `Iterator[T]`, in favor of the single-argument `Generator[T]` form enabled
+ * by PEP 696 default type parameters (Python 3.13+ - generated projects
+ * target >=3.14). `with_session_id_strands.py` and `session_context.py` both
+ * use this pattern. Both files are shared, protocol-agnostic files copied
+ * once per workspace (not per py#agent component), so that part scans the
+ * whole tree by basename rather than going through component metadata.
+ */
+const pyMatch = (snippet: string) => `language python\n\`${snippet}\``;
+
+const pyDelete = (snippet: string) => `${pyMatch(snippet)} => .`;
+
+const pyRewrite = (from: string, to: string): string => {
+  const replacement = to.includes('\n') ? `raw\`${to}\`` : `\`${to}\``;
+  return `${pyMatch(from)} => ${replacement}`;
+};
+
+const AGENT_ENTER = '_agent = _agent_ctx.__enter__()';
+
+const OLD_AGENT_CONTEXT = `_agent_ctx = with_session_id(
+    get_agent,
+    name="$name",
+    description="A Strands Agent exposed via the Agent-to-Agent (A2A) protocol.",
+)`;
+
+const NEW_CONSTANTS_AND_LIFESPAN = `AGENT_NAME = "$name"
+AGENT_DESCRIPTION = "A Strands Agent exposed via the Agent-to-Agent (A2A) protocol."
+
+# A2AServer.__init__ calls agent_factory once, synchronously, before the lifespan
+# below has run - this is what it reads name/description from at that point.
+# The cast is a lie about runtime shape, not behavior: only .name/.description
+# are ever read off this value.
+_card_placeholder = cast(
+    Agent, SimpleNamespace(name=AGENT_NAME, description=AGENT_DESCRIPTION)
+)
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    with with_session_id(
+        get_agent,
+        name=AGENT_NAME,
+        description=AGENT_DESCRIPTION,
+    ) as agent:
+        app.state.agent = agent
+        yield`;
+
+const A2A_SERVER_STATEMENT = 'a2a_server = A2AServer($args)';
+
+const OLD_MOUNT_STATEMENT = 'app.mount("/", a2a_server.to_fastapi_app())';
+
+const OLD_FASTAPI_APP = 'app = FastAPI()';
+
+const NEW_FASTAPI_APP = 'app = FastAPI(lifespan=lifespan)';
+
+const SERVER_MATCH =
+  'language python\n`A2AServer($args)` where { $args <: contains `agent=_agent` }';
+
+const allMatch = async (
+  tree: Tree,
+  filePath: string,
+  patterns: string[],
+): Promise<boolean> => {
+  for (const pattern of patterns) {
+    if (!(await matchGritQL(tree, filePath, pattern))) return false;
+  }
+  return true;
+};
+
+const migrateStrandsA2AAgent = async (
+  tree: Tree,
+  mainPath: string,
+  nextSteps: string[],
+): Promise<void> => {
+  if (!tree.exists(mainPath)) return;
+
+  const contents = tree.read(mainPath, 'utf-8') ?? '';
+  if (!contents.includes('_agent_ctx = with_session_id(')) return;
+
+  const ready = await allMatch(tree, mainPath, [
+    pyMatch('import logging'),
+    pyMatch('from $mod import session_id_context, with_session_id'),
+    pyMatch(OLD_AGENT_CONTEXT),
+    pyMatch(AGENT_ENTER),
+    pyMatch(OLD_FASTAPI_APP),
+    pyMatch(OLD_MOUNT_STATEMENT),
+    SERVER_MATCH,
+  ]);
+
+  const diverged = () => {
+    nextSteps.push(
+      `${mainPath}: diverged from the generated Strands A2A shape - left untouched. Manually rebuild the agent inside the FastAPI \`lifespan\` and have \`agent_factory\` read it off \`app.state\` (see the py#agent generator's strands/a2a template).`,
+    );
+  };
+
+  if (!ready) {
+    diverged();
+    return;
+  }
+
+  await addPythonDestructuredImport(
+    tree,
+    mainPath,
+    ['asynccontextmanager'],
+    'contextlib',
+  );
+  await addPythonDestructuredImport(
+    tree,
+    mainPath,
+    ['SimpleNamespace'],
+    'types',
+  );
+  await addPythonDestructuredImport(tree, mainPath, ['cast'], 'typing');
+  await addPythonDestructuredImport(tree, mainPath, ['Agent'], 'strands');
+  await applyGritQL(
+    tree,
+    mainPath,
+    pyRewrite(OLD_AGENT_CONTEXT, NEW_CONSTANTS_AND_LIFESPAN),
+  );
+  await applyGritQL(tree, mainPath, pyDelete(AGENT_ENTER));
+
+  // Swap the kwarg while the call is still in its original spot (any extra
+  // kwargs a user added are left alone), then capture the whole arg list so
+  // it can be reinserted at the call's new home below.
+  await applyGritQL(
+    tree,
+    mainPath,
+    pyRewrite(
+      'agent=_agent',
+      'agent_factory=lambda _context_id: getattr(app.state, "agent", _card_placeholder)',
+    ),
+  );
+  const capturedArgs = await captureGritQLVariable(
+    tree,
+    mainPath,
+    `language python\n\`${A2A_SERVER_STATEMENT}\``,
+    'args',
+  );
+  if (capturedArgs === undefined) {
+    diverged();
+    return;
+  }
+
+  await applyGritQL(tree, mainPath, pyDelete(A2A_SERVER_STATEMENT));
+  await applyGritQL(
+    tree,
+    mainPath,
+    pyRewrite(OLD_FASTAPI_APP, NEW_FASTAPI_APP),
+  );
+  await applyGritQL(
+    tree,
+    mainPath,
+    pyRewrite(
+      OLD_MOUNT_STATEMENT,
+      `a2a_server = A2AServer(${capturedArgs})\n\n${OLD_MOUNT_STATEMENT}`,
+    ),
+  );
+};
+
+// --- LangChain A2A -----------------------------------------------------------
+
+const LANGCHAIN_GRAPH_OLD = '_graph = get_agent()';
+
+const LANGCHAIN_LIFESPAN_NEW = `@asynccontextmanager
+async def lifespan(app: FastAPI):
+    app.state.agent = get_agent()
+    yield`;
+
+const LANGCHAIN_GRAPH_INVOKE_OLD = '_graph.ainvoke($args)';
+
+const LANGCHAIN_GRAPH_INVOKE_NEW = 'app.state.agent.ainvoke($args)';
+
+const LANGCHAIN_APP_OLD = 'app = FastAPI(title="$name")';
+
+const LANGCHAIN_APP_NEW = 'app = FastAPI(title="$name", lifespan=lifespan)';
+
+const migrateLangchainA2AAgent = async (
+  tree: Tree,
+  mainPath: string,
+  nextSteps: string[],
+): Promise<void> => {
+  if (!tree.exists(mainPath)) return;
+
+  const contents = tree.read(mainPath, 'utf-8') ?? '';
+  if (!contents.includes(LANGCHAIN_GRAPH_OLD)) return;
+
+  const ready = await allMatch(tree, mainPath, [
+    pyMatch(LANGCHAIN_GRAPH_OLD),
+    pyMatch('from .agent import get_agent'),
+    pyMatch(LANGCHAIN_GRAPH_INVOKE_OLD),
+    pyMatch(LANGCHAIN_APP_OLD),
+  ]);
+
+  if (!ready) {
+    nextSteps.push(
+      `${mainPath}: diverged from the generated LangChain A2A shape - left untouched. Manually wrap \`get_agent()\` in a \`lifespan\` handler storing the graph on \`app.state.agent\` (see the py#agent generator's langchain/a2a template).`,
+    );
+    return;
+  }
+
+  await addPythonDestructuredImport(
+    tree,
+    mainPath,
+    ['asynccontextmanager'],
+    'contextlib',
+  );
+  await applyGritQL(
+    tree,
+    mainPath,
+    pyRewrite(LANGCHAIN_GRAPH_OLD, LANGCHAIN_LIFESPAN_NEW),
+  );
+  await applyGritQL(
+    tree,
+    mainPath,
+    pyRewrite(LANGCHAIN_GRAPH_INVOKE_OLD, LANGCHAIN_GRAPH_INVOKE_NEW),
+  );
+  await applyGritQL(
+    tree,
+    mainPath,
+    pyRewrite(LANGCHAIN_APP_OLD, LANGCHAIN_APP_NEW),
+  );
+};
+
+// --- Iterator -> Generator (with_session_id_strands.py / session_context.py) ---
+
+const WITH_SESSION_ID_IMPORT_OLD =
+  'from collections.abc import Callable, Iterator';
+const WITH_SESSION_ID_IMPORT_NEW =
+  'from collections.abc import Callable, Generator';
+
+const migrateWithSessionId = async (
+  tree: Tree,
+  filePath: string,
+  nextSteps: string[],
+): Promise<void> => {
+  const contents = tree.read(filePath, 'utf-8') ?? '';
+  if (!contents.includes('Iterator[Any]')) return;
+
+  const ready = await allMatch(tree, filePath, [
+    pyMatch(WITH_SESSION_ID_IMPORT_OLD),
+    pyMatch('Iterator[Any]'),
+  ]);
+
+  if (!ready) {
+    nextSteps.push(
+      `${filePath}: diverged from the generated shape - left untouched. Manually change the \`Iterator\` import and \`Iterator[Any]\` return annotation on \`with_session_id\` to \`Generator\`/\`Generator[Any]\` (see the agent-connection generator's with_session_id_strands.py template).`,
+    );
+    return;
+  }
+
+  await applyGritQL(
+    tree,
+    filePath,
+    pyRewrite(WITH_SESSION_ID_IMPORT_OLD, WITH_SESSION_ID_IMPORT_NEW),
+  );
+  await applyGritQL(
+    tree,
+    filePath,
+    pyRewrite('Iterator[Any]', 'Generator[Any]'),
+  );
+};
+
+const SESSION_CONTEXT_IMPORT_OLD = 'from collections.abc import Iterator';
+const SESSION_CONTEXT_IMPORT_NEW = 'from collections.abc import Generator';
+
+const migrateSessionContext = async (
+  tree: Tree,
+  filePath: string,
+  nextSteps: string[],
+): Promise<void> => {
+  const contents = tree.read(filePath, 'utf-8') ?? '';
+  if (!contents.includes('Iterator[None]')) return;
+
+  const ready = await allMatch(tree, filePath, [
+    pyMatch(SESSION_CONTEXT_IMPORT_OLD),
+    pyMatch('Iterator[None]'),
+  ]);
+
+  if (!ready) {
+    nextSteps.push(
+      `${filePath}: diverged from the generated shape - left untouched. Manually change the \`Iterator\` import and \`Iterator[None]\` return annotation on \`session_id_context\` to \`Generator\`/\`Generator[None]\` (see the agent-connection generator's session_context.py template).`,
+    );
+    return;
+  }
+
+  await applyGritQL(
+    tree,
+    filePath,
+    pyRewrite(SESSION_CONTEXT_IMPORT_OLD, SESSION_CONTEXT_IMPORT_NEW),
+  );
+  await applyGritQL(
+    tree,
+    filePath,
+    pyRewrite('Iterator[None]', 'Generator[None]'),
+  );
+};
+
+const findAgentComponents = (
+  components: ComponentMetadata[] | undefined,
+): ComponentMetadata[] =>
+  (components ?? []).filter(
+    (component) => component.generator === PY_AGENT_GENERATOR_INFO.id,
+  );
+
+export default async function migration(
+  tree: Tree,
+): Promise<MigrationReturnObject> {
+  const nextSteps: string[] = [];
+
+  for (const project of getProjects(tree).values()) {
+    const components = findAgentComponents(
+      (project.metadata as { components?: ComponentMetadata[] })?.components,
+    );
+
+    for (const component of components) {
+      if (!component.path || component.protocol !== 'a2a') {
+        continue;
+      }
+
+      const componentDir = component.path.endsWith('/agent.py')
+        ? component.path.slice(0, -'/agent.py'.length)
+        : component.path;
+      const mainPath = joinPathFragments(project.root, componentDir, 'main.py');
+
+      if ((component.framework ?? 'strands') === 'langchain') {
+        await migrateLangchainA2AAgent(tree, mainPath, nextSteps);
+      } else {
+        await migrateStrandsA2AAgent(tree, mainPath, nextSteps);
+      }
+    }
+  }
+
+  const filePaths: string[] = [];
+  visitNotIgnoredFiles(tree, '', (filePath) => filePaths.push(filePath));
+
+  for (const filePath of filePaths) {
+    if (filePath.endsWith('/with_session_id_strands.py')) {
+      await migrateWithSessionId(tree, filePath, nextSteps);
+    } else if (filePath.endsWith('/session_context.py')) {
+      await migrateSessionContext(tree, filePath, nextSteps);
+    }
+  }
+
+  await formatFilesInSubtree(tree);
+
+  return { nextSteps };
+}

--- a/packages/nx-plugin/src/py/agent/files/langchain/a2a/main.py.template
+++ b/packages/nx-plugin/src/py/agent/files/langchain/a2a/main.py.template
@@ -1,6 +1,7 @@
 import logging
 import os
 import uuid
+from contextlib import asynccontextmanager
 
 from a2a.server.agent_execution import AgentExecutor, RequestContext
 from a2a.server.apps import A2AStarletteApplication
@@ -23,7 +24,11 @@ RUNTIME_URL = os.environ.get("AGENTCORE_RUNTIME_URL", f"http://localhost:{PORT}/
 SESSION_ID_HEADER = "x-amzn-bedrock-agentcore-runtime-session-id"
 DEFAULT_MODES = ["text/plain"]
 
-_graph = get_agent()
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    app.state.agent = get_agent()
+    yield
 
 
 class _GraphAgentExecutor(AgentExecutor):
@@ -37,7 +42,7 @@ class _GraphAgentExecutor(AgentExecutor):
         # The session bound by the middleware drives the LangGraph thread, keeping
         # checkpointed conversation state separate per caller session.
         session_id = get_current_session_id() or task.context_id
-        result = await _graph.ainvoke(
+        result = await app.state.agent.ainvoke(
             {"messages": [{"role": "user", "content": context.get_user_input()}]},
             {"configurable": {"thread_id": session_id}},
         )
@@ -77,7 +82,7 @@ class _SessionIdMiddleware(BaseHTTPMiddleware):
             return await call_next(request)
 
 
-app = FastAPI(title="<%= agentNameClassName %>")
+app = FastAPI(title="<%= agentNameClassName %>", lifespan=lifespan)
 app.add_middleware(_SessionIdMiddleware)
 
 

--- a/packages/nx-plugin/src/py/agent/files/strands/a2a/main.py.template
+++ b/packages/nx-plugin/src/py/agent/files/strands/a2a/main.py.template
@@ -1,9 +1,13 @@
 import logging
 import os
 import uuid
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from typing import cast
 
 from fastapi import FastAPI, Request
 from starlette.middleware.base import BaseHTTPMiddleware
+from strands import Agent
 from strands.multiagent.a2a import A2AServer
 from <%- agentConnectionModuleName %> import session_id_context, with_session_id
 
@@ -14,23 +18,27 @@ logging.basicConfig(level=logging.INFO)
 PORT = int(os.environ.get("PORT", "9000"))
 RUNTIME_URL = os.environ.get("AGENTCORE_RUNTIME_URL", f"http://localhost:{PORT}/")
 SESSION_ID_HEADER = "x-amzn-bedrock-agentcore-runtime-session-id"
+AGENT_NAME = "<%= agentNameClassName %>"
+AGENT_DESCRIPTION = "A Strands Agent exposed via the Agent-to-Agent (A2A) protocol."
 
-_agent_ctx = with_session_id(
-    get_agent,
-    name="<%= agentNameClassName %>",
-    description="A Strands Agent exposed via the Agent-to-Agent (A2A) protocol.",
+# A2AServer.__init__ calls agent_factory once, synchronously, before the lifespan
+# below has run - this is what it reads name/description from at that point.
+# The cast is a lie about runtime shape, not behavior: only .name/.description
+# are ever read off this value.
+_card_placeholder = cast(
+    Agent, SimpleNamespace(name=AGENT_NAME, description=AGENT_DESCRIPTION)
 )
-_agent = _agent_ctx.__enter__()
 
-a2a_server = A2AServer(
-    agent=_agent,
-    port=PORT,
-    http_url=RUNTIME_URL,
-    serve_at_root=True,
-    # Skip tool-registry introspection for the agent card — the per-session
-    # agents aren't constructed yet at import time.
-    skills=[],
-)
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    with with_session_id(
+        get_agent,
+        name=AGENT_NAME,
+        description=AGENT_DESCRIPTION,
+    ) as agent:
+        app.state.agent = agent
+        yield
 
 
 class _SessionIdMiddleware(BaseHTTPMiddleware):
@@ -42,7 +50,7 @@ class _SessionIdMiddleware(BaseHTTPMiddleware):
             return await call_next(request)
 
 
-app = FastAPI()
+app = FastAPI(lifespan=lifespan)
 app.add_middleware(_SessionIdMiddleware)
 
 
@@ -50,5 +58,15 @@ app.add_middleware(_SessionIdMiddleware)
 def ping() -> dict[str, str]:
     return {"status": "Healthy"}
 
+
+a2a_server = A2AServer(
+    agent_factory=lambda _context_id: getattr(app.state, "agent", _card_placeholder),
+    port=PORT,
+    http_url=RUNTIME_URL,
+    serve_at_root=True,
+    # Skip tool-registry introspection for the agent card — the per-session
+    # agents aren't constructed yet at startup.
+    skills=[],
+)
 
 app.mount("/", a2a_server.to_fastapi_app())

--- a/packages/nx-plugin/src/py/agent/generator.protocols.spec.ts
+++ b/packages/nx-plugin/src/py/agent/generator.protocols.spec.ts
@@ -377,6 +377,13 @@ dev-dependencies = []
       'utf-8',
     );
     expect(mainContent).toContain('A2AServer');
+    expect(mainContent).toContain('async def lifespan(app: FastAPI)');
+    expect(mainContent).toContain('with_session_id(');
+    expect(mainContent).toContain('app.state.agent = agent');
+    expect(mainContent).toContain(
+      'agent_factory=lambda _context_id: getattr(app.state, "agent", _card_placeholder)',
+    );
+    expect(mainContent).not.toContain('agent=_agent');
     expect(mainContent).toContain('to_fastapi_app');
     expect(mainContent).toContain('AGENTCORE_RUNTIME_URL');
     expect(mainContent).toContain('http_url');

--- a/packages/nx-plugin/src/utils/agent-connection/files/py-core-runtime-config/session_context.py.template
+++ b/packages/nx-plugin/src/utils/agent-connection/files/py-core-runtime-config/session_context.py.template
@@ -1,4 +1,4 @@
-from collections.abc import Iterator
+from collections.abc import Generator
 from contextlib import contextmanager
 from contextvars import ContextVar
 
@@ -13,7 +13,7 @@ def get_current_session_id() -> str | None:
 
 
 @contextmanager
-def session_id_context(session_id: str) -> Iterator[None]:
+def session_id_context(session_id: str) -> Generator[None]:
     """Bind *session_id* as the current session for the scope of the block."""
     token = _session_id_var.set(session_id)
     try:

--- a/packages/nx-plugin/src/utils/agent-connection/files/py-core-strands/base/with_session_id_strands.py.template
+++ b/packages/nx-plugin/src/utils/agent-connection/files/py-core-strands/base/with_session_id_strands.py.template
@@ -1,4 +1,4 @@
-from collections.abc import Callable, Iterator
+from collections.abc import Callable, Generator
 from contextlib import AbstractContextManager, ExitStack, contextmanager
 from typing import Any
 
@@ -11,7 +11,7 @@ def with_session_id(
     *,
     name: str,
     description: str,
-) -> Iterator[Any]:
+) -> Generator[Any]:
     """Wrap an agent factory so each session gets its own cached Agent."""
     stack = ExitStack()
     agents: dict[str, Any] = {}


### PR DESCRIPTION
### Reason for this change

Adding a `SessionManager` to an agent (for persisted session state) requires a real session id at construction time. The Strands A2A template didn't build its agent eagerly by itself — `_agent_ctx.__enter__()` just returns a lazy session-routing proxy that defers real `Agent` construction until first use. But `strands.multiagent.a2a.executor.StrandsA2AExecutor.__init__`, in its deprecated single-`agent=` mode, does `getattr(agent, "_session_manager", None)` — confirmed directly in the installed SDK source — which the proxy's `__getattr__` happily serves by building the real underlying `Agent` right then, under a bogus `"default"` session, since no request has bound a real session id yet. That call happens inside `A2AServer.__init__`, which the old template constructed at plain module import time — so the proxy's laziness gets forced open anyway, with no legitimate session id to construct against, breaking any `get_agent()` that requires one (e.g. via a `SessionManager`).

The earlier `py-agent-lifespan-construction` migration moved HTTP and AG-UI (both frameworks) to lifespan-based construction, but deliberately left A2A alone, reasoning that `with_session_id` only touches its agent factory lazily on first use, so the eager `_agent_ctx.__enter__()` was never actually eager in practice — true as far as it went, but it didn't account for the executor's own probe forcing that laziness open regardless.

### Description of changes

- **Strands A2A template**: agent now built inside a FastAPI `lifespan` handler and read off `app.state.agent`. `A2AServer` uses `agent_factory=` (not the deprecated `agent=`), sidestepping the `_session_manager` probe entirely — that mode takes a different code branch with no such check. The one synchronous call `A2AServer.__init__` makes before `lifespan` has run gets a `SimpleNamespace` placeholder (cast to `Agent` so `ty check` passes) carrying just the real `name`/`description` needed for the agent card.
- **LangChain A2A template**: moves `_graph = get_agent()` into `lifespan` too, storing on `app.state.agent` — for the same reason HTTP/AG-UI already do this: it can require env vars or network setup not guaranteed available at import time (test collection, OpenAPI spec generation tooling).
- **`with_session_id_strands.py`/`session_context.py`**: return type annotations changed from `Iterator[T]` to `Generator[T]`, resolving a Pylance deprecation warning on `@contextmanager` functions.
- **New migration** `py-agent-a2a-lifespan-construction` brings existing generated A2A agents (both frameworks) up to the new shape via GritQL rewrites, leaving diverged files untouched with `nextSteps` guidance.
- Updated `generator.protocols.spec.ts` assertions to match the new template output.

### Description of how you validated changes

- `migration.spec.ts` (14 tests) and `generator.protocols.spec.ts` (17 tests) pass on an uncached run.
- Verified the rendered Strands template compiles (`python -m py_compile`) and passes `ty check` (Astral's type checker) cleanly, both before/after reproducing and fixing a real type error found there.
- End-to-end: generated a real workspace (`test-a2a-agents`) with both Strands and LangChain A2A agents using the locally-linked updated generator/migration. Confirmed the generated `main.py` files match the new template shape, and `ty check` passes cleanly against both packages' real installed dependencies.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*