### PR TITLE
test(e2e): pin exact openai client versions in the local-dev smoke test

### DIFF
--- a/e2e/src/smoke-tests/local-dev.spec.ts
+++ b/e2e/src/smoke-tests/local-dev.spec.ts
@@ -24,6 +24,14 @@ const STARTUP_TIMEOUT_MS = 120_000;
 const HEALTH_CHECK_INTERVAL_MS = 2_000;
 const LLM_MOCK_PORT = 19823;
 
+// Exact versions for the OpenAI clients the agents are patched onto below. These
+// are pinned because the latest releases are not mutually resolvable: the npm
+// `openai` 7.x major is outside the `@strands-agents/sdk` peer range, and the
+// PyPI `openai` 3.x major is outside the range `langchain-openai` accepts.
+const OPENAI_NPM_VERSION = '6.49.0';
+const OPENAI_PY_VERSION = '2.54.0';
+const LANGCHAIN_OPENAI_PY_VERSION = '1.4.3';
+
 // The APIs the dev website is connected to, with the class names
 // matching their vended `use<ClassName>Client` hooks.
 const WEBSITE_APIS: ApiSpec[] = [
@@ -689,13 +697,16 @@ def list_examples_by_category(category: str) -> list[ExampleItem]:
 
       // Install openai dep for agents. TS projects declare their dependencies
       // at the workspace root, so install it there.
-      await runCLI(`pnpm add openai -w`, {
+      await runCLI(`pnpm add openai@${OPENAI_NPM_VERSION} -w`, {
         cwd: projectRoot,
         prefixWithPackageManagerCmd: false,
       });
-      await runCLI(`run local_dev_test.py_project:add -- openai`, opts);
       await runCLI(
-        `run local_dev_test.py_project:add -- langchain-openai`,
+        `run local_dev_test.py_project:add -- openai==${OPENAI_PY_VERSION}`,
+        opts,
+      );
+      await runCLI(
+        `run local_dev_test.py_project:add -- langchain-openai==${LANGCHAIN_OPENAI_PY_VERSION}`,
         opts,
       );
 


### PR DESCRIPTION
### Reason for this change

The `local-dev` smoke test lane is failing on `main`, blocking the release of `v1.0.0-rc.70`.

The test patches the generated agents onto a mock OpenAI-compatible endpoint and installs the OpenAI clients **unpinned**. Those installs now resolve to majors that can't satisfy their consumers:

- **PyPI `openai` 3.0.0** was published at `2026-08-12T01:55:48Z`. It is outside the `openai<3.0.0,>=2.45.0` range that `langchain-openai` (latest, 1.4.3) requires. Because the test runs `uv add openai` and *then* `uv add langchain-openai`, the first pins `openai==3.0.0` and the second is unsatisfiable:

  ```
  And because langchain-openai>=1.3.5 depends on openai>=2.45.0,<3.0.0 [...]
  we can conclude that your workspace's requirements are unsatisfiable.
  ERROR uv add langchain-openai --project packages/py_project command failed with exit code 1
  ```

  `strands-agents` caps at `openai<3.0.0` for the same extras, so this is not specific to LangChain.

- **npm `openai` 7.4.0** is outside the `^6.45.0` peer range declared by `@strands-agents/sdk`, so the TS side had the same latent exposure even though it was not the failing step.

Nothing about the generators changed — the lane was tracking the upstream release cadence, so it went red on a commit that did not touch it.

### Description of changes

Pin all three installs to exact versions, declared as named constants alongside the file's existing config constants:

- `OPENAI_NPM_VERSION = '6.49.0'` — the latest 6.x, inside the `@strands-agents/sdk` peer range
- `OPENAI_PY_VERSION = '2.54.0'` — the latest 2.x, inside the range `langchain-openai` accepts
- `LANGCHAIN_OPENAI_PY_VERSION = '1.4.3'` — the current latest

### Description of how you validated changes

Reproduced the resolution failure and verified the pins fix it, rather than only reading version metadata:

- Confirmed the trigger on PyPI: `openai` 3.0.0 uploaded `2026-08-12T01:55:48Z`, ~10 minutes before the failing run on `main` started. `langchain-openai` 1.4.3 still requires `openai<3.0.0,>=2.45.0`.
- In a scratch `uv` project with `requires-python = ">=3.14"`, ran the pinned adds in the **same sequential order** the test uses. Both resolve, and adding `strands-agents[openai]` on top still resolves: `openai 2.54.0`, `langchain-openai 1.4.3`, `strands-agents 1.51.0`.
- For npm, installed `openai@6.49.0` alongside `@strands-agents/sdk`: the SDK dedupes to the same copy (`@strands-agents/sdk@1.12.0 -> openai@6.49.0 deduped`) with no peer warnings.
- `pnpm nx run @aws/nx-plugin-e2e:lint` passes.

The `local-dev` lane itself runs in CI on this PR.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*