### PR TITLE
fix(agentcore-gateway): bump terraform provider version to avoid failure encountered with cedar policies

### DIFF
--- a/e2e/src/files/terraform-deploy/main.tf.template
+++ b/e2e/src/files/terraform-deploy/main.tf.template
@@ -246,16 +246,8 @@ module "ts_agui_agent" {
 }
 
 # ---------------------------------------------------------------------------
-# AgentCore Gateway (IAM-authenticated MCP endpoint)
+# AgentCore Gateway (Cedar policy engine + IAM-authenticated MCP endpoint)
 # ---------------------------------------------------------------------------
-
-# The gateways here are generated without a Cedar policy engine. AgentCore
-# injects a server-managed `metadata_configuration.allowed_request_headers` on
-# targets of a policy-engine gateway, which the AWS provider declares
-# `Optional` rather than `Computed`, so every apply fails its post-apply
-# consistency check; declaring the header explicitly is rejected as restricted.
-# cdk-deploy still covers Cedar. Restore it once the provider fixes the block —
-# tracked in #1065.
 
 # The gateway signs outbound calls to its MCP server targets with its own
 # role and fetches each target's tools at creation time, so it needs invoke
@@ -266,6 +258,11 @@ module "my_gateway" {
   additional_iam_policy_statements = [
     local.invoke_py_mcp_server_statement,
     local.invoke_ts_mcp_server_statement,
+  ]
+
+  policy_dependencies = [
+    aws_bedrockagentcore_gateway_target.ts_mcp_server.target_id,
+    aws_bedrockagentcore_gateway_target.py_mcp_server.target_id,
   ]
 
   # Aggregated by parent_gateway, so its gateway_url must not be consumed
@@ -280,9 +277,9 @@ module "my_gateway" {
 # Register both MCP servers as targets of the Gateway — the Terraform
 # analogue of `myGateway.addMcpServer(...)` in the CDK template. Target
 # names match the local-dev registrations (kebab-cased MCP project class
-# name) so tool prefixes are identical locally and deployed. The runtime ARNs
-# flow through each runtime's readiness probe, so targets are created only
-# once the runtimes serve MCP.
+# name) so Cedar action prefixes are identical locally and deployed. The
+# runtime ARNs flow through each runtime's readiness probe, so targets are
+# created only once the runtimes serve MCP.
 resource "aws_bedrockagentcore_gateway_target" "ts_mcp_server" {
   gateway_identifier = module.my_gateway.gateway_id
   name               = "hosted-mcp-server"
@@ -335,6 +332,10 @@ module "parent_gateway" {
       Action   = ["bedrock-agentcore:InvokeGateway"]
       Resource = [module.my_gateway.gateway_arn]
     }
+  ]
+
+  policy_dependencies = [
+    aws_bedrockagentcore_gateway_target.my_gateway.target_id,
   ]
 }
 

--- a/e2e/src/smoke-tests/generator-matrix.ts
+++ b/e2e/src/smoke-tests/generator-matrix.ts
@@ -25,21 +25,16 @@ interface RunCliOpts {
  * Pass `{ preferInstallDependencies: true }` to install after every generator
  * instead — the idempotency test needs this so lockfiles (including `uv.lock`)
  * are fully synced before it snapshots the workspace.
- *
- * Pass `{ cedarPolicy: false }` to scaffold the MCP gateways without a Cedar
- * policy engine — see the comment on the Terraform caller for why it opts out.
  */
 export const runGeneratorMatrix = async (
   opts: RunCliOpts,
   {
     preferInstallDependencies = false,
-    cedarPolicy = true,
-  }: { preferInstallDependencies?: boolean; cedarPolicy?: boolean } = {},
+  }: { preferInstallDependencies?: boolean } = {},
 ) => {
   const deferFlag = preferInstallDependencies
     ? ''
     : ' --prefer-install-dependencies=false';
-  const cedarFlag = cedarPolicy ? '' : ' --cedarPolicy=false';
   // Websites (with and without TanStack Router), plus auth on each.
   await runCLI(
     `generate @aws/nx-plugin:ts#website --name=website --no-interactive${deferFlag}`,
@@ -295,7 +290,7 @@ export const runGeneratorMatrix = async (
   // gateway -> ts/py mcp-server) so each smoke test exercises a deployable
   // gateway with multiple MCP server targets fronting both agent runtimes.
   await runCLI(
-    `generate @aws/nx-plugin:agentcore-gateway --name=my-gateway --no-interactive${cedarFlag}${deferFlag}`,
+    `generate @aws/nx-plugin:agentcore-gateway --name=my-gateway --no-interactive${deferFlag}`,
     opts,
   );
   await runCLI(
@@ -323,7 +318,7 @@ export const runGeneratorMatrix = async (
   // A parent gateway fronting my-gateway, exercising the
   // gateway -> gateway connection edge (chained gateways).
   await runCLI(
-    `generate @aws/nx-plugin:agentcore-gateway --name=parent-gateway --no-interactive${cedarFlag}${deferFlag}`,
+    `generate @aws/nx-plugin:agentcore-gateway --name=parent-gateway --no-interactive${deferFlag}`,
     opts,
   );
   await runCLI(

--- a/e2e/src/smoke-tests/terraform-deploy.spec.ts
+++ b/e2e/src/smoke-tests/terraform-deploy.spec.ts
@@ -309,7 +309,8 @@ const runTerraformDeployVariant = (config: TerraformDeployVariant) => {
           // Python (`my-mcp-server`) MCP servers as targets. Prompt each agent
           // to call a gateway-prefixed tool (`<target>___<tool>`) for each
           // upstream server. A successful round-trip proves agent -> deployed
-          // Gateway (SigV4) -> MCP server works end-to-end for both languages.
+          // Gateway (Cedar ENFORCE + SigV4) -> MCP server works end-to-end for
+          // both languages.
           expect(
             await invokeTrpcAgentCoreAgent(
               outputs.ts_agent_arn,
@@ -342,8 +343,8 @@ const runTerraformDeployVariant = (config: TerraformDeployVariant) => {
           // Chained gateways — the parent gateway fronts my_gateway via the
           // gateway -> gateway connection, re-exposing its tools under a
           // second prefix. Listing tools on the parent and calling one proves
-          // the parent -> my_gateway (SigV4 at both hops) -> MCP server chain
-          // works end-to-end.
+          // the parent -> my_gateway (SigV4 + Cedar at both hops) -> MCP
+          // server chain works end-to-end.
           await invokeAgentCoreGatewayTool(
             outputs.parent_gateway_url,
             'Parent Gateway -> Gateway -> TS MCP',

--- a/e2e/src/smoke-tests/terraform-smoke-test.ts
+++ b/e2e/src/smoke-tests/terraform-smoke-test.ts
@@ -17,15 +17,6 @@ import { runTerraformPlanTest } from './terraform-plan-test';
  * that `terraform` and `terraform-deploy` smoke tests both verify the same
  * generators, options and connection permutations under the Terraform IaC
  * provider.
- *
- * The MCP gateways are scaffolded without a Cedar policy engine: AgentCore
- * injects a server-managed `metadata_configuration.allowed_request_headers`
- * on targets of a policy-engine gateway, and the AWS provider declares that
- * block `Optional` rather than `Computed`, so every apply fails the post-apply
- * consistency check. The header is rejected if declared explicitly, so there
- * is no configuration that reconciles it. Cedar stays covered by `cdk-deploy`,
- * which CloudFormation applies without an equivalent check. Restore the policy
- * engine here once the provider marks the block `Computed` — tracked in #1065.
  */
 export const runTerraformSmokeTest = async (
   dir: string,
@@ -61,7 +52,7 @@ export const runTerraformSmokeTest = async (
     opts,
   );
 
-  await runGeneratorMatrix(opts, { cedarPolicy: false });
+  await runGeneratorMatrix(opts);
 
   // Since the smoke tests don't run in a git repo, we need to exclude some
   // patterns for the license sync.

--- a/packages/nx-plugin/src/agentcore-gateway/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/agentcore-gateway/__snapshots__/generator.spec.ts.snap
@@ -7,7 +7,7 @@ exports[`agentcore-gateway generator > protocol: http > omits protocol_type from
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.58.0"
+      version = "6.60.0"
     }
     time = {
       source  = "hashicorp/time"

--- a/packages/nx-plugin/src/py/agent/__snapshots__/generator.protocols.spec.ts.snap
+++ b/packages/nx-plugin/src/py/agent/__snapshots__/generator.protocols.spec.ts.snap
@@ -134,7 +134,7 @@ exports[`py#agent generator > should match snapshot for Terraform generated file
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.58.0"
+      version = "6.60.0"
     }
     null = {
       source  = "hashicorp/null"

--- a/packages/nx-plugin/src/py/dynamodb/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/dynamodb/__snapshots__/generator.spec.ts.snap
@@ -35,7 +35,7 @@ exports[`py#dynamodb generator > should generate terraform modules when iac is t
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.58.0"
+      version = "6.60.0"
     }
   }
 }
@@ -192,7 +192,7 @@ exports[`py#dynamodb generator > should generate terraform modules when iac is t
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.58.0"
+      version = "6.60.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/packages/nx-plugin/src/py/fast-api/__snapshots__/generator.terraform.spec.ts.snap
+++ b/packages/nx-plugin/src/py/fast-api/__snapshots__/generator.terraform.spec.ts.snap
@@ -11,7 +11,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.58.0"
+      version = "6.60.0"
     }
   }
 }
@@ -258,7 +258,7 @@ output "api_log_group_arn" {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.58.0"
+      version = "6.60.0"
     }
   }
 }
@@ -771,7 +771,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.58.0"
+      version = "6.60.0"
     }
   }
 }
@@ -1018,7 +1018,7 @@ output "api_log_group_arn" {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.58.0"
+      version = "6.60.0"
     }
   }
 }
@@ -1603,7 +1603,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.58.0"
+      version = "6.60.0"
     }
   }
 }
@@ -1850,7 +1850,7 @@ output "api_log_group_arn" {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.58.0"
+      version = "6.60.0"
     }
   }
 }
@@ -2340,7 +2340,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.58.0"
+      version = "6.60.0"
     }
     random = {
       source  = "hashicorp/random"
@@ -2596,7 +2596,7 @@ output "waf_web_acl_arn" {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.58.0"
+      version = "6.60.0"
     }
   }
 }
@@ -3346,7 +3346,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.58.0"
+      version = "6.60.0"
     }
     random = {
       source  = "hashicorp/random"
@@ -3602,7 +3602,7 @@ output "waf_web_acl_arn" {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.58.0"
+      version = "6.60.0"
     }
   }
 }
@@ -4341,7 +4341,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.58.0"
+      version = "6.60.0"
     }
     random = {
       source  = "hashicorp/random"
@@ -4597,7 +4597,7 @@ output "waf_web_acl_arn" {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.58.0"
+      version = "6.60.0"
     }
   }
 }

--- a/packages/nx-plugin/src/py/lambda-function/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/lambda-function/__snapshots__/generator.spec.ts.snap
@@ -70,7 +70,7 @@ exports[`lambda-handler project generator > terraform iac > should generate terr
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.58.0"
+      version = "6.60.0"
     }
     archive = {
       source  = "hashicorp/archive"
@@ -251,7 +251,7 @@ exports[`lambda-handler project generator > terraform iac > should match snapsho
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.58.0"
+      version = "6.60.0"
     }
     archive = {
       source  = "hashicorp/archive"

--- a/packages/nx-plugin/src/py/mcp-server/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/mcp-server/__snapshots__/generator.spec.ts.snap
@@ -155,7 +155,7 @@ exports[`py#mcp-server generator > should match snapshot for Terraform generated
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.58.0"
+      version = "6.60.0"
     }
     null = {
       source  = "hashicorp/null"

--- a/packages/nx-plugin/src/py/rdb/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/rdb/__snapshots__/generator.spec.ts.snap
@@ -214,7 +214,7 @@ exports[`py#rdb generator > should generate Terraform modules 1`] = `
     }
     aws = {
       source  = "hashicorp/aws"
-      version = "6.58.0"
+      version = "6.60.0"
     }
     null = {
       source  = "hashicorp/null"

--- a/packages/nx-plugin/src/smithy/ts/api/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/smithy/ts/api/__snapshots__/generator.spec.ts.snap
@@ -413,7 +413,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.58.0"
+      version = "6.60.0"
     }
     random = {
       source  = "hashicorp/random"
@@ -672,7 +672,7 @@ exports[`tsSmithyApiGenerator > should generate smithy ts api with Terraform pro
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.58.0"
+      version = "6.60.0"
     }
   }
 }
@@ -1904,7 +1904,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.58.0"
+      version = "6.60.0"
     }
     random = {
       source  = "hashicorp/random"
@@ -2160,7 +2160,7 @@ output "waf_web_acl_arn" {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.58.0"
+      version = "6.60.0"
     }
   }
 }
@@ -2879,7 +2879,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.58.0"
+      version = "6.60.0"
     }
     random = {
       source  = "hashicorp/random"
@@ -3135,7 +3135,7 @@ output "waf_web_acl_arn" {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.58.0"
+      version = "6.60.0"
     }
   }
 }
@@ -3839,7 +3839,7 @@ exports[`tsSmithyApiGenerator > terraform iac > should generate terraform with c
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.58.0"
+      version = "6.60.0"
     }
   }
 }

--- a/packages/nx-plugin/src/trpc/backend/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/trpc/backend/__snapshots__/generator.spec.ts.snap
@@ -3175,7 +3175,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.58.0"
+      version = "6.60.0"
     }
   }
 }
@@ -3422,7 +3422,7 @@ output "api_log_group_arn" {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.58.0"
+      version = "6.60.0"
     }
   }
 }
@@ -3917,7 +3917,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.58.0"
+      version = "6.60.0"
     }
   }
 }
@@ -4164,7 +4164,7 @@ output "api_log_group_arn" {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.58.0"
+      version = "6.60.0"
     }
   }
 }
@@ -4731,7 +4731,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.58.0"
+      version = "6.60.0"
     }
   }
 }
@@ -4978,7 +4978,7 @@ output "api_log_group_arn" {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.58.0"
+      version = "6.60.0"
     }
   }
 }
@@ -5450,7 +5450,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.58.0"
+      version = "6.60.0"
     }
     random = {
       source  = "hashicorp/random"
@@ -5706,7 +5706,7 @@ output "waf_web_acl_arn" {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.58.0"
+      version = "6.60.0"
     }
   }
 }
@@ -6426,7 +6426,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.58.0"
+      version = "6.60.0"
     }
     random = {
       source  = "hashicorp/random"
@@ -6682,7 +6682,7 @@ output "waf_web_acl_arn" {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.58.0"
+      version = "6.60.0"
     }
   }
 }
@@ -7391,7 +7391,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.58.0"
+      version = "6.60.0"
     }
     random = {
       source  = "hashicorp/random"
@@ -7647,7 +7647,7 @@ output "waf_web_acl_arn" {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.58.0"
+      version = "6.60.0"
     }
   }
 }

--- a/packages/nx-plugin/src/ts/agent/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/agent/__snapshots__/generator.spec.ts.snap
@@ -1263,7 +1263,7 @@ exports[`ts#agent generator > should match snapshot for Terraform generated file
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.58.0"
+      version = "6.60.0"
     }
     null = {
       source  = "hashicorp/null"

--- a/packages/nx-plugin/src/ts/dcr-proxy/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/dcr-proxy/__snapshots__/generator.spec.ts.snap
@@ -579,7 +579,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.58.0"
+      version = "6.60.0"
     }
     archive = {
       source  = "hashicorp/archive"

--- a/packages/nx-plugin/src/ts/dynamodb/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/dynamodb/__snapshots__/generator.spec.ts.snap
@@ -35,7 +35,7 @@ exports[`ts#dynamodb generator > should generate terraform modules when iac is t
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.58.0"
+      version = "6.60.0"
     }
   }
 }
@@ -192,7 +192,7 @@ exports[`ts#dynamodb generator > should generate terraform modules when iac is t
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.58.0"
+      version = "6.60.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/packages/nx-plugin/src/ts/lambda-function/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/lambda-function/__snapshots__/generator.spec.ts.snap
@@ -141,7 +141,7 @@ exports[`ts-lambda-function generator > terraform iac > should generate terrafor
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.58.0"
+      version = "6.60.0"
     }
     archive = {
       source  = "hashicorp/archive"
@@ -322,7 +322,7 @@ exports[`ts-lambda-function generator > terraform iac > should match snapshot fo
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.58.0"
+      version = "6.60.0"
     }
     archive = {
       source  = "hashicorp/archive"

--- a/packages/nx-plugin/src/ts/mcp-server/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/mcp-server/__snapshots__/generator.spec.ts.snap
@@ -155,7 +155,7 @@ exports[`ts#mcp-server generator > should match snapshot for Terraform generated
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.58.0"
+      version = "6.60.0"
     }
     null = {
       source  = "hashicorp/null"

--- a/packages/nx-plugin/src/ts/rdb/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/rdb/__snapshots__/generator.spec.ts.snap
@@ -799,7 +799,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.58.0"
+      version = "6.60.0"
     }
     null = {
       source  = "hashicorp/null"
@@ -1553,7 +1553,7 @@ exports[`ts#rdb generator > should generate terraform modules when iac is Terraf
     }
     aws = {
       source  = "hashicorp/aws"
-      version = "6.58.0"
+      version = "6.60.0"
     }
     null = {
       source  = "hashicorp/null"
@@ -2285,7 +2285,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.58.0"
+      version = "6.60.0"
     }
     null = {
       source  = "hashicorp/null"
@@ -3039,7 +3039,7 @@ exports[`ts#rdb generator > should generate terraform modules with MySQL engine 
     }
     aws = {
       source  = "hashicorp/aws"
-      version = "6.58.0"
+      version = "6.60.0"
     }
     null = {
       source  = "hashicorp/null"

--- a/packages/nx-plugin/src/ts/react-website/app/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/react-website/app/__snapshots__/generator.spec.ts.snap
@@ -131,7 +131,7 @@ exports[`react-website generator > TailwindCSS integration > terraform iac > sho
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.58.0"
+      version = "6.60.0"
       configuration_aliases = [aws.us_east_1]
     }
     random = {
@@ -908,7 +908,7 @@ output "waf_web_acl_arn" {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.58.0"
+      version = "6.60.0"
       configuration_aliases = [aws.us_east_1]
     }
   }

--- a/packages/nx-plugin/src/ts/react-website/cognito-auth/__snapshots__/generator.terraform.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/react-website/cognito-auth/__snapshots__/generator.terraform.spec.ts.snap
@@ -6,7 +6,7 @@ exports[`cognito-auth generator terraform iac > should generate terraform files 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.58.0"
+      version = "6.60.0"
     }
   }
 }

--- a/packages/nx-plugin/src/utils/versions.ts
+++ b/packages/nx-plugin/src/utils/versions.ts
@@ -347,7 +347,7 @@ export const containerImage = (tool: keyof typeof CONTAINER_VERSIONS): string =>
  * Pinned exactly (no range operator) so generated infrastructure is reproducible.
  */
 export const TERRAFORM_VERSIONS = {
-  aws: '6.58.0',
+  aws: '6.60.0',
   random: '3.9.0',
   null: '3.3.0',
   archive: '2.8.0',


### PR DESCRIPTION
### Reason for this change

The upstream AWS provider bug that forced us to disable Cedar on the Terraform e2e path **is fixed and released**.

[hashicorp/terraform-provider-aws#49447](https://github.com/hashicorp/terraform-provider-aws/pull/49447) merged 2026-08-13 and shipped in **6.60.0** (published ~1 hour later). Its release note:

> resource/aws_bedrockagentcore_gateway_target: Prevent state inconsistencies caused by the service-managed policy session header ([#49447](https://github.com/hashicorp/terraform-provider-aws/issues/49447))

Recap of the original problem (#1064, tracked in #1065): AgentCore injects a server-managed `metadata_configuration.allowed_request_headers = ["x-amzn-bedrock-agentcore-policy-session-id"]` on gateway targets — but only when the gateway has a Cedar policy engine attached. The provider declared that block `Optional` with no `Computed`, so the injected value failed Terraform's post-apply consistency check and every apply failed:

```
Error: Provider produced inconsistent result after apply
... .metadata_configuration: block count changed from 0 to 1
```

The upstream fix adds `normalizeGatewayTargetOutputForState(...)`, which strips the header case-insensitively from the `GetGatewayTarget` response before it is written to state — applied **after Create and during Read** — and sets the whole `metadata_configuration` block to `nil` when removing the header would leave it empty. That is exactly the shape our config plans when the block is omitted, so both of our original failure modes are resolved.

Notably it is a **filtering-only** fix: `metadata_configuration` remains block syntax, so there is **no HCL change for users and no major provider upgrade**. This supersedes the earlier expectation on #1065 of a breaking block→attribute conversion possibly requiring 7.x.

### Description of changes

- `versions.ts`: bump the pinned `aws` provider from 6.58.0 to **6.60.0** (the first release containing the fix).
- `terraform-smoke-test.ts`: `runGeneratorMatrix(opts)` again, and remove the explanatory paragraph about the opt-out.
- `generator-matrix.ts`: remove the now-unused `cedarPolicy` option and `cedarFlag`, so both MCP gateways (`my-gateway`, `parent-gateway`) are generated with the policy engine as before.
- `main.tf.template`: restore `policy_dependencies` on `module "my_gateway"` (its two MCP target ids) and on `module "parent_gateway"` (the `my_gateway` target id); restore the section heading and the Cedar wording in the target comment.
- `terraform-deploy.spec.ts`: restore the Cedar wording in the two assertions' comments.
- Snapshots updated for the provider version string only.

**Deliberately left untouched:**
- The `time_sleep.gateway_role_policy_propagation` fix from #1066 — a separate, genuine user-facing bug (missing IAM propagation wait on the non-Cedar gateway branch). Unrelated to the provider bug and still required.
- The generator's own `cedarPolicy: false` unit assertions in `generator.spec.ts`, which still cover the non-Cedar code path.

### Description of how you validated changes

- Verified the fix is present in the **released** `v6.60.0` tag, not just on provider `main`: `normalizeGatewayTargetOutputForState` exists in both, and the declaration is still `schema.ListNestedBlock` (confirming no breaking syntax change).
- Confirmed no generated `.tf` template in this repo declares `metadata_configuration` — the only occurrence was the explanatory comment this PR removes — so there is no HCL migration exposure.
- Full plugin unit suite: **3472 passed (185 files)**. The only snapshot delta was the `6.58.0` → `6.60.0` version string, reviewed line by line before accepting.
- `nx-plugin-e2e:lint` passes.

Note: the `*-deploy` smoke tests do **not** run on PRs — the PR workflow excludes them, so they only run on `main` post-merge. The real end-to-end validation is the post-merge `Smoke Tests - terraform-deploy` run, which I will monitor; if the `metadata_configuration` inconsistency recurs there, the upstream fix would be incomplete and this should be reverted.

### Issue # (if applicable)

Closes #1065.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*