### PR TITLE
fix(ts#agent): apply the distribution's security updates in vended container images

### DIFF
--- a/docs/src/content/docs/en/guides/docker-bundling.mdx
+++ b/docs/src/content/docs/en/guides/docker-bundling.mdx
@@ -304,6 +304,18 @@ Because the image is fully determined by your project source, declaring `inputs`
 Trivy reads a `.trivyignore` file (a list of vulnerability IDs, one per line) from the root of your project. `--ignore-unfixed` skips vulnerabilities with no available fix, so the scan only fails on issues you can action by upgrading tooling in your `Dockerfile`. See the [Trivy filtering documentation](https://trivy.dev/latest/docs/configuration/filtering/#by-finding-ids) for details.
 :::
 
+:::tip[Apply the distribution's security updates]
+A base image tag lags behind its distribution's security suite, so its OS packages carry vulnerabilities that already have a published fix. Upgrade them as the first step of your build, ahead of any other instruction so later layers install against the upgraded packages. For a Debian-derived base image (as used by the Node and Python images above):
+
+```dockerfile
+RUN apt-get update && \
+    apt-get upgrade -y --no-install-recommends && \
+    rm -rf /var/lib/apt/lists/*
+```
+
+The generated `Dockerfile`s do this for you.
+:::
+
 ## Infrastructure
 
 Wiring the resulting build-context directory to infrastructure as code is the same for both TypeScript and Python — only the path to the build-context directory differs (`dist/packages/my-project/bundle` for TypeScript, `dist/packages/my-project/docker` for Python).

--- a/docs/src/content/docs/es/guides/docker-bundling.mdx
+++ b/docs/src/content/docs/es/guides/docker-bundling.mdx
@@ -304,6 +304,18 @@ Debido a que la imagen está completamente determinada por el código fuente de 
 Trivy lee un archivo `.trivyignore` (una lista de IDs de vulnerabilidad, uno por línea) desde la raíz de tu proyecto. `--ignore-unfixed` omite vulnerabilidades sin corrección disponible, por lo que el escaneo solo falla en problemas que puedes resolver actualizando herramientas en tu `Dockerfile`. Consulta la [documentación de filtrado de Trivy](https://trivy.dev/latest/docs/configuration/filtering/#by-finding-ids) para más detalles.
 :::
 
+:::tip[Aplica las actualizaciones de seguridad de la distribución]
+Una etiqueta de imagen base va por detrás del conjunto de seguridad de su distribución, por lo que sus paquetes del sistema operativo contienen vulnerabilidades que ya tienen una corrección publicada. Actualízalos como el primer paso de tu construcción, antes de cualquier otra instrucción para que las capas posteriores se instalen contra los paquetes actualizados. Para una imagen base derivada de Debian (como las utilizadas por las imágenes de Node y Python anteriores):
+
+```dockerfile
+RUN apt-get update && \
+    apt-get upgrade -y --no-install-recommends && \
+    rm -rf /var/lib/apt/lists/*
+```
+
+Los `Dockerfile`s generados hacen esto por ti.
+:::
+
 ## Infraestructura
 
 Conectar el directorio de contexto de construcción resultante a la infraestructura como código es lo mismo tanto para TypeScript como para Python — solo difiere la ruta al directorio de contexto de construcción (`dist/packages/my-project/bundle` para TypeScript, `dist/packages/my-project/docker` para Python).

--- a/docs/src/content/docs/fr/guides/docker-bundling.mdx
+++ b/docs/src/content/docs/fr/guides/docker-bundling.mdx
@@ -304,6 +304,18 @@ Comme l'image est entièrement déterminée par le code source de votre projet, 
 Trivy lit un fichier `.trivyignore` (une liste d'identifiants de vulnérabilités, un par ligne) depuis la racine de votre projet. `--ignore-unfixed` ignore les vulnérabilités sans correctif disponible, de sorte que l'analyse échoue uniquement sur les problèmes que vous pouvez résoudre en mettant à niveau les outils dans votre `Dockerfile`. Consultez la [documentation de filtrage Trivy](https://trivy.dev/latest/docs/configuration/filtering/#by-finding-ids) pour plus de détails.
 :::
 
+:::tip[Appliquez les mises à jour de sécurité de la distribution]
+Un tag d'image de base est en retard par rapport à la suite de sécurité de sa distribution, de sorte que ses packages OS portent des vulnérabilités qui ont déjà un correctif publié. Mettez-les à niveau comme première étape de votre construction, avant toute autre instruction afin que les couches ultérieures s'installent contre les packages mis à niveau. Pour une image de base dérivée de Debian (comme utilisé par les images Node et Python ci-dessus) :
+
+```dockerfile
+RUN apt-get update && \
+    apt-get upgrade -y --no-install-recommends && \
+    rm -rf /var/lib/apt/lists/*
+```
+
+Les `Dockerfile` générés font cela pour vous.
+:::
+
 ## Infrastructure
 
 Connecter le répertoire de contexte de construction résultant à l'infrastructure as code est identique pour TypeScript et Python — seul le chemin vers le répertoire de contexte de construction diffère (`dist/packages/my-project/bundle` pour TypeScript, `dist/packages/my-project/docker` pour Python).

--- a/docs/src/content/docs/it/guides/docker-bundling.mdx
+++ b/docs/src/content/docs/it/guides/docker-bundling.mdx
@@ -304,6 +304,18 @@ Poiché l'immagine è completamente determinata dal sorgente del tuo progetto, d
 Trivy legge un file `.trivyignore` (un elenco di ID di vulnerabilità, uno per riga) dalla radice del tuo progetto. `--ignore-unfixed` salta le vulnerabilità senza una correzione disponibile, quindi la scansione fallisce solo su problemi su cui puoi agire aggiornando gli strumenti nel tuo `Dockerfile`. Vedi la [documentazione sul filtraggio di Trivy](https://trivy.dev/latest/docs/configuration/filtering/#by-finding-ids) per i dettagli.
 :::
 
+:::tip[Applica gli aggiornamenti di sicurezza della distribuzione]
+Un tag di immagine base è in ritardo rispetto alla suite di sicurezza della sua distribuzione, quindi i suoi pacchetti OS portano vulnerabilità che hanno già una correzione pubblicata. Aggiornali come primo step della tua build, prima di qualsiasi altra istruzione in modo che i layer successivi si installino contro i pacchetti aggiornati. Per un'immagine base derivata da Debian (come usato dalle immagini Node e Python sopra):
+
+```dockerfile
+RUN apt-get update && \
+    apt-get upgrade -y --no-install-recommends && \
+    rm -rf /var/lib/apt/lists/*
+```
+
+I `Dockerfile` generati fanno questo per te.
+:::
+
 ## Infrastruttura
 
 Collegare la directory del contesto di build risultante al codice infrastrutturale è lo stesso sia per TypeScript che per Python — solo il percorso alla directory del contesto di build differisce (`dist/packages/my-project/bundle` per TypeScript, `dist/packages/my-project/docker` per Python).

--- a/docs/src/content/docs/jp/guides/docker-bundling.mdx
+++ b/docs/src/content/docs/jp/guides/docker-bundling.mdx
@@ -304,6 +304,18 @@ Trivy の脆弱性データベースは新しい CVE で継続的に更新され
 Trivy は、プロジェクトのルートから `.trivyignore` ファイル（脆弱性 ID のリスト、1 行に 1 つ）を読み取ります。`--ignore-unfixed` は、利用可能な修正がない脆弱性をスキップするため、スキャンは `Dockerfile` のツールをアップグレードすることでアクションできる問題でのみ失敗します。詳細については、[Trivy フィルタリングドキュメント](https://trivy.dev/latest/docs/configuration/filtering/#by-finding-ids)を参照してください。
 :::
 
+:::tip[ディストリビューションのセキュリティアップデートを適用する]
+ベースイメージタグはディストリビューションのセキュリティスイートより遅れているため、その OS パッケージには既に公開された修正がある脆弱性が含まれています。ビルドの最初のステップとしてそれらをアップグレードし、他の命令より前に配置することで、後のレイヤーがアップグレードされたパッケージに対してインストールされるようにします。Debian 派生のベースイメージ（上記の Node および Python イメージで使用されているもの）の場合：
+
+```dockerfile
+RUN apt-get update && \
+    apt-get upgrade -y --no-install-recommends && \
+    rm -rf /var/lib/apt/lists/*
+```
+
+生成された `Dockerfile` はこれを自動的に行います。
+:::
+
 ## Infrastructure
 
 結果のビルドコンテキストディレクトリをインフラストラクチャコードに接続することは、TypeScript と Python の両方で同じです — ビルドコンテキストディレクトリへのパスのみが異なります（TypeScript の場合は `dist/packages/my-project/bundle`、Python の場合は `dist/packages/my-project/docker`）。

--- a/docs/src/content/docs/ko/guides/docker-bundling.mdx
+++ b/docs/src/content/docs/ko/guides/docker-bundling.mdx
@@ -304,6 +304,18 @@ Trivy의 취약점 데이터베이스가 새로운 CVE로 지속적으로 업데
 Trivy는 프로젝트 루트에서 `.trivyignore` 파일(한 줄에 하나씩 취약점 ID 목록)을 읽습니다. `--ignore-unfixed`는 사용 가능한 수정이 없는 취약점을 건너뛰므로 `Dockerfile`의 툴링을 업그레이드하여 조치할 수 있는 문제에 대해서만 스캔이 실패합니다. 자세한 내용은 [Trivy 필터링 문서](https://trivy.dev/latest/docs/configuration/filtering/#by-finding-ids)를 참조하세요.
 :::
 
+:::tip[배포판의 보안 업데이트 적용]
+베이스 이미지 태그는 배포판의 보안 제품군보다 뒤처지므로 OS 패키지에는 이미 게시된 수정 사항이 있는 취약점이 포함되어 있습니다. 빌드의 첫 번째 단계로 이를 업그레이드하여 다른 명령보다 먼저 수행하면 이후 레이어가 업그레이드된 패키지에 대해 설치됩니다. Debian 기반 베이스 이미지의 경우(위의 Node 및 Python 이미지에서 사용됨):
+
+```dockerfile
+RUN apt-get update && \
+    apt-get upgrade -y --no-install-recommends && \
+    rm -rf /var/lib/apt/lists/*
+```
+
+생성된 `Dockerfile`은 이를 자동으로 수행합니다.
+:::
+
 ## Infrastructure
 
 결과 빌드 컨텍스트 디렉토리를 코드형 인프라에 연결하는 것은 TypeScript와 Python 모두 동일합니다 — 빌드 컨텍스트 디렉토리 경로만 다릅니다(TypeScript의 경우 `dist/packages/my-project/bundle`, Python의 경우 `dist/packages/my-project/docker`).

--- a/docs/src/content/docs/pt/guides/docker-bundling.mdx
+++ b/docs/src/content/docs/pt/guides/docker-bundling.mdx
@@ -304,6 +304,18 @@ Como a imagem é totalmente determinada pelo código-fonte do seu projeto, decla
 O Trivy lê um arquivo `.trivyignore` (uma lista de IDs de vulnerabilidade, um por linha) da raiz do seu projeto. `--ignore-unfixed` pula vulnerabilidades sem correção disponível, então o escaneamento só falha em problemas que você pode resolver atualizando ferramentas no seu `Dockerfile`. Veja a [documentação de filtragem do Trivy](https://trivy.dev/latest/docs/configuration/filtering/#by-finding-ids) para detalhes.
 :::
 
+:::tip[Aplique as atualizações de segurança da distribuição]
+Uma tag de imagem base fica atrás do conjunto de segurança de sua distribuição, então seus pacotes do sistema operacional carregam vulnerabilidades que já têm uma correção publicada. Atualize-os como o primeiro passo da sua construção, antes de qualquer outra instrução para que as camadas posteriores instalem contra os pacotes atualizados. Para uma imagem base derivada do Debian (como usada pelas imagens Node e Python acima):
+
+```dockerfile
+RUN apt-get update && \
+    apt-get upgrade -y --no-install-recommends && \
+    rm -rf /var/lib/apt/lists/*
+```
+
+Os `Dockerfile`s gerados fazem isso para você.
+:::
+
 ## Infraestrutura
 
 Conectar o diretório de contexto de build resultante ao código de infraestrutura é o mesmo para TypeScript e Python — apenas o caminho para o diretório de contexto de build difere (`dist/packages/my-project/bundle` para TypeScript, `dist/packages/my-project/docker` para Python).
@@ -458,3 +470,4 @@ O bloco `data.external.docker_digest` garante que o `null_resource` seja executa
 - <Link path="/pt/guides/py-agent">Gerador `py#agent`</Link> — o equivalente para Python.
 - [Documentação do Rolldown](https://rolldown.rs/) — referência de configuração para o bundler TypeScript.
 - [Documentação do `uv`](https://docs.astral.sh/uv/) — referência para exportação e instalação de dependências Python.
+

--- a/docs/src/content/docs/vi/guides/docker-bundling.mdx
+++ b/docs/src/content/docs/vi/guides/docker-bundling.mdx
@@ -304,6 +304,18 @@ Vì image được xác định hoàn toàn bởi nguồn dự án của bạn, 
 Trivy đọc một file `.trivyignore` (một danh sách các ID lỗ hổng, một ID mỗi dòng) từ thư mục gốc của dự án bạn. `--ignore-unfixed` bỏ qua các lỗ hổng không có bản sửa lỗi khả dụng, do đó scan chỉ thất bại trên các vấn đề bạn có thể hành động bằng cách nâng cấp tooling trong `Dockerfile` của bạn. Xem [tài liệu lọc Trivy](https://trivy.dev/latest/docs/configuration/filtering/#by-finding-ids) để biết chi tiết.
 :::
 
+:::tip[Áp dụng các bản cập nhật bảo mật của bản phân phối]
+Một thẻ base image tụt hậu so với bộ bảo mật của bản phân phối của nó, do đó các gói OS của nó mang các lỗ hổng đã có bản sửa lỗi được xuất bản. Nâng cấp chúng như bước đầu tiên của bản build của bạn, trước bất kỳ chỉ thị nào khác để các layer sau cài đặt dựa trên các gói đã được nâng cấp. Đối với một base image dẫn xuất từ Debian (như được sử dụng bởi các images Node và Python ở trên):
+
+```dockerfile
+RUN apt-get update && \
+    apt-get upgrade -y --no-install-recommends && \
+    rm -rf /var/lib/apt/lists/*
+```
+
+Các `Dockerfile` được tạo ra làm điều này cho bạn.
+:::
+
 ## Infrastructure
 
 Kết nối thư mục build-context kết quả với infrastructure as code giống nhau cho cả TypeScript và Python — chỉ đường dẫn đến thư mục build-context khác nhau (`dist/packages/my-project/bundle` cho TypeScript, `dist/packages/my-project/docker` cho Python).

--- a/docs/src/content/docs/zh/guides/docker-bundling.mdx
+++ b/docs/src/content/docs/zh/guides/docker-bundling.mdx
@@ -304,6 +304,18 @@ CMD ["python", "-m", "my_project.main"]
 Trivy 从项目根目录读取 `.trivyignore` 文件（漏洞 ID 列表，每行一个）。`--ignore-unfixed` 跳过没有可用修复的漏洞，因此扫描仅在您可以通过升级 `Dockerfile` 中的工具来解决的问题上失败。有关详细信息，请参阅 [Trivy 过滤文档](https://trivy.dev/latest/docs/configuration/filtering/#by-finding-ids)。
 :::
 
+:::tip[应用发行版的安全更新]
+基础镜像标签落后于其发行版的安全套件，因此其操作系统包携带已有发布修复的漏洞。将它们升级作为构建的第一步，在任何其他指令之前，以便后续层针对升级后的包进行安装。对于基于 Debian 的基础镜像（如上面使用的 Node 和 Python 镜像）：
+
+```dockerfile
+RUN apt-get update && \
+    apt-get upgrade -y --no-install-recommends && \
+    rm -rf /var/lib/apt/lists/*
+```
+
+生成的 `Dockerfile` 会为您执行此操作。
+:::
+
 ## 基础设施
 
 将生成的构建上下文目录连接到基础设施即代码对于 TypeScript 和 Python 都是相同的——只有构建上下文目录的路径不同（TypeScript 为 `dist/packages/my-project/bundle`，Python 为 `dist/packages/my-project/docker`）。

--- a/packages/nx-plugin/src/migrations/latest/apt-security-updates-in-container-images/__snapshots__/migration.spec.ts.snap
+++ b/packages/nx-plugin/src/migrations/latest/apt-security-updates-in-container-images/__snapshots__/migration.spec.ts.snap
@@ -1,0 +1,90 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`apt-security-updates-in-container-images migration > adds the security updates to a py#agent Dockerfile 1`] = `
+"FROM public.ecr.aws/docker/library/python:3.14-slim
+
+# Apply the distribution's security updates: base image tags lag behind the
+# security suite, so its OS packages carry fixed HIGH/CRITICAL vulnerabilities
+# flagged by the image scan.
+RUN apt-get update && \\
+    apt-get upgrade -y --no-install-recommends && \\
+    rm -rf /var/lib/apt/lists/*
+
+# Remove the base image's pip: the agent runs from the bundled environment and
+# never needs it at runtime, and pip's vendored packages carry known
+# HIGH/CRITICAL vulnerabilities flagged by the image scan.
+RUN python -m pip uninstall -y pip && \\
+    rm -rf /usr/local/lib/python*/site-packages/pip \\
+           /usr/local/lib/python*/site-packages/pip-*.dist-info
+
+WORKDIR /app
+
+# Copy bundled package
+COPY . /app
+
+EXPOSE 8080
+
+ENV PYTHONPATH=/app
+ENV PATH="/app/bin:\${PATH}"
+
+CMD ["python", "bin/opentelemetry-instrument", "python", "-m", "proj_py_project.my_agent.main"]
+"
+`;
+
+exports[`apt-security-updates-in-container-images migration > adds the security updates to a py#mcp-server Dockerfile 1`] = `
+"FROM public.ecr.aws/docker/library/python:3.14-slim
+
+# Apply the distribution's security updates: base image tags lag behind the
+# security suite, so its OS packages carry fixed HIGH/CRITICAL vulnerabilities
+# flagged by the image scan.
+RUN apt-get update && \\
+    apt-get upgrade -y --no-install-recommends && \\
+    rm -rf /var/lib/apt/lists/*
+
+# Remove the base image's pip: the server runs from the bundled environment and
+# never needs it at runtime, and pip's vendored packages carry known
+# HIGH/CRITICAL vulnerabilities flagged by the image scan.
+RUN python -m pip uninstall -y pip && \\
+    rm -rf /usr/local/lib/python*/site-packages/pip \\
+           /usr/local/lib/python*/site-packages/pip-*.dist-info
+
+WORKDIR /app
+
+# Copy bundled package
+COPY . /app
+
+EXPOSE 8000
+
+ENV PYTHONPATH=/app
+
+CMD ["python", "bin/opentelemetry-instrument", "python", "-m", "uvicorn", "proj_py_project.my_mcp.http:app", "--host", "0.0.0.0", "--port", "8000"]
+"
+`;
+
+exports[`apt-security-updates-in-container-images migration > adds the security updates to a ts#agent Dockerfile 1`] = `
+"FROM public.ecr.aws/docker/library/node:lts-slim
+
+# Apply the distribution's security updates: base image tags lag behind the
+# security suite, so its OS packages carry fixed HIGH/CRITICAL vulnerabilities
+# flagged by the image scan.
+RUN apt-get update && \\
+    apt-get upgrade -y --no-install-recommends && \\
+    rm -rf /var/lib/apt/lists/*
+
+# Upgrade npm to a version free of known HIGH/CRITICAL vulnerabilities
+RUN npm install -g npm@11.0.0
+
+WORKDIR /app
+
+RUN npm init -y \\
+  && npm install @aws/aws-distro-opentelemetry-node-autoinstrumentation@0.12.0 \\
+  && npm uninstall -g npm
+
+# Copy bundled agent
+COPY index.js /app
+
+EXPOSE 8080
+
+CMD [ "node", "--require", "@aws/aws-distro-opentelemetry-node-autoinstrumentation/register", "index.js" ]
+"
+`;

--- a/packages/nx-plugin/src/migrations/latest/apt-security-updates-in-container-images/metadata.json
+++ b/packages/nx-plugin/src/migrations/latest/apt-security-updates-in-container-images/metadata.json
@@ -1,0 +1,3 @@
+{
+  "description": "Apply the distribution's security updates in vended agent / MCP server container images"
+}

--- a/packages/nx-plugin/src/migrations/latest/apt-security-updates-in-container-images/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/latest/apt-security-updates-in-container-images/migration.spec.ts
@@ -1,0 +1,233 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { addProjectConfiguration, type Tree } from '@nx/devkit';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test';
+import migration from './migration';
+
+const PY_PROJECT_ROOT = 'packages/py-project/proj_py_project';
+const TS_PROJECT_ROOT = 'packages/ts-project';
+const PY_AGENT_DIR = 'my_agent';
+const PY_MCP_DIR = 'my_mcp';
+const TS_AGENT_DIR = 'src/my-agent';
+const PY_AGENT_DOCKERFILE = `${PY_PROJECT_ROOT}/${PY_AGENT_DIR}/Dockerfile`;
+const PY_MCP_DOCKERFILE = `${PY_PROJECT_ROOT}/${PY_MCP_DIR}/Dockerfile`;
+const TS_AGENT_DOCKERFILE = `${TS_PROJECT_ROOT}/${TS_AGENT_DIR}/Dockerfile`;
+
+const VENDED_PY_AGENT_DOCKERFILE = `FROM public.ecr.aws/docker/library/python:3.14-slim
+
+# Remove the base image's pip: the agent runs from the bundled environment and
+# never needs it at runtime, and pip's vendored packages carry known
+# HIGH/CRITICAL vulnerabilities flagged by the image scan.
+RUN python -m pip uninstall -y pip && \\
+    rm -rf /usr/local/lib/python*/site-packages/pip \\
+           /usr/local/lib/python*/site-packages/pip-*.dist-info
+
+WORKDIR /app
+
+# Copy bundled package
+COPY . /app
+
+EXPOSE 8080
+
+ENV PYTHONPATH=/app
+ENV PATH="/app/bin:\${PATH}"
+
+CMD ["python", "bin/opentelemetry-instrument", "python", "-m", "proj_py_project.my_agent.main"]
+`;
+
+const VENDED_PY_MCP_DOCKERFILE = `FROM public.ecr.aws/docker/library/python:3.14-slim
+
+# Remove the base image's pip: the server runs from the bundled environment and
+# never needs it at runtime, and pip's vendored packages carry known
+# HIGH/CRITICAL vulnerabilities flagged by the image scan.
+RUN python -m pip uninstall -y pip && \\
+    rm -rf /usr/local/lib/python*/site-packages/pip \\
+           /usr/local/lib/python*/site-packages/pip-*.dist-info
+
+WORKDIR /app
+
+# Copy bundled package
+COPY . /app
+
+EXPOSE 8000
+
+ENV PYTHONPATH=/app
+
+CMD ["python", "bin/opentelemetry-instrument", "python", "-m", "uvicorn", "proj_py_project.my_mcp.http:app", "--host", "0.0.0.0", "--port", "8000"]
+`;
+
+const VENDED_TS_AGENT_DOCKERFILE = `FROM public.ecr.aws/docker/library/node:lts-slim
+
+# Upgrade npm to a version free of known HIGH/CRITICAL vulnerabilities
+RUN npm install -g npm@11.0.0
+
+WORKDIR /app
+
+RUN npm init -y \\
+  && npm install @aws/aws-distro-opentelemetry-node-autoinstrumentation@0.12.0 \\
+  && npm uninstall -g npm
+
+# Copy bundled agent
+COPY index.js /app
+
+EXPOSE 8080
+
+CMD [ "node", "--require", "@aws/aws-distro-opentelemetry-node-autoinstrumentation/register", "index.js" ]
+`;
+
+/**
+ * Register a project whose components point at the given Dockerfile dirs, so the
+ * migration locates them the way it does in a real workspace.
+ */
+const seedProject = (
+  tree: Tree,
+  components: { generator: string; path: string; name: string }[],
+  { name = 'proj.py-project', root = PY_PROJECT_ROOT } = {},
+) => {
+  addProjectConfiguration(tree, name, {
+    name,
+    root,
+    sourceRoot: root,
+    projectType: 'application',
+    targets: {},
+    metadata: { components } as any,
+  });
+};
+
+describe('apt-security-updates-in-container-images migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeUsingTsSolutionSetup();
+  });
+
+  it('does nothing when there are no runtime image components', async () => {
+    const result = await migration(tree);
+    expect(result.nextSteps).toBeUndefined();
+  });
+
+  it('adds the security updates to a py#agent Dockerfile', async () => {
+    seedProject(tree, [
+      { generator: 'py#agent', path: PY_AGENT_DIR, name: 'my-agent' },
+    ]);
+    tree.write(PY_AGENT_DOCKERFILE, VENDED_PY_AGENT_DOCKERFILE);
+
+    const result = await migration(tree);
+    const content = tree.read(PY_AGENT_DOCKERFILE, 'utf-8')!;
+
+    expect(content).toContain('RUN apt-get update');
+    expect(content).toContain('apt-get upgrade -y --no-install-recommends');
+    expect(content).toContain('rm -rf /var/lib/apt/lists/*');
+    // Inserted after FROM, ahead of every other instruction.
+    expect(content.indexOf('apt-get update')).toBeLessThan(
+      content.indexOf('pip uninstall'),
+    );
+    expect(result.nextSteps).toBeUndefined();
+    expect(content).toMatchSnapshot();
+  });
+
+  it('adds the security updates to a py#mcp-server Dockerfile', async () => {
+    seedProject(tree, [
+      { generator: 'py#mcp-server', path: PY_MCP_DIR, name: 'my-mcp' },
+    ]);
+    tree.write(PY_MCP_DOCKERFILE, VENDED_PY_MCP_DOCKERFILE);
+
+    const result = await migration(tree);
+    const content = tree.read(PY_MCP_DOCKERFILE, 'utf-8')!;
+
+    expect(content).toContain('RUN apt-get update');
+    expect(result.nextSteps).toBeUndefined();
+    expect(content).toMatchSnapshot();
+  });
+
+  it('adds the security updates to a ts#agent Dockerfile', async () => {
+    seedProject(
+      tree,
+      [{ generator: 'ts#agent', path: TS_AGENT_DIR, name: 'my-agent' }],
+      { name: 'ts-project', root: TS_PROJECT_ROOT },
+    );
+    tree.write(TS_AGENT_DOCKERFILE, VENDED_TS_AGENT_DOCKERFILE);
+
+    const result = await migration(tree);
+    const content = tree.read(TS_AGENT_DOCKERFILE, 'utf-8')!;
+
+    expect(content).toContain('RUN apt-get update');
+    // Ahead of the npm install so it resolves against upgraded packages.
+    expect(content.indexOf('apt-get update')).toBeLessThan(
+      content.indexOf('npm install -g npm'),
+    );
+    expect(result.nextSteps).toBeUndefined();
+    expect(content).toMatchSnapshot();
+  });
+
+  it('ignores Dockerfiles not belonging to a runtime image component', async () => {
+    // A py#agent component exists, but a stray Dockerfile in the project (not
+    // the component's) must not be touched.
+    seedProject(tree, [
+      { generator: 'py#agent', path: PY_AGENT_DIR, name: 'my-agent' },
+    ]);
+    tree.write(PY_AGENT_DOCKERFILE, VENDED_PY_AGENT_DOCKERFILE);
+    const strayDockerfile = `${PY_PROJECT_ROOT}/other/Dockerfile`;
+    tree.write(strayDockerfile, VENDED_PY_AGENT_DOCKERFILE);
+
+    await migration(tree);
+
+    expect(tree.read(PY_AGENT_DOCKERFILE, 'utf-8')).toContain('apt-get update');
+    expect(tree.read(strayDockerfile, 'utf-8')).toEqual(
+      VENDED_PY_AGENT_DOCKERFILE,
+    );
+  });
+
+  it('leaves a Dockerfile that already upgrades untouched', async () => {
+    seedProject(tree, [
+      { generator: 'py#agent', path: PY_AGENT_DIR, name: 'my-agent' },
+    ]);
+    const alreadyUpgrading = VENDED_PY_AGENT_DOCKERFILE.replace(
+      "# Remove the base image's pip",
+      "RUN apt-get update && apt-get upgrade -y && rm -rf /var/lib/apt/lists/*\n\n# Remove the base image's pip",
+    );
+    tree.write(PY_AGENT_DOCKERFILE, alreadyUpgrading);
+
+    const result = await migration(tree);
+
+    expect(tree.read(PY_AGENT_DOCKERFILE, 'utf-8')).toEqual(alreadyUpgrading);
+    expect(result.nextSteps).toBeUndefined();
+  });
+
+  it('leaves a Dockerfile re-based onto a non-Debian image untouched', async () => {
+    seedProject(tree, [
+      { generator: 'py#agent', path: PY_AGENT_DIR, name: 'my-agent' },
+    ]);
+    const alpine = VENDED_PY_AGENT_DOCKERFILE.replace(
+      'FROM public.ecr.aws/docker/library/python:3.14-slim',
+      'FROM public.ecr.aws/docker/library/alpine:3.22',
+    );
+    tree.write(PY_AGENT_DOCKERFILE, alpine);
+
+    const result = await migration(tree);
+
+    expect(tree.read(PY_AGENT_DOCKERFILE, 'utf-8')).toEqual(alpine);
+    expect(result.nextSteps).toBeUndefined();
+  });
+
+  it('is idempotent', async () => {
+    seedProject(tree, [
+      { generator: 'py#agent', path: PY_AGENT_DIR, name: 'my-agent' },
+      { generator: 'py#mcp-server', path: PY_MCP_DIR, name: 'my-mcp' },
+    ]);
+    tree.write(PY_AGENT_DOCKERFILE, VENDED_PY_AGENT_DOCKERFILE);
+    tree.write(PY_MCP_DOCKERFILE, VENDED_PY_MCP_DOCKERFILE);
+
+    await migration(tree);
+    const agentAfterFirst = tree.read(PY_AGENT_DOCKERFILE, 'utf-8');
+    const mcpAfterFirst = tree.read(PY_MCP_DOCKERFILE, 'utf-8');
+
+    const secondRun = await migration(tree);
+
+    expect(tree.read(PY_AGENT_DOCKERFILE, 'utf-8')).toEqual(agentAfterFirst);
+    expect(tree.read(PY_MCP_DOCKERFILE, 'utf-8')).toEqual(mcpAfterFirst);
+    expect(secondRun.nextSteps).toBeUndefined();
+  });
+});

--- a/packages/nx-plugin/src/migrations/latest/apt-security-updates-in-container-images/migration.ts
+++ b/packages/nx-plugin/src/migrations/latest/apt-security-updates-in-container-images/migration.ts
@@ -1,0 +1,129 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import {
+  getProjects,
+  joinPathFragments,
+  type MigrationReturnObject,
+  type ProjectConfiguration,
+  type Tree,
+} from '@nx/devkit';
+import { formatFilesInSubtree } from '../../../utils/format';
+import type { ComponentMetadata } from '../../../utils/nx';
+
+/**
+ * Apply the distribution's security updates in the vended agent / MCP server
+ * images.
+ *
+ * A base image tag lags behind its distribution's security suite, so the OS
+ * packages it ships carry vulnerabilities that already have a fixed version
+ * published — which the image scan flags as HIGH/CRITICAL. Upgrading them in the
+ * image build clears those findings whenever the scan runs, rather than waiting
+ * for the base image to be rebuilt. New workspaces get this from the generator
+ * templates; this brings existing ones up to date.
+ *
+ * Only the Dockerfiles of the components whose images the generators vend are
+ * touched, located from their project metadata. The Dockerfile is generated
+ * `KeepExisting`, so it is edited in place: the upgrade is inserted right after
+ * the `FROM` line, ahead of every other instruction, so later layers install
+ * against the upgraded packages. One that already runs `apt-get upgrade`, or
+ * which has been re-based onto an image `apt-get` can't upgrade, is left alone.
+ */
+
+/**
+ * The generators whose runtime images the vended Dockerfiles build. Hardcoded
+ * rather than imported from the generators: a migration matches the ids
+ * workspaces recorded at generation time, which must stay fixed even if the
+ * generators' current ids change later.
+ */
+const RUNTIME_IMAGE_GENERATOR_IDS = [
+  'py#agent',
+  'py#mcp-server',
+  'ts#agent',
+  'ts#mcp-server',
+];
+
+const APT_UPGRADE = `# Apply the distribution's security updates: base image tags lag behind the
+# security suite, so its OS packages carry fixed HIGH/CRITICAL vulnerabilities
+# flagged by the image scan.
+RUN apt-get update && \\
+    apt-get upgrade -y --no-install-recommends && \\
+    rm -rf /var/lib/apt/lists/*`;
+
+/** The apt command this migration adds; used to detect an applied fix. */
+const APT_UPGRADE_COMMAND = 'apt-get upgrade';
+
+/**
+ * The Debian-derived base images the generators vend, whose packages `apt-get`
+ * upgrades. A user who has re-based onto another image (Alpine, distroless,
+ * Amazon Linux) needs a different command, so theirs is left as they wrote it.
+ */
+const DEBIAN_BASE_IMAGE = /^FROM\s+\S*(?:node|python):\S*\n/m;
+
+/**
+ * The Dockerfiles of every runtime image component, located from each project's
+ * recorded component metadata (`path` is the component directory relative to
+ * the project root).
+ */
+const runtimeImageDockerfiles = (tree: Tree): string[] => {
+  const paths: string[] = [];
+  for (const project of getProjects(tree).values()) {
+    const components = ((
+      project.metadata as { components?: ComponentMetadata[] }
+    )?.components ?? []) as ComponentMetadata[];
+    for (const component of components) {
+      if (
+        !RUNTIME_IMAGE_GENERATOR_IDS.includes(component.generator) ||
+        !component.path
+      ) {
+        continue;
+      }
+      const dockerfile = joinPathFragments(
+        projectRoot(project),
+        component.path,
+        'Dockerfile',
+      );
+      if (tree.exists(dockerfile)) {
+        paths.push(dockerfile);
+      }
+    }
+  }
+  return paths;
+};
+
+/** A project's root, falling back to sourceRoot for the TS-solution layout. */
+const projectRoot = (project: ProjectConfiguration): string =>
+  project.root ?? project.sourceRoot ?? '';
+
+export default async function migration(
+  tree: Tree,
+): Promise<MigrationReturnObject> {
+  for (const filePath of runtimeImageDockerfiles(tree)) {
+    const content = tree.read(filePath, 'utf-8');
+    if (!content) {
+      continue;
+    }
+    if (content.includes(APT_UPGRADE_COMMAND)) {
+      continue; // Already upgrading (migrated or user-added).
+    }
+
+    const from = content.match(DEBIAN_BASE_IMAGE);
+    if (from?.index === undefined) {
+      continue; // The user has re-based the image; theirs to patch, not ours.
+    }
+
+    // Insert the upgrade after the FROM line, ahead of every other instruction
+    // so later layers install against the upgraded packages, with the spacing a
+    // freshly generated Dockerfile has.
+    const insertAt = from.index + from[0].length;
+    tree.write(
+      filePath,
+      `${content.slice(0, insertAt)}\n${APT_UPGRADE}\n${content.slice(insertAt)}`,
+    );
+  }
+
+  await formatFilesInSubtree(tree);
+
+  return {};
+}

--- a/packages/nx-plugin/src/py/agent/__snapshots__/generator.constructs.spec.ts.snap
+++ b/packages/nx-plugin/src/py/agent/__snapshots__/generator.constructs.spec.ts.snap
@@ -326,6 +326,13 @@ export class DynamodbAgent
 exports[`py#agent generator > should match snapshot for BedrockAgentCoreRuntime generated constructs files > agent-Dockerfile 1`] = `
 "FROM public.ecr.aws/docker/library/python:3.14-slim
 
+# Apply the distribution's security updates: base image tags lag behind the
+# security suite, so its OS packages carry fixed HIGH/CRITICAL vulnerabilities
+# flagged by the image scan.
+RUN apt-get update && \\
+    apt-get upgrade -y --no-install-recommends && \\
+    rm -rf /var/lib/apt/lists/*
+
 # Remove the base image's pip: the agent runs from the bundled environment and
 # never needs it at runtime, and pip's vendored packages carry known
 # HIGH/CRITICAL vulnerabilities flagged by the image scan.

--- a/packages/nx-plugin/src/py/agent/files/deploy/Dockerfile.template
+++ b/packages/nx-plugin/src/py/agent/files/deploy/Dockerfile.template
@@ -1,5 +1,12 @@
 FROM <%- pythonBaseImage %>
 
+# Apply the distribution's security updates: base image tags lag behind the
+# security suite, so its OS packages carry fixed HIGH/CRITICAL vulnerabilities
+# flagged by the image scan.
+RUN apt-get update && \
+    apt-get upgrade -y --no-install-recommends && \
+    rm -rf /var/lib/apt/lists/*
+
 # Remove the base image's pip: the agent runs from the bundled environment and
 # never needs it at runtime, and pip's vendored packages carry known
 # HIGH/CRITICAL vulnerabilities flagged by the image scan.

--- a/packages/nx-plugin/src/py/mcp-server/files/deploy/Dockerfile.template
+++ b/packages/nx-plugin/src/py/mcp-server/files/deploy/Dockerfile.template
@@ -1,5 +1,12 @@
 FROM <%- pythonBaseImage %>
 
+# Apply the distribution's security updates: base image tags lag behind the
+# security suite, so its OS packages carry fixed HIGH/CRITICAL vulnerabilities
+# flagged by the image scan.
+RUN apt-get update && \
+    apt-get upgrade -y --no-install-recommends && \
+    rm -rf /var/lib/apt/lists/*
+
 # Remove the base image's pip: the server runs from the bundled environment and
 # never needs it at runtime, and pip's vendored packages carry known
 # HIGH/CRITICAL vulnerabilities flagged by the image scan.

--- a/packages/nx-plugin/src/ts/agent/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/agent/__snapshots__/generator.spec.ts.snap
@@ -642,6 +642,13 @@ export const getSessionManager = async (): Promise<SessionManager> => {
 exports[`ts#agent generator > should match snapshot for BedrockAgentCoreRuntime generated constructs files > agent-Dockerfile 1`] = `
 "FROM public.ecr.aws/docker/library/node:lts-slim
 
+# Apply the distribution's security updates: base image tags lag behind the
+# security suite, so its OS packages carry fixed HIGH/CRITICAL vulnerabilities
+# flagged by the image scan.
+RUN apt-get update && \\
+    apt-get upgrade -y --no-install-recommends && \\
+    rm -rf /var/lib/apt/lists/*
+
 # Upgrade npm to a version free of known HIGH/CRITICAL vulnerabilities
 RUN npm install -g npm@12.0.2
 

--- a/packages/nx-plugin/src/ts/agent/files/deploy/Dockerfile.template
+++ b/packages/nx-plugin/src/ts/agent/files/deploy/Dockerfile.template
@@ -1,5 +1,12 @@
 FROM <%- nodeBaseImage %>
 
+# Apply the distribution's security updates: base image tags lag behind the
+# security suite, so its OS packages carry fixed HIGH/CRITICAL vulnerabilities
+# flagged by the image scan.
+RUN apt-get update && \
+    apt-get upgrade -y --no-install-recommends && \
+    rm -rf /var/lib/apt/lists/*
+
 # Upgrade npm to a version free of known HIGH/CRITICAL vulnerabilities
 RUN npm install -g npm@<%- npmVersion %>
 

--- a/packages/nx-plugin/src/ts/mcp-server/files/Dockerfile.template
+++ b/packages/nx-plugin/src/ts/mcp-server/files/Dockerfile.template
@@ -1,5 +1,12 @@
 FROM <%- nodeBaseImage %>
 
+# Apply the distribution's security updates: base image tags lag behind the
+# security suite, so its OS packages carry fixed HIGH/CRITICAL vulnerabilities
+# flagged by the image scan.
+RUN apt-get update && \
+    apt-get upgrade -y --no-install-recommends && \
+    rm -rf /var/lib/apt/lists/*
+
 # Upgrade npm to a version free of known HIGH/CRITICAL vulnerabilities
 RUN npm install -g npm@<%- npmVersion %>
 


### PR DESCRIPTION
### Reason for this change

The `Smoke Tests - trivy` lane fails on every vended Python agent / MCP server image:

```
/scan/image-0.tar (debian 13.6)
Total: 9 (HIGH: 9, CRITICAL: 0)
│ bsdutils      │ CVE-2026-53615 │ HIGH │ fixed │ 1:2.41-5 │ 2.41.5-0+deb13u1 │ [Integer Overflow or Wraparound in libblkid/src/partitions/dos.c]
│ libblkid1     │ ...
│ liblastlog2-2 │ ...
│ libmount1     │ ...
│ libsmartcols1 │ ...
│ libuuid1      │ ...
│ login         │ ...
│ mount         │ ...
│ util-linux    │ ...
```

`CVE-2026-53615` is an integer overflow in libblkid's DOS partition parser. Debian published the fix as `2.41.5-0+deb13u1` in `trixie-security`, but the `python:3.14-slim` base image tag still ships `2.41-5`:

```
$ docker run --rm public.ecr.aws/docker/library/python:3.14-slim \
    bash -c "apt-get update -qq && apt-cache policy util-linux"
util-linux:
  Installed: 2.41-5
  Candidate: 2.41.5-0+deb13u1
     2.41.5-0+deb13u1 500 http://deb.debian.org/debian-security trixie-security/main
 *** 2.41-5           500 http://deb.debian.org/debian trixie/main
```

So the scan is flagging packages that already have an available fix — it is not `--ignore-unfixed`-able, and it will keep failing until the base image is rebuilt. A base image tag always lags behind its distribution's security suite, so this recurs with every OS package CVE; pinning around each one as it lands doesn't scale.

### Description of changes

Apply the distribution's security updates as the first step of each vended image build, ahead of every other instruction so later layers install against the upgraded packages:

```dockerfile
RUN apt-get update && \
    apt-get upgrade -y --no-install-recommends && \
    rm -rf /var/lib/apt/lists/*
```

- **Templates** — added to the four vended Dockerfiles: `py#agent`, `py#mcp-server`, `ts#agent`, `ts#mcp-server`. The Python images (Debian 13 / trixie) are the ones failing today; the Node images (Debian 12 / bookworm) are clean right now but get the same treatment so the next OS package CVE doesn't reopen this.
- **Migration** (`latest/apt-security-updates-in-container-images`) — deterministic codemod inserting the upgrade after the `FROM` line in existing workspaces' Dockerfiles, located from each project's recorded component metadata. Skips a Dockerfile that already runs `apt-get upgrade` (idempotent) and one re-based onto an image `apt-get` can't upgrade. Follows the same shape as the `v1.0.0-rc.60/0003-strip-pip-from-python-images` migration.
- **Docs** — the Trivy snippet notes the upgrade as part of how generated images stay clear of fixable findings, and the Docker Bundling guide documents the step for users writing their own Dockerfiles.

The `rdb` migration images (`public.ecr.aws/lambda/*`) are Amazon Linux based and not part of the scanned matrix, so they are out of scope here.

### Description of how you validated changes

**Root cause reproduced and fix confirmed** — built the pre-change and post-change Python images locally and scanned both with the pinned Trivy version the generated target uses:

| image | result |
| --- | --- |
| `python:3.14-slim` + pip strip (pre-change) | `Total: 9 (HIGH: 9, CRITICAL: 0)` — exit 1 |
| same + `apt-get upgrade` (post-change) | no findings — exit 0 |

**End-to-end with the locally compiled plugin** — fresh workspace, `pnpm link`ed `dist/packages/nx-plugin`, generated `py#agent` and `ts#agent`, built both images via their real `*-docker` targets and scanned them:

```
$ docker run --rm ... trivy:0.72.0 image trivy-e2e-my-agent:latest \
    --scanners vuln --severity HIGH,CRITICAL --ignore-unfixed --exit-code 1
│ trivy-e2e-my-agent:latest (debian 13.6) │ debian │ 0 │      EXIT=0

$ docker run --rm trivy-e2e-my-agent:latest dpkg -l | grep util-linux
ii  util-linux  2.41.5-0+deb13u1  arm64
```

The TS agent image scans clean too (`EXIT=0`). Note the scan ran against the local daemon rather than through the target's bind mount, which this container can't use.

**Unit tests** — 8 new migration tests (per-generator insertion, ordering ahead of the pip/npm steps, stray Dockerfiles untouched, already-upgrading left alone, re-based image left alone, idempotency). Full suite green: `3542 passed`, snapshots updated for the two generators that snapshot their Dockerfile. Build and lint pass.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*