### PR TITLE
chore: route remaining GritQL array appends through the shared helper

### DIFF
--- a/packages/nx-plugin/src/py/agent/a2a-connection/generator.ts
+++ b/packages/nx-plugin/src/py/agent/a2a-connection/generator.ts
@@ -25,6 +25,7 @@ import {
 } from '../../../utils/agent-connection/agent-connection';
 import {
   addPythonDestructuredImport,
+  appendToArrayViaGritQL,
   applyGritQL,
   matchGritQL,
 } from '../../../utils/ast';
@@ -307,20 +308,10 @@ const addToolToAgent = async (
   toolName: string,
   framework: AgentFramework,
 ): Promise<void> => {
-  const scope = AGENT_CONSTRUCTOR[framework];
-  await applyGritQL(
-    tree,
-    filePath,
-    py(`\`tools=$old\` where {
-  $old <: within \`${scope}\`,
-  $old <: not contains \`${toolName}\`,
-  if ($old <: \`[]\`) {
-    $old => \`[${toolName}]\`
-  } else {
-    $old <: \`[$items]\` where { $items += \`, ${toolName}\` }
-  }
-}`),
-  );
+  await appendToArrayViaGritQL(tree, filePath, 'tools=', toolName, {
+    scope: AGENT_CONSTRUCTOR[framework],
+    language: 'py',
+  });
 };
 
 /**

--- a/packages/nx-plugin/src/utils/ast.spec.ts
+++ b/packages/nx-plugin/src/utils/ast.spec.ts
@@ -776,5 +776,33 @@ const agent = new Agent({ tools: [b] });`,
       expect(written).not.toMatch(/,\s*,/);
       expect(written).toContain('ask_remote');
     });
+
+    // Pins down which GritQL form is unsafe, so the `=>` variant is not
+    // reintroduced on the assumption that any list append is fine: rewriting the
+    // list re-emits its trailing comma, while accumulating into it does not.
+    it('should not reintroduce the sparse hole that rewriting the list produces', async () => {
+      const wrapped = `const a = new Agent({
+  tools: [
+    x,
+    y,
+  ],
+});`;
+
+      tree.write('rewrite.ts', wrapped);
+      await applyGritQL(
+        tree,
+        'rewrite.ts',
+        '`tools: [$items]` => `tools: [$items, newTool]`',
+      );
+      expect(tree.read('rewrite.ts', 'utf-8')).toMatch(/,\s*,/);
+
+      tree.write('helper.ts', wrapped);
+      expect(
+        await appendToArrayViaGritQL(tree, 'helper.ts', 'tools:', 'newTool', {
+          scope: 'new Agent($_)',
+        }),
+      ).toBe(true);
+      expect(tree.read('helper.ts', 'utf-8')).not.toMatch(/,\s*,/);
+    });
   });
 });

--- a/packages/nx-plugin/src/utils/ast.ts
+++ b/packages/nx-plugin/src/utils/ast.ts
@@ -423,9 +423,13 @@ export const insertViaGritQL = async (
  * assignment, `'"tools":'` for a quoted key. Which separator applies depends on
  * the construct rather than the language, so the caller states it.
  *
- * Appends after the last *element*, not after the element list: GritQL binds a
- * `[$items]` list to its trailing comma too, so rewriting the list yields the
- * sparse array `[a, b, , entry]` — a hole that is `undefined` at runtime.
+ * Appends after the last *element* rather than rewriting the element list with
+ * `=>`. GritQL binds a `[$items]` list to its trailing comma too, so
+ * `` `[$items]` => `[$items, entry]` `` emits the sparse array `[a, b, , entry]`
+ * once the formatter has wrapped the array — a hole that is `undefined` at
+ * runtime. (Accumulating with `$items += ", entry"` is safe by comparison, since
+ * it appends within the list rather than re-emitting it; both forms appear in
+ * this repo.)
  *
  * `scope` limits the match to an enclosing pattern, so same-named arrays
  * elsewhere in the file are left alone. `skipIfContains` overrides what the

--- a/packages/nx-plugin/src/utils/metrics.ts
+++ b/packages/nx-plugin/src/utils/metrics.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { joinPathFragments, type Tree } from '@nx/devkit';
-import { applyGritQL, captureAllGritQL } from './ast';
+import { appendToArrayViaGritQL, applyGritQL, captureAllGritQL } from './ast';
 import { formatFilesInSubtree } from './format';
 import { getPackageVersion, type NxGeneratorInfo } from './nx';
 import {
@@ -156,12 +156,11 @@ const updateTerraformMetrics = async (tree: Tree, tags: string[]) => {
 
   // Add each tag, leaving existing tags in place to keep re-runs stable
   for (const tag of tags) {
-    await applyGritQL(
+    await appendToArrayViaGritQL(
       tree,
       TERRAFORM_METRICS_FILE_PATH,
-      `or { \`metric_tags = []\` => \`metric_tags = ["${tag}"]\`,` +
-        ` \`metric_tags = [$items]\` where { $items += \`, "${tag}"\` }` +
-        ` where { $items <: not contains \`"${tag}"\` } }`,
+      'metric_tags =',
+      `"${tag}"`,
     );
   }
 };


### PR DESCRIPTION
### Reason for this change

Follow-up audit to #1083. That PR fixed one sparse-array append and introduced `appendToArrayViaGritQL`; this checks every other place in the repo that mutates an array literal via GritQL, and confirms none of them carry the same defect.

**The distinction that matters, verified empirically.** Applying each form to the same wrapped array:

| form | result |
| --- | --- |
| `` `tools: [$items]` => `tools: [$items, NEW]` `` | `tools: [x,\n    y,, NEW]` — **elision** |
| `` `tools: [$items]` where { $items += ", NEW" } `` | clean |
| `` `tools: [$..., $last]` where { $last += ", NEW" } `` (the helper) | clean |

So the hazard is **re-emitting the list with `=>`**, not the `$items` binding itself — accumulating into that same binding appends *within* the list rather than reproducing its trailing comma. #1083's description framed this less precisely, which risked the `=>` form being reintroduced on the assumption that any list append is equivalent.

**No unsafe appends remain.** The inventory:

- **4 sites use `=>` to re-emit a list** — `agentcore-gateway/attach-upstream.ts:59,98`, `utils/agent-connection/agent-connection.ts:677`, `ts/react-website/app/generator.ts:523`. All four **prepend** (`[entry, $items]`), which is safe for every shape: re-emitting the trailing comma yields `[entry, x, y,]`, and a trailing comma is not an elision — `[1, 2, 3,].length === 3` with no missing element, unlike `[1, , 3]`.
- **~11 sites accumulate with `+=`** — safe, as verified above.
- **2 sites now use the helper**, up from 3 to 5 call sites total.

### Description of changes

- **`utils/ast.ts`** — the helper's docstring now names the form that is unsafe (`=>`) and notes that `+=` is safe by comparison, since both appear in this repo. Previously it said "rewriting the list" without distinguishing them.
- **New test** in `ast.spec.ts` applying both forms to the same wrapped array and asserting the `=>` form produces `/,\s*,/` while the helper does not — so the distinction is pinned down rather than resting on a comment.
- **Converted two hand-rolled appends** onto the helper, which already owns the empty-array branch and dedupe guard they were duplicating:
  - `py#agent#a2a-connection`'s Python `tools=` list (was an `if ($old <: [])` / `else` pair)
  - the Terraform `metric_tags` list (was an `or {}` pair)

**Deliberately left alone**, each for a concrete reason rather than by omission:

| site | why the helper does not fit |
| --- | --- |
| CDK metrics `tags` (`utils/metrics.ts:131`) | its `within` scope binds `$old`, the same metavariable the helper needs; the prefix is a typed declaration (`tags: string[] =`) the helper's prefix form cannot express — I tried the conversion and it failed to match |
| rolldown config (`utils/bundle/bundle.ts:212,229`) | placeholder-based insertion, so entries containing regex literals survive |
| license config (`license/config.ts:160`) | `$scope <: contains` form, matched inside an outer scope |
| AG-UI useMemo deps (`ts/react-website/agui/generator.ts:288`) | nested inside a larger multi-branch pattern |
| Python imports / `__all__` (`ast.ts:119`, `agent-connection.ts:989,997,1019`) | statement lists, not array literals, with their own create-from-scratch fallbacks |

No functional change to generated output; no migration needed.

### Description of how you validated changes

**Unit:** 187 files / 3534 tests green (one new). Lint and `build --all` clean.

**End-to-end**, with the locally compiled plugin in fresh workspaces, exercising both converted paths:

- `py#agent#a2a-connection` — two successive A2A connections into one host agent:
  ```
  tools=[subtract, current_time, ask_remote_one]
  tools=[subtract, current_time, ask_remote_one, ask_remote_two]
  ```
  no elision, `build --all` green.
- Terraform `metric_tags` — hand-wrapped the array multi-line (the shape that triggers the bug), then ran a generator carrying a new tag:
  ```
  metric_tags    = [
      "g23",
      "g1", "g2",
    ]
  ```
  appended cleanly. Also confirmed the dedupe still holds: a generator reusing an existing tag correctly makes no change.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
