### PR TITLE
chore(license): treat comma separated license lists as alternatives

### DIFF
--- a/packages/nx-plugin/src/license/dependency-check/evaluator.spec.ts
+++ b/packages/nx-plugin/src/license/dependency-check/evaluator.spec.ts
@@ -11,7 +11,12 @@ const allow: AllowlistEntry[] = [
   {
     spdxId: 'Apache-2.0',
     fullName: 'Apache License 2.0',
-    aliases: ['Apache License 2.0', 'Apache Software License'],
+    aliases: [
+      'Apache License 2.0',
+      'Apache Software License',
+      // Mirrors the real pre-approved list, whose alias contains a comma
+      'Apache License, Version 2.0',
+    ],
   },
   {
     spdxId: 'BSD-3-Clause',
@@ -70,6 +75,30 @@ describe('SPDX evaluator', () => {
       'PRE_APPROVED',
     );
     expect(evaluator.evaluate('GPL-3.0; LGPL-3.0')).toBe('NOT_APPROVED');
+  });
+
+  it('handles , separated dual licenses as OR', () => {
+    // sqlite-vec declares both of its licenses in one free-text field
+    expect(evaluator.evaluate('MIT License, Apache License, Version 2.0')).toBe(
+      'PRE_APPROVED',
+    );
+    expect(evaluator.evaluate('MIT, Apache-2.0')).toBe('PRE_APPROVED');
+    // Only one operand needs to be allowed, since the operands are alternatives
+    expect(evaluator.evaluate('MIT License, GPL-3.0-or-later')).toBe(
+      'PRE_APPROVED',
+    );
+    expect(evaluator.evaluate('GPL-3.0-or-later, LGPL-2.1-or-later')).toBe(
+      'NOT_APPROVED',
+    );
+  });
+
+  it('does not split license names that themselves contain a comma', () => {
+    expect(evaluator.evaluate('Apache License, Version 2.0')).toBe(
+      'PRE_APPROVED',
+    );
+    expect(
+      evaluator.evaluate('The Apache License, Version 2.0, MIT License'),
+    ).toBe('PRE_APPROVED');
   });
 
   it('returns NOT_APPROVED for unknown SPDX ids', () => {

--- a/packages/nx-plugin/src/license/dependency-check/evaluator.ts
+++ b/packages/nx-plugin/src/license/dependency-check/evaluator.ts
@@ -69,6 +69,57 @@ const buildAliasLookup = (allow: AllowlistEntry[]): Map<string, true> => {
   return m;
 };
 
+/**
+ * Split a free-text license list on a separator, treating the operands as
+ * alternatives (OR).
+ *
+ * Commas need care: several allowed license names contain one themselves (e.g.
+ * "Apache License, Version 2.0"), so the string is left intact when it already
+ * resolves as a single license, and fragments are otherwise rejoined
+ * longest-match-first. That keeps "MIT License, Apache License, Version 2.0"
+ * parsing as MIT + Apache rather than three unresolvable fragments.
+ *
+ * Returns `undefined` when the value shouldn't be treated as a list.
+ */
+const splitAlternatives = (
+  value: string,
+  separator: string,
+  isKnown: (token: string) => boolean,
+): string[] | undefined => {
+  if (!value.includes(separator)) return undefined;
+  if (isKnown(value)) return undefined;
+
+  const parts = value
+    .split(separator)
+    .map((p) => p.trim())
+    .filter((p) => p.length > 0);
+  if (parts.length < 2) return undefined;
+
+  // Rejoin fragments that only make sense together, so a license name
+  // containing the separator survives the split. At each position take the
+  // longest run of fragments that forms a known license; failing that, emit the
+  // single fragment and let the caller report it.
+  const merged: string[] = [];
+  let i = 0;
+  while (i < parts.length) {
+    let matchedTo = -1;
+    let candidate = parts[i];
+    for (let j = i; j < parts.length; j++) {
+      if (j > i) candidate = `${candidate}${separator} ${parts[j]}`;
+      if (isKnown(candidate)) matchedTo = j;
+    }
+    if (matchedTo >= 0) {
+      merged.push(parts.slice(i, matchedTo + 1).join(`${separator} `));
+      i = matchedTo + 1;
+    } else {
+      merged.push(parts[i]);
+      i += 1;
+    }
+  }
+
+  return merged.length > 1 ? merged : undefined;
+};
+
 const evaluateToken = (
   token: string,
   spdxIds: string[],
@@ -101,21 +152,22 @@ export const createEvaluator = (options: EvaluatorOptions): Evaluator => {
       const normalised = normalise(rawLicense);
       if (isUnknownToken(normalised)) return 'UNKNOWN';
 
-      // Python tooling emits "Apache Software License; BSD License" — split and treat as OR
-      if (normalised.includes(';')) {
-        const parts = normalised
-          .split(';')
-          .map((p) => p.trim())
-          .filter((p) => p.length > 0);
-        if (parts.length > 1) {
-          for (const part of parts) {
-            const status = evaluateToken(part, spdxIds, aliasLookup);
-            if (status === 'PRE_APPROVED') return 'PRE_APPROVED';
-          }
-          if (parts.every((p) => isUnknownToken(normalise(p))))
-            return 'UNKNOWN';
-          return 'NOT_APPROVED';
+      // Python tooling emits free-text license lists rather than an SPDX
+      // expression: "Apache Software License; BSD License" (setuptools
+      // classifiers) or "MIT License, Apache License, Version 2.0" (a dual
+      // license declared in one `License:` field). Both mean "any of these
+      // applies", so treat the operands as OR.
+      const isKnown = (token: string) =>
+        evaluateToken(token, spdxIds, aliasLookup) === 'PRE_APPROVED';
+      for (const separator of [';', ',']) {
+        const parts = splitAlternatives(normalised, separator, isKnown);
+        if (!parts) continue;
+        for (const part of parts) {
+          if (evaluateToken(part, spdxIds, aliasLookup) === 'PRE_APPROVED')
+            return 'PRE_APPROVED';
         }
+        if (parts.every((p) => isUnknownToken(normalise(p)))) return 'UNKNOWN';
+        return 'NOT_APPROVED';
       }
 
       return evaluateToken(normalised, spdxIds, aliasLookup);


### PR DESCRIPTION
### Reason for this change

Some Python wheels declare a dual license in a single free-text `License:` field rather than as an SPDX expression. `sqlite-vec@0.1.9` is the case that surfaced this — it declares:

```
MIT License, Apache License, Version 2.0
```

The evaluator treated that whole string as one unknown license identifier and reported it as `NOT_APPROVED`, even though **both** halves are already on the pre-approved allowlist:

```
License check failed:

  NOT_APPROVED:
    - sqlite-vec@0.1.9 [pypi] MIT License, Apache License, Version 2.0
```

The evaluator already splits `;` separated lists (`"Apache Software License; BSD License"`, as setuptools classifiers emit) and treats the operands as alternatives. Comma separated lists mean the same thing, so this extends that handling rather than adding a per-package exception.

Worth noting why an exception isn't the better fix here: this is a metadata-formatting quirk that will recur with any dual-licensed Python package, and each occurrence would otherwise need its own entry in `license.dependencies.exceptions`.

### Description of changes

- `evaluator.ts` — generalise the free-text list handling to cover `;` and `,`, extracted into `splitAlternatives()`. A list is approved when at least one operand is allowed, unchanged from the existing `;` behaviour.

  Commas need more care than semicolons, because several **allowed** license names contain one themselves (`"Apache License, Version 2.0"`, `"The Apache License, Version 2.0"` — both aliases in `pre-approved.ts`). A naive split would turn a currently-passing license into two unresolvable fragments. So:
  - a value that already resolves as a single known license is left intact, and
  - otherwise fragments are rejoined longest-match-first, which parses `"MIT License, Apache License, Version 2.0"` as `MIT License` + `Apache License, Version 2.0`.

- `evaluator.spec.ts` — two new cases: comma separated dual licenses (including the exact `sqlite-vec` string), and a regression guard that license names containing a comma are still not split. The test allowlist gains the `'Apache License, Version 2.0'` alias so it mirrors the real pre-approved list on this point.

No behaviour change for SPDX expressions, `;` separated lists, or single licenses.

### Description of how you validated changes

- Verified against the **real** `PRE_APPROVED_LICENSES` list, not just the test fixture:

  ```
  PRE_APPROVED  "MIT License, Apache License, Version 2.0"   <- the CI failure
  PRE_APPROVED  "Apache License, Version 2.0"                <- not split
  PRE_APPROVED  "Apache Software License; BSD License"       <- unchanged
  PRE_APPROVED  "MIT"
  PRE_APPROVED  "MIT OR Apache-2.0"
  NOT_APPROVED  "LGPL"
  NOT_APPROVED  "GPL-3.0-or-later, LGPL-2.1-or-later"
  ```

  Note the last two: a genuinely non-permissive license is still rejected, and a list is only approved when an operand is actually allowed — so this doesn't weaken the check.

- `pnpm nx run @aws/nx-plugin:test` — 3485 tests pass (186 files), including the 2 new cases.
- `pnpm nx run-many --target build --all`, `:typecheck` and `--target lint --all` all pass.
- Traced the dependency to confirm the license string is real and the package is genuinely dual-licensed:

  ```
  sqlite-vec v0.1.9
  └── langgraph-checkpoint-sqlite v3.1.1
  ```

### Issue # (if applicable)

N/A.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*