### PR TITLE
fix(smithy#project): pre-install the Smithy CLI in CI so a GitHub API blip cannot fail a build

### DIFF
--- a/.github/actions/init-monorepo/action.yml
+++ b/.github/actions/init-monorepo/action.yml
@@ -29,10 +29,6 @@ inputs:
     description: 'Install the Smithy CLI on Windows, where it is a prerequisite rather than resolved by mise. Off by default — only the jobs that build a Smithy project need it. No effect on other runners.'
     required: false
     default: 'false'
-  smithy-version:
-    description: 'Smithy CLI version to install on Windows. Keep in step with MISE_VERSIONS.smithy in packages/nx-plugin/src/utils/versions.ts.'
-    required: false
-    default: '1.72.1'
 
 runs:
   using: 'composite'
@@ -167,6 +163,54 @@ runs:
         echo "$tfDir" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
         $env:PATH = "$tfDir;$env:PATH"
         terraform version
+    # Resolved from packages/nx-plugin/src/utils/versions.ts, the same pins a
+    # generated Smithy project's build command carries, so the runner cannot
+    # prepare a different CLI than the one the build asks for.
+    - name: Resolve tool pins
+      id: tool-pins
+      shell: bash
+      run: node .github/scripts/tool-pins.mjs >> "$GITHUB_OUTPUT"
+    - name: Cache the Smithy CLI install (non-Windows)
+      if: ${{ runner.os != 'Windows' }}
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      with:
+        # mise's default data directory, where it installs tools — cached rather
+        # than the whole of it so nothing but the pinned CLI is restored. Keyed on
+        # the pinned version, so moving the pin misses and reinstalls instead of
+        # serving the previous CLI.
+        path: ~/.local/share/mise/installs/smithy
+        key: ${{ runner.os }}-mise-smithy-${{ steps.tool-pins.outputs.smithy-version }}
+    - name: Warm the Smithy CLI cache (non-Windows)
+      if: ${{ runner.os != 'Windows' }}
+      shell: bash
+      # A Smithy project's compile target resolves the CLI through `mise` on
+      # first use, which reads the release's digest from the GitHub API to verify
+      # the download. A 5xx there aborts the install, and it happens mid-build
+      # where the only outcome is a failed compile that reruns the whole job.
+      #
+      # Installing up front moves that call into a step that owns nothing else,
+      # so a blip is retried here instead: once the tool is installed, every
+      # build in the job resolves it from the mise cache with no network call at
+      # all.
+      #
+      # Unconditional rather than gated on `setup-smithy`: several lanes build a
+      # Smithy project (standalone, smithy-api, migrate, test-matrix, local-dev,
+      # rdb, terraform-deploy), a warm cache costs seconds, and a lane that grows
+      # a Smithy project shouldn't have to remember to opt in.
+      run: |
+        for attempt in 1 2 3; do
+          if npx -y mise@${{ steps.tool-pins.outputs.mise-version }} \
+            install smithy@${{ steps.tool-pins.outputs.smithy-version }}; then
+            exit 0
+          fi
+          if [ "$attempt" -lt 3 ]; then
+            echo "Smithy CLI install attempt $attempt failed, retrying in $((attempt * 10))s"
+            sleep $((attempt * 10))
+          fi
+        done
+        # Not fatal: only some lanes build a Smithy project, and those that do
+        # still resolve the CLI on demand exactly as a user's machine would.
+        echo "::warning::Could not pre-install the Smithy CLI — Smithy builds in this job will resolve it on demand."
     - name: Set up the Smithy CLI (Windows)
       if: ${{ runner.os == 'Windows' && inputs.setup-smithy == 'true' }}
       shell: pwsh
@@ -181,7 +225,7 @@ runs:
         # PATH that Nx's run-commands executor (a cmd.exe subprocess) can see —
         # the same reason terraform is installed manually above.
         $ErrorActionPreference = "Stop"
-        $version = "${{ inputs.smithy-version }}"
+        $version = "${{ steps.tool-pins.outputs.smithy-version }}"
         $smithyDir = "C:\smithy"
         $url = "https://github.com/smithy-lang/smithy/releases/download/${version}/smithy-cli-windows-x64.zip"
         $zip = "$env:RUNNER_TEMP\smithy.zip"

--- a/.github/scripts/tool-pins.mjs
+++ b/.github/scripts/tool-pins.mjs
@@ -1,0 +1,43 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { readFileSync } from 'node:fs';
+
+/**
+ * Prints the tool pins CI needs to make the Smithy CLI available, as
+ * `name=value` lines for `$GITHUB_OUTPUT`.
+ *
+ * Read out of `versions.ts` by regex rather than imported: this runs before
+ * `pnpm i`, so there is no tsx to load the module with. Parsed from the same
+ * file the generators read so the runner cannot pin a different Smithy CLI than
+ * the one a generated project's build resolves.
+ *
+ * Usage: node .github/scripts/tool-pins.mjs
+ */
+
+const VERSIONS_FILE = 'packages/nx-plugin/src/utils/versions.ts';
+
+const source = readFileSync(VERSIONS_FILE, 'utf-8');
+
+/**
+ * Extracts a pin declared as a top-level entry of one of the version maps.
+ * Anchored to the start of a line so a substring match elsewhere in the file
+ * (`@smithy/*` npm packages, Maven coordinates) cannot satisfy it, and required
+ * to match exactly once so a second declaration is an error rather than a
+ * silently-picked first hit.
+ */
+const readPin = (name) => {
+  const matches = [
+    ...source.matchAll(new RegExp(`^  ${name}: '([^']+)',$`, 'gm')),
+  ];
+  if (matches.length !== 1) {
+    throw new Error(
+      `Expected exactly one \`${name}\` pin in ${VERSIONS_FILE}, found ${matches.length}`,
+    );
+  }
+  return matches[0][1];
+};
+
+console.log(`smithy-version=${readPin('smithy')}`);
+console.log(`mise-version=${readPin('mise')}`);

--- a/packages/nx-plugin/src/utils/smithy.spec.ts
+++ b/packages/nx-plugin/src/utils/smithy.spec.ts
@@ -2,9 +2,14 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
+import { execFileSync } from 'node:child_process';
+import { join } from 'node:path';
 import { logger } from '@nx/devkit';
 import { smithyCliCommand, warnIfSmithyMissing } from './smithy';
 import { MISE_VERSIONS, TS_VERSIONS } from './versions';
+
+/** Repo root, from `packages/nx-plugin/src/utils`. */
+const REPO_ROOT = join(__dirname, '../../../..');
 
 /**
  * The Windows behaviour, which CI cannot exercise from a Linux runner: `mise`
@@ -49,6 +54,24 @@ describe('smithyCliCommand', () => {
       expect(command).toContain(`mise@${TS_VERSIONS.mise}`);
       expect(command).toContain(`smithy@${MISE_VERSIONS.smithy}`);
     });
+  });
+
+  /**
+   * CI prepares the Smithy CLI before running any build, reading both pins out
+   * of `versions.ts` with `.github/scripts/tool-pins.mjs` (it runs before
+   * `pnpm i`, so it cannot import the module). That parse is by regex, so a
+   * reshape of either declaration would leave CI silently preparing nothing —
+   * caught here rather than by a flaky Smithy compile.
+   */
+  it('should expose both pins to the ci tool-pin script', () => {
+    const output = execFileSync(
+      process.execPath,
+      [join(REPO_ROOT, '.github/scripts/tool-pins.mjs')],
+      { cwd: REPO_ROOT, encoding: 'utf-8' },
+    );
+
+    expect(output).toContain(`smithy-version=${MISE_VERSIONS.smithy}\n`);
+    expect(output).toContain(`mise-version=${TS_VERSIONS.mise}\n`);
   });
 
   it('should invoke the cli directly on windows', () => {


### PR DESCRIPTION
### Reason for this change

The `Smoke Tests - migrate (4/5)` lane failed on an unrelated PR ([run 31496110706](https://github.com/awslabs/nx-plugin-for-aws/actions/runs/31496110706/job/93924591051?pr=1075)). The failing task was `@migrate-test/my-smithy-api-model:compile`:

```
mise ERROR Failed to install aqua:smithy-lang/smithy@1.72.1: HTTP status server error
(500 Internal Server Error) for url (https://api.github.com/repos/smithy-lang/smithy/releases/tags/1.72.1)
```

A generated Smithy project's `compile` target resolves the CLI through `mise` on first use, and mise reads the release's digest from the GitHub API to verify the download. That call happens **mid-build**, so a transient upstream 5xx has no outcome other than a failed compile — which fails the hop, the shard, and the run. The migrate lane is the most exposed to it: a hop scaffolds the full test matrix and builds it, so it is the first build of a Smithy project on a fresh machine with a cold mise cache.

Nothing about the migration under test was wrong. Worth recording what was ruled out, since the symptom points elsewhere:

- **Start versions were correct.** Shard 4/5 correctly selected `1.0.0-rc.66`, published the local build as `1.0.0-rc.70`, and the test's own assertion that `node_modules/@aws/nx-plugin` is exactly the start version passed. 4 migrations were queued and ran, so the hop asserted real work rather than silently skipping.
- **pnpm's release-age gate was not the cause.** It does fire (`Added 1 entry to minimumReleaseAgeExclude ... @aws/create-nx-workspace@1.0.0-rc.66`), but self-resolves: pnpm auto-excludes exact pins, and both ends of the upgrade are pinned exactly. Confirmed by installing a same-day release under pnpm 11.20.0 — it succeeds with an auto-exclude entry.
- **`GITHUB_TOKEN` is already set** workflow-wide for exactly this reason (rate limiting), so this was not a 403.

A second, latent problem in the same area: the action carried its own `smithy-version: '1.72.1'` default, a hand-maintained copy of `MISE_VERSIONS.smithy` whose only guard was a comment saying to keep them in step. Nothing failed if they drifted — the Windows lane would just prepare a different CLI than the one generated projects build with.

### Description of changes

- **Pre-install the pinned Smithy CLI in `init-monorepo`, before any build runs.** The GitHub API call moves into a step that owns nothing else, so a blip retries there (3 attempts, backoff) instead of failing a compile. Once the tool is installed, every build in the job resolves it from the mise cache with no network call at all — verified: a warm `mise exec` makes zero network requests and succeeds with `MISE_OFFLINE=1`.
- **Cache the install across runs**, keyed on the pinned version, so the common case makes no API call either. A cache hit makes the pre-warm step a no-op success.
- **Non-fatal on exhaustion.** Only some lanes build a Smithy project; if the pre-warm can't complete it emits a `::warning::` and those builds resolve the CLI on demand exactly as a user's machine would. This keeps a hard upstream outage from failing lanes that never touch Smithy.
- **Unconditional rather than gated on `setup-smithy`** — seven lanes build a Smithy project (standalone, smithy-api, migrate, test-matrix, local-dev, rdb, terraform-deploy), a warm cache costs seconds, and a lane that grows a Smithy project shouldn't have to remember to opt in.
- **Both pins now come from `versions.ts`** via `.github/scripts/tool-pins.mjs`, so the runner cannot prepare a different CLI than the one a generated project's build command carries. Removes the `smithy-version` input (no call site passed it). The script parses by regex rather than importing, because it runs before `pnpm i`, so there is no tsx to load the module with — and it errors if a pin isn't found exactly once, rather than silently resolving nothing.

### Description of how you validated changes

Reproduced and verified the mechanism locally against the pinned mise/Smithy versions:

- **Reproduced the failure mode**: a cold `mise install smithy@1.72.1` contacts `api.github.com` (confirmed via `MISE_VERBOSE=1`: `using GitHub API digest for checksum verification`), and fails the install when that call fails.
- **Verified the fix removes the call from the build path**: after the pre-warm, `mise exec smithy@1.72.1 -- smithy --version` makes **zero** network requests (verbose trace empty) and succeeds under `MISE_OFFLINE=1`.
- **Verified the cache-restore path**: restoring only `installs/smithy` makes the pre-warm step a no-op success, and a subsequent build resolves the CLI offline.
- **Verified the retry loop** at 0, 2 and 3+ consecutive failures — it succeeds on recovery, does not sleep after the final attempt, and warns without failing the step on exhaustion.
- **Verified the drift guard fails**: reshaping the `mise:` declaration in `versions.ts` makes both the script and the new unit test fail loudly (``Expected exactly one `mise` pin ... found 0``) rather than silently preparing nothing.
- Added a unit test in `smithy.spec.ts` asserting the script reports both pins, alongside the existing assertions that the same pins stay greppable for the version sync.
- `pnpm nx run @aws/nx-plugin:test` — 3459 tests / 184 files pass. `pnpm nx run-many --target build --all` and `lint --all --fix` both pass.

### Note on a coverage gap found while investigating (not addressed here)

The migrate lane starts from the newest 5 releases (`DEFAULT_START_VERSION_COUNT`), but migration folders in the tree go back to `v1.0.0-rc.50` — 20 releases. At the current ~1-2 releases/day cadence, 5 releases is about 3 days, so migrations older than that are never exercised end-to-end. Left as-is deliberately: widening multiplies the lane's wall-clock, and that's a separate call from fixing this flake.

### Issue # (if applicable)

N/A — found via CI flake on #1075.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
