### PR TITLE
fix(py#agent): rebuild the A2A httpx client per call instead of reusing one built at factory time

### DIFF
--- a/packages/nx-plugin/src/migrations/latest/py-agent-a2a-httpx-client-per-call/metadata.json
+++ b/packages/nx-plugin/src/migrations/latest/py-agent-a2a-httpx-client-per-call/metadata.json
@@ -1,0 +1,3 @@
+{
+  "description": "Rebuild the httpx.AsyncClient (and Strands A2AAgent) per A2A delegate call instead of reusing one built at factory time, fixing a RuntimeError: Event loop is closed on the second call through a shared client"
+}

--- a/packages/nx-plugin/src/migrations/latest/py-agent-a2a-httpx-client-per-call/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/latest/py-agent-a2a-httpx-client-per-call/migration.spec.ts
@@ -1,0 +1,387 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import type { Tree } from '@nx/devkit';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test';
+import migration from './migration';
+
+const AC_DIR = 'packages/common/agent_connection/proj_agent_connection/core';
+const LANGCHAIN_PATH = `${AC_DIR}/agentcore_a2a_client_langchain.py`;
+const STRANDS_PATH = `${AC_DIR}/agentcore_a2a_client_strands.py`;
+const WRAPPER_PATH =
+  'packages/common/agent_connection/proj_agent_connection/app/snapshot_agent_client_strands.py';
+
+const OLD_LANGCHAIN = `import asyncio
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
+from uuid import uuid4
+
+from a2a.client import A2ACardResolver, ClientConfig, ClientFactory
+from a2a.types import Message, Part, Role, Task, TextPart
+
+from .agentcore_a2a_client_config import AgentCoreA2aClientConfig
+
+
+def _run_sync(coro):
+    # The tool is invoked from sync agent code, which under uvicorn runs inside a
+    # live event loop where asyncio.run() would raise — fall back to a worker.
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coro)
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        return pool.submit(asyncio.run, coro).result()
+
+
+def _text(event) -> str:
+    # Collect text parts from a bare Message or a (Task, update) event.
+    parts = []
+    if isinstance(event, Message):
+        parts = event.parts
+    elif isinstance(event, tuple):
+        task, update = event
+        if isinstance(task, Task) and task.artifacts:
+            parts = [p for a in task.artifacts for p in (a.parts or [])]
+        elif update is not None and getattr(update, "status", None) and update.status.message:
+            parts = update.status.message.parts
+    return "".join(p.root.text for p in parts if getattr(p.root, "text", None))
+
+
+class _A2AClient:
+    """A synchronously-callable A2A client. Sends a text prompt to the remote
+    agent and returns its text reply. Built on the a2a SDK only — no Strands."""
+
+    def __init__(self, url: str, client_config: ClientConfig):
+        self._url = url
+        self._config = client_config
+
+    def __call__(self, prompt: str) -> str:
+        return _run_sync(self._invoke(prompt))
+
+    async def _invoke(self, prompt: str) -> str:
+        # AgentCoreA2aClientConfig always sets the signed httpx client.
+        httpx_client = self._config.httpx_client
+        if httpx_client is None:
+            raise RuntimeError("A2A client config is missing an httpx client")
+        card = await A2ACardResolver(
+            httpx_client=httpx_client, base_url=self._url
+        ).get_agent_card()
+        client = ClientFactory(self._config).create(card)
+        message = Message(
+            kind="message",
+            role=Role.user,
+            message_id=uuid4().hex,
+            parts=[Part(TextPart(kind="text", text=prompt))],
+        )
+        # The client config uses streaming=False, so the last event carries the
+        # complete response.
+        reply = ""
+        async for event in client.send_message(message):
+            text = _text(event)
+            if text:
+                reply = text
+        return reply
+
+
+class AgentCoreA2aClientLangChain:
+    """Factory for A2A clients that connect to an AgentCore runtime.
+
+    Reuses the framework-agnostic Layer-1 \`\`AgentCoreA2aClientConfig\`\` (signed
+    \`\`a2a.client.ClientConfig\`\`) and drives the a2a SDK directly, so a LangChain
+    agent delegating to an A2A agent pulls in no Strands dependency."""
+
+    @staticmethod
+    def with_iam_auth(agent_runtime_arn: str) -> _A2AClient:
+        """SigV4-authenticated client for a Bedrock AgentCore runtime."""
+        return _A2AClient(*AgentCoreA2aClientConfig.with_iam_auth(agent_runtime_arn))
+
+    @staticmethod
+    def with_jwt_auth(
+        agent_runtime_arn: str, access_token_provider: Callable[[], str]
+    ) -> _A2AClient:
+        """Bearer-authenticated client for a Bedrock AgentCore runtime."""
+        return _A2AClient(
+            *AgentCoreA2aClientConfig.with_jwt_auth(
+                agent_runtime_arn, access_token_provider
+            )
+        )
+
+    @staticmethod
+    def without_auth(url: str) -> _A2AClient:
+        """Plain-HTTP client for local dev."""
+        return _A2AClient(*AgentCoreA2aClientConfig.without_auth(url))
+`;
+
+const OLD_STRANDS = `from collections.abc import Callable
+
+from strands.agent.a2a_agent import A2AAgent
+
+from .agentcore_a2a_client_config import AgentCoreA2aClientConfig
+
+
+def _build(
+    config: tuple, *, name: str | None, description: str | None
+) -> A2AAgent:
+    url, client_config = config
+    kwargs: dict = {"endpoint": url, "client_config": client_config}
+    if name:
+        kwargs["name"] = name
+    if description:
+        kwargs["description"] = description
+    return A2AAgent(**kwargs)
+
+
+class AgentCoreA2aClientStrands:
+    """Factory for Strands A2A clients that connect to an AgentCore runtime."""
+
+    @staticmethod
+    def with_iam_auth(
+        agent_runtime_arn: str,
+        *,
+        name: str | None = None,
+        description: str | None = None,
+    ) -> A2AAgent:
+        """SigV4-authenticated client for a Bedrock AgentCore runtime."""
+        return _build(
+            AgentCoreA2aClientConfig.with_iam_auth(agent_runtime_arn),
+            name=name,
+            description=description,
+        )
+
+    @staticmethod
+    def with_jwt_auth(
+        agent_runtime_arn: str,
+        access_token_provider: Callable[[], str],
+        *,
+        name: str | None = None,
+        description: str | None = None,
+    ) -> A2AAgent:
+        """Bearer-authenticated client for a Bedrock AgentCore runtime."""
+        return _build(
+            AgentCoreA2aClientConfig.with_jwt_auth(
+                agent_runtime_arn, access_token_provider
+            ),
+            name=name,
+            description=description,
+        )
+
+    @staticmethod
+    def without_auth(
+        url: str,
+        *,
+        name: str | None = None,
+        description: str | None = None,
+    ) -> A2AAgent:
+        """Plain-HTTP client — for local dev."""
+        return _build(
+            AgentCoreA2aClientConfig.without_auth(url),
+            name=name,
+            description=description,
+        )
+`;
+
+const OLD_WRAPPER = `import os
+
+from strands.agent.a2a_agent import A2AAgent
+
+from proj_agent_connection.core.agentcore_a2a_client_strands import (
+    AgentCoreA2aClientStrands,
+)
+from proj_agent_connection.core.runtime_config import (
+    get_agentcore_runtime_config,
+)
+
+
+class SnapshotAgentClientStrands:
+    """Strands client for the SnapshotAgent A2A agent."""
+
+    @staticmethod
+    def create() -> A2AAgent:
+        if os.environ.get("LOCAL_DEV") == "true":
+            return AgentCoreA2aClientStrands.without_auth("http://localhost:9000/")
+        config = get_agentcore_runtime_config()
+        agent_runtime = config.get("agentRuntimes", {}).get("SnapshotAgent")
+        agent_runtime_arn = agent_runtime.get("arn") if agent_runtime else None
+        if not agent_runtime_arn:
+            raise RuntimeError(
+                "No connected agent runtime named 'SnapshotAgent' found in runtime configuration."
+            )
+        return AgentCoreA2aClientStrands.with_iam_auth(agent_runtime_arn)
+`;
+
+describe('py-agent-a2a-httpx-client-per-call migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeUsingTsSolutionSetup();
+  });
+
+  it('should do nothing when no matching files exist', async () => {
+    await expect(migration(tree)).resolves.toEqual({ nextSteps: [] });
+  });
+
+  describe('agentcore_a2a_client_langchain.py', () => {
+    it('should rebuild a fresh httpx.AsyncClient per call', async () => {
+      tree.write(LANGCHAIN_PATH, OLD_LANGCHAIN);
+
+      const result = await migration(tree);
+      const migrated = tree.read(LANGCHAIN_PATH, 'utf-8') ?? '';
+
+      expect(result.nextSteps).toEqual([]);
+      expect(migrated).toContain('import httpx');
+      expect(migrated).toContain('shared_client = self._config.httpx_client');
+      expect(migrated).toContain('async with httpx.AsyncClient(');
+      expect(migrated).toContain(
+        'ClientConfig(httpx_client=httpx_client, streaming=False)',
+      );
+      expect(migrated).not.toContain(
+        'httpx_client = self._config.httpx_client',
+      );
+      expect(migrated).not.toContain(
+        'client = ClientFactory(self._config).create(card)',
+      );
+    });
+
+    it('should report a diverged generated shape without partially rewriting it', async () => {
+      const diverged = OLD_LANGCHAIN.replace(
+        'raise RuntimeError("A2A client config is missing an httpx client")',
+        'raise RuntimeError("custom message")',
+      );
+      tree.write(LANGCHAIN_PATH, diverged);
+
+      const result = await migration(tree);
+      const contents = tree.read(LANGCHAIN_PATH, 'utf-8') ?? '';
+
+      expect(result.nextSteps).toHaveLength(1);
+      expect(result.nextSteps[0]).toContain(LANGCHAIN_PATH);
+      expect(contents).toContain('httpx_client = self._config.httpx_client');
+      expect(contents).not.toContain('import httpx');
+    });
+
+    it('should be idempotent', async () => {
+      tree.write(LANGCHAIN_PATH, OLD_LANGCHAIN);
+
+      await migration(tree);
+      const once = tree.read(LANGCHAIN_PATH, 'utf-8');
+      const result = await migration(tree);
+
+      expect(result.nextSteps).toEqual([]);
+      expect(tree.read(LANGCHAIN_PATH, 'utf-8')).toEqual(once);
+    });
+  });
+
+  describe('agentcore_a2a_client_strands.py', () => {
+    it('should rebuild a fresh httpx.AsyncClient and A2AAgent per call', async () => {
+      tree.write(STRANDS_PATH, OLD_STRANDS);
+
+      const result = await migration(tree);
+      const migrated = tree.read(STRANDS_PATH, 'utf-8') ?? '';
+
+      expect(result.nextSteps).toEqual([]);
+      expect(migrated).toContain('import httpx');
+      expect(migrated).toContain(
+        'from strands.agent.agent_result import AgentResult',
+      );
+      expect(migrated).toContain('class _A2AClient:');
+      expect(migrated).toContain('def _run_sync(coro):');
+      expect(migrated).toContain('async with httpx.AsyncClient(');
+      expect(migrated).toContain('return await agent.invoke_async(prompt)');
+      expect(migrated).toContain(') -> _A2AClient:');
+      expect(migrated).not.toContain('-> A2AAgent:');
+      expect(migrated).not.toContain('return A2AAgent(**kwargs)');
+    });
+
+    it('should report a diverged generated shape without partially rewriting it', async () => {
+      const diverged = OLD_STRANDS.replace(
+        '"""Plain-HTTP client — for local dev."""',
+        '"""Custom docstring."""',
+      );
+      tree.write(STRANDS_PATH, diverged);
+
+      const result = await migration(tree);
+      const contents = tree.read(STRANDS_PATH, 'utf-8') ?? '';
+
+      expect(result.nextSteps).toHaveLength(1);
+      expect(result.nextSteps[0]).toContain(STRANDS_PATH);
+      expect(contents).toContain('return A2AAgent(**kwargs)');
+      expect(contents).not.toContain('class _A2AClient:');
+    });
+
+    it('should be idempotent', async () => {
+      tree.write(STRANDS_PATH, OLD_STRANDS);
+
+      await migration(tree);
+      const once = tree.read(STRANDS_PATH, 'utf-8');
+      const result = await migration(tree);
+
+      expect(result.nextSteps).toEqual([]);
+      expect(tree.read(STRANDS_PATH, 'utf-8')).toEqual(once);
+    });
+  });
+
+  describe('<target>_client_strands.py wrapper', () => {
+    it('should drop the stale A2AAgent import and return annotation', async () => {
+      tree.write(WRAPPER_PATH, OLD_WRAPPER);
+
+      const result = await migration(tree);
+      const migrated = tree.read(WRAPPER_PATH, 'utf-8') ?? '';
+
+      expect(result.nextSteps).toEqual([]);
+      expect(migrated).toContain('def create():');
+      expect(migrated).not.toContain('A2AAgent');
+      // The rest of the body is untouched.
+      expect(migrated).toContain(
+        'return AgentCoreA2aClientStrands.without_auth("http://localhost:9000/")',
+      );
+      expect(migrated).toContain(
+        'return AgentCoreA2aClientStrands.with_iam_auth(agent_runtime_arn)',
+      );
+    });
+
+    it('should report a diverged generated shape without partially rewriting it', async () => {
+      const diverged = OLD_WRAPPER.replace(
+        'from strands.agent.a2a_agent import A2AAgent',
+        'from strands.agent.a2a_agent import A2AAgent as StrandsA2AAgent',
+      );
+      tree.write(WRAPPER_PATH, diverged);
+
+      const result = await migration(tree);
+      const contents = tree.read(WRAPPER_PATH, 'utf-8') ?? '';
+
+      expect(result.nextSteps).toHaveLength(1);
+      expect(result.nextSteps[0]).toContain(WRAPPER_PATH);
+      expect(contents).toContain('def create() -> A2AAgent:');
+    });
+
+    it('should be idempotent', async () => {
+      tree.write(WRAPPER_PATH, OLD_WRAPPER);
+
+      await migration(tree);
+      const once = tree.read(WRAPPER_PATH, 'utf-8');
+      const result = await migration(tree);
+
+      expect(result.nextSteps).toEqual([]);
+      expect(tree.read(WRAPPER_PATH, 'utf-8')).toEqual(once);
+    });
+
+    it('should not touch a non-A2A strands wrapper (e.g. an MCP client)', async () => {
+      const mcpWrapper = `from strands.tools.mcp import MCPClient
+
+
+class SomeMcpClientStrands:
+    @staticmethod
+    def create() -> MCPClient:
+        return MCPClient(lambda: None)
+`;
+      const mcpPath =
+        'packages/common/agent_connection/proj_agent_connection/app/some_mcp_client_strands.py';
+      tree.write(mcpPath, mcpWrapper);
+
+      const result = await migration(tree);
+
+      expect(result.nextSteps).toEqual([]);
+      expect(tree.read(mcpPath, 'utf-8')).toEqual(mcpWrapper);
+    });
+  });
+});

--- a/packages/nx-plugin/src/migrations/latest/py-agent-a2a-httpx-client-per-call/migration.ts
+++ b/packages/nx-plugin/src/migrations/latest/py-agent-a2a-httpx-client-per-call/migration.ts
@@ -1,0 +1,431 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import {
+  type MigrationReturnObject,
+  type Tree,
+  visitNotIgnoredFiles,
+} from '@nx/devkit';
+import { applyGritQL, matchGritQL } from '../../../utils/ast';
+import { formatFilesInSubtree } from '../../../utils/format';
+
+/**
+ * Rebuild the `httpx.AsyncClient` (and, for Strands, the `A2AAgent`) fresh on
+ * every A2A delegate call, instead of reusing the one built once at factory
+ * time - fixes a reproducible `RuntimeError: Event loop is closed` on the
+ * second call through a shared client.
+ *
+ * Both frameworks' A2A clients call out through a synchronous wrapper
+ * (`_run_sync`) that runs the async call via `asyncio.run(...)` - a brand new
+ * event loop per call, closed when the call returns. `AgentCoreA2aClientConfig`
+ * builds one `httpx.AsyncClient` a single time, at factory call time, and that
+ * client's connection pool binds to whichever event loop first touches it. So
+ * call #1 creates a loop, uses the shared client, closes the loop; call #2
+ * creates a *new* loop, but the shared client's pool is still bound to the
+ * old, now-closed one.
+ *
+ * Strands hits the same failure one layer down: `A2AAgent.__call__` is itself
+ * synchronous and does its own `asyncio.run(...)` per call internally, while
+ * reusing the same factory-built `httpx.AsyncClient` via `client_config`.
+ *
+ * The fix in both `AgentCoreA2aClientLangChain`/`AgentCoreA2aClientStrands` is
+ * to stop handing out a client wired to one long-lived `httpx.AsyncClient`.
+ * Instead each call opens a fresh `httpx.AsyncClient` (reusing only the
+ * `auth`/`timeout` off the once-built shared config) scoped to that call via
+ * `async with`, so its connection pool lives and dies with the same loop that
+ * created it. For Strands this also means `AgentCoreA2aClientStrands`'s
+ * factories no longer return a raw `A2AAgent` (dropped in favour of a private
+ * `_A2AClient` built per call), so the per-target `<Agent>ClientStrands.create`
+ * wrapper's `-> A2AAgent` return annotation and its now-unused `A2AAgent`
+ * import go stale too.
+ */
+const pyMatch = (snippet: string) => `language python\n\`${snippet}\``;
+
+const pyRewrite = (from: string, to: string): string => {
+  const replacement = to.includes('\n') ? `raw\`${to}\`` : `\`${to}\``;
+  return `${pyMatch(from)} => ${replacement}`;
+};
+
+const allMatch = async (
+  tree: Tree,
+  filePath: string,
+  patterns: string[],
+): Promise<boolean> => {
+  for (const pattern of patterns) {
+    if (!(await matchGritQL(tree, filePath, pattern))) return false;
+  }
+  return true;
+};
+
+// --- agentcore_a2a_client_langchain.py (framework-agnostic core, shared) ---
+
+const LANGCHAIN_IMPORT_OLD =
+  'from a2a.client import A2ACardResolver, ClientConfig, ClientFactory';
+const LANGCHAIN_IMPORT_NEW = `import httpx
+from a2a.client import A2ACardResolver, ClientConfig, ClientFactory`;
+
+const LANGCHAIN_INVOKE_OLD = `    async def _invoke(self, prompt: str) -> str:
+        # AgentCoreA2aClientConfig always sets the signed httpx client.
+        httpx_client = self._config.httpx_client
+        if httpx_client is None:
+            raise RuntimeError("A2A client config is missing an httpx client")
+        card = await A2ACardResolver(
+            httpx_client=httpx_client, base_url=self._url
+        ).get_agent_card()
+        client = ClientFactory(self._config).create(card)
+        message = Message(
+            kind="message",
+            role=Role.user,
+            message_id=uuid4().hex,
+            parts=[Part(TextPart(kind="text", text=prompt))],
+        )
+        # The client config uses streaming=False, so the last event carries the
+        # complete response.
+        reply = ""
+        async for event in client.send_message(message):
+            text = _text(event)
+            if text:
+                reply = text
+        return reply`;
+
+const LANGCHAIN_INVOKE_NEW = `async def _invoke(self, prompt: str) -> str:
+    # AgentCoreA2aClientConfig always sets the signed httpx client.
+    shared_client = self._config.httpx_client
+    if shared_client is None:
+        raise RuntimeError("A2A client config is missing an httpx client")
+    async with httpx.AsyncClient(
+        auth=shared_client.auth, timeout=shared_client.timeout
+    ) as httpx_client:
+        card = await A2ACardResolver(
+            httpx_client=httpx_client, base_url=self._url
+        ).get_agent_card()
+        client = ClientFactory(
+            ClientConfig(httpx_client=httpx_client, streaming=False)
+        ).create(card)
+        message = Message(
+            kind="message",
+            role=Role.user,
+            message_id=uuid4().hex,
+            parts=[Part(TextPart(kind="text", text=prompt))],
+        )
+        # The client config uses streaming=False, so the last event carries
+        # the complete response.
+        reply = ""
+        async for event in client.send_message(message):
+            text = _text(event)
+            if text:
+                reply = text
+        return reply`;
+
+const migrateLangchainCoreClient = async (
+  tree: Tree,
+  filePath: string,
+  nextSteps: string[],
+): Promise<void> => {
+  const contents = tree.read(filePath, 'utf-8') ?? '';
+  if (!contents.includes('client = ClientFactory(self._config).create(card)'))
+    return;
+
+  const ready = await allMatch(tree, filePath, [
+    pyMatch(LANGCHAIN_IMPORT_OLD),
+    pyMatch(LANGCHAIN_INVOKE_OLD),
+  ]);
+
+  if (!ready) {
+    nextSteps.push(
+      `${filePath}: diverged from the generated shape - left untouched. Manually rebuild a fresh httpx.AsyncClient per call in _invoke instead of reusing the one built at factory time (see the agent-connection generator's agentcore_a2a_client_langchain.py template).`,
+    );
+    return;
+  }
+
+  await applyGritQL(
+    tree,
+    filePath,
+    pyRewrite(LANGCHAIN_IMPORT_OLD, LANGCHAIN_IMPORT_NEW),
+  );
+  await applyGritQL(
+    tree,
+    filePath,
+    pyRewrite(LANGCHAIN_INVOKE_OLD, LANGCHAIN_INVOKE_NEW),
+  );
+};
+
+// --- agentcore_a2a_client_strands.py (Strands core client) ------------------
+
+const STRANDS_IMPORT1_OLD = 'from collections.abc import Callable';
+const STRANDS_IMPORT1_NEW = `import asyncio
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor`;
+
+const STRANDS_IMPORT2_OLD = 'from strands.agent.a2a_agent import A2AAgent';
+const STRANDS_IMPORT2_NEW = `import httpx
+from a2a.client import ClientConfig
+from strands.agent.a2a_agent import A2AAgent
+from strands.agent.agent_result import AgentResult`;
+
+const STRANDS_BUILD_OLD = `def _build(
+    config: tuple, *, name: str | None, description: str | None
+) -> A2AAgent:
+    url, client_config = config
+    kwargs: dict = {"endpoint": url, "client_config": client_config}
+    if name:
+        kwargs["name"] = name
+    if description:
+        kwargs["description"] = description
+    return A2AAgent(**kwargs)`;
+
+const STRANDS_BUILD_NEW = `def _run_sync(coro):
+    # The tool is invoked from sync agent code, which under uvicorn runs inside a
+    # live event loop where asyncio.run() would raise — fall back to a worker.
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coro)
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        return pool.submit(asyncio.run, coro).result()
+
+
+class _A2AClient:
+    def __init__(
+        self,
+        url: str,
+        client_config: ClientConfig,
+        *,
+        name: str | None,
+        description: str | None,
+    ):
+        shared_client = client_config.httpx_client
+        if shared_client is None:
+            raise RuntimeError("A2A client config is missing an httpx client")
+        self._url = url
+        self._auth = shared_client.auth
+        self._timeout = shared_client.timeout
+        self._name = name
+        self._description = description
+
+    def __call__(self, prompt: str) -> AgentResult:
+        return _run_sync(self._invoke(prompt))
+
+    async def _invoke(self, prompt: str) -> AgentResult:
+        async with httpx.AsyncClient(
+            auth=self._auth, timeout=self._timeout
+        ) as httpx_client:
+            agent = A2AAgent(
+                endpoint=self._url,
+                name=self._name,
+                description=self._description,
+                client_config=ClientConfig(httpx_client=httpx_client, streaming=False),
+            )
+            return await agent.invoke_async(prompt)
+
+
+def _build(
+    config: tuple, *, name: str | None, description: str | None
+) -> _A2AClient:
+    url, client_config = config
+    return _A2AClient(url, client_config, name=name, description=description)`;
+
+const STRANDS_IAM_OLD = `    @staticmethod
+    def with_iam_auth(
+        agent_runtime_arn: str,
+        *,
+        name: str | None = None,
+        description: str | None = None,
+    ) -> A2AAgent:
+        """SigV4-authenticated client for a Bedrock AgentCore runtime."""
+        return _build(
+            AgentCoreA2aClientConfig.with_iam_auth(agent_runtime_arn),
+            name=name,
+            description=description,
+        )`;
+
+const STRANDS_IAM_NEW = `@staticmethod
+def with_iam_auth(
+    agent_runtime_arn: str,
+    *,
+    name: str | None = None,
+    description: str | None = None,
+) -> _A2AClient:
+    """SigV4-authenticated client for a Bedrock AgentCore runtime."""
+    return _build(
+        AgentCoreA2aClientConfig.with_iam_auth(agent_runtime_arn),
+        name=name,
+        description=description,
+    )`;
+
+const STRANDS_JWT_OLD = `    @staticmethod
+    def with_jwt_auth(
+        agent_runtime_arn: str,
+        access_token_provider: Callable[[], str],
+        *,
+        name: str | None = None,
+        description: str | None = None,
+    ) -> A2AAgent:
+        """Bearer-authenticated client for a Bedrock AgentCore runtime."""
+        return _build(
+            AgentCoreA2aClientConfig.with_jwt_auth(
+                agent_runtime_arn, access_token_provider
+            ),
+            name=name,
+            description=description,
+        )`;
+
+const STRANDS_JWT_NEW = `@staticmethod
+def with_jwt_auth(
+    agent_runtime_arn: str,
+    access_token_provider: Callable[[], str],
+    *,
+    name: str | None = None,
+    description: str | None = None,
+) -> _A2AClient:
+    """Bearer-authenticated client for a Bedrock AgentCore runtime."""
+    return _build(
+        AgentCoreA2aClientConfig.with_jwt_auth(
+            agent_runtime_arn, access_token_provider
+        ),
+        name=name,
+        description=description,
+    )`;
+
+const STRANDS_NOAUTH_OLD = `    @staticmethod
+    def without_auth(
+        url: str,
+        *,
+        name: str | None = None,
+        description: str | None = None,
+    ) -> A2AAgent:
+        """Plain-HTTP client — for local dev."""
+        return _build(
+            AgentCoreA2aClientConfig.without_auth(url),
+            name=name,
+            description=description,
+        )`;
+
+const STRANDS_NOAUTH_NEW = `@staticmethod
+def without_auth(
+    url: str,
+    *,
+    name: str | None = None,
+    description: str | None = None,
+) -> _A2AClient:
+    """Plain-HTTP client — for local dev."""
+    return _build(
+        AgentCoreA2aClientConfig.without_auth(url),
+        name=name,
+        description=description,
+    )`;
+
+const migrateStrandsCoreClient = async (
+  tree: Tree,
+  filePath: string,
+  nextSteps: string[],
+): Promise<void> => {
+  const contents = tree.read(filePath, 'utf-8') ?? '';
+  if (!contents.includes('return A2AAgent(**kwargs)')) return;
+
+  const ready = await allMatch(tree, filePath, [
+    pyMatch(STRANDS_IMPORT1_OLD),
+    pyMatch(STRANDS_IMPORT2_OLD),
+    pyMatch(STRANDS_BUILD_OLD),
+    pyMatch(STRANDS_IAM_OLD),
+    pyMatch(STRANDS_JWT_OLD),
+    pyMatch(STRANDS_NOAUTH_OLD),
+  ]);
+
+  if (!ready) {
+    nextSteps.push(
+      `${filePath}: diverged from the generated shape - left untouched. Manually rebuild a fresh httpx.AsyncClient (and A2AAgent) per call instead of reusing the ones built at factory time (see the agent-connection generator's agentcore_a2a_client_strands.py template).`,
+    );
+    return;
+  }
+
+  await applyGritQL(
+    tree,
+    filePath,
+    pyRewrite(STRANDS_IMPORT1_OLD, STRANDS_IMPORT1_NEW),
+  );
+  await applyGritQL(
+    tree,
+    filePath,
+    pyRewrite(STRANDS_IMPORT2_OLD, STRANDS_IMPORT2_NEW),
+  );
+  await applyGritQL(
+    tree,
+    filePath,
+    pyRewrite(STRANDS_BUILD_OLD, STRANDS_BUILD_NEW),
+  );
+  await applyGritQL(
+    tree,
+    filePath,
+    pyRewrite(STRANDS_IAM_OLD, STRANDS_IAM_NEW),
+  );
+  await applyGritQL(
+    tree,
+    filePath,
+    pyRewrite(STRANDS_JWT_OLD, STRANDS_JWT_NEW),
+  );
+  await applyGritQL(
+    tree,
+    filePath,
+    pyRewrite(STRANDS_NOAUTH_OLD, STRANDS_NOAUTH_NEW),
+  );
+};
+
+// --- <target>_client_strands.py (per-target wrapper, one per connection) ---
+
+const WRAPPER_IMPORT_OLD = 'from strands.agent.a2a_agent import A2AAgent';
+
+const WRAPPER_CREATE_OLD = 'def create() -> A2AAgent:\n    $body';
+const WRAPPER_CREATE_NEW = 'def create():\n    $body';
+
+const migrateStrandsWrapperClient = async (
+  tree: Tree,
+  filePath: string,
+  nextSteps: string[],
+): Promise<void> => {
+  const contents = tree.read(filePath, 'utf-8') ?? '';
+  if (!contents.includes('def create() -> A2AAgent:')) return;
+
+  const ready = await allMatch(tree, filePath, [
+    pyMatch(WRAPPER_IMPORT_OLD),
+    pyMatch(WRAPPER_CREATE_OLD),
+  ]);
+
+  if (!ready) {
+    nextSteps.push(
+      `${filePath}: diverged from the generated shape - left untouched. Manually drop the A2AAgent import and its -> A2AAgent return annotation on create() (see the py#agent#a2a-connection generator's per-target client_strands.py template).`,
+    );
+    return;
+  }
+
+  await applyGritQL(tree, filePath, `${pyMatch(WRAPPER_IMPORT_OLD)} => .`);
+  await applyGritQL(
+    tree,
+    filePath,
+    pyRewrite(WRAPPER_CREATE_OLD, WRAPPER_CREATE_NEW),
+  );
+};
+
+export default async function migration(
+  tree: Tree,
+): Promise<MigrationReturnObject> {
+  const nextSteps: string[] = [];
+
+  const filePaths: string[] = [];
+  visitNotIgnoredFiles(tree, '', (filePath) => filePaths.push(filePath));
+
+  for (const filePath of filePaths) {
+    if (filePath.endsWith('/agentcore_a2a_client_langchain.py')) {
+      await migrateLangchainCoreClient(tree, filePath, nextSteps);
+    } else if (filePath.endsWith('/agentcore_a2a_client_strands.py')) {
+      await migrateStrandsCoreClient(tree, filePath, nextSteps);
+    } else if (filePath.endsWith('_client_strands.py')) {
+      await migrateStrandsWrapperClient(tree, filePath, nextSteps);
+    }
+  }
+
+  await formatFilesInSubtree(tree);
+
+  return { nextSteps };
+}

--- a/packages/nx-plugin/src/py/agent/a2a-connection/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/agent/a2a-connection/__snapshots__/generator.spec.ts.snap
@@ -42,21 +42,64 @@ class AgentCoreA2aClientConfig:
 `;
 
 exports[`py#agent#a2a-connection generator > should match snapshot for agent-connection core files > agentcore_a2a_client_strands.py 1`] = `
-"from collections.abc import Callable
+"import asyncio
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
 
+import httpx
+from a2a.client import ClientConfig
 from strands.agent.a2a_agent import A2AAgent
+from strands.agent.agent_result import AgentResult
 
 from .agentcore_a2a_client_config import AgentCoreA2aClientConfig
 
 
-def _build(config: tuple, *, name: str | None, description: str | None) -> A2AAgent:
+def _run_sync(coro):
+    # The tool is invoked from sync agent code, which under uvicorn runs inside a
+    # live event loop where asyncio.run() would raise — fall back to a worker.
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coro)
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        return pool.submit(asyncio.run, coro).result()
+
+
+class _A2AClient:
+    def __init__(
+        self,
+        url: str,
+        client_config: ClientConfig,
+        *,
+        name: str | None,
+        description: str | None,
+    ):
+        shared_client = client_config.httpx_client
+        if shared_client is None:
+            raise RuntimeError("A2A client config is missing an httpx client")
+        self._url = url
+        self._auth = shared_client.auth
+        self._timeout = shared_client.timeout
+        self._name = name
+        self._description = description
+
+    def __call__(self, prompt: str) -> AgentResult:
+        return _run_sync(self._invoke(prompt))
+
+    async def _invoke(self, prompt: str) -> AgentResult:
+        async with httpx.AsyncClient(auth=self._auth, timeout=self._timeout) as httpx_client:
+            agent = A2AAgent(
+                endpoint=self._url,
+                name=self._name,
+                description=self._description,
+                client_config=ClientConfig(httpx_client=httpx_client, streaming=False),
+            )
+            return await agent.invoke_async(prompt)
+
+
+def _build(config: tuple, *, name: str | None, description: str | None) -> _A2AClient:
     url, client_config = config
-    kwargs: dict = {"endpoint": url, "client_config": client_config}
-    if name:
-        kwargs["name"] = name
-    if description:
-        kwargs["description"] = description
-    return A2AAgent(**kwargs)
+    return _A2AClient(url, client_config, name=name, description=description)
 
 
 class AgentCoreA2aClientStrands:
@@ -68,7 +111,7 @@ class AgentCoreA2aClientStrands:
         *,
         name: str | None = None,
         description: str | None = None,
-    ) -> A2AAgent:
+    ) -> _A2AClient:
         """SigV4-authenticated client for a Bedrock AgentCore runtime."""
         return _build(
             AgentCoreA2aClientConfig.with_iam_auth(agent_runtime_arn),
@@ -83,7 +126,7 @@ class AgentCoreA2aClientStrands:
         *,
         name: str | None = None,
         description: str | None = None,
-    ) -> A2AAgent:
+    ) -> _A2AClient:
         """Bearer-authenticated client for a Bedrock AgentCore runtime."""
         return _build(
             AgentCoreA2aClientConfig.with_jwt_auth(agent_runtime_arn, access_token_provider),
@@ -97,7 +140,7 @@ class AgentCoreA2aClientStrands:
         *,
         name: str | None = None,
         description: str | None = None,
-    ) -> A2AAgent:
+    ) -> _A2AClient:
         """Plain-HTTP client — for local dev."""
         return _build(
             AgentCoreA2aClientConfig.without_auth(url),
@@ -109,8 +152,6 @@ class AgentCoreA2aClientStrands:
 
 exports[`py#agent#a2a-connection generator > should match snapshot for agent-connection core files > remote_client_strands.py 1`] = `
 "import os
-
-from strands.agent.a2a_agent import A2AAgent
 
 from test_agent_connection.core.agentcore_a2a_client_strands import (
     AgentCoreA2aClientStrands,
@@ -124,7 +165,7 @@ class RemoteClientStrands:
     """Strands client for the Remote A2A agent."""
 
     @staticmethod
-    def create() -> A2AAgent:
+    def create():
         if os.environ.get("LOCAL_DEV") == "true":
             return AgentCoreA2aClientStrands.without_auth("http://localhost:9001/")
         config = get_agentcore_runtime_config()

--- a/packages/nx-plugin/src/py/agent/a2a-connection/files/agent-connection/app/__targetAgentSnakeCase___client_strands.py.template
+++ b/packages/nx-plugin/src/py/agent/a2a-connection/files/agent-connection/app/__targetAgentSnakeCase___client_strands.py.template
@@ -1,7 +1,5 @@
 import os
 
-from strands.agent.a2a_agent import A2AAgent
-
 from <%- agentConnectionModuleName %>.core.agentcore_a2a_client_strands import (
     AgentCoreA2aClientStrands,
 )
@@ -14,7 +12,7 @@ class <%- targetAgentClassName %>ClientStrands:
     """Strands client for the <%- targetAgentClassName %> A2A agent."""
 
     @staticmethod
-    def create() -> A2AAgent:
+    def create():
         if os.environ.get("LOCAL_DEV") == "true":
             return AgentCoreA2aClientStrands.without_auth(
                 "http://localhost:<%- targetAgentPort %>/"

--- a/packages/nx-plugin/src/utils/agent-connection/files/py-core-langchain/a2a/agentcore_a2a_client_langchain.py.template
+++ b/packages/nx-plugin/src/utils/agent-connection/files/py-core-langchain/a2a/agentcore_a2a_client_langchain.py.template
@@ -3,6 +3,7 @@ from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from uuid import uuid4
 
+import httpx
 from a2a.client import A2ACardResolver, ClientConfig, ClientFactory
 from a2a.types import Message, Part, Role, Task, TextPart
 
@@ -47,27 +48,32 @@ class _A2AClient:
 
     async def _invoke(self, prompt: str) -> str:
         # AgentCoreA2aClientConfig always sets the signed httpx client.
-        httpx_client = self._config.httpx_client
-        if httpx_client is None:
+        shared_client = self._config.httpx_client
+        if shared_client is None:
             raise RuntimeError("A2A client config is missing an httpx client")
-        card = await A2ACardResolver(
-            httpx_client=httpx_client, base_url=self._url
-        ).get_agent_card()
-        client = ClientFactory(self._config).create(card)
-        message = Message(
-            kind="message",
-            role=Role.user,
-            message_id=uuid4().hex,
-            parts=[Part(TextPart(kind="text", text=prompt))],
-        )
-        # The client config uses streaming=False, so the last event carries the
-        # complete response.
-        reply = ""
-        async for event in client.send_message(message):
-            text = _text(event)
-            if text:
-                reply = text
-        return reply
+        async with httpx.AsyncClient(
+            auth=shared_client.auth, timeout=shared_client.timeout
+        ) as httpx_client:
+            card = await A2ACardResolver(
+                httpx_client=httpx_client, base_url=self._url
+            ).get_agent_card()
+            client = ClientFactory(
+                ClientConfig(httpx_client=httpx_client, streaming=False)
+            ).create(card)
+            message = Message(
+                kind="message",
+                role=Role.user,
+                message_id=uuid4().hex,
+                parts=[Part(TextPart(kind="text", text=prompt))],
+            )
+            # The client config uses streaming=False, so the last event carries
+            # the complete response.
+            reply = ""
+            async for event in client.send_message(message):
+                text = _text(event)
+                if text:
+                    reply = text
+            return reply
 
 
 class AgentCoreA2aClientLangChain:

--- a/packages/nx-plugin/src/utils/agent-connection/files/py-core-strands/a2a/agentcore_a2a_client_strands.py.template
+++ b/packages/nx-plugin/src/utils/agent-connection/files/py-core-strands/a2a/agentcore_a2a_client_strands.py.template
@@ -1,20 +1,65 @@
+import asyncio
 from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
 
+import httpx
+from a2a.client import ClientConfig
 from strands.agent.a2a_agent import A2AAgent
+from strands.agent.agent_result import AgentResult
 
 from .agentcore_a2a_client_config import AgentCoreA2aClientConfig
 
 
+def _run_sync(coro):
+    # The tool is invoked from sync agent code, which under uvicorn runs inside a
+    # live event loop where asyncio.run() would raise — fall back to a worker.
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coro)
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        return pool.submit(asyncio.run, coro).result()
+
+
+class _A2AClient:
+    def __init__(
+        self,
+        url: str,
+        client_config: ClientConfig,
+        *,
+        name: str | None,
+        description: str | None,
+    ):
+        shared_client = client_config.httpx_client
+        if shared_client is None:
+            raise RuntimeError("A2A client config is missing an httpx client")
+        self._url = url
+        self._auth = shared_client.auth
+        self._timeout = shared_client.timeout
+        self._name = name
+        self._description = description
+
+    def __call__(self, prompt: str) -> AgentResult:
+        return _run_sync(self._invoke(prompt))
+
+    async def _invoke(self, prompt: str) -> AgentResult:
+        async with httpx.AsyncClient(
+            auth=self._auth, timeout=self._timeout
+        ) as httpx_client:
+            agent = A2AAgent(
+                endpoint=self._url,
+                name=self._name,
+                description=self._description,
+                client_config=ClientConfig(httpx_client=httpx_client, streaming=False),
+            )
+            return await agent.invoke_async(prompt)
+
+
 def _build(
     config: tuple, *, name: str | None, description: str | None
-) -> A2AAgent:
+) -> _A2AClient:
     url, client_config = config
-    kwargs: dict = {"endpoint": url, "client_config": client_config}
-    if name:
-        kwargs["name"] = name
-    if description:
-        kwargs["description"] = description
-    return A2AAgent(**kwargs)
+    return _A2AClient(url, client_config, name=name, description=description)
 
 
 class AgentCoreA2aClientStrands:
@@ -26,7 +71,7 @@ class AgentCoreA2aClientStrands:
         *,
         name: str | None = None,
         description: str | None = None,
-    ) -> A2AAgent:
+    ) -> _A2AClient:
         """SigV4-authenticated client for a Bedrock AgentCore runtime."""
         return _build(
             AgentCoreA2aClientConfig.with_iam_auth(agent_runtime_arn),
@@ -41,7 +86,7 @@ class AgentCoreA2aClientStrands:
         *,
         name: str | None = None,
         description: str | None = None,
-    ) -> A2AAgent:
+    ) -> _A2AClient:
         """Bearer-authenticated client for a Bedrock AgentCore runtime."""
         return _build(
             AgentCoreA2aClientConfig.with_jwt_auth(
@@ -57,7 +102,7 @@ class AgentCoreA2aClientStrands:
         *,
         name: str | None = None,
         description: str | None = None,
-    ) -> A2AAgent:
+    ) -> _A2AClient:
         """Plain-HTTP client — for local dev."""
         return _build(
             AgentCoreA2aClientConfig.without_auth(url),


### PR DESCRIPTION
### Reason for this change

Every LangChain and Strands A2A agent that delegates to another agent over A2A hits a reproducible `RuntimeError: Event loop is closed` on the second call through the same client. `AgentCoreA2aClientConfig` builds one `httpx.AsyncClient` a single time, at factory call time, and that client's connection pool binds to whichever event loop first touches it. Every A2A delegate call runs through a fresh `asyncio.run()` loop (`_run_sync`, and — for Strands — `A2AAgent.__call__` does the same internally), so call 1 binds the pool to its loop, that loop closes when the call returns, and call 2's new loop then touches the same pool and blows up.

<img width="762" height="341" alt="Screenshot From 2026-08-13 17-08-22" src="https://github.com/user-attachments/assets/908dbbc4-af67-42bb-bb9e-04482c4acfb5" />

### Description of changes

- `agentcore_a2a_client_langchain.py.template` / `agentcore_a2a_client_strands.py.template` — both clients now open a fresh `httpx.AsyncClient` per call (`async with`, reusing only the `auth`/`timeout` off the once-built shared config) instead of reusing the one built at factory time. For Strands this also means the factory no longer hands out a raw `A2AAgent` — it now returns a private `_A2AClient` that builds a fresh `A2AAgent` per call via `invoke_async`.
- `__targetAgentSnakeCase___client_strands.py.template` — the per-target `<Agent>ClientStrands.create()` wrapper's now-stale `-> A2AAgent` return annotation and unused `A2AAgent` import are dropped, since the factory no longer returns that type.
- New migration `py-agent-a2a-httpx-client-per-call` carries existing workspaces to the same shape: it finds `agentcore_a2a_client_langchain.py`, `agentcore_a2a_client_strands.py`, and any `<target>_client_strands.py` wrapper by content shape, rewrites them via GritQL, and reports (without touching) any file that has diverged from the generated shape.

### Description of how you validated changes

- Added `migration.spec.ts` (11 tests): applies cleanly to the generated shape for all three files, detects and reports divergence without partial rewrites, is idempotent, and leaves an unrelated strands wrapper (e.g. an MCP client, which shares the `_client_strands.py` suffix) untouched.
- Dry-ran the migration's exact GritQL rewrites against the real pre-fix template content and diffed the result against the fixed templates — byte-identical for both core clients.
- `pnpm nx run @aws/nx-plugin:test` (migrations, py/agent, agent-connection suites): 493 tests pass. Snapshot updated for the Strands core client's new shape.
- `pnpm nx run @aws/nx-plugin:typecheck` and `:lint` pass.
- Manually reproduced the bug for both frameworks in a real generated workspace and confirmed the fix resolves it: [reproduction](https://github.com/AlexTo/py-agent-session-manager/commit/1012a40ca721d7de5c8445fe3aca333e54e6b7df), [migration + fix applied](https://github.com/AlexTo/py-agent-session-manager/commit/66f5a3f239d9c1922e08eb18dadd74820fd08327) — the second commit is `nx migrate` actually running this PR's migration against a real workspace, landing byte-for-byte the same rewrite the unit tests assert.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
