### PR TITLE
test(e2e): cover repeated A2A delegation through a reused session

### DIFF
--- a/e2e/src/smoke-tests/local-dev.spec.ts
+++ b/e2e/src/smoke-tests/local-dev.spec.ts
@@ -59,7 +59,7 @@ const A2A_DELEGATED_MARKER = 'delegated reply:';
  * Bounded with `.times()` + `.first()` so it neither hijacks the shared
  * fallback for other tests nor lingers afterwards.
  */
-function driveA2ADelegations(delegations: number): void {
+function driveA2ADelegations(mock: MockServer, delegations: number): void {
   type MockReq = {
     messages: { role: string; content: string }[];
     toolNames: readonly string[];
@@ -92,13 +92,13 @@ function driveA2ADelegations(delegations: number): void {
     return { text: `${A2A_DELEGATED_MARKER} ${result?.content ?? 'none'}` };
   };
 
-  llmMock!
+  mock
     .when(owesToolCall as never)
     .reply(callTool as never)
     .first()
     .times(delegations);
 
-  llmMock!
+  mock
     .when(answersToolResult as never)
     .reply(echoToolResult as never)
     .first()
@@ -1546,7 +1546,7 @@ def list_examples_by_category(category: str) -> list[ExampleItem]:
     //
     // The delegation tool returns its exception as the tool result, so a failed
     // call still streams back a 200: assert on the body, not just the status.
-    driveA2ADelegations(2);
+    driveA2ADelegations(llmMock!, 2);
     const sessionId = `py-agent-a2a-reuse-${'0'.repeat(20)}`;
     for (const attempt of [1, 2]) {
       const delegateRes = await fetch(
@@ -1579,6 +1579,9 @@ def list_examples_by_category(category: str) -> list[ExampleItem]:
       STARTUP_TIMEOUT_MS,
     );
     await stopLast();
+    // This agent's dev chain also starts the A2A agent it delegates to, so wait
+    // for that port to be released before the next chain tries to bind it.
+    await waitForPortFree(ports.pyA2a, STARTUP_TIMEOUT_MS);
   });
 
   it('Python A2A Agent - card + streaming message', async () => {
@@ -1712,7 +1715,7 @@ def list_examples_by_category(category: str) -> list[ExampleItem]:
     // Delegate twice on one session id, so the second delegation reuses the A2A
     // client the first built — see the Strands equivalent in the Python HTTP
     // Agent test above for why the second call is the one that matters.
-    driveA2ADelegations(2);
+    driveA2ADelegations(llmMock!, 2);
     const aguiSessionId = `py-langchain-a2a-reuse-${'0'.repeat(20)}`;
     for (const attempt of [1, 2]) {
       const delegateRes = await fetch(

--- a/e2e/src/smoke-tests/local-dev.spec.ts
+++ b/e2e/src/smoke-tests/local-dev.spec.ts
@@ -32,6 +32,79 @@ const OPENAI_NPM_VERSION = '6.49.0';
 const OPENAI_PY_VERSION = '2.54.0';
 const LANGCHAIN_OPENAI_PY_VERSION = '1.4.3';
 
+// The AgentCore session header the generated servers read to bind a request to
+// a session. Reusing one value across calls is what makes a server reuse its
+// session-cached agent (and that agent's clients) rather than building a fresh
+// one per request.
+const AGENT_CORE_SESSION_ID_HEADER =
+  'x-amzn-bedrock-agentcore-runtime-session-id';
+
+// Prompt that asks an agent to delegate to its connected A2A agent, and the
+// marker the scoped mock rule (see `driveA2ADelegations`) echoes the remote's
+// reply back under.
+const A2A_DELEGATE_PROMPT = 'delegate this question to the remote agent';
+const A2A_DELEGATED_MARKER = 'delegated reply:';
+
+/**
+ * Scope the mock to drive one A2A delegation per `A2A_DELEGATE_PROMPT` turn,
+ * then echo the remote's reply back under `A2A_DELEGATED_MARKER`.
+ *
+ * Whether a turn still owes a tool call is decided by comparing delegate asks
+ * against the tool results already in the conversation, rather than by looking
+ * at the last message alone: a reused session carries earlier delegations, and
+ * a model that answers a later turn from that history never calls the tool
+ * again — so the A2A client would be exercised once however many times the
+ * agent is invoked, and reuse would go untested.
+ *
+ * Bounded with `.times()` + `.first()` so it neither hijacks the shared
+ * fallback for other tests nor lingers afterwards.
+ */
+function driveA2ADelegations(delegations: number): void {
+  type MockReq = {
+    messages: { role: string; content: string }[];
+    toolNames: readonly string[];
+  };
+  const counts = (req: MockReq) => ({
+    asks: req.messages.filter(
+      (m) => m.role === 'user' && m.content.includes(A2A_DELEGATE_PROMPT),
+    ).length,
+    results: req.messages.filter((m) => m.role === 'tool').length,
+  });
+  const owesToolCall = (req: MockReq) => {
+    const { asks, results } = counts(req);
+    return asks > 0 && results < asks;
+  };
+  const answersToolResult = (req: MockReq) => {
+    const { asks, results } = counts(req);
+    return asks > 0 && results >= asks;
+  };
+
+  const callTool = (req: MockReq) => ({
+    tools: [
+      {
+        name: req.toolNames.find((n) => n.startsWith('ask_')) ?? 'ask_agent',
+        args: { prompt: 'ping from e2e' },
+      },
+    ],
+  });
+  const echoToolResult = (req: MockReq) => {
+    const result = [...req.messages].reverse().find((m) => m.role === 'tool');
+    return { text: `${A2A_DELEGATED_MARKER} ${result?.content ?? 'none'}` };
+  };
+
+  llmMock!
+    .when(owesToolCall as never)
+    .reply(callTool as never)
+    .first()
+    .times(delegations);
+
+  llmMock!
+    .when(answersToolResult as never)
+    .reply(echoToolResult as never)
+    .first()
+    .times(delegations);
+}
+
 // The APIs the dev website is connected to, with the class names
 // matching their vended `use<ClassName>Client` hooks.
 const WEBSITE_APIS: ApiSpec[] = [
@@ -512,6 +585,12 @@ describe('smoke test - local-dev', { timeout: 30 * 60 * 1000 }, () => {
       );
       await runCLI(
         `generate @aws/nx-plugin:connection --sourceProject=py_project --sourceComponent=my-py-agent --targetProject=py_project --targetComponent=my-py-mcp --no-interactive`,
+        opts,
+      );
+      // A2A delegation from a Strands agent, which wraps strands' A2AAgent —
+      // a different Layer-2 client to the langchain one connected below.
+      await runCLI(
+        `generate @aws/nx-plugin:connection --sourceProject=py_project --sourceComponent=my-py-agent --targetProject=py_project --targetComponent=my-py-a2a-agent --no-interactive`,
         opts,
       );
       // LangChain agent connections: MCP (langchain-mcp-adapters tool loader),
@@ -1460,6 +1539,38 @@ def list_examples_by_category(category: str) -> list[ExampleItem]:
     expect(chunks.length).toBeGreaterThan(0);
     expect(chunks[0]).toHaveProperty('content');
 
+    // Delegate to the remote A2A agent twice on ONE session id. The A2A client
+    // is built once per session-cached agent, so the second delegation is the
+    // first to reuse it — the case where a client bound to a previous (closed)
+    // event loop surfaces as `RuntimeError: Event loop is closed`.
+    //
+    // The delegation tool returns its exception as the tool result, so a failed
+    // call still streams back a 200: assert on the body, not just the status.
+    driveA2ADelegations(2);
+    const sessionId = `py-agent-a2a-reuse-${'0'.repeat(20)}`;
+    for (const attempt of [1, 2]) {
+      const delegateRes = await fetch(
+        `http://127.0.0.1:${ports.pyAgent}/invocations`,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            [AGENT_CORE_SESSION_ID_HEADER]: sessionId,
+          },
+          body: JSON.stringify({ prompt: A2A_DELEGATE_PROMPT }),
+        },
+      );
+      const delegateBody = await delegateRes.text();
+      console.log(
+        `Python Agent A2A delegation ${attempt} (${delegateRes.status}):`,
+        delegateBody.slice(0, 300),
+      );
+      expect(delegateRes.status).toBe(200);
+      expect(delegateBody).toContain(A2A_DELEGATED_MARKER);
+      expect(delegateBody).not.toContain('Event loop is closed');
+      expect(delegateBody).not.toMatch(/Error: \w*Error/);
+    }
+
     // HTTP chat builds the generated client first, then connects.
     await chatStreamsReply(
       projectRoot,
@@ -1597,6 +1708,48 @@ def list_examples_by_category(category: str) -> list[ExampleItem]:
     // The mock model must actually drive the run, not error out (the server
     // emits RUN_ERROR as a 'data:' event, so assert it is absent).
     expect(body).not.toContain('RUN_ERROR');
+
+    // Delegate twice on one session id, so the second delegation reuses the A2A
+    // client the first built — see the Strands equivalent in the Python HTTP
+    // Agent test above for why the second call is the one that matters.
+    driveA2ADelegations(2);
+    const aguiSessionId = `py-langchain-a2a-reuse-${'0'.repeat(20)}`;
+    for (const attempt of [1, 2]) {
+      const delegateRes = await fetch(
+        `http://127.0.0.1:${ports.pyLangchainAgui}/invocations`,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            [AGENT_CORE_SESSION_ID_HEADER]: aguiSessionId,
+          },
+          body: JSON.stringify({
+            threadId: 'delegate-thread',
+            runId: `delegate-run-${attempt}`,
+            messages: [
+              {
+                id: `msg-${attempt}`,
+                role: 'user',
+                content: A2A_DELEGATE_PROMPT,
+              },
+            ],
+            state: {},
+            tools: [],
+            context: [],
+            forwardedProps: {},
+          }),
+        },
+      );
+      const delegateBody = await delegateRes.text();
+      console.log(
+        `Python LangChain A2A delegation ${attempt} (${delegateRes.status}):`,
+        delegateBody.slice(0, 300),
+      );
+      expect(delegateRes.status).toBe(200);
+      expect(delegateBody).toContain(A2A_DELEGATED_MARKER);
+      expect(delegateBody).not.toContain('Event loop is closed');
+      expect(delegateBody).not.toContain('RUN_ERROR');
+    }
 
     await chatStreamsReply(
       projectRoot,


### PR DESCRIPTION
### Reason for this change

#1078 fixed a reproducible `RuntimeError: Event loop is closed` on the **second** A2A delegate call through a client built once at factory time. It shipped with no e2e coverage, and the existing local-dev smoke test could not have caught it for three independent reasons:

1. **No Strands py-agent → A2A connection existed at all.** Only `my-py-langchain-agent -> my-py-a2a-agent` was wired, so `py-core-strands/a2a/agentcore_a2a_client_strands.py` — the most heavily rewritten file in that PR — had no coverage.
2. **Each agent was invoked once per test.** The failure only appears on the second delegation.
3. **No session id was reused.** `with_session_id` caches an agent per session id, so without a stable header every request builds a fresh agent *and a fresh A2A client* — even two invocations would have passed.

There is also a fourth trap: the delegation tool returns its exception as the tool result, so a failed A2A call still streams back HTTP 200 with `Error: RuntimeError - Event loop is closed` as tool text. Assertions on status alone are blind to it.

### Description of changes

- `local-dev.spec.ts` — connect `my-py-agent` (Strands) to `my-py-a2a-agent`, so both frameworks' A2A Layer-2 clients are exercised rather than just the langchain one.
- Delegate **twice on one session id** in the Python HTTP (Strands) and Python LangChain AG-UI tests, asserting the body contains the delegated reply and does *not* contain `Event loop is closed` / an `Error: <...>Error` tool result.
- Add a scoped `driveA2ADelegations()` mock rule that drives one delegation per prompt turn. It decides whether a turn still owes a tool call by comparing delegate asks against tool results already in the conversation, rather than inspecting the last message: a reused session carries earlier delegations, and a model that answers a later turn from that history never calls the tool again — which would exercise the A2A client exactly once no matter how many times the agent is invoked. Bounded with `.first().times(n)` so it does not hijack the shared fallback for other tests, matching the existing gateway tests' pattern.

No product code changes — test-only.

### Description of how you validated changes

Verified the new assertions **fail before the fix and pass after it**, against a real generated workspace (Strands py-agent with A2A + MCP + gateway connections) driven through the same mock rule and a reused session id:

- **Pre-fix** (client templates reverted to `45465f0c`, i.e. the commit before #1078):
  ```
  delegation 1 (200): {"content":"delegated reply: The answer is 42.\n\n"}
    ok: status 200 [1] / contains marker [1] / no event loop closed [1]
  delegation 2 (200): {"content":"delegated reply: Error: RuntimeError - Event loop is closed"}
    ASSERTION FAILED: no event loop closed [2]
    ASSERTION FAILED: no Error: *Error [2]
  TEST WOULD FAIL (2 assertions)
  ```
- **Post-fix** (#1078 as merged), identical setup and a fresh session:
  ```
  delegation 1 (200): {"content":"delegated reply: The answer is 42.\n\n"}
  delegation 2 (200): {"content":"delegated reply: The answer is 42.\n\n"}
  TEST WOULD PASS
  ```
  Reproduced in both directions with fresh session ids to rule out conversation-history artifacts, and confirmed each delegation reached the remote A2A agent over the network (one `GET /.well-known/agent-card.json` + `POST /` per call in the target's access log).
- Separately unit-checked the mock rule itself: turn 1 issues a tool call, turn 1's follow-up echoes the tool result, and a second delegate ask on a session whose history already holds a tool result issues **another** tool call rather than answering from history.
- `pnpm nx run nx-plugin-e2e:lint` passes.

The wider #1078 validation behind these gap findings covered all 6 py-agent source permutations (strands/langchain × http/a2a/ag-ui) locally plus a CDK/AgentCore deployment of Strands and LangChain callers over SigV4 (18 A2A delegations, 0 event-loop errors), all torn down afterwards.

### Issue # (if applicable)

N/A — adds regression coverage for #1078.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*