### PR TITLE
fix(py#fast-api): replace bare multi-exception except with split clauses

### DIFF
--- a/packages/nx-plugin/src/py/fast-api/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/fast-api/__snapshots__/generator.spec.ts.snap
@@ -147,7 +147,9 @@ async def add_correlation_id(request: Request, call_next):
             try:
                 lambda_context = json.loads(lambda_context_header)
                 corr_id = lambda_context.get("request_id")
-            except json.JSONDecodeError, KeyError:
+            except json.JSONDecodeError:
+                pass
+            except KeyError:
                 pass
     if not corr_id:
         # If still empty, use uuid

--- a/packages/nx-plugin/src/py/fast-api/files/app/__name__/init.py.template
+++ b/packages/nx-plugin/src/py/fast-api/files/app/__name__/init.py.template
@@ -141,7 +141,9 @@ async def add_correlation_id(request: Request, call_next):
             try:
                 lambda_context = json.loads(lambda_context_header)
                 corr_id = lambda_context.get("request_id")
-            except (json.JSONDecodeError, KeyError):
+            except json.JSONDecodeError:
+                pass
+            except KeyError:
                 pass
     if not corr_id:
         # If still empty, use uuid


### PR DESCRIPTION
## Summary

- The `py#fast-api` generator emits `except (json.JSONDecodeError, KeyError):` in the `__init__.py` template, but `formatFilesInSubtree` runs ruff with `target-version=py314` (because `py#project` defaults to `requires-python = ">=3.14"`), which converts it to the bare PEP 758 form `except json.JSONDecodeError, KeyError:` — a Python 3.14+ only syntax.
- Fix: split into two separate `except` clauses, which is valid on all Python versions and is not altered by ruff's py314 formatter.
- Snapshot updated to reflect the corrected output.

Fixes: STE-14

## Test plan

- [ ] `pnpm nx run @aws/nx-plugin:test` passes with no snapshot failures
- [ ] Generated `__init__.py` no longer contains bare multi-exception `except` clause
- [ ] Snapshot at `src/py/fast-api/__snapshots__/generator.spec.ts.snap` shows two separate `except` clauses
