### PR TITLE
refactor(py#agent): extract duplicated _SessionIdMiddleware into a shared module

### DIFF
--- a/docs/src/content/docs/en/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/en/get_started/tutorials/dungeon-game/1.mdx
@@ -452,6 +452,8 @@ The `py#agent` generates these files:
         - main.py entrypoint for your agent in Bedrock AgentCore Runtime
         - agent.py defines an example agent and tools
         - session.py resolves a SessionManager for persisting conversation state
+        - middleware/
+          - session_id_middleware.py binds the inbound AgentCore session ID for the request
         - Dockerfile defines the docker image for deployment to AgentCore Runtime
   - common/constructs/
     - src
@@ -493,6 +495,29 @@ Refer to tools as your 'spellbook'.
 This creates an example Strands agent and defines a subtraction tool. `log_model_errors` and `log_tool_errors` are hooks from the shared `dungeon_adventure_agent_connection` project that log model/tool failures instead of letting them fail silently.
 
 ```python
+# agent/middleware/session_id_middleware.py
+import uuid
+
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from dungeon_adventure_agent_connection import session_id_context
+
+SESSION_ID_HEADER = "x-amzn-bedrock-agentcore-runtime-session-id"
+
+
+class SessionIdMiddleware(BaseHTTPMiddleware):
+    """Bind the session ID for this request so downstream MCP / A2A clients forward it on outbound calls."""
+
+    async def dispatch(self, request: Request, call_next):
+        session_id = request.headers.get(SESSION_ID_HEADER) or str(uuid.uuid4())
+        with session_id_context(session_id):
+            return await call_next(request)
+```
+
+The `SessionIdMiddleware` binds the inbound AgentCore runtime session ID onto a `ContextVar` for the duration of the request.
+
+```python
 # agent/main.py
 import logging
 import uuid
@@ -505,14 +530,12 @@ from dungeon_adventure_agent_connection import get_current_session_id, session_i
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import StreamingResponse
-from starlette.middleware.base import BaseHTTPMiddleware
 
 from .agent import get_agent
+from .middleware.session_id_middleware import SESSION_ID_HEADER, SessionIdMiddleware
 from .session import get_session_manager
 
 logging.basicConfig(level=logging.INFO)
-
-SESSION_ID_HEADER = "x-amzn-bedrock-agentcore-runtime-session-id"
 
 
 @asynccontextmanager
@@ -529,15 +552,6 @@ async def lifespan(app: FastAPI):
         yield
 
 
-class _SessionIdMiddleware(BaseHTTPMiddleware):
-    """Bind the session ID for this request so downstream MCP / A2A clients forward it on outbound calls."""
-
-    async def dispatch(self, request: Request, call_next):
-        session_id = request.headers.get(SESSION_ID_HEADER) or str(uuid.uuid4())
-        with session_id_context(session_id):
-            return await call_next(request)
-
-
 app = FastAPI(title="AWS Strands - StoryAgent", lifespan=lifespan)
 app.add_middleware(
     CORSMiddleware,
@@ -546,7 +560,7 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
-app.add_middleware(_SessionIdMiddleware)
+app.add_middleware(SessionIdMiddleware)
 
 
 @app.post("/invocations")
@@ -589,7 +603,7 @@ async def ping():
     return {"status": "healthy"}
 ```
 
-This is the entrypoint for the agent. Because we selected `--protocol=ag-ui`, the generator wraps our Strands `Agent` with `StrandsAgent` from [`ag_ui_strands`](https://docs.copilotkit.ai/aws-strands/integration) and mounts it on a FastAPI app that speaks the [AG-UI protocol](https://docs.copilotkit.ai/aws-strands/protocol) — this is what CopilotKit will talk to from the React website. The agent is built inside a `lifespan` handler — not at import time — so container startup, not module import, owns construction, and each AgentCore session gets its own container. The `_SessionIdMiddleware` binds the inbound AgentCore runtime session ID onto a `ContextVar` so any downstream MCP/A2A client we wire up later (e.g. the Inventory MCP server in <Link path="get_started/tutorials/dungeon-game/2">Module 2</Link>) automatically forwards it on its outbound calls. Since AG-UI caches one Strands agent per `thread_id`, we plug in a `session_manager_provider` rather than the template agent's own session manager — this gives each thread its own `SessionManager` so conversation history persists across turns. That `get_session_manager()` function comes from a generated `session.py` sibling: deployed, it returns a `strands.session.S3SessionManager` backed by an S3 bucket the generator provisions automatically; under `agent-dev` (`LOCAL_DEV=true`) it always returns a `FileSessionManager` writing to a local temp directory instead, regardless of deployed configuration.
+This is the entrypoint for the agent. Because we selected `--protocol=ag-ui`, the generator wraps our Strands `Agent` with `StrandsAgent` from [`ag_ui_strands`](https://docs.copilotkit.ai/aws-strands/integration) and mounts it on a FastAPI app that speaks the [AG-UI protocol](https://docs.copilotkit.ai/aws-strands/protocol) — this is what CopilotKit will talk to from the React website. The agent is built inside a `lifespan` handler — not at import time — so container startup, not module import, owns construction, and each AgentCore session gets its own container. The `SessionIdMiddleware` we saw above forwards the inbound AgentCore runtime session ID so any downstream MCP/A2A client we wire up later (e.g. the Inventory MCP server in <Link path="get_started/tutorials/dungeon-game/2">Module 2</Link>) automatically forwards it on its outbound calls. Since AG-UI caches one Strands agent per `thread_id`, we plug in a `session_manager_provider` rather than the template agent's own session manager — this gives each thread its own `SessionManager` so conversation history persists across turns. That `get_session_manager()` function comes from a generated `session.py` sibling: deployed, it returns a `strands.session.S3SessionManager` backed by an S3 bucket the generator provisions automatically; under `agent-dev` (`LOCAL_DEV=true`) it always returns a `FileSessionManager` writing to a local temp directory instead, regardless of deployed configuration.
 
 ```ts
 // common/constructs/src/app/agents/story-agent/story-agent.ts

--- a/docs/src/content/docs/en/guides/py-agent.mdx
+++ b/docs/src/content/docs/en/guides/py-agent.mdx
@@ -51,6 +51,9 @@ The generator will add the following files to your existing Python project. The 
         - init.py FastAPI application setup with CORS and error handling middleware
         - agent.py Main agent definition with sample tools
         - session.py Resolves the framework-specific session persistence implementation
+        - middleware/
+          - \_\_init\_\_.py Python package initialization
+          - session_id_middleware.py Binds the inbound AgentCore session ID for the request
         - main.py FastAPI entry point for Bedrock AgentCore Runtime
         - Dockerfile Entry point for hosting your agent (excluded when `infra` is set to `None`)
     - pyproject.toml Updated with Strands dependencies
@@ -70,6 +73,9 @@ The entry point exposes your agent over the A2A protocol (Strands uses the [Stra
         - \_\_init\_\_.py Python package initialization
         - agent.py Main agent definition with sample tools
         - session.py Resolves the framework-specific session persistence implementation
+        - middleware/
+          - \_\_init\_\_.py Python package initialization
+          - session_id_middleware.py Binds the inbound AgentCore session ID for the request
         - main.py A2A server entry point
         - Dockerfile Entry point for hosting your agent (excluded when `infra` is set to `None`)
     - pyproject.toml Updated with framework and A2A dependencies
@@ -89,6 +95,9 @@ The entry point exposes your agent via the [AG-UI](https://docs.ag-ui.com/) prot
         - \_\_init\_\_.py Python package initialization
         - agent.py Main agent definition with sample tools
         - session.py Resolves the framework-specific session persistence implementation
+        - middleware/
+          - \_\_init\_\_.py Python package initialization
+          - session_id_middleware.py Binds the inbound AgentCore session ID for the request
         - main.py AG-UI server entry point
         - Dockerfile Entry point for hosting your agent (excluded when `infra` is set to `None`)
     - pyproject.toml Updated with framework and AG-UI dependencies

--- a/docs/src/content/docs/es/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/es/get_started/tutorials/dungeon-game/1.mdx
@@ -1,6 +1,6 @@
 ---
 title: Configurar un monorepo
-description: "Un tutorial paso a paso sobre cómo construir un juego de aventuras de mazmorras impulsado por IA agéntica usando @aws/nx-plugin."
+description: "Un recorrido sobre cómo construir un juego de aventuras en mazmorras impulsado por IA agéntica usando el @aws/nx-plugin."
 ---
 
 import { Aside, Code, FileTree, Steps, Tabs, TabItem } from '@astrojs/starlight/components';
@@ -24,7 +24,7 @@ import gameConversationPng from '@assets/game-conversation.png'
 
 ## Tarea 1: Crear un monorepo
 
-Para crear un nuevo monorepo, desde tu directorio deseado, ejecuta el siguiente comando:
+Para crear un nuevo monorepo, desde el directorio deseado, ejecuta el siguiente comando:
 
 <CreateNxWorkspaceCommand workspace="dungeon-adventure" iac="cdk" />
 
@@ -53,24 +53,24 @@ Esto configurará un monorepo NX dentro del directorio `dungeon-adventure`. Cuan
 
 <Aside type="tip" title="Haz commits frecuentes">Es una buena práctica asegurarse de que todos tus archivos sin preparar estén confirmados en Git antes de ejecutar cualquier generador. Esto te permite ver qué ha cambiado después de ejecutar tu generador mediante `git diff`.</Aside>
 
-## Tarea 2: Estructurar el juego Dungeon Adventure
+## Tarea 2: Estructurar el Dungeon Adventure Game
 
-Con el espacio de trabajo en su lugar, estructuramos los sub-proyectos del juego: la API del juego, el agente de historia, el servidor MCP de inventario, la base de datos del juego y el sitio web, junto con las conexiones que los conectan. Hay dos formas de hacer esto:
+Con el espacio de trabajo listo, estructuramos los sub-proyectos del juego: la Game API, el Story Agent, el servidor MCP de inventario, la base de datos del juego y el sitio web, junto con las conexiones que los unen. Hay dos formas de hacerlo:
 
 - **Rápido** — copia los comandos directamente del diagrama a continuación y ejecútalos. La forma más rápida de llegar al mismo punto de partida.
-- **Paso a paso** — expande la sección a continuación para ejecutar cada generador tú mismo y examinar exactamente qué produce cada uno.
+- **Paso a paso** — expande la sección a continuación para ejecutar cada generador tú mismo y examinar exactamente lo que produce cada uno.
 
-El diagrama a continuación _es_ el espacio de trabajo Dungeon Adventure: cada proyecto, componente y conexión que construirás en este módulo. Presiona **Copy commands** para tomar toda la serie, luego ejecútalos desde el directorio `dungeon-adventure` que creaste en la Tarea 1.
+El diagrama a continuación _es_ el espacio de trabajo de Dungeon Adventure: cada proyecto, componente y conexión que construirás en este módulo. Haz clic en **Copy commands** para tomar toda la serie y luego ejecútalos desde dentro del directorio `dungeon-adventure` que creaste en la Tarea 1.
 
 <EmbeddedGraph preset="dungeon-adventure" workspace="dungeon-adventure" iac="cdk" skipWorkspace />
 
-<Drawer title="Paso a paso" trigger="Paso a paso: ejecuta cada generador tú mismo y ve qué produce">
+<Drawer title="Paso a paso" trigger="Paso a paso: ejecuta cada generador tú mismo y observa lo que produce">
 
-En lugar de copiar todos los comandos a la vez, puedes ejecutar cada generador individualmente. Esta es la mejor manera de entender qué agrega cada generador a tu espacio de trabajo. Ejecuta cada generador por turno, desde el directorio `dungeon-adventure` que creaste en la Tarea 1.
+En lugar de copiar todos los comandos a la vez, puedes ejecutar cada generador individualmente. Esta es la mejor manera de entender qué agrega cada generador a tu espacio de trabajo. Ejecuta cada generador en orden, desde dentro del directorio `dungeon-adventure` que creaste en la Tarea 1.
 
-##### Crear una API del juego
+##### Crear una Game API
 
-Primero, creemos nuestra API del juego. Para hacer esto, crea una API tRPC llamada `GameApi` usando estos pasos:
+Primero, creemos nuestra Game API. Para hacerlo, crea una API tRPC llamada `GameApi` siguiendo estos pasos:
 
 <RunGenerator generator="ts#api" requiredParameters={{ name: "GameApi", framework: "trpc" }} noInteractive />
 
@@ -398,28 +398,28 @@ Este es el construct CDK que define nuestro `GameApi`. Proporciona un método `d
 
 Ahora creemos nuestro Story Agent.
 
-###### Agente de historia: Proyecto Python
+###### Story agent: proyecto Python
 
 Para crear un proyecto Python:
 
 <RunGenerator generator="py#project" requiredParameters={{name:"story"}} noInteractive />
 
-Verás que aparecen algunos archivos nuevos en tu árbol de directorios.
+Verás algunos archivos nuevos aparecer en tu árbol de archivos.
 <details>
 <summary>Examinar los archivos generados por `py#project` en detalle</summary>
 
-El generador `py#project` genera estos archivos:
+El `py#project` genera estos archivos:
 
 <FileTree>
 - .venv/ entorno virtual único para el monorepo
 - packages/
   - story/
-    - dungeon_adventure_story/ módulo Python
+    - dungeon_adventure_story/ módulo python
     - tests/
     - .python-version
     - pyproject.toml
     - project.json
-- .python-version versión de Python fijada para UV
+- .python-version versión de python de uv fijada
 - pyproject.toml
 - uv.lock
 </FileTree>
@@ -428,31 +428,33 @@ Esto ha configurado un proyecto Python y un [UV Workspace](https://docs.astral.s
 
 </details>
 
-###### Agente de historia
+###### Story agent
 
 Para agregar un agente Strands al proyecto con el generador `py#agent`:
 
 <RunGenerator generator="py#agent" requiredParameters={{project:"story", auth:"cognito", protocol:"ag-ui"}} noInteractive />
 
 :::note[Protocolo AG-UI]
-Elegimos `--protocol=ag-ui` para que el agente hable el [protocolo Agent-User Interaction](https://docs.copilotkit.ai/aws-strands/protocol) — esto permite que nuestro sitio web React hable con él directamente a través de [CopilotKit](https://docs.copilotkit.ai/), con streaming, llamadas a herramientas e historial de conversación manejados por el protocolo en lugar de un cliente HTTP hecho a mano.
+Elegimos `--protocol=ag-ui` para que el agente hable el [protocolo Agent-User Interaction](https://docs.copilotkit.ai/aws-strands/protocol) — esto permite que nuestro sitio web React se comunique directamente con él a través de [CopilotKit](https://docs.copilotkit.ai/), con streaming, llamadas a herramientas e historial de conversación gestionados por el protocolo en lugar de un cliente HTTP personalizado.
 :::
 
-Verás que aparecen algunos archivos nuevos en tu árbol de directorios.
+Verás algunos archivos nuevos aparecer en tu árbol de archivos.
 <details>
 <summary>Examinar los archivos generados por `py#agent` en detalle</summary>
 
-El generador `py#agent` genera estos archivos:
+El `py#agent` genera estos archivos:
 
 <FileTree>
 - packages/
   - story/
-    - dungeon_adventure_story/ módulo Python
+    - dungeon_adventure_story/ módulo python
       - agent/
         - main.py punto de entrada para tu agente en Bedrock AgentCore Runtime
         - agent.py define un agente y herramientas de ejemplo
-        - session.py resuelve un SessionManager para persistir el estado de conversación
-        - Dockerfile define la imagen Docker para despliegue en AgentCore Runtime
+        - session.py resuelve un SessionManager para persistir el estado de la conversación
+        - middleware/
+          - session_id_middleware.py vincula el ID de sesión de AgentCore entrante para la solicitud
+        - Dockerfile define la imagen docker para el despliegue en AgentCore Runtime
   - common/constructs/
     - src
       - app/agents/story-agent/
@@ -490,7 +492,30 @@ Refer to tools as your 'spellbook'.
     )
 ```
 
-Esto crea un agente Strands de ejemplo y define una herramienta de resta. `log_model_errors` y `log_tool_errors` son hooks del proyecto compartido `dungeon_adventure_agent_connection` que registran fallos de modelo/herramienta en lugar de dejarlos fallar silenciosamente.
+Esto crea un agente Strands de ejemplo y define una herramienta de sustracción. `log_model_errors` y `log_tool_errors` son hooks del proyecto compartido `dungeon_adventure_agent_connection` que registran fallos de modelo/herramienta en lugar de dejarlos fallar silenciosamente.
+
+```python
+# agent/middleware/session_id_middleware.py
+import uuid
+
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from dungeon_adventure_agent_connection import session_id_context
+
+SESSION_ID_HEADER = "x-amzn-bedrock-agentcore-runtime-session-id"
+
+
+class SessionIdMiddleware(BaseHTTPMiddleware):
+    """Bind the session ID for this request so downstream MCP / A2A clients forward it on outbound calls."""
+
+    async def dispatch(self, request: Request, call_next):
+        session_id = request.headers.get(SESSION_ID_HEADER) or str(uuid.uuid4())
+        with session_id_context(session_id):
+            return await call_next(request)
+```
+
+El `SessionIdMiddleware` vincula el ID de sesión del runtime de AgentCore entrante a un `ContextVar` durante la duración de la solicitud.
 
 ```python
 # agent/main.py
@@ -505,14 +530,12 @@ from dungeon_adventure_agent_connection import get_current_session_id, session_i
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import StreamingResponse
-from starlette.middleware.base import BaseHTTPMiddleware
 
 from .agent import get_agent
+from .middleware.session_id_middleware import SESSION_ID_HEADER, SessionIdMiddleware
 from .session import get_session_manager
 
 logging.basicConfig(level=logging.INFO)
-
-SESSION_ID_HEADER = "x-amzn-bedrock-agentcore-runtime-session-id"
 
 
 @asynccontextmanager
@@ -529,15 +552,6 @@ async def lifespan(app: FastAPI):
         yield
 
 
-class _SessionIdMiddleware(BaseHTTPMiddleware):
-    """Bind the session ID for this request so downstream MCP / A2A clients forward it on outbound calls."""
-
-    async def dispatch(self, request: Request, call_next):
-        session_id = request.headers.get(SESSION_ID_HEADER) or str(uuid.uuid4())
-        with session_id_context(session_id):
-            return await call_next(request)
-
-
 app = FastAPI(title="AWS Strands - StoryAgent", lifespan=lifespan)
 app.add_middleware(
     CORSMiddleware,
@@ -546,7 +560,7 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
-app.add_middleware(_SessionIdMiddleware)
+app.add_middleware(SessionIdMiddleware)
 
 
 @app.post("/invocations")
@@ -589,7 +603,7 @@ async def ping():
     return {"status": "healthy"}
 ```
 
-Este es el punto de entrada para el agente. Debido a que seleccionamos `--protocol=ag-ui`, el generador envuelve nuestro `Agent` de Strands con `StrandsAgent` de [`ag_ui_strands`](https://docs.copilotkit.ai/aws-strands/integration) y lo monta en una aplicación FastAPI que habla el [protocolo AG-UI](https://docs.copilotkit.ai/aws-strands/protocol) — esto es con lo que CopilotKit hablará desde el sitio web React. El agente se construye dentro de un manejador `lifespan` — no en el momento de importación — para que el inicio del contenedor, no la importación del módulo, sea dueño de la construcción, y cada sesión de AgentCore obtenga su propio contenedor. El `_SessionIdMiddleware` vincula el ID de sesión de runtime de AgentCore entrante a un `ContextVar` para que cualquier cliente MCP/A2A descendente que conectemos más adelante (por ejemplo, el servidor MCP de Inventario en el <Link path="get_started/tutorials/dungeon-game/2">Módulo 2</Link>) lo reenvíe automáticamente en sus llamadas salientes. Dado que AG-UI almacena en caché un agente Strands por `thread_id`, conectamos un `session_manager_provider` en lugar del administrador de sesión propio del agente de plantilla — esto le da a cada thread su propio `SessionManager` para que el historial de conversación persista entre turnos. Esa función `get_session_manager()` proviene de un `session.py` hermano generado: desplegado, devuelve un `strands.session.S3SessionManager` respaldado por un bucket S3 que el generador aprovisiona automáticamente; bajo `agent-dev` (`LOCAL_DEV=true`) siempre devuelve un `FileSessionManager` escribiendo en un directorio temporal local en su lugar, independientemente de la configuración desplegada.
+Este es el punto de entrada para el agente. Dado que seleccionamos `--protocol=ag-ui`, el generador envuelve nuestro `Agent` de Strands con `StrandsAgent` de [`ag_ui_strands`](https://docs.copilotkit.ai/aws-strands/integration) y lo monta en una aplicación FastAPI que habla el [protocolo AG-UI](https://docs.copilotkit.ai/aws-strands/protocol) — esto es lo que CopilotKit usará para comunicarse desde el sitio web React. El agente se construye dentro de un manejador `lifespan` — no en el momento de la importación — por lo que el inicio del contenedor, no la importación del módulo, controla la construcción, y cada sesión de AgentCore obtiene su propio contenedor. El `SessionIdMiddleware` que vimos arriba reenvía el ID de sesión del runtime de AgentCore entrante para que cualquier cliente MCP/A2A que conectemos más adelante (por ejemplo, el servidor MCP de inventario en el <Link path="get_started/tutorials/dungeon-game/2">Módulo 2</Link>) lo reenvíe automáticamente en sus llamadas salientes. Dado que AG-UI almacena en caché un agente Strands por `thread_id`, conectamos un `session_manager_provider` en lugar del propio gestor de sesiones del agente plantilla — esto le da a cada hilo su propio `SessionManager` para que el historial de conversación persista entre turnos. Esa función `get_session_manager()` proviene de un `session.py` generado adyacente: cuando está desplegado, devuelve un `strands.session.S3SessionManager` respaldado por un bucket S3 que el generador aprovisiona automáticamente; bajo `agent-dev` (`LOCAL_DEV=true`) siempre devuelve un `FileSessionManager` que escribe en un directorio temporal local, independientemente de la configuración desplegada.
 
 ```ts
 // common/constructs/src/app/agents/story-agent/story-agent.ts
@@ -883,11 +897,11 @@ Puedes notar un `Dockerfile` adicional, que referencia la imagen Docker del proy
 
 </details>
 
-##### Configurar las herramientas de Inventario
+##### Configurar las herramientas de inventario
 
-###### Inventario: Proyecto TypeScript
+###### Inventario: proyecto TypeScript
 
-Creemos un servidor MCP para proveer herramientas para que nuestro Story Agent gestione el inventario de un jugador.
+Creemos un servidor MCP para proporcionar herramientas a nuestro Story Agent para gestionar el inventario de un jugador.
 
 Primero, creamos un proyecto TypeScript:
 
@@ -908,16 +922,16 @@ El generador `ts#project` genera estos archivos.
     - project.json configuración del proyecto
     - vitest.config.mts configuración de pruebas
     - tsconfig.json configuración base de TypeScript para el proyecto
-    - tsconfig.lib.json configuración de TypeScript para compilación y empaquetado
+    - tsconfig.lib.json configuración de TypeScript para el proyecto orientada a compilación y empaquetado
     - tsconfig.spec.json configuración de TypeScript para pruebas
-- tsconfig.base.json actualizado para configurar un alias que otros proyectos usen para referenciar este
+- tsconfig.base.json actualizado para configurar un alias para que otros proyectos hagan referencia a este
 </FileTree>
 
 </details>
 
-###### Inventario: Servidor MCP
+###### Inventario: servidor MCP
 
-Luego, agregaremos un servidor MCP a nuestro proyecto TypeScript:
+A continuación, agregaremos un servidor MCP a nuestro proyecto TypeScript:
 
 <RunGenerator generator="ts#mcp-server" requiredParameters={{project:"inventory"}} noInteractive />
 
@@ -931,14 +945,14 @@ El generador `ts#mcp-server` genera estos archivos.
 - packages/
   - inventory/
     - src/mcp-server/
-      - index.ts barrel export
+      - index.ts exportación barrel
       - server.ts crea el servidor MCP
       - tools/
         - divide.ts herramienta de ejemplo
       - resources/
         - sample-guidance.ts recurso de ejemplo
       - stdio.ts punto de entrada para MCP con transporte STDIO
-      - http.ts punto de entrada para MCP con transporte HTTP transmisible
+      - http.ts punto de entrada para MCP con transporte HTTP Streamable
       - Dockerfile construye la imagen para AgentCore Runtime
     - rolldown.config.ts configuración para empaquetar el servidor MCP para despliegue en AgentCore
   - common/constructs/
@@ -951,15 +965,15 @@ El generador `ts#mcp-server` genera estos archivos.
 
 ##### Crear la base de datos del juego
 
-El estado de nuestro juego — partidas guardadas y el inventario de cada jugador — reside en [Amazon DynamoDB](https://aws.amazon.com/dynamodb/). Crea un proyecto DynamoDB llamado `DungeonDb` con el generador `ts#dynamodb`:
+Nuestro estado de juego — partidas guardadas e inventario de cada jugador — vive en [Amazon DynamoDB](https://aws.amazon.com/dynamodb/). Crea un proyecto DynamoDB llamado `DungeonDb` con el generador `ts#dynamodb`:
 
 <RunGenerator generator="ts#dynamodb" requiredParameters={{name:"DungeonDb"}} noInteractive />
 
 :::tip[Desarrollo local primero]
-El generador `ts#dynamodb` proporciona un target `dev` que ejecuta [DynamoDB Local](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html) en un contenedor. Combinado con el generador `connection` (que ejecutamos a continuación), esto significa que **todo el juego se ejecuta en tu máquina sin un despliegue** hasta el final del tutorial.
+El generador `ts#dynamodb` vende un objetivo `dev` que ejecuta [DynamoDB Local](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html) en un contenedor. Combinado con el generador `connection` (que ejecutamos a continuación), esto significa que **el juego completo se ejecuta en tu máquina sin un despliegue** hasta el final del tutorial.
 :::
 
-Verás que aparecen algunos archivos nuevos en tu árbol de directorios.
+Verás algunos archivos nuevos aparecer en tu árbol de archivos.
 <details>
 <summary>Examinar los archivos generados por `ts#dynamodb` en detalle</summary>
 
@@ -968,14 +982,14 @@ El generador `ts#dynamodb` genera estos archivos.
 <FileTree>
 - packages/
   - dungeon-db/
-    - config.json configuración de DynamoDB incluyendo puerto, nombre de tabla, configuración de contenedor e Índices Secundarios Globales
+    - config.json configuración de DynamoDB incluyendo puerto, nombre de tabla, configuración del contenedor e Índices Secundarios Globales
     - src/
       - index.ts punto de entrada y exportaciones
       - client.ts singleton del cliente DynamoDB y resolución del nombre de tabla
       - entities/
-        - example.ts entidad ElectroDB de ejemplo (reemplazaremos esto)
+        - example.ts entidad ElectroDB de ejemplo (la reemplazaremos)
         - index.ts exportaciones de entidades
-    - project.json agrega los targets `dev` y `pull-image`
+    - project.json agrega los objetivos `dev` y `pull-image`
   - common/
     - scripts/
       - src/
@@ -991,7 +1005,7 @@ El generador `ts#dynamodb` genera estos archivos.
           - dynamodb.ts construct genérico de tabla DynamoDB
 </FileTree>
 
-El `src/client.ts` generado exporta `getDynamoDBClient()` y `resolveTableName()`. Cuando `LOCAL_DEV=true` (establecido automáticamente por los targets `dev`) estos se conectan a DynamoDB Local; de lo contrario, se conectan a AWS y resuelven el nombre de tabla desplegado desde <Link path="guides/runtime-config">Runtime Configuration</Link>. Modelaremos nuestras entidades `Game` e `Inventory` en este proyecto en el <Link path="get_started/tutorials/dungeon-game/2">Módulo 2</Link>.
+El `src/client.ts` generado exporta `getDynamoDBClient()` y `resolveTableName()`. Cuando `LOCAL_DEV=true` (establecido automáticamente por los objetivos `dev`) estos se conectan a DynamoDB Local; de lo contrario, se conectan a AWS y resuelven el nombre de tabla desplegado desde la <Link path="guides/runtime-config">Configuración de Runtime</Link>. Modelaremos nuestras entidades `Game` e `Inventory` en este proyecto en el <Link path="get_started/tutorials/dungeon-game/2">Módulo 2</Link>.
 
 Para más detalles, consulta la <Link path="guides/ts-dynamodb">guía del generador ts#dynamodb</Link>.
 
@@ -1001,33 +1015,33 @@ Para más detalles, consulta la <Link path="guides/ts-dynamodb">guía del genera
 
 A continuación, crearemos la UI que te permitirá interactuar con el juego.
 
-###### Interfaz del Juego: Sitio Web
+###### Game UI: Sitio web
 
-Para crear la UI, crea un sitio web llamado `GameUI` usando estos pasos:
+Para crear la UI, crea un sitio web llamado `GameUI` siguiendo estos pasos:
 
 <RunGenerator generator="ts#website" requiredParameters={{name:"GameUI", ux:"shadcn"}} noInteractive />
 
 :::note[Shadcn UI]
-Seleccionamos `--ux=shadcn` para que el sitio web generado use componentes de [shadcn/ui](https://ui.shadcn.com/) estilizados con Tailwind — todo nuestro código de rutas usa primitivos de shadcn como `Card`, `Button` e `Input`, y el generador `connection` más adelante conecta una superficie de chat de [CopilotKit](https://docs.copilotkit.ai/) con tema shadcn.
+Seleccionamos `--ux=shadcn` para que el sitio web generado use componentes de [shadcn/ui](https://ui.shadcn.com/) estilizados con Tailwind — todo nuestro código de rutas usa primitivas de shadcn como `Card`, `Button` e `Input`, y el generador `connection` más adelante conecta una superficie de chat de [CopilotKit](https://docs.copilotkit.ai/) con tema shadcn coincidente.
 :::
 
-Verás que aparecen algunos archivos nuevos en tu árbol de directorios.
+Verás algunos archivos nuevos aparecer en tu árbol de archivos.
 
 <details>
 <summary>Examinar los archivos generados por `ts#website` en detalle</summary>
 
-El generador `ts#website` genera estos archivos. Examinemos algunos de los archivos clave resaltados en el árbol de archivos:
+El `ts#website` genera estos archivos. Examinemos algunos de los archivos clave resaltados en el árbol de archivos:
 
 <FileTree>
 - packages/
   - common/
     - constructs/
       - src/
-        - app/ constructs CDK específicos de la aplicación
+        - app/ constructs cdk específicos de la aplicación
           - static-websites/
-            - **game-ui.ts** construct CDK para crear tu Game UI
+            - **game-ui.ts** construct cdk para crear tu Game UI
         - core/
-          - static-website.ts construct genérico para sitio web estático
+          - static-website.ts construct genérico de sitio web estático
   - game-ui/
     - public/
     - src/
@@ -1035,20 +1049,20 @@ El generador `ts#website` genera estos archivos. Examinemos algunos de los archi
         - AppLayout/
           - index.tsx diseño general de página usando shadcn `SidebarProvider` + encabezado
         - app-sidebar.tsx barra lateral shadcn predeterminada con elementos de navegación
-        - alert.tsx, spinner.tsx primitivos de retroalimentación envueltos en shadcn
-      - routes/ rutas basadas en @tanstack/react-router
+        - alert.tsx, spinner.tsx primitivas de retroalimentación envueltas en shadcn
+      - routes/ rutas basadas en archivos de @tanstack/react-router
         - **index.tsx** página raíz '/'
         - __root.tsx todas las páginas usan este componente como base
       - config.ts
       - **main.tsx** punto de entrada de React
-      - routeTree.gen.ts este archivo se actualiza automáticamente por @tanstack/react-router
-      - styles.css importa globales compartidos de shadcn (Tailwind v4)
+      - routeTree.gen.ts esto se actualiza automáticamente por @tanstack/react-router
+      - styles.css importa los globales compartidos de shadcn (Tailwind v4)
     - index.html
     - project.json
     - vite.config.mts
     - ...
   - common/
-    - shadcn/ biblioteca compartida shadcn/ui (tokens de tema, `Button`, `Card`, `Input`, `Sidebar`, …) importada por cada sitio web con `ux=shadcn`
+    - shadcn/ biblioteca shadcn/ui compartida (tokens de tema, `Button`, `Card`, `Input`, `Sidebar`, …) importada por cada sitio web con `ux=shadcn`
       - src/components/ui/*
       - src/styles/globals.css tokens de diseño de Tailwind + shadcn
     - ...
@@ -1132,13 +1146,13 @@ Un componente se renderizará al navegar a la ruta `/`. `@tanstack/react-router`
 
 </details>
 
-###### Interfaz del Juego: Autenticación
+###### Game UI: Autenticación
 
-Configuremos nuestra Game UI para requerir acceso autenticado mediante Amazon Cognito usando estos pasos:
+Configuremos nuestra Game UI para requerir acceso autenticado a través de Amazon Cognito siguiendo estos pasos:
 
 <RunGenerator generator="ts#website#auth" requiredParameters={{cognitoDomain:"game-ui", project:"@dungeon-adventure/game-ui", allowSignup:true}} noInteractive />
 
-Verás que aparecen/cambian algunos archivos nuevos en tu árbol de directorios.
+Verás algunos archivos nuevos aparecer/cambiar en tu árbol de archivos.
 
 <details>
 <summary>Examinar los archivos generados por `ts#website#auth` en detalle</summary>
@@ -1151,7 +1165,7 @@ El generador `ts#website#auth` actualiza/genera estos archivos. Examinemos algun
     - constructs/
       - src/
         - core/
-          - user-identity.ts construct CDK para crear pools de usuarios/identidad
+          - user-identity.ts construct cdk para crear grupos de usuarios/identidad
   - game-ui/
     - src/
       - components/
@@ -1160,7 +1174,7 @@ El generador `ts#website#auth` actualiza/genera estos archivos. Examinemos algun
         - CognitoAuth/
           - index.tsx gestiona el inicio de sesión en Cognito
         - RuntimeConfig/
-          - index.tsx obtiene el `runtime-config.json` y lo provee a los hijos vía contexto
+          - index.tsx obtiene el `runtime-config.json` y lo proporciona a los hijos a través del contexto
       - hooks/
         - useRuntimeConfig.tsx
       - **main.tsx** Actualizado para agregar Cognito
@@ -1212,17 +1226,17 @@ root &&
   );
 ```
 
-Los componentes `RuntimeConfigProvider` y `CognitoAuth` han sido agregados al archivo `main.tsx` mediante una transformación AST. Esto permite que el componente `CognitoAuth` se autentique con Amazon Cognito obteniendo el `runtime-config.json` que contiene la configuración de conexión a Cognito necesaria para realizar las llamadas al backend al destino correcto.
+Los componentes `RuntimeConfigProvider` y `CognitoAuth` se han agregado al archivo `main.tsx` mediante una transformación AST. Esto permite que el componente `CognitoAuth` se autentique con Amazon Cognito obteniendo el `runtime-config.json` que contiene la configuración de conexión de Cognito requerida para realizar las llamadas al backend al destino correcto.
 
 </details>
 
-###### Interfaz del Juego: Conectar a Game API
+###### Game UI: Conectar a la Game API
 
-Configuremos nuestra Game UI para conectarse a nuestra Game API creada previamente.
+Configuremos nuestra Game UI para conectarse a nuestra Game API creada anteriormente.
 
 <RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-ui", targetProject:"@dungeon-adventure/game-api"}} noInteractive />
 
-Verás que aparecen/cambian algunos archivos nuevos en tu árbol de directorios.
+Verás algunos archivos nuevos aparecer/cambiar en tu árbol de archivos.
 
 <details>
 <summary>Examinar los archivos de conexión UI → tRPC</summary>
@@ -1266,10 +1280,10 @@ export const useGameApiClient = () => {
 };
 ```
 
-Este hook proporciona acceso al cliente tRPC para llamar a la GameApi. Para ejemplos de cómo llamar a APIs tRPC, consulta la <Link path="guides/connection/react-trpc#using-the-generated-code">guía de uso del hook tRPC</Link>.
+Este hook proporciona acceso al cliente tRPC para llamar a la GameApi. Para ejemplos sobre cómo llamar a APIs tRPC, consulta la <Link path="guides/connection/react-trpc#using-the-generated-code">guía de uso del hook tRPC</Link>.
 
-<Aside title="Hooks con tipos seguros">
-Gracias a la [inferencia de TypeScript](https://trpc.io/docs/concepts) de tRPC, `useGameApi` no necesita un paso de build para que los cambios del backend lleguen al frontend — las ediciones al router o cualquier procedimiento son detectadas por el verificador de tipos instantáneamente.
+<Aside title="Hooks con seguridad de tipos">
+Gracias a la [inferencia de TypeScript](https://trpc.io/docs/concepts) de tRPC, `useGameApi` no necesita un paso de compilación para que los cambios del backend lleguen al frontend — las ediciones al router o a cualquier procedimiento son detectadas por el verificador de tipos al instante.
 </Aside>
 
 ```diff lang="tsx"
@@ -1307,9 +1321,9 @@ El archivo `main.tsx` ha sido actualizado mediante una transformación AST para 
 
 </details>
 
-###### Agente de Historia: Conectar al Servidor MCP de Inventario
+###### Story Agent: Conectar al servidor MCP de inventario
 
-Conectemos nuestro Story Agent al servidor MCP de Inventario para que el agente pueda descubrir e invocar las herramientas del servidor MCP.
+Conectemos nuestro Story Agent al servidor MCP de inventario para que el agente pueda descubrir e invocar las herramientas del servidor MCP.
 
 <RunGenerator generator="connection" requiredParameters={{sourceProject:"story", targetProject:"inventory"}} noInteractive />
 
@@ -1327,9 +1341,9 @@ El generador `connection` genera/actualiza estos archivos:
           - **agentcore\_endpoints.py** Resolución de ARN/URL independiente del framework
           - **agentcore\_mcp\_transport.py** Transporte MCP independiente del framework
           - **agentcore\_mcp\_client\_strands.py** Cliente MCP de Strands que envuelve el transporte
-          - auth/ `httpx.Auth` independiente del framework para SigV4 / reenvío de sesión
+          - auth/ SigV4 / reenvío de sesión `httpx.Auth` independiente del framework
         - app/
-          - **inventory\_mcp\_server\_client\_strands.py** Cliente Strands para conectarse al servidor MCP de Inventario
+          - **inventory\_mcp\_server\_client\_strands.py** Cliente Strands para conectarse al servidor MCP de inventario
         - **\_\_init\_\_.py** Re-exporta clientes por conexión
   - story/
     - dungeon\_adventure\_story/agent/
@@ -1338,16 +1352,16 @@ El generador `connection` genera/actualiza estos archivos:
 </FileTree>
 
 El generador:
-- Crea un proyecto Python compartido `agent_connection` (si aún no existe) con el `AgentCoreMCPClientStrands` central
-- Genera una clase `InventoryMcpServerClientStrands` que maneja la conexión al servidor MCP tanto localmente (HTTP directo) como cuando está desplegado (vía AgentCore con autenticación IAM)
+- Crea un proyecto Python `agent_connection` compartido (si no existe ya) con el núcleo `AgentCoreMCPClientStrands`
+- Genera una clase `InventoryMcpServerClientStrands` que maneja la conexión al servidor MCP tanto localmente (HTTP directo) como cuando está desplegado (a través de AgentCore con autenticación IAM)
 - Transforma `agent.py` para importar el cliente, crear una instancia y conectar las herramientas del servidor MCP al agente
-- Agrega el proyecto `agent_connection` como una dependencia de workspace del proyecto story
-- Actualiza el target `dev` para iniciar automáticamente el servidor MCP cuando se ejecuta localmente
+- Agrega el proyecto `agent_connection` como dependencia del espacio de trabajo del proyecto story
+- Actualiza el objetivo `dev` para iniciar automáticamente el servidor MCP al ejecutar localmente
 
-Para más detalles, consulta la <Link path="guides/connection/py-agent-mcp">guía de conexión de Python Agent a MCP</Link>.
+Para más detalles, consulta la <Link path="guides/connection/py-agent-mcp">guía de conexión de agente Python a MCP</Link>.
 </details>
 
-###### Interfaz del Juego: Conectar a Story Agent
+###### Game UI: Conectar al Story Agent
 
 Conectemos nuestra Game UI al Story Agent. Dado que el agente habla AG-UI, el generador `connection` conecta [CopilotKit](https://docs.copilotkit.ai/): un componente de chat con tema y un `HttpAgent` de `@ag-ui/client` listo para renderizar.
 
@@ -1368,43 +1382,43 @@ El generador `connection` genera/actualiza estos archivos:
           - **index.tsx** `CopilotChat` / `CopilotSidebar` / `CopilotPopup` con tema Shadcn
           - ShadcnAssistantMessage.tsx, ShadcnUserMessage.tsx, ShadcnChatInput.tsx, ShadcnCursor.tsx, copilot.css
       - hooks/
-        - **useAguiStoryAgent.tsx** Construye un `HttpAgent`, inyecta el token bearer de Cognito y rellena `threadId` al id de sesión de 33 caracteres de AgentCore
+        - **useAguiStoryAgent.tsx** Construye un `HttpAgent`, inyecta el token bearer de Cognito y rellena `threadId` al ID de sesión de 33 caracteres de AgentCore
     - **main.tsx** Envuelve `<App />` en `<AguiProvider>`
 
 </FileTree>
 
 El generador:
-- Detecta el `ux` del sitio web React (Shadcn aquí) y proporciona componentes de chat coincidentes.
+- Detecta el `ux` del sitio web React (Shadcn aquí) y vende componentes de chat coincidentes.
 - Registra cada agente conectado en un único `CopilotKitProvider` — volver a ejecutar para otro agente simplemente agrega otro hook.
-- Lee el ARN de runtime del agente desde Runtime Configuration, construye la URL de invocación de AgentCore y adjunta el token bearer de Cognito más el encabezado de id de sesión de AgentCore.
+- Lee el ARN de runtime del agente desde la Configuración de Runtime, construye la URL de invocación de AgentCore y adjunta el token bearer de Cognito más el encabezado de ID de sesión de AgentCore.
 
-Para más detalles, consulta la <Link path="guides/connection/react-agui">guía de conexión de React a AG-UI</Link>.
+Para más detalles, consulta la <Link path="guides/connection/react-agui">guía de conexión React a AG-UI</Link>.
 </details>
 
-###### Conectar la Game API y el servidor MCP de Inventario a la base de datos
+###### Conectar la Game API y el servidor MCP de inventario a la base de datos
 
-Tanto la Game API como el servidor MCP de Inventario leen y escriben en nuestra tabla DynamoDB, así que conectémoslos al proyecto `DungeonDb`. El generador `connection` detecta que el objetivo es un proyecto `ts#dynamodb` y configura el target `dev` de cada proyecto fuente para iniciar DynamoDB Local automáticamente.
+Tanto la Game API como el servidor MCP de inventario leen y escriben en nuestra tabla DynamoDB, así que conectémoslos al proyecto `DungeonDb`. El generador `connection` detecta que el objetivo es un proyecto `ts#dynamodb` y conecta el objetivo `dev` de cada proyecto fuente para iniciar DynamoDB Local automáticamente.
 
 <RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-api", targetProject:"@dungeon-adventure/dungeon-db"}} noInteractive />
 
 <RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/inventory", targetProject:"@dungeon-adventure/dungeon-db"}} noInteractive />
 
-<Aside type="tip" title="Un comando inicia todo el stack localmente">
-Debido a que el `agent-dev` del Story Agent ya depende del `mcp-server-dev` del servidor MCP de Inventario (a través de la conexión `story → inventory` anterior), y tanto la Game API como el servidor MCP ahora dependen de `dungeon-db:dev`, ejecutar el target `dev` de cualquier proyecto inicia todas las dependencias que necesita en el orden correcto.
+<Aside type="tip" title="Un comando inicia toda la pila localmente">
+Dado que el `agent-dev` del Story Agent ya depende del `mcp-server-dev` del servidor MCP de inventario (a través de la conexión `story → inventory` anterior), y tanto la Game API como el servidor MCP ahora dependen de `dungeon-db:dev`, ejecutar el objetivo `dev` de cualquier proyecto inicia todas las dependencias que necesita en el orden correcto.
 </Aside>
 
-###### Interfaz del Juego: Infraestructura
+###### Game UI: Infraestructura
 
-Creemos el último subproyecto para la infraestructura CDK.
+Creemos el sub-proyecto final para la infraestructura CDK.
 
 <RunGenerator generator="ts#infra" requiredParameters={{name:"infra"}} noInteractive />
 
-Verás que aparecen/cambian algunos archivos nuevos en tu árbol de directorios.
+Verás algunos archivos nuevos aparecer/cambiar en tu árbol de archivos.
 
 <details>
 <summary>Examinar los archivos generados por `ts#infra` en detalle</summary>
 
-El generador `ts#infra` genera/actualiza estos archivos. Examinemos algunos de los archivos clave resaltados en el árbol de archivos:
+El generador `ts#infra` genera/actualiza estos. Examinemos algunos de los archivos clave resaltados en el árbol de archivos:
 
 <FileTree>
 - packages/
@@ -1417,17 +1431,17 @@ El generador `ts#infra` genera/actualiza estos archivos. Examinemos algunos de l
   - infra
     - src/
       - stages/
-        - **application-stage.ts** stacks CDK definidos aquí
+        - **application-stage.ts** stacks cdk definidos aquí
       - stacks/
-        - **application-stack.ts** recursos CDK definidos aquí
+        - **application-stack.ts** recursos cdk definidos aquí
       - **main.ts** punto de entrada que define todas las etapas
     - cdk.json
     - checkov.yml
     - project.json
     - ...
   - package.json
-  - tsconfig.json agregadas referencias
-  - tsconfig.base.json agregado alias
+  - tsconfig.json agrega referencias
+  - tsconfig.base.json agrega alias
 
 </FileTree>
 
@@ -1449,7 +1463,7 @@ new ApplicationStage(app, 'dungeon-adventure-infra-sandbox', {
 app.synth();
 ```
 
-<Aside type="tip" title="Corrigiendo errores de importación">Si ves un error de importación en tu IDE, es porque nuestro proyecto de infraestructura aún no tiene una referencia TypeScript configurada en el `tsconfig.json`. Nx ha sido [configurado](https://nx.dev/nx-api/js/generators/typescript-sync) para crear estas referencias *dinámicamente* cuando se ejecuta un build/compile o si ejecutas el comando `nx sync` manualmente. Para más información consulta la <Link path="guides/typescript-project#importing-your-library-code-in-other-projects">guía de TypeScript</Link>.</Aside>
+<Aside type="tip" title="Corregir errores de importación">Si ves un error de importación en tu IDE, es porque nuestro proyecto de infraestructura aún no tiene una referencia de TypeScript configurada en el `tsconfig.json`. Nx ha sido [configurado](https://nx.dev/nx-api/js/generators/typescript-sync) para crear estas referencias *dinámicamente* cada vez que se ejecuta una compilación/compilación o si ejecutas el comando `nx sync` manualmente. Para más información, consulta la <Link path="guides/typescript-project#importing-your-library-code-in-other-projects">guía de TypeScript</Link>.</Aside>
 
 Este es el punto de entrada para tu aplicación CDK.
 
@@ -1467,7 +1481,7 @@ export class ApplicationStack extends Stack {
 }
 ```
 
-Instanciaremos nuestros constructs CDK para construir nuestro juego de aventuras de mazmorra.
+Instanciemos nuestros constructs CDK para construir nuestro juego de aventuras en mazmorras.
 
 </details>
 
@@ -1480,26 +1494,26 @@ Actualicemos `packages/infra/src/stacks/application-stack.ts` para instanciar al
 <E2EDiff before="dungeon-adventure/1/application-stack.ts.original.template" after="dungeon-adventure/1/application-stack.ts.template" lang="ts" />
 
 :::note[Integraciones predeterminadas]
-Proveemos integraciones predeterminadas para nuestra Game API. Por defecto, cada operación en nuestra API se mapea a una función Lambda individual para manejar esa operación.
+Proporcionamos integraciones predeterminadas para nuestra Game API. Por defecto, cada operación en nuestra API se mapea a una función Lambda individual para manejar esa operación.
 :::
 
-## Tarea 4: Construir el código
+## Tarea 4: Compilar el código
 
-<Drawer title="Comandos de Nx" trigger="Ahora es momento de construir nuestro código por primera vez">
+<Drawer title="Comandos de Nx" trigger="Ahora es el momento de compilar nuestro código por primera vez">
 
-###### Targets únicos vs múltiples
+###### Objetivos individuales vs múltiples
 
-El comando `run-many` ejecutará un target en múltiples subproyectos listados (`--all` los seleccionará todos). Esto asegura que las dependencias se ejecuten en el orden correcto.
+El comando `run-many` ejecutará un objetivo en múltiples sub-proyectos listados (`--all` los apuntará a todos). Esto asegura que las dependencias se ejecuten en el orden correcto.
 
-También puedes disparar un build (o cualquier otra tarea) para un target de proyecto único ejecutando el target directamente en el proyecto. Por ejemplo, para construir el proyecto `@dungeon-adventure/infra`, ejecuta el siguiente comando:
-
-<NxCommands commands={['build infra']} />
-
-También puedes omitir el scope y usar la sintaxis abreviada de Nx si prefieres:
+También puedes activar una compilación (o cualquier otra tarea) para un objetivo de proyecto único ejecutando el objetivo directamente en el proyecto. Por ejemplo, para compilar el proyecto `@dungeon-adventure/infra`, ejecuta el siguiente comando:
 
 <NxCommands commands={['build infra']} />
 
-###### Visualizando tus dependencias
+También puedes omitir el alcance y usar la sintaxis abreviada de Nx si lo prefieres:
+
+<NxCommands commands={['build infra']} />
+
+###### Visualizar tus dependencias
 
 Para visualizar tus dependencias, ejecuta:
 
@@ -1510,24 +1524,24 @@ Para visualizar tus dependencias, ejecuta:
 
 ###### Caché
 
-Nx depende del [caching](https://nx.dev/concepts/how-caching-works) para reutilizar artefactos de builds previos y acelerar el desarrollo. Se requiere cierta configuración para que esto funcione correctamente y puede haber casos donde quieras realizar un build **sin usar la caché**. Para eso, simplemente agrega el argumento `--skip-nx-cache` a tu comando. Por ejemplo:
+Nx se basa en el [caché](https://nx.dev/concepts/how-caching-works) para que puedas reutilizar artefactos de compilaciones anteriores y acelerar el desarrollo. Se requiere algo de configuración para que esto funcione correctamente y puede haber casos en los que quieras realizar una compilación **sin usar el caché**. Para hacerlo, simplemente agrega el argumento `--skip-nx-cache` a tu comando. Por ejemplo:
 
 <NxCommands commands={['build infra --skip-nx-cache']} />
-Si por alguna razón quisieras limpiar tu caché (almacenada en la carpeta `.nx`), puedes ejecutar el siguiente comando:
+Si por alguna razón quisieras limpiar tu caché (almacenado en la carpeta `.nx`), puedes ejecutar el siguiente comando:
 
 <NxCommands commands={['reset']} />
 
 </Drawer>
 
-Usando la línea de comandos, ejecuta el siguiente comando para corregir primero cualquier error de lint:
+Usando la línea de comandos, ejecuta el siguiente comando para corregir primero cualquier problema de lint:
 
 <PackageManagerShortCommand commands={["lint"]} />
 
-Luego, ejecuta el siguiente comando para un build completo:
+Luego, ejecuta el siguiente comando para una compilación completa:
 
 <PackageManagerShortCommand commands={["build"]} />
 
-Se te solicitará lo siguiente:
+Se te presentará lo siguiente:
 
 ```bash
  NX   The workspace is out of sync
@@ -1541,10 +1555,10 @@ Yes, sync the changes and run the tasks
 No, run the tasks without syncing the changes
 ```
 
-Este mensaje indica que NX ha detectado algunos archivos que pueden actualizarse automáticamente para ti. En este caso, se refiere a los archivos `tsconfig.json` que no tienen referencias de TypeScript configuradas en proyectos referenciados.
+Este mensaje indica que NX ha detectado algunos archivos que pueden actualizarse automáticamente. En este caso, se refiere a los archivos `tsconfig.json` que no tienen referencias de TypeScript configuradas en los proyectos referenciados.
 
-Selecciona la opción **Yes, sync the changes and run the tasks** para continuar. Deberías notar que todos los errores de importación relacionados con tu IDE se resuelven automáticamente, ya que el generador de sincronización agregará las referencias TypeScript faltantes automáticamente.
+Selecciona la opción **Yes, sync the changes and run the tasks** para continuar. ¡Deberías notar que todos los errores de importación relacionados con tu IDE se resuelven automáticamente, ya que el generador de sincronización agregará las referencias de TypeScript faltantes automáticamente!
 
-Todos los artefactos construidos están ahora disponibles dentro de la carpeta `dist/` ubicada en la raíz del monorepo. Esta es una práctica estándar cuando se usan proyectos generados por el `@aws/nx-plugin` ya que no contamina tu árbol de archivos con archivos generados. En caso de que quieras limpiar tus archivos, elimina la carpeta `dist/` sin preocuparte por artefactos de construcción esparcidos por todo el árbol de archivos.
+Todos los artefactos compilados ahora están disponibles dentro de la carpeta `dist/` ubicada en la raíz del monorepo. Esta es una práctica estándar cuando se usan proyectos generados por el `@aws/nx-plugin`, ya que no contamina tu árbol de archivos con archivos generados. En caso de que quieras limpiar tus archivos, elimina la carpeta `dist/` sin preocuparte por los artefactos de compilación dispersos por todo el árbol de archivos.
 
-¡Felicidades! Has creado todos los subproyectos requeridos para comenzar a implementar el núcleo de nuestro juego de aventuras de mazmorra con IA.  🎉🎉🎉
+¡Felicitaciones! Has creado todos los sub-proyectos necesarios para comenzar a implementar el núcleo de nuestro juego de aventuras AI en mazmorras. 🎉🎉🎉

--- a/docs/src/content/docs/es/guides/py-agent.mdx
+++ b/docs/src/content/docs/es/guides/py-agent.mdx
@@ -51,6 +51,9 @@ El generador agregará los siguientes archivos a tu proyecto Python existente. L
         - init.py FastAPI application setup with CORS and error handling middleware
         - agent.py Main agent definition with sample tools
         - session.py Resolves the framework-specific session persistence implementation
+        - middleware/
+          - \_\_init\_\_.py Python package initialization
+          - session_id_middleware.py Binds the inbound AgentCore session ID for the request
         - main.py FastAPI entry point for Bedrock AgentCore Runtime
         - Dockerfile Entry point for hosting your agent (excluded when `infra` is set to `None`)
     - pyproject.toml Updated with Strands dependencies
@@ -70,6 +73,9 @@ El punto de entrada expone tu agente a través del protocolo A2A (Strands usa el
         - \_\_init\_\_.py Python package initialization
         - agent.py Main agent definition with sample tools
         - session.py Resolves the framework-specific session persistence implementation
+        - middleware/
+          - \_\_init\_\_.py Python package initialization
+          - session_id_middleware.py Binds the inbound AgentCore session ID for the request
         - main.py A2A server entry point
         - Dockerfile Entry point for hosting your agent (excluded when `infra` is set to `None`)
     - pyproject.toml Updated with framework and A2A dependencies
@@ -89,6 +95,9 @@ El punto de entrada expone tu agente a través del protocolo [AG-UI](https://doc
         - \_\_init\_\_.py Python package initialization
         - agent.py Main agent definition with sample tools
         - session.py Resolves the framework-specific session persistence implementation
+        - middleware/
+          - \_\_init\_\_.py Python package initialization
+          - session_id_middleware.py Binds the inbound AgentCore session ID for the request
         - main.py AG-UI server entry point
         - Dockerfile Entry point for hosting your agent (excluded when `infra` is set to `None`)
     - pyproject.toml Updated with framework and AG-UI dependencies
@@ -422,7 +431,7 @@ Luego, en otra terminal, inicia el chat:
 
 <NxCommands commands={['run your-project:agent-chat']} />
 
-El generador emite un `scripts/<your-agent-name>/chat.ts` para cada protocolo. Se conecta al agente local por defecto, o a tu agente desplegado cuando se establece `RUNTIME_CONFIG_APP_ID` (consulta [Chatear con tu agente desplegado](#chat-with-your-deployed-agent) a continuación).
+El generador emite un `scripts/<your-agent-name>/chat.ts` para cada protocolo. Se conecta al agente local por defecto, o a tu agente desplegado cuando se establece `RUNTIME_CONFIG_APP_ID` (consulta [Chatear con tu agente desplegado](#chatear-con-tu-agente-desplegado) a continuación).
 
 Para agentes **HTTP**, el script de chat usa un cliente TypeScript con seguridad de tipos generado a partir de la especificación OpenAPI del agente. El generador también emite:
 
@@ -558,7 +567,7 @@ acurl <region> bedrock-agentcore -N -X POST \
 -H 'Content-Type: application/json'
 ```
 
-<Drawer title="Sigv4 enabled curl" trigger="Haz clic aquí para más detalles sobre cómo configurar el comando acurl anterior">
+<Drawer title="Sigv4 enabled curl" trigger="Click here for more details on configuring the above acurl command">
 <Snippet name="tools/acurl" />
 </Drawer>
 </TabItem>

--- a/docs/src/content/docs/fr/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/fr/get_started/tutorials/dungeon-game/1.mdx
@@ -1,6 +1,6 @@
 ---
 title: Configurer un monorepo
-description: "Un guide détaillé pour construire un jeu d'aventure de donjon alimenté par une IA agentique en utilisant le @aws/nx-plugin."
+description: "Une présentation de la création d'un jeu d'aventure dans un donjon propulsé par une IA agentique, en utilisant le @aws/nx-plugin."
 ---
 
 import { Aside, Code, FileTree, Steps, Tabs, TabItem } from '@astrojs/starlight/components';
@@ -24,7 +24,7 @@ import gameConversationPng from '@assets/game-conversation.png'
 
 ## Tâche 1 : Créer un monorepo
 
-Pour créer un nouveau monorepo, depuis le répertoire de votre choix, exécutez la commande suivante :
+Pour créer un nouveau monorepo, depuis le répertoire souhaité, exécutez la commande suivante :
 
 <CreateNxWorkspaceCommand workspace="dungeon-adventure" iac="cdk" />
 
@@ -38,39 +38,39 @@ Cela configurera un monorepo NX dans le répertoire `dungeon-adventure`. Lorsque
 - .nx/
 - .vscode/
 - node_modules/
-- packages/ c'est ici que vos sous-projets résideront
+- packages/ c'est ici que résideront vos sous-projets
 - .gitignore
 - biome.json configure Biome pour le linting et le formatage
-- nx.json configure le CLI Nx et les valeurs par défaut du monorepo
+- nx.json configure le CLI Nx et les paramètres par défaut du monorepo
 - package.json toutes les dépendances node sont définies ici
 - pnpm-lock.yaml ou bun.lock, yarn.lock, package-lock.json selon le gestionnaire de paquets
 - pnpm-workspace.yaml si vous utilisez pnpm
 - README.md
-- tsconfig.base.json tous les sous-projets basés sur node étendent ceci
+- tsconfig.base.json tous les sous-projets node étendent ce fichier
 - tsconfig.json
-- aws-nx-plugin.config.mts configuration pour le Nx Plugin for AWS
+- aws-nx-plugin.config.mts configuration du Nx Plugin for AWS
 </FileTree>
 
-<Aside type="tip" title="Commitez souvent">C'est une bonne pratique de s'assurer que tous vos fichiers non indexés sont commités dans Git avant d'exécuter des générateurs. Cela vous permet de voir ce qui a changé après l'exécution de votre générateur via `git diff`.</Aside>
+<Aside type="tip" title="Committez souvent">Il est recommandé de s'assurer que tous vos fichiers non stagés sont commités dans Git avant d'exécuter des générateurs. Cela vous permet de voir ce qui a changé après l'exécution de votre générateur via `git diff`.</Aside>
 
-## Tâche 2 : Échafauder le jeu Dungeon Adventure
+## Tâche 2 : Créer l'échafaudage du jeu d'aventure dans le donjon
 
-Avec l'espace de travail en place, nous échafaudons les sous-projets du jeu — l'API Game, l'agent Story, le serveur MCP Inventory, la base de données du jeu et le site web — ainsi que les connexions qui les relient ensemble. Il y a deux façons de faire cela :
+Une fois l'espace de travail en place, nous créons l'échafaudage des sous-projets du jeu — l'API de jeu, l'agent Story, le serveur MCP d'inventaire, la base de données du jeu et le site web — ainsi que les connexions qui les relient. Il y a deux façons de procéder :
 
-- **Rapide** — copiez les commandes directement depuis le diagramme ci-dessous et exécutez-les. Le moyen le plus rapide d'atteindre le même point de départ.
+- **Rapide** — copiez les commandes directement depuis le diagramme ci-dessous et exécutez-les. C'est le moyen le plus rapide d'atteindre le même point de départ.
 - **Étape par étape** — développez la section ci-dessous pour exécuter chaque générateur vous-même et examiner exactement ce que chacun produit.
 
-Le diagramme ci-dessous _est_ l'espace de travail Dungeon Adventure : chaque projet, composant et connexion que vous construirez dans ce module. Cliquez sur **Copy commands** pour prendre toute la série, puis exécutez-les depuis le répertoire `dungeon-adventure` que vous avez créé dans la Tâche 1.
+Le diagramme ci-dessous _est_ l'espace de travail Dungeon Adventure : chaque projet, composant et connexion que vous allez construire dans ce module. Cliquez sur **Copier les commandes** pour prendre toute la série, puis exécutez-les depuis le répertoire `dungeon-adventure` que vous avez créé à la Tâche 1.
 
 <EmbeddedGraph preset="dungeon-adventure" workspace="dungeon-adventure" iac="cdk" skipWorkspace />
 
 <Drawer title="Étape par étape" trigger="Étape par étape : exécutez chaque générateur vous-même et voyez ce qu'il produit">
 
-Plutôt que de copier toutes les commandes en une fois, vous pouvez exécuter chaque générateur individuellement. C'est la meilleure façon de comprendre ce que chaque générateur ajoute à votre espace de travail. Exécutez chaque générateur à tour de rôle, depuis le répertoire `dungeon-adventure` que vous avez créé dans la Tâche 1.
+Plutôt que de copier toutes les commandes en une seule fois, vous pouvez exécuter chaque générateur individuellement. C'est la meilleure façon de comprendre ce que chaque générateur ajoute à votre espace de travail. Exécutez chaque générateur à tour de rôle, depuis le répertoire `dungeon-adventure` que vous avez créé à la Tâche 1.
 
-##### Créer une API Game
+##### Créer une API de jeu
 
-Tout d'abord, créons notre API Game. Pour ce faire, créez une API tRPC appelée `GameApi` en suivant ces étapes :
+Commençons par créer notre API de jeu. Pour ce faire, créez une API tRPC appelée `GameApi` en suivant ces étapes :
 
 <RunGenerator generator="ts#api" requiredParameters={{ name: "GameApi", framework: "trpc" }} noInteractive />
 
@@ -79,12 +79,12 @@ Tout d'abord, créons notre API Game. Pour ce faire, créez une API tRPC appelé
 Vous verrez de nouveaux fichiers apparaître dans votre arborescence de fichiers.
 
 <Aside title="Dépendances racine">
-Le `package.json` racine est maintenant configuré avec un `type` de `module`, ce qui signifie qu'ESM est le type de module par défaut pour tous les sous-projets basés sur node fournis par le `@aws/nx-plugin`.
-Pour plus de détails sur le travail avec les projets TypeScript, consultez le <Link path="guides/typescript-project">guide du générateur ts#project</Link>.
+Le `package.json` racine est maintenant configuré avec un `type` de `module`, ce qui signifie que ESM est le type de module par défaut pour tous les sous-projets node fournis par le `@aws/nx-plugin`.
+Pour plus de détails sur l'utilisation des projets TypeScript, consultez le <Link path="guides/typescript-project">guide du générateur ts#project</Link>.
 </Aside>
 
 <details>
-<summary>Examiner les fichiers générés par `ts#api` en détail</summary>
+<summary>Examiner en détail les fichiers générés par `ts#api`</summary>
 
 Voici la liste de tous les fichiers générés par le générateur `ts#api`. Nous allons examiner certains des fichiers clés mis en évidence dans l'arborescence :
 <FileTree>
@@ -92,15 +92,15 @@ Voici la liste de tous les fichiers générés par le générateur `ts#api`. Nou
   - common/
     - constructs/
       - src/
-        - app/ constructs CDK spécifiques à l'application
+        - app/ constructs cdk spécifiques à l'application
           - apis/
-            - **game-api.ts** construct CDK pour créer votre API tRPC
+            - **game-api.ts** construct cdk pour créer votre API tRPC
             - index.ts
             - ...
           - index.ts
-        - core/ constructs CDK génériques
+        - core/ constructs cdk génériques
           - api/
-            - rest-api.ts construct CDK de base pour une API Gateway Rest API
+            - rest-api.ts construct cdk de base pour une API Gateway Rest API
             - trpc-utils.ts utilitaires pour les constructs CDK d'API tRPC
             - utils.ts utilitaires pour les constructs d'API
           - index.ts
@@ -110,24 +110,24 @@ Voici la liste de tous les fichiers générés par le générateur `ts#api`. Nou
       - ...
   - game-api/ API tRPC
     - src/
-      - client/ client vanilla typiquement utilisé pour les appels TypeScript machine à machine
+      - client/ client vanilla généralement utilisé pour les appels machine à machine en TypeScript
         - index.ts
-      - middleware/ instrumentation Powertools
+      - middleware/ instrumentation powertools
         - error.ts
         - index.ts
         - logger.ts
         - metrics.ts
         - tracer.ts
-      - schema/ définitions des entrées et sorties pour votre API
+      - schema/ définitions des entrées et sorties de votre API
         - index.ts
-        - **echo.ts** exemple de schéma d'entrée et de sortie
-        - z-async-iterable.ts wrapper schéma Zod pour la sortie d'abonnement tRPC
-      - procedures/ implémentations spécifiques pour vos procédures/routes d'API
-        - **echo.ts** exemple d'implémentation de procédure
+        - **echo.ts** schéma d'entrée et de sortie d'exemple
+        - z-async-iterable.ts schéma Zod wrapper pour la sortie d'abonnement tRPC
+      - procedures/ implémentations spécifiques pour les procédures/routes de votre API
+        - **echo.ts** implémentation de procédure d'exemple
       - index.ts
       - init.ts configure le contexte et le middleware
-      - handler.ts point d'entrée du handler Lambda (utilise le streaming de réponse pour les API REST)
-      - local-server.ts utilisé lors de l'exécution du serveur tRPC localement
+      - handler.ts point d'entrée du gestionnaire Lambda (utilise le streaming de réponse pour les API REST)
+      - local-server.ts utilisé lors de l'exécution locale du serveur tRPC
       - **router.ts** définit le routeur tRPC et toutes les procédures
     - project.json
     - ...
@@ -149,7 +149,7 @@ export const appRouter = router({
 
 export type AppRouter = typeof appRouter;
 ```
-Le routeur définit le routeur tRPC de votre API et c'est l'endroit où vous déclarerez toutes vos méthodes d'API. Comme vous pouvez le voir ci-dessus, nous avons une méthode appelée `echo` avec son implémentation dans le fichier `./procedures/echo.ts`. Le point d'entrée du handler Lambda se trouve dans `handler.ts`, qui est configuré automatiquement par le générateur.
+Le routeur définit le routeur tRPC pour votre API et est l'endroit où vous déclarerez toutes vos méthodes d'API. Comme vous pouvez le voir ci-dessus, nous avons une méthode appelée `echo` avec son implémentation dans le fichier `./procedures/echo.ts`. Le point d'entrée du gestionnaire Lambda se trouve dans `handler.ts`, qui est configuré automatiquement par le générateur.
 
 ```ts {7-10}
 // packages/game-api/src/procedures/echo.ts
@@ -165,7 +165,7 @@ export const echo = publicProcedure
   .query((opts) => ({ message: opts.input.message }));
 ```
 
-Ce fichier est l'implémentation de la méthode `echo` et comme vous pouvez le voir, elle est fortement typée en déclarant ses structures de données d'entrée et de sortie.
+Ce fichier est l'implémentation de la méthode `echo` et, comme vous pouvez le voir, est fortement typé en déclarant ses structures de données d'entrée et de sortie.
 
 ```ts
 // packages/game-api/src/schema/echo.ts
@@ -184,7 +184,7 @@ export const EchoOutputSchema = z.object({
 export type IEchoOutput = z.TypeOf<typeof EchoOutputSchema>;
 ```
 
-Toutes les définitions de schéma tRPC sont définies en utilisant [Zod](https://zod.dev/) et sont exportées en tant que types TypeScript via la syntaxe `z.TypeOf`.
+Toutes les définitions de schéma tRPC sont définies à l'aide de [Zod](https://zod.dev/) et sont exportées en tant que types TypeScript via la syntaxe `z.TypeOf`.
 
 ```ts
 // packages/common/constructs/src/app/apis/game-api.ts
@@ -390,7 +390,7 @@ export class GameApi<
 }
 ```
 
-C'est le construct CDK qui définit notre `GameApi`. Il fournit une méthode `defaultIntegrations` qui crée automatiquement une fonction Lambda pour chaque procédure de notre API tRPC, pointant vers l'implémentation d'API empaquetée. Cela signifie qu'au moment de `cdk synth`, l'empaquetage ne se produit pas (contrairement à l'utilisation de [NodeJsFunction](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_lambda_nodejs.NodejsFunction.html)) car nous l'avons déjà empaqueté dans le cadre de la cible de build du projet backend.
+Il s'agit du construct CDK qui définit notre `GameApi`. Il fournit une méthode `defaultIntegrations` qui crée automatiquement une fonction Lambda pour chaque procédure de notre API tRPC, pointant vers l'implémentation de l'API bundlée. Cela signifie qu'au moment du `cdk synth`, le bundling n'a pas lieu (contrairement à l'utilisation de [NodeJsFunction](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_lambda_nodejs.NodejsFunction.html)) car nous l'avons déjà bundlé dans le cadre de la cible de build du projet backend.
 
 </details>
 
@@ -406,20 +406,20 @@ Pour créer un projet Python :
 
 Vous verrez de nouveaux fichiers apparaître dans votre arborescence de fichiers.
 <details>
-<summary>Examiner les fichiers générés par `py#project` en détail</summary>
+<summary>Examiner en détail les fichiers générés par `py#project`</summary>
 
-Le générateur `py#project` génère ces fichiers :
+Le `py#project` génère ces fichiers :
 
 <FileTree>
 - .venv/ environnement virtuel unique pour le monorepo
 - packages/
   - story/
-    - dungeon_adventure_story/ module Python
+    - dungeon_adventure_story/ module python
     - tests/
     - .python-version
     - pyproject.toml
     - project.json
-- .python-version version Python uv figée
+- .python-version version python uv épinglée
 - pyproject.toml
 - uv.lock
 </FileTree>
@@ -435,24 +435,26 @@ Pour ajouter un agent Strands au projet avec le générateur `py#agent` :
 <RunGenerator generator="py#agent" requiredParameters={{project:"story", auth:"cognito", protocol:"ag-ui"}} noInteractive />
 
 :::note[Protocole AG-UI]
-Nous choisissons `--protocol=ag-ui` pour que l'agent parle le [protocole Agent-User Interaction](https://docs.copilotkit.ai/aws-strands/protocol) — cela permet à notre site web React de lui parler directement via [CopilotKit](https://docs.copilotkit.ai/), avec le streaming, les appels d'outils et l'historique de conversation gérés par le protocole au lieu d'un client HTTP fait maison.
+Nous choisissons `--protocol=ag-ui` pour que l'agent parle le [protocole Agent-User Interaction](https://docs.copilotkit.ai/aws-strands/protocol) — cela permet à notre site web React de lui parler directement via [CopilotKit](https://docs.copilotkit.ai/), avec le streaming, les appels d'outils et l'historique des conversations gérés par le protocole plutôt qu'un client HTTP personnalisé.
 :::
 
 Vous verrez de nouveaux fichiers apparaître dans votre arborescence de fichiers.
 <details>
-<summary>Examiner les fichiers générés par `py#agent` en détail</summary>
+<summary>Examiner en détail les fichiers générés par `py#agent`</summary>
 
-Le générateur `py#agent` génère ces fichiers :
+Le `py#agent` génère ces fichiers :
 
 <FileTree>
 - packages/
   - story/
-    - dungeon_adventure_story/ module Python
+    - dungeon_adventure_story/ module python
       - agent/
-        - main.py point d'entrée pour votre agent dans Bedrock AgentCore Runtime
+        - main.py point d'entrée de votre agent dans Bedrock AgentCore Runtime
         - agent.py définit un exemple d'agent et d'outils
-        - session.py résout un SessionManager pour persister l'état de conversation
-        - Dockerfile définit l'image Docker pour le déploiement sur AgentCore Runtime
+        - session.py résout un SessionManager pour persister l'état de la conversation
+        - middleware/
+          - session_id_middleware.py lie l'ID de session AgentCore entrant pour la requête
+        - Dockerfile définit l'image docker pour le déploiement sur AgentCore Runtime
   - common/constructs/
     - src
       - app/agents/story-agent/
@@ -493,6 +495,29 @@ Refer to tools as your 'spellbook'.
 Cela crée un exemple d'agent Strands et définit un outil de soustraction. `log_model_errors` et `log_tool_errors` sont des hooks du projet partagé `dungeon_adventure_agent_connection` qui enregistrent les échecs de modèle/outil au lieu de les laisser échouer silencieusement.
 
 ```python
+# agent/middleware/session_id_middleware.py
+import uuid
+
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from dungeon_adventure_agent_connection import session_id_context
+
+SESSION_ID_HEADER = "x-amzn-bedrock-agentcore-runtime-session-id"
+
+
+class SessionIdMiddleware(BaseHTTPMiddleware):
+    """Bind the session ID for this request so downstream MCP / A2A clients forward it on outbound calls."""
+
+    async def dispatch(self, request: Request, call_next):
+        session_id = request.headers.get(SESSION_ID_HEADER) or str(uuid.uuid4())
+        with session_id_context(session_id):
+            return await call_next(request)
+```
+
+Le `SessionIdMiddleware` lie l'ID de session AgentCore runtime entrant sur un `ContextVar` pour la durée de la requête.
+
+```python
 # agent/main.py
 import logging
 import uuid
@@ -505,14 +530,12 @@ from dungeon_adventure_agent_connection import get_current_session_id, session_i
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import StreamingResponse
-from starlette.middleware.base import BaseHTTPMiddleware
 
 from .agent import get_agent
+from .middleware.session_id_middleware import SESSION_ID_HEADER, SessionIdMiddleware
 from .session import get_session_manager
 
 logging.basicConfig(level=logging.INFO)
-
-SESSION_ID_HEADER = "x-amzn-bedrock-agentcore-runtime-session-id"
 
 
 @asynccontextmanager
@@ -529,15 +552,6 @@ async def lifespan(app: FastAPI):
         yield
 
 
-class _SessionIdMiddleware(BaseHTTPMiddleware):
-    """Bind the session ID for this request so downstream MCP / A2A clients forward it on outbound calls."""
-
-    async def dispatch(self, request: Request, call_next):
-        session_id = request.headers.get(SESSION_ID_HEADER) or str(uuid.uuid4())
-        with session_id_context(session_id):
-            return await call_next(request)
-
-
 app = FastAPI(title="AWS Strands - StoryAgent", lifespan=lifespan)
 app.add_middleware(
     CORSMiddleware,
@@ -546,7 +560,7 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
-app.add_middleware(_SessionIdMiddleware)
+app.add_middleware(SessionIdMiddleware)
 
 
 @app.post("/invocations")
@@ -589,7 +603,7 @@ async def ping():
     return {"status": "healthy"}
 ```
 
-C'est le point d'entrée pour l'agent. Parce que nous avons sélectionné `--protocol=ag-ui`, le générateur enveloppe notre `Agent` Strands avec `StrandsAgent` de [`ag_ui_strands`](https://docs.copilotkit.ai/aws-strands/integration) et le monte sur une application FastAPI qui parle le [protocole AG-UI](https://docs.copilotkit.ai/aws-strands/protocol) — c'est ce à quoi CopilotKit parlera depuis le site web React. L'agent est construit à l'intérieur d'un gestionnaire `lifespan` — pas au moment de l'importation — donc le démarrage du conteneur, et non l'importation du module, possède la construction, et chaque session AgentCore obtient son propre conteneur. Le `_SessionIdMiddleware` lie l'ID de session AgentCore runtime entrant sur un `ContextVar` afin que tout client MCP/A2A en aval que nous connectons plus tard (par exemple le serveur MCP Inventory dans le <Link path="get_started/tutorials/dungeon-game/2">Module 2</Link>) le transfère automatiquement sur ses appels sortants. Puisque AG-UI met en cache un agent Strands par `thread_id`, nous branchons un `session_manager_provider` plutôt que le gestionnaire de session propre à l'agent du modèle — cela donne à chaque thread son propre `SessionManager` afin que l'historique de conversation persiste entre les tours. Cette fonction `get_session_manager()` provient d'un `session.py` frère généré : déployé, il renvoie un `strands.session.S3SessionManager` soutenu par un bucket S3 que le générateur provisionne automatiquement ; sous `agent-dev` (`LOCAL_DEV=true`) il renvoie toujours un `FileSessionManager` écrivant dans un répertoire temporaire local à la place, quelle que soit la configuration déployée.
+Il s'agit du point d'entrée de l'agent. Parce que nous avons sélectionné `--protocol=ag-ui`, le générateur enveloppe notre `Agent` Strands avec `StrandsAgent` de [`ag_ui_strands`](https://docs.copilotkit.ai/aws-strands/integration) et le monte sur une application FastAPI qui parle le [protocole AG-UI](https://docs.copilotkit.ai/aws-strands/protocol) — c'est ce avec quoi CopilotKit communiquera depuis le site web React. L'agent est construit dans un gestionnaire `lifespan` — pas au moment de l'import — de sorte que le démarrage du conteneur, et non l'import du module, gère la construction, et chaque session AgentCore obtient son propre conteneur. Le `SessionIdMiddleware` que nous avons vu ci-dessus transfère l'ID de session AgentCore runtime entrant afin que tout client MCP/A2A en aval que nous connectons plus tard (par exemple, le serveur MCP d'inventaire dans le <Link path="get_started/tutorials/dungeon-game/2">Module 2</Link>) le transfère automatiquement lors de ses appels sortants. Puisque AG-UI met en cache un agent Strands par `thread_id`, nous branchons un `session_manager_provider` plutôt que le gestionnaire de session propre à l'agent modèle — cela donne à chaque thread son propre `SessionManager` afin que l'historique des conversations persiste entre les tours. Cette fonction `get_session_manager()` provient d'un `session.py` généré : déployé, il retourne un `strands.session.S3SessionManager` soutenu par un bucket S3 que le générateur provisionne automatiquement ; sous `agent-dev` (`LOCAL_DEV=true`), il retourne toujours un `FileSessionManager` écrivant dans un répertoire temporaire local, quelle que soit la configuration déployée.
 
 ```ts
 // common/constructs/src/app/agents/story-agent/story-agent.ts
@@ -877,7 +891,7 @@ export class StoryAgent extends Construct implements IGrantable, IConnectable {
 }
 ```
 
-Cela configure un `AgentRuntimeArtifact` CDK qui télécharge votre image Docker d'agent vers ECR, et l'héberge en utilisant AgentCore Runtime. Parce que nous avons choisi `--auth=cognito`, le construct nécessite l'identité du pool d'utilisateurs/client et autorise les invocations AgentCore Runtime via Cognito, en transférant l'en-tête `Authorization` de l'appelant. Il provisionne également le bucket de session que le `session.py` de l'agent Story lit au moment de l'exécution — un bucket S3 chiffré KMS avec des journaux d'accès au serveur livrés à CloudWatch Logs — lui accorde un accès en lecture/écriture, lui accorde l'accès pour invoquer les modèles Bedrock, et enregistre son ARN et le nom du bucket dans `RuntimeConfig` afin que l'agent (au moment de l'exécution, via AppConfig) et l'API Game (au moment de la synthèse, via `invocationUrl`) puissent le trouver.
+Cela configure un `AgentRuntimeArtifact` CDK qui télécharge votre image Docker d'agent vers ECR et l'héberge en utilisant AgentCore Runtime. Parce que nous avons choisi `--auth=cognito`, le construct nécessite l'identité du pool d'utilisateurs/client et autorise les invocations AgentCore Runtime via Cognito, en transmettant l'en-tête `Authorization` de l'appelant. Il provisionne également le bucket de session que le `session.py` de l'agent Story lit au moment de l'exécution — un bucket S3 chiffré KMS avec des journaux d'accès au serveur livrés à CloudWatch Logs — accorde à l'agent un accès en lecture/écriture, lui accorde l'accès pour invoquer des modèles Bedrock, et enregistre son ARN et le nom du bucket dans `RuntimeConfig` afin que l'agent (au moment de l'exécution, via AppConfig) et l'API de jeu (au moment de la synthèse, via `invocationUrl`) puissent le trouver.
 
 Vous remarquerez peut-être un `Dockerfile` supplémentaire, qui référence l'image Docker du projet `story`, nous permettant de co-localiser le Dockerfile et le code source de l'agent.
 
@@ -885,7 +899,7 @@ Vous remarquerez peut-être un `Dockerfile` supplémentaire, qui référence l'i
 
 ##### Configurer les outils d'inventaire
 
-###### Inventaire : Projet TypeScript
+###### Inventaire : projet TypeScript
 
 Créons un serveur MCP pour fournir des outils à notre agent Story afin de gérer l'inventaire d'un joueur.
 
@@ -896,7 +910,7 @@ Tout d'abord, nous créons un projet TypeScript :
 Cela créera un projet TypeScript vide.
 
 <details>
-<summary>Examiner les fichiers générés par `ts#project` en détail</summary>
+<summary>Examiner en détail les fichiers générés par `ts#project`</summary>
 
 Le générateur `ts#project` génère ces fichiers.
 
@@ -904,18 +918,18 @@ Le générateur `ts#project` génère ces fichiers.
 - packages/
   - inventory/
     - src/
-      - index.ts point d'entrée avec fonction d'exemple
+      - index.ts point d'entrée avec une fonction d'exemple
     - project.json configuration du projet
     - vitest.config.mts configuration des tests
     - tsconfig.json configuration TypeScript de base pour le projet
-    - tsconfig.lib.json configuration TypeScript pour le projet ciblée pour la compilation et l'empaquetage
+    - tsconfig.lib.json configuration TypeScript pour le projet ciblé pour la compilation et le bundling
     - tsconfig.spec.json configuration TypeScript pour les tests
-- tsconfig.base.json mis à jour pour configurer un alias permettant aux autres projets de référencer celui-ci
+- tsconfig.base.json mis à jour pour configurer un alias permettant à d'autres projets de le référencer
 </FileTree>
 
 </details>
 
-###### Inventaire : Serveur MCP
+###### Inventaire : serveur MCP
 
 Ensuite, nous allons ajouter un serveur MCP à notre projet TypeScript :
 
@@ -923,7 +937,7 @@ Ensuite, nous allons ajouter un serveur MCP à notre projet TypeScript :
 
 Cela ajoutera un serveur MCP.
 <details>
-<summary>Examiner les fichiers générés par `ts#mcp-server` en détail</summary>
+<summary>Examiner en détail les fichiers générés par `ts#mcp-server`</summary>
 
 Le générateur `ts#mcp-server` génère ces fichiers.
 
@@ -931,16 +945,16 @@ Le générateur `ts#mcp-server` génère ces fichiers.
 - packages/
   - inventory/
     - src/mcp-server/
-      - index.ts barrel export
+      - index.ts export barrel
       - server.ts crée le serveur MCP
       - tools/
         - divide.ts outil d'exemple
       - resources/
         - sample-guidance.ts ressource d'exemple
       - stdio.ts point d'entrée pour MCP avec transport STDIO
-      - http.ts point d'entrée pour MCP avec transport HTTP streamable
+      - http.ts point d'entrée pour MCP avec transport HTTP Streamable
       - Dockerfile construit l'image pour AgentCore Runtime
-    - rolldown.config.ts configuration pour empaqueter le serveur MCP pour le déploiement sur AgentCore
+    - rolldown.config.ts configuration pour le bundling du serveur MCP pour le déploiement sur AgentCore
   - common/constructs/
     - src
       - app/mcp-servers/inventory-mcp-server/
@@ -955,33 +969,33 @@ L'état de notre jeu — les parties sauvegardées et l'inventaire de chaque jou
 
 <RunGenerator generator="ts#dynamodb" requiredParameters={{name:"DungeonDb"}} noInteractive />
 
-:::tip[Développement local d'abord]
-Le générateur `ts#dynamodb` fournit une cible `dev` qui exécute [DynamoDB Local](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html) dans un conteneur. Combiné avec le générateur `connection` (que nous exécutons ci-dessous), cela signifie que **le jeu entier s'exécute sur votre machine sans déploiement** jusqu'à la fin du tutoriel.
+:::tip[Développement local en premier]
+Le générateur `ts#dynamodb` fournit une cible `dev` qui exécute [DynamoDB Local](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html) dans un conteneur. Combiné avec le générateur `connection` (que nous exécutons ci-dessous), cela signifie que **le jeu entier fonctionne sur votre machine sans déploiement** jusqu'à la fin du tutoriel.
 :::
 
 Vous verrez de nouveaux fichiers apparaître dans votre arborescence de fichiers.
 <details>
-<summary>Examiner les fichiers générés par `ts#dynamodb` en détail</summary>
+<summary>Examiner en détail les fichiers générés par `ts#dynamodb`</summary>
 
 Le générateur `ts#dynamodb` génère ces fichiers.
 
 <FileTree>
 - packages/
   - dungeon-db/
-    - config.json configuration DynamoDB incluant le port, le nom de table, les paramètres du conteneur et les Global Secondary Indexes
+    - config.json configuration DynamoDB incluant le port, le nom de la table, les paramètres du conteneur et les Index Secondaires Globaux
     - src/
       - index.ts point d'entrée et exports
       - client.ts singleton du client DynamoDB et résolution du nom de table
       - entities/
-        - example.ts entité ElectroDB d'exemple (nous la remplacerons)
-        - index.ts exports d'entités
+        - example.ts exemple d'entité ElectroDB (nous remplacerons ceci)
+        - index.ts exports des entités
     - project.json ajoute les cibles `dev` et `pull-image`
   - common/
     - scripts/
       - src/
         - dynamodb/
           - create-local-table.ts crée la table dans DynamoDB Local
-          - pull-image.ts récupère l'image DynamoDB Local
+          - pull-image.ts télécharge l'image DynamoDB Local
           - start-container.ts démarre le conteneur DynamoDB Local
     - constructs/
       - src/
@@ -991,7 +1005,7 @@ Le générateur `ts#dynamodb` génère ces fichiers.
           - dynamodb.ts construct générique de table DynamoDB
 </FileTree>
 
-Le `src/client.ts` généré exporte `getDynamoDBClient()` et `resolveTableName()`. Lorsque `LOCAL_DEV=true` (défini automatiquement par les cibles `dev`), ceux-ci se connectent à DynamoDB Local ; sinon ils se connectent à AWS et résolvent le nom de table déployé depuis <Link path="guides/runtime-config">Runtime Configuration</Link>. Nous modéliserons nos entités `Game` et `Inventory` dans ce projet dans le <Link path="get_started/tutorials/dungeon-game/2">Module 2</Link>.
+Le `src/client.ts` généré exporte `getDynamoDBClient()` et `resolveTableName()`. Lorsque `LOCAL_DEV=true` (défini automatiquement par les cibles `dev`), ceux-ci se connectent à DynamoDB Local ; sinon, ils se connectent à AWS et résolvent le nom de la table déployée depuis la <Link path="guides/runtime-config">Configuration Runtime</Link>. Nous modéliserons nos entités `Game` et `Inventory` dans ce projet dans le <Link path="get_started/tutorials/dungeon-game/2">Module 2</Link>.
 
 Pour plus de détails, consultez le <Link path="guides/ts-dynamodb">guide du générateur ts#dynamodb</Link>.
 
@@ -1001,31 +1015,31 @@ Pour plus de détails, consultez le <Link path="guides/ts-dynamodb">guide du gé
 
 Ensuite, nous allons créer l'interface utilisateur qui vous permettra d'interagir avec le jeu.
 
-###### Interface utilisateur du jeu : Site web
+###### Interface de jeu : site web
 
 Pour créer l'interface utilisateur, créez un site web appelé `GameUI` en suivant ces étapes :
 
 <RunGenerator generator="ts#website" requiredParameters={{name:"GameUI", ux:"shadcn"}} noInteractive />
 
 :::note[Shadcn UI]
-Nous sélectionnons `--ux=shadcn` pour que le site web généré utilise les composants [shadcn/ui](https://ui.shadcn.com/) stylisés avec Tailwind — tout notre code de route utilise des primitives shadcn comme `Card`, `Button` et `Input`, et le générateur `connection` câblera plus tard une surface de chat [CopilotKit](https://docs.copilotkit.ai/) thématisée shadcn correspondante.
+Nous sélectionnons `--ux=shadcn` pour que le site web généré utilise les composants [shadcn/ui](https://ui.shadcn.com/) stylisés avec Tailwind — tout notre code de route utilise des primitives shadcn comme `Card`, `Button` et `Input`, et le générateur `connection` connecte plus tard une surface de chat [CopilotKit](https://docs.copilotkit.ai/) avec un thème shadcn correspondant.
 :::
 
 Vous verrez de nouveaux fichiers apparaître dans votre arborescence de fichiers.
 
 <details>
-<summary>Examiner les fichiers générés par `ts#website` en détail</summary>
+<summary>Examiner en détail les fichiers générés par `ts#website`</summary>
 
-Le générateur `ts#website` génère ces fichiers. Examinons certains des fichiers clés mis en évidence dans l'arborescence :
+Le `ts#website` génère ces fichiers. Examinons certains des fichiers clés mis en évidence dans l'arborescence :
 
 <FileTree>
 - packages/
   - common/
     - constructs/
       - src/
-        - app/ constructs CDK spécifiques à l'application
+        - app/ constructs cdk spécifiques à l'application
           - static-websites/
-            - **game-ui.ts** construct CDK pour créer votre interface utilisateur du jeu
+            - **game-ui.ts** construct cdk pour créer votre interface de jeu
         - core/
           - static-website.ts construct générique de site web statique
   - game-ui/
@@ -1035,22 +1049,22 @@ Le générateur `ts#website` génère ces fichiers. Examinons certains des fichi
         - AppLayout/
           - index.tsx mise en page globale utilisant shadcn `SidebarProvider` + en-tête
         - app-sidebar.tsx barre latérale shadcn par défaut avec éléments de navigation
-        - alert.tsx, spinner.tsx primitives de feedback enveloppées dans shadcn
-      - routes/ routes basées sur des fichiers @tanstack/react-router
+        - alert.tsx, spinner.tsx primitives de feedback encapsulées dans shadcn
+      - routes/ routes basées sur les fichiers @tanstack/react-router
         - **index.tsx** page racine '/'
         - __root.tsx toutes les pages utilisent ce composant comme base
       - config.ts
       - **main.tsx** point d'entrée React
-      - routeTree.gen.ts automatiquement mis à jour par @tanstack/react-router
+      - routeTree.gen.ts mis à jour automatiquement par @tanstack/react-router
       - styles.css importe les globaux shadcn partagés (Tailwind v4)
     - index.html
     - project.json
     - vite.config.mts
     - ...
   - common/
-    - shadcn/ bibliothèque shadcn/ui partagée (tokens de thème, `Button`, `Card`, `Input`, `Sidebar`, …) importée par chaque site web `ux=shadcn`
+    - shadcn/ bibliothèque shadcn/ui partagée (jetons de thème, `Button`, `Card`, `Input`, `Sidebar`, …) importée par chaque site web `ux=shadcn`
       - src/components/ui/*
-      - src/styles/globals.css Tailwind + tokens de design shadcn
+      - src/styles/globals.css jetons de design Tailwind + shadcn
     - ...
 </FileTree>
 
@@ -1075,7 +1089,7 @@ export class GameUI extends StaticWebsite {
 }
 ```
 
-C'est le construct CDK qui définit notre GameUI. Il a déjà configuré le chemin de fichier vers le bundle généré pour notre interface utilisateur basée sur Vite. Cela signifie qu'au moment du `build`, l'empaquetage se produit dans la cible de build du projet game-ui et la sortie est utilisée ici.
+Il s'agit du construct CDK qui définit notre GameUI. Il a déjà configuré le chemin vers le bundle généré pour notre interface basée sur Vite. Cela signifie qu'au moment du `build`, le bundling se produit dans la cible de build du projet game-ui et la sortie est utilisée ici.
 
 ```tsx
 // packages/game-ui/src/main.tsx
@@ -1106,7 +1120,7 @@ root &&
   );
 ```
 
-C'est le point d'entrée où React est monté. Le style provient des tokens Tailwind v4 importés via `styles.css`. `@tanstack/react-router` est configuré en mode [file-based routing](https://tanstack.com/router/v1/docs/framework/react/routing/file-based-routing) : tant que le serveur de développement est en cours d'exécution, tout fichier que vous créez sous `routes/` est automatiquement détecté et l'arbre de routes est régénéré. Les générateurs ultérieurs (auth, connection) patcheront ce fichier via AST pour envelopper `<App />` dans des fournisseurs supplémentaires.
+Il s'agit du point d'entrée où React est monté. Le style provient des jetons Tailwind v4 importés via `styles.css`. `@tanstack/react-router` est configuré en mode [routage basé sur les fichiers](https://tanstack.com/router/v1/docs/framework/react/routing/file-based-routing) : tant que le serveur de développement est en cours d'exécution, tout fichier que vous créez sous `routes/` est automatiquement pris en compte et l'arbre de routes est régénéré. Les générateurs ultérieurs (auth, connection) vont patcher ce fichier via AST pour envelopper `<App />` dans des fournisseurs supplémentaires.
 
 ```tsx
 // packages/game-ui/src/routes/index.tsx
@@ -1132,16 +1146,16 @@ Un composant sera rendu lors de la navigation vers la route `/`. `@tanstack/reac
 
 </details>
 
-###### Interface utilisateur du jeu : Authentification
+###### Interface de jeu : authentification
 
-Configurons notre interface utilisateur du jeu pour exiger un accès authentifié via Amazon Cognito en suivant ces étapes :
+Configurons notre interface de jeu pour exiger un accès authentifié via Amazon Cognito en suivant ces étapes :
 
 <RunGenerator generator="ts#website#auth" requiredParameters={{cognitoDomain:"game-ui", project:"@dungeon-adventure/game-ui", allowSignup:true}} noInteractive />
 
 Vous verrez de nouveaux fichiers apparaître/changer dans votre arborescence de fichiers.
 
 <details>
-<summary>Examiner les fichiers générés par `ts#website#auth` en détail</summary>
+<summary>Examiner en détail les fichiers générés par `ts#website#auth`</summary>
 
 Le générateur `ts#website#auth` met à jour/génère ces fichiers. Examinons certains des fichiers clés mis en évidence dans l'arborescence :
 
@@ -1151,7 +1165,7 @@ Le générateur `ts#website#auth` met à jour/génère ces fichiers. Examinons c
     - constructs/
       - src/
         - core/
-          - user-identity.ts construct CDK pour créer des pools d'utilisateurs/d'identité
+          - user-identity.ts construct cdk pour créer des pools d'utilisateurs/d'identités
   - game-ui/
     - src/
       - components/
@@ -1163,7 +1177,7 @@ Le générateur `ts#website#auth` met à jour/génère ces fichiers. Examinons c
           - index.tsx récupère le `runtime-config.json` et le fournit aux enfants via le contexte
       - hooks/
         - useRuntimeConfig.tsx
-      - **main.tsx** Mis à jour pour ajouter Cognito
+      - **main.tsx** mis à jour pour ajouter Cognito
 </FileTree>
 
 ```diff lang="tsx"
@@ -1212,13 +1226,13 @@ root &&
   );
 ```
 
-Les composants `RuntimeConfigProvider` et `CognitoAuth` ont été ajoutés au fichier `main.tsx` via une transformation AST. Cela permet au composant `CognitoAuth` de s'authentifier avec Amazon Cognito en récupérant le `runtime-config.json` qui contient la configuration de connexion Cognito requise pour effectuer les appels backend vers la bonne destination.
+Les composants `RuntimeConfigProvider` et `CognitoAuth` ont été ajoutés au fichier `main.tsx` via une transformation AST. Cela permet au composant `CognitoAuth` de s'authentifier auprès d'Amazon Cognito en récupérant le `runtime-config.json` qui contient la configuration de connexion Cognito requise pour effectuer les appels backend vers la bonne destination.
 
 </details>
 
-###### Interface utilisateur du jeu : Connexion à l'API du jeu
+###### Interface de jeu : connexion à l'API de jeu
 
-Configurons notre interface utilisateur du jeu pour se connecter à notre API GameApi créée précédemment.
+Configurons notre interface de jeu pour se connecter à notre API de jeu précédemment créée.
 
 <RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-ui", targetProject:"@dungeon-adventure/game-api"}} noInteractive />
 
@@ -1236,8 +1250,8 @@ Le générateur `connection` génère/met à jour ces fichiers. Examinons certai
       - components/
         - GameApiClientProvider.tsx configure le client GameAPI
       - hooks/
-        - **useGameApi.tsx** hooks pour appeler l'API GameApi
-      - **main.tsx** injecte les fournisseurs de client tRPC
+        - **useGameApi.tsx** hooks pour appeler le GameApi
+      - **main.tsx** injecte les fournisseurs du client trpc
 - package.json
 
 </FileTree>
@@ -1268,8 +1282,8 @@ export const useGameApiClient = () => {
 
 Ce hook fournit un accès au client tRPC pour appeler le GameApi. Pour des exemples sur la façon d'appeler des API tRPC, consultez le <Link path="guides/connection/react-trpc#using-the-generated-code">guide d'utilisation du hook tRPC</Link>.
 
-<Aside title="Hooks typés">
-Grâce à [l'inférence TypeScript](https://trpc.io/docs/concepts) de tRPC, `useGameApi` n'a pas besoin d'une étape de build pour que les changements backend atteignent le frontend — les modifications du routeur ou de toute procédure sont détectées instantanément par le vérificateur de types.
+<Aside title="Hooks type-safe">
+Grâce à l'[inférence TypeScript](https://trpc.io/docs/concepts) de tRPC, `useGameApi` n'a pas besoin d'une étape de build pour que les modifications du backend atteignent le frontend — les modifications du routeur ou de toute procédure sont immédiatement détectées par le vérificateur de types.
 </Aside>
 
 ```diff lang="tsx"
@@ -1307,14 +1321,14 @@ Le fichier `main.tsx` a été mis à jour via une transformation AST pour inject
 
 </details>
 
-###### Agent Story : connexion au serveur MCP Inventory
+###### Agent Story : connexion au serveur MCP d'inventaire
 
-Connectons notre agent Story au serveur MCP Inventory afin que l'agent puisse découvrir et invoquer les outils du serveur MCP.
+Connectons notre agent Story au serveur MCP d'inventaire afin que l'agent puisse découvrir et invoquer les outils du serveur MCP.
 
 <RunGenerator generator="connection" requiredParameters={{sourceProject:"story", targetProject:"inventory"}} noInteractive />
 
 <details>
-<summary>Examiner les fichiers de connexion Agent Story → Inventaire MCP</summary>
+<summary>Examiner les fichiers de connexion Agent Story → MCP d'inventaire</summary>
 
 Le générateur `connection` génère/met à jour ces fichiers :
 
@@ -1327,7 +1341,7 @@ Le générateur `connection` génère/met à jour ces fichiers :
           - **agentcore\_endpoints.py** Résolution ARN/URL indépendante du framework
           - **agentcore\_mcp\_transport.py** Transport MCP indépendant du framework
           - **agentcore\_mcp\_client\_strands.py** Client MCP Strands encapsulant le transport
-          - auth/ `httpx.Auth` SigV4 / transfert de session indépendant du framework
+          - auth/ SigV4 / session-forwarding `httpx.Auth` indépendant du framework
         - app/
           - **inventory\_mcp\_server\_client\_strands.py** Client Strands pour se connecter au serveur MCP d'inventaire
         - **\_\_init\_\_.py** Ré-exporte les clients par connexion
@@ -1338,18 +1352,18 @@ Le générateur `connection` génère/met à jour ces fichiers :
 </FileTree>
 
 Le générateur :
-- Crée un projet Python partagé `agent_connection` (s'il n'existe pas déjà) avec le `AgentCoreMCPClientStrands` principal
-- Génère une classe `InventoryMcpServerClientStrands` qui gère la connexion au serveur MCP à la fois localement (HTTP direct) et lors du déploiement (via AgentCore avec authentification IAM)
+- Crée un projet Python `agent_connection` partagé (s'il n'existe pas déjà) avec le `AgentCoreMCPClientStrands` de base
+- Génère une classe `InventoryMcpServerClientStrands` qui gère la connexion au serveur MCP localement (HTTP direct) et lors du déploiement (via AgentCore avec authentification IAM)
 - Transforme `agent.py` pour importer le client, créer une instance et connecter les outils du serveur MCP à l'agent
-- Ajoute le projet `agent_connection` en tant que dépendance workspace du projet story
+- Ajoute le projet `agent_connection` comme dépendance de l'espace de travail du projet story
 - Met à jour la cible `dev` pour démarrer automatiquement le serveur MCP lors de l'exécution locale
 
-Pour plus de détails, consultez le <Link path="guides/connection/py-agent-mcp">guide de connexion Python Agent vers MCP</Link>.
+Pour plus de détails, consultez le <Link path="guides/connection/py-agent-mcp">guide de connexion Agent Python vers MCP</Link>.
 </details>
 
-###### Interface utilisateur du jeu : Connexion à l'agent Story
+###### Interface de jeu : connexion à l'agent Story
 
-Connectons notre interface utilisateur du jeu à l'agent Story. Puisque l'agent parle AG-UI, le générateur `connection` câble [CopilotKit](https://docs.copilotkit.ai/) : un composant de chat thématisé et un `HttpAgent` `@ag-ui/client` prêt à rendre.
+Connectons notre interface de jeu à l'agent Story. Puisque l'agent parle AG-UI, le générateur `connection` connecte [CopilotKit](https://docs.copilotkit.ai/) : un composant de chat avec thème et un `HttpAgent` `@ag-ui/client` prêt à être rendu.
 
 <RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-ui", targetProject:"story"}} noInteractive />
 
@@ -1365,44 +1379,44 @@ Le générateur `connection` génère/met à jour ces fichiers :
       - components/
         - **AguiProvider.tsx** `CopilotKitProvider` avec chaque agent AG-UI connecté enregistré
         - copilot/
-          - **index.tsx** `CopilotChat` / `CopilotSidebar` / `CopilotPopup` thématisés Shadcn
+          - **index.tsx** `CopilotChat` / `CopilotSidebar` / `CopilotPopup` avec thème Shadcn
           - ShadcnAssistantMessage.tsx, ShadcnUserMessage.tsx, ShadcnChatInput.tsx, ShadcnCursor.tsx, copilot.css
       - hooks/
-        - **useAguiStoryAgent.tsx** Construit un `HttpAgent`, injecte le token bearer Cognito et remplit `threadId` à l'id de session de 33 caractères d'AgentCore
+        - **useAguiStoryAgent.tsx** Construit un `HttpAgent`, injecte le jeton bearer Cognito et complète `threadId` jusqu'à l'ID de session de 33 caractères d'AgentCore
     - **main.tsx** Enveloppe `<App />` dans `<AguiProvider>`
 
 </FileTree>
 
 Le générateur :
-- Détecte le `ux` du site web React (Shadcn ici) et fournit les composants de chat correspondants.
+- Détecte le `ux` du site web React (Shadcn ici) et fournit des composants de chat correspondants.
 - Enregistre chaque agent connecté sur un seul `CopilotKitProvider` — réexécuter pour un autre agent ajoute simplement un autre hook.
-- Lit l'ARN du runtime de l'agent depuis Runtime Configuration, construit l'URL d'invocation AgentCore et attache le token bearer Cognito plus l'en-tête d'id de session AgentCore.
+- Lit l'ARN runtime de l'agent depuis la Configuration Runtime, construit l'URL d'invocation AgentCore et attache le jeton bearer Cognito ainsi que l'en-tête d'ID de session AgentCore.
 
 Pour plus de détails, consultez le <Link path="guides/connection/react-agui">guide de connexion React vers AG-UI</Link>.
 </details>
 
 ###### Connecter l'API de jeu et le serveur MCP d'inventaire à la base de données
 
-L'API de jeu et le serveur MCP d'inventaire lisent et écrivent tous deux dans notre table DynamoDB, connectons-les donc au projet `DungeonDb`. Le générateur `connection` détecte que la cible est un projet `ts#dynamodb` et câble la cible `dev` de chaque projet source pour démarrer automatiquement DynamoDB Local.
+L'API de jeu et le serveur MCP d'inventaire lisent et écrivent dans notre table DynamoDB, alors connectons-les au projet `DungeonDb`. Le générateur `connection` détecte que la cible est un projet `ts#dynamodb` et connecte la cible `dev` de chaque projet source pour démarrer DynamoDB Local automatiquement.
 
 <RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-api", targetProject:"@dungeon-adventure/dungeon-db"}} noInteractive />
 
 <RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/inventory", targetProject:"@dungeon-adventure/dungeon-db"}} noInteractive />
 
 <Aside type="tip" title="Une commande démarre toute la pile localement">
-Comme la cible `agent-dev` de l'agent Story dépend déjà de la cible `mcp-server-dev` du serveur MCP d'inventaire (via la connexion `story → inventory` ci-dessus), et que l'API de jeu et le serveur MCP dépendent maintenant de `dungeon-db:dev`, l'exécution de la cible `dev` de n'importe quel projet démarre toutes les dépendances dont il a besoin dans le bon ordre.
+Parce que le `agent-dev` de l'agent Story dépend déjà du `mcp-server-dev` du serveur MCP d'inventaire (via la connexion `story → inventory` ci-dessus), et que l'API de jeu et le serveur MCP dépendent maintenant de `dungeon-db:dev`, l'exécution de la cible `dev` d'un projet démarre toutes ses dépendances dans le bon ordre.
 </Aside>
 
-###### Interface utilisateur du jeu : Infrastructure
+###### Interface de jeu : infrastructure
 
-Créons le sous-projet final pour l'infrastructure CDK.
+Créons le dernier sous-projet pour l'infrastructure CDK.
 
 <RunGenerator generator="ts#infra" requiredParameters={{name:"infra"}} noInteractive />
 
 Vous verrez de nouveaux fichiers apparaître/changer dans votre arborescence de fichiers.
 
 <details>
-<summary>Examiner les fichiers générés par `ts#infra` en détail</summary>
+<summary>Examiner en détail les fichiers générés par `ts#infra`</summary>
 
 Le générateur `ts#infra` génère/met à jour ces fichiers. Examinons certains des fichiers clés mis en évidence dans l'arborescence :
 
@@ -1417,17 +1431,17 @@ Le générateur `ts#infra` génère/met à jour ces fichiers. Examinons certains
   - infra
     - src/
       - stages/
-        - **application-stage.ts** stacks CDK définis ici
+        - **application-stage.ts** stacks cdk définies ici
       - stacks/
-        - **application-stack.ts** ressources CDK définies ici
+        - **application-stack.ts** ressources cdk définies ici
       - **main.ts** point d'entrée qui définit toutes les étapes
     - cdk.json
     - checkov.yml
     - project.json
     - ...
   - package.json
-  - tsconfig.json ajoute des références
-  - tsconfig.base.json ajoute un alias
+  - tsconfig.json ajouter des références
+  - tsconfig.base.json ajouter un alias
 
 </FileTree>
 
@@ -1449,9 +1463,9 @@ new ApplicationStage(app, 'dungeon-adventure-infra-sandbox', {
 app.synth();
 ```
 
-<Aside type="tip" title="Corriger les erreurs d'importation">Si vous voyez une erreur d'importation dans votre IDE, c'est parce que notre projet d'infrastructure n'a pas encore de référence TypeScript configurée dans le `tsconfig.json`. Nx a été [configuré](https://nx.dev/nx-api/js/generators/typescript-sync) pour créer ces références *dynamiquement* chaque fois qu'un build/compilation est exécuté ou si vous exécutez la commande `nx sync` manuellement. Pour plus d'informations, consultez le <Link path="guides/typescript-project#importing-your-library-code-in-other-projects">guide TypeScript</Link>.</Aside>
+<Aside type="tip" title="Corriger les erreurs d'import">Si vous voyez une erreur d'import dans votre IDE, c'est parce que notre projet d'infrastructure n'a pas encore de référence TypeScript configurée dans le `tsconfig.json`. Nx a été [configuré](https://nx.dev/nx-api/js/generators/typescript-sync) pour créer ces références *dynamiquement* chaque fois qu'un build/compilation est exécuté ou si vous exécutez la commande `nx sync` manuellement. Pour plus d'informations, consultez le <Link path="guides/typescript-project#importing-your-library-code-in-other-projects">guide TypeScript</Link>.</Aside>
 
-C'est le point d'entrée de votre application CDK.
+Il s'agit du point d'entrée de votre application CDK.
 
 ```ts
 // packages/infra/src/stacks/application-stack.ts
@@ -1467,7 +1481,7 @@ export class ApplicationStack extends Stack {
 }
 ```
 
-Instancions nos constructs CDK pour construire notre jeu d'aventure de donjon.
+Instancions nos constructs CDK pour construire notre jeu d'aventure dans le donjon.
 
 </details>
 
@@ -1480,7 +1494,7 @@ Mettons à jour `packages/infra/src/stacks/application-stack.ts` pour instancier
 <E2EDiff before="dungeon-adventure/1/application-stack.ts.original.template" after="dungeon-adventure/1/application-stack.ts.template" lang="ts" />
 
 :::note[Intégrations par défaut]
-Nous fournissons des intégrations par défaut pour notre API GameApi. Par défaut, chaque opération dans notre API est mappée à une fonction Lambda individuelle pour gérer cette opération.
+Nous fournissons des intégrations par défaut pour notre API de jeu. Par défaut, chaque opération de notre API est mappée à une fonction Lambda individuelle pour gérer cette opération.
 :::
 
 ## Tâche 4 : Construire le code
@@ -1491,7 +1505,7 @@ Nous fournissons des intégrations par défaut pour notre API GameApi. Par défa
 
 La commande `run-many` exécutera une cible sur plusieurs sous-projets listés (`--all` les ciblera tous). Cela garantit que les dépendances sont exécutées dans le bon ordre.
 
-Vous pouvez également déclencher un build (ou toute autre tâche) pour une cible de projet unique en exécutant la cible directement sur le projet. Par exemple, pour construire le projet `@dungeon-adventure/infra`, exécutez la commande suivante :
+Vous pouvez également déclencher un build (ou toute autre tâche) pour une seule cible de projet en exécutant la cible directement sur le projet. Par exemple, pour construire le projet `@dungeon-adventure/infra`, exécutez la commande suivante :
 
 <NxCommands commands={['build infra']} />
 
@@ -1510,7 +1524,7 @@ Pour visualiser vos dépendances, exécutez :
 
 ###### Mise en cache
 
-Nx s'appuie sur la [mise en cache](https://nx.dev/concepts/how-caching-works) pour que vous puissiez réutiliser les artefacts de builds précédents afin d'accélérer le développement. Il y a une certaine configuration requise pour que cela fonctionne correctement et il peut y avoir des cas où vous souhaitez effectuer un build **sans utiliser le cache**. Pour ce faire, ajoutez simplement l'argument `--skip-nx-cache` à votre commande. Par exemple :
+Nx s'appuie sur la [mise en cache](https://nx.dev/concepts/how-caching-works) pour vous permettre de réutiliser les artefacts des builds précédents afin d'accélérer le développement. Une certaine configuration est nécessaire pour que cela fonctionne correctement et il peut y avoir des cas où vous souhaitez effectuer un build **sans utiliser le cache**. Pour ce faire, ajoutez simplement l'argument `--skip-nx-cache` à votre commande. Par exemple :
 
 <NxCommands commands={['build infra --skip-nx-cache']} />
 Si pour une raison quelconque vous souhaitez vider votre cache (stocké dans le dossier `.nx`), vous pouvez exécuter la commande suivante :
@@ -1519,7 +1533,7 @@ Si pour une raison quelconque vous souhaitez vider votre cache (stocké dans le 
 
 </Drawer>
 
-En utilisant la ligne de commande, exécutez la commande suivante pour corriger d'abord les problèmes de lint :
+En utilisant la ligne de commande, exécutez d'abord la commande suivante pour corriger les problèmes de lint :
 
 <PackageManagerShortCommand commands={["lint"]} />
 
@@ -1527,7 +1541,7 @@ Ensuite, exécutez la commande suivante pour un build complet :
 
 <PackageManagerShortCommand commands={["build"]} />
 
-Vous serez invité avec le message suivant :
+Vous serez invité avec ce qui suit :
 
 ```bash
  NX   The workspace is out of sync
@@ -1543,8 +1557,8 @@ No, run the tasks without syncing the changes
 
 Ce message indique que NX a détecté certains fichiers qui peuvent être mis à jour automatiquement pour vous. Dans ce cas, il fait référence aux fichiers `tsconfig.json` qui n'ont pas de références TypeScript configurées sur les projets référencés.
 
-Sélectionnez l'option **Yes, sync the changes and run the tasks** pour continuer. Vous devriez remarquer que toutes vos erreurs d'importation liées à l'IDE sont automatiquement résolues car le générateur de synchronisation ajoutera automatiquement les références TypeScript manquantes !
+Sélectionnez l'option **Yes, sync the changes and run the tasks** pour continuer. Vous devriez remarquer que toutes les erreurs d'import liées à votre IDE sont automatiquement résolues car le générateur de synchronisation ajoutera automatiquement les références TypeScript manquantes !
 
-Tous les artefacts construits sont maintenant disponibles dans le dossier `dist/` situé à la racine du monorepo. C'est une pratique standard lors de l'utilisation de projets générés par le `@aws/nx-plugin` car cela ne pollue pas votre arborescence de fichiers avec des fichiers générés. Si vous souhaitez nettoyer vos fichiers, supprimez le dossier `dist/` sans vous soucier des artefacts de build dispersés dans l'arborescence de fichiers.
+Tous les artefacts construits sont maintenant disponibles dans le `dossier dist/` situé à la racine du monorepo. Il s'agit d'une pratique standard lors de l'utilisation de projets générés par le `@aws/nx-plugin` car cela ne pollue pas votre arborescence de fichiers avec des fichiers générés. Si vous souhaitez nettoyer vos fichiers, supprimez le dossier `dist/` sans vous soucier des artefacts de build dispersés dans l'arborescence de fichiers.
 
-Félicitations ! Vous avez créé tous les sous-projets requis pour commencer à implémenter le cœur de notre jeu d'aventure de donjon IA.  🎉🎉🎉
+Félicitations ! Vous avez créé tous les sous-projets nécessaires pour commencer à implémenter le cœur de notre jeu d'aventure IA dans le donjon.  🎉🎉🎉

--- a/docs/src/content/docs/fr/guides/py-agent.mdx
+++ b/docs/src/content/docs/fr/guides/py-agent.mdx
@@ -51,6 +51,9 @@ Le générateur ajoutera les fichiers suivants à votre projet Python existant. 
         - init.py FastAPI application setup with CORS and error handling middleware
         - agent.py Main agent definition with sample tools
         - session.py Resolves the framework-specific session persistence implementation
+        - middleware/
+          - \_\_init\_\_.py Python package initialization
+          - session_id_middleware.py Binds the inbound AgentCore session ID for the request
         - main.py FastAPI entry point for Bedrock AgentCore Runtime
         - Dockerfile Entry point for hosting your agent (excluded when `infra` is set to `None`)
     - pyproject.toml Updated with Strands dependencies
@@ -70,6 +73,9 @@ Le point d'entrée expose votre agent via le protocole A2A (Strands utilise le [
         - \_\_init\_\_.py Python package initialization
         - agent.py Main agent definition with sample tools
         - session.py Resolves the framework-specific session persistence implementation
+        - middleware/
+          - \_\_init\_\_.py Python package initialization
+          - session_id_middleware.py Binds the inbound AgentCore session ID for the request
         - main.py A2A server entry point
         - Dockerfile Entry point for hosting your agent (excluded when `infra` is set to `None`)
     - pyproject.toml Updated with framework and A2A dependencies
@@ -89,6 +95,9 @@ Le point d'entrée expose votre agent via le protocole [AG-UI](https://docs.ag-u
         - \_\_init\_\_.py Python package initialization
         - agent.py Main agent definition with sample tools
         - session.py Resolves the framework-specific session persistence implementation
+        - middleware/
+          - \_\_init\_\_.py Python package initialization
+          - session_id_middleware.py Binds the inbound AgentCore session ID for the request
         - main.py AG-UI server entry point
         - Dockerfile Entry point for hosting your agent (excluded when `infra` is set to `None`)
     - pyproject.toml Updated with framework and AG-UI dependencies

--- a/docs/src/content/docs/it/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/it/get_started/tutorials/dungeon-game/1.mdx
@@ -1,6 +1,6 @@
 ---
 title: Configurare un monorepo
-description: "Una guida passo-passo su come costruire un gioco di avventura in un dungeon potenziato da AI agentica utilizzando @aws/nx-plugin."
+description: "Una guida su come costruire un gioco d'avventura nel dungeon basato su AI agente usando il @aws/nx-plugin."
 ---
 
 import { Aside, Code, FileTree, Steps, Tabs, TabItem } from '@astrojs/starlight/components';
@@ -450,13 +450,15 @@ Il `py#agent` genera questi file:
     - dungeon_adventure_story/ modulo python
       - agent/
         - main.py punto di ingresso per il tuo agente in Bedrock AgentCore Runtime
-        - agent.py definisce un agente di esempio e strumenti
+        - agent.py definisce un agente e strumenti di esempio
         - session.py risolve un SessionManager per persistere lo stato della conversazione
+        - middleware/
+          - session_id_middleware.py associa l'ID sessione AgentCore in entrata per la richiesta
         - Dockerfile definisce l'immagine docker per il deployment su AgentCore Runtime
   - common/constructs/
     - src
       - app/agents/story-agent/
-        - story-agent.ts costrutto per il deployment del tuo agente Story su AgentCore Runtime
+        - story-agent.ts costrutto per il deployment del tuo Story agent su AgentCore Runtime
 </FileTree>
 
 Diamo un'occhiata ad alcuni dei file in dettaglio:
@@ -490,7 +492,30 @@ Refer to tools as your 'spellbook'.
     )
 ```
 
-Questo crea un agente Strands di esempio e definisce uno strumento di sottrazione. `log_model_errors` e `log_tool_errors` sono hook dal progetto condiviso `dungeon_adventure_agent_connection` che registrano i fallimenti di modello/strumento invece di lasciarli fallire silenziosamente.
+Questo crea un agente Strands di esempio e definisce uno strumento di sottrazione. `log_model_errors` e `log_tool_errors` sono hook del progetto condiviso `dungeon_adventure_agent_connection` che registrano i fallimenti del modello/strumento invece di lasciarli fallire silenziosamente.
+
+```python
+# agent/middleware/session_id_middleware.py
+import uuid
+
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from dungeon_adventure_agent_connection import session_id_context
+
+SESSION_ID_HEADER = "x-amzn-bedrock-agentcore-runtime-session-id"
+
+
+class SessionIdMiddleware(BaseHTTPMiddleware):
+    """Bind the session ID for this request so downstream MCP / A2A clients forward it on outbound calls."""
+
+    async def dispatch(self, request: Request, call_next):
+        session_id = request.headers.get(SESSION_ID_HEADER) or str(uuid.uuid4())
+        with session_id_context(session_id):
+            return await call_next(request)
+```
+
+Il `SessionIdMiddleware` associa l'ID sessione del runtime AgentCore in entrata a un `ContextVar` per la durata della richiesta.
 
 ```python
 # agent/main.py
@@ -505,14 +530,12 @@ from dungeon_adventure_agent_connection import get_current_session_id, session_i
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import StreamingResponse
-from starlette.middleware.base import BaseHTTPMiddleware
 
 from .agent import get_agent
+from .middleware.session_id_middleware import SESSION_ID_HEADER, SessionIdMiddleware
 from .session import get_session_manager
 
 logging.basicConfig(level=logging.INFO)
-
-SESSION_ID_HEADER = "x-amzn-bedrock-agentcore-runtime-session-id"
 
 
 @asynccontextmanager
@@ -529,15 +552,6 @@ async def lifespan(app: FastAPI):
         yield
 
 
-class _SessionIdMiddleware(BaseHTTPMiddleware):
-    """Bind the session ID for this request so downstream MCP / A2A clients forward it on outbound calls."""
-
-    async def dispatch(self, request: Request, call_next):
-        session_id = request.headers.get(SESSION_ID_HEADER) or str(uuid.uuid4())
-        with session_id_context(session_id):
-            return await call_next(request)
-
-
 app = FastAPI(title="AWS Strands - StoryAgent", lifespan=lifespan)
 app.add_middleware(
     CORSMiddleware,
@@ -546,7 +560,7 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
-app.add_middleware(_SessionIdMiddleware)
+app.add_middleware(SessionIdMiddleware)
 
 
 @app.post("/invocations")
@@ -589,7 +603,7 @@ async def ping():
     return {"status": "healthy"}
 ```
 
-Questo è il punto di ingresso per l'agente. Poiché abbiamo selezionato `--protocol=ag-ui`, il generatore avvolge il nostro `Agent` Strands con `StrandsAgent` da [`ag_ui_strands`](https://docs.copilotkit.ai/aws-strands/integration) e lo monta su un'app FastAPI che parla il [protocollo AG-UI](https://docs.copilotkit.ai/aws-strands/protocol) — questo è ciò con cui CopilotKit comunicherà dal sito web React. L'agente è costruito all'interno di un gestore `lifespan` — non al momento dell'import — quindi l'avvio del container, non l'import del modulo, possiede la costruzione, e ogni sessione AgentCore ottiene il proprio container. Il `_SessionIdMiddleware` lega l'ID di sessione AgentCore runtime in ingresso su un `ContextVar` in modo che qualsiasi client MCP/A2A downstream che colleghiamo in seguito (ad es. il server MCP Inventory nel <Link path="get_started/tutorials/dungeon-game/2">Modulo 2</Link>) lo inoltri automaticamente sulle sue chiamate in uscita. Poiché AG-UI memorizza nella cache un agente Strands per `thread_id`, colleghiamo un `session_manager_provider` invece del session manager dell'agente template — questo dà a ogni thread il proprio `SessionManager` in modo che la cronologia delle conversazioni persista tra i turni. Quella funzione `get_session_manager()` proviene da un `session.py` generato: quando deployato, restituisce un `strands.session.S3SessionManager` supportato da un bucket S3 che il generatore fornisce automaticamente; sotto `agent-dev` (`LOCAL_DEV=true`) restituisce sempre un `FileSessionManager` che scrive in una directory temporanea locale, indipendentemente dalla configurazione deployata.
+Questo è il punto di ingresso per l'agente. Poiché abbiamo selezionato `--protocol=ag-ui`, il generatore avvolge il nostro `Agent` Strands con `StrandsAgent` da [`ag_ui_strands`](https://docs.copilotkit.ai/aws-strands/integration) e lo monta su un'app FastAPI che parla il [protocollo AG-UI](https://docs.copilotkit.ai/aws-strands/protocol) — questo è ciò con cui CopilotKit comunicherà dal sito web React. L'agente viene costruito all'interno di un handler `lifespan` — non al momento dell'importazione — quindi l'avvio del container, non l'importazione del modulo, gestisce la costruzione, e ogni sessione AgentCore ottiene il proprio container. Il `SessionIdMiddleware` che abbiamo visto sopra inoltra l'ID sessione del runtime AgentCore in entrata in modo che qualsiasi client MCP/A2A downstream che colleghiamo in seguito (ad es. il server MCP Inventory nel <Link path="get_started/tutorials/dungeon-game/2">Modulo 2</Link>) lo inoltri automaticamente nelle sue chiamate in uscita. Poiché AG-UI memorizza nella cache un agente Strands per `thread_id`, colleghiamo un `session_manager_provider` invece del session manager dell'agente template — questo dà a ogni thread il proprio `SessionManager` in modo che la cronologia delle conversazioni persista tra i turni. Quella funzione `get_session_manager()` proviene da un `session.py` generato: quando deployato, restituisce un `strands.session.S3SessionManager` supportato da un bucket S3 che il generatore fornisce automaticamente; sotto `agent-dev` (`LOCAL_DEV=true`) restituisce sempre un `FileSessionManager` che scrive in una directory temporanea locale, indipendentemente dalla configurazione deployata.
 
 ```ts
 // common/constructs/src/app/agents/story-agent/story-agent.ts

--- a/docs/src/content/docs/it/guides/py-agent.mdx
+++ b/docs/src/content/docs/it/guides/py-agent.mdx
@@ -51,6 +51,9 @@ Il generatore aggiungerà i seguenti file al tuo progetto Python esistente. I fi
         - init.py FastAPI application setup with CORS and error handling middleware
         - agent.py Main agent definition with sample tools
         - session.py Resolves the framework-specific session persistence implementation
+        - middleware/
+          - \_\_init\_\_.py Python package initialization
+          - session_id_middleware.py Binds the inbound AgentCore session ID for the request
         - main.py FastAPI entry point for Bedrock AgentCore Runtime
         - Dockerfile Entry point for hosting your agent (excluded when `infra` is set to `None`)
     - pyproject.toml Updated with Strands dependencies
@@ -70,6 +73,9 @@ Il punto di ingresso espone il tuo agente tramite il protocollo A2A (Strands uti
         - \_\_init\_\_.py Python package initialization
         - agent.py Main agent definition with sample tools
         - session.py Resolves the framework-specific session persistence implementation
+        - middleware/
+          - \_\_init\_\_.py Python package initialization
+          - session_id_middleware.py Binds the inbound AgentCore session ID for the request
         - main.py A2A server entry point
         - Dockerfile Entry point for hosting your agent (excluded when `infra` is set to `None`)
     - pyproject.toml Updated with framework and A2A dependencies
@@ -89,6 +95,9 @@ Il punto di ingresso espone il tuo agente tramite il protocollo [AG-UI](https://
         - \_\_init\_\_.py Python package initialization
         - agent.py Main agent definition with sample tools
         - session.py Resolves the framework-specific session persistence implementation
+        - middleware/
+          - \_\_init\_\_.py Python package initialization
+          - session_id_middleware.py Binds the inbound AgentCore session ID for the request
         - main.py AG-UI server entry point
         - Dockerfile Entry point for hosting your agent (excluded when `infra` is set to `None`)
     - pyproject.toml Updated with framework and AG-UI dependencies
@@ -422,7 +431,7 @@ Quindi, in un altro terminale, avvia la chat:
 
 <NxCommands commands={['run your-project:agent-chat']} />
 
-Il generatore emette uno `scripts/<your-agent-name>/chat.ts` per ogni protocollo. Si connette all'agente locale per impostazione predefinita, o al tuo agente distribuito quando `RUNTIME_CONFIG_APP_ID` è impostato (vedi [Chattare con il tuo agente distribuito](#chat-with-your-deployed-agent) di seguito).
+Il generatore emette uno `scripts/<your-agent-name>/chat.ts` per ogni protocollo. Si connette all'agente locale per impostazione predefinita, o al tuo agente distribuito quando `RUNTIME_CONFIG_APP_ID` è impostato (vedi [Chattare con il tuo agente distribuito](#chattare-con-il-tuo-agente-distribuito) di seguito).
 
 Per gli agenti **HTTP**, lo script di chat utilizza un client TypeScript type-safe generato dalla specifica OpenAPI dell'agente. Il generatore emette anche:
 
@@ -558,7 +567,7 @@ acurl <region> bedrock-agentcore -N -X POST \
 -H 'Content-Type: application/json'
 ```
 
-<Drawer title="Sigv4 enabled curl" trigger="Clicca qui per maggiori dettagli sulla configurazione del comando acurl sopra">
+<Drawer title="Sigv4 enabled curl" trigger="Click here for more details on configuring the above acurl command">
 <Snippet name="tools/acurl" />
 </Drawer>
 </TabItem>
@@ -671,7 +680,7 @@ Utilizza il generatore <Link path="guides/connection">`connection`</Link> per in
   <ConnectionCard
     title="React to Python Agent"
     description="Call a Python Agent from a React website"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'it'}/guides/connection/react-py-agent`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/react-py-agent`}
     source="react"
     target="strands"
     targetBadge="python"
@@ -679,14 +688,14 @@ Utilizza il generatore <Link path="guides/connection">`connection`</Link> per in
   <ConnectionCard
     title="React to AG-UI Agent"
     description="Call an Agent exposing the AG-UI protocol from a React website via CopilotKit"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'it'}/guides/connection/react-agui`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/react-agui`}
     source="react"
     target="copilotkit"
   />
   <ConnectionCard
     title="Python Agent to MCP"
     description="Connect a Python Agent to an MCP server"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'it'}/guides/connection/py-agent-mcp`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/py-agent-mcp`}
     source="strands"
     sourceBadge="python"
     target="mcp"
@@ -694,7 +703,7 @@ Utilizza il generatore <Link path="guides/connection">`connection`</Link> per in
   <ConnectionCard
     title="Python Agent to A2A Agent"
     description="Connect a Python Agent to a remote A2A agent"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'it'}/guides/connection/py-agent-a2a`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/py-agent-a2a`}
     source="strands"
     sourceBadge="python"
     target="a2a"
@@ -702,7 +711,7 @@ Utilizza il generatore <Link path="guides/connection">`connection`</Link> per in
   <ConnectionCard
     title="TypeScript Agent to A2A Agent"
     description="Connect a TypeScript Agent to a remote A2A agent"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'it'}/guides/connection/ts-agent-a2a`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/ts-agent-a2a`}
     source="strands"
     sourceBadge="typescript"
     target="a2a"
@@ -710,7 +719,7 @@ Utilizza il generatore <Link path="guides/connection">`connection`</Link> per in
   <ConnectionCard
     title="Python Agent to Python DynamoDB"
     description="Connect a Python Agent to a DynamoDB table"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'it'}/guides/connection/py-agent-dynamodb`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/py-agent-dynamodb`}
     source="strands"
     sourceBadge="python"
     target="dynamodb"
@@ -719,7 +728,7 @@ Utilizza il generatore <Link path="guides/connection">`connection`</Link> per in
   <ConnectionCard
     title="Python Agent to AgentCore Gateway"
     description="Connect a Python Agent to an AgentCore Gateway"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'it'}/guides/connection/py-agent-gateway`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/py-agent-gateway`}
     source="strands"
     sourceBadge="python"
     target="agentcore"
@@ -727,7 +736,7 @@ Utilizza il generatore <Link path="guides/connection">`connection`</Link> per in
   <ConnectionCard
     title="AgentCore Gateway to Agent"
     description="Front an agent with an AgentCore Gateway as a runtime target"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'it'}/guides/connection/agentcore-gateway-agent`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/agentcore-gateway-agent`}
     source="agentcore"
     target="strands"
   />

--- a/docs/src/content/docs/jp/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/jp/get_started/tutorials/dungeon-game/1.mdx
@@ -1,6 +1,6 @@
 ---
 title: モノレポのセットアップ
-description: "@aws/nx-pluginを使用してエージェント型AI駆動のダンジョンアドベンチャーゲームを構築する方法のウォークスルー。"
+description: "@aws/nx-plugin を使ってエージェント型 AI ダンジョンアドベンチャーゲームを構築するウォークスルー。"
 ---
 
 import { Aside, Code, FileTree, Steps, Tabs, TabItem } from '@astrojs/starlight/components';
@@ -22,17 +22,17 @@ import nxGraphPng from '@assets/nx-graph.png'
 import gameSelectPng from '@assets/game-select.png'
 import gameConversationPng from '@assets/game-conversation.png'
 
-## タスク1: モノレポの作成
+## タスク 1: モノレポを作成する
 
-新しいモノレポを作成するには、目的のディレクトリ内から次のコマンドを実行します:
+新しいモノレポを作成するには、任意のディレクトリ内で次のコマンドを実行します:
 
 <CreateNxWorkspaceCommand workspace="dungeon-adventure" iac="cdk" />
 
-:::note[IaCプロバイダーとしてのCDK]
-このチュートリアルではインフラストラクチャをコードとして管理するためにCDKを使用するため、`--iac=cdk`を使用します。Nx Plugin for AWSは`terraform`もサポートしています。
+:::note[IaC プロバイダーとしての CDK]
+このチュートリアルではインフラストラクチャーコードに CDK を使用するため、`--iac=cdk` を指定します。AWS 向け Nx Plugin は `terraform` もサポートしています。
 :::
 
-これにより、`dungeon-adventure`ディレクトリ内にNXモノレポがセットアップされます。VSCodeでディレクトリを開くと、次のファイル構造が表示されます:
+これにより `dungeon-adventure` ディレクトリ内に NX モノレポがセットアップされます。VSCode でそのディレクトリを開くと、次のファイル構造が表示されます:
 
 <FileTree>
 - .nx/
@@ -40,37 +40,37 @@ import gameConversationPng from '@assets/game-conversation.png'
 - node_modules/
 - packages/ サブプロジェクトが配置される場所
 - .gitignore
-- biome.json Biomeのリントとフォーマットを設定
-- nx.json Nx CLIとモノレポのデフォルトを設定
-- package.json すべてのnode依存関係がここで定義される
-- pnpm-lock.yaml または bun.lock、yarn.lock、package-lock.json（パッケージマネージャーによる）
-- pnpm-workspace.yaml pnpmを使用する場合
+- biome.json リントとフォーマットのための Biome 設定
+- nx.json Nx CLI とモノレポのデフォルト設定
+- package.json すべての node 依存関係はここで定義
+- pnpm-lock.yaml パッケージマネージャーによって bun.lock、yarn.lock、package-lock.json になる場合もある
+- pnpm-workspace.yaml pnpm を使用する場合
 - README.md
-- tsconfig.base.json すべてのnodeベースのサブプロジェクトがこれを拡張
+- tsconfig.base.json すべての node ベースのサブプロジェクトはこれを継承する
 - tsconfig.json
-- aws-nx-plugin.config.mts Nx Plugin for AWSの設定
+- aws-nx-plugin.config.mts AWS 向け Nx Plugin の設定
 </FileTree>
 
-<Aside type="tip" title="頻繁にコミット">ジェネレーターを実行する前に、ステージングされていないすべてのファイルがGitにコミットされていることを確認するのがベストプラクティスです。これにより、`git diff`を使用してジェネレーター実行後の変更を確認できます。</Aside>
+<Aside type="tip" title="こまめにコミットしよう">ジェネレーターを実行する前に、すべてのステージングされていないファイルを Git にコミットしておくことがベストプラクティスです。これにより、`git diff` でジェネレーター実行後の変更を確認できます。</Aside>
 
-## タスク2: Dungeon Adventure Gameのスキャフォールディング
+## タスク 2: ダンジョンアドベンチャーゲームのスキャフォールド
 
-ワークスペースが準備できたら、ゲームのサブプロジェクト（Game API、Story Agent、Inventory MCPサーバー、ゲームデータベース、ウェブサイト）と、それらを接続する配線をスキャフォールディングします。これには2つの方法があります：
+ワークスペースが整ったら、ゲームのサブプロジェクト（Game API、Story Agent、Inventory MCP サーバー、ゲームデータベース、ウェブサイト）と、それらを繋ぐ接続をスキャフォールドします。方法は 2 つあります:
 
-- **クイック** — 以下の図からコマンドを直接コピーして実行します。同じ開始点に到達する最速の方法です。
-- **ステップバイステップ** — 以下のセクションを展開して、各ジェネレーターを自分で実行し、それぞれが何を生成するかを正確に確認します。
+- **クイック** — 下の図からコマンドをそのままコピーして実行します。同じ出発点に最速で到達できます。
+- **ステップバイステップ** — 下のセクションを展開して、各ジェネレーターを自分で実行し、それぞれが何を生成するかを詳しく確認します。
 
-以下の図は、Dungeon Adventureワークスペース_そのもの_です：このモジュールで構築するすべてのプロジェクト、コンポーネント、接続が含まれています。**Copy commands**をクリックして全シリーズを取得し、タスク1で作成した`dungeon-adventure`ディレクトリ内から実行してください。
+下の図はダンジョンアドベンチャーワークスペースそのものです: このモジュールで構築するすべてのプロジェクト、コンポーネント、接続が含まれています。**コマンドをコピー** をクリックしてシリーズ全体を取得し、タスク 1 で作成した `dungeon-adventure` ディレクトリ内から実行してください。
 
 <EmbeddedGraph preset="dungeon-adventure" workspace="dungeon-adventure" iac="cdk" skipWorkspace />
 
-<Drawer title="ステップバイステップ" trigger="ステップバイステップ: 各ジェネレーターを自分で実行して、何が生成されるかを確認する">
+<Drawer title="ステップバイステップ" trigger="ステップバイステップ: 各ジェネレーターを自分で実行して何が生成されるか確認する">
 
-コマンドを一度にすべてコピーするのではなく、各ジェネレーターを個別に実行できます。これは、各ジェネレーターがワークスペースに何を追加するかを理解するための最良の方法です。タスク1で作成した`dungeon-adventure`ディレクトリ内から、各ジェネレーターを順番に実行してください。
+コマンドを一度にコピーする代わりに、各ジェネレーターを個別に実行できます。これは各ジェネレーターがワークスペースに何を追加するかを理解する最良の方法です。タスク 1 で作成した `dungeon-adventure` ディレクトリ内から、各ジェネレーターを順番に実行してください。
 
-##### Game APIの作成
+##### Game API を作成する
 
-まず、Game APIを作成しましょう。これを行うには、次の手順で`GameApi`というtRPC APIを作成します：
+まず、Game API を作成しましょう。次の手順で `GameApi` という名前の tRPC API を作成します:
 
 <RunGenerator generator="ts#api" requiredParameters={{ name: "GameApi", framework: "trpc" }} noInteractive />
 
@@ -79,30 +79,30 @@ import gameConversationPng from '@assets/game-conversation.png'
 ファイルツリーに新しいファイルが表示されます。
 
 <Aside title="ルート依存関係">
-ルートの`package.json`は、`type`が`module`として設定されており、これは`@aws/nx-plugin`によって提供されるすべてのnodeベースのサブプロジェクトのデフォルトモジュールタイプがESMであることを意味します。
-TypeScriptプロジェクトの操作の詳細については、<Link path="guides/typescript-project">ts#projectジェネレーターガイド</Link>を参照してください。
+ルートの `package.json` には `module` タイプが設定されており、これは `@aws/nx-plugin` が提供するすべての node ベースのサブプロジェクトのデフォルトモジュールタイプが ESM であることを意味します。
+TypeScript プロジェクトの操作の詳細については、<Link path="guides/typescript-project">ts#project ジェネレーターガイド</Link>を参照してください。
 </Aside>
 
 <details>
-<summary>生成された`ts#api`ファイルを詳しく調べる</summary>
+<summary>生成された `ts#api` ファイルを詳しく確認する</summary>
 
-以下は、`ts#api`ジェネレーターによって生成されたすべてのファイルのリストです。ファイルツリーで強調表示されている主要なファイルのいくつかを調べます：
+以下は `ts#api` ジェネレーターによって生成されたすべてのファイルの一覧です。ファイルツリーでハイライトされているいくつかの重要なファイルを確認します:
 <FileTree>
 - packages/
   - common/
     - constructs/
       - src/
-        - app/ アプリ固有のcdkコンストラクト
+        - app/ アプリ固有の cdk コンストラクト
           - apis/
-            - **game-api.ts** tRPC APIを作成するためのcdkコンストラクト
+            - **game-api.ts** tRPC API を作成する cdk コンストラクト
             - index.ts
             - ...
           - index.ts
-        - core/ 汎用cdkコンストラクト
+        - core/ 汎用 cdk コンストラクト
           - api/
-            - rest-api.ts API Gateway Rest APIの基本cdkコンストラクト
-            - trpc-utils.ts trpc API CDKコンストラクトのユーティリティ
-            - utils.ts APIコンストラクトのユーティリティ
+            - rest-api.ts API Gateway Rest API のベース cdk コンストラクト
+            - trpc-utils.ts trpc API CDK コンストラクトのユーティリティ
+            - utils.ts API コンストラクトのユーティリティ
           - index.ts
           - runtime-config.ts
         - index.ts
@@ -110,31 +110,31 @@ TypeScriptプロジェクトの操作の詳細については、<Link path="guid
       - ...
   - game-api/ tRPC API
     - src/
-      - client/ 通常、tsマシン間通信に使用されるバニラクライアント
+      - client/ ts のマシン間通信に使用するバニラクライアント
         - index.ts
-      - middleware/ powertoolsインストルメンテーション
+      - middleware/ powertools インストルメンテーション
         - error.ts
         - index.ts
         - logger.ts
         - metrics.ts
         - tracer.ts
-      - schema/ APIの入力と出力の定義
+      - schema/ API の入出力定義
         - index.ts
-        - **echo.ts** サンプル入力と出力スキーマ
-        - z-async-iterable.ts tRPCサブスクリプション出力用のラッパーZodスキーマ
-      - procedures/ APIプロシージャ/ルートの具体的な実装
-        - **echo.ts** サンプルプロシージャ実装
+        - **echo.ts** サンプルの入出力スキーマ
+        - z-async-iterable.ts tRPC サブスクリプション出力用のラッパー Zod スキーマ
+      - procedures/ API プロシージャ/ルートの具体的な実装
+        - **echo.ts** サンプルプロシージャの実装
       - index.ts
-      - init.ts コンテキストとミドルウェアをセットアップ
-      - handler.ts Lambdaハンドラーエントリーポイント（REST APIのレスポンスストリーミングを使用）
-      - local-server.ts tRPCサーバーをローカルで実行する際に使用
-      - **router.ts** tRPCルーターとすべてのプロシージャを定義
+      - init.ts コンテキストとミドルウェアのセットアップ
+      - handler.ts Lambda ハンドラーエントリーポイント（REST API にはレスポンスストリーミングを使用）
+      - local-server.ts tRPC サーバーをローカルで実行する際に使用
+      - **router.ts** tRPC ルーターとすべてのプロシージャを定義
     - project.json
     - ...
 - vitest.workspace.ts
 </FileTree>
 
-これらの主要なファイルを見てみましょう：
+これらの重要なファイルを見てみましょう:
 
 ```ts {7}
 // packages/game-api/src/router.ts
@@ -149,7 +149,7 @@ export const appRouter = router({
 
 export type AppRouter = typeof appRouter;
 ```
-ルーターはAPIのtRPCルーターを定義し、すべてのAPIメソッドを宣言する場所です。上記のように、`echo`というメソッドがあり、その実装は`./procedures/echo.ts`ファイルにあります。Lambdaハンドラーエントリーポイントは`handler.ts`にあり、ジェネレーターによって自動的に設定されます。
+ルーターは API の tRPC ルーターを定義し、すべての API メソッドを宣言する場所です。上記のように、`echo` というメソッドがあり、その実装は `./procedures/echo.ts` ファイルにあります。Lambda ハンドラーエントリーポイントは `handler.ts` にあり、ジェネレーターによって自動的に設定されます。
 
 ```ts {7-10}
 // packages/game-api/src/procedures/echo.ts
@@ -165,7 +165,7 @@ export const echo = publicProcedure
   .query((opts) => ({ message: opts.input.message }));
 ```
 
-このファイルは`echo`メソッドの実装であり、入力と出力のデータ構造を宣言することで強く型付けされています。
+このファイルは `echo` メソッドの実装であり、入出力データ構造を宣言することで強く型付けされています。
 
 ```ts
 // packages/game-api/src/schema/echo.ts
@@ -184,7 +184,7 @@ export const EchoOutputSchema = z.object({
 export type IEchoOutput = z.TypeOf<typeof EchoOutputSchema>;
 ```
 
-すべてのtRPCスキーマ定義は[Zod](https://zod.dev/)を使用して定義され、`z.TypeOf`構文を介してtypescriptタイプとしてエクスポートされます。
+すべての tRPC スキーマ定義は [Zod](https://zod.dev/) を使用して定義され、`z.TypeOf` 構文を通じて TypeScript 型としてエクスポートされます。
 
 ```ts
 // packages/common/constructs/src/app/apis/game-api.ts
@@ -390,76 +390,78 @@ export class GameApi<
 }
 ```
 
-これは`GameApi`を定義するCDKコンストラクトです。`defaultIntegrations`メソッドを提供し、tRPC APIの各プロシージャに対してLambda関数を自動的に作成し、バンドルされたAPI実装を指します。これは、`cdk synth`時にバンドルが発生しないことを意味します（[NodeJsFunction](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_lambda_nodejs.NodejsFunction.html)を使用する場合とは対照的）。バックエンドプロジェクトのビルドターゲットの一部として既にバンドルされているためです。
+これは `GameApi` を定義する CDK コンストラクトです。`defaultIntegrations` メソッドを提供し、tRPC API の各プロシージャに対して Lambda 関数を自動的に作成し、バンドルされた API 実装を指定します。これは `cdk synth` 時にバンドルが発生しないことを意味します（[NodeJsFunction](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_lambda_nodejs.NodejsFunction.html) を使用する場合とは異なり）。バックエンドプロジェクトのビルドターゲットの一部としてすでにバンドルされているためです。
 
 </details>
 
-##### Story Agentの作成
+##### Story Agent を作成する
 
-次に、Story Agentを作成しましょう。
+次に Story Agent を作成しましょう。
 
-###### Story agent: Pythonプロジェクト
+###### Story agent: Python プロジェクト
 
-Pythonプロジェクトを作成するには：
+Python プロジェクトを作成するには:
 
 <RunGenerator generator="py#project" requiredParameters={{name:"story"}} noInteractive />
 
 ファイルツリーに新しいファイルが表示されます。
 <details>
-<summary>生成された`py#project`ファイルを詳しく調べる</summary>
+<summary>生成された `py#project` ファイルを詳しく確認する</summary>
 
-`py#project`は次のファイルを生成します：
+`py#project` は次のファイルを生成します:
 
 <FileTree>
 - .venv/ モノレポ用の単一仮想環境
 - packages/
   - story/
-    - dungeon_adventure_story/ pythonモジュール
+    - dungeon_adventure_story/ Python モジュール
     - tests/
     - .python-version
     - pyproject.toml
     - project.json
-- .python-version 固定されたuvのpythonバージョン
+- .python-version ピン留めされた uv Python バージョン
 - pyproject.toml
 - uv.lock
 </FileTree>
 
-これにより、共有仮想環境を持つPythonプロジェクトと[UV Workspace](https://docs.astral.sh/uv/concepts/projects/workspaces/)が設定されました。
+これにより、Python プロジェクトと共有仮想環境を持つ [UV Workspace](https://docs.astral.sh/uv/concepts/projects/workspaces/) が設定されます。
 
 </details>
 
 ###### Story agent
 
-`py#agent`ジェネレーターを使用してプロジェクトにStrandsエージェントを追加するには：
+`py#agent` ジェネレーターでプロジェクトに Strands エージェントを追加するには:
 
 <RunGenerator generator="py#agent" requiredParameters={{project:"story", auth:"cognito", protocol:"ag-ui"}} noInteractive />
 
-:::note[AG-UIプロトコル]
-`--protocol=ag-ui`を選択することで、エージェントが[Agent-User Interactionプロトコル](https://docs.copilotkit.ai/aws-strands/protocol)を話すようになります。これにより、Reactウェブサイトが[CopilotKit](https://docs.copilotkit.ai/)を介して直接通信でき、ストリーミング、ツール呼び出し、会話履歴がプロトコルによって処理され、手作りのHTTPクライアントは不要になります。
+:::note[AG-UI プロトコル]
+`--protocol=ag-ui` を選択することで、エージェントが [Agent-User Interaction プロトコル](https://docs.copilotkit.ai/aws-strands/protocol) を話すようになります。これにより、React ウェブサイトが [CopilotKit](https://docs.copilotkit.ai/) を通じて直接エージェントと通信でき、ストリーミング、ツール呼び出し、会話履歴がプロトコルによって処理されます（手作りの HTTP クライアントは不要）。
 :::
 
 ファイルツリーに新しいファイルが表示されます。
 <details>
-<summary>生成された`py#agent`ファイルを詳しく調べる</summary>
+<summary>生成された `py#agent` ファイルを詳しく確認する</summary>
 
-`py#agent`は次のファイルを生成します：
+`py#agent` は次のファイルを生成します:
 
 <FileTree>
 - packages/
   - story/
-    - dungeon_adventure_story/ pythonモジュール
+    - dungeon_adventure_story/ Python モジュール
       - agent/
-        - main.py Bedrock AgentCore Runtimeでのエージェントのエントリーポイント
+        - main.py Bedrock AgentCore Runtime でのエージェントのエントリーポイント
         - agent.py サンプルエージェントとツールを定義
-        - session.py 会話状態を永続化するためのSessionManagerを解決
-        - Dockerfile AgentCore Runtimeへのデプロイ用のDockerイメージを定義
+        - session.py 会話状態を永続化するための SessionManager を解決
+        - middleware/
+          - session_id_middleware.py リクエストの受信 AgentCore セッション ID をバインド
+        - Dockerfile AgentCore Runtime へのデプロイ用 Docker イメージを定義
   - common/constructs/
     - src
       - app/agents/story-agent/
-        - story-agent.ts StoryエージェントをAgentCore Runtimeにデプロイするためのコンストラクト
+        - story-agent.ts Story エージェントを AgentCore Runtime にデプロイするコンストラクト
 </FileTree>
 
-いくつかのファイルを詳しく見てみましょう：
+いくつかのファイルを詳しく見てみましょう:
 
 ```python
 # agent/agent.py
@@ -490,7 +492,30 @@ Refer to tools as your 'spellbook'.
     )
 ```
 
-これはサンプルのStrandsエージェントを作成し、減算ツールを定義します。`log_model_errors`と`log_tool_errors`は、共有の`dungeon_adventure_agent_connection`プロジェクトのフックで、モデル/ツールの失敗を黙って失敗させるのではなく、ログに記録します。
+これはサンプルの Strands エージェントを作成し、減算ツールを定義します。`log_model_errors` と `log_tool_errors` は共有の `dungeon_adventure_agent_connection` プロジェクトのフックで、モデル/ツールの失敗をサイレントに失敗させる代わりにログに記録します。
+
+```python
+# agent/middleware/session_id_middleware.py
+import uuid
+
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from dungeon_adventure_agent_connection import session_id_context
+
+SESSION_ID_HEADER = "x-amzn-bedrock-agentcore-runtime-session-id"
+
+
+class SessionIdMiddleware(BaseHTTPMiddleware):
+    """Bind the session ID for this request so downstream MCP / A2A clients forward it on outbound calls."""
+
+    async def dispatch(self, request: Request, call_next):
+        session_id = request.headers.get(SESSION_ID_HEADER) or str(uuid.uuid4())
+        with session_id_context(session_id):
+            return await call_next(request)
+```
+
+`SessionIdMiddleware` はリクエストの期間中、受信した AgentCore ランタイムセッション ID を `ContextVar` にバインドします。
 
 ```python
 # agent/main.py
@@ -505,14 +530,12 @@ from dungeon_adventure_agent_connection import get_current_session_id, session_i
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import StreamingResponse
-from starlette.middleware.base import BaseHTTPMiddleware
 
 from .agent import get_agent
+from .middleware.session_id_middleware import SESSION_ID_HEADER, SessionIdMiddleware
 from .session import get_session_manager
 
 logging.basicConfig(level=logging.INFO)
-
-SESSION_ID_HEADER = "x-amzn-bedrock-agentcore-runtime-session-id"
 
 
 @asynccontextmanager
@@ -529,15 +552,6 @@ async def lifespan(app: FastAPI):
         yield
 
 
-class _SessionIdMiddleware(BaseHTTPMiddleware):
-    """Bind the session ID for this request so downstream MCP / A2A clients forward it on outbound calls."""
-
-    async def dispatch(self, request: Request, call_next):
-        session_id = request.headers.get(SESSION_ID_HEADER) or str(uuid.uuid4())
-        with session_id_context(session_id):
-            return await call_next(request)
-
-
 app = FastAPI(title="AWS Strands - StoryAgent", lifespan=lifespan)
 app.add_middleware(
     CORSMiddleware,
@@ -546,7 +560,7 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
-app.add_middleware(_SessionIdMiddleware)
+app.add_middleware(SessionIdMiddleware)
 
 
 @app.post("/invocations")
@@ -589,7 +603,7 @@ async def ping():
     return {"status": "healthy"}
 ```
 
-これはエージェントのエントリーポイントです。`--protocol=ag-ui`を選択したため、ジェネレーターは[`ag_ui_strands`](https://docs.copilotkit.ai/aws-strands/integration)の`StrandsAgent`でStrandsの`Agent`をラップし、[AG-UIプロトコル](https://docs.copilotkit.ai/aws-strands/protocol)を話すFastAPIアプリにマウントします。これがReactウェブサイトからCopilotKitが通信する相手です。エージェントは`lifespan`ハンドラー内で構築されます（インポート時ではありません）。これにより、コンテナの起動（モジュールのインポートではなく）が構築を所有し、各AgentCoreセッションが独自のコンテナを取得します。`_SessionIdMiddleware`は、インバウンドのAgentCoreランタイムセッションIDを`ContextVar`にバインドするため、後で配線する下流のMCP/A2Aクライアント（<Link path="jp/get_started/tutorials/dungeon-game/2">モジュール2</Link>のInventory MCPサーバーなど）が、アウトバウンド呼び出しで自動的に転送します。AG-UIは`thread_id`ごとに1つのStrandsエージェントをキャッシュするため、テンプレートエージェント自身のセッションマネージャーではなく、`session_manager_provider`をプラグインします。これにより、各スレッドが独自の`SessionManager`を取得し、会話履歴がターン間で永続化されます。その`get_session_manager()`関数は、生成された`session.py`の兄弟から来ています：デプロイされると、ジェネレーターが自動的にプロビジョニングするS3バケットに支えられた`strands.session.S3SessionManager`を返します。`agent-dev`（`LOCAL_DEV=true`）では、デプロイされた設定に関係なく、常にローカルの一時ディレクトリに書き込む`FileSessionManager`を返します。
+これはエージェントのエントリーポイントです。`--protocol=ag-ui` を選択したため、ジェネレーターは Strands の `Agent` を [`ag_ui_strands`](https://docs.copilotkit.ai/aws-strands/integration) の `StrandsAgent` でラップし、[AG-UI プロトコル](https://docs.copilotkit.ai/aws-strands/protocol) を話す FastAPI アプリにマウントします。これが React ウェブサイトから CopilotKit が通信する相手です。エージェントはインポート時ではなく `lifespan` ハンドラー内で構築されるため、コンテナの起動（モジュールのインポートではなく）が構築を担い、各 AgentCore セッションは独自のコンテナを取得します。上記の `SessionIdMiddleware` は受信した AgentCore ランタイムセッション ID を転送するため、後でワイヤーアップするダウンストリームの MCP/A2A クライアント（例: <Link path="get_started/tutorials/dungeon-game/2">モジュール 2</Link> の Inventory MCP サーバー）が送信呼び出し時に自動的に転送します。AG-UI は `thread_id` ごとに 1 つの Strands エージェントをキャッシュするため、テンプレートエージェント自身のセッションマネージャーではなく `session_manager_provider` を接続します。これにより各スレッドが独自の `SessionManager` を持ち、会話履歴がターン間で永続化されます。その `get_session_manager()` 関数は生成された `session.py` の兄弟ファイルから来ています: デプロイ時はジェネレーターが自動的にプロビジョニングする S3 バケットに裏付けられた `strands.session.S3SessionManager` を返し、`agent-dev`（`LOCAL_DEV=true`）では、デプロイ設定に関わらず常にローカルの一時ディレクトリに書き込む `FileSessionManager` を返します。
 
 ```ts
 // common/constructs/src/app/agents/story-agent/story-agent.ts
@@ -877,28 +891,28 @@ export class StoryAgent extends Construct implements IGrantable, IConnectable {
 }
 ```
 
-これは、エージェントのDockerイメージをECRにアップロードし、AgentCore Runtimeを使用してホストするCDK `AgentRuntimeArtifact`を設定します。`--auth=cognito`を選択したため、コンストラクトはユーザープール/クライアントIDを必要とし、Cognitoを介してAgentCore Runtime呼び出しを認可し、呼び出し元の`Authorization`ヘッダーを転送します。また、Story Agentの`session.py`が実行時に読み取るセッションバケット（CloudWatch Logsに配信されるサーバーアクセスログを持つKMS暗号化されたS3バケット）をプロビジョニングし、エージェントに読み取り/書き込みアクセスを許可し、Bedrockモデルを呼び出すアクセスを許可し、そのARNとバケット名を`RuntimeConfig`に登録して、エージェント（実行時、AppConfig経由）とGame API（synth時、`invocationUrl`経由）の両方が見つけられるようにします。
+これは CDK の `AgentRuntimeArtifact` を設定し、エージェントの Docker イメージを ECR にアップロードして AgentCore Runtime でホストします。`--auth=cognito` を選択したため、コンストラクトはユーザープール/クライアントの ID を必要とし、Cognito を通じて AgentCore Runtime の呼び出しを認可し、呼び出し元の `Authorization` ヘッダーを転送します。また、Story Agent の `session.py` がランタイムで読み取るセッションバケット（CloudWatch Logs にサーバーアクセスログを配信する KMS 暗号化 S3 バケット）をプロビジョニングし、エージェントへの読み書きアクセスを付与し、Bedrock モデルを呼び出すアクセスを付与し、エージェント（ランタイム時、AppConfig 経由）と Game API（synth 時、`invocationUrl` 経由）の両方が見つけられるように ARN とバケット名を `RuntimeConfig` に登録します。
 
-追加の`Dockerfile`があることに気付くかもしれません。これは`story`プロジェクトのDockerイメージを参照しており、Dockerfileとエージェントのソースコードを同じ場所に配置できます。
+`story` プロジェクトの Docker イメージを参照する追加の `Dockerfile` があることに気づくかもしれません。これにより Dockerfile とエージェントのソースコードを同じ場所に配置できます。
 
 </details>
 
-##### Inventoryツールのセットアップ
+##### Inventory ツールのセットアップ
 
-###### Inventory: TypeScriptプロジェクト
+###### Inventory: TypeScript プロジェクト
 
-Story Agentがプレイヤーのインベントリを管理するためのツールを提供するMCPサーバーを作成しましょう。
+Story Agent がプレイヤーのインベントリを管理するためのツールを提供する MCP サーバーを作成しましょう。
 
-まず、TypeScriptプロジェクトを作成します：
+まず、TypeScript プロジェクトを作成します:
 
 <RunGenerator generator="ts#project" requiredParameters={{name:"inventory"}} noInteractive />
 
-これにより、空のTypeScriptプロジェクトが作成されます。
+これにより空の TypeScript プロジェクトが作成されます。
 
 <details>
-<summary>生成された`ts#project`ファイルを詳しく調べる</summary>
+<summary>生成された `ts#project` ファイルを詳しく確認する</summary>
 
-`ts#project`ジェネレーターは次のファイルを生成します。
+`ts#project` ジェネレーターはこれらのファイルを生成します。
 
 <FileTree>
 - packages/
@@ -907,125 +921,125 @@ Story Agentがプレイヤーのインベントリを管理するためのツー
       - index.ts サンプル関数を含むエントリーポイント
     - project.json プロジェクト設定
     - vitest.config.mts テスト設定
-    - tsconfig.json プロジェクトの基本typescript設定
-    - tsconfig.lib.json コンパイルとバンドル用のプロジェクトのtypescript設定
-    - tsconfig.spec.json テスト用のtypescript設定
-- tsconfig.base.json 他のプロジェクトがこれを参照するためのエイリアスを設定するように更新
+    - tsconfig.json プロジェクトのベース TypeScript 設定
+    - tsconfig.lib.json コンパイルとバンドル向けの TypeScript 設定
+    - tsconfig.spec.json テスト用の TypeScript 設定
+- tsconfig.base.json 他のプロジェクトがこれを参照するためのエイリアスを設定するよう更新
 </FileTree>
 
 </details>
 
-###### Inventory: MCPサーバー
+###### Inventory: MCP サーバー
 
-次に、TypeScriptプロジェクトにMCPサーバーを追加します：
+次に、TypeScript プロジェクトに MCP サーバーを追加します:
 
 <RunGenerator generator="ts#mcp-server" requiredParameters={{project:"inventory"}} noInteractive />
 
-これによりMCPサーバーが追加されます。
+これにより MCP サーバーが追加されます。
 <details>
-<summary>生成された`ts#mcp-server`ファイルを詳しく調べる</summary>
+<summary>生成された `ts#mcp-server` ファイルを詳しく確認する</summary>
 
-`ts#mcp-server`ジェネレーターは次のファイルを生成します。
+`ts#mcp-server` ジェネレーターはこれらのファイルを生成します。
 
 <FileTree>
 - packages/
   - inventory/
     - src/mcp-server/
       - index.ts バレルエクスポート
-      - server.ts MCPサーバーを作成
+      - server.ts MCP サーバーを作成
       - tools/
         - divide.ts サンプルツール
       - resources/
         - sample-guidance.ts サンプルリソース
-      - stdio.ts STDIO転送を使用したMCPのエントリーポイント
-      - http.ts ストリーマブルHTTP転送を使用したMCPのエントリーポイント
-      - Dockerfile AgentCore Runtimeへのデプロイ用のイメージをビルド
-    - rolldown.config.ts AgentCoreへのデプロイ用にMCPサーバーをバンドルするための設定
+      - stdio.ts STDIO トランスポートを使用した MCP のエントリーポイント
+      - http.ts Streamable HTTP トランスポートを使用した MCP のエントリーポイント
+      - Dockerfile AgentCore Runtime へのデプロイ用イメージをビルド
+    - rolldown.config.ts AgentCore へのデプロイ用 MCP サーバーバンドルの設定
   - common/constructs/
     - src
       - app/mcp-servers/inventory-mcp-server/
-        - inventory-mcp-server.ts inventory MCPサーバーをAgentCore Runtimeにデプロイするためのコンストラクト
+        - inventory-mcp-server.ts inventory MCP サーバーを AgentCore Runtime にデプロイするコンストラクト
 </FileTree>
 
 </details>
 
-##### ゲームデータベースの作成
+##### ゲームデータベースを作成する
 
-ゲームの状態（保存されたゲームと各プレイヤーのインベントリ）は[Amazon DynamoDB](https://aws.amazon.com/dynamodb/)に保存されます。`ts#dynamodb`ジェネレーターを使用して`DungeonDb`というDynamoDBプロジェクトを作成します：
+ゲームの状態（セーブデータと各プレイヤーのインベントリ）は [Amazon DynamoDB](https://aws.amazon.com/dynamodb/) に保存されます。`ts#dynamodb` ジェネレーターで `DungeonDb` という名前の DynamoDB プロジェクトを作成します:
 
 <RunGenerator generator="ts#dynamodb" requiredParameters={{name:"DungeonDb"}} noInteractive />
 
 :::tip[ローカルファースト開発]
-`ts#dynamodb`ジェネレーターは、コンテナ内で[DynamoDB Local](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html)を実行する`dev`ターゲットを提供します。以下で実行する`connection`ジェネレーターと組み合わせることで、**チュートリアルの最後までデプロイせずに、ゲーム全体がマシン上で実行されます**。
+`ts#dynamodb` ジェネレーターはコンテナ内で [DynamoDB Local](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html) を実行する `dev` ターゲットを提供します。`connection` ジェネレーター（以下で実行）と組み合わせることで、チュートリアルの終わりまで**デプロイなしでゲーム全体がマシン上で動作します**。
 :::
 
 ファイルツリーに新しいファイルが表示されます。
 <details>
-<summary>生成された`ts#dynamodb`ファイルを詳しく調べる</summary>
+<summary>生成された `ts#dynamodb` ファイルを詳しく確認する</summary>
 
-`ts#dynamodb`ジェネレーターは次のファイルを生成します。
+`ts#dynamodb` ジェネレーターはこれらのファイルを生成します。
 
 <FileTree>
 - packages/
   - dungeon-db/
-    - config.json ポート、テーブル名、コンテナ設定、グローバルセカンダリインデックスを含むDynamoDB設定
+    - config.json ポート、テーブル名、コンテナ設定、グローバルセカンダリインデックスを含む DynamoDB 設定
     - src/
       - index.ts エントリーポイントとエクスポート
-      - client.ts DynamoDBクライアントシングルトンとテーブル名解決
+      - client.ts DynamoDB クライアントシングルトンとテーブル名解決
       - entities/
-        - example.ts サンプルElectroDBエンティティ（これを置き換えます）
+        - example.ts サンプル ElectroDB エンティティ（後で置き換えます）
         - index.ts エンティティエクスポート
-    - project.json `dev`と`pull-image`ターゲットを追加
+    - project.json `dev` と `pull-image` ターゲットを追加
   - common/
     - scripts/
       - src/
         - dynamodb/
-          - create-local-table.ts DynamoDB Localにテーブルを作成
-          - pull-image.ts DynamoDB Localイメージをプル
-          - start-container.ts DynamoDB Localコンテナを起動
+          - create-local-table.ts DynamoDB Local にテーブルを作成
+          - pull-image.ts DynamoDB Local イメージをプル
+          - start-container.ts DynamoDB Local コンテナを起動
     - constructs/
       - src/
         - app/dynamodb/
-          - dungeon-db.ts テーブルをプロビジョニングするためのコンストラクト
+          - dungeon-db.ts テーブルをプロビジョニングするコンストラクト
         - core/
-          - dynamodb.ts 汎用DynamoDBテーブルコンストラクト
+          - dynamodb.ts 汎用 DynamoDB テーブルコンストラクト
 </FileTree>
 
-生成された`src/client.ts`は`getDynamoDBClient()`と`resolveTableName()`をエクスポートします。`LOCAL_DEV=true`の場合（`dev`ターゲットによって自動的に設定されます）、これらはDynamoDB Localに接続します。それ以外の場合は、AWSに接続し、<Link path="guides/runtime-config">ランタイム設定</Link>からデプロイされたテーブル名を解決します。<Link path="jp/get_started/tutorials/dungeon-game/2">モジュール2</Link>で、このプロジェクトで`Game`と`Inventory`エンティティをモデル化します。
+生成された `src/client.ts` は `getDynamoDBClient()` と `resolveTableName()` をエクスポートします。`LOCAL_DEV=true`（`dev` ターゲットによって自動的に設定）の場合は DynamoDB Local に接続し、それ以外の場合は AWS に接続して<Link path="guides/runtime-config">ランタイム設定</Link>からデプロイされたテーブル名を解決します。`Game` と `Inventory` エンティティは<Link path="get_started/tutorials/dungeon-game/2">モジュール 2</Link> でこのプロジェクトにモデル化します。
 
-詳細については、<Link path="guides/ts-dynamodb">ts#dynamodbジェネレーターガイド</Link>を参照してください。
+詳細については、<Link path="guides/ts-dynamodb">ts#dynamodb ジェネレーターガイド</Link>を参照してください。
 
 </details>
 
-##### ユーザーインターフェース（UI）の作成
+##### ユーザーインターフェース（UI）を作成する
 
-次に、ゲームと対話できるUIを作成します。
+次に、ゲームと対話するための UI を作成します。
 
 ###### Game UI: ウェブサイト
 
-UIを作成するには、次の手順で`GameUI`というウェブサイトを作成します：
+UI を作成するには、次の手順で `GameUI` という名前のウェブサイトを作成します:
 
 <RunGenerator generator="ts#website" requiredParameters={{name:"GameUI", ux:"shadcn"}} noInteractive />
 
 :::note[Shadcn UI]
-`--ux=shadcn`を選択することで、生成されたウェブサイトがTailwindでスタイル設定された[shadcn/ui](https://ui.shadcn.com/)コンポーネントを使用します。すべてのルートコードは`Card`、`Button`、`Input`などのshadcnプリミティブを使用し、後の`connection`ジェネレーターは、一致するshadcnテーマの[CopilotKit](https://docs.copilotkit.ai/)チャットサーフェスを配線します。
+`--ux=shadcn` を選択することで、生成されたウェブサイトが Tailwind でスタイリングされた [shadcn/ui](https://ui.shadcn.com/) コンポーネントを使用します。すべてのルートコードは `Card`、`Button`、`Input` などの shadcn プリミティブを使用し、`connection` ジェネレーターは後で一致する shadcn テーマの [CopilotKit](https://docs.copilotkit.ai/) チャットサーフェスをワイヤーアップします。
 :::
 
 ファイルツリーに新しいファイルが表示されます。
 
 <details>
-<summary>生成された`ts#website`ファイルを詳しく調べる</summary>
+<summary>生成された `ts#website` ファイルを詳しく確認する</summary>
 
-`ts#website`は次のファイルを生成します。ファイルツリーで強調表示されている主要なファイルのいくつかを調べましょう：
+`ts#website` はこれらのファイルを生成します。ファイルツリーでハイライトされているいくつかの重要なファイルを確認しましょう:
 
 <FileTree>
 - packages/
   - common/
     - constructs/
       - src/
-        - app/ アプリ固有のcdkコンストラクト
+        - app/ アプリ固有の cdk コンストラクト
           - static-websites/
-            - **game-ui.ts** Game UIを作成するためのcdkコンストラクト
+            - **game-ui.ts** Game UI を作成する cdk コンストラクト
         - core/
           - static-website.ts 汎用静的ウェブサイトコンストラクト
   - game-ui/
@@ -1033,24 +1047,24 @@ UIを作成するには、次の手順で`GameUI`というウェブサイトを�
     - src/
       - components/
         - AppLayout/
-          - index.tsx shadcnの`SidebarProvider` + ヘッダーを使用した全体的なページレイアウト
-        - app-sidebar.tsx ナビゲーション項目を含むデフォルトのshadcnサイドバー
-        - alert.tsx, spinner.tsx shadcnでラップされたフィードバックプリミティブ
-      - routes/ @tanstack/react-routerファイルベースルート
-        - **index.tsx** ルート'/'ページ
+          - index.tsx shadcn `SidebarProvider` + ヘッダーを使用した全体ページレイアウト
+        - app-sidebar.tsx ナビゲーション項目を持つデフォルト shadcn サイドバー
+        - alert.tsx, spinner.tsx shadcn でラップされたフィードバックプリミティブ
+      - routes/ @tanstack/react-router ファイルベースルート
+        - **index.tsx** ルート '/' ページ
         - __root.tsx すべてのページがこのコンポーネントをベースとして使用
       - config.ts
-      - **main.tsx** Reactエントリーポイント
-      - routeTree.gen.ts @tanstack/react-routerによって自動的に更新される
-      - styles.css 共有shadcnグローバル（Tailwind v4）をインポート
+      - **main.tsx** React エントリーポイント
+      - routeTree.gen.ts @tanstack/react-router によって自動更新される
+      - styles.css 共有 shadcn グローバルをインポート（Tailwind v4）
     - index.html
     - project.json
     - vite.config.mts
     - ...
   - common/
-    - shadcn/ すべての`ux=shadcn`ウェブサイトによってインポートされる共有shadcn/uiライブラリ（テーマトークン、`Button`、`Card`、`Input`、`Sidebar`など）
+    - shadcn/ 共有 shadcn/ui ライブラリ（テーマトークン、`Button`、`Card`、`Input`、`Sidebar`、…）すべての `ux=shadcn` ウェブサイトがインポート
       - src/components/ui/*
-      - src/styles/globals.css Tailwind + shadcnデザイントークン
+      - src/styles/globals.css Tailwind + shadcn デザイントークン
     - ...
 </FileTree>
 
@@ -1075,7 +1089,7 @@ export class GameUI extends StaticWebsite {
 }
 ```
 
-これはGameUIを定義するCDKコンストラクトです。ViteベースのUIの生成されたバンドルへのファイルパスが既に設定されています。これは、`build`時にgame-uiプロジェクトのビルドターゲット内でバンドルが発生し、その出力がここで使用されることを意味します。
+これは GameUI を定義する CDK コンストラクトです。Vite ベースの UI の生成されたバンドルへのファイルパスがすでに設定されています。これは `build` 時に game-ui プロジェクトのビルドターゲット内でバンドルが発生し、その出力がここで使用されることを意味します。
 
 ```tsx
 // packages/game-ui/src/main.tsx
@@ -1106,7 +1120,7 @@ root &&
   );
 ```
 
-これはReactがマウントされるエントリーポイントです。スタイリングは`styles.css`を介してインポートされたTailwind v4トークンから提供されます。`@tanstack/react-router`は[ファイルベースルーティング](https://tanstack.com/router/v1/docs/framework/react/routing/file-based-routing)モードで設定されています：開発サーバーが実行されている限り、`routes/`の下に作成したファイルは自動的に検出され、ルートツリーが再生成されます。後のジェネレーター（auth、connection）は、このファイルをAST-パッチして`<App />`を追加のプロバイダーでラップします。
+これは React がマウントされるエントリーポイントです。スタイリングは `styles.css` 経由でインポートされた Tailwind v4 トークンから来ています。`@tanstack/react-router` は[ファイルベースルーティング](https://tanstack.com/router/v1/docs/framework/react/routing/file-based-routing)モードで設定されています: 開発サーバーが実行中である限り、`routes/` 以下に作成したファイルは自動的に検出され、ルートツリーが再生成されます。後のジェネレーター（auth、connection）はこのファイルを AST パッチして `<App />` を追加のプロバイダーでラップします。
 
 ```tsx
 // packages/game-ui/src/routes/index.tsx
@@ -1128,22 +1142,22 @@ function RouteComponent() {
 }
 ```
 
-`/`ルートにナビゲートすると、コンポーネントがレンダリングされます。`@tanstack/react-router`は、このファイルを作成/移動するたびに`Route`を管理します（開発サーバーが実行されている限り）。
+`/` ルートに移動するとこのコンポーネントがレンダリングされます。`@tanstack/react-router` はこのファイルを作成/移動するたびに（開発サーバーが実行中である限り）`Route` を管理します。
 
 </details>
 
 ###### Game UI: 認証
 
-次の手順を使用して、Amazon Cognitoを介した認証済みアクセスを必要とするようにGame UIを設定しましょう：
+Amazon Cognito を通じた認証アクセスを必要とするよう Game UI を設定しましょう:
 
 <RunGenerator generator="ts#website#auth" requiredParameters={{cognitoDomain:"game-ui", project:"@dungeon-adventure/game-ui", allowSignup:true}} noInteractive />
 
 ファイルツリーに新しいファイルが表示/変更されます。
 
 <details>
-<summary>生成された`ts#website#auth`ファイルを詳しく調べる</summary>
+<summary>生成された `ts#website#auth` ファイルを詳しく確認する</summary>
 
-`ts#website#auth`ジェネレーターは次のファイルを更新/生成します。ファイルツリーで強調表示されている主要なファイルのいくつかを調べましょう：
+`ts#website#auth` ジェネレーターはこれらのファイルを更新/生成します。ファイルツリーでハイライトされているいくつかの重要なファイルを確認しましょう:
 
 <FileTree>
 - packages/
@@ -1151,19 +1165,19 @@ function RouteComponent() {
     - constructs/
       - src/
         - core/
-          - user-identity.ts ユーザー/アイデンティティプールを作成するためのcdkコンストラクト
+          - user-identity.ts ユーザー/ID プールを作成する cdk コンストラクト
   - game-ui/
     - src/
       - components/
         - AppLayout/
-          - index.tsx ログインユーザー/ログアウトをヘッダーに追加
+          - index.tsx ヘッダーにログインユーザー/ログアウトを追加
         - CognitoAuth/
-          - index.tsx Cognitoへのログインを管理
+          - index.tsx Cognito へのログインを管理
         - RuntimeConfig/
-          - index.tsx `runtime-config.json`を取得し、コンテキストを介して子に提供
+          - index.tsx `runtime-config.json` を取得してコンテキスト経由で子に提供
       - hooks/
         - useRuntimeConfig.tsx
-      - **main.tsx** Cognitoを追加するように更新
+      - **main.tsx** Cognito を追加するよう更新
 </FileTree>
 
 ```diff lang="tsx"
@@ -1212,32 +1226,32 @@ root &&
   );
 ```
 
-`RuntimeConfigProvider`と`CognitoAuth`コンポーネントがAST変換を介して`main.tsx`ファイルに追加されました。これにより、`CognitoAuth`コンポーネントは、正しい宛先へのバックエンド呼び出しを行うために必要なcognito接続設定を含む`runtime-config.json`を取得することで、Amazon Cognitoで認証できます。
+`RuntimeConfigProvider` と `CognitoAuth` コンポーネントが AST 変換を通じて `main.tsx` ファイルに追加されました。これにより `CognitoAuth` コンポーネントが `runtime-config.json` を取得して Amazon Cognito で認証できるようになります。`runtime-config.json` には、バックエンド呼び出しを正しい宛先に向けるために必要な Cognito 接続設定が含まれています。
 
 </details>
 
-###### Game UI: Game APIへの接続
+###### Game UI: Game API への接続
 
-以前に作成したGame APIに接続するようにGame UIを設定しましょう。
+以前に作成した Game API に接続するよう Game UI を設定しましょう。
 
 <RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-ui", targetProject:"@dungeon-adventure/game-api"}} noInteractive />
 
 ファイルツリーに新しいファイルが表示/変更されます。
 
 <details>
-<summary>UI → tRPC接続ファイルを調べる</summary>
+<summary>UI → tRPC 接続ファイルを確認する</summary>
 
-`connection`ジェネレーターは次のファイルを生成/更新します。ファイルツリーで強調表示されている主要なファイルのいくつかを調べましょう：
+`connection` ジェネレーターはこれらのファイルを生成/更新します。ファイルツリーでハイライトされているいくつかの重要なファイルを確認しましょう:
 
 <FileTree>
 - packages/
   - game-ui/
     - src/
       - components/
-        - GameApiClientProvider.tsx GameAPIクライアントをセットアップ
+        - GameApiClientProvider.tsx GameAPI クライアントをセットアップ
       - hooks/
-        - **useGameApi.tsx** GameApiを呼び出すためのフック
-      - **main.tsx** trpcクライアントプロバイダーを注入
+        - **useGameApi.tsx** GameApi を呼び出すフック
+      - **main.tsx** trpc クライアントプロバイダーを注入
 - package.json
 
 </FileTree>
@@ -1266,10 +1280,10 @@ export const useGameApiClient = () => {
 };
 ```
 
-このフックは、GameApiを呼び出すためのtRPCクライアントへのアクセスを提供します。tRPC APIの呼び出し方法の例については、<Link path="guides/connection/react-trpc#using-the-generated-code">tRPCフックの使用ガイド</Link>を参照してください。
+このフックは GameApi を呼び出すための tRPC クライアントへのアクセスを提供します。tRPC API の呼び出し方法の例については、<Link path="guides/connection/react-trpc#using-the-generated-code">tRPC フックガイドの使用方法</Link>を参照してください。
 
 <Aside title="型安全なフック">
-tRPCの[Typescript推論](https://trpc.io/docs/concepts)のおかげで、`useGameApi`はバックエンドの変更がフロントエンドに到達するためのビルドステップを必要としません。ルーターまたは任意のプロシージャへの編集は、型チェッカーによって即座に検出されます。
+tRPC の [TypeScript 推論](https://trpc.io/docs/concepts) のおかげで、`useGameApi` はバックエンドの変更がフロントエンドに反映されるためのビルドステップを必要としません。ルーターやプロシージャへの編集は型チェッカーによって即座に検出されます。
 </Aside>
 
 ```diff lang="tsx"
@@ -1303,20 +1317,20 @@ root &&
   );
 ```
 
-`main.tsx`ファイルは、tRPCプロバイダーを注入するためにAST変換を介して更新されました。
+`main.tsx` ファイルは AST 変換を通じて tRPC プロバイダーを注入するよう更新されました。
 
 </details>
 
-###### Story Agent: Inventory MCPサーバーへの接続
+###### Story Agent: Inventory MCP サーバーへの接続
 
-Story AgentをInventory MCPサーバーに接続して、エージェントがMCPサーバーのツールを検出して呼び出せるようにしましょう。
+Story Agent が MCP サーバーのツールを検出して呼び出せるよう、Story Agent を Inventory MCP サーバーに接続しましょう。
 
 <RunGenerator generator="connection" requiredParameters={{sourceProject:"story", targetProject:"inventory"}} noInteractive />
 
 <details>
-<summary>Story Agent → Inventory MCP接続ファイルを調べる</summary>
+<summary>Story Agent → Inventory MCP 接続ファイルを確認する</summary>
 
-`connection`ジェネレーターは次のファイルを生成/更新します：
+`connection` ジェネレーターはこれらのファイルを生成/更新します:
 
 <FileTree>
 - packages/
@@ -1324,87 +1338,87 @@ Story AgentをInventory MCPサーバーに接続して、エージェントがMC
     - agent\_connection/
       - dungeon\_adventure\_agent\_connection/
         - core/
-          - **agentcore\_endpoints.py** フレームワークに依存しないARN/URL解決
-          - **agentcore\_mcp\_transport.py** フレームワークに依存しないMCP転送
-          - **agentcore\_mcp\_client\_strands.py** 転送をラップするStrands MCPクライアント
-          - auth/ フレームワークに依存しないSigV4 / セッション転送`httpx.Auth`
+          - **agentcore\_endpoints.py** フレームワーク非依存の ARN/URL 解決
+          - **agentcore\_mcp\_transport.py** フレームワーク非依存の MCP トランスポート
+          - **agentcore\_mcp\_client\_strands.py** トランスポートをラップする Strands MCP クライアント
+          - auth/ フレームワーク非依存の SigV4 / セッション転送 `httpx.Auth`
         - app/
-          - **inventory\_mcp\_server\_client\_strands.py** Inventory MCPサーバーに接続するためのStrandsクライアント
+          - **inventory\_mcp\_server\_client\_strands.py** Inventory MCP サーバーに接続するための Strands クライアント
         - **\_\_init\_\_.py** 接続ごとのクライアントを再エクスポート
   - story/
     - dungeon\_adventure\_story/agent/
-      - **agent.py** MCPクライアントをインポートして使用するように変更
+      - **agent.py** MCP クライアントをインポートして使用するよう変更
 
 </FileTree>
 
-ジェネレーターは：
-- コア`AgentCoreMCPClientStrands`を持つ共有`agent_connection` Pythonプロジェクトを作成します（まだ存在しない場合）
-- ローカル（直接HTTP）とデプロイ時（IAM認証を使用したAgentCore経由）の両方でMCPサーバーへの接続を処理する`InventoryMcpServerClientStrands`クラスを生成します
-- `agent.py`を変換して、クライアントをインポートし、インスタンスを作成し、MCPサーバーのツールをエージェントに配線します
-- `agent_connection`プロジェクトをstoryプロジェクトのワークスペース依存関係として追加します
-- ローカルで実行する際にMCPサーバーを自動的に起動するように`dev`ターゲットを更新します
+ジェネレーターは:
+- コア `AgentCoreMCPClientStrands` を持つ共有 `agent_connection` Python プロジェクトを作成します（まだ存在しない場合）
+- ローカル（直接 HTTP）とデプロイ時（IAM 認証を使用した AgentCore 経由）の両方で MCP サーバーへの接続を処理する `InventoryMcpServerClientStrands` クラスを生成します
+- クライアントをインポートし、インスタンスを作成し、MCP サーバーのツールをエージェントにワイヤーアップするよう `agent.py` を変換します
+- `agent_connection` プロジェクトを story プロジェクトのワークスペース依存関係として追加します
+- ローカルで実行する際に MCP サーバーを自動的に起動するよう `dev` ターゲットを更新します
 
-詳細については、<Link path="guides/connection/py-agent-mcp">Python AgentからMCPへの接続ガイド</Link>を参照してください。
+詳細については、<Link path="guides/connection/py-agent-mcp">Python Agent から MCP への接続ガイド</Link>を参照してください。
 </details>
 
-###### Game UI: Story Agentへの接続
+###### Game UI: Story Agent への接続
 
-Game UIをStory Agentに接続しましょう。エージェントはAG-UIを話すため、`connection`ジェネレーターは[CopilotKit](https://docs.copilotkit.ai/)を配線します：テーマ付きチャットコンポーネントと、レンダリング準備ができた`@ag-ui/client` `HttpAgent`です。
+Game UI を Story Agent に接続しましょう。エージェントが AG-UI を話すため、`connection` ジェネレーターは [CopilotKit](https://docs.copilotkit.ai/) をワイヤーアップします: テーマ付きチャットコンポーネントとレンダリング準備済みの `@ag-ui/client` `HttpAgent` です。
 
 <RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-ui", targetProject:"story"}} noInteractive />
 
 <details>
-<summary>UI → Story Agent接続ファイルを調べる</summary>
+<summary>UI → Story Agent 接続ファイルを確認する</summary>
 
-`connection`ジェネレーターは次のファイルを生成/更新します：
+`connection` ジェネレーターはこれらのファイルを生成/更新します:
 
 <FileTree>
 - packages/
   - game-ui/
     - src/
       - components/
-        - **AguiProvider.tsx** 接続されたすべてのAG-UIエージェントが登録された`CopilotKitProvider`
+        - **AguiProvider.tsx** 接続されたすべての AG-UI エージェントが登録された `CopilotKitProvider`
         - copilot/
-          - **index.tsx** Shadcnテーマの`CopilotChat` / `CopilotSidebar` / `CopilotPopup`
+          - **index.tsx** Shadcn テーマの `CopilotChat` / `CopilotSidebar` / `CopilotPopup`
           - ShadcnAssistantMessage.tsx, ShadcnUserMessage.tsx, ShadcnChatInput.tsx, ShadcnCursor.tsx, copilot.css
       - hooks/
-        - **useAguiStoryAgent.tsx** `HttpAgent`を構築し、Cognitoベアラートークンを注入し、`threadId`をAgentCoreの33文字のセッションIDにパディング
-    - **main.tsx** `<App />`を`<AguiProvider>`でラップ
+        - **useAguiStoryAgent.tsx** `HttpAgent` を構築し、Cognito ベアラートークンを注入し、`threadId` を AgentCore の 33 文字セッション ID にパディング
+    - **main.tsx** `<App />` を `<AguiProvider>` でラップ
 
 </FileTree>
 
-ジェネレーターは：
-- Reactウェブサイトの`ux`（ここではShadcn）を検出し、一致するチャットコンポーネントを提供します。
-- すべての接続されたエージェントを単一の`CopilotKitProvider`に登録します。別のエージェントに対して再実行すると、別のフックが追加されるだけです。
-- ランタイム設定からエージェントのランタイムARNを読み取り、AgentCore呼び出しURLを構築し、CognitoベアラートークンとAgentCoreセッションIDヘッダーを添付します。
+ジェネレーターは:
+- React ウェブサイトの `ux`（ここでは Shadcn）を検出し、一致するチャットコンポーネントを提供します。
+- 接続されたすべてのエージェントを単一の `CopilotKitProvider` に登録します。別のエージェントのために再実行すると、別のフックが追加されるだけです。
+- ランタイム設定からエージェントのランタイム ARN を読み取り、AgentCore 呼び出し URL を構築し、Cognito ベアラートークンと AgentCore セッション ID ヘッダーを添付します。
 
-詳細については、<Link path="guides/connection/react-agui">ReactからAG-UIへの接続ガイド</Link>を参照してください。
+詳細については、<Link path="guides/connection/react-agui">React から AG-UI への接続ガイド</Link>を参照してください。
 </details>
 
-###### Game APIとInventory MCPサーバーをデータベースに接続
+###### Game API と Inventory MCP サーバーをデータベースに接続する
 
-Game APIとInventory MCPサーバーの両方がDynamoDBテーブルを読み書きするため、`DungeonDb`プロジェクトに接続しましょう。`connection`ジェネレーターは、ターゲットが`ts#dynamodb`プロジェクトであることを検出し、各ソースプロジェクトの`dev`ターゲットがDynamoDB Localを自動的に起動するように配線します。
+両方が DynamoDB テーブルを読み書きするため、それらを `DungeonDb` プロジェクトに接続しましょう。`connection` ジェネレーターはターゲットが `ts#dynamodb` プロジェクトであることを検出し、各ソースプロジェクトの `dev` ターゲットが DynamoDB Local を自動的に起動するようにワイヤーアップします。
 
 <RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-api", targetProject:"@dungeon-adventure/dungeon-db"}} noInteractive />
 
 <RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/inventory", targetProject:"@dungeon-adventure/dungeon-db"}} noInteractive />
 
-<Aside type="tip" title="1つのコマンドでスタック全体をローカルで起動">
-Story Agentの`agent-dev`は既にInventory MCPサーバーの`mcp-server-dev`に依存しており（上記の`story → inventory`接続を介して）、Game APIとMCPサーバーの両方が`dungeon-db:dev`に依存しているため、任意のプロジェクトの`dev`ターゲットを実行すると、必要なすべての依存関係が正しい順序で起動します。
+<Aside type="tip" title="1 つのコマンドでスタック全体をローカルで起動">
+Story Agent の `agent-dev` はすでに Inventory MCP サーバーの `mcp-server-dev` に依存しており（上記の `story → inventory` 接続経由）、Game API と MCP サーバーの両方が `dungeon-db:dev` に依存しているため、任意のプロジェクトの `dev` ターゲットを実行するだけで、必要なすべての依存関係が正しい順序で起動されます。
 </Aside>
 
-###### Game UI: インフラストラクチャ
+###### Game UI: インフラストラクチャー
 
-CDKインフラストラクチャの最終サブプロジェクトを作成しましょう。
+CDK インフラストラクチャーの最終サブプロジェクトを作成しましょう。
 
 <RunGenerator generator="ts#infra" requiredParameters={{name:"infra"}} noInteractive />
 
 ファイルツリーに新しいファイルが表示/変更されます。
 
 <details>
-<summary>生成された`ts#infra`ファイルを詳しく調べる</summary>
+<summary>生成された `ts#infra` ファイルを詳しく確認する</summary>
 
-`ts#infra`ジェネレーターは次のファイルを生成/更新します。ファイルツリーで強調表示されている主要なファイルのいくつかを調べましょう：
+`ts#infra` ジェネレーターはこれらを生成/更新します。ファイルツリーでハイライトされているいくつかの重要なファイルを確認しましょう:
 
 <FileTree>
 - packages/
@@ -1417,9 +1431,9 @@ CDKインフラストラクチャの最終サブプロジェクトを作成し�
   - infra
     - src/
       - stages/
-        - **application-stage.ts** cdkスタックがここで定義される
+        - **application-stage.ts** cdk スタックはここで定義
       - stacks/
-        - **application-stack.ts** cdkリソースがここで定義される
+        - **application-stack.ts** cdk リソースはここで定義
       - **main.ts** すべてのステージを定義するエントリーポイント
     - cdk.json
     - checkov.yml
@@ -1449,9 +1463,9 @@ new ApplicationStage(app, 'dungeon-adventure-infra-sandbox', {
 app.synth();
 ```
 
-<Aside type="tip" title="インポートエラーの修正">IDE内でインポートエラーが表示される場合、これはインフラストラクチャプロジェクトの`tsconfig.json`にtypescript参照がまだ設定されていないためです。Nxは、ビルド/コンパイルが実行されるたびに、または`nx sync`コマンドを手動で実行する場合に、これらの参照を*動的に*作成するように[設定](https://nx.dev/nx-api/js/generators/typescript-sync)されています。詳細については、<Link path="guides/typescript-project#importing-your-library-code-in-other-projects">Typescriptガイド</Link>を参照してください。</Aside>
+<Aside type="tip" title="インポートエラーの修正">IDE 内でインポートエラーが表示される場合、これはインフラストラクチャープロジェクトの `tsconfig.json` にまだ TypeScript 参照が設定されていないためです。Nx はビルド/コンパイルが実行されるたびに、または `nx sync` コマンドを手動で実行したときに、これらの参照を*動的に*作成するよう[設定](https://nx.dev/nx-api/js/generators/typescript-sync)されています。詳細については、<Link path="guides/typescript-project#importing-your-library-code-in-other-projects">TypeScript ガイド</Link>を参照してください。</Aside>
 
-これはCDKアプリケーションのエントリーポイントです。
+これは CDK アプリケーションのエントリーポイントです。
 
 ```ts
 // packages/infra/src/stacks/application-stack.ts
@@ -1467,41 +1481,41 @@ export class ApplicationStack extends Stack {
 }
 ```
 
-生成されたコンストラクトをインスタンス化して、ダンジョンアドベンチャーゲームを構築しましょう。
+ダンジョンアドベンチャーゲームを構築するために CDK コンストラクトをインスタンス化しましょう。
 
 </details>
 
 </Drawer>
 
-## タスク3: インフラストラクチャの更新
+## タスク 3: インフラストラクチャーを更新する
 
-`packages/infra/src/stacks/application-stack.ts`を更新して、生成されたコンストラクトのいくつかをインスタンス化しましょう：
+生成されたコンストラクトの一部をインスタンス化するために `packages/infra/src/stacks/application-stack.ts` を更新しましょう:
 
 <E2EDiff before="dungeon-adventure/1/application-stack.ts.original.template" after="dungeon-adventure/1/application-stack.ts.template" lang="ts" />
 
 :::note[デフォルトインテグレーション]
-Game APIにデフォルトのインテグレーションを提供します。デフォルトでは、APIの各操作は、その操作を処理する個別のLambda関数にマッピングされます。
+Game API にデフォルトインテグレーションを提供します。デフォルトでは、API の各オペレーションはそのオペレーションを処理する個別の Lambda 関数にマッピングされます。
 :::
 
-## タスク4: コードのビルド
+## タスク 4: コードをビルドする
 
-<Drawer title="Nxコマンド" trigger="初めてコードをビルドする時が来ました">
+<Drawer title="Nx コマンド" trigger="コードを初めてビルドする時が来ました">
 
-###### 単一ターゲット vs 複数ターゲット
+###### 単一 vs 複数ターゲット
 
-`run-many`コマンドは、リストされた複数のサブプロジェクトでターゲットを実行します（`--all`はすべてをターゲットにします）。これにより、依存関係が正しい順序で実行されます。
+`run-many` コマンドは複数のリストされたサブプロジェクトでターゲットを実行します（`--all` はすべてをターゲットにします）。これにより依存関係が正しい順序で実行されます。
 
-単一のプロジェクトターゲットに対して直接ターゲットを実行することで、ビルド（または他のタスク）をトリガーすることもできます。たとえば、`@dungeon-adventure/infra`プロジェクトをビルドするには、次のコマンドを実行します：
+また、プロジェクトのターゲットを直接実行することで、単一プロジェクトのビルド（または他のタスク）をトリガーすることもできます。例えば、`@dungeon-adventure/infra` プロジェクトをビルドするには、次のコマンドを実行します:
 
 <NxCommands commands={['build infra']} />
 
-スコープを省略して、Nxの短縮構文を使用することもできます：
+スコープを省略して、好みに応じて Nx の短縮構文を使用することもできます:
 
 <NxCommands commands={['build infra']} />
 
 ###### 依存関係の可視化
 
-依存関係を可視化するには、次を実行します：
+依存関係を可視化するには、次を実行します:
 
 <NxCommands commands={['graph']} />
 <br/>
@@ -1510,24 +1524,24 @@ Game APIにデフォルトのインテグレーションを提供します。デ
 
 ###### キャッシング
 
-Nxは[キャッシング](https://nx.dev/concepts/how-caching-works)に依存しているため、以前のビルドからアーティファクトを再利用して開発を高速化できます。これを正しく機能させるには、いくつかの設定が必要であり、**キャッシュを使用せずに**ビルドを実行したい場合があります。そのためには、コマンドに`--skip-nx-cache`引数を追加するだけです。例えば：
+Nx は[キャッシング](https://nx.dev/concepts/how-caching-works)に依存しており、以前のビルドのアーティファクトを再利用して開発を高速化できます。これを正しく機能させるためにいくつかの設定が必要であり、**キャッシュを使用せずに**ビルドを実行したい場合があります。その場合は、コマンドに `--skip-nx-cache` 引数を追加するだけです。例えば:
 
 <NxCommands commands={['build infra --skip-nx-cache']} />
-何らかの理由でキャッシュ（`.nx`フォルダーに保存）をクリアしたい場合は、次のコマンドを実行できます：
+何らかの理由でキャッシュ（`.nx` フォルダーに保存）をクリアしたい場合は、次のコマンドを実行できます:
 
 <NxCommands commands={['reset']} />
 
 </Drawer>
 
-コマンドラインを使用して、次のコマンドを実行してリントの問題を最初に修正します：
+コマンドラインを使用して、まず次のコマンドでリントの問題を修正します:
 
 <PackageManagerShortCommand commands={["lint"]} />
 
-次に、完全なビルドのために次のコマンドを実行します：
+次に、フルビルドのために次のコマンドを実行します:
 
 <PackageManagerShortCommand commands={["build"]} />
 
-次のプロンプトが表示されます：
+次のプロンプトが表示されます:
 
 ```bash
  NX   The workspace is out of sync
@@ -1541,10 +1555,10 @@ Yes, sync the changes and run the tasks
 No, run the tasks without syncing the changes
 ```
 
-このメッセージは、NXが自動的に更新できるファイルを検出したことを示しています。この場合、参照プロジェクトにTypescript参照が設定されていない`tsconfig.json`ファイルを指しています。
+このメッセージは、NX が自動的に更新できるファイルを検出したことを示しています。この場合、参照プロジェクトに TypeScript 参照が設定されていない `tsconfig.json` ファイルを指しています。
 
-**Yes, sync the changes and run the tasks**オプションを選択して続行します。syncジェネレーターが欠落しているtypescript参照を自動的に追加するため、すべてのIDE関連のインポートエラーが自動的に解決されることに気付くはずです！
+**Yes, sync the changes and run the tasks** オプションを選択して続行します。sync ジェネレーターが不足している TypeScript 参照を自動的に追加するため、IDE 関連のインポートエラーがすべて自動的に解決されることに気づくでしょう！
 
-すべてのビルドアーティファクトは、モノレポのルートにある`dist/`フォルダー内で利用できるようになりました。これは、`@aws/nx-plugin`によって生成されたプロジェクトを使用する際の標準的な慣行であり、生成されたファイルでファイルツリーを汚染しません。ファイルをクリーンアップしたい場合は、ビルドアーティファクトがファイルツリー全体に散らばることを心配せずに`dist/`フォルダーを削除してください。
+すべてのビルドアーティファクトは、モノレポのルートにある `dist/` フォルダー内で利用可能になります。これは `@aws/nx-plugin` によって生成されたプロジェクトを使用する際の標準的な慣行であり、生成されたファイルでファイルツリーを汚染しません。ファイルをクリーンアップしたい場合は、ビルドアーティファクトがファイルツリー全体に散らばることを心配せずに `dist/` フォルダーを削除できます。
 
-おめでとうございます！AI Dungeon Adventureゲームのコアの実装を開始するために必要なすべてのサブプロジェクトを作成しました。🎉🎉🎉
+おめでとうございます！AI ダンジョンアドベンチャーゲームのコアを実装するために必要なすべてのサブプロジェクトを作成しました。🎉🎉🎉

--- a/docs/src/content/docs/jp/guides/py-agent.mdx
+++ b/docs/src/content/docs/jp/guides/py-agent.mdx
@@ -1,6 +1,6 @@
 ---
-title: Python Agent
-description: ツールを使用してAIエージェントを構築するためのPython Agentを生成し、Amazon Bedrock AgentCore Runtimeにデプロイします
+title: Python エージェント
+description: ツールを使ったAIエージェントを構築するためのPythonエージェントを生成し、Amazon Bedrock AgentCore Runtimeにデプロイする
 generator: py#agent
 ---
 
@@ -16,20 +16,20 @@ import GeneratorParameters from '@components/generator-parameters.astro';
 import Drawer from '@components/drawer.astro';
 import OptionFilter from '@components/option-filter.astro';
 
-ツールを使用してエージェントを構築するためのPython AIエージェントを生成し、オプションで[Amazon Bedrock AgentCore Runtime](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/)にデプロイします。`framework`オプションでエージェントフレームワークを選択します：[Strands](https://strandsagents.com/)（デフォルト）または[LangChain](https://docs.langchain.com/oss/python/langchain/overview)（[LangGraph](https://docs.langchain.com/oss/python/langgraph/overview)上に構築）。
+ツールを使ったエージェントを構築するためのPython AIエージェントを生成し、オプションで [Amazon Bedrock AgentCore Runtime](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/) にデプロイできます。`framework` オプションでエージェントフレームワークを選択します: [Strands](https://strandsagents.com/)（デフォルト）または [LangChain](https://docs.langchain.com/oss/python/langchain/overview)（[LangGraph](https://docs.langchain.com/oss/python/langgraph/overview) 上に構築）。
 
-ジェネレーターは、サーバー`protocol`を介してエージェントを公開します。両方のフレームワークは、[HTTP](https://fastapi.tiangolo.com/)（デフォルト）、他のA2A互換エージェントとの相互運用性のための[Agent-to-Agent (A2A)](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-a2a.html)プロトコル、および[CopilotKit](https://docs.copilotkit.ai/)を介した直接的なフロントエンド統合のための[AG-UI](https://docs.ag-ui.com/)プロトコルをサポートしています。
+ジェネレーターはサーバー `protocol` を通じてエージェントを公開します。両フレームワークとも [HTTP](https://fastapi.tiangolo.com/)（デフォルト）、他のA2A互換エージェントとの相互運用のための [Agent-to-Agent (A2A)](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-a2a.html) プロトコル、および [CopilotKit](https://docs.copilotkit.ai/) を介したフロントエンド直接統合のための [AG-UI](https://docs.ag-ui.com/) プロトコルをサポートしています。
 
 ## 使用方法
 
-### Agentの生成
+### エージェントの生成
 
-Python Agentは2つの方法で生成できます：
+Python エージェントは2つの方法で生成できます:
 
 <RunGenerator generator="py#agent" />
 
 :::tip[プロジェクトの前提条件]
-まず<Link path="/guides/python-project">`py#project`</Link>ジェネレーターを使用して、Agentを追加するプロジェクトを作成してください。
+まず <Link path="/guides/python-project">`py#project`</Link> ジェネレーターを使用して、エージェントを追加するプロジェクトを作成してください。
 :::
 
 ### オプション
@@ -38,10 +38,10 @@ Python Agentは2つの方法で生成できます：
 
 ## ジェネレーターの出力
 
-ジェネレーターは、既存のPythonプロジェクトに以下のファイルを追加します。生成されるファイルは、選択した`protocol`によって異なります：
+ジェネレーターは既存のPythonプロジェクトに以下のファイルを追加します。生成されるファイルは選択した `protocol` によって異なります:
 
 <OptionFilter when={{ protocol: 'http' }} description="FastAPI HTTP server layout">
-### HTTPプロトコル（デフォルト）
+### HTTP プロトコル（デフォルト）
 
 <FileTree>
   - your-project/
@@ -51,6 +51,9 @@ Python Agentは2つの方法で生成できます：
         - init.py FastAPI application setup with CORS and error handling middleware
         - agent.py Main agent definition with sample tools
         - session.py Resolves the framework-specific session persistence implementation
+        - middleware/
+          - \_\_init\_\_.py Python package initialization
+          - session_id_middleware.py Binds the inbound AgentCore session ID for the request
         - main.py FastAPI entry point for Bedrock AgentCore Runtime
         - Dockerfile Entry point for hosting your agent (excluded when `infra` is set to `None`)
     - pyproject.toml Updated with Strands dependencies
@@ -59,9 +62,9 @@ Python Agentは2つの方法で生成できます：
 </OptionFilter>
 
 <OptionFilter when={{ protocol: 'a2a' }} description="A2A server layout">
-### A2Aプロトコル
+### A2A プロトコル
 
-エントリーポイントは、A2Aプロトコルを介してエージェントを公開します（Strandsは[Strands A2A Server](https://strandsagents.com/docs/user-guide/concepts/multi-agent/agent-to-agent)を使用し、LangChainはグラフを[`a2a-sdk`](https://a2a-protocol.org/)エグゼキューターでラップします）、FastAPIアプリにマウントされます：
+エントリーポイントはA2Aプロトコル経由でエージェントを公開します（Strandsは [Strands A2A Server](https://strandsagents.com/docs/user-guide/concepts/multi-agent/agent-to-agent) を使用し、LangChainはグラフを [`a2a-sdk`](https://a2a-protocol.org/) エグゼキューターでラップします）。FastAPIアプリにマウントされます:
 
 <FileTree>
   - your-project/
@@ -70,6 +73,9 @@ Python Agentは2つの方法で生成できます：
         - \_\_init\_\_.py Python package initialization
         - agent.py Main agent definition with sample tools
         - session.py Resolves the framework-specific session persistence implementation
+        - middleware/
+          - \_\_init\_\_.py Python package initialization
+          - session_id_middleware.py Binds the inbound AgentCore session ID for the request
         - main.py A2A server entry point
         - Dockerfile Entry point for hosting your agent (excluded when `infra` is set to `None`)
     - pyproject.toml Updated with framework and A2A dependencies
@@ -78,9 +84,9 @@ Python Agentは2つの方法で生成できます：
 </OptionFilter>
 
 <OptionFilter when={{ protocol: 'ag-ui' }} description="AG-UI / CopilotKit server layout">
-### AG-UIプロトコル
+### AG-UI プロトコル
 
-エントリーポイントは、[CopilotKit](https://docs.copilotkit.ai/)との直接的なフロントエンド統合のために、[AG-UI](https://docs.ag-ui.com/)プロトコルを介してエージェントを公開します。Strandsエージェントは[ag-ui-strands](https://docs.ag-ui.com/)統合を使用し、LangChainエージェントは[ag-ui-langgraph](https://docs.ag-ui.com/)を使用します：
+エントリーポイントは [AG-UI](https://docs.ag-ui.com/) プロトコルを介して [CopilotKit](https://docs.copilotkit.ai/) とのフロントエンド直接統合のためにエージェントを公開します。Strandsエージェントは [ag-ui-strands](https://docs.ag-ui.com/) 統合を使用し、LangChainエージェントは [ag-ui-langgraph](https://docs.ag-ui.com/) を使用します:
 
 <FileTree>
   - your-project/
@@ -89,6 +95,9 @@ Python Agentは2つの方法で生成できます：
         - \_\_init\_\_.py Python package initialization
         - agent.py Main agent definition with sample tools
         - session.py Resolves the framework-specific session persistence implementation
+        - middleware/
+          - \_\_init\_\_.py Python package initialization
+          - session_id_middleware.py Binds the inbound AgentCore session ID for the request
         - main.py AG-UI server entry point
         - Dockerfile Entry point for hosting your agent (excluded when `infra` is set to `None`)
     - pyproject.toml Updated with framework and AG-UI dependencies
@@ -96,7 +105,7 @@ Python Agentは2つの方法で生成できます：
 </FileTree>
 
 :::tip[Reactウェブサイトへの接続]
-AG-UIエージェントは、<Link path="/guides/connection/react-agui">`connection`ジェネレーター</Link>を使用してReactフロントエンドに接続でき、リッチなチャット体験のための[CopilotKit](https://docs.copilotkit.ai/)コンポーネントをセットアップします。
+AG-UIエージェントは <Link path="/guides/connection/react-agui">`connection` ジェネレーター</Link> を使用してReactフロントエンドに接続できます。これにより、リッチなチャット体験のための [CopilotKit](https://docs.copilotkit.ai/) コンポーネントがセットアップされます。
 :::
 </OptionFilter>
 
@@ -105,7 +114,7 @@ AG-UIエージェントは、<Link path="/guides/connection/react-agui">`connect
 <OptionFilter when={{ infra: 'agentcore' }} description="Bedrock AgentCore Runtime deployment">
 <Snippet name="shared-constructs" />
 
-Agentをデプロイするために、以下のファイルが生成されます：
+エージェントのデプロイのために、以下のファイルが生成されます:
 
 <Infrastructure>
 <Fragment slot="cdk">
@@ -133,20 +142,20 @@ Agentをデプロイするために、以下のファイルが生成されます
 </OptionFilter>
 
 <OptionFilter when={{ infra: 'none' }} description="No infrastructure is vended for infra=none">
-`infra`に`none`を選択した場合、CDKコンストラクトやTerraformモジュールは生成されません。Agentはローカルでのみ実行できます。このモードでは、認証するホストされたエンドポイントがないため、`auth`オプションは無視されます。
+`infra` に `none` を選択した場合、CDKコンストラクトやTerraformモジュールは生成されません — エージェントはローカルでのみ実行できます。このモードでは認証するホストエンドポイントがないため、`auth` オプションは無視されます。
 </OptionFilter>
 
 #### アーキテクチャ
 
 <Snippet name="agent/architecture" />
 
-## Agentの操作
+## エージェントの操作
 
-`agent.py`を編集して、ツールの追加、モデルの設定、システムプロンプトのカスタマイズができます。APIは選択したフレームワークによって異なります。
+`agent.py` を編集してツールの追加、モデルの設定、システムプロンプトのカスタマイズができます。APIは選択したフレームワークによって異なります。
 
 ### ツールの追加
 
-ツールは、AIエージェントがアクションを実行するために呼び出すことができる関数です。両方のフレームワークは、ツールを定義するためのデコレーターベースのアプローチを使用し、関数名とdocstringからツール名と説明を導出し、型ヒントから入力スキーマを生成します。
+ツールはAIエージェントがアクションを実行するために呼び出せる関数です。両フレームワークともツール定義にデコレーターベースのアプローチを使用し、関数名とdocstringからツール名と説明を導出し、型ヒントから入力スキーマを生成します。
 
 <Tabs syncKey="agent-framework">
 <TabItem label="Strands" _filter={{ framework: 'strands' }}>
@@ -198,11 +207,11 @@ agent = create_agent(
 </TabItem>
 </Tabs>
 
-### 事前構築されたツールの使用
+### 事前構築済みツールの使用
 
 <Tabs syncKey="agent-framework">
 <TabItem label="Strands" _filter={{ framework: 'strands' }}>
-Strandsは、`strands-tools`パッケージを通じて事前構築されたツールのコレクションを提供します：
+Strandsは `strands-tools` パッケージを通じて事前構築済みツールのコレクションを提供しています:
 
 ```python
 from strands_tools import current_time, http_request, file_read
@@ -214,7 +223,7 @@ agent = Agent(
 ```
 </TabItem>
 <TabItem label="LangChain" _filter={{ framework: 'langchain' }}>
-LangChainは、[ツールと統合](https://docs.langchain.com/oss/python/integrations/tools)の大規模なエコシステムを提供します。関連する統合パッケージをインストールし、ツールを`create_agent`に渡します：
+LangChainは大規模な [ツールと統合](https://docs.langchain.com/oss/python/integrations/tools) のエコシステムを提供しています。関連する統合パッケージをインストールし、ツールを `create_agent` に渡します:
 
 ```python
 from langchain_community.tools import DuckDuckGoSearchRun
@@ -232,7 +241,7 @@ agent = create_agent(
 
 <Tabs syncKey="agent-framework">
 <TabItem label="Strands" _filter={{ framework: 'strands' }}>
-デフォルトでは、StrandsエージェントはClaude 4 Sonnetを使用しますが、モデルプロバイダーをカスタマイズできます。設定オプションについては、[Strandsのモデルプロバイダーに関するドキュメント](https://strandsagents.com/docs/user-guide/concepts/model-providers/)を参照してください：
+デフォルトでは、StrandsエージェントはClaude 4 Sonnetを使用しますが、モデルプロバイダーをカスタマイズできます。設定オプションについては [Strandsのモデルプロバイダーに関するドキュメント](https://strandsagents.com/docs/user-guide/concepts/model-providers/) を参照してください:
 
 ```python
 from strands import Agent
@@ -249,7 +258,7 @@ agent = Agent(model=bedrock_model)
 ```
 </TabItem>
 <TabItem label="LangChain" _filter={{ framework: 'langchain' }}>
-LangChainエージェントは[`ChatBedrockConverse`](https://docs.langchain.com/oss/python/integrations/chat/bedrock_converse)モデルを使用します。生成されたエージェントは、`MODEL_ID`と`AWS_REGION`環境変数からモデルIDとリージョンを読み取りますが、`agent.py`でモデルを直接設定できます：
+LangChainエージェントは [`ChatBedrockConverse`](https://docs.langchain.com/oss/python/integrations/chat/bedrock_converse) モデルを使用します。生成されたエージェントは `MODEL_ID` および `AWS_REGION` 環境変数からモデルIDとリージョンを読み取りますが、`agent.py` でモデルを直接設定することもできます:
 
 ```python
 from langchain_aws import ChatBedrockConverse
@@ -263,49 +272,49 @@ model = ChatBedrockConverse(
 </TabItem>
 </Tabs>
 
-### MCPサーバーの使用
+### MCPサーバーの利用
 
-<Link path="/guides/py-mcp-server">`py#mcp-server`</Link>または<Link path="/guides/ts-mcp-server">`ts#mcp-server`</Link>ジェネレーターを使用して作成したMCPサーバーを使用するには、<Link path="/guides/connection/py-agent-mcp">`connection`ジェネレーター</Link>を使用できます。これにより、両方のフレームワークでMCPサーバーのツールがエージェントに組み込まれます。
+<Link path="/guides/py-mcp-server">`py#mcp-server`</Link> または <Link path="/guides/ts-mcp-server">`ts#mcp-server`</Link> ジェネレーターで作成したMCPサーバーを利用するには、<Link path="/guides/connection/py-agent-mcp">`connection` ジェネレーター</Link> を使用できます。これにより、両フレームワークでMCPサーバーのツールがエージェントに組み込まれます。
 
 <RunGenerator generator="connection" />
 
-接続の設定方法の詳細については、<Link path="/guides/connection/py-agent-mcp">`connection`ジェネレーターガイド</Link>を参照してください。
+接続のセットアップ方法の詳細については、<Link path="/guides/connection/py-agent-mcp">`connection` ジェネレーターガイド</Link> を参照してください。
 
-他のMCPサーバーについては、[Strands](https://strandsagents.com/docs/user-guide/concepts/tools/mcp-tools/)または[LangChain](https://docs.langchain.com/oss/python/langchain/mcp)のMCPドキュメントを参照してください。
+他のMCPサーバーについては、[Strands](https://strandsagents.com/docs/user-guide/concepts/tools/mcp-tools/) または [LangChain](https://docs.langchain.com/oss/python/langchain/mcp) のMCPドキュメントを参照してください。
 
 ### その他
 
-エージェントの作成に関するより詳細なガイドについては、[Strands](https://strandsagents.com/docs/user-guide/quickstart/overview/)または[LangChain](https://docs.langchain.com/oss/python/langchain/overview)のドキュメントを参照してください。
+エージェントの作成に関するより詳細なガイドについては、[Strands](https://strandsagents.com/docs/user-guide/quickstart/overview/) または [LangChain](https://docs.langchain.com/oss/python/langchain/overview) のドキュメントを参照してください。
 
 ## プロトコル
 
-エージェントのサーバープロトコルは、通信方法を決定します。すべてのオプションは[FastAPI](https://fastapi.tiangolo.com/)によって提供されます。エントリーポイントが異なります：
+エージェントのサーバープロトコルは通信方法を決定します。すべてのオプションは [FastAPI](https://fastapi.tiangolo.com/) によって提供されます — エントリーポイントが異なります:
 
-- **HTTP**（デフォルト）：カスタム`/invocations`エンドポイント、CORS、ストリーミングを備えた標準のFastAPIサーバー。カスタムクライアント統合に最適です。
-- **A2A**：FastAPIアプリにマウントされた[Agent-to-Agent](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-a2a.html)サーバー（Strandsは[Strands A2A Server](https://strandsagents.com/docs/user-guide/concepts/multi-agent/agent-to-agent)を使用し、LangChainはフレームワークに依存しない[`a2a-sdk`](https://a2a-protocol.org/)を使用します）。エージェントが他のA2A互換エージェントによって検出可能で呼び出し可能である必要がある場合に最適です。
-- **AG-UI**：SSE経由の[AG-UIプロトコル](https://docs.ag-ui.com/)（Strandsは`ag-ui-strands`を使用し、LangChainは`ag-ui-langgraph`を使用します）。Reactウェブサイトでの[CopilotKit](https://docs.copilotkit.ai/)との直接的なフロントエンド統合に最適です。
+- **HTTP**（デフォルト）: カスタム `/invocations` エンドポイント、CORS、ストリーミングを備えた標準FastAPIサーバー。カスタムクライアント統合に最適です。
+- **A2A**: FastAPIアプリにマウントされた [Agent-to-Agent](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-a2a.html) サーバー（Strandsは [Strands A2A Server](https://strandsagents.com/docs/user-guide/concepts/multi-agent/agent-to-agent) を使用し、LangChainはフレームワーク非依存の [`a2a-sdk`](https://a2a-protocol.org/) を使用）。エージェントが他のA2A互換エージェントから検出・呼び出し可能である必要がある場合に最適です。
+- **AG-UI**: SSE経由の [AG-UIプロトコル](https://docs.ag-ui.com/)（Strandsは `ag-ui-strands` を使用し、LangChainは `ag-ui-langgraph` を使用）。ReactウェブサイトでのCopilotKitとの直接フロントエンド統合に最適です。
 
-サーバーのエントリーポイントはフレームワークによって異なります（Strandsはコンテキスト管理された`Agent`を生成し、LangChainはコンパイルされた`create_agent`グラフを駆動します）が、各プロトコルの外部契約は同じです。
+サーバーエントリーポイントはフレームワークによって異なります（Strandsはコンテキスト管理された `Agent` を生成し、LangChainはコンパイルされた `create_agent` グラフを駆動します）が、各プロトコルの外部コントラクトは同じです。
 
-すべてのプロトコルは、AgentCoreランタイムのヘルスチェック契約のために`/ping`を公開します。A2Aエージェントはポート`9000`でリッスンし、HTTPおよびAG-UIエージェントはポート`8080`でリッスンします。生成されたDockerfileとインフラストラクチャは自動的に設定されます。
+すべてのプロトコルはAgentCoreランタイムヘルスチェックコントラクトのために `/ping` を公開します。A2Aエージェントはポート `9000` でリッスンし、HTTPおよびAG-UIエージェントはポート `8080` でリッスンします。生成されたDockerfileとインフラストラクチャは自動的に設定されます。
 
 <OptionFilter when={{ protocol: 'http' }} description="FastAPI HTTP server details">
 ## FastAPIサーバー（HTTPプロトコル）
 
-生成されたHTTPサーバーには以下が含まれます：
+生成されたHTTPサーバーには以下が含まれます:
 - CORSミドルウェアを備えたFastAPIアプリケーションのセットアップ
 - エラーハンドリングミドルウェア
 - OpenAPIスキーマ生成
 - ヘルスチェックエンドポイント（`/ping`）
 - エージェント呼び出しエンドポイント（`/invocations`）
 
-### Pydanticを使用した呼び出し入力と出力のカスタマイズ
+### Pydanticを使った呼び出し入出力のカスタマイズ
 
-エージェントの呼び出しエンドポイントは、[Pydantic](https://docs.pydantic.dev/)モデルを使用してリクエストとレスポンスのスキーマを定義および検証します。これらのモデルを`main.py`でカスタマイズして、エージェントの要件に合わせることができます。
+エージェントの呼び出しエンドポイントは [Pydantic](https://docs.pydantic.dev/) モデルを使用してリクエストとレスポンスのスキーマを定義・検証します。`main.py` でこれらのモデルをカスタマイズして、エージェントの要件に合わせることができます。
 
 #### 入力モデルの定義
 
-デフォルトの`InvokeInput`モデルはプロンプトを受け入れます。
+デフォルトの `InvokeInput` モデルはプロンプトを受け付けます。
 
 ```python
 from pydantic import BaseModel
@@ -314,28 +323,28 @@ class InvokeInput(BaseModel):
     prompt: str
 ```
 
-このモデルを拡張して、エージェントが必要とする追加のフィールドを含めることができます。
+このモデルを拡張して、エージェントが必要とする追加フィールドを含めることができます。
 
-セッションIDは、[Bedrock AgentCore Runtimeセッション契約](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-service-contract.html)と一致する`x-amzn-bedrock-agentcore-runtime-session-id` HTTPヘッダーから抽出されます。ヘッダーが提供されない場合、フォールバックとしてランダムなUUIDが生成されます。
+セッションIDは `x-amzn-bedrock-agentcore-runtime-session-id` HTTPヘッダーから抽出されます。これは [Bedrock AgentCore Runtimeセッションコントラクト](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-service-contract.html) と一致しています。ヘッダーが提供されない場合、フォールバックとしてランダムなUUIDが生成されます。
 
 :::caution[コードの整理]
-ユーザーがエージェントを直接呼び出す場合、呼び出し元からセッションIDの一部またはすべてを抽象化することをお勧めします。たとえば、認証されたユーザーIDをセッションIDの一部として使用できます。
+ユーザーがエージェントを直接呼び出す場合、呼び出し元からセッションIDの一部またはすべてを抽象化することをお勧めします。例えば、認証済みユーザーIDをセッションIDの一部として使用することができます。
 
-また、ユースケースによっては、セッションの認証を実装する必要がある場合があります。たとえば、ユーザーが自分のセッションにのみアクセスでき、他のユーザーのセッションにはアクセスできないようにします。
+また、ユースケースによっては、ユーザーが自分のセッションのみにアクセスでき、他のユーザーのセッションにはアクセスできないようにするなど、セッションの認可を実装する必要がある場合があることも注意してください。
 :::
 
 #### 出力モデルの定義
 
-ストリーミングレスポンスの場合、ジェネレーターは`JsonStreamingResponse`を提供します。これは、PydanticモデルをJSON Lines形式（`application/jsonl`）に自動的にシリアル化します。この形式は、OpenAPI 3.2のストリーミング仕様と互換性があり、生成されたTypeScriptクライアントとシームレスに動作します。
+ストリーミングレスポンスの場合、ジェネレーターはPydanticモデルをJSON Lines形式（`application/jsonl`）に自動シリアライズする `JsonStreamingResponse` を提供します。この形式はOpenAPI 3.2のストリーミング仕様と互換性があり、生成されたTypeScriptクライアントとシームレスに動作します。
 
-デフォルトでは、エージェントはエージェントのレスポンステキストを含む`StreamChunk`オブジェクトを生成します：
+デフォルトでは、エージェントはエージェントのレスポンステキストを含む `StreamChunk` オブジェクトを生成します:
 
 ```python
 class StreamChunk(BaseModel):
     content: str
 ```
 
-`StreamChunk`モデルをニーズに合わせてカスタマイズできます：
+`StreamChunk` モデルをニーズに合わせてカスタマイズできます:
 
 ```python
 from pydantic import BaseModel
@@ -347,7 +356,7 @@ class StreamChunk(BaseModel):
 ```
 
 :::note[FastAPIストリーミングの制限]
-FastAPIは現在、ストリーミングレスポンスのOpenAPI仕様の生成をサポートしていないため、各ストリーミング操作のレスポンスモデルを明示的に設定する必要があります：
+FastAPIは現在ストリーミングレスポンスのOpenAPI仕様の生成をサポートしていないため、各ストリーミング操作のレスポンスモデルを明示的に設定する必要があります:
 
 ```python
 @app.post(
@@ -360,96 +369,96 @@ async def invoke(input: InvokeInput) -> JsonStreamingResponse:
 ```
 :::
 
-FastAPIでのネイティブサポートについては、[オープンな機能リクエスト](https://github.com/fastapi/fastapi/discussions/14362)があります。
+[FastAPIでのネイティブサポートに関するオープンな機能リクエスト](https://github.com/fastapi/fastapi/discussions/14362) があります。
 </OptionFilter>
 
 ## Bedrock AgentCore Python SDK
 
-ジェネレーターには、`PingStatus`定数のための[Bedrock AgentCore Python SDK](https://github.com/aws/bedrock-agentcore-sdk-python)への依存関係が含まれています。必要に応じて、FastAPIの代わりに`BedrockAgentCoreApp`を使用することは簡単ですが、型安全性が失われることに注意してください。
+ジェネレーターには `PingStatus` 定数のために [Bedrock AgentCore Python SDK](https://github.com/aws/bedrock-agentcore-sdk-python) への依存関係が含まれています。必要に応じて、FastAPIの代わりに `BedrockAgentCoreApp` を使用することも簡単ですが、型安全性が失われることに注意してください。
 
-SDKの機能の詳細については、[こちらのドキュメント](https://aws.github.io/bedrock-agentcore-starter-toolkit/user-guide/runtime/quickstart.html)を参照してください。
+SDKの機能の詳細については、[こちらのドキュメント](https://aws.github.io/bedrock-agentcore-starter-toolkit/user-guide/runtime/quickstart.html) を参照してください。
 
 :::note[Infrastructure as Code]
-ジェネレーターはエージェントのデプロイを管理するCDKまたはTerraformインフラストラクチャを提供するため、エージェントをデプロイするためにドキュメントで言及されている`bedrock-agentcore-starter-toolkit`を利用する必要はありません。
+ジェネレーターはエージェントのデプロイを管理するCDKまたはTerraformインフラストラクチャを提供するため、ドキュメントに記載されているエージェントのデプロイ用の `bedrock-agentcore-starter-toolkit` を使用する必要はありません。
 :::
 
 <OptionFilter when={{ protocol: 'a2a' }} description="A2A server details">
 ## A2Aサーバー（A2Aプロトコル）
 
-生成された`main.py`は、A2Aサーバーを親FastAPIアプリにマウントし、`/ping`も公開します。Strandsエージェントは、Strands `A2AServer`を使用します。LangChainエージェントは、コンパイルされたグラフを[`a2a-sdk`](https://a2a-protocol.org/) `AgentExecutor`でラップします。AgentCoreにデプロイされると、エントリーポイントはAppConfigからランタイムのパブリックARNを解決し、エージェントカードでアドバタイズします。
+生成された `main.py` は、`/ping` も公開する親FastAPIアプリにA2Aサーバーをマウントします。StrandsエージェントはStrands `A2AServer` を使用し、LangChainエージェントはコンパイルされたグラフを [`a2a-sdk`](https://a2a-protocol.org/) `AgentExecutor` でラップします。AgentCoreにデプロイされると、エントリーポイントはAppConfigからランタイムのパブリックARNを解決し、エージェントカードにアドバタイズします。
 
-ほとんどのユーザーはこのファイルを変更する必要はありません。ツールやシステムプロンプトを変更するには、`agent.py`を編集してください。A2Aサーバーは、エージェントの`name`と`description`からエージェントカード（`/.well-known/agent-card.json`）を生成します。
+ほとんどのユーザーはこのファイルを変更する必要はありません。ツールやシステムプロンプトを変更するには `agent.py` を編集してください。A2Aサーバーはエージェントの `name` と `description` からエージェントカード（`/.well-known/agent-card.json`）を生成します。
 </OptionFilter>
 
 <OptionFilter when={{ protocol: 'ag-ui' }} description="AG-UI / CopilotKit server details">
 ## AG-UIサーバー（AG-UIプロトコル）
 
-生成された`main.py`は、Server-Sent Events（SSE）を介して[AG-UI](https://docs.ag-ui.com/)イベントをストリーミングする単一のPOSTエンドポイントと、AgentCoreランタイムのヘルスチェックのための`/ping`を公開します。配線はフレームワークによって異なります：
+生成された `main.py` は、Server-Sent Events（SSE）経由で [AG-UI](https://docs.ag-ui.com/) イベントをストリーミングする単一のPOSTエンドポイントと、AgentCoreランタイムヘルスチェック用の `/ping` を公開します。配線はフレームワークによって異なります:
 
-- **Strands**：`Agent`を`ag_ui_strands.StrandsAgent`でラップし、FastAPIの`lifespan`ハンドラー内で構築され（インポート時ではなく、コンテナ/セッション起動時に構築が行われます）、手作りのFastAPI `/invocations`ループから提供されます。
-- **LangChain**：コンパイルされたグラフを`ag_ui_langgraph.LangGraphAgent`でラップし、同じように`lifespan`内で構築され、手作りのFastAPI `/invocations`ループから提供されます。
+- **Strands**: `Agent` を `ag_ui_strands.StrandsAgent` でラップし、FastAPI `lifespan` ハンドラー内で構築（インポート時ではなくコンテナ/セッション起動時に構築が行われる）し、手動作成のFastAPI `/invocations` ループから提供します。
+- **LangChain**: コンパイルされたグラフを `ag_ui_langgraph.LangGraphAgent` でラップし、同様に `lifespan` 内で構築し、手動作成のFastAPI `/invocations` ループから提供します。
 
-ほとんどのユーザーはこのファイルを変更する必要はありません。ツールやシステムプロンプトを変更するには、`agent.py`を編集してください。
+ほとんどのユーザーはこのファイルを変更する必要はありません — ツールやシステムプロンプトを変更するには `agent.py` を編集してください。
 
 :::tip[Reactウェブサイトへの接続]
-AG-UIエージェントは、フロントエンドから直接使用されるように設計されています。<Link path="/guides/connection/react-agui">`connection`ジェネレーター</Link>を使用して、Reactウェブサイトを[CopilotKit](https://docs.copilotkit.ai/)プロバイダーと[AG-UI HttpAgent](https://docs.ag-ui.com/)クライアントでエージェントに接続します。
+AG-UIエージェントはフロントエンドから直接利用されるように設計されています。<Link path="/guides/connection/react-agui">`connection` ジェネレーター</Link> を使用して、[CopilotKit](https://docs.copilotkit.ai/) プロバイダーと [AG-UI HttpAgent](https://docs.ag-ui.com/) クライアントでReactウェブサイトをエージェントに接続してください。
 :::
 </OptionFilter>
 
-## Agentの実行
+## エージェントの実行
 
 ### ローカル開発
 
-Agent（およびそれに接続されているすべてのもの）をローカルで実行するには、プロジェクトの`dev`ターゲットを使用します：
+エージェント（およびそれに接続されているすべてのもの）をローカルで実行するには、プロジェクトの `dev` ターゲットを使用します:
 
 <NxCommands commands={['dev your-project']} />
 
-プロジェクトに複数のコンポーネント（エージェント、MCPサーバーなど）を追加した場合、これによりすべてが起動します。このエージェントのみを実行するには、その`<your-agent-name>-dev`ターゲットをターゲットにします：
+プロジェクトに複数のコンポーネント（エージェント、MCPサーバーなど）を追加した場合、これらすべてが起動します。このエージェントのみを実行するには、`<your-agent-name>-dev` ターゲットを指定します:
 
 <NxCommands commands={['agent-dev your-project']} />
 
-これは、`uv run`を使用して[Bedrock AgentCore Python SDK](https://github.com/aws/bedrock-agentcore-sdk-python)を使用してAgentを実行します。
+これは `uv run` を使用して [Bedrock AgentCore Python SDK](https://github.com/aws/bedrock-agentcore-sdk-python) でエージェントを実行します。
 
-### Agentとのチャット
+### エージェントとのチャット
 
-ジェネレーターは、エージェントとの対話型ターミナルチャットに入る`<your-agent-name>-chat` Nxターゲットを設定します。
+ジェネレーターはエージェントとのインタラクティブなターミナルチャットに入るための `<your-agent-name>-chat` Nxターゲットを設定します。
 
-チャットターゲットはスタンドアロンで実行されます。デフォルトでは、ローカルで実行されているエージェントに接続するため、まずエージェントの`<your-agent-name>-dev`ターゲットを（別のターミナルで）起動します：
+チャットターゲットはスタンドアロンで実行されます。デフォルトではローカルで実行中のエージェントに接続するため、まず別のターミナルでエージェントの `<your-agent-name>-dev` ターゲットを起動してください:
 
 <NxCommands commands={['agent-dev your-project']} />
 
-次に、別のターミナルでチャットを開始します：
+次に、別のターミナルでチャットを開始します:
 
 <NxCommands commands={['run your-project:agent-chat']} />
 
-ジェネレーターは、すべてのプロトコルに対して`scripts/<your-agent-name>/chat.ts`を生成します。デフォルトではローカルエージェントに接続しますが、`RUNTIME_CONFIG_APP_ID`が設定されている場合はデプロイされたエージェントに接続します（以下の[デプロイされたエージェントとのチャット](#chat-with-your-deployed-agent)を参照）。
+ジェネレーターはすべてのプロトコルに対して `scripts/<your-agent-name>/chat.ts` を生成します。デフォルトではローカルエージェントに接続し、`RUNTIME_CONFIG_APP_ID` が設定されている場合はデプロイされたエージェントに接続します（以下の[デプロイされたエージェントとのチャット](#chat-with-your-deployed-agent)を参照）。
 
-**HTTP**エージェントの場合、チャットスクリプトは、エージェントのOpenAPI仕様から生成された型安全なTypeScriptクライアントを使用します。ジェネレーターは以下も生成します：
+**HTTP** エージェントの場合、チャットスクリプトはエージェントのOpenAPI仕様から生成された型安全なTypeScriptクライアントを使用します。ジェネレーターはさらに以下も生成します:
 
 - `scripts/<your-agent-name>_openapi.py` — エージェントのOpenAPI仕様をエクスポートする小さなスクリプト
-- それを実行する`<your-agent-name>-openapi` Nxターゲット
-- `scripts/<your-agent-name>/generated/`の下に型安全なTypeScriptクライアントを生成する`<your-agent-name>-generate-client` Nxターゲット
+- それを実行する `<your-agent-name>-openapi` Nxターゲット
+- `scripts/<your-agent-name>/generated/` 以下に型安全なTypeScriptクライアントを生成する `<your-agent-name>-generate-client` Nxターゲット
 
-エージェントの入力形状をカスタマイズする場合（例：`InvokeInput`に新しいフィールドを追加）、`chat.ts`を更新してエージェントを呼び出すときに新しいフィールドを渡すと、残りは自動的に機能します。
+エージェントの入力形状をカスタマイズした場合（例: `InvokeInput` に新しいフィールドを追加）、エージェントを呼び出す際に新しいフィールドを渡すように `chat.ts` を更新すれば、残りは自動的に機能します。
 
 <OptionFilter when={{ infra: 'agentcore' }} description="Deployed agent chat details">
 #### デプロイされたエージェントとのチャット
 
-Bedrock AgentCoreにデプロイされたエージェントとチャットするには、`RUNTIME_CONFIG_APP_ID`環境変数をデプロイのAppConfigアプリケーションID（デプロイされたスタックによって`RuntimeConfigApplicationId`として出力されます）に設定します。チャットスクリプトは、ランタイム設定からエージェントのランタイムARNを解決し、デプロイされたエンドポイントに接続します：
+Bedrock AgentCoreにデプロイされたエージェントとチャットするには、`RUNTIME_CONFIG_APP_ID` 環境変数をデプロイメントのAppConfigアプリケーションID（デプロイされたスタックによって `RuntimeConfigApplicationId` として出力）に設定します。チャットスクリプトはランタイム設定からエージェントのランタイムARNを解決し、デプロイされたエンドポイントに接続します:
 
 <Tabs syncKey="auth">
 <TabItem label="IAM" _filter={{ auth: 'iam' }}>
-IAM認証されたエージェントの場合、リクエストはデフォルトのAWS認証情報を使用して[SigV4](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_sigv.html)で署名されます。環境にランタイムを呼び出す権限を持つAWS認証情報があることを確認してください：
+IAM認証エージェントの場合、リクエストはデフォルトのAWS認証情報を使用して [SigV4](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_sigv.html) で署名されます。環境にランタイムを呼び出す権限を持つAWS認証情報があることを確認してください:
 
 <NxCommands commands={['run your-project:agent-chat']} env={{ RUNTIME_CONFIG_APP_ID: '<app-id>' }} />
 </TabItem>
 
 <TabItem label="Cognito" _filter={{ auth: 'cognito' }}>
-Cognito認証されたエージェントの場合、`AGENT_ACCESS_TOKEN`環境変数を介してCognitoアクセストークンを提供します。これはベアラートークンとして送信されます：
+Cognito認証エージェントの場合、`AGENT_ACCESS_TOKEN` 環境変数を通じてCognitoアクセストークンを提供します。これはベアラートークンとして送信されます:
 
 <NxCommands commands={['run your-project:agent-chat']} env={{ RUNTIME_CONFIG_APP_ID: '<app-id>', AGENT_ACCESS_TOKEN: '<access-token>' }} />
 
-AWS CLIの`cognito-idp admin-initiate-auth`コマンドを使用してアクセストークンを取得できます。例：
+AWS CLIの `cognito-idp admin-initiate-auth` コマンドを使用してアクセストークンを取得できます。例:
 
 ```bash
 aws cognito-idp admin-initiate-auth \
@@ -465,71 +474,71 @@ aws cognito-idp admin-initiate-auth \
 </OptionFilter>
 
 <OptionFilter when={{ infra: 'agentcore' }} description="Bedrock AgentCore Runtime deployment details">
-## Bedrock AgentCore RuntimeへのAgentのデプロイ
+## Bedrock AgentCore Runtimeへのエージェントのデプロイ
 
-<Snippet name="agent/bedrock-deployment" parentHeading="Bedrock AgentCore RuntimeへのAgentのデプロイ" />
+<Snippet name="agent/bedrock-deployment" parentHeading="Bedrock AgentCore Runtimeへのエージェントのデプロイ" />
 
-### BundleとDockerターゲット
+### バンドルとDockerターゲット
 
-Bedrock AgentCore Runtime用にAgentをビルドするために、プロジェクトに`bundle`ターゲットが追加されます。これは以下を行います：
+Bedrock AgentCore Runtime向けにエージェントをビルドするために、プロジェクトに `bundle` ターゲットが追加されます。これは以下を行います:
 
-- `uv export`を使用してPython依存関係を`requirements.txt`ファイルにエクスポート
-- `uv pip install`を使用してターゲットプラットフォーム（`aarch64-manylinux_2_28`）用の依存関係をインストール
+- `uv export` を使用してPython依存関係を `requirements.txt` ファイルにエクスポート
+- ターゲットプラットフォーム（`aarch64-manylinux_2_28`）向けに `uv pip install` を使用して依存関係をインストール
 
-Agentに固有の`docker`ターゲットも追加され、`Dockerfile`とバンドルされたアーティファクトをdockerコンテキストディレクトリにコピーします。これにより、`Dockerfile`がビルド出力と同じ場所に配置され、CDKが`AgentRuntimeArtifact.fromAsset`を使用してDockerイメージを直接ビルドできます。
+エージェント固有の `docker` ターゲットも追加されます。これは `Dockerfile` とバンドルされたアーティファクトをDockerコンテキストディレクトリにコピーします。これにより `Dockerfile` がビルド出力と同じ場所に配置され、CDKが `AgentRuntimeArtifact.fromAsset` を使用してDockerイメージを直接ビルドできるようになります。
 
 ### イメージスキャン
 
 <Snippet name="trivy-image-scan" parentHeading="イメージスキャン" />
 
-### 可観測性
+### オブザーバビリティ
 
-エージェントは、`Dockerfile`で自動計装を設定することにより、[AWS Distro for Open Telemetry](https://aws.amazon.com/otel/)（ADOT）を使用した可観測性で自動的に設定されます。
+エージェントは `Dockerfile` で自動インストルメンテーションを設定することで、[AWS Distro for Open Telemetry](https://aws.amazon.com/otel/)（ADOT）を使用したオブザーバビリティが自動的に設定されます。
 
-CloudWatch AWSコンソールで、メニューから「GenAI Observability」を選択することで、トレースを見つけることができます。トレースを入力するには、[Transaction Search](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Transaction-Search.html)を有効にする必要があることに注意してください。
+CloudWatch AWSコンソールでトレースを確認できます。メニューで「GenAI Observability」を選択してください。トレースを表示するには [Transaction Search](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Transaction-Search.html) を有効にする必要があります。
 
-詳細については、[AgentCoreの可観測性に関するドキュメント](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/observability-configure.html)を参照してください。
+詳細については、[オブザーバビリティに関するAgentCoreドキュメント](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/observability-configure.html) を参照してください。
 
 ### セッション管理
 
-`session`オプションは、選択したフレームワークに応じて、異なる基礎となる永続化概念にマップされます：`strands`フレームワークの場合はStrandsの[セッション管理](https://strandsagents.com/docs/user-guide/concepts/agents/session-management/)概念、`langchain`フレームワークの場合はLangGraphの[checkpointer](https://docs.langchain.com/oss/python/langgraph/persistence)概念です。
+`session` オプションは、選択したフレームワークによって異なる基盤となる永続化概念にマッピングされます: `strands` フレームワークの場合はStrandsの [セッション管理](https://strandsagents.com/docs/user-guide/concepts/agents/session-management/) 概念、`langchain` フレームワークの場合はLangGraphの [チェックポインター](https://docs.langchain.com/oss/python/langgraph/persistence) 概念です。
 
 <OptionFilter when={{ framework: 'strands' }} description="Strands session management (session.py)">
-`session`オプションは、Strands SDKの[SessionManager](https://strandsagents.com/docs/user-guide/concepts/agents/session-management/)を使用して、エージェントが呼び出し間で会話状態（メッセージ履歴、ツール状態など）を永続化する方法を制御します：
+`session` オプションは、Strands SDKの [SessionManager](https://strandsagents.com/docs/user-guide/concepts/agents/session-management/) を使用して、呼び出し間でエージェントが会話状態（メッセージ履歴、ツール状態など）をどのように永続化するかを制御します:
 
-- **`s3`**（デフォルト）：CDK/Terraformインフラストラクチャは、セッションデータ用の専用S3バケットをプロビジョニングし、専用のKMSキーで暗号化され、すべてのパブリックアクセスがブロックされます。サーバーアクセスログは、同じキーを介してCloudWatch Logsロググループに配信されます。エージェントのIAMロールには、バケットへの読み取り/書き込み/リスト/削除アクセスと、キーへの復号化/データキー生成アクセスが付与され、バケット名はAppConfigランタイム設定でエージェントのARNと一緒に登録されます。
-- **`in-memory`**：バケットはプロビジョニングされません。会話状態は、実行中のプロセスの存続期間中のみメモリに保持され、再起動やスケールインには耐えられません。
+- **`s3`**（デフォルト）: CDK/Terraformインフラストラクチャはセッションデータ用の専用S3バケットをプロビジョニングします。専用KMSキーで暗号化され、すべてのパブリックアクセスがブロックされます。サーバーアクセスログは同じキーを介してCloudWatch Logsロググループに配信されます。エージェントのIAMロールにはバケットへの読み取り/書き込み/一覧/削除アクセスとキーへの復号/データキー生成アクセスが付与され、バケット名はエージェントのARNとともにAppConfigランタイム設定に登録されます。
+- **`in-memory`**: バケットはプロビジョニングされません。会話状態は実行中のプロセスの存続期間中のみメモリに保持され、再起動やスケールインでは保持されません。
 
-これは、生成された`session.py`に実装されており、現在のセッションの`SessionManager`を解決する`get_session_manager()`関数をエクスポートします。
+これは生成された `session.py` に実装されており、現在のセッションの `SessionManager` を解決する `get_session_manager()` 関数をエクスポートします。
 
-セッションID自体は、AgentCore Runtimeセッション（`x-amzn-bedrock-agentcore-runtime-session-id`ヘッダーを介して伝播）から取得され、[`contextvars.ContextVar`](https://docs.python.org/3/library/contextvars.html)ベースのコンテキストにバインドされるため、`get_current_session_id()`はリクエスト内のどこでもそれを解決できます。これには、<Link path="/guides/connection">`connection`ジェネレーター</Link>を介して配線された下流のMCPまたはA2Aクライアントも含まれるため、呼び出しチェーン全体が一貫したセッションを共有します。
+セッションID自体はAgentCore Runtimeセッション（`x-amzn-bedrock-agentcore-runtime-session-id` ヘッダーを介して伝播）から取得され、[`contextvars.ContextVar`](https://docs.python.org/3/library/contextvars.html) ベースのコンテキストにバインドされるため、`get_current_session_id()` はリクエスト内のどこからでも解決できます — <Link path="/guides/connection">`connection` ジェネレーター</Link> を介して接続されたダウンストリームのMCPまたはA2Aクライアントを含め、コール全体で一貫したセッションが共有されます。
 
 :::note[ローカル開発]
-ローカルで実行する場合（`LOCAL_DEV=true`、`-dev`ターゲットによって自動的に設定されます）、設定された`session`オプションに関係なく、セッションデータは常にワークスペースルートの`tmp/agents/strands/<agent-name>`の下のディスクに保存されます。
+ローカルで実行する場合（`-dev` ターゲットによって自動的に設定される `LOCAL_DEV=true`）、設定された `session` オプションに関わらず、セッションデータは常にワークスペースルートの `tmp/agents/strands/<agent-name>` 以下のディスクに保存されます（利便性のため）。
 :::
 </OptionFilter>
 
 <OptionFilter when={{ framework: 'langchain' }} description="LangChain session management (session.py)">
-`session`オプションは、エージェントのLangGraphチェックポインターが会話状態を永続化する方法を制御します：
+`session` オプションは、エージェントのLangGraphチェックポインターが会話状態をどのように永続化するかを制御します:
 
-- **`s3`**（デフォルト）：デプロイされたエージェントは、プロビジョニングされたセッションバケットで`S3CheckpointSaver`を使用し、`checkpoints/`プレフィックスの下にチェックポイントと保留中の書き込みを保存します。このクラスは、共有エージェント接続プロジェクトの`s3_checkpoint_saver_langchain.py`にあります。
-- **`dynamodb-s3`**：CDK/Terraformインフラストラクチャは、チェックポイント用のDynamoDBテーブルをプロビジョニングし、[LangGraphエージェントのチェックポイントストアとしてDynamoDBを使用することに関するAWSドキュメント](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ddb-langgraph-checkpoint.html)で推奨されているように設定されます（統一された`PK`/`SK`スキーマ、`PAY_PER_REQUEST`課金、ポイントインタイムリカバリ、および`ttl`属性）、さらに350KBを超えるチェックポイントをオフロードするためのS3バケット。両方とも専用のKMSキーで暗号化されます。バケットのサーバーアクセスログは、同じキーを介してCloudWatch Logsロググループに配信されます。エージェントのIAMロールには、テーブルとバケットへの読み取り/書き込みアクセスが付与され、テーブル/バケット名はAppConfigランタイム設定でエージェントのARNと一緒に登録されます。
-- **`in-memory`**：テーブルまたはバケットはプロビジョニングされません。会話状態は、実行中のプロセスの存続期間中のみメモリに保持され、再起動やスケールインには耐えられません。
+- **`s3`**（デフォルト）: デプロイされたエージェントはプロビジョニングされたセッションバケットで `S3CheckpointSaver` を使用し、`checkpoints/` プレフィックス以下にチェックポイントと保留中の書き込みを保存します。このクラスは共有エージェント接続プロジェクトの `s3_checkpoint_saver_langchain.py` に存在します。
+- **`dynamodb-s3`**: CDK/Terraformインフラストラクチャはチェックポイント用のDynamoDBテーブルをプロビジョニングします。[LangGraphエージェントのチェックポイントストアとしてDynamoDBを使用するAWSドキュメント](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ddb-langgraph-checkpoint.html) の推奨に従って設定されます（統合 `PK`/`SK` スキーマ、`PAY_PER_REQUEST` 課金、ポイントインタイムリカバリ、`ttl` 属性）。350KBを超えるチェックポイントのオフロード用S3バケットも含まれます。両方とも専用KMSキーで暗号化され、バケットのサーバーアクセスログは同じキーを介してCloudWatch Logsロググループに配信されます。エージェントのIAMロールにはテーブルとバケットへの読み取り/書き込みアクセスが付与され、テーブル/バケット名はエージェントのARNとともにAppConfigランタイム設定に登録されます。
+- **`in-memory`**: テーブルもバケットもプロビジョニングされません。会話状態は実行中のプロセスの存続期間中のみメモリに保持され、再起動やスケールインでは保持されません。
 
-これは、生成された`session.py`に実装されており、`agent.py`の`create_agent(..., checkpointer=get_checkpointer())`から呼び出される`get_checkpointer()`関数をエクスポートします。
+これは生成された `session.py` に実装されており、`agent.py` の `create_agent(..., checkpointer=get_checkpointer())` から呼び出される `get_checkpointer()` 関数をエクスポートします。
 
 :::note[ローカル開発]
-ローカルで実行する場合（`LOCAL_DEV=true`、`-dev`ターゲットによって自動的に設定されます）、`get_checkpointer()`は、設定された`session`オプションに関係なく、常にワークスペースルートの`tmp/agents/langchain/<agent-name>`の下のローカルSQLiteデータベースによってバックアップされた[`AsyncSqliteSaver`](https://reference.langchain.com/python/langgraph.checkpoint.sqlite/aio/AsyncSqliteSaver)を返します。
+ローカルで実行する場合（`-dev` ターゲットによって自動的に設定される `LOCAL_DEV=true`）、設定された `session` オプションに関わらず、`get_checkpointer()` は常にワークスペースルートの `tmp/agents/langchain/<agent-name>` 以下のローカルSQLiteデータベースに基づく [`AsyncSqliteSaver`](https://reference.langchain.com/python/langgraph.checkpoint.sqlite/aio/AsyncSqliteSaver) を返します（利便性のため）。
 :::
 </OptionFilter>
 </OptionFilter>
 
-## Agentの呼び出し
+## エージェントの呼び出し
 
 <OptionFilter when={{ protocol: 'http' }} description="FastAPI HTTP invocation details">
 ### ローカルサーバーの呼び出し
 
-`<your-agent-name>-serve`ターゲットを介してローカルで実行されているAgentを呼び出すには、ローカルエージェントが実行されているポートの`/invocations`に簡単なPOSTリクエストを送信できます。たとえば、`curl`を使用して：
+`<your-agent-name>-serve` ターゲットを介してローカルで実行中のエージェントを呼び出すには、ローカルエージェントが実行されているポートの `/invocations` に単純なPOSTリクエストを送信できます。例えば、`curl` を使用する場合:
 
 ```bash
 curl -N -X POST http://localhost:8081/invocations \
@@ -538,12 +547,12 @@ curl -N -X POST http://localhost:8081/invocations \
 ```
 
 :::note[Curlストリーミングフラグ]
-`curl`に与えられる`-N`引数は、出力ストリームのバッファリングを無効にするため、ストリーミングレスポンスをリアルタイムで確認できます。
+`curl` に渡される `-N` 引数は出力ストリームのバッファリングを無効にするため、ストリーミングレスポンスをリアルタイムで確認できます。
 :::
 
-### デプロイされたAgentの呼び出し
+### デプロイされたエージェントの呼び出し
 
-<Snippet name="agent/runtime-arn" parentHeading="デプロイされたAgentの呼び出し" />
+<Snippet name="agent/runtime-arn" parentHeading="デプロイされたエージェントの呼び出し" />
 
 <Tabs syncKey="auth">
 <TabItem label="IAM" _filter={{ auth: 'iam' }}>
@@ -558,7 +567,7 @@ acurl <region> bedrock-agentcore -N -X POST \
 -H 'Content-Type: application/json'
 ```
 
-<Drawer title="Sigv4 enabled curl" trigger="上記のacurlコマンドの設定の詳細についてはこちらをクリックしてください">
+<Drawer title="Sigv4 enabled curl" trigger="Click here for more details on configuring the above acurl command">
 <Snippet name="tools/acurl" />
 </Drawer>
 </TabItem>
@@ -566,7 +575,7 @@ acurl <region> bedrock-agentcore -N -X POST \
 <TabItem label="Cognito" _filter={{ auth: 'cognito' }}>
 #### JWT / Cognito認証
 
-Cognito認証の場合、`Authorization`ヘッダーでCognitoアクセストークンを渡します：
+Cognito認証の場合、`Authorization` ヘッダーにCognitoアクセストークンを渡します:
 
 ```bash
 curl -N -X POST 'https://bedrock-agentcore.<region>.amazonaws.com/runtimes/<url-encoded-arn>/invocations' \
@@ -575,7 +584,7 @@ curl -N -X POST 'https://bedrock-agentcore.<region>.amazonaws.com/runtimes/<url-
   -H "Authorization: Bearer <access-token>"
 ```
 
-AWS CLIの`cognito-idp admin-initiate-auth`コマンドを使用してアクセストークンを取得できます。例：
+AWS CLIの `cognito-idp admin-initiate-auth` コマンドを使用してアクセストークンを取得できます。例:
 
 ```bash
 aws cognito-idp admin-initiate-auth \
@@ -592,36 +601,36 @@ aws cognito-idp admin-initiate-auth \
 
 #### ブラウザ / Reactウェブサイト
 
-Reactウェブサイトからエージェントを呼び出すには、<Link path="/guides/connection/react-py-agent">`connection`ジェネレーター</Link>を使用できます。これにより、正しい認証（IAMまたはCognito）を持つクライアントが自動的にセットアップされます。
+ReactウェブサイトからエージェントをInvokeするには、<Link path="/guides/connection/react-py-agent">`connection` ジェネレーター</Link> を使用できます。これにより、正しい認証（IAMまたはCognito）を持つクライアントが自動的にセットアップされます。
 
 <RunGenerator generator="connection" />
 
-接続の設定方法の詳細については、<Link path="/guides/connection/react-py-agent">`connection`ジェネレーターガイド</Link>を参照してください。
+接続のセットアップ方法の詳細については、<Link path="/guides/connection/react-py-agent">`connection` ジェネレーターガイド</Link> を参照してください。
 </OptionFilter>
 
 <OptionFilter when={{ protocol: 'a2a' }} description="A2A delegation details">
-### A2A Agentをツールとして呼び出す
+### ツールとしてのA2Aエージェントの呼び出し
 
-このエージェントからリモートA2Aエージェント（<Link path="/guides/ts-agent">TypeScript</Link>または<Link path="/guides/py-agent">Python</Link>）に作業を委任するには、<Link path="/guides/connection/py-agent-a2a">`connection`ジェネレーター</Link>を使用します。これにより、ターゲットエージェント用のSigV4認証クライアントが提供され、このエージェントの`agent.py`がAST変換されて、リモートA2Aエージェントが`@tool`デコレートされたデリゲートとして登録されます。
+このエージェントからリモートA2Aエージェント（<Link path="/guides/ts-agent">TypeScript</Link> または <Link path="/guides/py-agent">Python</Link>）に作業を委任するには、<Link path="/guides/connection/py-agent-a2a">`connection` ジェネレーター</Link> を使用します。これはターゲットエージェント用のSigV4認証クライアントを提供し、このエージェントの `agent.py` をAST変換してリモートA2Aエージェントを `@tool` デコレーターで装飾されたデリゲートとして登録します。
 
 <RunGenerator generator="connection" />
 
-接続の設定方法の詳細については、<Link path="/guides/connection/py-agent-a2a">`connection`ジェネレーターガイド</Link>を参照してください。
+接続のセットアップ方法の詳細については、<Link path="/guides/connection/py-agent-a2a">`connection` ジェネレーターガイド</Link> を参照してください。
 </OptionFilter>
 
 <OptionFilter when={{ protocol: 'ag-ui' }} description="AG-UI / React connection details">
-### AG-UI Agentの呼び出し
+### AG-UIエージェントの呼び出し
 
-ReactウェブサイトからAG-UIエージェントを呼び出すには、<Link path="/guides/connection/react-agui">`connection`ジェネレーター</Link>を使用します。これにより、正しい認証（IAMまたはCognito）を持つデプロイされたエージェント用に設定された[CopilotKit](https://docs.copilotkit.ai/)クライアントが配線されます。
+ReactウェブサイトからAG-UIエージェントを呼び出すには、<Link path="/guides/connection/react-agui">`connection` ジェネレーター</Link> を使用します。これにより、正しい認証（IAMまたはCognito）でデプロイされたエージェント用に設定された [CopilotKit](https://docs.copilotkit.ai/) クライアントが接続されます。
 
 <RunGenerator generator="connection" />
 
-接続の設定方法の詳細については、<Link path="/guides/connection/react-agui">`connection`ジェネレーターガイド</Link>を参照してください。
+接続のセットアップ方法の詳細については、<Link path="/guides/connection/react-agui">`connection` ジェネレーターガイド</Link> を参照してください。
 </OptionFilter>
 
-## Agentの保護
+## エージェントのセキュリティ保護
 
-<Snippet name="agent/securing-your-agent" parentHeading="Agentの保護" />
+<Snippet name="agent/securing-your-agent" parentHeading="エージェントのセキュリティ保護" />
 
 <Tabs syncKey="agent-framework">
 <TabItem label="Strands" _filter={{ framework: 'strands' }}>
@@ -641,7 +650,7 @@ model = BedrockModel(
 agent = Agent(model=model)
 ```
 
-詳細については、Strandsの[Guardrails](https://strandsagents.com/docs/user-guide/safety-security/guardrails/)ガイドを参照してください。
+詳細については、Strandsの [Guardrails](https://strandsagents.com/docs/user-guide/safety-security/guardrails/) ガイドを参照してください。
 </TabItem>
 <TabItem label="LangChain" _filter={{ framework: 'langchain' }}>
 ```python
@@ -659,18 +668,18 @@ model = ChatBedrockConverse(
 )
 ```
 
-`guardrail_config`フィールドについては、[`ChatBedrockConverse`](https://docs.langchain.com/oss/python/integrations/chat/bedrock_converse)ドキュメントを参照してください。
+`guardrail_config` フィールドについては [`ChatBedrockConverse`](https://docs.langchain.com/oss/python/integrations/chat/bedrock_converse) ドキュメントを参照してください。
 </TabItem>
 </Tabs>
 
 ## 接続
 
-<Link path="guides/connection">`connection`</Link>ジェネレーターを使用して、このプロジェクトをワークスペース内の他のプロジェクトと統合します。このプロジェクトに関連する接続は以下のとおりです：
+<Link path="guides/connection">`connection`</Link> ジェネレーターを使用して、このプロジェクトをワークスペース内の他のプロジェクトと統合します。以下の接続はこのプロジェクトに関連しています:
 
 <CardGrid>
   <ConnectionCard
     title="React to Python Agent"
-    description="ReactウェブサイトからPython Agentを呼び出す"
+    description="Call a Python Agent from a React website"
     href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/react-py-agent`}
     source="react"
     target="strands"
@@ -678,14 +687,14 @@ model = ChatBedrockConverse(
   />
   <ConnectionCard
     title="React to AG-UI Agent"
-    description="CopilotKitを介してReactウェブサイトからAG-UIプロトコルを公開するAgentを呼び出す"
+    description="Call an Agent exposing the AG-UI protocol from a React website via CopilotKit"
     href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/react-agui`}
     source="react"
     target="copilotkit"
   />
   <ConnectionCard
     title="Python Agent to MCP"
-    description="Python AgentをMCPサーバーに接続する"
+    description="Connect a Python Agent to an MCP server"
     href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/py-agent-mcp`}
     source="strands"
     sourceBadge="python"
@@ -693,7 +702,7 @@ model = ChatBedrockConverse(
   />
   <ConnectionCard
     title="Python Agent to A2A Agent"
-    description="Python AgentをリモートA2Aエージェントに接続する"
+    description="Connect a Python Agent to a remote A2A agent"
     href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/py-agent-a2a`}
     source="strands"
     sourceBadge="python"
@@ -701,7 +710,7 @@ model = ChatBedrockConverse(
   />
   <ConnectionCard
     title="TypeScript Agent to A2A Agent"
-    description="TypeScript AgentをリモートA2Aエージェントに接続する"
+    description="Connect a TypeScript Agent to a remote A2A agent"
     href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/ts-agent-a2a`}
     source="strands"
     sourceBadge="typescript"
@@ -709,7 +718,7 @@ model = ChatBedrockConverse(
   />
   <ConnectionCard
     title="Python Agent to Python DynamoDB"
-    description="Python AgentをDynamoDBテーブルに接続する"
+    description="Connect a Python Agent to a DynamoDB table"
     href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/py-agent-dynamodb`}
     source="strands"
     sourceBadge="python"
@@ -718,7 +727,7 @@ model = ChatBedrockConverse(
   />
   <ConnectionCard
     title="Python Agent to AgentCore Gateway"
-    description="Python AgentをAgentCore Gatewayに接続する"
+    description="Connect a Python Agent to an AgentCore Gateway"
     href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/py-agent-gateway`}
     source="strands"
     sourceBadge="python"
@@ -726,10 +735,9 @@ model = ChatBedrockConverse(
   />
   <ConnectionCard
     title="AgentCore Gateway to Agent"
-    description="エージェントをランタイムターゲットとしてAgentCore Gatewayでフロントする"
+    description="Front an agent with an AgentCore Gateway as a runtime target"
     href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/agentcore-gateway-agent`}
     source="agentcore"
     target="strands"
   />
 </CardGrid>
-

--- a/docs/src/content/docs/ko/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/ko/get_started/tutorials/dungeon-game/1.mdx
@@ -1,6 +1,6 @@
 ---
 title: 모노레포 설정하기
-description: "@aws/nx-plugin을 사용하여 에이전트 AI 기반 던전 어드벤처 게임을 구축하는 방법에 대한 안내입니다."
+description: "@aws/nx-plugin을 사용하여 에이전트 AI 기반 던전 어드벤처 게임을 만드는 방법을 안내합니다."
 ---
 
 import { Aside, Code, FileTree, Steps, Tabs, TabItem } from '@astrojs/starlight/components';
@@ -22,87 +22,87 @@ import nxGraphPng from '@assets/nx-graph.png'
 import gameSelectPng from '@assets/game-select.png'
 import gameConversationPng from '@assets/game-conversation.png'
 
-## 작업 1: 모노레포 생성하기
+## 작업 1: 모노레포 생성
 
-새 모노레포를 생성하려면 원하는 디렉토리 내에서 다음 명령을 실행하세요:
+새 모노레포를 생성하려면 원하는 디렉터리 안에서 다음 명령어를 실행하세요:
 
 <CreateNxWorkspaceCommand workspace="dungeon-adventure" iac="cdk" />
 
-:::note[IaC 제공자로서의 CDK]
-이 튜토리얼에서는 코드형 인프라(Infrastructure as Code)로 CDK를 사용하므로 `--iac=cdk`를 사용합니다. Nx Plugin for AWS는 `terraform`도 지원합니다.
+:::note[CDK as IaC Provider]
+이 튜토리얼에서는 인프라 코드로 CDK를 사용하므로 `--iac=cdk`를 사용합니다. Nx Plugin for AWS는 `terraform`도 지원합니다.
 :::
 
-이렇게 하면 `dungeon-adventure` 디렉토리 내에 NX 모노레포가 설정됩니다. VSCode에서 디렉토리를 열면 다음과 같은 파일 구조를 볼 수 있습니다:
+이 명령어는 `dungeon-adventure` 디렉터리 안에 NX 모노레포를 설정합니다. VSCode에서 해당 디렉터리를 열면 다음과 같은 파일 구조를 볼 수 있습니다:
 
 <FileTree>
 - .nx/
 - .vscode/
 - node_modules/
-- packages/ 하위 프로젝트가 위치할 곳
+- packages/ 서브 프로젝트가 위치하는 곳
 - .gitignore
-- biome.json Biome의 린팅 및 포맷팅 설정
+- biome.json 린팅 및 포맷팅을 위한 Biome 설정
 - nx.json Nx CLI 및 모노레포 기본값 설정
-- package.json 모든 노드 의존성이 정의됨
-- pnpm-lock.yaml 또는 bun.lock, yarn.lock, package-lock.json (패키지 매니저에 따라)
+- package.json 모든 node 의존성이 정의된 곳
+- pnpm-lock.yaml 또는 패키지 매니저에 따라 bun.lock, yarn.lock, package-lock.json
 - pnpm-workspace.yaml pnpm 사용 시
 - README.md
-- tsconfig.base.json 모든 노드 기반 하위 프로젝트가 이를 확장함
+- tsconfig.base.json 모든 node 기반 서브 프로젝트가 이를 확장
 - tsconfig.json
 - aws-nx-plugin.config.mts Nx Plugin for AWS 설정
 </FileTree>
 
-<Aside type="tip" title="자주 커밋하기">제너레이터를 실행하기 전에 스테이징되지 않은 모든 파일을 Git에 커밋하는 것이 모범 사례입니다. 이렇게 하면 `git diff`를 통해 제너레이터 실행 후 변경된 내용을 확인할 수 있습니다.</Aside>
+<Aside type="tip" title="자주 커밋하세요">제너레이터를 실행하기 전에 스테이징되지 않은 모든 파일을 Git에 커밋해 두는 것이 좋습니다. 이렇게 하면 `git diff`를 통해 제너레이터 실행 후 변경된 내용을 확인할 수 있습니다.</Aside>
 
-## 작업 2: 던전 어드벤처 게임 스캐폴딩하기
+## 작업 2: 던전 어드벤처 게임 스캐폴딩
 
-워크스페이스가 준비되면 게임의 하위 프로젝트들(Game API, Story Agent, Inventory MCP 서버, 게임 데이터베이스, 웹사이트)과 이들을 연결하는 연결을 스캐폴딩합니다. 두 가지 방법이 있습니다:
+워크스페이스가 준비되었으면 게임의 서브 프로젝트들 — Game API, Story Agent, Inventory MCP 서버, 게임 데이터베이스, 웹사이트 — 과 이들을 연결하는 연결 설정을 스캐폴딩합니다. 두 가지 방법이 있습니다:
 
-- **빠른 방법** — 아래 다이어그램에서 명령을 직접 복사하여 실행합니다. 동일한 시작점에 도달하는 가장 빠른 방법입니다.
-- **단계별 방법** — 아래 섹션을 펼쳐 각 제너레이터를 직접 실행하고 각각이 생성하는 것을 정확히 확인합니다.
+- **빠른 방법** — 아래 다이어그램에서 명령어를 바로 복사하여 실행합니다. 동일한 시작점에 가장 빠르게 도달하는 방법입니다.
+- **단계별 방법** — 아래 섹션을 펼쳐 각 제너레이터를 직접 실행하고 각각이 무엇을 생성하는지 확인합니다.
 
-아래 다이어그램은 던전 어드벤처 워크스페이스 그 자체입니다: 이 모듈에서 구축할 모든 프로젝트, 컴포넌트, 연결이 포함되어 있습니다. **Copy commands**를 눌러 전체 시리즈를 가져온 다음 작업 1에서 생성한 `dungeon-adventure` 디렉토리 내에서 실행하세요.
+아래 다이어그램은 던전 어드벤처 워크스페이스 그 자체입니다: 이 모듈에서 빌드할 모든 프로젝트, 컴포넌트, 연결이 포함되어 있습니다. **명령어 복사**를 클릭하여 전체 시리즈를 가져온 다음, 작업 1에서 생성한 `dungeon-adventure` 디렉터리 안에서 실행하세요.
 
 <EmbeddedGraph preset="dungeon-adventure" workspace="dungeon-adventure" iac="cdk" skipWorkspace />
 
-<Drawer title="단계별 방법" trigger="단계별 방법: 각 제너레이터를 직접 실행하고 생성되는 것을 확인하기">
+<Drawer title="단계별 방법" trigger="단계별 방법: 각 제너레이터를 직접 실행하고 결과 확인하기">
 
-모든 명령을 한 번에 복사하는 대신 각 제너레이터를 개별적으로 실행할 수 있습니다. 이것은 각 제너레이터가 워크스페이스에 무엇을 추가하는지 이해하는 가장 좋은 방법입니다. 작업 1에서 생성한 `dungeon-adventure` 디렉토리 내에서 각 제너레이터를 차례로 실행하세요.
+명령어를 한꺼번에 복사하는 대신, 각 제너레이터를 개별적으로 실행할 수 있습니다. 이 방법은 각 제너레이터가 워크스페이스에 무엇을 추가하는지 이해하는 가장 좋은 방법입니다. 작업 1에서 생성한 `dungeon-adventure` 디렉터리 안에서 각 제너레이터를 순서대로 실행하세요.
 
-##### Game API 생성하기
+##### Game API 생성
 
-먼저 Game API를 생성해 보겠습니다. 다음 단계에 따라 `GameApi`라는 tRPC API를 생성합니다:
+먼저 Game API를 생성해 보겠습니다. 이를 위해 다음 단계를 따라 `GameApi`라는 tRPC API를 생성합니다:
 
 <RunGenerator generator="ts#api" requiredParameters={{ name: "GameApi", framework: "trpc" }} noInteractive />
 
 <br />
 
-파일 트리에 몇 가지 새 파일이 나타난 것을 확인할 수 있습니다.
+파일 트리에 새 파일들이 나타나는 것을 볼 수 있습니다.
 
 <Aside title="루트 의존성">
-루트 `package.json`이 이제 `type`이 `module`로 설정되었습니다. 이는 ESM이 `@aws/nx-plugin`에서 제공하는 모든 노드 기반 하위 프로젝트의 기본 모듈 타입임을 의미합니다.
-TypeScript 프로젝트 작업에 대한 자세한 내용은 <Link path="guides/typescript-project">ts#project 생성기 가이드</Link>를 참조하세요.
+루트 `package.json`은 이제 `module` 타입으로 설정되어 있으며, 이는 `@aws/nx-plugin`이 제공하는 모든 node 기반 서브 프로젝트의 기본 모듈 타입이 ESM임을 의미합니다.
+TypeScript 프로젝트 작업에 대한 자세한 내용은 <Link path="guides/typescript-project">ts#project 제너레이터 가이드</Link>를 참조하세요.
 </Aside>
 
 <details>
-<summary>생성된 `ts#api` 파일을 자세히 살펴보기</summary>
+<summary>생성된 `ts#api` 파일 자세히 살펴보기</summary>
 
-다음은 `ts#api` 생성기에 의해 생성된 모든 파일 목록입니다. 파일 트리에서 강조 표시된 주요 파일을 살펴보겠습니다:
+아래는 `ts#api` 제너레이터가 생성한 모든 파일 목록입니다. 파일 트리에서 강조 표시된 주요 파일들을 살펴보겠습니다:
 <FileTree>
 - packages/
   - common/
     - constructs/
       - src/
-        - app/ 앱 특정 CDK 구성 요소
+        - app/ 앱별 cdk 구성
           - apis/
-            - **game-api.ts** tRPC API를 생성하는 CDK 구성 요소
+            - **game-api.ts** tRPC API를 생성하는 cdk 구성
             - index.ts
             - ...
           - index.ts
-        - core/ 일반 CDK 구성 요소
+        - core/ 일반 cdk 구성
           - api/
-            - rest-api.ts API Gateway Rest API 기본 CDK 구성 요소
-            - trpc-utils.ts trpc API CDK 구성 요소 유틸리티
-            - utils.ts API 구성 요소 유틸리티
+            - rest-api.ts API Gateway Rest API의 기본 cdk 구성
+            - trpc-utils.ts trpc API CDK 구성을 위한 유틸리티
+            - utils.ts API 구성을 위한 유틸리티
           - index.ts
           - runtime-config.ts
         - index.ts
@@ -110,31 +110,31 @@ TypeScript 프로젝트 작업에 대한 자세한 내용은 <Link path="guides/
       - ...
   - game-api/ tRPC API
     - src/
-      - client/ 기계 간 통신용 바닐라 클라이언트
+      - client/ 일반적으로 ts 머신 간 호출에 사용되는 바닐라 클라이언트
         - index.ts
-      - middleware/ Powertools 계측
+      - middleware/ powertools 계측
         - error.ts
         - index.ts
         - logger.ts
         - metrics.ts
         - tracer.ts
-      - schema/ API 입력/출력 정의
+      - schema/ API의 입력 및 출력 정의
         - index.ts
         - **echo.ts** 샘플 입력 및 출력 스키마
-        - z-async-iterable.ts tRPC 구독 출력용 래퍼 Zod 스키마
-      - procedures/ API 프로시저/라우트 구현
+        - z-async-iterable.ts tRPC 구독 출력을 위한 래퍼 Zod 스키마
+      - procedures/ API 프로시저/라우트의 구체적인 구현
         - **echo.ts** 샘플 프로시저 구현
       - index.ts
       - init.ts 컨텍스트 및 미들웨어 설정
-      - handler.ts Lambda 핸들러 진입점 (REST API용 응답 스트리밍 사용)
-      - local-server.ts 로컬 tRPC 서버 실행용
+      - handler.ts Lambda 핸들러 진입점 (REST API에 응답 스트리밍 사용)
+      - local-server.ts tRPC 서버를 로컬에서 실행할 때 사용
       - **router.ts** tRPC 라우터 및 모든 프로시저 정의
     - project.json
     - ...
 - vitest.workspace.ts
 </FileTree>
 
-주요 파일 몇 가지를 살펴보겠습니다:
+주요 파일들을 살펴보겠습니다:
 
 ```ts {7}
 // packages/game-api/src/router.ts
@@ -149,7 +149,7 @@ export const appRouter = router({
 
 export type AppRouter = typeof appRouter;
 ```
-라우터는 API의 tRPC 라우터를 정의하며 모든 API 메서드를 선언하는 곳입니다. 위에서 볼 수 있듯이 `echo` 메서드가 있으며 구현은 `./procedures/echo.ts` 파일에 있습니다. Lambda 핸들러 진입점은 `handler.ts`에 있으며, 생성기에 의해 자동으로 구성됩니다.
+라우터는 API의 tRPC 라우터를 정의하며 모든 API 메서드를 선언하는 곳입니다. 위에서 볼 수 있듯이, `./procedures/echo.ts` 파일에 구현이 있는 `echo`라는 메서드가 있습니다. Lambda 핸들러 진입점은 `handler.ts`에 있으며, 제너레이터에 의해 자동으로 설정됩니다.
 
 ```ts {7-10}
 // packages/game-api/src/procedures/echo.ts
@@ -165,7 +165,7 @@ export const echo = publicProcedure
   .query((opts) => ({ message: opts.input.message }));
 ```
 
-이 파일은 `echo` 메서드의 구현이며, 입력 및 출력 데이터 구조를 선언하여 강력하게 타입화되어 있습니다.
+이 파일은 `echo` 메서드의 구현이며, 입력 및 출력 데이터 구조를 선언하여 강력한 타입 검사를 제공합니다.
 
 ```ts
 // packages/game-api/src/schema/echo.ts
@@ -390,7 +390,7 @@ export class GameApi<
 }
 ```
 
-이 CDK 구성 요소는 `GameApi`를 정의합니다. `defaultIntegrations` 메서드는 tRPC API의 각 프로시저에 대해 자동으로 Lambda 함수를 생성하며, 번들된 API 구현을 가리킵니다. 이는 `cdk synth` 시점에 번들링이 발생하지 않음을 의미합니다([NodeJsFunction](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_lambda_nodejs.NodejsFunction.html) 사용과는 달리). 백엔드 프로젝트의 빌드 대상의 일부로 이미 번들링했기 때문입니다.
+이것은 `GameApi`를 정의하는 CDK 구성입니다. tRPC API의 각 프로시저에 대해 자동으로 Lambda 함수를 생성하는 `defaultIntegrations` 메서드를 제공하며, 번들된 API 구현을 가리킵니다. 이는 `cdk synth` 시점에 번들링이 발생하지 않음을 의미합니다([NodeJsFunction](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_lambda_nodejs.NodejsFunction.html) 사용과 달리), 백엔드 프로젝트의 빌드 타겟의 일부로 이미 번들링이 완료되었기 때문입니다.
 
 </details>
 
@@ -404,59 +404,61 @@ Python 프로젝트를 생성하려면:
 
 <RunGenerator generator="py#project" requiredParameters={{name:"story"}} noInteractive />
 
-파일 트리에 새 파일이 나타난 것을 확인할 수 있습니다.
+파일 트리에 새 파일들이 나타나는 것을 볼 수 있습니다.
 <details>
-<summary>생성된 `py#project` 파일을 자세히 살펴보기</summary>
+<summary>생성된 `py#project` 파일 자세히 살펴보기</summary>
 
-`py#project`는 다음 파일을 생성합니다:
+`py#project`는 다음 파일들을 생성합니다:
 
 <FileTree>
-- .venv/ 모노레포용 단일 가상 환경
+- .venv/ 모노레포를 위한 단일 가상 환경
 - packages/
   - story/
-    - dungeon_adventure_story/ Python 모듈
+    - dungeon_adventure_story/ python 모듈
     - tests/
     - .python-version
     - pyproject.toml
     - project.json
-- .python-version 고정된 uv Python 버전
+- .python-version 고정된 uv python 버전
 - pyproject.toml
 - uv.lock
 </FileTree>
 
-이 구성은 공유 가상 환경을 가진 [UV Workspace](https://docs.astral.sh/uv/concepts/projects/workspaces/)와 Python 프로젝트를 설정합니다.
+이는 공유 가상 환경을 가진 Python 프로젝트와 [UV Workspace](https://docs.astral.sh/uv/concepts/projects/workspaces/)를 설정합니다.
 
 </details>
 
 ###### Story agent
 
-`py#agent` 생성기를 사용하여 프로젝트에 Strands 에이전트를 추가하려면:
+`py#agent` 제너레이터로 프로젝트에 Strands 에이전트를 추가하려면:
 
 <RunGenerator generator="py#agent" requiredParameters={{project:"story", auth:"cognito", protocol:"ag-ui"}} noInteractive />
 
-:::note[AG-UI protocol]
-에이전트가 [Agent-User Interaction 프로토콜](https://docs.copilotkit.ai/aws-strands/protocol)을 사용하도록 `--protocol=ag-ui`를 선택합니다. 이를 통해 React 웹사이트가 [CopilotKit](https://docs.copilotkit.ai/)를 통해 직접 통신할 수 있으며, 스트리밍, 도구 호출 및 대화 기록이 수작업 HTTP 클라이언트 대신 프로토콜에 의해 처리됩니다.
+:::note[AG-UI 프로토콜]
+`--protocol=ag-ui`를 선택하면 에이전트가 [Agent-User Interaction 프로토콜](https://docs.copilotkit.ai/aws-strands/protocol)을 사용합니다 — 이를 통해 React 웹사이트가 [CopilotKit](https://docs.copilotkit.ai/)을 통해 직접 에이전트와 통신할 수 있으며, 스트리밍, 도구 호출, 대화 기록이 직접 만든 HTTP 클라이언트 대신 프로토콜에 의해 처리됩니다.
 :::
 
-파일 트리에 새 파일이 나타난 것을 확인할 수 있습니다.
+파일 트리에 새 파일들이 나타나는 것을 볼 수 있습니다.
 <details>
-<summary>생성된 `py#agent` 파일을 자세히 살펴보기</summary>
+<summary>생성된 `py#agent` 파일 자세히 살펴보기</summary>
 
-`py#agent`는 다음 파일을 생성합니다:
+`py#agent`는 다음 파일들을 생성합니다:
 
 <FileTree>
 - packages/
   - story/
-    - dungeon_adventure_story/ Python 모듈
+    - dungeon_adventure_story/ python 모듈
       - agent/
-        - main.py Bedrock AgentCore 런타임용 에이전트 진입점
-        - agent.py 예제 에이전트 및 도구 정의
-        - session.py 대화 상태 유지를 위한 SessionManager 확인
-        - Dockerfile AgentCore 런타임 배포용 Docker 이미지 정의
+        - main.py Bedrock AgentCore Runtime에서 에이전트의 진입점
+        - agent.py 예시 에이전트 및 도구 정의
+        - session.py 대화 상태 유지를 위한 SessionManager 해결
+        - middleware/
+          - session_id_middleware.py 요청에 대한 인바운드 AgentCore 세션 ID 바인딩
+        - Dockerfile AgentCore Runtime에 배포하기 위한 docker 이미지 정의
   - common/constructs/
     - src
       - app/agents/story-agent/
-        - story-agent.ts Story 에이전트를 AgentCore 런타임에 배포하는 구성 요소
+        - story-agent.ts Story 에이전트를 AgentCore Runtime에 배포하기 위한 구성
 </FileTree>
 
 일부 파일을 자세히 살펴보겠습니다:
@@ -490,7 +492,30 @@ Refer to tools as your 'spellbook'.
     )
 ```
 
-이 코드는 예제 Strands 에이전트를 생성하고 뺄셈 도구를 정의합니다. `log_model_errors`와 `log_tool_errors`는 공유 `dungeon_adventure_agent_connection` 프로젝트의 훅으로, 모델/도구 실패를 조용히 실패하도록 두는 대신 로깅합니다.
+이는 예시 Strands 에이전트를 생성하고 빼기 도구를 정의합니다. `log_model_errors`와 `log_tool_errors`는 공유 `dungeon_adventure_agent_connection` 프로젝트의 훅으로, 모델/도구 실패를 자동으로 실패하게 두지 않고 로깅합니다.
+
+```python
+# agent/middleware/session_id_middleware.py
+import uuid
+
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from dungeon_adventure_agent_connection import session_id_context
+
+SESSION_ID_HEADER = "x-amzn-bedrock-agentcore-runtime-session-id"
+
+
+class SessionIdMiddleware(BaseHTTPMiddleware):
+    """Bind the session ID for this request so downstream MCP / A2A clients forward it on outbound calls."""
+
+    async def dispatch(self, request: Request, call_next):
+        session_id = request.headers.get(SESSION_ID_HEADER) or str(uuid.uuid4())
+        with session_id_context(session_id):
+            return await call_next(request)
+```
+
+`SessionIdMiddleware`는 요청 기간 동안 인바운드 AgentCore 런타임 세션 ID를 `ContextVar`에 바인딩합니다.
 
 ```python
 # agent/main.py
@@ -505,14 +530,12 @@ from dungeon_adventure_agent_connection import get_current_session_id, session_i
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import StreamingResponse
-from starlette.middleware.base import BaseHTTPMiddleware
 
 from .agent import get_agent
+from .middleware.session_id_middleware import SESSION_ID_HEADER, SessionIdMiddleware
 from .session import get_session_manager
 
 logging.basicConfig(level=logging.INFO)
-
-SESSION_ID_HEADER = "x-amzn-bedrock-agentcore-runtime-session-id"
 
 
 @asynccontextmanager
@@ -529,15 +552,6 @@ async def lifespan(app: FastAPI):
         yield
 
 
-class _SessionIdMiddleware(BaseHTTPMiddleware):
-    """Bind the session ID for this request so downstream MCP / A2A clients forward it on outbound calls."""
-
-    async def dispatch(self, request: Request, call_next):
-        session_id = request.headers.get(SESSION_ID_HEADER) or str(uuid.uuid4())
-        with session_id_context(session_id):
-            return await call_next(request)
-
-
 app = FastAPI(title="AWS Strands - StoryAgent", lifespan=lifespan)
 app.add_middleware(
     CORSMiddleware,
@@ -546,7 +560,7 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
-app.add_middleware(_SessionIdMiddleware)
+app.add_middleware(SessionIdMiddleware)
 
 
 @app.post("/invocations")
@@ -589,7 +603,7 @@ async def ping():
     return {"status": "healthy"}
 ```
 
-이 파일은 에이전트의 진입점입니다. `--protocol=ag-ui`를 선택했기 때문에 생성기는 Strands `Agent`를 [`ag_ui_strands`](https://docs.copilotkit.ai/aws-strands/integration)의 `StrandsAgent`로 래핑하고 [AG-UI 프로토콜](https://docs.copilotkit.ai/aws-strands/protocol)을 사용하는 FastAPI 앱에 마운트합니다. 이것이 React 웹사이트에서 CopilotKit이 통신할 대상입니다. 에이전트는 가져오기 시점이 아닌 `lifespan` 핸들러 내부에서 빌드되므로 모듈 가져오기가 아닌 컨테이너 시작이 구성을 소유하며, 각 AgentCore 세션은 자체 컨테이너를 갖습니다. `_SessionIdMiddleware`는 인바운드 AgentCore 런타임 세션 ID를 `ContextVar`에 바인딩하여 나중에 연결할 다운스트림 MCP/A2A 클라이언트(예: <Link path="get_started/tutorials/dungeon-game/2">모듈 2</Link>의 인벤토리 MCP 서버)가 아웃바운드 호출 시 자동으로 이를 전달하도록 합니다. AG-UI는 `thread_id`당 하나의 Strands 에이전트를 캐시하므로, 템플릿 에이전트 자체의 세션 매니저 대신 `session_manager_provider`를 연결합니다. 이렇게 하면 각 스레드가 자체 `SessionManager`를 갖게 되어 대화 기록이 턴 간에 유지됩니다. 이 `get_session_manager()` 함수는 생성된 `session.py` 형제 파일에서 제공됩니다: 배포 시에는 생성기가 자동으로 프로비저닝하는 S3 버킷을 백엔드로 하는 `strands.session.S3SessionManager`를 반환하고, `agent-dev`(`LOCAL_DEV=true`) 하에서는 배포된 구성과 관계없이 항상 로컬 임시 디렉토리에 쓰는 `FileSessionManager`를 반환합니다.
+이것은 에이전트의 진입점입니다. `--protocol=ag-ui`를 선택했기 때문에, 제너레이터는 Strands `Agent`를 [`ag_ui_strands`](https://docs.copilotkit.ai/aws-strands/integration)의 `StrandsAgent`로 래핑하고 [AG-UI 프로토콜](https://docs.copilotkit.ai/aws-strands/protocol)을 사용하는 FastAPI 앱에 마운트합니다 — 이것이 React 웹사이트의 CopilotKit이 통신하는 대상입니다. 에이전트는 임포트 시점이 아닌 `lifespan` 핸들러 내부에서 빌드됩니다 — 따라서 컨테이너 시작이 구성을 소유하며, 각 AgentCore 세션은 자체 컨테이너를 갖습니다. 위에서 본 `SessionIdMiddleware`는 인바운드 AgentCore 런타임 세션 ID를 전달하므로 나중에 연결하는 다운스트림 MCP/A2A 클라이언트(예: <Link path="get_started/tutorials/dungeon-game/2">모듈 2</Link>의 Inventory MCP 서버)가 아웃바운드 호출 시 자동으로 전달합니다. AG-UI는 `thread_id`당 하나의 Strands 에이전트를 캐시하므로, 템플릿 에이전트의 자체 세션 매니저 대신 `session_manager_provider`를 연결합니다 — 이렇게 하면 각 스레드가 자체 `SessionManager`를 가져 대화 기록이 턴 간에 유지됩니다. 해당 `get_session_manager()` 함수는 생성된 `session.py` 형제 파일에서 옵니다: 배포 시에는 제너레이터가 자동으로 프로비저닝하는 S3 버킷을 기반으로 하는 `strands.session.S3SessionManager`를 반환하고, `agent-dev`(`LOCAL_DEV=true`) 하에서는 배포 설정에 관계없이 항상 로컬 임시 디렉터리에 쓰는 `FileSessionManager`를 반환합니다.
 
 ```ts
 // common/constructs/src/app/agents/story-agent/story-agent.ts
@@ -877,17 +891,17 @@ export class StoryAgent extends Construct implements IGrantable, IConnectable {
 }
 ```
 
-이 코드는 ECR에 에이전트 Docker 이미지를 업로드하고 AgentCore 런타임을 사용하여 호스팅하는 CDK `AgentRuntimeArtifact`를 구성합니다. `--auth=cognito`를 선택했기 때문에 구성 요소는 사용자 풀/클라이언트 ID를 요구하고 Cognito를 통해 AgentCore 런타임 호출을 인증하며, 호출자의 `Authorization` 헤더를 전달합니다. 또한 Story Agent의 `session.py`가 런타임에 읽는 세션 버킷을 프로비저닝합니다 — CloudWatch Logs로 서버 액세스 로그가 전달되는 KMS 암호화된 S3 버킷 — 에이전트에 읽기/쓰기 액세스 권한을 부여하고, Bedrock 모델 호출 액세스 권한을 부여하며, 에이전트(런타임에 AppConfig를 통해)와 Game API(synth 시점에 `invocationUrl`을 통해) 모두가 찾을 수 있도록 ARN과 버킷 이름을 `RuntimeConfig`에 등록합니다.
+이는 에이전트 Docker 이미지를 ECR에 업로드하고 AgentCore Runtime을 사용하여 호스팅하는 CDK `AgentRuntimeArtifact`를 설정합니다. `--auth=cognito`를 선택했기 때문에, 구성은 사용자 풀/클라이언트 ID를 요구하고 Cognito를 통해 AgentCore Runtime 호출을 인증하며, 호출자의 `Authorization` 헤더를 전달합니다. 또한 Story Agent의 `session.py`가 런타임에 읽는 세션 버킷 — CloudWatch Logs에 서버 액세스 로그가 전달되는 KMS 암호화된 S3 버킷 — 을 프로비저닝하고, 에이전트에 읽기/쓰기 액세스를 부여하고, Bedrock 모델을 호출할 수 있는 액세스를 부여하며, ARN과 버킷 이름을 `RuntimeConfig`에 등록하여 에이전트(런타임에 AppConfig를 통해)와 Game API(synth 시점에 `invocationUrl`을 통해) 모두 찾을 수 있게 합니다.
 
-추가 `Dockerfile`이 있는데, 이는 `story` 프로젝트의 Docker 이미지를 참조하여 Dockerfile과 에이전트 소스 코드를 함께 위치시킬 수 있도록 합니다.
+`story` 프로젝트의 Docker 이미지를 참조하는 추가 `Dockerfile`이 있어 Dockerfile과 에이전트 소스 코드를 함께 배치할 수 있습니다.
 
 </details>
 
-##### 인벤토리 도구 설정
+##### Inventory 도구 설정
 
-###### 인벤토리: TypeScript 프로젝트
+###### Inventory: TypeScript 프로젝트
 
-스토리 에이전트가 플레이어의 인벤토리를 관리할 수 있도록 도구를 제공하는 MCP 서버를 생성해 보겠습니다.
+Story Agent가 플레이어의 인벤토리를 관리하는 도구를 제공하는 MCP 서버를 생성해 보겠습니다.
 
 먼저 TypeScript 프로젝트를 생성합니다:
 
@@ -896,26 +910,26 @@ export class StoryAgent extends Construct implements IGrantable, IConnectable {
 이렇게 하면 빈 TypeScript 프로젝트가 생성됩니다.
 
 <details>
-<summary>생성된 `ts#project` 파일을 자세히 살펴보기</summary>
+<summary>생성된 `ts#project` 파일 자세히 살펴보기</summary>
 
-`ts#project` 생성기는 다음 파일을 생성합니다.
+`ts#project` 제너레이터는 다음 파일들을 생성합니다.
 
 <FileTree>
 - packages/
   - inventory/
     - src/
-      - index.ts 예제 함수가 포함된 진입점
-    - project.json 프로젝트 구성
-    - vitest.config.mts 테스트 구성
-    - tsconfig.json 프로젝트 기본 TypeScript 구성
-    - tsconfig.lib.json 컴파일 및 번들링용 TypeScript 구성
-    - tsconfig.spec.json 테스트용 TypeScript 구성
-- tsconfig.base.json 다른 프로젝트에서 참조할 수 있도록 별칭 구성 업데이트
+      - index.ts 예시 함수가 있는 진입점
+    - project.json 프로젝트 설정
+    - vitest.config.mts 테스트 설정
+    - tsconfig.json 프로젝트의 기본 TypeScript 설정
+    - tsconfig.lib.json 컴파일 및 번들링을 위한 TypeScript 설정
+    - tsconfig.spec.json 테스트를 위한 TypeScript 설정
+- tsconfig.base.json 다른 프로젝트가 이를 참조할 수 있도록 별칭 설정 업데이트
 </FileTree>
 
 </details>
 
-###### 인벤토리: MCP 서버
+###### Inventory: MCP 서버
 
 다음으로 TypeScript 프로젝트에 MCP 서버를 추가합니다:
 
@@ -923,77 +937,77 @@ export class StoryAgent extends Construct implements IGrantable, IConnectable {
 
 이렇게 하면 MCP 서버가 추가됩니다.
 <details>
-<summary>생성된 `ts#mcp-server` 파일을 자세히 살펴보기</summary>
+<summary>생성된 `ts#mcp-server` 파일 자세히 살펴보기</summary>
 
-`ts#mcp-server` 생성기는 다음 파일을 생성합니다.
+`ts#mcp-server` 제너레이터는 다음 파일들을 생성합니다.
 
 <FileTree>
 - packages/
   - inventory/
     - src/mcp-server/
-      - index.ts 배럴 익스포트
+      - index.ts 배럴 내보내기
       - server.ts MCP 서버 생성
       - tools/
-        - divide.ts 예제 도구
+        - divide.ts 예시 도구
       - resources/
-        - sample-guidance.ts 예제 리소스
-      - stdio.ts STDIO 전송을 사용한 MCP 진입점
-      - http.ts Streamable HTTP 전송을 사용한 MCP 진입점
-      - Dockerfile AgentCore 런타임 배포용 이미지 빌드
-    - rolldown.config.ts AgentCore 배포용 MCP 서버 번들 구성
+        - sample-guidance.ts 예시 리소스
+      - stdio.ts STDIO 전송을 사용하는 MCP 진입점
+      - http.ts Streamable HTTP 전송을 사용하는 MCP 진입점
+      - Dockerfile AgentCore Runtime에 배포하기 위한 이미지 빌드
+    - rolldown.config.ts AgentCore에 배포하기 위한 MCP 서버 번들링 설정
   - common/constructs/
     - src
       - app/mcp-servers/inventory-mcp-server/
-        - inventory-mcp-server.ts 인벤토리 MCP 서버를 AgentCore 런타임에 배포하는 구성 요소
+        - inventory-mcp-server.ts inventory MCP 서버를 AgentCore Runtime에 배포하기 위한 구성
 </FileTree>
 
 </details>
 
 ##### 게임 데이터베이스 생성
 
-게임 상태 — 저장된 게임과 각 플레이어의 인벤토리 — 는 [Amazon DynamoDB](https://aws.amazon.com/dynamodb/)에 저장됩니다. `ts#dynamodb` 생성기를 사용하여 `DungeonDb`라는 DynamoDB 프로젝트를 생성합니다:
+게임 상태 — 저장된 게임과 각 플레이어의 인벤토리 — 는 [Amazon DynamoDB](https://aws.amazon.com/dynamodb/)에 저장됩니다. `ts#dynamodb` 제너레이터로 `DungeonDb`라는 DynamoDB 프로젝트를 생성합니다:
 
 <RunGenerator generator="ts#dynamodb" requiredParameters={{name:"DungeonDb"}} noInteractive />
 
 :::tip[로컬 우선 개발]
-`ts#dynamodb` 생성기는 컨테이너에서 [DynamoDB Local](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html)을 실행하는 `dev` 대상을 제공합니다. 아래에서 실행할 `connection` 생성기와 결합하면 **전체 게임이 튜토리얼 마지막까지 배포 없이 로컬 머신에서 실행됩니다**.
+`ts#dynamodb` 제너레이터는 컨테이너에서 [DynamoDB Local](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html)을 실행하는 `dev` 타겟을 제공합니다. 아래에서 실행하는 `connection` 제너레이터와 결합하면, **튜토리얼 끝까지 배포 없이 전체 게임이 로컬 머신에서 실행됩니다**.
 :::
 
-파일 트리에 새 파일이 나타난 것을 확인할 수 있습니다.
+파일 트리에 새 파일들이 나타나는 것을 볼 수 있습니다.
 <details>
-<summary>생성된 `ts#dynamodb` 파일을 자세히 살펴보기</summary>
+<summary>생성된 `ts#dynamodb` 파일 자세히 살펴보기</summary>
 
-`ts#dynamodb` 생성기는 다음 파일을 생성합니다.
+`ts#dynamodb` 제너레이터는 다음 파일들을 생성합니다.
 
 <FileTree>
 - packages/
   - dungeon-db/
-    - config.json DynamoDB configuration including port, table name, container settings and Global Secondary Indexes
+    - config.json 포트, 테이블 이름, 컨테이너 설정 및 글로벌 보조 인덱스를 포함한 DynamoDB 설정
     - src/
-      - index.ts 진입점 및 익스포트
-      - client.ts DynamoDB 클라이언트 싱글톤 및 테이블 이름 확인
+      - index.ts 진입점 및 내보내기
+      - client.ts DynamoDB 클라이언트 싱글톤 및 테이블 이름 해결
       - entities/
-        - example.ts 예제 ElectroDB 엔티티 (이것을 교체할 예정)
-        - index.ts 엔티티 익스포트
-    - project.json `dev` 및 `pull-image` 대상 추가
+        - example.ts 예시 ElectroDB 엔티티 (이것을 교체할 예정)
+        - index.ts 엔티티 내보내기
+    - project.json `dev` 및 `pull-image` 타겟 추가
   - common/
     - scripts/
       - src/
         - dynamodb/
           - create-local-table.ts DynamoDB Local에 테이블 생성
-          - pull-image.ts DynamoDB Local 이미지 가져오기
+          - pull-image.ts DynamoDB Local 이미지 풀
           - start-container.ts DynamoDB Local 컨테이너 시작
     - constructs/
       - src/
         - app/dynamodb/
-          - dungeon-db.ts 테이블 프로비저닝을 위한 구성 요소
+          - dungeon-db.ts 테이블 프로비저닝을 위한 구성
         - core/
-          - dynamodb.ts 일반 DynamoDB 테이블 구성 요소
+          - dynamodb.ts 일반 DynamoDB 테이블 구성
 </FileTree>
 
-생성된 `src/client.ts`는 `getDynamoDBClient()` 및 `resolveTableName()`을 익스포트합니다. `LOCAL_DEV=true`일 때(`dev` 대상에 의해 자동으로 설정됨) 이들은 DynamoDB Local에 연결하고, 그렇지 않으면 AWS에 연결하여 <Link path="guides/runtime-config">런타임 구성</Link>에서 배포된 테이블 이름을 확인합니다. <Link path="get_started/tutorials/dungeon-game/2">모듈 2</Link>에서 이 프로젝트의 `Game` 및 `Inventory` 엔티티를 모델링할 것입니다.
+생성된 `src/client.ts`는 `getDynamoDBClient()`와 `resolveTableName()`을 내보냅니다. `LOCAL_DEV=true`(`dev` 타겟에 의해 자동으로 설정됨)일 때는 DynamoDB Local에 연결하고, 그렇지 않으면 AWS에 연결하여 <Link path="guides/runtime-config">런타임 설정</Link>에서 배포된 테이블 이름을 해결합니다. <Link path="get_started/tutorials/dungeon-game/2">모듈 2</Link>에서 이 프로젝트에 `Game` 및 `Inventory` 엔티티를 모델링할 것입니다.
 
-자세한 내용은 <Link path="guides/ts-dynamodb">ts#dynamodb 생성기 가이드</Link>를 참조하세요.
+자세한 내용은 <Link path="guides/ts-dynamodb">ts#dynamodb 제너레이터 가이드</Link>를 참조하세요.
 
 </details>
 
@@ -1001,54 +1015,54 @@ export class StoryAgent extends Construct implements IGrantable, IConnectable {
 
 다음으로 게임과 상호작용할 수 있는 UI를 생성합니다.
 
-###### 게임 UI: 웹사이트
+###### Game UI: 웹사이트
 
-UI를 생성하려면 다음 단계에 따라 `GameUI`라는 웹사이트를 생성합니다:
+UI를 생성하려면 다음 단계를 따라 `GameUI`라는 웹사이트를 생성합니다:
 
 <RunGenerator generator="ts#website" requiredParameters={{name:"GameUI", ux:"shadcn"}} noInteractive />
 
 :::note[Shadcn UI]
-생성된 웹사이트가 Tailwind로 스타일링된 [shadcn/ui](https://ui.shadcn.com/) 컴포넌트를 사용하도록 `--ux=shadcn`을 선택합니다. 모든 라우트 코드는 `Card`, `Button`, `Input`과 같은 shadcn 프리미티브를 사용하며, 나중에 `connection` 생성기가 일치하는 shadcn 테마의 [CopilotKit](https://docs.copilotkit.ai/) 채팅 표면을 연결합니다.
+`--ux=shadcn`을 선택하면 생성된 웹사이트가 Tailwind로 스타일링된 [shadcn/ui](https://ui.shadcn.com/) 컴포넌트를 사용합니다 — 모든 라우트 코드는 `Card`, `Button`, `Input`과 같은 shadcn 프리미티브를 사용하며, 나중에 `connection` 제너레이터가 일치하는 shadcn 테마의 [CopilotKit](https://docs.copilotkit.ai/) 채팅 인터페이스를 연결합니다.
 :::
 
-파일 트리에 새 파일이 나타난 것을 확인할 수 있습니다.
+파일 트리에 새 파일들이 나타나는 것을 볼 수 있습니다.
 
 <details>
-<summary>생성된 `ts#website` 파일을 자세히 살펴보기</summary>
+<summary>생성된 `ts#website` 파일 자세히 살펴보기</summary>
 
-`ts#website`는 다음 파일을 생성합니다. 파일 트리에서 강조 표시된 주요 파일을 살펴보겠습니다:
+`ts#website`는 다음 파일들을 생성합니다. 파일 트리에서 강조 표시된 주요 파일들을 살펴보겠습니다:
 
 <FileTree>
 - packages/
   - common/
     - constructs/
       - src/
-        - app/ 앱 특정 CDK 구성 요소
+        - app/ 앱별 cdk 구성
           - static-websites/
-            - **game-ui.ts** Game UI 생성용 CDK 구성 요소
+            - **game-ui.ts** Game UI를 생성하는 cdk 구성
         - core/
-          - static-website.ts 일반 정적 웹사이트 구성 요소
+          - static-website.ts 일반 정적 웹사이트 구성
   - game-ui/
     - public/
     - src/
       - components/
         - AppLayout/
-          - index.tsx shadcn `SidebarProvider` + 헤더를 사용한 전체 페이지 레이아웃
-        - app-sidebar.tsx 네비게이션 항목이 있는 기본 shadcn 사이드바
+          - index.tsx shadcn `SidebarProvider` + 헤더를 사용하는 전체 페이지 레이아웃
+        - app-sidebar.tsx 탐색 항목이 있는 기본 shadcn 사이드바
         - alert.tsx, spinner.tsx shadcn으로 래핑된 피드백 프리미티브
       - routes/ @tanstack/react-router 파일 기반 라우트
         - **index.tsx** 루트 '/' 페이지
-        - __root.tsx 모든 페이지의 기본 컴포넌트
+        - __root.tsx 모든 페이지가 이 컴포넌트를 기반으로 사용
       - config.ts
       - **main.tsx** React 진입점
-      - routeTree.gen.ts @tanstack/react-router에 의해 자동 업데이트
-      - styles.css 공유 shadcn 글로벌 가져오기 (Tailwind v4)
+      - routeTree.gen.ts @tanstack/react-router에 의해 자동으로 업데이트됨
+      - styles.css 공유 shadcn 글로벌 임포트 (Tailwind v4)
     - index.html
     - project.json
     - vite.config.mts
     - ...
   - common/
-    - shadcn/ 모든 `ux=shadcn` 웹사이트에서 가져오는 공유 shadcn/ui 라이브러리 (테마 토큰, `Button`, `Card`, `Input`, `Sidebar`, …)
+    - shadcn/ 공유 shadcn/ui 라이브러리 (테마 토큰, `Button`, `Card`, `Input`, `Sidebar`, …) 모든 `ux=shadcn` 웹사이트에서 임포트
       - src/components/ui/*
       - src/styles/globals.css Tailwind + shadcn 디자인 토큰
     - ...
@@ -1075,7 +1089,7 @@ export class GameUI extends StaticWebsite {
 }
 ```
 
-이 CDK 구성 요소는 GameUI를 정의합니다. Vite 기반 UI의 번들 경로가 이미 구성되어 있습니다. 이는 `build` 시점에 번들링이 game-ui 프로젝트의 빌드 대상 내에서 수행되고 그 출력이 여기서 사용됨을 의미합니다.
+이것은 GameUI를 정의하는 CDK 구성입니다. Vite 기반 UI의 생성된 번들에 대한 파일 경로가 이미 설정되어 있습니다. 이는 `build` 시점에 game-ui 프로젝트의 빌드 타겟 내에서 번들링이 발생하고 그 출력이 여기서 사용됨을 의미합니다.
 
 ```tsx
 // packages/game-ui/src/main.tsx
@@ -1106,7 +1120,7 @@ root &&
   );
 ```
 
-이 코드는 React를 마운트하는 진입점입니다. 스타일링은 `styles.css`를 통해 가져온 Tailwind v4 토큰에서 제공됩니다. `@tanstack/react-router`는 [파일 기반 라우팅](https://tanstack.com/router/v1/docs/framework/react/routing/file-based-routing) 모드로 구성됩니다. 개발 서버가 실행 중인 동안 `routes/` 아래에 생성하는 모든 파일이 자동으로 감지되고 라우트 트리가 재생성됩니다. 나중에 생성기(auth, connection)가 이 파일을 AST 패치하여 `<App />`를 추가 프로바이더로 래핑합니다.
+이것은 React가 마운트되는 진입점입니다. 스타일링은 `styles.css`를 통해 임포트된 Tailwind v4 토큰에서 옵니다. `@tanstack/react-router`는 [파일 기반 라우팅](https://tanstack.com/router/v1/docs/framework/react/routing/file-based-routing) 모드로 설정됩니다: 개발 서버가 실행 중인 한, `routes/` 아래에 생성하는 모든 파일이 자동으로 감지되고 라우트 트리가 재생성됩니다. 이후 제너레이터(auth, connection)는 AST 패치를 통해 이 파일을 수정하여 `<App />`을 추가 프로바이더로 래핑합니다.
 
 ```tsx
 // packages/game-ui/src/routes/index.tsx
@@ -1128,22 +1142,22 @@ function RouteComponent() {
 }
 ```
 
-`/` 라우트로 이동할 때 컴포넌트가 렌더링됩니다. `@tanstack/react-router`는 파일 생성/이동 시 `Route`를 관리합니다(개발 서버가 실행 중인 경우).
+`/` 라우트로 이동할 때 렌더링될 컴포넌트입니다. `@tanstack/react-router`는 이 파일을 생성/이동할 때마다(개발 서버가 실행 중인 한) `Route`를 관리합니다.
 
 </details>
 
-###### 게임 UI: 인증
+###### Game UI: 인증
 
-Amazon Cognito를 통해 인증된 액세스가 필요한 Game UI를 구성해 보겠습니다. 다음 단계를 따르세요:
+다음 단계를 따라 Amazon Cognito를 통한 인증된 액세스를 요구하도록 Game UI를 설정합니다:
 
 <RunGenerator generator="ts#website#auth" requiredParameters={{cognitoDomain:"game-ui", project:"@dungeon-adventure/game-ui", allowSignup:true}} noInteractive />
 
-파일 트리에 새 파일이 생성/변경된 것을 확인할 수 있습니다.
+파일 트리에 새 파일들이 나타나거나 변경되는 것을 볼 수 있습니다.
 
 <details>
-<summary>생성된 `ts#website#auth` 파일을 자세히 살펴보기</summary>
+<summary>생성된 `ts#website#auth` 파일 자세히 살펴보기</summary>
 
-`ts#website#auth` 생성기는 다음 파일을 업데이트/생성합니다. 파일 트리에서 강조 표시된 주요 파일을 살펴보겠습니다:
+`ts#website#auth` 제너레이터는 다음 파일들을 업데이트/생성합니다. 파일 트리에서 강조 표시된 주요 파일들을 살펴보겠습니다:
 
 <FileTree>
 - packages/
@@ -1151,19 +1165,19 @@ Amazon Cognito를 통해 인증된 액세스가 필요한 Game UI를 구성해 �
     - constructs/
       - src/
         - core/
-          - user-identity.ts 사용자/ID 풀 생성용 CDK 구성 요소
+          - user-identity.ts 사용자/ID 풀 생성을 위한 cdk 구성
   - game-ui/
     - src/
       - components/
         - AppLayout/
-          - index.tsx 로그인 사용자/로그아웃을 헤더에 추가
+          - index.tsx 헤더에 로그인한 사용자/로그아웃 추가
         - CognitoAuth/
           - index.tsx Cognito 로그인 관리
         - RuntimeConfig/
-          - index.tsx `runtime-config.json` 가져와 컨텍스트로 제공
+          - index.tsx `runtime-config.json`을 가져와 컨텍스트를 통해 자식에게 제공
       - hooks/
         - useRuntimeConfig.tsx
-      - **main.tsx** Cognito 추가로 업데이트됨
+      - **main.tsx** Cognito를 추가하도록 업데이트됨
 </FileTree>
 
 ```diff lang="tsx"
@@ -1212,22 +1226,22 @@ root &&
   );
 ```
 
-`RuntimeConfigProvider` 및 `CognitoAuth` 컴포넌트가 AST 변환을 통해 `main.tsx` 파일에 추가되었습니다. 이를 통해 `CognitoAuth` 컴포넌트는 필요한 Cognito 연결 구성을 포함하는 `runtime-config.json`을 가져와 올바른 대상으로 백엔드 호출을 수행하여 Amazon Cognito로 인증할 수 있습니다.
+`RuntimeConfigProvider`와 `CognitoAuth` 컴포넌트가 AST 변환을 통해 `main.tsx` 파일에 추가되었습니다. 이를 통해 `CognitoAuth` 컴포넌트가 백엔드 호출을 올바른 대상으로 보내기 위해 필요한 Cognito 연결 설정이 포함된 `runtime-config.json`을 가져와 Amazon Cognito로 인증할 수 있습니다.
 
 </details>
 
-###### 게임 UI: Game API 연결
+###### Game UI: Game API 연결
 
-이전에 생성한 Game API에 Game UI를 연결하도록 구성해 보겠습니다.
+이전에 생성한 Game API에 Game UI를 연결합니다.
 
 <RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-ui", targetProject:"@dungeon-adventure/game-api"}} noInteractive />
 
-파일 트리에 새 파일이 생성/변경된 것을 확인할 수 있습니다.
+파일 트리에 새 파일들이 나타나거나 변경되는 것을 볼 수 있습니다.
 
 <details>
 <summary>UI → tRPC 연결 파일 살펴보기</summary>
 
-`connection` 생성기는 다음 파일을 생성/업데이트합니다. 파일 트리에서 강조 표시된 주요 파일을 살펴보겠습니다:
+`connection` 제너레이터는 다음 파일들을 생성/업데이트합니다. 파일 트리에서 강조 표시된 주요 파일들을 살펴보겠습니다:
 
 <FileTree>
 - packages/
@@ -1236,7 +1250,7 @@ root &&
       - components/
         - GameApiClientProvider.tsx GameAPI 클라이언트 설정
       - hooks/
-        - **useGameApi.tsx** GameApi 호출용 훅
+        - **useGameApi.tsx** GameApi를 호출하는 훅
       - **main.tsx** trpc 클라이언트 프로바이더 주입
 - package.json
 
@@ -1266,10 +1280,10 @@ export const useGameApiClient = () => {
 };
 ```
 
-이 훅은 GameApi 호출을 위한 tRPC 클라이언트에 대한 액세스를 제공합니다. tRPC API 호출 예제는 <Link path="guides/connection/react-trpc#using-the-generated-code">tRPC 훅 사용 가이드</Link>를 참조하세요.
+이 훅은 GameApi를 호출하기 위한 tRPC 클라이언트에 대한 액세스를 제공합니다. tRPC API 호출 예시는 <Link path="guides/connection/react-trpc#using-the-generated-code">tRPC 훅 사용 가이드</Link>를 참조하세요.
 
 <Aside title="타입 안전 훅">
-tRPC의 [TypeScript 추론](https://trpc.io/docs/concepts) 덕분에 `useGameApi`는 백엔드 변경 사항이 프론트엔드에 도달하기 위해 빌드 단계가 필요하지 않습니다 — 라우터나 프로시저에 대한 편집이 타입 체커에 의해 즉시 감지됩니다.
+tRPC의 [TypeScript 추론](https://trpc.io/docs/concepts) 덕분에, `useGameApi`는 백엔드 변경 사항이 프론트엔드에 반영되기 위한 빌드 단계가 필요하지 않습니다 — 라우터나 프로시저에 대한 편집이 타입 검사기에 즉시 반영됩니다.
 </Aside>
 
 ```diff lang="tsx"
@@ -1307,16 +1321,16 @@ root &&
 
 </details>
 
-###### Story Agent: 인벤토리 MCP 서버 연결
+###### Story Agent: Inventory MCP 서버 연결
 
-스토리 에이전트를 인벤토리 MCP 서버에 연결하여 에이전트가 MCP 서버의 도구를 검색하고 호출할 수 있도록 해 보겠습니다.
+에이전트가 MCP 서버의 도구를 발견하고 호출할 수 있도록 Story Agent를 Inventory MCP 서버에 연결합니다.
 
 <RunGenerator generator="connection" requiredParameters={{sourceProject:"story", targetProject:"inventory"}} noInteractive />
 
 <details>
-<summary>Story Agent → 인벤토리 MCP 연결 파일 살펴보기</summary>
+<summary>Story Agent → Inventory MCP 연결 파일 살펴보기</summary>
 
-`connection` 생성기는 다음 파일을 생성/업데이트합니다:
+`connection` 제너레이터는 다음 파일들을 생성/업데이트합니다:
 
 <FileTree>
 - packages/
@@ -1324,39 +1338,39 @@ root &&
     - agent\_connection/
       - dungeon\_adventure\_agent\_connection/
         - core/
-          - **agentcore\_endpoints.py** 프레임워크 독립적인 ARN/URL 해석
+          - **agentcore\_endpoints.py** 프레임워크 독립적인 ARN/URL 해결
           - **agentcore\_mcp\_transport.py** 프레임워크 독립적인 MCP 전송
           - **agentcore\_mcp\_client\_strands.py** 전송을 래핑하는 Strands MCP 클라이언트
           - auth/ 프레임워크 독립적인 SigV4 / 세션 전달 `httpx.Auth`
         - app/
-          - **inventory\_mcp\_server\_client\_strands.py** 인벤토리 MCP 서버 연결용 Strands 클라이언트
+          - **inventory\_mcp\_server\_client\_strands.py** Inventory MCP 서버에 연결하기 위한 Strands 클라이언트
         - **\_\_init\_\_.py** 연결별 클라이언트 재내보내기
   - story/
     - dungeon\_adventure\_story/agent/
-      - **agent.py** MCP 클라이언트를 가져와 사용하도록 수정됨
+      - **agent.py** MCP 클라이언트를 임포트하고 사용하도록 수정됨
 
 </FileTree>
 
-생성기는 다음을 수행합니다:
-- 핵심 `AgentCoreMCPClientStrands`가 포함된 공유 `agent_connection` Python 프로젝트 생성(아직 없는 경우)
-- 로컬(직접 HTTP) 및 배포 시(IAM 인증을 통한 AgentCore) 모두에서 MCP 서버에 연결하는 `InventoryMcpServerClientStrands` 클래스 생성
-- 클라이언트를 가져오고, 인스턴스를 생성하며, MCP 서버의 도구를 에이전트에 연결하도록 `agent.py` 변환
-- story 프로젝트의 워크스페이스 종속성으로 `agent_connection` 프로젝트 추가
-- 로컬 실행 시 MCP 서버를 자동으로 시작하도록 `dev` 대상 업데이트
+제너레이터는:
+- 핵심 `AgentCoreMCPClientStrands`를 포함하는 공유 `agent_connection` Python 프로젝트를 생성합니다(아직 없는 경우)
+- 로컬(직접 HTTP)과 배포 시(IAM 인증을 통한 AgentCore) 모두에서 MCP 서버에 연결하는 `InventoryMcpServerClientStrands` 클래스를 생성합니다
+- `agent.py`를 변환하여 클라이언트를 임포트하고, 인스턴스를 생성하고, MCP 서버의 도구를 에이전트에 연결합니다
+- `agent_connection` 프로젝트를 story 프로젝트의 워크스페이스 의존성으로 추가합니다
+- 로컬에서 실행할 때 MCP 서버를 자동으로 시작하도록 `dev` 타겟을 업데이트합니다
 
-자세한 내용은 <Link path="guides/connection/py-agent-mcp">Python 에이전트에서 MCP로의 연결 가이드</Link>를 참조하세요.
+자세한 내용은 <Link path="guides/connection/py-agent-mcp">Python Agent to MCP 연결 가이드</Link>를 참조하세요.
 </details>
 
-###### 게임 UI: Story Agent 연결
+###### Game UI: Story Agent 연결
 
-Game UI를 Story Agent에 연결해 보겠습니다. 에이전트가 AG-UI를 사용하기 때문에 `connection` 생성기는 [CopilotKit](https://docs.copilotkit.ai/)를 연결합니다: 테마가 적용된 채팅 컴포넌트와 렌더링 준비가 된 `@ag-ui/client` `HttpAgent`를 얻게 됩니다.
+Game UI를 Story Agent에 연결합니다. 에이전트가 AG-UI를 사용하므로, `connection` 제너레이터는 [CopilotKit](https://docs.copilotkit.ai/)을 연결합니다: 테마가 적용된 채팅 컴포넌트와 렌더링 준비가 된 `@ag-ui/client` `HttpAgent`.
 
 <RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-ui", targetProject:"story"}} noInteractive />
 
 <details>
 <summary>UI → Story Agent 연결 파일 살펴보기</summary>
 
-`connection` 생성기는 다음 파일을 생성/업데이트합니다:
+`connection` 제너레이터는 다음 파일들을 생성/업데이트합니다:
 
 <FileTree>
 - packages/
@@ -1369,42 +1383,42 @@ Game UI를 Story Agent에 연결해 보겠습니다. 에이전트가 AG-UI를 �
           - ShadcnAssistantMessage.tsx, ShadcnUserMessage.tsx, ShadcnChatInput.tsx, ShadcnCursor.tsx, copilot.css
       - hooks/
         - **useAguiStoryAgent.tsx** `HttpAgent`를 빌드하고, Cognito 베어러 토큰을 주입하며, `threadId`를 AgentCore의 33자 세션 ID로 패딩
-    - **main.tsx** `<App />`를 `<AguiProvider>`로 래핑
+    - **main.tsx** `<App />`을 `<AguiProvider>`로 래핑
 
 </FileTree>
 
-생성기는 다음을 수행합니다:
+제너레이터는:
 - React 웹사이트의 `ux`(여기서는 Shadcn)를 감지하고 일치하는 채팅 컴포넌트를 제공합니다.
-- 연결된 모든 에이전트를 단일 `CopilotKitProvider`에 등록합니다. 다른 에이전트에 대해 재실행하면 다른 훅만 추가됩니다.
-- Runtime Configuration에서 에이전트의 런타임 ARN을 읽고, AgentCore 호출 URL을 빌드하며, Cognito 베어러 토큰과 AgentCore 세션 ID 헤더를 첨부합니다.
+- 연결된 모든 에이전트를 단일 `CopilotKitProvider`에 등록합니다 — 다른 에이전트에 대해 다시 실행하면 다른 훅이 추가됩니다.
+- 런타임 설정에서 에이전트의 런타임 ARN을 읽고, AgentCore 호출 URL을 빌드하며, Cognito 베어러 토큰과 AgentCore 세션 ID 헤더를 첨부합니다.
 
-자세한 내용은 <Link path="guides/connection/react-agui">React에서 AG-UI로의 연결 가이드</Link>를 참조하세요.
+자세한 내용은 <Link path="guides/connection/react-agui">React to AG-UI 연결 가이드</Link>를 참조하세요.
 </details>
 
-###### Game API 및 인벤토리 MCP 서버를 데이터베이스에 연결
+###### Game API와 Inventory MCP 서버를 데이터베이스에 연결
 
-Game API와 인벤토리 MCP 서버 모두 DynamoDB 테이블을 읽고 쓰므로 `DungeonDb` 프로젝트에 연결해 보겠습니다. `connection` 생성기는 대상이 `ts#dynamodb` 프로젝트임을 감지하고 각 소스 프로젝트의 `dev` 대상이 DynamoDB Local을 자동으로 시작하도록 연결합니다.
+Game API와 Inventory MCP 서버 모두 DynamoDB 테이블을 읽고 씁니다. 따라서 이들을 `DungeonDb` 프로젝트에 연결합니다. `connection` 제너레이터는 대상이 `ts#dynamodb` 프로젝트임을 감지하고 각 소스 프로젝트의 `dev` 타겟이 DynamoDB Local을 자동으로 시작하도록 연결합니다.
 
 <RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-api", targetProject:"@dungeon-adventure/dungeon-db"}} noInteractive />
 
 <RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/inventory", targetProject:"@dungeon-adventure/dungeon-db"}} noInteractive />
 
-<Aside type="tip" title="하나의 명령으로 전체 스택을 로컬에서 부팅">
-스토리 에이전트의 `agent-dev`가 이미 인벤토리 MCP 서버의 `mcp-server-dev`에 의존하고(위의 `story → inventory` 연결을 통해), Game API와 MCP 서버 모두 이제 `dungeon-db:dev`에 의존하므로, 어떤 프로젝트의 `dev` 대상을 실행하든 필요한 모든 종속성을 올바른 순서로 시작합니다.
+<Aside type="tip" title="하나의 명령으로 전체 스택을 로컬에서 시작">
+Story Agent의 `agent-dev`는 이미 Inventory MCP 서버의 `mcp-server-dev`에 의존하고 있으며(`story → inventory` 연결을 통해), Game API와 MCP 서버 모두 이제 `dungeon-db:dev`에 의존합니다. 따라서 어떤 프로젝트의 `dev` 타겟을 실행하든 필요한 모든 의존성이 올바른 순서로 시작됩니다.
 </Aside>
 
-###### 게임 UI: 인프라스트럭처
+###### Game UI: 인프라
 
-CDK 인프라스트럭처를 위한 마지막 하위 프로젝트를 생성해 보겠습니다.
+CDK 인프라를 위한 최종 서브 프로젝트를 생성합니다.
 
 <RunGenerator generator="ts#infra" requiredParameters={{name:"infra"}} noInteractive />
 
-파일 트리에 새 파일이 생성/변경된 것을 확인할 수 있습니다.
+파일 트리에 새 파일들이 나타나거나 변경되는 것을 볼 수 있습니다.
 
 <details>
-<summary>생성된 `ts#infra` 파일을 자세히 살펴보기</summary>
+<summary>생성된 `ts#infra` 파일 자세히 살펴보기</summary>
 
-`ts#infra` 생성기는 다음을 생성/업데이트합니다. 파일 트리에서 강조 표시된 주요 파일을 살펴보겠습니다:
+`ts#infra` 제너레이터는 다음 파일들을 생성/업데이트합니다. 파일 트리에서 강조 표시된 주요 파일들을 살펴보겠습니다:
 
 <FileTree>
 - packages/
@@ -1417,10 +1431,10 @@ CDK 인프라스트럭처를 위한 마지막 하위 프로젝트를 생성해 �
   - infra
     - src/
       - stages/
-        - **application-stage.ts** CDK 스택 정의
+        - **application-stage.ts** cdk 스택이 정의되는 곳
       - stacks/
-        - **application-stack.ts** CDK 리소스 정의
-      - **main.ts** 모든 스테이지 정의 진입점
+        - **application-stack.ts** cdk 리소스가 정의되는 곳
+      - **main.ts** 모든 스테이지를 정의하는 진입점
     - cdk.json
     - checkov.yml
     - project.json
@@ -1449,9 +1463,9 @@ new ApplicationStage(app, 'dungeon-adventure-infra-sandbox', {
 app.synth();
 ```
 
-<Aside type="tip" title="가져오기 오류 수정">IDE 내에서 가져오기 오류가 표시되면 인프라 프로젝트의 `tsconfig.json`에 TypeScript 참조가 아직 설정되지 않았기 때문입니다. Nx는 빌드/컴파일 실행 시 또는 `nx sync` 명령을 수동으로 실행할 때 이러한 참조를 *동적으로* 생성하도록 [구성](https://nx.dev/nx-api/js/generators/typescript-sync)되어 있습니다. 자세한 내용은 <Link path="guides/typescript-project#importing-your-library-code-in-other-projects">TypeScript 가이드</Link>를 참조하세요.</Aside>
+<Aside type="tip" title="임포트 오류 수정">IDE에서 임포트 오류가 표시되는 경우, 이는 인프라 프로젝트에 `tsconfig.json`에 TypeScript 참조가 아직 설정되지 않았기 때문입니다. Nx는 빌드/컴파일이 실행되거나 `nx sync` 명령을 수동으로 실행할 때마다 이러한 참조를 *동적으로* 생성하도록 [설정](https://nx.dev/nx-api/js/generators/typescript-sync)되어 있습니다. 자세한 내용은 <Link path="guides/typescript-project#importing-your-library-code-in-other-projects">TypeScript 가이드</Link>를 참조하세요.</Aside>
 
-이 코드는 CDK 애플리케이션의 진입점입니다.
+이것은 CDK 애플리케이션의 진입점입니다.
 
 ```ts
 // packages/infra/src/stacks/application-stack.ts
@@ -1467,19 +1481,19 @@ export class ApplicationStack extends Stack {
 }
 ```
 
-던전 어드벤처 게임을 구축하기 위해 CDK 구성 요소를 인스턴스화해 보겠습니다.
+던전 어드벤처 게임을 빌드하기 위해 CDK 구성을 인스턴스화해 보겠습니다.
 
 </details>
 
 </Drawer>
 
-## 작업 3: 인프라스트럭처 업데이트
+## 작업 3: 인프라 업데이트
 
-생성된 구성 요소 일부를 인스턴스화하기 위해 `packages/infra/src/stacks/application-stack.ts`를 업데이트합니다:
+생성된 구성 중 일부를 인스턴스화하기 위해 `packages/infra/src/stacks/application-stack.ts`를 업데이트해 보겠습니다:
 
 <E2EDiff before="dungeon-adventure/1/application-stack.ts.original.template" after="dungeon-adventure/1/application-stack.ts.template" lang="ts" />
 
-:::note[Default Integrations]
+:::note[기본 통합]
 Game API에 기본 통합을 제공합니다. 기본적으로 API의 각 작업은 해당 작업을 처리하는 개별 Lambda 함수에 매핑됩니다.
 :::
 
@@ -1487,47 +1501,47 @@ Game API에 기본 통합을 제공합니다. 기본적으로 API의 각 작업�
 
 <Drawer title="Nx 명령어" trigger="이제 처음으로 코드를 빌드할 시간입니다">
 
-###### Single vs Multiple targets
+###### 단일 vs 다중 타겟
 
-`run-many` 명령은 여러 하위 프로젝트에 대해 대상을 실행합니다(`--all`은 모두 대상으로 지정). 이는 종속성이 올바른 순서로 실행되도록 보장합니다.
+`run-many` 명령어는 여러 나열된 서브 프로젝트에서 타겟을 실행합니다(`--all`은 모두를 대상으로 합니다). 이렇게 하면 의존성이 올바른 순서로 실행됩니다.
 
-단일 프로젝트 대상에 대해 빌드(또는 기타 작업)를 트리거하려면 프로젝트에 직접 대상을 실행할 수 있습니다. 예를 들어 `@dungeon-adventure/infra` 프로젝트를 빌드하려면 다음 명령을 실행합니다:
-
-<NxCommands commands={['build infra']} />
-
-범위를 생략하고 Nx 단축 구문을 사용할 수도 있습니다:
+단일 프로젝트 타겟에 대한 빌드(또는 다른 작업)를 직접 프로젝트에서 실행하여 트리거할 수도 있습니다. 예를 들어, `@dungeon-adventure/infra` 프로젝트를 빌드하려면 다음 명령어를 실행합니다:
 
 <NxCommands commands={['build infra']} />
 
-###### Visualizing your dependencies
+범위를 생략하고 원하는 경우 Nx 단축 구문을 사용할 수도 있습니다:
 
-종속성을 시각화하려면 다음을 실행합니다:
+<NxCommands commands={['build infra']} />
+
+###### 의존성 시각화
+
+의존성을 시각화하려면 다음을 실행합니다:
 
 <NxCommands commands={['graph']} />
 <br/>
 
 <Image src={nxGraphPng} alt="nx-graph.png" width="800" height="600" />
 
-###### Caching
+###### 캐싱
 
-Nx는 개발 속도 향상을 위해 이전 빌드 아티팩트를 재사용하기 위해 [캐싱](https://nx.dev/concepts/how-caching-works)에 의존합니다. 이 기능이 올바르게 작동하려면 일부 구성이 필요하며 **캐시를 사용하지 않고** 빌드를 수행해야 하는 경우가 있을 수 있습니다. 이 경우 명령에 `--skip-nx-cache` 인수를 추가하면 됩니다. 예:
+Nx는 [캐싱](https://nx.dev/concepts/how-caching-works)을 사용하여 이전 빌드의 아티팩트를 재사용하여 개발 속도를 높입니다. 이를 올바르게 작동시키기 위한 일부 설정이 필요하며, **캐시를 사용하지 않고** 빌드를 수행하고 싶은 경우가 있을 수 있습니다. 그렇게 하려면 명령어에 `--skip-nx-cache` 인수를 추가하면 됩니다. 예를 들어:
 
 <NxCommands commands={['build infra --skip-nx-cache']} />
-캐시(`.nx` 폴더에 저장)를 지워야 하는 경우 다음 명령을 실행합니다:
+어떤 이유로든 캐시(`.nx` 폴더에 저장됨)를 지우고 싶다면 다음 명령어를 실행할 수 있습니다:
 
 <NxCommands commands={['reset']} />
 
 </Drawer>
 
-명령줄을 사용하여 먼저 린트 문제를 수정하기 위해 다음 명령을 실행합니다:
+명령줄을 사용하여 먼저 린트 문제를 수정하는 다음 명령어를 실행합니다:
 
 <PackageManagerShortCommand commands={["lint"]} />
 
-그런 다음 전체 빌드를 위해 다음 명령을 실행합니다:
+그런 다음 전체 빌드를 위해 다음 명령어를 실행합니다:
 
 <PackageManagerShortCommand commands={["build"]} />
 
-다음과 같은 프롬프트가 표시됩니다:
+다음과 같은 메시지가 표시됩니다:
 
 ```bash
  NX   The workspace is out of sync
@@ -1541,10 +1555,10 @@ Yes, sync the changes and run the tasks
 No, run the tasks without syncing the changes
 ```
 
-이 메시지는 NX가 자동으로 업데이트할 수 있는 일부 파일을 감지했음을 나타냅니다. 이 경우 참조 프로젝트에 대한 TypeScript 참조가 설정되지 않은 `tsconfig.json` 파일을 가리킵니다.
+이 메시지는 NX가 자동으로 업데이트할 수 있는 일부 파일을 감지했음을 나타냅니다. 이 경우, 참조 프로젝트에 TypeScript 참조가 설정되지 않은 `tsconfig.json` 파일을 가리킵니다.
 
-**Yes, sync the changes and run the tasks** 옵션을 선택하여 진행합니다. 동기화 생성기가 누락된 TypeScript 참조를 자동으로 추가하므로 모든 IDE 관련 가져오기 오류가 자동으로 해결됩니다!
+**Yes, sync the changes and run the tasks** 옵션을 선택하여 진행합니다. sync 제너레이터가 누락된 TypeScript 참조를 자동으로 추가하면서 IDE 관련 임포트 오류가 자동으로 해결되는 것을 볼 수 있습니다!
 
-모든 빌드 아티팩트는 이제 모노레포 루트에 위치한 `dist/` 폴더 내에서 사용할 수 있습니다. 이는 `@aws/nx-plugin`으로 생성된 프로젝트를 사용할 때의 표준 관행으로, 생성된 파일로 파일 트리를 오염시키지 않습니다. 파일을 정리하려는 경우 빌드 아티팩트가 파일 트리 전체에 흩어져 있을 걱정 없이 `dist/` 폴더를 삭제하면 됩니다.
+모든 빌드 아티팩트는 이제 모노레포 루트에 위치한 `dist/` 폴더 내에서 사용 가능합니다. 이는 `@aws/nx-plugin`이 생성한 프로젝트를 사용할 때의 표준 관행으로, 파일 트리에 생성된 파일이 흩어지지 않습니다. 파일을 정리하고 싶다면 파일 트리 전체에 빌드 아티팩트가 흩어질 걱정 없이 `dist/` 폴더를 삭제하면 됩니다.
 
-축하합니다! AI 던전 어드벤처 게임의 핵심 구현을 시작하는 데 필요한 모든 하위 프로젝트를 생성했습니다. 🎉🎉🎉
+축하합니다! AI 던전 어드벤처 게임의 핵심을 구현하는 데 필요한 모든 하위 프로젝트를 생성했습니다. 🎉🎉🎉

--- a/docs/src/content/docs/ko/guides/py-agent.mdx
+++ b/docs/src/content/docs/ko/guides/py-agent.mdx
@@ -1,6 +1,6 @@
 ---
 title: Python Agent
-description: 도구를 사용하는 AI 에이전트를 구축하기 위한 Python Agent를 생성하고 Amazon Bedrock AgentCore Runtime에 배포합니다
+description: 도구를 갖춘 AI 에이전트를 구축하고 Amazon Bedrock AgentCore Runtime에 배포하기 위한 Python Agent 생성
 generator: py#agent
 ---
 
@@ -16,20 +16,20 @@ import GeneratorParameters from '@components/generator-parameters.astro';
 import Drawer from '@components/drawer.astro';
 import OptionFilter from '@components/option-filter.astro';
 
-도구를 사용하는 에이전트를 구축하기 위한 Python AI 에이전트를 생성하고, 선택적으로 [Amazon Bedrock AgentCore Runtime](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/)에 배포합니다. `framework` 옵션으로 에이전트 프레임워크를 선택하세요: [Strands](https://strandsagents.com/) (기본값) 또는 [LangChain](https://docs.langchain.com/oss/python/langchain/overview) ([LangGraph](https://docs.langchain.com/oss/python/langgraph/overview) 기반).
+도구를 갖춘 AI 에이전트를 구축하기 위한 Python AI 에이전트를 생성하고, 선택적으로 [Amazon Bedrock AgentCore Runtime](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/)에 배포합니다. `framework` 옵션으로 에이전트 프레임워크를 선택하세요: [Strands](https://strandsagents.com/) (기본값) 또는 [LangChain](https://docs.langchain.com/oss/python/langchain/overview) ([LangGraph](https://docs.langchain.com/oss/python/langgraph/overview) 기반).
 
-생성기는 서버 `protocol`을 통해 에이전트를 노출합니다. 두 프레임워크 모두 [HTTP](https://fastapi.tiangolo.com/) (기본값), 다른 A2A 호환 에이전트와의 상호 운용성을 위한 [Agent-to-Agent (A2A)](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-a2a.html) 프로토콜, 그리고 [CopilotKit](https://docs.copilotkit.ai/)을 통한 직접 프론트엔드 통합을 위한 [AG-UI](https://docs.ag-ui.com/) 프로토콜을 지원합니다.
+생성기는 서버 `protocol`을 통해 에이전트를 노출합니다. 두 프레임워크 모두 [HTTP](https://fastapi.tiangolo.com/) (기본값), 다른 A2A 호환 에이전트와의 상호 운용을 위한 [Agent-to-Agent (A2A)](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-a2a.html) 프로토콜, 그리고 [CopilotKit](https://docs.copilotkit.ai/)을 통한 직접 프론트엔드 통합을 위한 [AG-UI](https://docs.ag-ui.com/) 프로토콜을 지원합니다.
 
 ## 사용법
 
-### Agent 생성
+### 에이전트 생성
 
-Python Agent는 두 가지 방법으로 생성할 수 있습니다:
+Python Agent를 생성하는 두 가지 방법이 있습니다:
 
 <RunGenerator generator="py#agent" />
 
 :::tip[프로젝트 전제 조건]
-먼저 <Link path="/guides/python-project">`py#project`</Link> 생성기를 사용하여 Agent를 추가할 프로젝트를 생성하세요.
+먼저 <Link path="/guides/python-project">`py#project`</Link> 생성기를 사용하여 에이전트를 추가할 프로젝트를 생성하세요.
 :::
 
 ### 옵션
@@ -38,7 +38,7 @@ Python Agent는 두 가지 방법으로 생성할 수 있습니다:
 
 ## 생성기 출력
 
-생성기는 기존 Python 프로젝트에 다음 파일을 추가합니다. 생성되는 파일은 선택한 `protocol`에 따라 다릅니다:
+생성기는 기존 Python 프로젝트에 다음 파일들을 추가합니다. 생성되는 파일은 선택한 `protocol`에 따라 다릅니다:
 
 <OptionFilter when={{ protocol: 'http' }} description="FastAPI HTTP server layout">
 ### HTTP 프로토콜 (기본값)
@@ -51,6 +51,9 @@ Python Agent는 두 가지 방법으로 생성할 수 있습니다:
         - init.py FastAPI application setup with CORS and error handling middleware
         - agent.py Main agent definition with sample tools
         - session.py Resolves the framework-specific session persistence implementation
+        - middleware/
+          - \_\_init\_\_.py Python package initialization
+          - session_id_middleware.py Binds the inbound AgentCore session ID for the request
         - main.py FastAPI entry point for Bedrock AgentCore Runtime
         - Dockerfile Entry point for hosting your agent (excluded when `infra` is set to `None`)
     - pyproject.toml Updated with Strands dependencies
@@ -61,7 +64,7 @@ Python Agent는 두 가지 방법으로 생성할 수 있습니다:
 <OptionFilter when={{ protocol: 'a2a' }} description="A2A server layout">
 ### A2A 프로토콜
 
-진입점은 A2A 프로토콜을 통해 에이전트를 노출합니다 (Strands는 [Strands A2A Server](https://strandsagents.com/docs/user-guide/concepts/multi-agent/agent-to-agent)를 사용하고, LangChain은 그래프를 [`a2a-sdk`](https://a2a-protocol.org/) 실행기로 래핑합니다), FastAPI 앱에 마운트됩니다:
+엔트리 포인트는 A2A 프로토콜을 통해 에이전트를 노출합니다 (Strands는 [Strands A2A Server](https://strandsagents.com/docs/user-guide/concepts/multi-agent/agent-to-agent)를 사용하고, LangChain은 그래프를 [`a2a-sdk`](https://a2a-protocol.org/) 실행기로 래핑), FastAPI 앱에 마운트됩니다:
 
 <FileTree>
   - your-project/
@@ -70,6 +73,9 @@ Python Agent는 두 가지 방법으로 생성할 수 있습니다:
         - \_\_init\_\_.py Python package initialization
         - agent.py Main agent definition with sample tools
         - session.py Resolves the framework-specific session persistence implementation
+        - middleware/
+          - \_\_init\_\_.py Python package initialization
+          - session_id_middleware.py Binds the inbound AgentCore session ID for the request
         - main.py A2A server entry point
         - Dockerfile Entry point for hosting your agent (excluded when `infra` is set to `None`)
     - pyproject.toml Updated with framework and A2A dependencies
@@ -80,7 +86,7 @@ Python Agent는 두 가지 방법으로 생성할 수 있습니다:
 <OptionFilter when={{ protocol: 'ag-ui' }} description="AG-UI / CopilotKit server layout">
 ### AG-UI 프로토콜
 
-진입점은 [CopilotKit](https://docs.copilotkit.ai/)과의 직접 프론트엔드 통합을 위해 [AG-UI](https://docs.ag-ui.com/) 프로토콜을 통해 에이전트를 노출합니다. Strands 에이전트는 [ag-ui-strands](https://docs.ag-ui.com/) 통합을 사용하고, LangChain 에이전트는 [ag-ui-langgraph](https://docs.ag-ui.com/)를 사용합니다:
+엔트리 포인트는 [CopilotKit](https://docs.copilotkit.ai/)을 통한 직접 프론트엔드 통합을 위해 [AG-UI](https://docs.ag-ui.com/) 프로토콜을 통해 에이전트를 노출합니다. Strands 에이전트는 [ag-ui-strands](https://docs.ag-ui.com/) 통합을 사용하고, LangChain 에이전트는 [ag-ui-langgraph](https://docs.ag-ui.com/)를 사용합니다:
 
 <FileTree>
   - your-project/
@@ -89,13 +95,16 @@ Python Agent는 두 가지 방법으로 생성할 수 있습니다:
         - \_\_init\_\_.py Python package initialization
         - agent.py Main agent definition with sample tools
         - session.py Resolves the framework-specific session persistence implementation
+        - middleware/
+          - \_\_init\_\_.py Python package initialization
+          - session_id_middleware.py Binds the inbound AgentCore session ID for the request
         - main.py AG-UI server entry point
         - Dockerfile Entry point for hosting your agent (excluded when `infra` is set to `None`)
     - pyproject.toml Updated with framework and AG-UI dependencies
     - project.json Updated with agent serve targets
 </FileTree>
 
-:::tip[React 웹사이트에 연결]
+:::tip[React 웹사이트에 연결하기]
 AG-UI 에이전트는 <Link path="/guides/connection/react-agui">`connection` 생성기</Link>를 사용하여 React 프론트엔드에 연결할 수 있으며, 풍부한 채팅 경험을 위한 [CopilotKit](https://docs.copilotkit.ai/) 컴포넌트를 설정합니다.
 :::
 </OptionFilter>
@@ -105,7 +114,7 @@ AG-UI 에이전트는 <Link path="/guides/connection/react-agui">`connection` �
 <OptionFilter when={{ infra: 'agentcore' }} description="Bedrock AgentCore Runtime deployment">
 <Snippet name="shared-constructs" />
 
-Agent를 배포하기 위해 다음 파일이 생성됩니다:
+에이전트 배포를 위해 다음 파일들이 생성됩니다:
 
 <Infrastructure>
 <Fragment slot="cdk">
@@ -133,20 +142,20 @@ Agent를 배포하기 위해 다음 파일이 생성됩니다:
 </OptionFilter>
 
 <OptionFilter when={{ infra: 'none' }} description="No infrastructure is vended for infra=none">
-`infra`에 `none`을 선택한 경우, CDK 구성 또는 Terraform 모듈이 생성되지 않으며 Agent는 로컬에서만 실행할 수 있습니다. 인증할 호스팅 엔드포인트가 없으므로 이 모드에서는 `auth` 옵션이 무시됩니다.
+`infra`에 `none`을 선택한 경우, CDK 구성 요소나 Terraform 모듈이 생성되지 않으며 에이전트는 로컬에서만 실행할 수 있습니다. 호스팅된 엔드포인트가 없으므로 이 모드에서는 `auth` 옵션이 무시됩니다.
 </OptionFilter>
 
 #### 아키텍처
 
 <Snippet name="agent/architecture" />
 
-## Agent 작업하기
+## 에이전트 작업하기
 
-`agent.py`를 편집하여 도구를 추가하고, 모델을 구성하고, 시스템 프롬프트를 사용자 정의할 수 있습니다. API는 선택한 프레임워크에 따라 다릅니다.
+`agent.py`를 편집하여 도구를 추가하고, 모델을 구성하고, 시스템 프롬프트를 커스터마이즈할 수 있습니다. API는 선택한 프레임워크에 따라 다릅니다.
 
-### 도구 추가
+### 도구 추가하기
 
-도구는 AI 에이전트가 작업을 수행하기 위해 호출할 수 있는 함수입니다. 두 프레임워크 모두 도구를 정의하기 위해 데코레이터 기반 접근 방식을 사용하며, 함수 이름과 docstring에서 도구 이름과 설명을 파생하고, 타입 힌트에서 입력 스키마를 생성합니다.
+도구는 AI 에이전트가 작업을 수행하기 위해 호출할 수 있는 함수입니다. 두 프레임워크 모두 도구 정의에 데코레이터 기반 접근 방식을 사용하며, 함수 이름과 독스트링에서 도구 이름과 설명을 도출하고, 타입 힌트에서 입력 스키마를 생성합니다.
 
 <Tabs syncKey="agent-framework">
 <TabItem label="Strands" _filter={{ framework: 'strands' }}>
@@ -198,7 +207,7 @@ agent = create_agent(
 </TabItem>
 </Tabs>
 
-### 사전 구축된 도구 사용
+### 사전 구축된 도구 사용하기
 
 <Tabs syncKey="agent-framework">
 <TabItem label="Strands" _filter={{ framework: 'strands' }}>
@@ -214,7 +223,7 @@ agent = Agent(
 ```
 </TabItem>
 <TabItem label="LangChain" _filter={{ framework: 'langchain' }}>
-LangChain은 [도구 및 통합](https://docs.langchain.com/oss/python/integrations/tools)의 대규모 생태계를 제공합니다. 관련 통합 패키지를 설치한 다음 도구를 `create_agent`에 전달하세요:
+LangChain은 방대한 [도구 및 통합 생태계](https://docs.langchain.com/oss/python/integrations/tools)를 제공합니다. 관련 통합 패키지를 설치한 후 `create_agent`에 도구를 전달하세요:
 
 ```python
 from langchain_community.tools import DuckDuckGoSearchRun
@@ -232,7 +241,7 @@ agent = create_agent(
 
 <Tabs syncKey="agent-framework">
 <TabItem label="Strands" _filter={{ framework: 'strands' }}>
-기본적으로 Strands 에이전트는 Claude 4 Sonnet을 사용하지만, 모델 제공자를 사용자 정의할 수 있습니다. 구성 옵션은 [모델 제공자에 대한 Strands 문서](https://strandsagents.com/docs/user-guide/concepts/model-providers/)를 참조하세요:
+기본적으로 Strands 에이전트는 Claude 4 Sonnet을 사용하지만, 모델 공급자를 커스터마이즈할 수 있습니다. 구성 옵션은 [Strands 모델 공급자 문서](https://strandsagents.com/docs/user-guide/concepts/model-providers/)를 참조하세요:
 
 ```python
 from strands import Agent
@@ -249,7 +258,7 @@ agent = Agent(model=bedrock_model)
 ```
 </TabItem>
 <TabItem label="LangChain" _filter={{ framework: 'langchain' }}>
-LangChain 에이전트는 [`ChatBedrockConverse`](https://docs.langchain.com/oss/python/integrations/chat/bedrock_converse) 모델을 사용합니다. 생성된 에이전트는 `MODEL_ID` 및 `AWS_REGION` 환경 변수에서 모델 ID와 리전을 읽지만, `agent.py`에서 직접 모델을 구성할 수 있습니다:
+LangChain 에이전트는 [`ChatBedrockConverse`](https://docs.langchain.com/oss/python/integrations/chat/bedrock_converse) 모델을 사용합니다. 생성된 에이전트는 `MODEL_ID` 및 `AWS_REGION` 환경 변수에서 모델 ID와 리전을 읽지만, `agent.py`에서 직접 모델을 구성할 수도 있습니다:
 
 ```python
 from langchain_aws import ChatBedrockConverse
@@ -263,9 +272,9 @@ model = ChatBedrockConverse(
 </TabItem>
 </Tabs>
 
-### MCP 서버 사용
+### MCP 서버 사용하기
 
-<Link path="/guides/py-mcp-server">`py#mcp-server`</Link> 또는 <Link path="/guides/ts-mcp-server">`ts#mcp-server`</Link> 생성기를 사용하여 생성한 MCP 서버를 사용하려면 <Link path="/guides/connection/py-agent-mcp">`connection` 생성기</Link>를 사용할 수 있으며, 이는 두 프레임워크 모두에 대해 MCP 서버의 도구를 에이전트에 연결합니다.
+<Link path="/guides/py-mcp-server">`py#mcp-server`</Link> 또는 <Link path="/guides/ts-mcp-server">`ts#mcp-server`</Link> 생성기를 사용하여 생성한 MCP 서버를 사용하려면 <Link path="/guides/connection/py-agent-mcp">`connection` 생성기</Link>를 활용할 수 있으며, 이는 두 프레임워크 모두에서 MCP 서버의 도구를 에이전트에 연결합니다.
 
 <RunGenerator generator="connection" />
 
@@ -273,37 +282,37 @@ model = ChatBedrockConverse(
 
 다른 MCP 서버의 경우 [Strands](https://strandsagents.com/docs/user-guide/concepts/tools/mcp-tools/) 또는 [LangChain](https://docs.langchain.com/oss/python/langchain/mcp) MCP 문서를 참조하세요.
 
-### 더 보기
+### 더 알아보기
 
 에이전트 작성에 대한 더 심층적인 가이드는 [Strands](https://strandsagents.com/docs/user-guide/quickstart/overview/) 또는 [LangChain](https://docs.langchain.com/oss/python/langchain/overview) 문서를 참조하세요.
 
 ## 프로토콜
 
-에이전트의 서버 프로토콜은 통신 방식을 결정합니다. 모든 옵션은 [FastAPI](https://fastapi.tiangolo.com/)로 제공되며 진입점이 다릅니다:
+에이전트의 서버 프로토콜은 통신 방식을 결정합니다. 모든 옵션은 [FastAPI](https://fastapi.tiangolo.com/)로 제공되며 엔트리 포인트만 다릅니다:
 
-- **HTTP** (기본값): 사용자 정의 `/invocations` 엔드포인트, CORS 및 스트리밍을 갖춘 표준 FastAPI 서버입니다. 사용자 정의 클라이언트 통합에 가장 적합합니다.
-- **A2A**: FastAPI 앱에 마운트된 [Agent-to-Agent](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-a2a.html) 서버입니다 (Strands는 [Strands A2A Server](https://strandsagents.com/docs/user-guide/concepts/multi-agent/agent-to-agent)를 사용하고, LangChain은 프레임워크에 구애받지 않는 [`a2a-sdk`](https://a2a-protocol.org/)를 사용합니다). 에이전트가 다른 A2A 호환 에이전트에 의해 검색 및 호출 가능해야 할 때 가장 적합합니다.
-- **AG-UI**: SSE를 통한 [AG-UI 프로토콜](https://docs.ag-ui.com/)입니다 (Strands는 `ag-ui-strands`를 사용하고, LangChain은 `ag-ui-langgraph`를 사용합니다). React 웹사이트에서 [CopilotKit](https://docs.copilotkit.ai/)과의 직접 프론트엔드 통합에 가장 적합합니다.
+- **HTTP** (기본값): 커스텀 `/invocations` 엔드포인트, CORS, 스트리밍을 갖춘 표준 FastAPI 서버. 커스텀 클라이언트 통합에 가장 적합합니다.
+- **A2A**: FastAPI 앱에 마운트된 [Agent-to-Agent](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-a2a.html) 서버 (Strands는 [Strands A2A Server](https://strandsagents.com/docs/user-guide/concepts/multi-agent/agent-to-agent)를 사용하고, LangChain은 프레임워크 독립적인 [`a2a-sdk`](https://a2a-protocol.org/)를 사용). 에이전트가 다른 A2A 호환 에이전트에 의해 검색되고 호출될 수 있어야 할 때 가장 적합합니다.
+- **AG-UI**: SSE를 통한 [AG-UI 프로토콜](https://docs.ag-ui.com/) (Strands는 `ag-ui-strands`를 사용하고, LangChain은 `ag-ui-langgraph`를 사용). React 웹사이트에서 [CopilotKit](https://docs.copilotkit.ai/)을 통한 직접 프론트엔드 통합에 가장 적합합니다.
 
-서버 진입점은 프레임워크에 따라 다르지만 (Strands는 컨텍스트 관리 `Agent`를 생성하고, LangChain은 컴파일된 `create_agent` 그래프를 구동합니다), 각 프로토콜의 외부 계약은 동일합니다.
+서버 엔트리 포인트는 프레임워크에 따라 다르지만 (Strands는 컨텍스트 관리되는 `Agent`를 생성하고, LangChain은 컴파일된 `create_agent` 그래프를 구동), 각 프로토콜의 외부 계약은 동일합니다.
 
-모든 프로토콜은 AgentCore 런타임 상태 확인 계약을 위해 `/ping`을 노출합니다. A2A 에이전트는 포트 `9000`에서 수신하고, HTTP 및 AG-UI 에이전트는 포트 `8080`에서 수신합니다. 생성된 Dockerfile 및 인프라는 자동으로 구성됩니다.
+모든 프로토콜은 AgentCore 런타임 헬스 체크 계약을 위해 `/ping`을 노출합니다. A2A 에이전트는 포트 `9000`에서 수신하고, HTTP 및 AG-UI 에이전트는 포트 `8080`에서 수신합니다. 생성된 Dockerfile과 인프라는 자동으로 구성됩니다.
 
 <OptionFilter when={{ protocol: 'http' }} description="FastAPI HTTP server details">
 ## FastAPI 서버 (HTTP 프로토콜)
 
 생성된 HTTP 서버에는 다음이 포함됩니다:
-- CORS 미들웨어를 사용한 FastAPI 애플리케이션 설정
+- CORS 미들웨어를 갖춘 FastAPI 애플리케이션 설정
 - 오류 처리 미들웨어
 - OpenAPI 스키마 생성
-- 상태 확인 엔드포인트 (`/ping`)
+- 헬스 체크 엔드포인트 (`/ping`)
 - 에이전트 호출 엔드포인트 (`/invocations`)
 
-### Pydantic으로 호출 입력 및 출력 사용자 정의
+### Pydantic으로 호출 입출력 커스터마이즈하기
 
-에이전트의 호출 엔드포인트는 [Pydantic](https://docs.pydantic.dev/) 모델을 사용하여 요청 및 응답 스키마를 정의하고 검증합니다. `main.py`에서 이러한 모델을 사용자 정의하여 에이전트의 요구 사항에 맞출 수 있습니다.
+에이전트의 호출 엔드포인트는 [Pydantic](https://docs.pydantic.dev/) 모델을 사용하여 요청 및 응답 스키마를 정의하고 검증합니다. `main.py`에서 이 모델들을 커스터마이즈하여 에이전트의 요구 사항에 맞출 수 있습니다.
 
-#### 입력 모델 정의
+#### 입력 모델 정의하기
 
 기본 `InvokeInput` 모델은 프롬프트를 받습니다.
 
@@ -316,15 +325,15 @@ class InvokeInput(BaseModel):
 
 에이전트에 필요한 추가 필드를 포함하도록 이 모델을 확장할 수 있습니다.
 
-세션 ID는 [Bedrock AgentCore Runtime 세션 계약](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-service-contract.html)과 일치하는 `x-amzn-bedrock-agentcore-runtime-session-id` HTTP 헤더에서 추출됩니다. 헤더가 제공되지 않으면 임의의 UUID가 대체로 생성됩니다.
+세션 ID는 `x-amzn-bedrock-agentcore-runtime-session-id` HTTP 헤더에서 추출되며, [Bedrock AgentCore Runtime 세션 계약](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-service-contract.html)과 일치합니다. 헤더가 제공되지 않으면 대체로 임의의 UUID가 생성됩니다.
 
 :::caution[코드 구성]
-사용자가 에이전트를 직접 호출하는 경우 호출자로부터 세션 ID의 일부 또는 전부를 추상화하고 싶을 것입니다. 예를 들어, 인증된 사용자 ID를 세션 ID의 일부로 사용할 수 있습니다.
+사용자가 에이전트를 직접 호출하는 경우 호출자로부터 세션 ID의 일부 또는 전부를 추상화하고 싶을 수 있습니다. 예를 들어, 인증된 사용자 ID를 세션 ID의 일부로 사용할 수 있습니다.
 
-또한 사용 사례에 따라 세션에 대한 권한 부여를 구현해야 할 수도 있습니다. 예를 들어 사용자가 다른 사용자의 세션이 아닌 자신의 세션에만 액세스할 수 있도록 보장해야 합니다.
+또한 사용 사례에 따라 세션에 대한 권한 부여를 구현해야 할 수도 있습니다. 예를 들어, 사용자가 다른 사용자의 세션이 아닌 자신의 세션에만 접근할 수 있도록 보장하는 것입니다.
 :::
 
-#### 출력 모델 정의
+#### 출력 모델 정의하기
 
 스트리밍 응답의 경우, 생성기는 Pydantic 모델을 JSON Lines 형식(`application/jsonl`)으로 자동 직렬화하는 `JsonStreamingResponse`를 제공합니다. 이 형식은 OpenAPI 3.2의 스트리밍 사양과 호환되며 생성된 TypeScript 클라이언트와 원활하게 작동합니다.
 
@@ -335,7 +344,7 @@ class StreamChunk(BaseModel):
     content: str
 ```
 
-필요에 맞게 `StreamChunk` 모델을 사용자 정의할 수 있습니다:
+필요에 맞게 `StreamChunk` 모델을 커스터마이즈할 수 있습니다:
 
 ```python
 from pydantic import BaseModel
@@ -347,7 +356,7 @@ class StreamChunk(BaseModel):
 ```
 
 :::note[FastAPI 스트리밍 제한]
-FastAPI가 현재 스트리밍 응답에 대한 OpenAPI 사양 생성을 지원하지 않으므로 각 스트리밍 작업에 대해 응답 모델을 명시적으로 설정해야 합니다:
+FastAPI가 현재 스트리밍 응답에 대한 OpenAPI 사양 생성을 지원하지 않으므로, 각 스트리밍 작업에 대해 응답 모델을 명시적으로 설정해야 합니다:
 
 ```python
 @app.post(
@@ -360,61 +369,61 @@ async def invoke(input: InvokeInput) -> JsonStreamingResponse:
 ```
 :::
 
-[FastAPI의 네이티브 지원을 위한 기능 요청](https://github.com/fastapi/fastapi/discussions/14362)이 열려 있습니다.
+[FastAPI에서 네이티브 지원을 위한 공개 기능 요청](https://github.com/fastapi/fastapi/discussions/14362)이 있습니다.
 </OptionFilter>
 
 ## Bedrock AgentCore Python SDK
 
-생성기는 `PingStatus` 상수를 위해 [Bedrock AgentCore Python SDK](https://github.com/aws/bedrock-agentcore-sdk-python)에 대한 종속성을 포함합니다. 원하는 경우 FastAPI 대신 `BedrockAgentCoreApp`을 사용하는 것이 간단하지만, 타입 안전성이 손실됩니다.
+생성기는 `PingStatus` 상수를 위해 [Bedrock AgentCore Python SDK](https://github.com/aws/bedrock-agentcore-sdk-python)에 대한 의존성을 포함합니다. 원하는 경우 FastAPI 대신 `BedrockAgentCoreApp`을 사용하는 것도 간단하지만, 타입 안전성이 손실된다는 점에 유의하세요.
 
-SDK의 기능에 대한 자세한 내용은 [여기 문서](https://aws.github.io/bedrock-agentcore-starter-toolkit/user-guide/runtime/quickstart.html)에서 확인할 수 있습니다.
+SDK 기능에 대한 자세한 내용은 [여기 문서](https://aws.github.io/bedrock-agentcore-starter-toolkit/user-guide/runtime/quickstart.html)에서 확인할 수 있습니다.
 
 :::note[코드형 인프라]
-생성기가 에이전트 배포를 관리하는 CDK 또는 Terraform 인프라를 제공하므로, 문서에서 언급하는 에이전트 배포를 위한 `bedrock-agentcore-starter-toolkit`을 사용할 필요가 없습니다.
+생성기가 에이전트 배포를 관리하는 CDK 또는 Terraform 인프라를 제공하므로, 문서에서 언급하는 에이전트 배포용 `bedrock-agentcore-starter-toolkit`을 사용할 필요가 없습니다.
 :::
 
 <OptionFilter when={{ protocol: 'a2a' }} description="A2A server details">
 ## A2A 서버 (A2A 프로토콜)
 
-생성된 `main.py`는 `/ping`도 노출하는 상위 FastAPI 앱에 A2A 서버를 마운트합니다. Strands 에이전트는 Strands `A2AServer`를 사용하고, LangChain 에이전트는 컴파일된 그래프를 [`a2a-sdk`](https://a2a-protocol.org/) `AgentExecutor`로 래핑합니다. AgentCore에 배포되면 진입점은 AppConfig에서 런타임의 공개 ARN을 확인하고 에이전트 카드에 광고합니다.
+생성된 `main.py`는 `/ping`도 노출하는 상위 FastAPI 앱에 A2A 서버를 마운트합니다. Strands 에이전트는 Strands `A2AServer`를 사용하고, LangChain 에이전트는 컴파일된 그래프를 [`a2a-sdk`](https://a2a-protocol.org/) `AgentExecutor`로 래핑합니다. AgentCore에 배포될 때 엔트리 포인트는 AppConfig에서 런타임의 공개 ARN을 확인하고 에이전트 카드에 광고합니다.
 
-대부분의 사용자는 이 파일을 수정할 필요가 없습니다. 도구나 시스템 프롬프트를 변경하려면 `agent.py`를 편집하세요. A2A 서버는 에이전트의 `name` 및 `description`에서 에이전트 카드(`/.well-known/agent-card.json`)를 채웁니다.
+대부분의 사용자는 이 파일을 수정할 필요가 없습니다. 도구나 시스템 프롬프트를 변경하려면 `agent.py`를 편집하세요. A2A 서버는 에이전트의 `name`과 `description`에서 에이전트 카드(`/.well-known/agent-card.json`)를 채웁니다.
 </OptionFilter>
 
 <OptionFilter when={{ protocol: 'ag-ui' }} description="AG-UI / CopilotKit server details">
 ## AG-UI 서버 (AG-UI 프로토콜)
 
-생성된 `main.py`는 Server-Sent Events (SSE)를 통해 [AG-UI](https://docs.ag-ui.com/) 이벤트를 스트리밍하는 단일 POST 엔드포인트와 AgentCore 런타임 상태 확인을 위한 `/ping`을 노출합니다. 연결은 프레임워크에 따라 다릅니다:
+생성된 `main.py`는 Server-Sent Events (SSE)를 통해 [AG-UI](https://docs.ag-ui.com/) 이벤트를 스트리밍하는 단일 POST 엔드포인트와 AgentCore 런타임 헬스 체크를 위한 `/ping`을 노출합니다. 연결 방식은 프레임워크에 따라 다릅니다:
 
-- **Strands**: `Agent`를 FastAPI `lifespan` 핸들러 내부에 구축된 `ag_ui_strands.StrandsAgent`로 래핑하고 (따라서 구성이 가져오기 시간이 아닌 컨테이너/세션 시작 시 발생), 수동으로 작성된 FastAPI `/invocations` 루프에서 제공합니다.
-- **LangChain**: 컴파일된 그래프를 `lifespan` 내부에서 동일한 방식으로 구축된 `ag_ui_langgraph.LangGraphAgent`로 래핑하고, 수동으로 작성된 FastAPI `/invocations` 루프에서 제공합니다.
+- **Strands**: `Agent`를 `ag_ui_strands.StrandsAgent`로 래핑하고, FastAPI `lifespan` 핸들러 내부에서 구축(임포트 시간이 아닌 컨테이너/세션 시작 시 구성이 이루어짐)하여 직접 작성된 FastAPI `/invocations` 루프에서 제공합니다.
+- **LangChain**: 컴파일된 그래프를 `ag_ui_langgraph.LangGraphAgent`로 래핑하고, `lifespan` 내부에서 동일한 방식으로 구축하여 직접 작성된 FastAPI `/invocations` 루프에서 제공합니다.
 
-대부분의 사용자는 이 파일을 수정할 필요가 없습니다. 도구나 시스템 프롬프트를 변경하려면 `agent.py`를 편집하세요.
+대부분의 사용자는 이 파일을 수정할 필요가 없습니다 — 도구나 시스템 프롬프트를 변경하려면 `agent.py`를 편집하세요.
 
-:::tip[React 웹사이트에 연결]
-AG-UI 에이전트는 프론트엔드에서 직접 사용하도록 설계되었습니다. <Link path="/guides/connection/react-agui">`connection` 생성기</Link>를 사용하여 [CopilotKit](https://docs.copilotkit.ai/) 제공자 및 [AG-UI HttpAgent](https://docs.ag-ui.com/) 클라이언트로 React 웹사이트를 에이전트에 연결하세요.
+:::tip[React 웹사이트에 연결하기]
+AG-UI 에이전트는 프론트엔드에서 직접 사용하도록 설계되었습니다. <Link path="/guides/connection/react-agui">`connection` 생성기</Link>를 사용하여 [CopilotKit](https://docs.copilotkit.ai/) 공급자와 [AG-UI HttpAgent](https://docs.ag-ui.com/) 클라이언트로 React 웹사이트를 에이전트에 연결하세요.
 :::
 </OptionFilter>
 
-## Agent 실행
+## 에이전트 실행하기
 
 ### 로컬 개발
 
-Agent(및 연결된 모든 것)를 로컬에서 실행하려면 프로젝트의 `dev` 대상을 사용하세요:
+에이전트(및 연결된 모든 것)를 로컬에서 실행하려면 프로젝트의 `dev` 타겟을 사용하세요:
 
 <NxCommands commands={['dev your-project']} />
 
-프로젝트에 여러 컴포넌트(에이전트, MCP 서버 등)를 추가한 경우 모두 시작됩니다. 이 에이전트만 실행하려면 `<your-agent-name>-dev` 대상을 지정하세요:
+프로젝트에 여러 컴포넌트(에이전트, MCP 서버 등)를 추가한 경우 모두 시작됩니다. 이 에이전트만 실행하려면 `<your-agent-name>-dev` 타겟을 지정하세요:
 
 <NxCommands commands={['agent-dev your-project']} />
 
-이는 `uv run`을 사용하여 [Bedrock AgentCore Python SDK](https://github.com/aws/bedrock-agentcore-sdk-python)를 사용하여 Agent를 실행합니다.
+이는 `uv run`을 사용하여 [Bedrock AgentCore Python SDK](https://github.com/aws/bedrock-agentcore-sdk-python)로 에이전트를 실행합니다.
 
-### Agent와 채팅
+### 에이전트와 채팅하기
 
-생성기는 에이전트와 대화형 터미널 채팅을 시작하는 `<your-agent-name>-chat` Nx 대상을 구성합니다.
+생성기는 에이전트와 대화형 터미널 채팅을 시작하는 `<your-agent-name>-chat` Nx 타겟을 구성합니다.
 
-채팅 대상은 독립적으로 실행됩니다. 기본적으로 로컬에서 실행 중인 에이전트에 연결되므로 먼저 에이전트의 `<your-agent-name>-dev` 대상을 시작하세요 (별도의 터미널에서):
+채팅 타겟은 독립적으로 실행됩니다. 기본적으로 로컬에서 실행 중인 에이전트에 연결되므로, 먼저 에이전트의 `<your-agent-name>-dev` 타겟을 시작하세요 (별도의 터미널에서):
 
 <NxCommands commands={['agent-dev your-project']} />
 
@@ -422,30 +431,30 @@ Agent(및 연결된 모든 것)를 로컬에서 실행하려면 프로젝트의 
 
 <NxCommands commands={['run your-project:agent-chat']} />
 
-생성기는 모든 프로토콜에 대해 `scripts/<your-agent-name>/chat.ts`를 생성합니다. 기본적으로 로컬 에이전트에 연결하거나 `RUNTIME_CONFIG_APP_ID`가 설정된 경우 배포된 에이전트에 연결합니다 (아래 [배포된 에이전트와 채팅](#chat-with-your-deployed-agent) 참조).
+생성기는 모든 프로토콜에 대해 `scripts/<your-agent-name>/chat.ts`를 생성합니다. 기본적으로 로컬 에이전트에 연결하거나, `RUNTIME_CONFIG_APP_ID`가 설정된 경우 배포된 에이전트에 연결합니다 (아래 [배포된 에이전트와 채팅하기](#chat-with-your-deployed-agent) 참조).
 
-**HTTP** 에이전트의 경우 채팅 스크립트는 에이전트의 OpenAPI 사양에서 생성된 타입 안전 TypeScript 클라이언트를 사용합니다. 생성기는 또한 다음을 생성합니다:
+**HTTP** 에이전트의 경우, 채팅 스크립트는 에이전트의 OpenAPI 스펙에서 생성된 타입 안전 TypeScript 클라이언트를 사용합니다. 생성기는 또한 다음을 생성합니다:
 
-- `scripts/<your-agent-name>_openapi.py` — 에이전트의 OpenAPI 사양을 내보내는 작은 스크립트
-- 이를 실행하는 `<your-agent-name>-openapi` Nx 대상
-- `scripts/<your-agent-name>/generated/` 아래에 타입 안전 TypeScript 클라이언트를 생성하는 `<your-agent-name>-generate-client` Nx 대상
+- `scripts/<your-agent-name>_openapi.py` — 에이전트의 OpenAPI 스펙을 내보내는 작은 스크립트
+- 이를 실행하는 `<your-agent-name>-openapi` Nx 타겟
+- `scripts/<your-agent-name>/generated/` 아래에 타입 안전 TypeScript 클라이언트를 생성하는 `<your-agent-name>-generate-client` Nx 타겟
 
-에이전트의 입력 형태를 사용자 정의할 때 (예: `InvokeInput`에 새 필드 추가), 에이전트를 호출할 때 새 필드를 전달하도록 `chat.ts`를 업데이트하면 나머지는 자동으로 작동합니다.
+에이전트의 입력 형태를 커스터마이즈할 때 (예: `InvokeInput`에 새 필드 추가), `chat.ts`를 업데이트하여 에이전트 호출 시 새 필드를 전달하면 나머지는 자동으로 작동합니다.
 
 <OptionFilter when={{ infra: 'agentcore' }} description="Deployed agent chat details">
-#### 배포된 에이전트와 채팅
+#### 배포된 에이전트와 채팅하기
 
-Bedrock AgentCore에 배포된 에이전트와 채팅하려면 `RUNTIME_CONFIG_APP_ID` 환경 변수를 배포의 AppConfig 애플리케이션 ID(배포된 스택에서 `RuntimeConfigApplicationId`로 출력됨)로 설정하세요. 채팅 스크립트는 런타임 구성에서 에이전트의 런타임 ARN을 확인하고 배포된 엔드포인트에 연결합니다:
+Bedrock AgentCore에 배포된 에이전트와 채팅하려면 `RUNTIME_CONFIG_APP_ID` 환경 변수를 배포 스택에서 `RuntimeConfigApplicationId`로 출력된 AppConfig 애플리케이션 ID로 설정하세요. 채팅 스크립트는 런타임 구성에서 에이전트의 런타임 ARN을 확인하고 배포된 엔드포인트에 연결합니다:
 
 <Tabs syncKey="auth">
 <TabItem label="IAM" _filter={{ auth: 'iam' }}>
-IAM 인증 에이전트의 경우 요청은 기본 AWS 자격 증명을 사용하여 [SigV4](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_sigv.html)로 서명됩니다. 환경에 런타임을 호출할 권한이 있는 AWS 자격 증명이 있는지 확인하세요:
+IAM 인증 에이전트의 경우, 요청은 기본 AWS 자격 증명을 사용하여 [SigV4](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_sigv.html)로 서명됩니다. 환경에 런타임을 호출할 권한이 있는 AWS 자격 증명이 있는지 확인하세요:
 
 <NxCommands commands={['run your-project:agent-chat']} env={{ RUNTIME_CONFIG_APP_ID: '<app-id>' }} />
 </TabItem>
 
 <TabItem label="Cognito" _filter={{ auth: 'cognito' }}>
-Cognito 인증 에이전트의 경우 `AGENT_ACCESS_TOKEN` 환경 변수를 통해 Cognito 액세스 토큰을 제공하며, 이는 bearer 토큰으로 전송됩니다:
+Cognito 인증 에이전트의 경우, `AGENT_ACCESS_TOKEN` 환경 변수를 통해 Cognito 액세스 토큰을 제공하면 베어러 토큰으로 전송됩니다:
 
 <NxCommands commands={['run your-project:agent-chat']} env={{ RUNTIME_CONFIG_APP_ID: '<app-id>', AGENT_ACCESS_TOKEN: '<access-token>' }} />
 
@@ -465,18 +474,18 @@ aws cognito-idp admin-initiate-auth \
 </OptionFilter>
 
 <OptionFilter when={{ infra: 'agentcore' }} description="Bedrock AgentCore Runtime deployment details">
-## Bedrock AgentCore Runtime에 Agent 배포
+## Bedrock AgentCore Runtime에 에이전트 배포하기
 
-<Snippet name="agent/bedrock-deployment" parentHeading="Bedrock AgentCore Runtime에 Agent 배포" />
+<Snippet name="agent/bedrock-deployment" parentHeading="Bedrock AgentCore Runtime에 에이전트 배포하기" />
 
-### 번들 및 Docker 대상
+### 번들 및 Docker 타겟
 
-Bedrock AgentCore Runtime용 Agent를 빌드하기 위해 프로젝트에 `bundle` 대상이 추가되며, 이는:
+Bedrock AgentCore Runtime을 위해 에이전트를 빌드하기 위해 프로젝트에 `bundle` 타겟이 추가됩니다. 이 타겟은:
 
-- `uv export`를 사용하여 Python 종속성을 `requirements.txt` 파일로 내보냅니다
-- `uv pip install`을 사용하여 대상 플랫폼(`aarch64-manylinux_2_28`)용 종속성을 설치합니다
+- `uv export`를 사용하여 Python 의존성을 `requirements.txt` 파일로 내보냅니다
+- 대상 플랫폼(`aarch64-manylinux_2_28`)용 의존성을 `uv pip install`로 설치합니다
 
-Agent에 특정한 `docker` 대상도 추가되며, 이는 `Dockerfile` 및 번들된 아티팩트를 docker 컨텍스트 디렉토리에 복사합니다. 이는 `Dockerfile`을 빌드 출력과 함께 배치하여 CDK가 `AgentRuntimeArtifact.fromAsset`을 사용하여 Docker 이미지를 직접 빌드할 수 있도록 합니다.
+에이전트에 특화된 `docker` 타겟도 추가되며, `Dockerfile`과 번들된 아티팩트를 docker 컨텍스트 디렉토리에 복사합니다. 이렇게 하면 `Dockerfile`이 빌드 출력과 함께 위치하여 CDK가 `AgentRuntimeArtifact.fromAsset`을 사용하여 Docker 이미지를 직접 빌드할 수 있습니다.
 
 ### 이미지 스캔
 
@@ -492,44 +501,44 @@ CloudWatch AWS 콘솔에서 메뉴의 "GenAI Observability"를 선택하여 추�
 
 ### 세션 관리
 
-`session` 옵션은 선택한 프레임워크에 따라 다른 기본 지속성 개념에 매핑됩니다: `strands` 프레임워크의 경우 Strands의 [세션 관리](https://strandsagents.com/docs/user-guide/concepts/agents/session-management/) 개념, `langchain` 프레임워크의 경우 LangGraph의 [checkpointer](https://docs.langchain.com/oss/python/langgraph/persistence) 개념입니다.
+`session` 옵션은 선택한 프레임워크에 따라 다른 기본 지속성 개념에 매핑됩니다: `strands` 프레임워크의 경우 Strands의 [세션 관리](https://strandsagents.com/docs/user-guide/concepts/agents/session-management/) 개념, `langchain` 프레임워크의 경우 LangGraph의 [체크포인터](https://docs.langchain.com/oss/python/langgraph/persistence) 개념.
 
 <OptionFilter when={{ framework: 'strands' }} description="Strands session management (session.py)">
 `session` 옵션은 Strands SDK의 [SessionManager](https://strandsagents.com/docs/user-guide/concepts/agents/session-management/)를 사용하여 에이전트가 호출 간에 대화 상태(메시지 기록, 도구 상태 등)를 유지하는 방법을 제어합니다:
 
-- **`s3`** (기본값): CDK/Terraform 인프라는 세션 데이터를 위한 전용 S3 버킷을 프로비저닝하며, 전용 KMS 키로 암호화되고 모든 공개 액세스가 차단됩니다. 서버 액세스 로그는 동일한 키를 통해 CloudWatch Logs 로그 그룹으로 전달됩니다. 에이전트의 IAM 역할에는 버킷에 대한 읽기/쓰기/목록/삭제 액세스 권한과 키에 대한 복호화/데이터 키 생성 액세스 권한이 부여되며, 버킷 이름은 AppConfig 런타임 구성에서 에이전트의 ARN과 함께 등록됩니다.
+- **`s3`** (기본값): CDK/Terraform 인프라는 세션 데이터를 위한 전용 S3 버킷을 프로비저닝하며, 전용 KMS 키로 암호화되고 모든 공개 액세스가 차단됩니다. 서버 액세스 로그는 동일한 키를 통해 CloudWatch Logs 로그 그룹으로 전달됩니다. 에이전트의 IAM 역할에는 버킷에 대한 읽기/쓰기/목록/삭제 액세스와 키에 대한 복호화/데이터 키 생성 액세스가 부여되며, 버킷 이름은 AppConfig 런타임 구성에 에이전트의 ARN과 함께 등록됩니다.
 - **`in-memory`**: 버킷이 프로비저닝되지 않습니다. 대화 상태는 실행 중인 프로세스의 수명 동안만 메모리에 유지되며 재시작이나 스케일 인 시 유지되지 않습니다.
 
 이는 생성된 `session.py`에 구현되며, 현재 세션에 대한 `SessionManager`를 확인하는 `get_session_manager()` 함수를 내보냅니다.
 
-세션 ID 자체는 AgentCore Runtime 세션(`x-amzn-bedrock-agentcore-runtime-session-id` 헤더를 통해 전파됨)에서 가져오며 [`contextvars.ContextVar`](https://docs.python.org/3/library/contextvars.html) 기반 컨텍스트에 바인딩되므로 `get_current_session_id()`가 요청의 어디에서나 이를 확인할 수 있습니다. 여기에는 <Link path="/guides/connection">`connection` 생성기</Link>를 통해 연결된 다운스트림 MCP 또는 A2A 클라이언트도 포함되므로 전체 호출 체인이 일관된 세션을 공유합니다.
+세션 ID 자체는 AgentCore Runtime 세션에서 가져오며 (`x-amzn-bedrock-agentcore-runtime-session-id` 헤더를 통해 전파), [`contextvars.ContextVar`](https://docs.python.org/3/library/contextvars.html) 기반 컨텍스트에 바인딩되어 `get_current_session_id()`가 요청의 어디서든 확인할 수 있습니다 — <Link path="/guides/connection">`connection` 생성기</Link>를 통해 연결된 다운스트림 MCP 또는 A2A 클라이언트 포함, 전체 호출 체인이 일관된 세션을 공유합니다.
 
 :::note[로컬 개발]
-로컬에서 실행할 때(`LOCAL_DEV=true`, `-dev` 대상에 의해 자동으로 설정됨), 구성된 `session` 옵션에 관계없이 편의를 위해 세션 데이터는 항상 작업 공간 루트의 `tmp/agents/strands/<agent-name>` 아래 디스크에 저장됩니다.
+로컬에서 실행할 때 (`LOCAL_DEV=true`, `-dev` 타겟에 의해 자동으로 설정), 구성된 `session` 옵션에 관계없이 세션 데이터는 편의를 위해 워크스페이스 루트의 `tmp/agents/strands/<agent-name>` 아래 디스크에 항상 저장됩니다.
 :::
 </OptionFilter>
 
 <OptionFilter when={{ framework: 'langchain' }} description="LangChain session management (session.py)">
-`session` 옵션은 에이전트의 LangGraph checkpointer가 대화 상태를 유지하는 방법을 제어합니다:
+`session` 옵션은 에이전트의 LangGraph 체크포인터가 대화 상태를 유지하는 방법을 제어합니다:
 
-- **`s3`** (기본값): 배포된 에이전트는 프로비저닝된 세션 버킷과 함께 `S3CheckpointSaver`를 사용하여 `checkpoints/` 접두사 아래에 체크포인트 및 보류 중인 쓰기를 저장합니다. 이 클래스는 공유 에이전트 연결 프로젝트의 `s3_checkpoint_saver_langchain.py`에 있습니다.
-- **`dynamodb-s3`**: CDK/Terraform 인프라는 체크포인트를 위한 DynamoDB 테이블을 프로비저닝하며, [LangGraph 에이전트의 체크포인트 저장소로 DynamoDB 사용에 대한 AWS 문서](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ddb-langgraph-checkpoint.html)에서 권장하는 대로 구성됩니다(통합 `PK`/`SK` 스키마, `PAY_PER_REQUEST` 청구, 특정 시점 복구 및 `ttl` 속성), 350KB 이상의 체크포인트를 오프로드하기 위한 S3 버킷도 함께 제공됩니다. 둘 다 전용 KMS 키로 암호화됩니다. 버킷의 서버 액세스 로그는 동일한 키를 통해 CloudWatch Logs 로그 그룹으로 전달됩니다. 에이전트의 IAM 역할에는 테이블 및 버킷에 대한 읽기/쓰기 액세스 권한이 부여되며, 테이블/버킷 이름은 AppConfig 런타임 구성에서 에이전트의 ARN과 함께 등록됩니다.
+- **`s3`** (기본값): 배포된 에이전트는 프로비저닝된 세션 버킷과 함께 `S3CheckpointSaver`를 사용하여 `checkpoints/` 접두사 아래에 체크포인트와 보류 중인 쓰기를 저장합니다. 이 클래스는 공유 에이전트 연결 프로젝트의 `s3_checkpoint_saver_langchain.py`에 있습니다.
+- **`dynamodb-s3`**: CDK/Terraform 인프라는 체크포인트를 위한 DynamoDB 테이블을 프로비저닝하며, [LangGraph 에이전트의 체크포인트 저장소로 DynamoDB 사용에 관한 AWS 문서](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ddb-langgraph-checkpoint.html)에서 권장하는 대로 구성됩니다 (통합 `PK`/`SK` 스키마, `PAY_PER_REQUEST` 청구, 특정 시점 복구, `ttl` 속성), 350KB를 초과하는 체크포인트를 오프로드하기 위한 S3 버킷도 포함됩니다. 둘 다 전용 KMS 키로 암호화되며, 버킷의 서버 액세스 로그는 동일한 키를 통해 CloudWatch Logs 로그 그룹으로 전달됩니다. 에이전트의 IAM 역할에는 테이블과 버킷에 대한 읽기/쓰기 액세스가 부여되며, 테이블/버킷 이름은 AppConfig 런타임 구성에 에이전트의 ARN과 함께 등록됩니다.
 - **`in-memory`**: 테이블이나 버킷이 프로비저닝되지 않습니다. 대화 상태는 실행 중인 프로세스의 수명 동안만 메모리에 유지되며 재시작이나 스케일 인 시 유지되지 않습니다.
 
 이는 생성된 `session.py`에 구현되며, `agent.py`의 `create_agent(..., checkpointer=get_checkpointer())`에서 호출되는 `get_checkpointer()` 함수를 내보냅니다.
 
 :::note[로컬 개발]
-로컬에서 실행할 때(`LOCAL_DEV=true`, `-dev` 대상에 의해 자동으로 설정됨), `get_checkpointer()`는 구성된 `session` 옵션에 관계없이 편의를 위해 항상 작업 공간 루트의 `tmp/agents/langchain/<agent-name>` 아래 로컬 SQLite 데이터베이스로 지원되는 [`AsyncSqliteSaver`](https://reference.langchain.com/python/langgraph.checkpoint.sqlite/aio/AsyncSqliteSaver)를 반환합니다.
+로컬에서 실행할 때 (`LOCAL_DEV=true`, `-dev` 타겟에 의해 자동으로 설정), `get_checkpointer()`는 구성된 `session` 옵션에 관계없이 편의를 위해 워크스페이스 루트의 `tmp/agents/langchain/<agent-name>` 아래 로컬 SQLite 데이터베이스로 지원되는 [`AsyncSqliteSaver`](https://reference.langchain.com/python/langgraph.checkpoint.sqlite/aio/AsyncSqliteSaver)를 항상 반환합니다.
 :::
 </OptionFilter>
 </OptionFilter>
 
-## Agent 호출
+## 에이전트 호출하기
 
 <OptionFilter when={{ protocol: 'http' }} description="FastAPI HTTP invocation details">
-### 로컬 서버 호출
+### 로컬 서버 호출하기
 
-`<your-agent-name>-serve` 대상을 통해 로컬에서 실행 중인 Agent를 호출하려면 로컬 에이전트가 실행 중인 포트의 `/invocations`에 간단한 POST 요청을 보낼 수 있습니다. 예를 들어 `curl`을 사용하면:
+`<your-agent-name>-serve` 타겟을 통해 로컬에서 실행 중인 에이전트를 호출하려면, 로컬 에이전트가 실행 중인 포트의 `/invocations`에 간단한 POST 요청을 보낼 수 있습니다. 예를 들어 `curl`을 사용하면:
 
 ```bash
 curl -N -X POST http://localhost:8081/invocations \
@@ -541,15 +550,15 @@ curl -N -X POST http://localhost:8081/invocations \
 `curl`에 제공된 `-N` 인수는 출력 스트림 버퍼링을 비활성화하여 실시간으로 스트리밍 응답을 볼 수 있습니다.
 :::
 
-### 배포된 Agent 호출
+### 배포된 에이전트 호출하기
 
-<Snippet name="agent/runtime-arn" parentHeading="배포된 Agent 호출" />
+<Snippet name="agent/runtime-arn" parentHeading="배포된 에이전트 호출하기" />
 
 <Tabs syncKey="auth">
 <TabItem label="IAM" _filter={{ auth: 'iam' }}>
 #### IAM 인증
 
-IAM 인증의 경우 요청은 AWS Signature Version 4 (SigV4)를 사용하여 서명되어야 합니다.
+IAM 인증의 경우, 요청은 AWS Signature Version 4 (SigV4)를 사용하여 서명되어야 합니다.
 
 ```bash
 acurl <region> bedrock-agentcore -N -X POST \
@@ -558,7 +567,7 @@ acurl <region> bedrock-agentcore -N -X POST \
 -H 'Content-Type: application/json'
 ```
 
-<Drawer title="Sigv4 enabled curl" trigger="위의 acurl 명령 구성에 대한 자세한 내용을 보려면 여기를 클릭하세요">
+<Drawer title="Sigv4 enabled curl" trigger="Click here for more details on configuring the above acurl command">
 <Snippet name="tools/acurl" />
 </Drawer>
 </TabItem>
@@ -566,7 +575,7 @@ acurl <region> bedrock-agentcore -N -X POST \
 <TabItem label="Cognito" _filter={{ auth: 'cognito' }}>
 #### JWT / Cognito 인증
 
-Cognito 인증의 경우 `Authorization` 헤더에 Cognito 액세스 토큰을 전달하세요:
+Cognito 인증의 경우, `Authorization` 헤더에 Cognito 액세스 토큰을 전달하세요:
 
 ```bash
 curl -N -X POST 'https://bedrock-agentcore.<region>.amazonaws.com/runtimes/<url-encoded-arn>/invocations' \
@@ -592,7 +601,7 @@ aws cognito-idp admin-initiate-auth \
 
 #### 브라우저 / React 웹사이트
 
-React 웹사이트에서 Agent를 호출하려면 <Link path="/guides/connection/react-py-agent">`connection` 생성기</Link>를 사용할 수 있으며, 이는 올바른 인증(IAM 또는 Cognito)으로 클라이언트를 자동으로 설정합니다.
+React 웹사이트에서 에이전트를 호출하려면 <Link path="/guides/connection/react-py-agent">`connection` 생성기</Link>를 활용할 수 있으며, 올바른 인증(IAM 또는 Cognito)으로 클라이언트를 자동으로 설정합니다.
 
 <RunGenerator generator="connection" />
 
@@ -600,9 +609,9 @@ React 웹사이트에서 Agent를 호출하려면 <Link path="/guides/connection
 </OptionFilter>
 
 <OptionFilter when={{ protocol: 'a2a' }} description="A2A delegation details">
-### A2A Agent를 도구로 호출
+### A2A 에이전트를 도구로 호출하기
 
-이 에이전트에서 원격 A2A 에이전트(<Link path="/guides/ts-agent">TypeScript</Link> 또는 <Link path="/guides/py-agent">Python</Link>)로 작업을 위임하려면 <Link path="/guides/connection/py-agent-a2a">`connection` 생성기</Link>를 사용하세요. 대상 에이전트에 대한 SigV4 인증 클라이언트를 제공하고 이 에이전트의 `agent.py`를 AST 변환하여 원격 A2A 에이전트를 `@tool` 데코레이팅된 위임자로 등록합니다.
+이 에이전트에서 원격 A2A 에이전트(<Link path="/guides/ts-agent">TypeScript</Link> 또는 <Link path="/guides/py-agent">Python</Link>)로 작업을 위임하려면 <Link path="/guides/connection/py-agent-a2a">`connection` 생성기</Link>를 사용하세요. 이는 대상 에이전트에 대한 SigV4 인증 클라이언트를 제공하고 이 에이전트의 `agent.py`를 AST 변환하여 원격 A2A 에이전트를 `@tool` 데코레이터 위임자로 등록합니다.
 
 <RunGenerator generator="connection" />
 
@@ -610,18 +619,18 @@ React 웹사이트에서 Agent를 호출하려면 <Link path="/guides/connection
 </OptionFilter>
 
 <OptionFilter when={{ protocol: 'ag-ui' }} description="AG-UI / React connection details">
-### AG-UI Agent 호출
+### AG-UI 에이전트 호출하기
 
-React 웹사이트에서 AG-UI 에이전트를 호출하려면 <Link path="/guides/connection/react-agui">`connection` 생성기</Link>를 사용하세요. 이는 올바른 인증(IAM 또는 Cognito)으로 배포된 에이전트에 대해 구성된 [CopilotKit](https://docs.copilotkit.ai/) 클라이언트를 연결합니다.
+React 웹사이트에서 AG-UI 에이전트를 호출하려면 <Link path="/guides/connection/react-agui">`connection` 생성기</Link>를 사용하세요. 이는 올바른 인증(IAM 또는 Cognito)으로 배포된 에이전트에 구성된 [CopilotKit](https://docs.copilotkit.ai/) 클라이언트를 연결합니다.
 
 <RunGenerator generator="connection" />
 
 연결 설정 방법에 대한 자세한 내용은 <Link path="/guides/connection/react-agui">`connection` 생성기 가이드</Link>를 참조하세요.
 </OptionFilter>
 
-## Agent 보안
+## 에이전트 보안
 
-<Snippet name="agent/securing-your-agent" parentHeading="Agent 보안" />
+<Snippet name="agent/securing-your-agent" parentHeading="에이전트 보안" />
 
 <Tabs syncKey="agent-framework">
 <TabItem label="Strands" _filter={{ framework: 'strands' }}>
@@ -641,7 +650,7 @@ model = BedrockModel(
 agent = Agent(model=model)
 ```
 
-자세한 내용은 Strands [Guardrails](https://strandsagents.com/docs/user-guide/safety-security/guardrails/) 가이드를 참조하세요.
+자세한 내용은 Strands [가드레일](https://strandsagents.com/docs/user-guide/safety-security/guardrails/) 가이드를 참조하세요.
 </TabItem>
 <TabItem label="LangChain" _filter={{ framework: 'langchain' }}>
 ```python
@@ -665,12 +674,12 @@ model = ChatBedrockConverse(
 
 ## 연결
 
-<Link path="guides/connection">`connection`</Link> 생성기를 사용하여 이 프로젝트를 작업 공간의 다른 프로젝트와 통합하세요. 다음 연결에는 이 프로젝트가 포함됩니다:
+<Link path="guides/connection">`connection`</Link> 생성기를 사용하여 이 프로젝트를 워크스페이스의 다른 프로젝트와 통합하세요. 이 프로젝트와 관련된 연결은 다음과 같습니다:
 
 <CardGrid>
   <ConnectionCard
     title="React to Python Agent"
-    description="React 웹사이트에서 Python Agent 호출"
+    description="Call a Python Agent from a React website"
     href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/react-py-agent`}
     source="react"
     target="strands"
@@ -678,14 +687,14 @@ model = ChatBedrockConverse(
   />
   <ConnectionCard
     title="React to AG-UI Agent"
-    description="CopilotKit을 통해 React 웹사이트에서 AG-UI 프로토콜을 노출하는 Agent 호출"
+    description="Call an Agent exposing the AG-UI protocol from a React website via CopilotKit"
     href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/react-agui`}
     source="react"
     target="copilotkit"
   />
   <ConnectionCard
     title="Python Agent to MCP"
-    description="Python Agent를 MCP 서버에 연결"
+    description="Connect a Python Agent to an MCP server"
     href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/py-agent-mcp`}
     source="strands"
     sourceBadge="python"
@@ -693,7 +702,7 @@ model = ChatBedrockConverse(
   />
   <ConnectionCard
     title="Python Agent to A2A Agent"
-    description="Python Agent를 원격 A2A 에이전트에 연결"
+    description="Connect a Python Agent to a remote A2A agent"
     href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/py-agent-a2a`}
     source="strands"
     sourceBadge="python"
@@ -701,7 +710,7 @@ model = ChatBedrockConverse(
   />
   <ConnectionCard
     title="TypeScript Agent to A2A Agent"
-    description="TypeScript Agent를 원격 A2A 에이전트에 연결"
+    description="Connect a TypeScript Agent to a remote A2A agent"
     href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/ts-agent-a2a`}
     source="strands"
     sourceBadge="typescript"
@@ -709,7 +718,7 @@ model = ChatBedrockConverse(
   />
   <ConnectionCard
     title="Python Agent to Python DynamoDB"
-    description="Python Agent를 DynamoDB 테이블에 연결"
+    description="Connect a Python Agent to a DynamoDB table"
     href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/py-agent-dynamodb`}
     source="strands"
     sourceBadge="python"
@@ -718,7 +727,7 @@ model = ChatBedrockConverse(
   />
   <ConnectionCard
     title="Python Agent to AgentCore Gateway"
-    description="Python Agent를 AgentCore Gateway에 연결"
+    description="Connect a Python Agent to an AgentCore Gateway"
     href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/py-agent-gateway`}
     source="strands"
     sourceBadge="python"
@@ -726,7 +735,7 @@ model = ChatBedrockConverse(
   />
   <ConnectionCard
     title="AgentCore Gateway to Agent"
-    description="런타임 대상으로 AgentCore Gateway로 에이전트 프론트"
+    description="Front an agent with an AgentCore Gateway as a runtime target"
     href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/agentcore-gateway-agent`}
     source="agentcore"
     target="strands"

--- a/docs/src/content/docs/pt/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/pt/get_started/tutorials/dungeon-game/1.mdx
@@ -1,6 +1,6 @@
 ---
 title: Configurar um monorepo
-description: "Um passo a passo de como construir um jogo de aventura em masmorra com IA agêntica usando o @aws/nx-plugin."
+description: "Um guia passo a passo de como construir um jogo de aventura em dungeon com IA agêntica usando o @aws/nx-plugin."
 ---
 
 import { Aside, Code, FileTree, Steps, Tabs, TabItem } from '@astrojs/starlight/components';
@@ -32,7 +32,7 @@ Para criar um novo monorepo, dentro do diretório desejado, execute o seguinte c
 Usamos `--iac=cdk` pois utilizaremos CDK para infraestrutura como código neste tutorial. O Nx Plugin for AWS também suporta `terraform`.
 :::
 
-Isso configurará um monorepo NX dentro do diretório `dungeon-adventure`. Quando você abrir o diretório no VSCode, verá esta estrutura de arquivos:
+Isso irá configurar um monorepo NX dentro do diretório `dungeon-adventure`. Ao abrir o diretório no VSCode, você verá esta estrutura de arquivos:
 
 <FileTree>
 - .nx/
@@ -41,7 +41,7 @@ Isso configurará um monorepo NX dentro do diretório `dungeon-adventure`. Quand
 - packages/ aqui é onde seus sub-projetos residirão
 - .gitignore
 - biome.json configura o Biome para linting e formatação
-- nx.json configura o Nx CLI e padrões do monorepo
+- nx.json configura o CLI do Nx e os padrões do monorepo
 - package.json todas as dependências node são definidas aqui
 - pnpm-lock.yaml ou bun.lock, yarn.lock, package-lock.json dependendo do gerenciador de pacotes
 - pnpm-workspace.yaml se estiver usando pnpm
@@ -51,26 +51,26 @@ Isso configurará um monorepo NX dentro do diretório `dungeon-adventure`. Quand
 - aws-nx-plugin.config.mts configuração para o Nx Plugin for AWS
 </FileTree>
 
-<Aside type="tip" title="Faça Commits Frequentes">É uma boa prática garantir que todos os seus arquivos não preparados estejam commitados no Git antes de executar qualquer gerador. Isso permite que você veja o que mudou após executar seu gerador via `git diff`.</Aside>
+<Aside type="tip" title="Faça commits com frequência">É uma boa prática garantir que todos os seus arquivos não preparados estejam commitados no Git antes de executar qualquer gerador. Isso permite que você veja o que mudou após executar seu gerador via `git diff`.</Aside>
 
-## Tarefa 2: Estruturar o Jogo Dungeon Adventure
+## Tarefa 2: Estruturar o Dungeon Adventure Game
 
-Com o workspace configurado, estruturamos os sub-projetos do jogo — a API do Jogo, Agente de História, servidor MCP de Inventário, banco de dados do jogo e website — juntamente com as conexões que os conectam. Existem duas maneiras de fazer isso:
+Com o workspace configurado, estruturamos os sub-projetos do jogo — a Game API, o Story Agent, o servidor MCP de Inventário, o banco de dados do jogo e o website — juntamente com as conexões que os interligam. Há duas maneiras de fazer isso:
 
-- **Rápido** — copie os comandos diretamente do diagrama abaixo e execute-os. A maneira mais rápida de alcançar o mesmo ponto de partida.
+- **Rápido** — copie os comandos diretamente do diagrama abaixo e execute-os. A maneira mais rápida de chegar ao mesmo ponto de partida.
 - **Passo a Passo** — expanda a seção abaixo para executar cada gerador você mesmo e examinar exatamente o que cada um produz.
 
-O diagrama abaixo _é_ o workspace Dungeon Adventure: cada projeto, componente e conexão que você construirá neste módulo. Clique em **Copy commands** para pegar toda a série, depois execute-os de dentro do diretório `dungeon-adventure` que você criou na Tarefa 1.
+O diagrama abaixo _é_ o workspace do Dungeon Adventure: cada projeto, componente e conexão que você construirá neste módulo. Clique em **Copy commands** para obter toda a série e execute-os dentro do diretório `dungeon-adventure` criado na Tarefa 1.
 
 <EmbeddedGraph preset="dungeon-adventure" workspace="dungeon-adventure" iac="cdk" skipWorkspace />
 
 <Drawer title="Passo a Passo" trigger="Passo a Passo: execute cada gerador você mesmo e veja o que ele produz">
 
-Em vez de copiar os comandos de uma vez, você pode executar cada gerador individualmente. Esta é a melhor maneira de entender o que cada gerador adiciona ao seu workspace. Execute cada gerador por vez, de dentro do diretório `dungeon-adventure` que você criou na Tarefa 1.
+Em vez de copiar todos os comandos de uma vez, você pode executar cada gerador individualmente. Esta é a melhor maneira de entender o que cada gerador adiciona ao seu workspace. Execute cada gerador em sequência, dentro do diretório `dungeon-adventure` criado na Tarefa 1.
 
-##### Criar uma API do Jogo
+##### Criar uma Game API
 
-Primeiro, vamos criar nossa API do Jogo. Para fazer isso, crie uma API tRPC chamada `GameApi` usando estas etapas:
+Primeiro, vamos criar nossa Game API. Para isso, crie uma API tRPC chamada `GameApi` usando estas etapas:
 
 <RunGenerator generator="ts#api" requiredParameters={{ name: "GameApi", framework: "trpc" }} noInteractive />
 
@@ -390,15 +390,15 @@ export class GameApi<
 }
 ```
 
-Este é o construct CDK que define nossa `GameApi`. Ele fornece um método `defaultIntegrations` que cria automaticamente uma função Lambda para cada procedimento em nossa API tRPC, apontando para a implementação da API empacotada. Isso significa que no tempo de `cdk synth`, o empacotamento não ocorre (ao contrário de usar [NodeJsFunction](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_lambda_nodejs.NodejsFunction.html)) pois já empacotamos como parte do target de build do projeto backend.
+Este é o construct CDK que define nossa `GameApi`. Ele fornece um método `defaultIntegrations` que cria automaticamente uma função Lambda para cada procedimento em nossa API tRPC, apontando para a implementação da API empacotada. Isso significa que no momento do `cdk synth`, o empacotamento não ocorre (ao contrário de usar [NodeJsFunction](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_lambda_nodejs.NodejsFunction.html)) pois já o empacotamos como parte do target de build do projeto backend.
 
 </details>
 
-##### Criar o Agente de História
+##### Criar o Story Agent
 
-Agora vamos criar nosso Agente de História.
+Agora vamos criar nosso Story Agent.
 
-###### Agente de história: Projeto Python
+###### Story agent: Projeto Python
 
 Para criar um projeto Python:
 
@@ -419,7 +419,7 @@ O `py#project` gera estes arquivos:
     - .python-version
     - pyproject.toml
     - project.json
-- .python-version versão python fixada do uv
+- .python-version versão python fixada pelo uv
 - pyproject.toml
 - uv.lock
 </FileTree>
@@ -428,14 +428,14 @@ Isso configurou um projeto Python e [UV Workspace](https://docs.astral.sh/uv/con
 
 </details>
 
-###### Agente de história
+###### Story agent
 
 Para adicionar um agente Strands ao projeto com o gerador `py#agent`:
 
 <RunGenerator generator="py#agent" requiredParameters={{project:"story", auth:"cognito", protocol:"ag-ui"}} noInteractive />
 
 :::note[Protocolo AG-UI]
-Escolhemos `--protocol=ag-ui` para que o agente fale o [protocolo Agent-User Interaction](https://docs.copilotkit.ai/aws-strands/protocol) — isso permite que nosso website React converse com ele diretamente via [CopilotKit](https://docs.copilotkit.ai/), com streaming, chamadas de ferramentas e histórico de conversação tratados pelo protocolo em vez de um cliente HTTP feito à mão.
+Escolhemos `--protocol=ag-ui` para que o agente fale o [protocolo Agent-User Interaction](https://docs.copilotkit.ai/aws-strands/protocol) — isso permite que nosso website React se comunique diretamente com ele via [CopilotKit](https://docs.copilotkit.ai/), com streaming, chamadas de ferramentas e histórico de conversas gerenciados pelo protocolo em vez de um cliente HTTP manual.
 :::
 
 Você verá alguns novos arquivos aparecerem na sua árvore de arquivos.
@@ -450,8 +450,10 @@ O `py#agent` gera estes arquivos:
     - dungeon_adventure_story/ módulo python
       - agent/
         - main.py ponto de entrada para seu agente no Bedrock AgentCore Runtime
-        - agent.py define um agente de exemplo e ferramentas
-        - session.py resolve um SessionManager para persistir o estado da conversação
+        - agent.py define um agente e ferramentas de exemplo
+        - session.py resolve um SessionManager para persistir o estado da conversa
+        - middleware/
+          - session_id_middleware.py vincula o ID de sessão AgentCore de entrada para a requisição
         - Dockerfile define a imagem docker para implantação no AgentCore Runtime
   - common/constructs/
     - src
@@ -459,7 +461,7 @@ O `py#agent` gera estes arquivos:
         - story-agent.ts construct para implantar seu agente Story no AgentCore Runtime
 </FileTree>
 
-Vamos dar uma olhada em alguns dos arquivos em detalhes:
+Vamos examinar alguns dos arquivos em detalhes:
 
 ```python
 # agent/agent.py
@@ -493,6 +495,29 @@ Refer to tools as your 'spellbook'.
 Isso cria um agente Strands de exemplo e define uma ferramenta de subtração. `log_model_errors` e `log_tool_errors` são hooks do projeto compartilhado `dungeon_adventure_agent_connection` que registram falhas de modelo/ferramenta em vez de deixá-las falhar silenciosamente.
 
 ```python
+# agent/middleware/session_id_middleware.py
+import uuid
+
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from dungeon_adventure_agent_connection import session_id_context
+
+SESSION_ID_HEADER = "x-amzn-bedrock-agentcore-runtime-session-id"
+
+
+class SessionIdMiddleware(BaseHTTPMiddleware):
+    """Bind the session ID for this request so downstream MCP / A2A clients forward it on outbound calls."""
+
+    async def dispatch(self, request: Request, call_next):
+        session_id = request.headers.get(SESSION_ID_HEADER) or str(uuid.uuid4())
+        with session_id_context(session_id):
+            return await call_next(request)
+```
+
+O `SessionIdMiddleware` vincula o ID de sessão do runtime AgentCore de entrada a um `ContextVar` durante a requisição.
+
+```python
 # agent/main.py
 import logging
 import uuid
@@ -505,14 +530,12 @@ from dungeon_adventure_agent_connection import get_current_session_id, session_i
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import StreamingResponse
-from starlette.middleware.base import BaseHTTPMiddleware
 
 from .agent import get_agent
+from .middleware.session_id_middleware import SESSION_ID_HEADER, SessionIdMiddleware
 from .session import get_session_manager
 
 logging.basicConfig(level=logging.INFO)
-
-SESSION_ID_HEADER = "x-amzn-bedrock-agentcore-runtime-session-id"
 
 
 @asynccontextmanager
@@ -529,15 +552,6 @@ async def lifespan(app: FastAPI):
         yield
 
 
-class _SessionIdMiddleware(BaseHTTPMiddleware):
-    """Bind the session ID for this request so downstream MCP / A2A clients forward it on outbound calls."""
-
-    async def dispatch(self, request: Request, call_next):
-        session_id = request.headers.get(SESSION_ID_HEADER) or str(uuid.uuid4())
-        with session_id_context(session_id):
-            return await call_next(request)
-
-
 app = FastAPI(title="AWS Strands - StoryAgent", lifespan=lifespan)
 app.add_middleware(
     CORSMiddleware,
@@ -546,7 +560,7 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
-app.add_middleware(_SessionIdMiddleware)
+app.add_middleware(SessionIdMiddleware)
 
 
 @app.post("/invocations")
@@ -589,7 +603,7 @@ async def ping():
     return {"status": "healthy"}
 ```
 
-Este é o ponto de entrada para o agente. Como selecionamos `--protocol=ag-ui`, o gerador envolve nosso `Agent` Strands com `StrandsAgent` de [`ag_ui_strands`](https://docs.copilotkit.ai/aws-strands/integration) e o monta em um app FastAPI que fala o [protocolo AG-UI](https://docs.copilotkit.ai/aws-strands/protocol) — é com isso que o CopilotKit conversará a partir do website React. O agente é construído dentro de um handler `lifespan` — não no momento da importação — então a inicialização do container, não a importação do módulo, possui a construção, e cada sessão AgentCore obtém seu próprio container. O `_SessionIdMiddleware` vincula o ID de sessão do AgentCore Runtime de entrada a um `ContextVar` para que qualquer cliente MCP/A2A downstream que conectarmos mais tarde (por exemplo, o servidor MCP de Inventário no <Link path="get_started/tutorials/dungeon-game/2">Módulo 2</Link>) o encaminhe automaticamente em suas chamadas de saída. Como o AG-UI armazena em cache um agente Strands por `thread_id`, conectamos um `session_manager_provider` em vez do gerenciador de sessão do próprio agente de template — isso dá a cada thread seu próprio `SessionManager` para que o histórico de conversação persista entre turnos. Essa função `get_session_manager()` vem de um `session.py` irmão gerado: implantado, ele retorna um `strands.session.S3SessionManager` apoiado por um bucket S3 que o gerador provisiona automaticamente; sob `agent-dev` (`LOCAL_DEV=true`) ele sempre retorna um `FileSessionManager` escrevendo em um diretório temporário local, independentemente da configuração implantada.
+Este é o ponto de entrada para o agente. Como selecionamos `--protocol=ag-ui`, o gerador envolve nosso `Agent` Strands com `StrandsAgent` de [`ag_ui_strands`](https://docs.copilotkit.ai/aws-strands/integration) e o monta em um app FastAPI que fala o [protocolo AG-UI](https://docs.copilotkit.ai/aws-strands/protocol) — é com isso que o CopilotKit se comunicará a partir do website React. O agente é construído dentro de um handler `lifespan` — não no momento da importação — para que a inicialização do container, e não a importação do módulo, controle a construção, e cada sessão AgentCore obtenha seu próprio container. O `SessionIdMiddleware` que vimos acima encaminha o ID de sessão do runtime AgentCore de entrada para que qualquer cliente MCP/A2A downstream que conectarmos posteriormente (por exemplo, o servidor MCP de Inventário no <Link path="get_started/tutorials/dungeon-game/2">Módulo 2</Link>) o encaminhe automaticamente em suas chamadas de saída. Como o AG-UI armazena em cache um agente Strands por `thread_id`, conectamos um `session_manager_provider` em vez do gerenciador de sessão do agente template — isso dá a cada thread seu próprio `SessionManager` para que o histórico de conversas persista entre turnos. Essa função `get_session_manager()` vem de um `session.py` gerado como irmão: implantado, retorna um `strands.session.S3SessionManager` apoiado por um bucket S3 que o gerador provisiona automaticamente; sob `agent-dev` (`LOCAL_DEV=true`) sempre retorna um `FileSessionManager` gravando em um diretório temporário local, independentemente da configuração implantada.
 
 ```ts
 // common/constructs/src/app/agents/story-agent/story-agent.ts
@@ -877,9 +891,9 @@ export class StoryAgent extends Construct implements IGrantable, IConnectable {
 }
 ```
 
-Isso configura um `AgentRuntimeArtifact` CDK que faz upload da imagem Docker do seu agente para o ECR e o hospeda usando o AgentCore Runtime. Como escolhemos `--auth=cognito`, o construct requer a identidade do user pool/client e autoriza invocações do AgentCore Runtime através do Cognito, encaminhando o cabeçalho `Authorization` do chamador. Ele também provisiona o bucket de sessão que o `session.py` do Story Agent lê de volta em tempo de execução — um bucket S3 criptografado com KMS com logs de acesso do servidor entregues ao CloudWatch Logs — concede ao agente acesso de leitura/gravação a ele, concede acesso para invocar modelos Bedrock e registra seu ARN e nome do bucket no `RuntimeConfig` para que tanto o agente (em tempo de execução, via AppConfig) quanto a API do Jogo (em tempo de synth, via `invocationUrl`) possam encontrá-lo.
+Isso configura um `AgentRuntimeArtifact` CDK que faz upload da imagem Docker do seu agente para o ECR e a hospeda usando o AgentCore Runtime. Como escolhemos `--auth=cognito`, o construct requer a identidade do user pool/client e autoriza as invocações do AgentCore Runtime através do Cognito, encaminhando o cabeçalho `Authorization` do chamador. Ele também provisiona o bucket de sessão que o `session.py` do Story Agent lê em tempo de execução — um bucket S3 criptografado com KMS com logs de acesso ao servidor entregues ao CloudWatch Logs — concede ao agente acesso de leitura/gravação a ele, concede acesso para invocar modelos Bedrock e registra seu ARN e nome do bucket no `RuntimeConfig` para que tanto o agente (em tempo de execução, via AppConfig) quanto a Game API (em tempo de síntese, via `invocationUrl`) possam encontrá-lo.
 
-Você pode notar um `Dockerfile` extra, que referencia a imagem Docker do projeto `story`, permitindo-nos co-localizar o Dockerfile e o código-fonte do agente.
+Você pode notar um `Dockerfile` extra que referencia a imagem Docker do projeto `story`, permitindo co-localizar o Dockerfile e o código-fonte do agente.
 
 </details>
 
@@ -887,7 +901,7 @@ Você pode notar um `Dockerfile` extra, que referencia a imagem Docker do projet
 
 ###### Inventário: Projeto TypeScript
 
-Vamos criar um servidor MCP para fornecer ferramentas para nosso Agente de História gerenciar o inventário de um jogador.
+Vamos criar um servidor MCP para fornecer ferramentas ao nosso Story Agent para gerenciar o inventário de um jogador.
 
 Primeiro, criamos um projeto TypeScript:
 
@@ -951,12 +965,12 @@ O gerador `ts#mcp-server` gera estes arquivos.
 
 ##### Criar o banco de dados do jogo
 
-O estado do nosso jogo — jogos salvos e o inventário de cada jogador — vive no [Amazon DynamoDB](https://aws.amazon.com/dynamodb/). Crie um projeto DynamoDB chamado `DungeonDb` com o gerador `ts#dynamodb`:
+O estado do nosso jogo — partidas salvas e o inventário de cada jogador — reside no [Amazon DynamoDB](https://aws.amazon.com/dynamodb/). Crie um projeto DynamoDB chamado `DungeonDb` com o gerador `ts#dynamodb`:
 
 <RunGenerator generator="ts#dynamodb" requiredParameters={{name:"DungeonDb"}} noInteractive />
 
-:::tip[Desenvolvimento local-first]
-O gerador `ts#dynamodb` fornece um target `dev` que executa [DynamoDB Local](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html) em um container. Combinado com o gerador `connection` (que executamos abaixo), isso significa que **o jogo inteiro roda na sua máquina sem uma implantação** até o final do tutorial.
+:::tip[Desenvolvimento local primeiro]
+O gerador `ts#dynamodb` fornece um target `dev` que executa o [DynamoDB Local](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html) em um container. Combinado com o gerador `connection` (que executamos abaixo), isso significa que **o jogo inteiro roda na sua máquina sem uma implantação** até o final do tutorial.
 :::
 
 Você verá alguns novos arquivos aparecerem na sua árvore de arquivos.
@@ -991,7 +1005,7 @@ O gerador `ts#dynamodb` gera estes arquivos.
           - dynamodb.ts construct de tabela DynamoDB genérico
 </FileTree>
 
-O `src/client.ts` gerado exporta `getDynamoDBClient()` e `resolveTableName()`. Quando `LOCAL_DEV=true` (definido automaticamente pelos targets `dev`) estes se conectam ao DynamoDB Local; caso contrário, eles se conectam à AWS e resolvem o nome da tabela implantada a partir da <Link path="guides/runtime-config">Configuração de Runtime</Link>. Vamos modelar nossas entidades `Game` e `Inventory` neste projeto no <Link path="get_started/tutorials/dungeon-game/2">Módulo 2</Link>.
+O `src/client.ts` gerado exporta `getDynamoDBClient()` e `resolveTableName()`. Quando `LOCAL_DEV=true` (definido automaticamente pelos targets `dev`) eles se conectam ao DynamoDB Local; caso contrário, conectam-se à AWS e resolvem o nome da tabela implantada a partir da <Link path="guides/runtime-config">Configuração de Runtime</Link>. Modelaremos nossas entidades `Game` e `Inventory` neste projeto no <Link path="get_started/tutorials/dungeon-game/2">Módulo 2</Link>.
 
 Para mais detalhes, consulte o <Link path="guides/ts-dynamodb">guia do gerador ts#dynamodb</Link>.
 
@@ -999,9 +1013,9 @@ Para mais detalhes, consulte o <Link path="guides/ts-dynamodb">guia do gerador t
 
 ##### Criar a Interface do Usuário (UI)
 
-Em seguida, criaremos a UI que permitirá que você interaja com o jogo.
+Em seguida, criaremos a UI que permitirá interagir com o jogo.
 
-###### UI do Jogo: Website
+###### Game UI: Website
 
 Para criar a UI, crie um website chamado `GameUI` usando estas etapas:
 
@@ -1075,7 +1089,7 @@ export class GameUI extends StaticWebsite {
 }
 ```
 
-Este é o construct CDK que define nossa GameUI. Ele já configurou o caminho do arquivo para o bundle gerado para nossa UI baseada em Vite. Isso significa que no tempo de `build`, o empacotamento ocorre dentro do target de build do projeto game-ui e a saída é usada aqui.
+Este é o construct CDK que define nossa GameUI. Ele já configurou o caminho do arquivo para o bundle gerado para nossa UI baseada em Vite. Isso significa que no momento do `build`, o empacotamento ocorre dentro do target de build do projeto game-ui e a saída é usada aqui.
 
 ```tsx
 // packages/game-ui/src/main.tsx
@@ -1132,9 +1146,9 @@ Um componente será renderizado ao navegar para a rota `/`. `@tanstack/react-rou
 
 </details>
 
-###### UI do Jogo: Autenticação
+###### Game UI: Auth
 
-Vamos configurar nossa UI do Jogo para exigir acesso autenticado via Amazon Cognito usando estas etapas:
+Vamos configurar nossa Game UI para exigir acesso autenticado via Amazon Cognito usando estas etapas:
 
 <RunGenerator generator="ts#website#auth" requiredParameters={{cognitoDomain:"game-ui", project:"@dungeon-adventure/game-ui", allowSignup:true}} noInteractive />
 
@@ -1216,9 +1230,9 @@ Os componentes `RuntimeConfigProvider` e `CognitoAuth` foram adicionados ao arqu
 
 </details>
 
-###### UI do Jogo: Conectar à API do Jogo
+###### Game UI: Conectar à Game API
 
-Vamos configurar nossa UI do Jogo para se conectar à nossa API do Jogo criada anteriormente.
+Vamos configurar nossa Game UI para se conectar à nossa Game API criada anteriormente.
 
 <RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-ui", targetProject:"@dungeon-adventure/game-api"}} noInteractive />
 
@@ -1268,8 +1282,8 @@ export const useGameApiClient = () => {
 
 Este hook fornece acesso ao cliente tRPC para chamar a GameApi. Para exemplos de como chamar APIs tRPC, consulte o <Link path="guides/connection/react-trpc#using-the-generated-code">guia de uso do hook tRPC</Link>.
 
-<Aside title="Hooks Type-Safe">
-Graças à [inferência TypeScript](https://trpc.io/docs/concepts) do tRPC, `useGameApi` não precisa de uma etapa de build para que as mudanças do backend cheguem ao frontend — edições no router ou em qualquer procedimento são capturadas pelo verificador de tipos instantaneamente.
+<Aside title="Hooks com Segurança de Tipos">
+Graças à [inferência de Typescript](https://trpc.io/docs/concepts) do tRPC, o `useGameApi` não precisa de uma etapa de build para que as mudanças no backend cheguem ao frontend — edições no roteador ou em qualquer procedimento são detectadas pelo verificador de tipos instantaneamente.
 </Aside>
 
 ```diff lang="tsx"
@@ -1307,9 +1321,9 @@ O arquivo `main.tsx` foi atualizado via uma transformação AST para injetar os 
 
 </details>
 
-###### Agente de História: Conectar ao Servidor MCP de Inventário
+###### Story Agent: Conectar ao Servidor MCP de Inventário
 
-Vamos conectar nosso Agente de História ao servidor MCP de Inventário para que o agente possa descobrir e invocar as ferramentas do servidor MCP.
+Vamos conectar nosso Story Agent ao servidor MCP de Inventário para que o agente possa descobrir e invocar as ferramentas do servidor MCP.
 
 <RunGenerator generator="connection" requiredParameters={{sourceProject:"story", targetProject:"inventory"}} noInteractive />
 
@@ -1347,9 +1361,9 @@ O gerador:
 Para mais detalhes, consulte o <Link path="guides/connection/py-agent-mcp">guia de conexão Python Agent para MCP</Link>.
 </details>
 
-###### UI do Jogo: Conectar ao Agente de História
+###### Game UI: Conectar ao Story Agent
 
-Vamos conectar nossa UI do Jogo ao Agente de História. Como o agente fala AG-UI, o gerador `connection` conecta o [CopilotKit](https://docs.copilotkit.ai/): um componente de chat com tema e um `HttpAgent` `@ag-ui/client` pronto para renderizar.
+Vamos conectar nossa Game UI ao Story Agent. Como o agente fala AG-UI, o gerador `connection` conecta o [CopilotKit](https://docs.copilotkit.ai/): um componente de chat com tema e um `HttpAgent` do `@ag-ui/client` pronto para renderizar.
 
 <RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-ui", targetProject:"story"}} noInteractive />
 
@@ -1381,19 +1395,19 @@ O gerador:
 Para mais detalhes, consulte o <Link path="guides/connection/react-agui">guia de conexão React para AG-UI</Link>.
 </details>
 
-###### Conectar a API do Jogo e o servidor MCP de Inventário ao banco de dados
+###### Conectar a Game API e o servidor MCP de Inventário ao banco de dados
 
-Tanto a API do Jogo quanto o servidor MCP de Inventário leem e escrevem nossa tabela DynamoDB, então vamos conectá-los ao projeto `DungeonDb`. O gerador `connection` detecta que o alvo é um projeto `ts#dynamodb` e conecta o target `dev` de cada projeto de origem para iniciar o DynamoDB Local automaticamente.
+Tanto a Game API quanto o servidor MCP de Inventário leem e escrevem em nossa tabela DynamoDB, então vamos conectá-los ao projeto `DungeonDb`. O gerador `connection` detecta que o alvo é um projeto `ts#dynamodb` e conecta o target `dev` de cada projeto de origem para iniciar o DynamoDB Local automaticamente.
 
 <RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-api", targetProject:"@dungeon-adventure/dungeon-db"}} noInteractive />
 
 <RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/inventory", targetProject:"@dungeon-adventure/dungeon-db"}} noInteractive />
 
 <Aside type="tip" title="Um comando inicializa toda a stack localmente">
-Como o `agent-dev` do Agente de História já depende do `mcp-server-dev` do servidor MCP de Inventário (via a conexão `story → inventory` acima), e tanto a API do Jogo quanto o servidor MCP agora dependem de `dungeon-db:dev`, executar o target `dev` de qualquer projeto inicia todas as dependências necessárias na ordem correta.
+Como o `agent-dev` do Story Agent já depende do `mcp-server-dev` do servidor MCP de Inventário (via a conexão `story → inventory` acima), e tanto a Game API quanto o servidor MCP agora dependem de `dungeon-db:dev`, executar o target `dev` de qualquer projeto inicia todas as dependências necessárias na ordem correta.
 </Aside>
 
-###### UI do Jogo: Infraestrutura
+###### Game UI: Infraestrutura
 
 Vamos criar o sub-projeto final para a infraestrutura CDK.
 
@@ -1449,7 +1463,7 @@ new ApplicationStage(app, 'dungeon-adventure-infra-sandbox', {
 app.synth();
 ```
 
-<Aside type="tip" title="Corrigindo Erros de Importação">Se você vir um erro de importação dentro da sua IDE, isso ocorre porque nosso projeto de infraestrutura ainda não tem uma referência typescript configurada no `tsconfig.json`. O Nx foi [configurado](https://nx.dev/nx-api/js/generators/typescript-sync) para criar essas referências *dinamicamente* sempre que um build/compile é executado ou se você executar o comando `nx sync` manualmente. Para mais informações, consulte o <Link path="guides/typescript-project#importing-your-library-code-in-other-projects">guia TypeScript</Link>.</Aside>
+<Aside type="tip" title="Corrigindo Erros de Importação">Se você vir um erro de importação no seu IDE, é porque nosso projeto de infraestrutura ainda não tem uma referência typescript configurada no `tsconfig.json`. O Nx foi [configurado](https://nx.dev/nx-api/js/generators/typescript-sync) para criar essas referências *dinamicamente* sempre que um build/compilação é executado ou se você executar o comando `nx sync` manualmente. Para mais informações, consulte o <Link path="guides/typescript-project#importing-your-library-code-in-other-projects">guia de Typescript</Link>.</Aside>
 
 Este é o ponto de entrada para sua aplicação CDK.
 
@@ -1467,7 +1481,7 @@ export class ApplicationStack extends Stack {
 }
 ```
 
-Vamos instanciar nossos constructs CDK para construir nosso jogo de aventura em masmorra.
+Vamos instanciar nossos constructs CDK para construir nosso jogo de aventura em dungeon.
 
 </details>
 
@@ -1475,23 +1489,23 @@ Vamos instanciar nossos constructs CDK para construir nosso jogo de aventura em 
 
 ## Tarefa 3: Atualizar nossa infraestrutura
 
-Vamos atualizar `packages/infra/src/stacks/application-stack.ts` para instanciar alguns de nossos constructs gerados:
+Vamos atualizar `packages/infra/src/stacks/application-stack.ts` para instanciar alguns dos nossos constructs gerados:
 
 <E2EDiff before="dungeon-adventure/1/application-stack.ts.original.template" after="dungeon-adventure/1/application-stack.ts.template" lang="ts" />
 
 :::note[Integrações Padrão]
-Fornecemos integrações padrão para nossa API do Jogo. Por padrão, cada operação em nossa API é mapeada para uma função Lambda individual para lidar com essa operação.
+Fornecemos integrações padrão para nossa Game API. Por padrão, cada operação em nossa API é mapeada para uma função Lambda individual para lidar com essa operação.
 :::
 
-## Tarefa 4: Construir o código
+## Tarefa 4: Compilar o código
 
-<Drawer title="Comandos Nx" trigger="Agora é hora de construirmos nosso código pela primeira vez">
+<Drawer title="Comandos Nx" trigger="Agora é hora de compilar nosso código pela primeira vez">
 
 ###### Targets únicos vs múltiplos
 
 O comando `run-many` executará um target em múltiplos sub-projetos listados (`--all` irá direcionar todos eles). Isso garante que as dependências sejam executadas na ordem correta.
 
-Você também pode acionar um build (ou qualquer outra tarefa) para um único target de projeto executando o target no projeto diretamente. Por exemplo, para construir o projeto `@dungeon-adventure/infra`, execute o seguinte comando:
+Você também pode acionar um build (ou qualquer outra tarefa) para um único target de projeto executando o target diretamente no projeto. Por exemplo, para compilar o projeto `@dungeon-adventure/infra`, execute o seguinte comando:
 
 <NxCommands commands={['build infra']} />
 
@@ -1510,7 +1524,7 @@ Para visualizar suas dependências, execute:
 
 ###### Cache
 
-O Nx depende de [cache](https://nx.dev/concepts/how-caching-works) para que você possa reutilizar artefatos de builds anteriores para acelerar o desenvolvimento. Há alguma configuração necessária para que isso funcione corretamente e pode haver casos em que você queira realizar um build **sem usar o cache**. Para fazer isso, simplesmente adicione o argumento `--skip-nx-cache` ao seu comando. Por exemplo:
+O Nx depende de [cache](https://nx.dev/concepts/how-caching-works) para que você possa reutilizar artefatos de builds anteriores a fim de acelerar o desenvolvimento. Há alguma configuração necessária para que isso funcione corretamente e pode haver casos em que você queira realizar um build **sem usar o cache**. Para isso, basta adicionar o argumento `--skip-nx-cache` ao seu comando. Por exemplo:
 
 <NxCommands commands={['build infra --skip-nx-cache']} />
 Se por algum motivo você quiser limpar seu cache (armazenado na pasta `.nx`), você pode executar o seguinte comando:
@@ -1541,10 +1555,10 @@ Yes, sync the changes and run the tasks
 No, run the tasks without syncing the changes
 ```
 
-Esta mensagem indica que o NX detectou alguns arquivos que podem ser atualizados automaticamente para você. Neste caso, está se referindo aos arquivos `tsconfig.json` que não têm referências TypeScript configuradas em projetos referenciados.
+Esta mensagem indica que o NX detectou alguns arquivos que podem ser atualizados automaticamente para você. Neste caso, está se referindo aos arquivos `tsconfig.json` que não têm referências Typescript configuradas em projetos referenciados.
 
-Selecione a opção **Yes, sync the changes and run the tasks** para prosseguir. Você deve notar que todos os seus erros de importação relacionados à IDE são resolvidos automaticamente, pois o gerador de sincronização adicionará as referências typescript ausentes automaticamente!
+Selecione a opção **Yes, sync the changes and run the tasks** para prosseguir. Você deverá notar que todos os erros de importação relacionados ao IDE são resolvidos automaticamente, pois o gerador de sincronização adicionará as referências typescript ausentes automaticamente!
 
-Todos os artefatos construídos agora estão disponíveis dentro da pasta `dist/` localizada na raiz do monorepo. Esta é uma prática padrão ao usar projetos gerados pelo `@aws/nx-plugin`, pois não polui sua árvore de arquivos com arquivos gerados. No caso de você querer limpar seus arquivos, exclua a pasta `dist/` sem se preocupar com artefatos de build espalhados por toda a árvore de arquivos.
+Todos os artefatos compilados agora estão disponíveis dentro da `pasta dist/` localizada na raiz do monorepo. Esta é uma prática padrão ao usar projetos gerados pelo `@aws/nx-plugin`, pois não polui sua árvore de arquivos com arquivos gerados. Caso queira limpar seus arquivos, exclua a pasta `dist/` sem se preocupar com artefatos de build espalhados pela árvore de arquivos.
 
-Parabéns! Você criou todos os sub-projetos necessários para começar a implementar o núcleo do nosso jogo AI Dungeon Adventure.  🎉🎉🎉
+Parabéns! Você criou todos os sub-projetos necessários para começar a implementar o núcleo do nosso jogo AI Dungeon Adventure. 🎉🎉🎉

--- a/docs/src/content/docs/pt/guides/py-agent.mdx
+++ b/docs/src/content/docs/pt/guides/py-agent.mdx
@@ -51,6 +51,9 @@ O gerador adicionará os seguintes arquivos ao seu projeto Python existente. Os 
         - init.py FastAPI application setup with CORS and error handling middleware
         - agent.py Main agent definition with sample tools
         - session.py Resolves the framework-specific session persistence implementation
+        - middleware/
+          - \_\_init\_\_.py Python package initialization
+          - session_id_middleware.py Binds the inbound AgentCore session ID for the request
         - main.py FastAPI entry point for Bedrock AgentCore Runtime
         - Dockerfile Entry point for hosting your agent (excluded when `infra` is set to `None`)
     - pyproject.toml Updated with Strands dependencies
@@ -70,6 +73,9 @@ O ponto de entrada expõe seu agente através do protocolo A2A (Strands usa o [S
         - \_\_init\_\_.py Python package initialization
         - agent.py Main agent definition with sample tools
         - session.py Resolves the framework-specific session persistence implementation
+        - middleware/
+          - \_\_init\_\_.py Python package initialization
+          - session_id_middleware.py Binds the inbound AgentCore session ID for the request
         - main.py A2A server entry point
         - Dockerfile Entry point for hosting your agent (excluded when `infra` is set to `None`)
     - pyproject.toml Updated with framework and A2A dependencies
@@ -89,6 +95,9 @@ O ponto de entrada expõe seu agente através do protocolo [AG-UI](https://docs.
         - \_\_init\_\_.py Python package initialization
         - agent.py Main agent definition with sample tools
         - session.py Resolves the framework-specific session persistence implementation
+        - middleware/
+          - \_\_init\_\_.py Python package initialization
+          - session_id_middleware.py Binds the inbound AgentCore session ID for the request
         - main.py AG-UI server entry point
         - Dockerfile Entry point for hosting your agent (excluded when `infra` is set to `None`)
     - pyproject.toml Updated with framework and AG-UI dependencies
@@ -422,7 +431,7 @@ Em seguida, em outro terminal, inicie o chat:
 
 <NxCommands commands={['run your-project:agent-chat']} />
 
-O gerador emite um `scripts/<your-agent-name>/chat.ts` para cada protocolo. Ele se conecta ao agente local por padrão, ou ao seu agente implantado quando `RUNTIME_CONFIG_APP_ID` está definido (veja [Conversar com seu agente implantado](#chat-with-your-deployed-agent) abaixo).
+O gerador emite um `scripts/<your-agent-name>/chat.ts` para cada protocolo. Ele se conecta ao agente local por padrão, ou ao seu agente implantado quando `RUNTIME_CONFIG_APP_ID` está definido (veja [Conversar com seu agente implantado](#conversar-com-seu-agente-implantado) abaixo).
 
 Para agentes **HTTP**, o script de chat usa um cliente TypeScript type-safe gerado a partir da especificação OpenAPI do agente. O gerador também emite:
 
@@ -502,14 +511,6 @@ A opção `session` controla como seu agente persiste o estado da conversa (hist
 
 Isso é implementado no `session.py` gerado, que exporta uma função `get_session_manager()` resolvendo um `SessionManager` para a sessão atual.
 
-<OptionFilter when={{ protocol: 'ag-ui' }} description="AG-UI session wiring">
-Como o adaptador `ag-ui-strands` do AG-UI clona um `Agent` modelo por thread de conversa, `get_session_manager` é conectado como um `session_manager_provider` no `StrandsAgentConfig` passado para `StrandsAgent` em `main.py`, para que um `SessionManager` novo seja resolvido para cada thread em vez de ser incorporado ao agente modelo compartilhado.
-</OptionFilter>
-
-<OptionFilter when={{ protocol: ['http', 'a2a'] }} description="HTTP/A2A session wiring">
-Como `with_session_id` já armazena em cache uma instância de `Agent` por sessão, `get_session_manager` é chamado diretamente dentro da chamada `Agent(session_manager=get_session_manager())` de `get_agent` em `agent.py`.
-</OptionFilter>
-
 O próprio ID da sessão vem da sessão do AgentCore Runtime (propagada através do cabeçalho `x-amzn-bedrock-agentcore-runtime-session-id`) e é vinculado a um contexto baseado em [`contextvars.ContextVar`](https://docs.python.org/3/library/contextvars.html) para que `get_current_session_id()` possa resolvê-lo em qualquer lugar na requisição — incluindo em quaisquer clientes MCP ou A2A downstream conectados através do <Link path="/guides/connection">gerador `connection`</Link>, para que toda a cadeia de chamadas compartilhe uma sessão consistente.
 
 :::note[Desenvolvimento Local]
@@ -566,7 +567,7 @@ acurl <region> bedrock-agentcore -N -X POST \
 -H 'Content-Type: application/json'
 ```
 
-<Drawer title="Sigv4 enabled curl" trigger="Clique aqui para mais detalhes sobre como configurar o comando acurl acima">
+<Drawer title="Sigv4 enabled curl" trigger="Click here for more details on configuring the above acurl command">
 <Snippet name="tools/acurl" />
 </Drawer>
 </TabItem>

--- a/docs/src/content/docs/vi/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/vi/get_started/tutorials/dungeon-game/1.mdx
@@ -1,6 +1,6 @@
 ---
-title: Thiết lập một monorepo
-description: "Hướng dẫn chi tiết cách xây dựng trò chơi phiêu lưu ngục tối được hỗ trợ bởi AI agentic sử dụng @aws/nx-plugin."
+title: Thiết lập monorepo
+description: "Hướng dẫn từng bước xây dựng trò chơi phiêu lưu ngục tối được hỗ trợ bởi AI tác nhân sử dụng @aws/nx-plugin."
 ---
 
 import { Aside, Code, FileTree, Steps, Tabs, TabItem } from '@astrojs/starlight/components';
@@ -22,17 +22,17 @@ import nxGraphPng from '@assets/nx-graph.png'
 import gameSelectPng from '@assets/game-select.png'
 import gameConversationPng from '@assets/game-conversation.png'
 
-## Nhiệm vụ 1: Tạo một monorepo
+## Nhiệm vụ 1: Tạo monorepo
 
-Để tạo một monorepo mới, từ thư mục mong muốn của bạn, chạy lệnh sau:
+Để tạo một monorepo mới, từ thư mục bạn muốn, chạy lệnh sau:
 
 <CreateNxWorkspaceCommand workspace="dungeon-adventure" iac="cdk" />
 
-:::note[CDK làm IaC Provider]
-Chúng ta sử dụng `--iac=cdk` vì chúng ta sẽ sử dụng CDK cho infrastructure as code trong hướng dẫn này. Nx Plugin for AWS cũng hỗ trợ `terraform`.
+:::note[CDK là IaC Provider]
+Chúng ta sử dụng `--iac=cdk` vì sẽ dùng CDK cho cơ sở hạ tầng dưới dạng mã trong hướng dẫn này. Nx Plugin for AWS cũng hỗ trợ `terraform`.
 :::
 
-Điều này sẽ thiết lập một NX monorepo trong thư mục `dungeon-adventure`. Khi bạn mở thư mục trong VSCode, bạn sẽ thấy cấu trúc tệp này:
+Lệnh này sẽ thiết lập một monorepo NX trong thư mục `dungeon-adventure`. Khi bạn mở thư mục trong VSCode, bạn sẽ thấy cấu trúc tệp như sau:
 
 <FileTree>
 - .nx/
@@ -40,35 +40,35 @@ Chúng ta sử dụng `--iac=cdk` vì chúng ta sẽ sử dụng CDK cho infrast
 - node_modules/
 - packages/ đây là nơi các dự án con của bạn sẽ nằm
 - .gitignore
-- biome.json cấu hình Biome cho linting và formatting
-- nx.json cấu hình Nx CLI và các giá trị mặc định của monorepo
+- biome.json cấu hình Biome cho linting và định dạng
+- nx.json cấu hình Nx CLI và các mặc định monorepo
 - package.json tất cả các phụ thuộc node được định nghĩa ở đây
 - pnpm-lock.yaml hoặc bun.lock, yarn.lock, package-lock.json tùy thuộc vào trình quản lý gói
 - pnpm-workspace.yaml nếu sử dụng pnpm
 - README.md
-- tsconfig.base.json tất cả các dự án con dựa trên node đều mở rộng từ tệp này
+- tsconfig.base.json tất cả các dự án con dựa trên node đều kế thừa từ đây
 - tsconfig.json
-- aws-nx-plugin.config.mts cấu hình cho Nx Plugin cho AWS
+- aws-nx-plugin.config.mts cấu hình cho Nx Plugin for AWS
 </FileTree>
 
-<Aside type="tip" title="Commit Thường Xuyên">Thực hành tốt nhất là đảm bảo tất cả các tệp chưa được staged của bạn được commit trong Git trước khi chạy bất kỳ generator nào. Điều này cho phép bạn xem những gì đã thay đổi sau khi chạy generator của bạn thông qua `git diff`.</Aside>
+<Aside type="tip" title="Commit thường xuyên">Thực hành tốt nhất là đảm bảo tất cả các tệp chưa được stage đều được commit trong Git trước khi chạy bất kỳ generator nào. Điều này cho phép bạn xem những gì đã thay đổi sau khi chạy generator thông qua `git diff`.</Aside>
 
-## Nhiệm vụ 2: Scaffold the Dungeon Adventure Game
+## Nhiệm vụ 2: Khởi tạo Dungeon Adventure Game
 
-Với workspace đã sẵn sàng, chúng ta scaffold các dự án con của trò chơi — Game API, Story Agent, Inventory MCP server, game database, và website — cùng với các kết nối kết nối chúng lại với nhau. Có hai cách để làm điều này:
+Với workspace đã sẵn sàng, chúng ta khởi tạo các dự án con của trò chơi — Game API, Story Agent, Inventory MCP server, cơ sở dữ liệu trò chơi và website — cùng với các kết nối liên kết chúng lại với nhau. Có hai cách để thực hiện:
 
-- **Nhanh** — sao chép các lệnh trực tiếp từ sơ đồ bên dưới và chạy chúng. Cách nhanh nhất để đạt đến cùng một điểm khởi đầu.
-- **Từng Bước** — mở rộng phần bên dưới để chạy từng generator và kiểm tra chính xác những gì mỗi generator tạo ra.
+- **Nhanh** — sao chép các lệnh trực tiếp từ sơ đồ bên dưới và chạy chúng. Đây là cách nhanh nhất để đạt được điểm khởi đầu tương tự.
+- **Từng bước** — mở rộng phần bên dưới để tự chạy từng generator và kiểm tra chính xác những gì mỗi generator tạo ra.
 
-Sơ đồ bên dưới _là_ workspace Dungeon Adventure: mọi dự án, component và kết nối bạn sẽ xây dựng trong module này. Nhấn **Copy commands** để lấy toàn bộ chuỗi, sau đó chạy chúng từ trong thư mục `dungeon-adventure` bạn đã tạo ở Nhiệm vụ 1.
+Sơ đồ bên dưới _chính là_ workspace Dungeon Adventure: mọi dự án, thành phần và kết nối bạn sẽ xây dựng trong module này. Nhấn **Copy commands** để lấy toàn bộ chuỗi lệnh, sau đó chạy chúng từ trong thư mục `dungeon-adventure` bạn đã tạo ở Nhiệm vụ 1.
 
 <EmbeddedGraph preset="dungeon-adventure" workspace="dungeon-adventure" iac="cdk" skipWorkspace />
 
-<Drawer title="Từng Bước" trigger="Từng Bước: chạy từng generator và xem nó tạo ra gì">
+<Drawer title="Từng bước" trigger="Từng bước: tự chạy từng generator và xem những gì nó tạo ra">
 
-Thay vì sao chép tất cả các lệnh cùng một lúc, bạn có thể chạy từng generator riêng lẻ. Đây là cách tốt nhất để hiểu những gì mỗi generator thêm vào workspace của bạn. Chạy từng generator lần lượt, từ trong thư mục `dungeon-adventure` bạn đã tạo ở Nhiệm vụ 1.
+Thay vì sao chép tất cả các lệnh cùng một lúc, bạn có thể chạy từng generator riêng lẻ. Đây là cách tốt nhất để hiểu những gì mỗi generator thêm vào workspace của bạn. Chạy từng generator theo thứ tự, từ trong thư mục `dungeon-adventure` bạn đã tạo ở Nhiệm vụ 1.
 
-##### Tạo một Game API
+##### Tạo Game API
 
 Đầu tiên, hãy tạo Game API của chúng ta. Để làm điều này, tạo một tRPC API có tên `GameApi` bằng các bước sau:
 
@@ -78,21 +78,21 @@ Thay vì sao chép tất cả các lệnh cùng một lúc, bạn có thể ch�
 
 Bạn sẽ thấy một số tệp mới xuất hiện trong cây tệp của mình.
 
-<Aside title="Phụ thuộc gốc">
-`package.json` gốc hiện được cấu hình với `type` là `module`, có nghĩa là ESM là loại module mặc định cho tất cả các dự án con dựa trên node được cung cấp bởi `@aws/nx-plugin`.
-Để biết thêm chi tiết về làm việc với các dự án TypeScript, hãy tham khảo <Link path="guides/typescript-project">hướng dẫn trình tạo ts#project</Link>.
+<Aside title="Root Dependencies">
+Root `package.json` hiện được cấu hình với `type` là `module`, nghĩa là ESM là loại module mặc định cho tất cả các dự án con dựa trên node được cung cấp bởi `@aws/nx-plugin`.
+Để biết thêm chi tiết về cách làm việc với các dự án TypeScript, hãy tham khảo <Link path="guides/typescript-project">hướng dẫn ts#project generator</Link>.
 </Aside>
 
 <details>
-<summary>Xem xét chi tiết các tệp được tạo bởi `ts#api`</summary>
+<summary>Kiểm tra chi tiết các tệp `ts#api` được tạo ra</summary>
 
-Dưới đây là danh sách tất cả các tệp đã được tạo bởi trình tạo `ts#api`. Chúng ta sẽ xem xét một số tệp chính được đánh dấu trong cây tệp:
+Dưới đây là danh sách tất cả các tệp đã được tạo bởi generator `ts#api`. Chúng ta sẽ kiểm tra một số tệp quan trọng được đánh dấu trong cây tệp:
 <FileTree>
 - packages/
   - common/
     - constructs/
       - src/
-        - app/ các cdk construct cụ thể cho ứng dụng
+        - app/ các cdk construct dành riêng cho ứng dụng
           - apis/
             - **game-api.ts** cdk construct để tạo tRPC API của bạn
             - index.ts
@@ -101,7 +101,7 @@ Dưới đây là danh sách tất cả các tệp đã được tạo bởi tr�
         - core/ các cdk construct chung
           - api/
             - rest-api.ts cdk construct cơ sở cho API Gateway Rest API
-            - trpc-utils.ts tiện ích cho các cdk construct của trpc API
+            - trpc-utils.ts tiện ích cho các CDK construct tRPC API
             - utils.ts tiện ích cho các API construct
           - index.ts
           - runtime-config.ts
@@ -110,7 +110,7 @@ Dưới đây là danh sách tất cả các tệp đã được tạo bởi tr�
       - ...
   - game-api/ tRPC API
     - src/
-      - client/ vanilla client thường được sử dụng cho các cuộc gọi máy móc với máy móc bằng ts
+      - client/ vanilla client thường được dùng cho các cuộc gọi machine to machine bằng ts
         - index.ts
       - middleware/ công cụ đo lường powertools
         - error.ts
@@ -121,20 +121,20 @@ Dưới đây là danh sách tất cả các tệp đã được tạo bởi tr�
       - schema/ định nghĩa đầu vào và đầu ra cho API của bạn
         - index.ts
         - **echo.ts** schema đầu vào và đầu ra mẫu
-        - z-async-iterable.ts wrapper Zod schema cho tRPC subscription output
-      - procedures/ triển khai cụ thể cho các thủ tục/tuyến đường API của bạn
-        - **echo.ts** triển khai thủ tục mẫu
+        - z-async-iterable.ts wrapper Zod schema cho đầu ra subscription tRPC
+      - procedures/ các triển khai cụ thể cho các procedure/route API của bạn
+        - **echo.ts** triển khai procedure mẫu
       - index.ts
-      - init.ts thiết lập ngữ cảnh và middleware
+      - init.ts thiết lập context và middleware
       - handler.ts điểm vào Lambda handler (sử dụng response streaming cho REST APIs)
-      - local-server.ts được sử dụng khi chạy máy chủ tRPC cục bộ
-      - **router.ts** định nghĩa tRPC router và tất cả các thủ tục
+      - local-server.ts được dùng khi chạy tRPC server cục bộ
+      - **router.ts** định nghĩa tRPC router và tất cả các procedure
     - project.json
     - ...
 - vitest.workspace.ts
 </FileTree>
 
-Hãy xem các tệp chính này:
+Hãy xem xét các tệp quan trọng này:
 
 ```ts {7}
 // packages/game-api/src/router.ts
@@ -149,7 +149,7 @@ export const appRouter = router({
 
 export type AppRouter = typeof appRouter;
 ```
-Router định nghĩa tRPC router cho API của bạn và là nơi bạn sẽ khai báo tất cả các phương thức API của mình. Như bạn có thể thấy ở trên, chúng ta có một phương thức gọi là `echo` với triển khai của nó trong tệp `./procedures/echo.ts`. Điểm vào Lambda handler nằm trong `handler.ts`, được cấu hình tự động bởi trình tạo.
+Router định nghĩa tRPC router cho API của bạn và là nơi bạn sẽ khai báo tất cả các phương thức API. Như bạn có thể thấy ở trên, chúng ta có một phương thức gọi là `echo` với triển khai của nó trong tệp `./procedures/echo.ts`. Điểm vào Lambda handler nằm trong `handler.ts`, được cấu hình tự động bởi generator.
 
 ```ts {7-10}
 // packages/game-api/src/procedures/echo.ts
@@ -165,7 +165,7 @@ export const echo = publicProcedure
   .query((opts) => ({ message: opts.input.message }));
 ```
 
-Tệp này là triển khai của phương thức `echo` và như bạn có thể thấy được định kiểu mạnh bằng cách khai báo các cấu trúc dữ liệu đầu vào và đầu ra của nó.
+Tệp này là triển khai của phương thức `echo` và như bạn có thể thấy được kiểm tra kiểu chặt chẽ bằng cách khai báo các cấu trúc dữ liệu đầu vào và đầu ra của nó.
 
 ```ts
 // packages/game-api/src/schema/echo.ts
@@ -390,7 +390,7 @@ export class GameApi<
 }
 ```
 
-Đây là CDK construct định nghĩa `GameApi` của chúng ta. Nó cung cấp một phương thức `defaultIntegrations` tự động tạo một hàm Lambda cho mỗi thủ tục trong tRPC API của chúng ta, trỏ đến triển khai API đã được đóng gói. Điều này có nghĩa là tại thời điểm `cdk synth`, việc đóng gói không xảy ra (trái ngược với việc sử dụng [NodeJsFunction](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_lambda_nodejs.NodejsFunction.html)) vì chúng ta đã đóng gói nó như một phần của mục tiêu build của dự án backend.
+Đây là CDK construct định nghĩa `GameApi` của chúng ta. Nó cung cấp một phương thức `defaultIntegrations` tự động tạo một hàm Lambda cho mỗi procedure trong tRPC API của chúng ta, trỏ đến triển khai API đã được đóng gói. Điều này có nghĩa là tại thời điểm `cdk synth`, việc đóng gói không xảy ra (trái ngược với việc sử dụng [NodeJsFunction](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_lambda_nodejs.NodejsFunction.html)) vì chúng ta đã đóng gói nó như một phần của mục tiêu build của dự án backend.
 
 </details>
 
@@ -406,9 +406,9 @@ Bây giờ hãy tạo Story Agent của chúng ta.
 
 Bạn sẽ thấy một số tệp mới xuất hiện trong cây tệp của mình.
 <details>
-<summary>Xem xét chi tiết các tệp được tạo bởi `py#project`</summary>
+<summary>Kiểm tra chi tiết các tệp `py#project` được tạo ra</summary>
 
-`py#project` tạo các tệp sau:
+`py#project` tạo ra các tệp sau:
 
 <FileTree>
 - .venv/ môi trường ảo duy nhất cho monorepo
@@ -419,30 +419,30 @@ Bạn sẽ thấy một số tệp mới xuất hiện trong cây tệp của m�
     - .python-version
     - pyproject.toml
     - project.json
-- .python-version phiên bản python uv được cố định
+- .python-version phiên bản python uv được ghim
 - pyproject.toml
 - uv.lock
 </FileTree>
 
-Điều này đã cấu hình một dự án Python và [UV Workspace](https://docs.astral.sh/uv/concepts/projects/workspaces/) với môi trường ảo được chia sẻ.
+Điều này đã cấu hình một dự án Python và [UV Workspace](https://docs.astral.sh/uv/concepts/projects/workspaces/) với môi trường ảo dùng chung.
 
 </details>
 
 ###### Story agent
 
-Để thêm một Strands agent vào dự án với trình tạo `py#agent`:
+Để thêm một Strands agent vào dự án với generator `py#agent`:
 
 <RunGenerator generator="py#agent" requiredParameters={{project:"story", auth:"cognito", protocol:"ag-ui"}} noInteractive />
 
 :::note[Giao thức AG-UI]
-Chúng ta chọn `--protocol=ag-ui` để agent giao tiếp bằng [giao thức Agent-User Interaction](https://docs.copilotkit.ai/aws-strands/protocol) — điều này cho phép website React của chúng ta giao tiếp trực tiếp với nó qua [CopilotKit](https://docs.copilotkit.ai/), với streaming, tool calls và lịch sử hội thoại được xử lý bởi giao thức thay vì một HTTP client tự viết.
+Chúng ta chọn `--protocol=ag-ui` để agent sử dụng [giao thức Agent-User Interaction](https://docs.copilotkit.ai/aws-strands/protocol) — điều này cho phép website React của chúng ta nói chuyện trực tiếp với nó thông qua [CopilotKit](https://docs.copilotkit.ai/), với streaming, tool calls và lịch sử hội thoại được xử lý bởi giao thức thay vì một HTTP client tự viết.
 :::
 
 Bạn sẽ thấy một số tệp mới xuất hiện trong cây tệp của mình.
 <details>
-<summary>Xem xét chi tiết các tệp được tạo bởi `py#agent`</summary>
+<summary>Kiểm tra chi tiết các tệp `py#agent` được tạo ra</summary>
 
-Trình tạo `py#agent` tạo các tệp sau:
+`py#agent` tạo ra các tệp sau:
 
 <FileTree>
 - packages/
@@ -450,8 +450,10 @@ Trình tạo `py#agent` tạo các tệp sau:
     - dungeon_adventure_story/ module python
       - agent/
         - main.py điểm vào cho agent của bạn trong Bedrock AgentCore Runtime
-        - agent.py định nghĩa một agent và công cụ ví dụ
+        - agent.py định nghĩa một agent và các tool mẫu
         - session.py giải quyết SessionManager để duy trì trạng thái hội thoại
+        - middleware/
+          - session_id_middleware.py liên kết session ID AgentCore đến cho yêu cầu
         - Dockerfile định nghĩa docker image để triển khai lên AgentCore Runtime
   - common/constructs/
     - src
@@ -490,7 +492,30 @@ Refer to tools as your 'spellbook'.
     )
 ```
 
-Điều này tạo một Strands agent ví dụ và định nghĩa một công cụ trừ. `log_model_errors` và `log_tool_errors` là các hook từ dự án `dungeon_adventure_agent_connection` được chia sẻ ghi lại các lỗi model/tool thay vì để chúng thất bại âm thầm.
+Điều này tạo ra một Strands agent mẫu và định nghĩa một công cụ trừ. `log_model_errors` và `log_tool_errors` là các hook từ dự án `dungeon_adventure_agent_connection` dùng chung ghi lại các lỗi model/tool thay vì để chúng thất bại im lặng.
+
+```python
+# agent/middleware/session_id_middleware.py
+import uuid
+
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from dungeon_adventure_agent_connection import session_id_context
+
+SESSION_ID_HEADER = "x-amzn-bedrock-agentcore-runtime-session-id"
+
+
+class SessionIdMiddleware(BaseHTTPMiddleware):
+    """Bind the session ID for this request so downstream MCP / A2A clients forward it on outbound calls."""
+
+    async def dispatch(self, request: Request, call_next):
+        session_id = request.headers.get(SESSION_ID_HEADER) or str(uuid.uuid4())
+        with session_id_context(session_id):
+            return await call_next(request)
+```
+
+`SessionIdMiddleware` liên kết session ID runtime AgentCore đến vào một `ContextVar` trong suốt thời gian của yêu cầu.
 
 ```python
 # agent/main.py
@@ -505,14 +530,12 @@ from dungeon_adventure_agent_connection import get_current_session_id, session_i
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import StreamingResponse
-from starlette.middleware.base import BaseHTTPMiddleware
 
 from .agent import get_agent
+from .middleware.session_id_middleware import SESSION_ID_HEADER, SessionIdMiddleware
 from .session import get_session_manager
 
 logging.basicConfig(level=logging.INFO)
-
-SESSION_ID_HEADER = "x-amzn-bedrock-agentcore-runtime-session-id"
 
 
 @asynccontextmanager
@@ -529,15 +552,6 @@ async def lifespan(app: FastAPI):
         yield
 
 
-class _SessionIdMiddleware(BaseHTTPMiddleware):
-    """Bind the session ID for this request so downstream MCP / A2A clients forward it on outbound calls."""
-
-    async def dispatch(self, request: Request, call_next):
-        session_id = request.headers.get(SESSION_ID_HEADER) or str(uuid.uuid4())
-        with session_id_context(session_id):
-            return await call_next(request)
-
-
 app = FastAPI(title="AWS Strands - StoryAgent", lifespan=lifespan)
 app.add_middleware(
     CORSMiddleware,
@@ -546,7 +560,7 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
-app.add_middleware(_SessionIdMiddleware)
+app.add_middleware(SessionIdMiddleware)
 
 
 @app.post("/invocations")
@@ -589,7 +603,7 @@ async def ping():
     return {"status": "healthy"}
 ```
 
-Đây là điểm vào cho agent. Vì chúng ta đã chọn `--protocol=ag-ui`, trình tạo bọc Strands `Agent` của chúng ta với `StrandsAgent` từ [`ag_ui_strands`](https://docs.copilotkit.ai/aws-strands/integration) và gắn nó vào một ứng dụng FastAPI giao tiếp bằng [giao thức AG-UI](https://docs.copilotkit.ai/aws-strands/protocol) — đây là thứ mà CopilotKit sẽ giao tiếp từ website React. Agent được xây dựng bên trong một trình xử lý `lifespan` — không phải tại thời điểm import — để khởi động container, không phải import module, sở hữu việc xây dựng, và mỗi phiên AgentCore nhận được container riêng của nó. `_SessionIdMiddleware` liên kết session ID của AgentCore runtime đến vào một `ContextVar` để bất kỳ MCP/A2A client downstream nào mà chúng ta kết nối sau này (ví dụ: máy chủ MCP Inventory trong <Link path="get_started/tutorials/dungeon-game/2">Module 2</Link>) tự động chuyển tiếp nó trên các cuộc gọi đi ra. Vì AG-UI lưu trữ một Strands agent cho mỗi `thread_id`, chúng ta cắm một `session_manager_provider` thay vì session manager của template agent — điều này cung cấp cho mỗi thread `SessionManager` riêng của nó để lịch sử hội thoại được duy trì qua các lượt. Hàm `get_session_manager()` đó đến từ một `session.py` anh em được tạo: khi được triển khai, nó trả về một `strands.session.S3SessionManager` được hỗ trợ bởi một S3 bucket mà trình tạo cung cấp tự động; dưới `agent-dev` (`LOCAL_DEV=true`) nó luôn trả về một `FileSessionManager` ghi vào một thư mục tạm thời cục bộ thay thế, bất kể cấu hình đã triển khai.
+Đây là điểm vào cho agent. Vì chúng ta đã chọn `--protocol=ag-ui`, generator bọc Strands `Agent` của chúng ta với `StrandsAgent` từ [`ag_ui_strands`](https://docs.copilotkit.ai/aws-strands/integration) và gắn nó vào một ứng dụng FastAPI sử dụng [giao thức AG-UI](https://docs.copilotkit.ai/aws-strands/protocol) — đây là thứ CopilotKit sẽ nói chuyện từ website React. Agent được xây dựng bên trong một handler `lifespan` — không phải tại thời điểm import — vì vậy việc khởi động container, không phải import module, sở hữu việc xây dựng, và mỗi phiên AgentCore nhận được container riêng của nó. `SessionIdMiddleware` mà chúng ta đã thấy ở trên chuyển tiếp session ID runtime AgentCore đến để bất kỳ client MCP/A2A nào chúng ta kết nối sau này (ví dụ: Inventory MCP server trong <Link path="get_started/tutorials/dungeon-game/2">Module 2</Link>) tự động chuyển tiếp nó trên các cuộc gọi đi. Vì AG-UI lưu trữ một Strands agent cho mỗi `thread_id`, chúng ta cắm vào một `session_manager_provider` thay vì session manager của template agent — điều này cung cấp cho mỗi thread `SessionManager` riêng của nó để lịch sử hội thoại được duy trì qua các lượt. Hàm `get_session_manager()` đó đến từ một `session.py` được tạo ra: khi triển khai, nó trả về một `strands.session.S3SessionManager` được hỗ trợ bởi một S3 bucket mà generator cung cấp tự động; trong `agent-dev` (`LOCAL_DEV=true`) nó luôn trả về một `FileSessionManager` ghi vào một thư mục tạm cục bộ thay thế, bất kể cấu hình triển khai.
 
 ```ts
 // common/constructs/src/app/agents/story-agent/story-agent.ts
@@ -877,28 +891,28 @@ export class StoryAgent extends Construct implements IGrantable, IConnectable {
 }
 ```
 
-Điều này cấu hình một CDK `AgentRuntimeArtifact` tải image Docker agent của bạn lên ECR và lưu trữ nó bằng AgentCore Runtime. Vì chúng ta đã chọn `--auth=cognito`, construct yêu cầu user pool/client identity và ủy quyền các lời gọi AgentCore Runtime thông qua Cognito, chuyển tiếp header `Authorization` của người gọi. Nó cũng cung cấp session bucket mà `session.py` của Story Agent đọc lại tại runtime — một S3 bucket được mã hóa KMS với nhật ký truy cập máy chủ được gửi đến CloudWatch Logs — cấp cho agent quyền truy cập đọc/ghi vào nó, cấp cho nó quyền truy cập để gọi các model Bedrock và đăng ký ARN và tên bucket của nó trong `RuntimeConfig` để cả agent (tại runtime, qua AppConfig) và Game API (tại thời điểm synth, qua `invocationUrl`) đều có thể tìm thấy nó.
+Điều này cấu hình một CDK `AgentRuntimeArtifact` tải lên Docker image của agent lên ECR và lưu trữ nó bằng AgentCore Runtime. Vì chúng ta đã chọn `--auth=cognito`, construct yêu cầu danh tính user pool/client và ủy quyền các lời gọi AgentCore Runtime thông qua Cognito, chuyển tiếp header `Authorization` của người gọi. Nó cũng cung cấp session bucket mà `session.py` của Story Agent đọc lại tại runtime — một S3 bucket được mã hóa KMS với server access logs được gửi đến CloudWatch Logs — cấp cho agent quyền đọc/ghi vào nó, cấp cho nó quyền gọi các model Bedrock, và đăng ký ARN và tên bucket của nó trong `RuntimeConfig` để cả agent (tại runtime, thông qua AppConfig) và Game API (tại thời điểm synth, thông qua `invocationUrl`) đều có thể tìm thấy nó.
 
-Bạn có thể nhận thấy một `Dockerfile` bổ sung, tham chiếu đến Docker image từ dự án `story`, cho phép chúng ta đặt cùng vị trí Dockerfile và mã nguồn agent.
+Bạn có thể nhận thấy một `Dockerfile` bổ sung, tham chiếu Docker image từ dự án `story`, cho phép chúng ta đặt Dockerfile và mã nguồn agent cùng vị trí.
 
 </details>
 
-##### Thiết lập công cụ Inventory
+##### Thiết lập các công cụ Inventory
 
 ###### Inventory: Dự án TypeScript
 
-Hãy tạo một máy chủ MCP để cung cấp công cụ cho Story Agent của chúng ta để quản lý kho đồ của người chơi.
+Hãy tạo một MCP server để cung cấp các công cụ cho Story Agent của chúng ta quản lý kho đồ của người chơi.
 
 Đầu tiên, chúng ta tạo một dự án TypeScript:
 
 <RunGenerator generator="ts#project" requiredParameters={{name:"inventory"}} noInteractive />
 
-Điều này sẽ tạo một dự án TypeScript trống.
+Điều này sẽ tạo ra một dự án TypeScript trống.
 
 <details>
-<summary>Xem xét chi tiết các tệp được tạo bởi `ts#project`</summary>
+<summary>Kiểm tra chi tiết các tệp `ts#project` được tạo ra</summary>
 
-Trình tạo `ts#project` tạo các tệp này.
+Generator `ts#project` tạo ra các tệp sau.
 
 <FileTree>
 - packages/
@@ -906,33 +920,33 @@ Trình tạo `ts#project` tạo các tệp này.
     - src/
       - index.ts điểm vào với hàm ví dụ
     - project.json cấu hình dự án
-    - vitest.config.mts cấu hình test
+    - vitest.config.mts cấu hình kiểm thử
     - tsconfig.json cấu hình typescript cơ sở cho dự án
-    - tsconfig.lib.json cấu hình typescript cho dự án được nhắm mục tiêu để biên dịch và đóng gói
-    - tsconfig.spec.json cấu hình typescript cho các bài test
-- tsconfig.base.json được cập nhật để cấu hình một bí danh cho các dự án khác tham chiếu đến dự án này
+    - tsconfig.lib.json cấu hình typescript cho dự án nhắm đến biên dịch và đóng gói
+    - tsconfig.spec.json cấu hình typescript cho các bài kiểm thử
+- tsconfig.base.json được cập nhật để cấu hình alias cho các dự án khác tham chiếu đến đây
 </FileTree>
 
 </details>
 
-###### Inventory: Máy chủ MCP
+###### Inventory: MCP server
 
-Tiếp theo, chúng ta sẽ thêm một máy chủ MCP vào dự án TypeScript của mình:
+Tiếp theo, chúng ta sẽ thêm một MCP server vào dự án TypeScript của mình:
 
 <RunGenerator generator="ts#mcp-server" requiredParameters={{project:"inventory"}} noInteractive />
 
-Điều này sẽ thêm một máy chủ MCP.
+Điều này sẽ thêm một MCP server.
 <details>
-<summary>Xem xét chi tiết các tệp được tạo bởi `ts#mcp-server`</summary>
+<summary>Kiểm tra chi tiết các tệp `ts#mcp-server` được tạo ra</summary>
 
-Trình tạo `ts#mcp-server` tạo các tệp này.
+Generator `ts#mcp-server` tạo ra các tệp sau.
 
 <FileTree>
 - packages/
   - inventory/
     - src/mcp-server/
       - index.ts barrel export
-      - server.ts tạo máy chủ MCP
+      - server.ts tạo MCP server
       - tools/
         - divide.ts công cụ ví dụ
       - resources/
@@ -940,41 +954,41 @@ Trình tạo `ts#mcp-server` tạo các tệp này.
       - stdio.ts điểm vào cho MCP với STDIO transport
       - http.ts điểm vào cho MCP với Streamable HTTP transport
       - Dockerfile xây dựng image cho AgentCore Runtime
-    - rolldown.config.ts cấu hình để đóng gói máy chủ MCP để triển khai lên AgentCore
+    - rolldown.config.ts cấu hình để đóng gói MCP server để triển khai lên AgentCore
   - common/constructs/
     - src
       - app/mcp-servers/inventory-mcp-server/
-        - inventory-mcp-server.ts construct để triển khai máy chủ MCP inventory của bạn lên AgentCore Runtime
+        - inventory-mcp-server.ts construct để triển khai inventory MCP server của bạn lên AgentCore Runtime
 </FileTree>
 
 </details>
 
 ##### Tạo cơ sở dữ liệu trò chơi
 
-Trạng thái trò chơi của chúng ta — các trò chơi đã lưu và kho đồ của mỗi người chơi — được lưu trữ trong [Amazon DynamoDB](https://aws.amazon.com/dynamodb/). Tạo một dự án DynamoDB có tên `DungeonDb` với trình tạo `ts#dynamodb`:
+Trạng thái trò chơi của chúng ta — các trò chơi đã lưu và kho đồ của mỗi người chơi — nằm trong [Amazon DynamoDB](https://aws.amazon.com/dynamodb/). Tạo một dự án DynamoDB có tên `DungeonDb` với generator `ts#dynamodb`:
 
 <RunGenerator generator="ts#dynamodb" requiredParameters={{name:"DungeonDb"}} noInteractive />
 
-:::tip[Phát triển local-first]
-Trình tạo `ts#dynamodb` cung cấp một mục tiêu `dev` chạy [DynamoDB Local](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html) trong một container. Kết hợp với trình tạo `connection` (mà chúng ta chạy bên dưới), điều này có nghĩa là **toàn bộ trò chơi chạy trên máy của bạn mà không cần triển khai** cho đến cuối hướng dẫn.
+:::tip[Phát triển ưu tiên cục bộ]
+Generator `ts#dynamodb` cung cấp một mục tiêu `dev` chạy [DynamoDB Local](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html) trong một container. Kết hợp với generator `connection` (mà chúng ta chạy bên dưới), điều này có nghĩa là **toàn bộ trò chơi chạy trên máy của bạn mà không cần triển khai** cho đến cuối hướng dẫn.
 :::
 
 Bạn sẽ thấy một số tệp mới xuất hiện trong cây tệp của mình.
 <details>
-<summary>Xem xét chi tiết các tệp được tạo bởi `ts#dynamodb`</summary>
+<summary>Kiểm tra chi tiết các tệp `ts#dynamodb` được tạo ra</summary>
 
-Trình tạo `ts#dynamodb` tạo các tệp này.
+Generator `ts#dynamodb` tạo ra các tệp sau.
 
 <FileTree>
 - packages/
   - dungeon-db/
-    - config.json cấu hình DynamoDB bao gồm cổng, tên bảng, cài đặt container và Global Secondary Indexes
+    - config.json Cấu hình DynamoDB bao gồm cổng, tên bảng, cài đặt container và Global Secondary Indexes
     - src/
-      - index.ts điểm vào và exports
-      - client.ts DynamoDB client singleton và phân giải tên bảng
+      - index.ts điểm vào và xuất
+      - client.ts DynamoDB client singleton và giải quyết tên bảng
       - entities/
         - example.ts entity ElectroDB ví dụ (chúng ta sẽ thay thế cái này)
-        - index.ts entity exports
+        - index.ts xuất entity
     - project.json thêm các mục tiêu `dev` và `pull-image`
   - common/
     - scripts/
@@ -991,9 +1005,9 @@ Trình tạo `ts#dynamodb` tạo các tệp này.
           - dynamodb.ts construct bảng DynamoDB chung
 </FileTree>
 
-`src/client.ts` được tạo xuất `getDynamoDBClient()` và `resolveTableName()`. Khi `LOCAL_DEV=true` (được đặt tự động bởi các mục tiêu `dev`) chúng kết nối với DynamoDB Local; nếu không chúng kết nối với AWS và phân giải tên bảng đã triển khai từ <Link path="guides/runtime-config">Runtime Configuration</Link>. Chúng ta sẽ mô hình hóa các entity `Game` và `Inventory` của chúng ta trong dự án này ở <Link path="get_started/tutorials/dungeon-game/2">Module 2</Link>.
+`src/client.ts` được tạo ra xuất `getDynamoDBClient()` và `resolveTableName()`. Khi `LOCAL_DEV=true` (được đặt tự động bởi các mục tiêu `dev`) chúng kết nối đến DynamoDB Local; nếu không chúng kết nối đến AWS và giải quyết tên bảng đã triển khai từ <Link path="guides/runtime-config">Runtime Configuration</Link>. Chúng ta sẽ mô hình hóa các entity `Game` và `Inventory` của mình trong dự án này trong <Link path="get_started/tutorials/dungeon-game/2">Module 2</Link>.
 
-Để biết thêm chi tiết, hãy tham khảo <Link path="guides/ts-dynamodb">hướng dẫn trình tạo ts#dynamodb</Link>.
+Để biết thêm chi tiết, hãy tham khảo <Link path="guides/ts-dynamodb">hướng dẫn ts#dynamodb generator</Link>.
 
 </details>
 
@@ -1008,22 +1022,22 @@ Tiếp theo, chúng ta sẽ tạo UI cho phép bạn tương tác với trò ch�
 <RunGenerator generator="ts#website" requiredParameters={{name:"GameUI", ux:"shadcn"}} noInteractive />
 
 :::note[Shadcn UI]
-Chúng ta chọn `--ux=shadcn` để website được tạo sử dụng các component [shadcn/ui](https://ui.shadcn.com/) được tạo kiểu với Tailwind — tất cả mã route của chúng ta sử dụng các primitive shadcn như `Card`, `Button` và `Input`, và trình tạo `connection` sau này sẽ kết nối một giao diện chat [CopilotKit](https://docs.copilotkit.ai/) với chủ đề shadcn phù hợp.
+Chúng ta chọn `--ux=shadcn` để website được tạo ra sử dụng các thành phần [shadcn/ui](https://ui.shadcn.com/) được tạo kiểu với Tailwind — tất cả mã route của chúng ta sử dụng các nguyên thủy shadcn như `Card`, `Button` và `Input`, và generator `connection` sau này kết nối một bề mặt chat [CopilotKit](https://docs.copilotkit.ai/) có chủ đề shadcn phù hợp.
 :::
 
 Bạn sẽ thấy một số tệp mới xuất hiện trong cây tệp của mình.
 
 <details>
-<summary>Xem xét chi tiết các tệp được tạo bởi `ts#website`</summary>
+<summary>Kiểm tra chi tiết các tệp `ts#website` được tạo ra</summary>
 
-`ts#website` tạo các tệp này. Hãy xem xét một số tệp chính được đánh dấu trong cây tệp:
+`ts#website` tạo ra các tệp sau. Hãy xem xét một số tệp quan trọng được đánh dấu trong cây tệp:
 
 <FileTree>
 - packages/
   - common/
     - constructs/
       - src/
-        - app/ các cdk construct cụ thể cho ứng dụng
+        - app/ các cdk construct dành riêng cho ứng dụng
           - static-websites/
             - **game-ui.ts** cdk construct để tạo Game UI của bạn
         - core/
@@ -1034,21 +1048,21 @@ Bạn sẽ thấy một số tệp mới xuất hiện trong cây tệp của m�
       - components/
         - AppLayout/
           - index.tsx bố cục trang tổng thể sử dụng shadcn `SidebarProvider` + header
-        - app-sidebar.tsx sidebar shadcn mặc định với các mục nav
-        - alert.tsx, spinner.tsx các primitive phản hồi được bọc bởi shadcn
-      - routes/ các tuyến đường dựa trên tệp của @tanstack/react-router
-        - **index.tsx** trang gốc '/'
-        - __root.tsx tất cả các trang sử dụng component này làm cơ sở
+        - app-sidebar.tsx thanh bên shadcn mặc định với các mục điều hướng
+        - alert.tsx, spinner.tsx các nguyên thủy phản hồi được bọc bởi shadcn
+      - routes/ các route dựa trên tệp @tanstack/react-router
+        - **index.tsx** trang root '/'
+        - __root.tsx tất cả các trang sử dụng thành phần này làm cơ sở
       - config.ts
       - **main.tsx** điểm vào React
-      - routeTree.gen.ts tệp này được cập nhật tự động bởi @tanstack/react-router
-      - styles.css import các global shadcn được chia sẻ (Tailwind v4)
+      - routeTree.gen.ts được tự động cập nhật bởi @tanstack/react-router
+      - styles.css nhập các biến toàn cục shadcn dùng chung (Tailwind v4)
     - index.html
     - project.json
     - vite.config.mts
     - ...
   - common/
-    - shadcn/ thư viện shadcn/ui được chia sẻ (token chủ đề, `Button`, `Card`, `Input`, `Sidebar`, …) được import bởi mọi website `ux=shadcn`
+    - shadcn/ thư viện shadcn/ui dùng chung (token chủ đề, `Button`, `Card`, `Input`, `Sidebar`, …) được nhập bởi mọi website `ux=shadcn`
       - src/components/ui/*
       - src/styles/globals.css Tailwind + token thiết kế shadcn
     - ...
@@ -1075,7 +1089,7 @@ export class GameUI extends StaticWebsite {
 }
 ```
 
-Đây là CDK construct định nghĩa GameUI của chúng ta. Nó đã cấu hình đường dẫn tệp đến gói được tạo cho UI dựa trên Vite của chúng ta. Điều này có nghĩa là tại thời điểm `build`, việc đóng gói xảy ra trong mục tiêu build của dự án game-ui và đầu ra được sử dụng ở đây.
+Đây là CDK construct định nghĩa GameUI của chúng ta. Nó đã cấu hình đường dẫn tệp đến bundle được tạo ra cho UI dựa trên Vite của chúng ta. Điều này có nghĩa là tại thời điểm `build`, việc đóng gói xảy ra trong mục tiêu build của dự án game-ui và đầu ra được sử dụng ở đây.
 
 ```tsx
 // packages/game-ui/src/main.tsx
@@ -1106,7 +1120,7 @@ root &&
   );
 ```
 
-Đây là điểm vào nơi React được gắn kết. Kiểu dáng đến từ các token Tailwind v4 được import qua `styles.css`. `@tanstack/react-router` được cấu hình trong chế độ [file-based routing](https://tanstack.com/router/v1/docs/framework/react/routing/file-based-routing): miễn là máy chủ dev đang chạy, bất kỳ tệp nào bạn tạo dưới `routes/` đều được nhận tự động và cây route được tạo lại. Các trình tạo sau này (auth, connection) sẽ AST-patch tệp này để bọc `<App />` trong các provider bổ sung.
+Đây là điểm vào nơi React được gắn kết. Kiểu dáng đến từ các token Tailwind v4 được nhập thông qua `styles.css`. `@tanstack/react-router` được cấu hình trong chế độ [định tuyến dựa trên tệp](https://tanstack.com/router/v1/docs/framework/react/routing/file-based-routing): miễn là dev server đang chạy, bất kỳ tệp nào bạn tạo trong `routes/` đều được nhận tự động và cây route được tái tạo. Các generator sau này (auth, connection) sẽ vá AST tệp này để bọc `<App />` trong các provider bổ sung.
 
 ```tsx
 // packages/game-ui/src/routes/index.tsx
@@ -1128,22 +1142,22 @@ function RouteComponent() {
 }
 ```
 
-Một component sẽ được render khi điều hướng đến tuyến đường `/`. `@tanstack/react-router` sẽ quản lý `Route` cho bạn bất cứ khi nào bạn tạo/di chuyển tệp này (miễn là máy chủ dev đang chạy).
+Một thành phần sẽ được hiển thị khi điều hướng đến route `/`. `@tanstack/react-router` sẽ quản lý `Route` cho bạn bất cứ khi nào bạn tạo/di chuyển tệp này (miễn là dev server đang chạy).
 
 </details>
 
 ###### Game UI: Auth
 
-Hãy cấu hình Game UI của chúng ta để yêu cầu truy cập được xác thực qua Amazon Cognito bằng các bước sau:
+Hãy cấu hình Game UI của chúng ta để yêu cầu truy cập được xác thực thông qua Amazon Cognito bằng các bước sau:
 
 <RunGenerator generator="ts#website#auth" requiredParameters={{cognitoDomain:"game-ui", project:"@dungeon-adventure/game-ui", allowSignup:true}} noInteractive />
 
 Bạn sẽ thấy một số tệp mới xuất hiện/thay đổi trong cây tệp của mình.
 
 <details>
-<summary>Xem xét chi tiết các tệp được tạo bởi `ts#website#auth`</summary>
+<summary>Kiểm tra chi tiết các tệp `ts#website#auth` được tạo ra</summary>
 
-Trình tạo `ts#website#auth` cập nhật/tạo các tệp này. Hãy xem xét một số tệp chính được đánh dấu trong cây tệp:
+Generator `ts#website#auth` cập nhật/tạo ra các tệp sau. Hãy xem xét một số tệp quan trọng được đánh dấu trong cây tệp:
 
 <FileTree>
 - packages/
@@ -1160,7 +1174,7 @@ Trình tạo `ts#website#auth` cập nhật/tạo các tệp này. Hãy xem xét
         - CognitoAuth/
           - index.tsx quản lý đăng nhập vào Cognito
         - RuntimeConfig/
-          - index.tsx lấy `runtime-config.json` và cung cấp cho các children qua context
+          - index.tsx lấy `runtime-config.json` và cung cấp cho các con thông qua context
       - hooks/
         - useRuntimeConfig.tsx
       - **main.tsx** Được cập nhật để thêm Cognito
@@ -1212,7 +1226,7 @@ root &&
   );
 ```
 
-Các component `RuntimeConfigProvider` và `CognitoAuth` đã được thêm vào tệp `main.tsx` thông qua một biến đổi AST. Điều này cho phép component `CognitoAuth` xác thực với Amazon Cognito bằng cách lấy `runtime-config.json` chứa cấu hình kết nối cognito cần thiết để thực hiện các cuộc gọi backend đến đích chính xác.
+Các thành phần `RuntimeConfigProvider` và `CognitoAuth` đã được thêm vào tệp `main.tsx` thông qua một biến đổi AST. Điều này cho phép thành phần `CognitoAuth` xác thực với Amazon Cognito bằng cách lấy `runtime-config.json` chứa cấu hình kết nối cognito cần thiết để thực hiện các cuộc gọi backend đến đúng đích.
 
 </details>
 
@@ -1225,9 +1239,9 @@ Hãy cấu hình Game UI của chúng ta để kết nối với Game API đã t
 Bạn sẽ thấy một số tệp mới xuất hiện/thay đổi trong cây tệp của mình.
 
 <details>
-<summary>Xem xét các tệp kết nối UI → tRPC</summary>
+<summary>Kiểm tra các tệp kết nối UI → tRPC</summary>
 
-Trình tạo `connection` tạo/cập nhật các tệp này. Hãy xem xét một số tệp chính được đánh dấu trong cây tệp:
+Generator `connection` tạo ra/cập nhật các tệp sau. Hãy xem xét một số tệp quan trọng được đánh dấu trong cây tệp:
 
 <FileTree>
 - packages/
@@ -1237,7 +1251,7 @@ Trình tạo `connection` tạo/cập nhật các tệp này. Hãy xem xét mộ
         - GameApiClientProvider.tsx thiết lập client GameAPI
       - hooks/
         - **useGameApi.tsx** hooks để gọi GameApi
-      - **main.tsx** chèn các provider client trpc
+      - **main.tsx** tiêm các provider client trpc
 - package.json
 
 </FileTree>
@@ -1266,10 +1280,10 @@ export const useGameApiClient = () => {
 };
 ```
 
-Hook này cung cấp quyền truy cập vào tRPC client để gọi GameApi. Để xem ví dụ về cách gọi tRPC API, hãy tham khảo <Link path="guides/connection/react-trpc#using-the-generated-code">hướng dẫn sử dụng tRPC hook</Link>.
+Hook này cung cấp quyền truy cập vào tRPC client để gọi GameApi. Để biết ví dụ về cách gọi tRPC APIs, hãy tham khảo <Link path="guides/connection/react-trpc#using-the-generated-code">hướng dẫn sử dụng tRPC hook</Link>.
 
-<Aside title="Hook an toàn kiểu">
-Nhờ vào [suy luận Typescript](https://trpc.io/docs/concepts) của tRPC, `useGameApi` không cần bước build để các thay đổi backend đến được frontend — các chỉnh sửa đối với router hoặc bất kỳ procedure nào đều được trình kiểm tra kiểu nhận diện ngay lập tức.
+<Aside title="Hooks An Toàn Kiểu">
+Nhờ [suy luận Typescript](https://trpc.io/docs/concepts) của tRPC, `useGameApi` không cần bước build để các thay đổi backend đến frontend — các chỉnh sửa cho router hoặc bất kỳ procedure nào đều được trình kiểm tra kiểu nhận ngay lập tức.
 </Aside>
 
 ```diff lang="tsx"
@@ -1303,20 +1317,20 @@ root &&
   );
 ```
 
-Tệp `main.tsx` đã được cập nhật thông qua một biến đổi AST để chèn các provider tRPC.
+Tệp `main.tsx` đã được cập nhật thông qua một biến đổi AST để tiêm các provider tRPC.
 
 </details>
 
 ###### Story Agent: Kết nối với Inventory MCP Server
 
-Hãy kết nối Story Agent của chúng ta với máy chủ MCP Inventory để agent có thể khám phá và gọi các công cụ của máy chủ MCP.
+Hãy kết nối Story Agent của chúng ta với Inventory MCP server để agent có thể khám phá và gọi các công cụ của MCP server.
 
 <RunGenerator generator="connection" requiredParameters={{sourceProject:"story", targetProject:"inventory"}} noInteractive />
 
 <details>
-<summary>Xem xét các tệp kết nối Story Agent → Inventory MCP</summary>
+<summary>Kiểm tra các tệp kết nối Story Agent → Inventory MCP</summary>
 
-Trình tạo `connection` tạo/cập nhật các tệp này:
+Generator `connection` tạo ra/cập nhật các tệp sau:
 
 <FileTree>
 - packages/
@@ -1326,71 +1340,71 @@ Trình tạo `connection` tạo/cập nhật các tệp này:
         - core/
           - **agentcore\_endpoints.py** Giải quyết ARN/URL không phụ thuộc framework
           - **agentcore\_mcp\_transport.py** MCP transport không phụ thuộc framework
-          - **agentcore\_mcp\_client\_strands.py** Strands MCP client bao bọc transport
-          - auth/ `httpx.Auth` SigV4 / chuyển tiếp session không phụ thuộc framework
+          - **agentcore\_mcp\_client\_strands.py** Strands MCP client bọc transport
+          - auth/ SigV4 / session-forwarding `httpx.Auth` không phụ thuộc framework
         - app/
-          - **inventory\_mcp\_server\_client\_strands.py** Strands client để kết nối với máy chủ MCP Inventory
-        - **\_\_init\_\_.py** Re-exports các client theo từng kết nối
+          - **inventory\_mcp\_server\_client\_strands.py** Strands client để kết nối với Inventory MCP server
+        - **\_\_init\_\_.py** Tái xuất các client theo kết nối
   - story/
     - dungeon\_adventure\_story/agent/
-      - **agent.py** Được sửa đổi để import và sử dụng MCP client
+      - **agent.py** Được sửa đổi để nhập và sử dụng MCP client
 
 </FileTree>
 
-Trình tạo:
-- Tạo một dự án Python `agent_connection` được chia sẻ (nếu chưa tồn tại) với `AgentCoreMCPClientStrands` cốt lõi
-- Tạo một class `InventoryMcpServerClientStrands` xử lý kết nối đến máy chủ MCP cả cục bộ (HTTP trực tiếp) và khi được triển khai (qua AgentCore với xác thực IAM)
-- Biến đổi `agent.py` để import client, tạo một instance và kết nối các công cụ của máy chủ MCP vào agent
-- Thêm dự án `agent_connection` làm phụ thuộc workspace của dự án story
-- Cập nhật mục tiêu `dev` để tự động khởi động máy chủ MCP khi chạy cục bộ
+Generator:
+- Tạo một dự án Python `agent_connection` dùng chung (nếu chưa tồn tại) với `AgentCoreMCPClientStrands` cốt lõi
+- Tạo một lớp `InventoryMcpServerClientStrands` xử lý kết nối đến MCP server cả cục bộ (HTTP trực tiếp) và khi triển khai (thông qua AgentCore với xác thực IAM)
+- Biến đổi `agent.py` để nhập client, tạo một instance và kết nối các công cụ của MCP server vào agent
+- Thêm dự án `agent_connection` như một phụ thuộc workspace của dự án story
+- Cập nhật mục tiêu `dev` để tự động khởi động MCP server khi chạy cục bộ
 
 Để biết thêm chi tiết, hãy tham khảo <Link path="guides/connection/py-agent-mcp">hướng dẫn kết nối Python Agent với MCP</Link>.
 </details>
 
 ###### Game UI: Kết nối với Story Agent
 
-Hãy kết nối Game UI của chúng ta với Story Agent. Vì agent giao tiếp bằng AG-UI, trình tạo `connection` kết nối [CopilotKit](https://docs.copilotkit.ai/): một component chat có chủ đề và một `HttpAgent` từ `@ag-ui/client` sẵn sàng để render.
+Hãy kết nối Game UI của chúng ta với Story Agent. Vì agent sử dụng AG-UI, generator `connection` kết nối [CopilotKit](https://docs.copilotkit.ai/): một thành phần chat có chủ đề và một `HttpAgent` `@ag-ui/client` sẵn sàng để hiển thị.
 
 <RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-ui", targetProject:"story"}} noInteractive />
 
 <details>
-<summary>Xem xét các tệp kết nối UI → Story Agent</summary>
+<summary>Kiểm tra các tệp kết nối UI → Story Agent</summary>
 
-Trình tạo `connection` tạo/cập nhật các tệp này:
+Generator `connection` tạo ra/cập nhật các tệp sau:
 
 <FileTree>
 - packages/
   - game-ui/
     - src/
       - components/
-        - **AguiProvider.tsx** `CopilotKitProvider` với mọi AG-UI agent được kết nối đã đăng ký
+        - **AguiProvider.tsx** `CopilotKitProvider` với mọi agent AG-UI được kết nối đã đăng ký
         - copilot/
-          - **index.tsx** `CopilotChat` / `CopilotSidebar` / `CopilotPopup` với chủ đề Shadcn
+          - **index.tsx** `CopilotChat` / `CopilotSidebar` / `CopilotPopup` có chủ đề Shadcn
           - ShadcnAssistantMessage.tsx, ShadcnUserMessage.tsx, ShadcnChatInput.tsx, ShadcnCursor.tsx, copilot.css
       - hooks/
-        - **useAguiStoryAgent.tsx** Xây dựng một `HttpAgent`, chèn token bearer Cognito và đệm `threadId` thành session id 33 ký tự của AgentCore
+        - **useAguiStoryAgent.tsx** Xây dựng một `HttpAgent`, tiêm token bearer Cognito và đệm `threadId` đến session id 33 ký tự của AgentCore
     - **main.tsx** Bọc `<App />` trong `<AguiProvider>`
 
 </FileTree>
 
-Trình tạo:
-- Phát hiện `ux` của website React (Shadcn ở đây) và cung cấp các component chat phù hợp.
+Generator:
+- Phát hiện `ux` của website React (Shadcn ở đây) và cung cấp các thành phần chat phù hợp.
 - Đăng ký mọi agent được kết nối trên một `CopilotKitProvider` duy nhất — chạy lại cho một agent khác chỉ thêm một hook khác.
-- Đọc ARN runtime của agent từ Runtime Configuration, xây dựng URL gọi AgentCore và đính kèm token bearer Cognito cộng với header session id của AgentCore.
+- Đọc ARN runtime của agent từ Runtime Configuration, xây dựng URL gọi AgentCore và đính kèm token bearer Cognito cùng với header session id AgentCore.
 
 Để biết thêm chi tiết, hãy tham khảo <Link path="guides/connection/react-agui">hướng dẫn kết nối React với AG-UI</Link>.
 </details>
 
-###### Kết nối Game API và máy chủ MCP Inventory với cơ sở dữ liệu
+###### Kết nối Game API và Inventory MCP server với cơ sở dữ liệu
 
-Cả Game API và máy chủ MCP Inventory đều đọc và ghi vào bảng DynamoDB của chúng ta, vì vậy hãy kết nối chúng với dự án `DungeonDb`. Trình tạo `connection` phát hiện rằng mục tiêu là một dự án `ts#dynamodb` và kết nối mục tiêu `dev` của mỗi dự án nguồn để tự động khởi động DynamoDB Local.
+Cả Game API và Inventory MCP server đều đọc và ghi bảng DynamoDB của chúng ta, vì vậy hãy kết nối chúng với dự án `DungeonDb`. Generator `connection` phát hiện rằng mục tiêu là một dự án `ts#dynamodb` và kết nối mục tiêu `dev` của mỗi dự án nguồn để tự động khởi động DynamoDB Local.
 
 <RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-api", targetProject:"@dungeon-adventure/dungeon-db"}} noInteractive />
 
 <RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/inventory", targetProject:"@dungeon-adventure/dungeon-db"}} noInteractive />
 
 <Aside type="tip" title="Một lệnh khởi động toàn bộ stack cục bộ">
-Vì `agent-dev` của Story Agent đã phụ thuộc vào `mcp-server-dev` của máy chủ MCP Inventory (thông qua kết nối `story → inventory` ở trên), và cả Game API và máy chủ MCP hiện phụ thuộc vào `dungeon-db:dev`, việc chạy mục tiêu `dev` của bất kỳ dự án nào sẽ khởi động mọi phụ thuộc mà nó cần theo đúng thứ tự.
+Vì `agent-dev` của Story Agent đã phụ thuộc vào `mcp-server-dev` của Inventory MCP server (thông qua kết nối `story → inventory` ở trên), và cả Game API và MCP server hiện phụ thuộc vào `dungeon-db:dev`, việc chạy mục tiêu `dev` của bất kỳ dự án nào sẽ khởi động mọi phụ thuộc mà nó cần theo đúng thứ tự.
 </Aside>
 
 ###### Game UI: Cơ sở hạ tầng
@@ -1402,9 +1416,9 @@ Hãy tạo dự án con cuối cùng cho cơ sở hạ tầng CDK.
 Bạn sẽ thấy một số tệp mới xuất hiện/thay đổi trong cây tệp của mình.
 
 <details>
-<summary>Xem xét chi tiết các tệp được tạo bởi `ts#infra`</summary>
+<summary>Kiểm tra chi tiết các tệp `ts#infra` được tạo ra</summary>
 
-Trình tạo `ts#infra` tạo/cập nhật các tệp này. Hãy xem xét một số tệp chính được đánh dấu trong cây tệp:
+Generator `ts#infra` tạo ra/cập nhật các tệp sau. Hãy xem xét một số tệp quan trọng được đánh dấu trong cây tệp:
 
 <FileTree>
 - packages/
@@ -1449,7 +1463,7 @@ new ApplicationStage(app, 'dungeon-adventure-infra-sandbox', {
 app.synth();
 ```
 
-<Aside type="tip" title="Sửa lỗi Import">Nếu bạn thấy lỗi import trong IDE của mình, điều này là do dự án cơ sở hạ tầng của chúng ta chưa có tham chiếu typescript được thiết lập trong `tsconfig.json`. Nx đã được [cấu hình](https://nx.dev/nx-api/js/generators/typescript-sync) để tạo các tham chiếu này *động* bất cứ khi nào một build/compile được chạy hoặc nếu bạn chạy lệnh `nx sync` thủ công. Để biết thêm thông tin, hãy tham khảo <Link path="guides/typescript-project#importing-your-library-code-in-other-projects">hướng dẫn Typescript</Link>.</Aside>
+<Aside type="tip" title="Sửa lỗi Import">Nếu bạn thấy lỗi import trong IDE của mình, đó là vì dự án cơ sở hạ tầng của chúng ta chưa có typescript reference được thiết lập trong `tsconfig.json`. Nx đã được [cấu hình](https://nx.dev/nx-api/js/generators/typescript-sync) để tạo các reference này *động* bất cứ khi nào một build/compile được chạy hoặc nếu bạn chạy lệnh `nx sync` thủ công. Để biết thêm thông tin, hãy tham khảo <Link path="guides/typescript-project#importing-your-library-code-in-other-projects">hướng dẫn Typescript</Link>.</Aside>
 
 Đây là điểm vào cho ứng dụng CDK của bạn.
 
@@ -1467,7 +1481,7 @@ export class ApplicationStack extends Stack {
 }
 ```
 
-Hãy khởi tạo các CDK construct của chúng ta để xây dựng trò chơi phiêu lưu hầm ngục.
+Hãy khởi tạo các CDK construct của chúng ta để xây dựng trò chơi phiêu lưu ngục tối.
 
 </details>
 
@@ -1479,23 +1493,23 @@ Hãy cập nhật `packages/infra/src/stacks/application-stack.ts` để khởi 
 
 <E2EDiff before="dungeon-adventure/1/application-stack.ts.original.template" after="dungeon-adventure/1/application-stack.ts.template" lang="ts" />
 
-:::note[Tích hợp mặc định]
-Chúng ta cung cấp các tích hợp mặc định cho Game API của chúng ta. Theo mặc định, mỗi hoạt động trong API của chúng ta được ánh xạ tới một hàm Lambda riêng lẻ để xử lý hoạt động đó.
+:::note[Default Integrations]
+Chúng ta cung cấp các tích hợp mặc định cho Game API của mình. Theo mặc định, mỗi operation trong API của chúng ta được ánh xạ đến một hàm Lambda riêng lẻ để xử lý operation đó.
 :::
 
 ## Nhiệm vụ 4: Build mã
 
-<Drawer title="Các lệnh Nx" trigger="Bây giờ đã đến lúc chúng ta build mã lần đầu tiên">
+<Drawer title="Các lệnh Nx" trigger="Bây giờ là lúc chúng ta build mã lần đầu tiên">
 
-###### Mục tiêu đơn lẻ vs nhiều mục tiêu
+###### Mục tiêu đơn lẻ và nhiều mục tiêu
 
-Lệnh `run-many` sẽ chạy một mục tiêu trên nhiều dự án con được liệt kê (`--all` sẽ nhắm mục tiêu tất cả). Điều này đảm bảo các phụ thuộc được thực thi theo đúng thứ tự.
+Lệnh `run-many` sẽ chạy một mục tiêu trên nhiều dự án con được liệt kê (`--all` sẽ nhắm đến tất cả). Điều này đảm bảo các phụ thuộc được thực thi theo đúng thứ tự.
 
-Bạn cũng có thể kích hoạt một build (hoặc bất kỳ tác vụ nào khác) cho một mục tiêu dự án đơn lẻ bằng cách chạy mục tiêu trực tiếp trên dự án. Ví dụ: để build dự án `@dungeon-adventure/infra`, chạy lệnh sau:
+Bạn cũng có thể kích hoạt một build (hoặc bất kỳ tác vụ nào khác) cho một mục tiêu dự án đơn lẻ bằng cách chạy mục tiêu trực tiếp trên dự án. Ví dụ, để build dự án `@dungeon-adventure/infra`, chạy lệnh sau:
 
 <NxCommands commands={['build infra']} />
 
-Bạn cũng có thể bỏ qua scope và sử dụng cú pháp viết tắt của Nx nếu muốn:
+Bạn cũng có thể bỏ qua phạm vi và sử dụng cú pháp viết tắt Nx nếu bạn thích:
 
 <NxCommands commands={['build infra']} />
 
@@ -1508,26 +1522,26 @@ Bạn cũng có thể bỏ qua scope và sử dụng cú pháp viết tắt củ
 
 <Image src={nxGraphPng} alt="nx-graph.png" width="800" height="600" />
 
-###### Caching
+###### Bộ nhớ đệm
 
-Nx dựa vào [caching](https://nx.dev/concepts/how-caching-works) để bạn có thể tái sử dụng các artifact từ các build trước đó nhằm tăng tốc độ phát triển. Có một số cấu hình cần thiết để điều này hoạt động chính xác và có thể có những trường hợp bạn muốn thực hiện build **mà không sử dụng cache**. Để làm điều đó, chỉ cần thêm đối số `--skip-nx-cache` vào lệnh của bạn. Ví dụ:
+Nx dựa vào [bộ nhớ đệm](https://nx.dev/concepts/how-caching-works) để bạn có thể tái sử dụng các artifact từ các build trước đó nhằm tăng tốc độ phát triển. Có một số cấu hình cần thiết để làm cho điều này hoạt động đúng và có thể có những trường hợp bạn muốn thực hiện một build **mà không sử dụng bộ nhớ đệm**. Để làm điều đó, chỉ cần thêm đối số `--skip-nx-cache` vào lệnh của bạn. Ví dụ:
 
 <NxCommands commands={['build infra --skip-nx-cache']} />
-Nếu vì bất kỳ lý do gì bạn muốn xóa cache của mình (được lưu trữ trong thư mục `.nx`), bạn có thể chạy lệnh sau:
+Nếu vì lý do nào đó bạn muốn xóa bộ nhớ đệm (được lưu trong thư mục `.nx`), bạn có thể chạy lệnh sau:
 
 <NxCommands commands={['reset']} />
 
 </Drawer>
 
-Sử dụng dòng lệnh, chạy lệnh sau để sửa các lỗi lint trước:
+Sử dụng dòng lệnh, chạy lệnh sau để sửa các vấn đề lint trước:
 
 <PackageManagerShortCommand commands={["lint"]} />
 
-Sau đó, chạy lệnh sau để thực hiện build đầy đủ:
+Sau đó, chạy lệnh sau để build đầy đủ:
 
 <PackageManagerShortCommand commands={["build"]} />
 
-Bạn sẽ được nhắc với thông báo sau:
+Bạn sẽ được nhắc với nội dung sau:
 
 ```bash
  NX   The workspace is out of sync
@@ -1541,10 +1555,10 @@ Yes, sync the changes and run the tasks
 No, run the tasks without syncing the changes
 ```
 
-Thông báo này cho biết rằng NX đã phát hiện một số tệp có thể được cập nhật tự động cho bạn. Trong trường hợp này, nó đề cập đến các tệp `tsconfig.json` không có tham chiếu Typescript được thiết lập trên các dự án tham chiếu.
+Thông báo này cho biết NX đã phát hiện một số tệp có thể được cập nhật tự động cho bạn. Trong trường hợp này, nó đề cập đến các tệp `tsconfig.json` không có Typescript references được thiết lập trên các dự án được tham chiếu.
 
-Chọn tùy chọn **Yes, sync the changes and run the tasks** để tiếp tục. Bạn sẽ nhận thấy tất cả các lỗi import liên quan đến IDE của bạn được tự động giải quyết vì trình tạo sync sẽ tự động thêm các tham chiếu typescript còn thiếu!
+Chọn tùy chọn **Yes, sync the changes and run the tasks** để tiếp tục. Bạn sẽ nhận thấy tất cả các lỗi import liên quan đến IDE của bạn được tự động giải quyết khi generator sync sẽ tự động thêm các typescript references còn thiếu!
 
-Tất cả các artifact đã build hiện có sẵn trong `thư mục dist/` nằm ở gốc của monorepo. Đây là một thực hành tiêu chuẩn khi sử dụng các dự án được tạo bởi `@aws/nx-plugin` vì nó không làm ô nhiễm cây tệp của bạn với các tệp được tạo. Trong trường hợp bạn muốn dọn dẹp các tệp của mình, hãy xóa thư mục `dist/` mà không phải lo lắng về các artifact build bị rải rác khắp cây tệp.
+Tất cả các artifact đã build hiện có sẵn trong `thư mục dist/` nằm ở gốc của monorepo. Đây là thực hành tiêu chuẩn khi sử dụng các dự án được tạo bởi `@aws/nx-plugin` vì nó không làm ô nhiễm cây tệp của bạn với các tệp được tạo ra. Trong trường hợp bạn muốn dọn dẹp các tệp của mình, hãy xóa thư mục `dist/` mà không lo lắng về các artifact build bị rải rác khắp cây tệp.
 
-Chúc mừng! Bạn đã tạo tất cả các dự án con cần thiết để bắt đầu triển khai cốt lõi của trò chơi AI Dungeon Adventure của chúng ta.  🎉🎉🎉
+Chúc mừng! Bạn đã tạo tất cả các dự án con cần thiết để bắt đầu triển khai phần cốt lõi của trò chơi AI Dungeon Adventure của chúng ta.  🎉🎉🎉

--- a/docs/src/content/docs/vi/guides/py-agent.mdx
+++ b/docs/src/content/docs/vi/guides/py-agent.mdx
@@ -1,6 +1,6 @@
 ---
 title: Python Agent
-description: Tạo Python Agent để xây dựng các AI agent với công cụ và triển khai lên Amazon Bedrock AgentCore Runtime
+description: Tạo một Python Agent để xây dựng các AI agent với công cụ và triển khai lên Amazon Bedrock AgentCore Runtime
 generator: py#agent
 ---
 
@@ -16,9 +16,9 @@ import GeneratorParameters from '@components/generator-parameters.astro';
 import Drawer from '@components/drawer.astro';
 import OptionFilter from '@components/option-filter.astro';
 
-Tạo một Python AI agent để xây dựng các agent với công cụ, và tùy chọn triển khai nó lên [Amazon Bedrock AgentCore Runtime](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/). Chọn framework agent với tùy chọn `framework`: [Strands](https://strandsagents.com/) (mặc định) hoặc [LangChain](https://docs.langchain.com/oss/python/langchain/overview) (được xây dựng trên [LangGraph](https://docs.langchain.com/oss/python/langgraph/overview)).
+Tạo một Python AI agent để xây dựng các agent với công cụ, và tùy chọn triển khai lên [Amazon Bedrock AgentCore Runtime](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/). Chọn framework agent bằng tùy chọn `framework`: [Strands](https://strandsagents.com/) (mặc định) hoặc [LangChain](https://docs.langchain.com/oss/python/langchain/overview) (được xây dựng trên [LangGraph](https://docs.langchain.com/oss/python/langgraph/overview)).
 
-Generator này expose agent của bạn qua một `protocol` máy chủ. Cả hai framework đều hỗ trợ [HTTP](https://fastapi.tiangolo.com/) (mặc định), giao thức [Agent-to-Agent (A2A)](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-a2a.html) để tương tác với các agent tương thích A2A khác, và giao thức [AG-UI](https://docs.ag-ui.com/) để tích hợp trực tiếp frontend thông qua [CopilotKit](https://docs.copilotkit.ai/).
+Generator hiển thị agent của bạn qua một `protocol` máy chủ. Cả hai framework đều hỗ trợ [HTTP](https://fastapi.tiangolo.com/) (mặc định), giao thức [Agent-to-Agent (A2A)](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-a2a.html) để tương tác với các agent tương thích A2A khác, và giao thức [AG-UI](https://docs.ag-ui.com/) để tích hợp frontend trực tiếp qua [CopilotKit](https://docs.copilotkit.ai/).
 
 ## Cách sử dụng
 
@@ -28,17 +28,17 @@ Bạn có thể tạo một Python Agent theo hai cách:
 
 <RunGenerator generator="py#agent" />
 
-:::tip[Yêu cầu Project]
-Trước tiên hãy sử dụng generator <Link path="/vi/guides/python-project">`py#project`</Link> để tạo một project để thêm Agent của bạn vào.
+:::tip[Điều kiện tiên quyết về dự án]
+Trước tiên hãy sử dụng generator <Link path="/guides/python-project">`py#project`</Link> để tạo một dự án để thêm Agent của bạn vào.
 :::
 
 ### Tùy chọn
 
 <GeneratorParameters generator="py#agent" />
 
-## Kết quả từ Generator
+## Đầu ra của Generator
 
-Generator sẽ thêm các file sau vào project Python hiện có của bạn. Các file được tạo phụ thuộc vào `protocol` được chọn:
+Generator sẽ thêm các tệp sau vào dự án Python hiện có của bạn. Các tệp được tạo ra phụ thuộc vào `protocol` đã chọn:
 
 <OptionFilter when={{ protocol: 'http' }} description="FastAPI HTTP server layout">
 ### Giao thức HTTP (mặc định)
@@ -51,6 +51,9 @@ Generator sẽ thêm các file sau vào project Python hiện có của bạn. C
         - init.py FastAPI application setup with CORS and error handling middleware
         - agent.py Main agent definition with sample tools
         - session.py Resolves the framework-specific session persistence implementation
+        - middleware/
+          - \_\_init\_\_.py Python package initialization
+          - session_id_middleware.py Binds the inbound AgentCore session ID for the request
         - main.py FastAPI entry point for Bedrock AgentCore Runtime
         - Dockerfile Entry point for hosting your agent (excluded when `infra` is set to `None`)
     - pyproject.toml Updated with Strands dependencies
@@ -61,7 +64,7 @@ Generator sẽ thêm các file sau vào project Python hiện có của bạn. C
 <OptionFilter when={{ protocol: 'a2a' }} description="A2A server layout">
 ### Giao thức A2A
 
-Entry point expose agent của bạn qua giao thức A2A (Strands sử dụng [Strands A2A Server](https://strandsagents.com/docs/user-guide/concepts/multi-agent/agent-to-agent); LangChain bọc graph trong một [`a2a-sdk`](https://a2a-protocol.org/) executor), được mount lên một ứng dụng FastAPI:
+Điểm vào hiển thị agent của bạn qua giao thức A2A (Strands sử dụng [Strands A2A Server](https://strandsagents.com/docs/user-guide/concepts/multi-agent/agent-to-agent); LangChain bọc graph trong một executor [`a2a-sdk`](https://a2a-protocol.org/)), được gắn vào một ứng dụng FastAPI:
 
 <FileTree>
   - your-project/
@@ -70,6 +73,9 @@ Entry point expose agent của bạn qua giao thức A2A (Strands sử dụng [S
         - \_\_init\_\_.py Python package initialization
         - agent.py Main agent definition with sample tools
         - session.py Resolves the framework-specific session persistence implementation
+        - middleware/
+          - \_\_init\_\_.py Python package initialization
+          - session_id_middleware.py Binds the inbound AgentCore session ID for the request
         - main.py A2A server entry point
         - Dockerfile Entry point for hosting your agent (excluded when `infra` is set to `None`)
     - pyproject.toml Updated with framework and A2A dependencies
@@ -80,7 +86,7 @@ Entry point expose agent của bạn qua giao thức A2A (Strands sử dụng [S
 <OptionFilter when={{ protocol: 'ag-ui' }} description="AG-UI / CopilotKit server layout">
 ### Giao thức AG-UI
 
-Entry point expose agent của bạn thông qua giao thức [AG-UI](https://docs.ag-ui.com/) để tích hợp trực tiếp frontend với [CopilotKit](https://docs.copilotkit.ai/). Các agent Strands sử dụng tích hợp [ag-ui-strands](https://docs.ag-ui.com/); các agent LangChain sử dụng [ag-ui-langgraph](https://docs.ag-ui.com/):
+Điểm vào hiển thị agent của bạn qua giao thức [AG-UI](https://docs.ag-ui.com/) để tích hợp frontend trực tiếp với [CopilotKit](https://docs.copilotkit.ai/). Các agent Strands sử dụng tích hợp [ag-ui-strands](https://docs.ag-ui.com/); các agent LangChain sử dụng [ag-ui-langgraph](https://docs.ag-ui.com/):
 
 <FileTree>
   - your-project/
@@ -89,14 +95,17 @@ Entry point expose agent của bạn thông qua giao thức [AG-UI](https://docs
         - \_\_init\_\_.py Python package initialization
         - agent.py Main agent definition with sample tools
         - session.py Resolves the framework-specific session persistence implementation
+        - middleware/
+          - \_\_init\_\_.py Python package initialization
+          - session_id_middleware.py Binds the inbound AgentCore session ID for the request
         - main.py AG-UI server entry point
         - Dockerfile Entry point for hosting your agent (excluded when `infra` is set to `None`)
     - pyproject.toml Updated with framework and AG-UI dependencies
     - project.json Updated with agent serve targets
 </FileTree>
 
-:::tip[Kết nối với website React]
-Các agent AG-UI có thể được kết nối với một frontend React bằng cách sử dụng <Link path="/vi/guides/connection/react-agui">`connection` generator</Link>, nó sẽ thiết lập các component [CopilotKit](https://docs.copilotkit.ai/) cho trải nghiệm chat phong phú.
+:::tip[Kết nối với một trang web React]
+Các agent AG-UI có thể được kết nối với frontend React bằng cách sử dụng <Link path="/guides/connection/react-agui">generator `connection`</Link>, sẽ thiết lập các thành phần [CopilotKit](https://docs.copilotkit.ai/) cho trải nghiệm chat phong phú.
 :::
 </OptionFilter>
 
@@ -105,7 +114,7 @@ Các agent AG-UI có thể được kết nối với một frontend React bằn
 <OptionFilter when={{ infra: 'agentcore' }} description="Bedrock AgentCore Runtime deployment">
 <Snippet name="shared-constructs" />
 
-Để triển khai Agent của bạn, các file sau được tạo:
+Để triển khai Agent của bạn, các tệp sau được tạo ra:
 
 <Infrastructure>
 <Fragment slot="cdk">
@@ -133,7 +142,7 @@ Các agent AG-UI có thể được kết nối với một frontend React bằn
 </OptionFilter>
 
 <OptionFilter when={{ infra: 'none' }} description="No infrastructure is vended for infra=none">
-Nếu bạn chọn `none` cho `infra`, không có CDK construct hoặc Terraform module nào được tạo — Agent chỉ có thể chạy cục bộ. Tùy chọn `auth` bị bỏ qua trong chế độ này vì không có endpoint được host để xác thực.
+Nếu bạn chọn `none` cho `infra`, không có CDK construct hay Terraform module nào được tạo ra — Agent chỉ có thể chạy cục bộ. Tùy chọn `auth` bị bỏ qua trong chế độ này vì không có endpoint được lưu trữ để xác thực.
 </OptionFilter>
 
 #### Kiến trúc
@@ -142,11 +151,11 @@ Nếu bạn chọn `none` cho `infra`, không có CDK construct hoặc Terraform
 
 ## Làm việc với Agent của bạn
 
-Bạn có thể chỉnh sửa `agent.py` để thêm công cụ, cấu hình model và tùy chỉnh system prompt. API phụ thuộc vào framework bạn đã chọn.
+Bạn có thể chỉnh sửa `agent.py` để thêm công cụ, cấu hình mô hình và tùy chỉnh system prompt. API phụ thuộc vào framework bạn đã chọn.
 
-### Thêm công cụ
+### Thêm Công cụ
 
-Công cụ là các hàm mà AI agent có thể gọi để thực hiện các hành động. Cả hai framework đều sử dụng cách tiếp cận dựa trên decorator để định nghĩa công cụ, lấy tên và mô tả công cụ từ tên hàm và docstring, và tạo input schema từ type hint của bạn.
+Công cụ là các hàm mà AI agent có thể gọi để thực hiện các hành động. Cả hai framework đều sử dụng cách tiếp cận dựa trên decorator để định nghĩa công cụ, lấy tên và mô tả công cụ từ tên hàm và docstring, và tạo schema đầu vào từ các type hint của bạn.
 
 <Tabs syncKey="agent-framework">
 <TabItem label="Strands" _filter={{ framework: 'strands' }}>
@@ -198,11 +207,11 @@ agent = create_agent(
 </TabItem>
 </Tabs>
 
-### Sử dụng các công cụ có sẵn
+### Sử dụng Công cụ Dựng sẵn
 
 <Tabs syncKey="agent-framework">
 <TabItem label="Strands" _filter={{ framework: 'strands' }}>
-Strands cung cấp một bộ sưu tập các công cụ có sẵn thông qua package `strands-tools`:
+Strands cung cấp một bộ sưu tập các công cụ dựng sẵn thông qua gói `strands-tools`:
 
 ```python
 from strands_tools import current_time, http_request, file_read
@@ -228,11 +237,11 @@ agent = create_agent(
 </TabItem>
 </Tabs>
 
-### Cấu hình Model
+### Cấu hình Mô hình
 
 <Tabs syncKey="agent-framework">
 <TabItem label="Strands" _filter={{ framework: 'strands' }}>
-Theo mặc định, các agent Strands sử dụng Claude 4 Sonnet, nhưng bạn có thể tùy chỉnh model provider. Xem [tài liệu Strands về model provider](https://strandsagents.com/docs/user-guide/concepts/model-providers/) để biết các tùy chọn cấu hình:
+Theo mặc định, các agent Strands sử dụng Claude 4 Sonnet, nhưng bạn có thể tùy chỉnh nhà cung cấp mô hình. Xem [tài liệu Strands về nhà cung cấp mô hình](https://strandsagents.com/docs/user-guide/concepts/model-providers/) để biết các tùy chọn cấu hình:
 
 ```python
 from strands import Agent
@@ -249,7 +258,7 @@ agent = Agent(model=bedrock_model)
 ```
 </TabItem>
 <TabItem label="LangChain" _filter={{ framework: 'langchain' }}>
-Các agent LangChain sử dụng model [`ChatBedrockConverse`](https://docs.langchain.com/oss/python/integrations/chat/bedrock_converse). Agent được tạo đọc model id và region từ các biến môi trường `MODEL_ID` và `AWS_REGION`, nhưng bạn có thể cấu hình model trực tiếp trong `agent.py`:
+Các agent LangChain sử dụng mô hình [`ChatBedrockConverse`](https://docs.langchain.com/oss/python/integrations/chat/bedrock_converse). Agent được tạo ra đọc id mô hình và region từ các biến môi trường `MODEL_ID` và `AWS_REGION`, nhưng bạn có thể cấu hình mô hình trực tiếp trong `agent.py`:
 
 ```python
 from langchain_aws import ChatBedrockConverse
@@ -265,47 +274,47 @@ model = ChatBedrockConverse(
 
 ### Sử dụng MCP Server
 
-Để sử dụng các MCP Server mà bạn đã tạo bằng generator <Link path="/vi/guides/py-mcp-server">`py#mcp-server`</Link> hoặc <Link path="/vi/guides/ts-mcp-server">`ts#mcp-server`</Link>, bạn có thể sử dụng <Link path="/vi/guides/connection/py-agent-mcp">`connection` generator</Link>, nó kết nối các công cụ của MCP server vào agent của bạn cho cả hai framework.
+Để sử dụng các MCP Server mà bạn đã tạo bằng generator <Link path="/guides/py-mcp-server">`py#mcp-server`</Link> hoặc <Link path="/guides/ts-mcp-server">`ts#mcp-server`</Link>, bạn có thể sử dụng <Link path="/guides/connection/py-agent-mcp">generator `connection`</Link>, kết nối các công cụ của MCP server vào agent của bạn cho cả hai framework.
 
 <RunGenerator generator="connection" />
 
-Tham khảo hướng dẫn <Link path="/vi/guides/connection/py-agent-mcp">`connection` generator</Link> để biết chi tiết về cách thiết lập kết nối.
+Tham khảo <Link path="/guides/connection/py-agent-mcp">hướng dẫn generator `connection`</Link> để biết chi tiết về cách kết nối được thiết lập.
 
 Đối với các MCP server khác, tham khảo tài liệu MCP của [Strands](https://strandsagents.com/docs/user-guide/concepts/tools/mcp-tools/) hoặc [LangChain](https://docs.langchain.com/oss/python/langchain/mcp).
 
 ### Thêm
 
-Để có hướng dẫn chuyên sâu hơn về cách viết agent, tham khảo tài liệu của [Strands](https://strandsagents.com/docs/user-guide/quickstart/overview/) hoặc [LangChain](https://docs.langchain.com/oss/python/langchain/overview).
+Để có hướng dẫn chuyên sâu hơn về việc viết agent, tham khảo tài liệu của [Strands](https://strandsagents.com/docs/user-guide/quickstart/overview/) hoặc [LangChain](https://docs.langchain.com/oss/python/langchain/overview).
 
 ## Giao thức
 
-Giao thức máy chủ của agent xác định cách nó giao tiếp. Tất cả các tùy chọn đều được phục vụ bởi [FastAPI](https://fastapi.tiangolo.com/) — entry point khác nhau:
+Giao thức máy chủ của agent xác định cách nó giao tiếp. Tất cả các tùy chọn đều được phục vụ bởi [FastAPI](https://fastapi.tiangolo.com/) — điểm vào khác nhau:
 
-- **HTTP** (mặc định): Một máy chủ FastAPI tiêu chuẩn với endpoint `/invocations` tùy chỉnh, CORS và streaming. Tốt nhất cho tích hợp client tùy chỉnh.
-- **A2A**: Một máy chủ [Agent-to-Agent](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-a2a.html) được mount lên một ứng dụng FastAPI (Strands sử dụng [Strands A2A Server](https://strandsagents.com/docs/user-guide/concepts/multi-agent/agent-to-agent); LangChain sử dụng [`a2a-sdk`](https://a2a-protocol.org/) không phụ thuộc framework). Tốt nhất khi agent của bạn cần có thể được phát hiện và gọi bởi các agent tương thích A2A khác.
-- **AG-UI**: [Giao thức AG-UI](https://docs.ag-ui.com/) qua SSE (Strands sử dụng `ag-ui-strands`; LangChain sử dụng `ag-ui-langgraph`). Tốt nhất cho tích hợp trực tiếp frontend với [CopilotKit](https://docs.copilotkit.ai/) trong một website React.
+- **HTTP** (mặc định): Một máy chủ FastAPI tiêu chuẩn với endpoint `/invocations` tùy chỉnh, CORS và streaming. Tốt nhất cho các tích hợp client tùy chỉnh.
+- **A2A**: Một máy chủ [Agent-to-Agent](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-a2a.html) được gắn vào một ứng dụng FastAPI (Strands sử dụng [Strands A2A Server](https://strandsagents.com/docs/user-guide/concepts/multi-agent/agent-to-agent); LangChain sử dụng [`a2a-sdk`](https://a2a-protocol.org/) không phụ thuộc framework). Tốt nhất khi agent của bạn cần có thể được khám phá và gọi bởi các agent tương thích A2A khác.
+- **AG-UI**: Giao thức [AG-UI](https://docs.ag-ui.com/) qua SSE (Strands sử dụng `ag-ui-strands`; LangChain sử dụng `ag-ui-langgraph`). Tốt nhất cho tích hợp frontend trực tiếp với [CopilotKit](https://docs.copilotkit.ai/) trong một trang web React.
 
-Entry point máy chủ khác nhau theo framework (Strands tạo ra một `Agent` được quản lý context, trong khi LangChain điều khiển một graph `create_agent` đã được biên dịch), nhưng hợp đồng bên ngoài cho mỗi giao thức là giống nhau.
+Điểm vào máy chủ khác nhau theo framework (Strands tạo ra một `Agent` được quản lý theo context, trong khi LangChain điều khiển một graph `create_agent` đã được biên dịch), nhưng hợp đồng bên ngoài cho mỗi giao thức là như nhau.
 
-Tất cả các giao thức đều expose `/ping` cho hợp đồng kiểm tra sức khỏe của AgentCore runtime. Các agent A2A lắng nghe trên cổng `9000`; các agent HTTP và AG-UI lắng nghe trên cổng `8080`. Dockerfile và hạ tầng được tạo đã được cấu hình sẵn cho bạn.
+Tất cả các giao thức đều hiển thị `/ping` cho hợp đồng kiểm tra sức khỏe runtime AgentCore. Các agent A2A lắng nghe trên cổng `9000`; các agent HTTP và AG-UI lắng nghe trên cổng `8080`. Dockerfile và hạ tầng được tạo ra đã được cấu hình sẵn cho bạn.
 
 <OptionFilter when={{ protocol: 'http' }} description="FastAPI HTTP server details">
 ## Máy chủ FastAPI (giao thức HTTP)
 
-Máy chủ HTTP được tạo bao gồm:
+Máy chủ HTTP được tạo ra bao gồm:
 - Thiết lập ứng dụng FastAPI với CORS middleware
 - Error handling middleware
-- Tạo OpenAPI schema
-- Health check endpoint (`/ping`)
-- Agent invocation endpoint (`/invocations`)
+- Tạo schema OpenAPI
+- Endpoint kiểm tra sức khỏe (`/ping`)
+- Endpoint gọi agent (`/invocations`)
 
-### Tùy chỉnh Invoke Input và Output với Pydantic
+### Tùy chỉnh Đầu vào và Đầu ra Invoke với Pydantic
 
-Endpoint invocation của agent sử dụng các model [Pydantic](https://docs.pydantic.dev/) để định nghĩa và xác thực các schema request và response. Bạn có thể tùy chỉnh các model này trong `main.py` để phù hợp với yêu cầu của agent.
+Endpoint gọi của agent sử dụng các mô hình [Pydantic](https://docs.pydantic.dev/) để định nghĩa và xác thực schema yêu cầu và phản hồi. Bạn có thể tùy chỉnh các mô hình này trong `main.py` để phù hợp với yêu cầu của agent.
 
-#### Định nghĩa Input Model
+#### Định nghĩa Mô hình Đầu vào
 
-Model `InvokeInput` mặc định chấp nhận một prompt.
+Mô hình `InvokeInput` mặc định chấp nhận một prompt.
 
 ```python
 from pydantic import BaseModel
@@ -314,28 +323,28 @@ class InvokeInput(BaseModel):
     prompt: str
 ```
 
-Bạn có thể mở rộng model này để bao gồm bất kỳ trường bổ sung nào mà agent của bạn cần.
+Bạn có thể mở rộng mô hình này để bao gồm bất kỳ trường bổ sung nào mà agent của bạn cần.
 
-Session ID được trích xuất từ HTTP header `x-amzn-bedrock-agentcore-runtime-session-id`, phù hợp với [hợp đồng session của Bedrock AgentCore Runtime](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-service-contract.html). Nếu header không được cung cấp, một UUID ngẫu nhiên được tạo làm dự phòng.
+Session ID được trích xuất từ HTTP header `x-amzn-bedrock-agentcore-runtime-session-id`, nhất quán với [hợp đồng session Bedrock AgentCore Runtime](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-service-contract.html). Nếu header không được cung cấp, một UUID ngẫu nhiên được tạo ra như một phương án dự phòng.
 
 :::caution[Tổ chức Code]
-Bạn có thể sẽ muốn trừu tượng hóa một số hoặc tất cả session ID từ người gọi nếu người dùng gọi agent của bạn trực tiếp. Ví dụ, bạn có thể sử dụng ID người dùng đã xác thực như một phần của session ID.
+Bạn có thể muốn trừu tượng hóa một phần hoặc toàn bộ session ID khỏi người gọi nếu người dùng sẽ gọi agent của bạn trực tiếp. Ví dụ, bạn có thể sử dụng ID người dùng đã xác thực như một phần của session ID.
 
-Cũng đáng chú ý rằng tùy thuộc vào trường hợp sử dụng của bạn, bạn có thể cần triển khai ủy quyền cho các session, ví dụ đảm bảo rằng người dùng chỉ có thể truy cập các session của riêng họ chứ không phải của người dùng khác.
+Cũng đáng lưu ý rằng tùy thuộc vào trường hợp sử dụng của bạn, bạn có thể cần triển khai ủy quyền cho các session, ví dụ đảm bảo rằng người dùng chỉ có thể truy cập session của chính họ chứ không phải của người dùng khác.
 :::
 
-#### Định nghĩa Output Model
+#### Định nghĩa Mô hình Đầu ra
 
-Đối với các response streaming, generator cung cấp `JsonStreamingResponse` tự động serialize các model Pydantic sang định dạng JSON Lines (`application/jsonl`). Định dạng này tương thích với đặc tả streaming của OpenAPI 3.2 và hoạt động liền mạch với TypeScript client được tạo.
+Đối với các phản hồi streaming, generator cung cấp `JsonStreamingResponse` tự động serialize các mô hình Pydantic sang định dạng JSON Lines (`application/jsonl`). Định dạng này tương thích với đặc tả streaming của OpenAPI 3.2 và hoạt động liền mạch với TypeScript client được tạo ra.
 
-Theo mặc định, agent tạo ra các đối tượng `StreamChunk` chứa văn bản response của agent:
+Theo mặc định, agent tạo ra các đối tượng `StreamChunk` chứa văn bản phản hồi của agent:
 
 ```python
 class StreamChunk(BaseModel):
     content: str
 ```
 
-Bạn có thể tùy chỉnh model `StreamChunk` để phù hợp với nhu cầu của bạn:
+Bạn có thể tùy chỉnh mô hình `StreamChunk` để phù hợp với nhu cầu của bạn:
 
 ```python
 from pydantic import BaseModel
@@ -346,8 +355,8 @@ class StreamChunk(BaseModel):
     token_count: int
 ```
 
-:::note[Hạn chế Streaming của FastAPI]
-Lưu ý rằng vì FastAPI hiện không hỗ trợ tạo đặc tả OpenAPI cho các response streaming, chúng ta phải đặt response model một cách rõ ràng cho mỗi thao tác streaming, tức là:
+:::note[Giới hạn Streaming của FastAPI]
+Lưu ý rằng vì FastAPI hiện tại không hỗ trợ tạo đặc tả OpenAPI cho các phản hồi streaming, chúng ta phải đặt rõ ràng mô hình phản hồi cho mỗi thao tác streaming, tức là:
 
 ```python
 @app.post(
@@ -360,51 +369,51 @@ async def invoke(input: InvokeInput) -> JsonStreamingResponse:
 ```
 :::
 
-Có một [yêu cầu tính năng mở cho hỗ trợ native trong FastAPI](https://github.com/fastapi/fastapi/discussions/14362).
+Có một [yêu cầu tính năng mở để hỗ trợ gốc trong FastAPI](https://github.com/fastapi/fastapi/discussions/14362).
 </OptionFilter>
 
 ## Bedrock AgentCore Python SDK
 
-Generator bao gồm một dependency vào [Bedrock AgentCore Python SDK](https://github.com/aws/bedrock-agentcore-sdk-python) cho các hằng số `PingStatus`. Nếu muốn, việc sử dụng `BedrockAgentCoreApp` thay vì FastAPI là đơn giản, tuy nhiên lưu ý rằng type-safety bị mất.
+Generator bao gồm một phụ thuộc vào [Bedrock AgentCore Python SDK](https://github.com/aws/bedrock-agentcore-sdk-python) cho các hằng số `PingStatus`. Nếu muốn, bạn có thể dễ dàng sử dụng `BedrockAgentCoreApp` thay vì FastAPI, tuy nhiên lưu ý rằng tính an toàn kiểu sẽ bị mất.
 
 Bạn có thể tìm thêm chi tiết về khả năng của SDK trong [tài liệu tại đây](https://aws.github.io/bedrock-agentcore-starter-toolkit/user-guide/runtime/quickstart.html).
 
 :::note[Infrastructure as Code]
-Vì generator tạo ra hạ tầng CDK hoặc Terraform để quản lý việc triển khai agent của bạn, bạn không cần sử dụng `bedrock-agentcore-starter-toolkit` mà tài liệu đề cập để triển khai agent của bạn.
+Vì generator cung cấp hạ tầng CDK hoặc Terraform để quản lý việc triển khai agent của bạn, bạn không cần sử dụng `bedrock-agentcore-starter-toolkit` mà tài liệu đề cập để triển khai agent của bạn.
 :::
 
 <OptionFilter when={{ protocol: 'a2a' }} description="A2A server details">
 ## Máy chủ A2A (giao thức A2A)
 
-`main.py` được tạo mount một máy chủ A2A lên một ứng dụng FastAPI cha cũng expose `/ping`. Các agent Strands sử dụng Strands `A2AServer`; các agent LangChain bọc graph đã biên dịch trong một `AgentExecutor` của [`a2a-sdk`](https://a2a-protocol.org/). Khi được triển khai lên AgentCore, entry point resolve ARN công khai của runtime từ AppConfig và quảng cáo nó trong agent card.
+`main.py` được tạo ra gắn một máy chủ A2A vào một ứng dụng FastAPI cha cũng hiển thị `/ping`. Các agent Strands sử dụng `A2AServer` của Strands; các agent LangChain bọc graph đã biên dịch trong một `AgentExecutor` của [`a2a-sdk`](https://a2a-protocol.org/). Khi được triển khai lên AgentCore, điểm vào giải quyết ARN công khai của runtime từ AppConfig và quảng cáo nó trong agent card.
 
-Hầu hết người dùng sẽ không cần sửa đổi file này; chỉnh sửa `agent.py` để thay đổi công cụ hoặc system prompt. Máy chủ A2A điền agent card (`/.well-known/agent-card.json`) từ `name` và `description` của agent.
+Hầu hết người dùng sẽ không cần sửa đổi tệp này; chỉnh sửa `agent.py` để thay đổi công cụ hoặc system prompt. Máy chủ A2A điền vào agent card (`/.well-known/agent-card.json`) từ `name` và `description` của agent.
 </OptionFilter>
 
 <OptionFilter when={{ protocol: 'ag-ui' }} description="AG-UI / CopilotKit server details">
 ## Máy chủ AG-UI (giao thức AG-UI)
 
-`main.py` được tạo expose một POST endpoint duy nhất stream các sự kiện [AG-UI](https://docs.ag-ui.com/) qua Server-Sent Events (SSE), cũng như `/ping` cho kiểm tra sức khỏe của AgentCore runtime. Cách kết nối phụ thuộc vào framework:
+`main.py` được tạo ra hiển thị một endpoint POST duy nhất streaming các sự kiện [AG-UI](https://docs.ag-ui.com/) qua Server-Sent Events (SSE), cũng như `/ping` cho kiểm tra sức khỏe runtime AgentCore. Cách kết nối phụ thuộc vào framework:
 
-- **Strands**: bọc `Agent` của bạn trong một `ag_ui_strands.StrandsAgent`, được xây dựng bên trong một handler `lifespan` của FastAPI (để việc xây dựng xảy ra khi khởi động container/session thay vì thời gian import), và được phục vụ từ một vòng lặp `/invocations` FastAPI được viết thủ công.
-- **LangChain**: bọc graph đã biên dịch trong một `ag_ui_langgraph.LangGraphAgent`, được xây dựng theo cách tương tự bên trong `lifespan`, và được phục vụ từ một vòng lặp `/invocations` FastAPI được viết thủ công.
+- **Strands**: bọc `Agent` của bạn trong một `ag_ui_strands.StrandsAgent`, được xây dựng bên trong một handler FastAPI `lifespan` (để việc khởi tạo xảy ra khi container/session khởi động thay vì lúc import), và được phục vụ từ một vòng lặp FastAPI `/invocations` tự tạo.
+- **LangChain**: bọc graph đã biên dịch trong một `ag_ui_langgraph.LangGraphAgent`, được xây dựng theo cách tương tự bên trong `lifespan`, và được phục vụ từ một vòng lặp FastAPI `/invocations` tự tạo.
 
-Hầu hết người dùng sẽ không cần sửa đổi file này — chỉnh sửa `agent.py` để thay đổi công cụ hoặc system prompt.
+Hầu hết người dùng sẽ không cần sửa đổi tệp này — chỉnh sửa `agent.py` để thay đổi công cụ hoặc system prompt.
 
-:::tip[Kết nối với website React]
-Các agent AG-UI được thiết kế để được sử dụng trực tiếp bởi frontend. Sử dụng <Link path="/vi/guides/connection/react-agui">`connection` generator</Link> để kết nối website React của bạn với agent bằng một provider [CopilotKit](https://docs.copilotkit.ai/) và client [AG-UI HttpAgent](https://docs.ag-ui.com/).
+:::tip[Kết nối với một trang web React]
+Các agent AG-UI được thiết kế để được sử dụng trực tiếp bởi frontend. Sử dụng <Link path="/guides/connection/react-agui">generator `connection`</Link> để kết nối trang web React của bạn với agent bằng provider [CopilotKit](https://docs.copilotkit.ai/) và client [AG-UI HttpAgent](https://docs.ag-ui.com/).
 :::
 </OptionFilter>
 
 ## Chạy Agent của bạn
 
-### Phát triển cục bộ
+### Phát triển Cục bộ
 
-Để chạy Agent của bạn (và mọi thứ được kết nối với nó) cục bộ, sử dụng target `dev` của project:
+Để chạy Agent của bạn (và mọi thứ kết nối với nó) cục bộ, sử dụng target `dev` của dự án:
 
 <NxCommands commands={['dev your-project']} />
 
-Nếu bạn đã thêm nhiều component vào project của mình (agent, MCP server, v.v.), điều này sẽ khởi động tất cả chúng. Để chỉ chạy agent này, nhắm đến target `<your-agent-name>-dev` của nó:
+Nếu bạn đã thêm nhiều thành phần vào dự án của mình (agent, MCP server, v.v.), điều này sẽ khởi động tất cả chúng. Để chỉ chạy agent này, nhắm vào target `<your-agent-name>-dev` của nó:
 
 <NxCommands commands={['agent-dev your-project']} />
 
@@ -412,9 +421,9 @@ Nếu bạn đã thêm nhiều component vào project của mình (agent, MCP se
 
 ### Chat với Agent của bạn
 
-Generator cấu hình một Nx target `<your-agent-name>-chat` đưa bạn vào một terminal chat tương tác với agent của bạn.
+Generator cấu hình một Nx target `<your-agent-name>-chat` đưa bạn vào một phiên chat terminal tương tác với agent của bạn.
 
-Target chat chạy độc lập. Theo mặc định, nó kết nối với agent đang chạy cục bộ của bạn, vì vậy hãy khởi động target `<your-agent-name>-dev` của agent trước (trong một terminal riêng):
+Target chat chạy độc lập. Theo mặc định nó kết nối với agent đang chạy cục bộ của bạn, vì vậy hãy khởi động target `<your-agent-name>-dev` của agent trước (trong một terminal riêng):
 
 <NxCommands commands={['agent-dev your-project']} />
 
@@ -424,28 +433,28 @@ Sau đó, trong một terminal khác, khởi động chat:
 
 Generator tạo ra một `scripts/<your-agent-name>/chat.ts` cho mỗi giao thức. Nó kết nối với agent cục bộ theo mặc định, hoặc với agent đã triển khai của bạn khi `RUNTIME_CONFIG_APP_ID` được đặt (xem [Chat với agent đã triển khai của bạn](#chat-với-agent-đã-triển-khai-của-bạn) bên dưới).
 
-Đối với các agent **HTTP**, script chat sử dụng một TypeScript client type-safe được tạo từ OpenAPI spec của agent. Generator cũng tạo ra:
+Đối với các agent **HTTP**, script chat sử dụng một TypeScript client an toàn kiểu được tạo ra từ đặc tả OpenAPI của agent. Generator cũng tạo ra:
 
-- `scripts/<your-agent-name>_openapi.py` — một script nhỏ export OpenAPI spec của agent
+- `scripts/<your-agent-name>_openapi.py` — một script nhỏ xuất đặc tả OpenAPI của agent
 - Một Nx target `<your-agent-name>-openapi` chạy nó
-- Một Nx target `<your-agent-name>-generate-client` tạo ra một TypeScript client type-safe dưới `scripts/<your-agent-name>/generated/`
+- Một Nx target `<your-agent-name>-generate-client` tạo ra một TypeScript client an toàn kiểu dưới `scripts/<your-agent-name>/generated/`
 
-Khi bạn tùy chỉnh input shape của agent (ví dụ: thêm trường mới vào `InvokeInput`), cập nhật `chat.ts` để truyền các trường mới khi gọi agent và phần còn lại hoạt động tự động.
+Khi bạn tùy chỉnh hình dạng đầu vào của agent (ví dụ: thêm các trường mới vào `InvokeInput`), hãy cập nhật `chat.ts` để truyền các trường mới khi gọi agent và phần còn lại hoạt động tự động.
 
 <OptionFilter when={{ infra: 'agentcore' }} description="Deployed agent chat details">
 #### Chat với agent đã triển khai của bạn
 
-Để chat với agent của bạn đã triển khai lên Bedrock AgentCore, đặt biến môi trường `RUNTIME_CONFIG_APP_ID` thành AppConfig application id của deployment (được xuất ra dưới dạng `RuntimeConfigApplicationId` bởi stack đã triển khai). Script chat resolve ARN runtime của agent từ cấu hình runtime và kết nối với endpoint đã triển khai:
+Để chat với agent của bạn đã triển khai lên Bedrock AgentCore, đặt biến môi trường `RUNTIME_CONFIG_APP_ID` thành id ứng dụng AppConfig của việc triển khai (được xuất ra là `RuntimeConfigApplicationId` bởi stack đã triển khai). Script chat giải quyết ARN runtime của agent từ cấu hình runtime và kết nối với endpoint đã triển khai:
 
 <Tabs syncKey="auth">
 <TabItem label="IAM" _filter={{ auth: 'iam' }}>
-Đối với các agent được xác thực IAM, các request được ký bằng [SigV4](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_sigv.html) sử dụng thông tin xác thực AWS mặc định của bạn. Đảm bảo môi trường có thông tin xác thực AWS với quyền gọi runtime:
+Đối với các agent được xác thực bằng IAM, các yêu cầu được ký bằng [SigV4](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_sigv.html) sử dụng thông tin xác thực AWS mặc định của bạn. Đảm bảo môi trường có thông tin xác thực AWS với quyền gọi runtime:
 
 <NxCommands commands={['run your-project:agent-chat']} env={{ RUNTIME_CONFIG_APP_ID: '<app-id>' }} />
 </TabItem>
 
 <TabItem label="Cognito" _filter={{ auth: 'cognito' }}>
-Đối với các agent được xác thực Cognito, cung cấp Cognito access token thông qua biến môi trường `AGENT_ACCESS_TOKEN`, được gửi dưới dạng bearer token:
+Đối với các agent được xác thực bằng Cognito, cung cấp Cognito access token qua biến môi trường `AGENT_ACCESS_TOKEN`, được gửi như một bearer token:
 
 <NxCommands commands={['run your-project:agent-chat']} env={{ RUNTIME_CONFIG_APP_ID: '<app-id>', AGENT_ACCESS_TOKEN: '<access-token>' }} />
 
@@ -469,57 +478,57 @@ aws cognito-idp admin-initiate-auth \
 
 <Snippet name="agent/bedrock-deployment" parentHeading="Triển khai Agent của bạn lên Bedrock AgentCore Runtime" />
 
-### Bundle và Docker Target
+### Bundle và Docker Targets
 
-Để build Agent của bạn cho Bedrock AgentCore Runtime, một target `bundle` được thêm vào project của bạn, nó:
+Để build Agent của bạn cho Bedrock AgentCore Runtime, một target `bundle` được thêm vào dự án của bạn, thực hiện:
 
-- Export các dependency Python của bạn vào file `requirements.txt` bằng `uv export`
-- Cài đặt các dependency cho nền tảng đích (`aarch64-manylinux_2_28`) bằng `uv pip install`
+- Xuất các phụ thuộc Python của bạn sang tệp `requirements.txt` bằng `uv export`
+- Cài đặt các phụ thuộc cho nền tảng đích (`aarch64-manylinux_2_28`) bằng `uv pip install`
 
-Một target `docker` cụ thể cho Agent của bạn cũng được thêm vào, nó sao chép `Dockerfile` và các artifact đã bundle vào một thư mục docker context. Điều này đặt `Dockerfile` cùng với output đã build, cho phép CDK build Docker image trực tiếp bằng `AgentRuntimeArtifact.fromAsset`.
+Một target `docker` dành riêng cho Agent của bạn cũng được thêm vào, sao chép `Dockerfile` và các artifact đã bundle vào một thư mục docker context. Điều này đặt `Dockerfile` cùng vị trí với đầu ra đã build, cho phép CDK build Docker image trực tiếp bằng `AgentRuntimeArtifact.fromAsset`.
 
 ### Quét Image
 
 <Snippet name="trivy-image-scan" parentHeading="Quét Image" />
 
-### Khả năng quan sát
+### Khả năng Quan sát
 
-Agent của bạn được tự động cấu hình với khả năng quan sát bằng [AWS Distro for Open Telemetry](https://aws.amazon.com/otel/) (ADOT), bằng cách cấu hình auto-instrumentation trong `Dockerfile` của bạn.
+Agent của bạn được tự động cấu hình với khả năng quan sát bằng cách sử dụng [AWS Distro for Open Telemetry](https://aws.amazon.com/otel/) (ADOT), bằng cách cấu hình auto-instrumentation trong `Dockerfile` của bạn.
 
-Bạn có thể tìm thấy các trace trong CloudWatch AWS Console, bằng cách chọn "GenAI Observability" trong menu. Lưu ý rằng để các trace được điền, bạn sẽ cần bật [Transaction Search](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Transaction-Search.html).
+Bạn có thể tìm thấy các trace trong AWS Console CloudWatch, bằng cách chọn "GenAI Observability" trong menu. Lưu ý rằng để các trace được điền vào, bạn sẽ cần bật [Transaction Search](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Transaction-Search.html).
 
 Để biết thêm chi tiết, tham khảo [tài liệu AgentCore về khả năng quan sát](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/observability-configure.html).
 
 ### Quản lý Session
 
-Tùy chọn `session` ánh xạ đến một khái niệm persistence cơ bản khác nhau tùy thuộc vào framework bạn chọn: khái niệm [quản lý session](https://strandsagents.com/docs/user-guide/concepts/agents/session-management/) của Strands cho framework `strands`, hoặc khái niệm [checkpointer](https://docs.langchain.com/oss/python/langgraph/persistence) của LangGraph cho framework `langchain`.
+Tùy chọn `session` ánh xạ đến một khái niệm lưu trữ cơ bản khác nhau tùy thuộc vào framework bạn đã chọn: khái niệm [quản lý session](https://strandsagents.com/docs/user-guide/concepts/agents/session-management/) của Strands cho framework `strands`, hoặc khái niệm [checkpointer](https://docs.langchain.com/oss/python/langgraph/persistence) của LangGraph cho framework `langchain`.
 
 <OptionFilter when={{ framework: 'strands' }} description="Strands session management (session.py)">
-Tùy chọn `session` kiểm soát cách agent của bạn duy trì trạng thái hội thoại (lịch sử tin nhắn, trạng thái công cụ, v.v.) qua các lần gọi, sử dụng [SessionManager](https://strandsagents.com/docs/user-guide/concepts/agents/session-management/) của Strands SDK:
+Tùy chọn `session` kiểm soát cách agent của bạn lưu trữ trạng thái hội thoại (lịch sử tin nhắn, trạng thái công cụ, v.v.) qua các lần gọi, sử dụng [SessionManager](https://strandsagents.com/docs/user-guide/concepts/agents/session-management/) của Strands SDK:
 
-- **`s3`** (mặc định): Hạ tầng CDK/Terraform cung cấp một S3 bucket chuyên dụng cho dữ liệu session, được mã hóa bằng KMS key chuyên dụng và với tất cả quyền truy cập công khai bị chặn; server access log được gửi đến CloudWatch Logs log group thông qua cùng một key. IAM role của agent được cấp quyền read/write/list/delete vào bucket và quyền decrypt/generate-data-key vào key, và tên bucket được đăng ký cùng với ARN của agent trong cấu hình runtime AppConfig.
-- **`in-memory`**: Không có bucket nào được cung cấp. Trạng thái hội thoại chỉ được giữ trong bộ nhớ trong suốt thời gian tồn tại của process đang chạy và không tồn tại qua các lần khởi động lại hoặc scale-in.
+- **`s3`** (mặc định): Hạ tầng CDK/Terraform cung cấp một S3 bucket chuyên dụng cho dữ liệu session, được mã hóa bằng KMS key chuyên dụng và với tất cả quyền truy cập công khai bị chặn; server access log được gửi đến một CloudWatch Logs log group qua cùng key. IAM role của agent được cấp quyền đọc/ghi/liệt kê/xóa vào bucket và quyền decrypt/generate-data-key vào key, và tên bucket được đăng ký cùng với ARN của agent trong cấu hình runtime AppConfig.
+- **`in-memory`**: Không có bucket nào được cung cấp. Trạng thái hội thoại chỉ được giữ trong bộ nhớ trong suốt thời gian tồn tại của tiến trình đang chạy và không tồn tại qua các lần khởi động lại hoặc scale-in.
 
-Điều này được triển khai trong `session.py` được tạo, nó export một hàm `get_session_manager()` resolve một `SessionManager` cho session hiện tại.
+Điều này được triển khai trong `session.py` được tạo ra, xuất một hàm `get_session_manager()` giải quyết một `SessionManager` cho session hiện tại.
 
-Bản thân session ID đến từ AgentCore Runtime session (được truyền qua header `x-amzn-bedrock-agentcore-runtime-session-id`) và được gắn với một context dựa trên [`contextvars.ContextVar`](https://docs.python.org/3/library/contextvars.html) để `get_current_session_id()` có thể resolve nó ở bất kỳ đâu trong request — bao gồm trong bất kỳ MCP hoặc A2A client downstream nào được kết nối thông qua <Link path="/vi/guides/connection">`connection` generator</Link>, vì vậy toàn bộ chuỗi gọi chia sẻ một session nhất quán.
+Session ID đến từ session AgentCore Runtime (được truyền qua header `x-amzn-bedrock-agentcore-runtime-session-id`) và được gắn vào một context dựa trên [`contextvars.ContextVar`](https://docs.python.org/3/library/contextvars.html) để `get_current_session_id()` có thể giải quyết nó ở bất kỳ đâu trong yêu cầu — bao gồm trong bất kỳ MCP hoặc A2A client nào được kết nối qua <Link path="/guides/connection">generator `connection`</Link>, vì vậy toàn bộ chuỗi gọi chia sẻ một session nhất quán.
 
-:::note[Phát triển cục bộ]
-Khi chạy cục bộ (`LOCAL_DEV=true`, được đặt tự động bởi target `-dev`), dữ liệu session luôn được lưu trữ trên đĩa dưới `tmp/agents/strands/<agent-name>` tại workspace root, bất kể tùy chọn `session` được cấu hình, để thuận tiện.
+:::note[Phát triển Cục bộ]
+Khi chạy cục bộ (`LOCAL_DEV=true`, được đặt tự động bởi target `-dev`), dữ liệu session luôn được lưu trữ trên đĩa dưới `tmp/agents/strands/<agent-name>` tại thư mục gốc workspace, bất kể tùy chọn `session` đã cấu hình, để thuận tiện.
 :::
 </OptionFilter>
 
 <OptionFilter when={{ framework: 'langchain' }} description="LangChain session management (session.py)">
-Tùy chọn `session` kiểm soát cách checkpointer LangGraph của agent duy trì trạng thái hội thoại:
+Tùy chọn `session` kiểm soát cách checkpointer LangGraph của agent lưu trữ trạng thái hội thoại:
 
-- **`s3`** (mặc định): Agent đã triển khai sử dụng một `S3CheckpointSaver` với session bucket được cung cấp, lưu trữ các checkpoint và pending write dưới prefix `checkpoints/`. Class này nằm trong `s3_checkpoint_saver_langchain.py` trong project agent-connection được chia sẻ.
-- **`dynamodb-s3`**: Hạ tầng CDK/Terraform cung cấp một DynamoDB table cho các checkpoint, được cấu hình như được khuyến nghị trong [tài liệu AWS về sử dụng DynamoDB làm checkpoint store cho các agent LangGraph](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ddb-langgraph-checkpoint.html) (schema `PK`/`SK` thống nhất, billing `PAY_PER_REQUEST`, point-in-time recovery, và một thuộc tính `ttl`), cộng với một S3 bucket để offload các checkpoint trên 350KB. Cả hai đều được mã hóa bằng KMS key chuyên dụng; server access log của bucket được gửi đến CloudWatch Logs log group thông qua cùng một key. IAM role của agent được cấp quyền read/write vào table và bucket, và tên table/bucket được đăng ký cùng với ARN của agent trong cấu hình runtime AppConfig.
-- **`in-memory`**: Không có table hoặc bucket nào được cung cấp. Trạng thái hội thoại chỉ được giữ trong bộ nhớ trong suốt thời gian tồn tại của process đang chạy và không tồn tại qua các lần khởi động lại hoặc scale-in.
+- **`s3`** (mặc định): Agent đã triển khai sử dụng `S3CheckpointSaver` với session bucket đã cung cấp, lưu trữ các checkpoint và pending write dưới tiền tố `checkpoints/`. Class này nằm trong `s3_checkpoint_saver_langchain.py` trong dự án agent-connection dùng chung.
+- **`dynamodb-s3`**: Hạ tầng CDK/Terraform cung cấp một bảng DynamoDB cho các checkpoint, được cấu hình theo khuyến nghị trong [tài liệu AWS về sử dụng DynamoDB làm checkpoint store cho các agent LangGraph](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ddb-langgraph-checkpoint.html) (schema `PK`/`SK` thống nhất, thanh toán `PAY_PER_REQUEST`, point-in-time recovery, và thuộc tính `ttl`), cộng với một S3 bucket để offload các checkpoint trên 350KB. Cả hai đều được mã hóa bằng KMS key chuyên dụng; server access log của bucket được gửi đến một CloudWatch Logs log group qua cùng key. IAM role của agent được cấp quyền đọc/ghi vào bảng và bucket, và tên bảng/bucket được đăng ký cùng với ARN của agent trong cấu hình runtime AppConfig.
+- **`in-memory`**: Không có bảng hay bucket nào được cung cấp. Trạng thái hội thoại chỉ được giữ trong bộ nhớ trong suốt thời gian tồn tại của tiến trình đang chạy và không tồn tại qua các lần khởi động lại hoặc scale-in.
 
-Điều này được triển khai trong `session.py` được tạo, nó export một hàm `get_checkpointer()` được gọi từ `create_agent(..., checkpointer=get_checkpointer())` của `agent.py`.
+Điều này được triển khai trong `session.py` được tạo ra, xuất một hàm `get_checkpointer()` được gọi từ `create_agent(..., checkpointer=get_checkpointer())` của `agent.py`.
 
-:::note[Phát triển cục bộ]
-Khi chạy cục bộ (`LOCAL_DEV=true`, được đặt tự động bởi target `-dev`), `get_checkpointer()` luôn trả về một [`AsyncSqliteSaver`](https://reference.langchain.com/python/langgraph.checkpoint.sqlite/aio/AsyncSqliteSaver) được hỗ trợ bởi một cơ sở dữ liệu SQLite cục bộ dưới `tmp/agents/langchain/<agent-name>` tại workspace root, bất kể tùy chọn `session` được cấu hình, để thuận tiện.
+:::note[Phát triển Cục bộ]
+Khi chạy cục bộ (`LOCAL_DEV=true`, được đặt tự động bởi target `-dev`), `get_checkpointer()` luôn trả về một [`AsyncSqliteSaver`](https://reference.langchain.com/python/langgraph.checkpoint.sqlite/aio/AsyncSqliteSaver) được hỗ trợ bởi cơ sở dữ liệu SQLite cục bộ dưới `tmp/agents/langchain/<agent-name>` tại thư mục gốc workspace, bất kể tùy chọn `session` đã cấu hình, để thuận tiện.
 :::
 </OptionFilter>
 </OptionFilter>
@@ -527,9 +536,9 @@ Khi chạy cục bộ (`LOCAL_DEV=true`, được đặt tự động bởi targ
 ## Gọi Agent của bạn
 
 <OptionFilter when={{ protocol: 'http' }} description="FastAPI HTTP invocation details">
-### Gọi Máy chủ cục bộ
+### Gọi Máy chủ Cục bộ
 
-Để gọi một Agent đang chạy cục bộ thông qua target `<your-agent-name>-serve`, bạn có thể gửi một POST request đơn giản đến `/invocations` trên cổng mà agent cục bộ của bạn đang chạy. Ví dụ, với `curl`:
+Để gọi một Agent đang chạy cục bộ qua target `<your-agent-name>-serve`, bạn có thể gửi một yêu cầu POST đơn giản đến `/invocations` trên cổng mà agent cục bộ của bạn đang chạy. Ví dụ, với `curl`:
 
 ```bash
 curl -N -X POST http://localhost:8081/invocations \
@@ -538,18 +547,18 @@ curl -N -X POST http://localhost:8081/invocations \
 ```
 
 :::note[Cờ Streaming của Curl]
-Tham số `-N` được cung cấp cho `curl` vô hiệu hóa việc buffer output stream, vì vậy bạn có thể thấy streaming response theo thời gian thực.
+Đối số `-N` được cung cấp cho `curl` vô hiệu hóa việc đệm luồng đầu ra, vì vậy bạn có thể thấy phản hồi streaming theo thời gian thực.
 :::
 
-### Gọi Agent đã triển khai
+### Gọi Agent Đã Triển khai
 
-<Snippet name="agent/runtime-arn" parentHeading="Gọi Agent đã triển khai" />
+<Snippet name="agent/runtime-arn" parentHeading="Gọi Agent Đã Triển khai" />
 
 <Tabs syncKey="auth">
 <TabItem label="IAM" _filter={{ auth: 'iam' }}>
 #### Xác thực IAM
 
-Đối với Xác thực IAM, request phải được ký bằng AWS Signature Version 4 (SigV4).
+Đối với Xác thực IAM, yêu cầu phải được ký bằng AWS Signature Version 4 (SigV4).
 
 ```bash
 acurl <region> bedrock-agentcore -N -X POST \
@@ -558,7 +567,7 @@ acurl <region> bedrock-agentcore -N -X POST \
 -H 'Content-Type: application/json'
 ```
 
-<Drawer title="Sigv4 enabled curl" trigger="Nhấp vào đây để biết thêm chi tiết về cấu hình lệnh acurl ở trên">
+<Drawer title="Sigv4 enabled curl" trigger="Click here for more details on configuring the above acurl command">
 <Snippet name="tools/acurl" />
 </Drawer>
 </TabItem>
@@ -590,33 +599,33 @@ aws cognito-idp admin-initiate-auth \
 </TabItem>
 </Tabs>
 
-#### Trình duyệt / Website React
+#### Trình duyệt / Trang web React
 
-Để gọi Agent của bạn từ một website React, bạn có thể sử dụng <Link path="/vi/guides/connection/react-py-agent">`connection` generator</Link>, nó tự động thiết lập một client với xác thực chính xác (IAM hoặc Cognito).
+Để gọi Agent của bạn từ một trang web React, bạn có thể sử dụng <Link path="/guides/connection/react-py-agent">generator `connection`</Link>, tự động thiết lập một client với xác thực đúng (IAM hoặc Cognito).
 
 <RunGenerator generator="connection" />
 
-Tham khảo hướng dẫn <Link path="/vi/guides/connection/react-py-agent">`connection` generator</Link> để biết chi tiết về cách thiết lập kết nối.
+Tham khảo <Link path="/guides/connection/react-py-agent">hướng dẫn generator `connection`</Link> để biết chi tiết về cách kết nối được thiết lập.
 </OptionFilter>
 
 <OptionFilter when={{ protocol: 'a2a' }} description="A2A delegation details">
-### Gọi Agent A2A như một Công cụ
+### Gọi một A2A Agent như một Công cụ
 
-Để ủy quyền công việc từ agent này cho một agent A2A từ xa (hoặc <Link path="/vi/guides/ts-agent">TypeScript</Link> hoặc <Link path="/vi/guides/py-agent">Python</Link>), sử dụng <Link path="/vi/guides/connection/py-agent-a2a">`connection` generator</Link>. Nó tạo ra một client được xác thực SigV4 cho agent đích và AST-transform `agent.py` của agent này để đăng ký agent A2A từ xa như một delegate được trang trí `@tool`.
+Để ủy thác công việc từ agent này đến một A2A agent từ xa (hoặc <Link path="/guides/ts-agent">TypeScript</Link> hoặc <Link path="/guides/py-agent">Python</Link>), sử dụng <Link path="/guides/connection/py-agent-a2a">generator `connection`</Link>. Nó cung cấp một client được xác thực SigV4 cho agent đích và AST-transform `agent.py` của agent này để đăng ký A2A agent từ xa như một delegate được trang trí `@tool`.
 
 <RunGenerator generator="connection" />
 
-Tham khảo hướng dẫn <Link path="/vi/guides/connection/py-agent-a2a">`connection` generator</Link> để biết chi tiết về cách thiết lập kết nối.
+Tham khảo <Link path="/guides/connection/py-agent-a2a">hướng dẫn generator `connection`</Link> để biết chi tiết về cách kết nối được thiết lập.
 </OptionFilter>
 
 <OptionFilter when={{ protocol: 'ag-ui' }} description="AG-UI / React connection details">
-### Gọi Agent AG-UI
+### Gọi một AG-UI Agent
 
-Để gọi agent AG-UI của bạn từ một website React, sử dụng <Link path="/vi/guides/connection/react-agui">`connection` generator</Link>, nó kết nối một client [CopilotKit](https://docs.copilotkit.ai/) được cấu hình cho agent đã triển khai của bạn với xác thực chính xác (IAM hoặc Cognito).
+Để gọi AG-UI agent của bạn từ một trang web React, sử dụng <Link path="/guides/connection/react-agui">generator `connection`</Link>, kết nối một client [CopilotKit](https://docs.copilotkit.ai/) được cấu hình cho agent đã triển khai của bạn với xác thực đúng (IAM hoặc Cognito).
 
 <RunGenerator generator="connection" />
 
-Tham khảo hướng dẫn <Link path="/vi/guides/connection/react-agui">`connection` generator</Link> để biết chi tiết về cách thiết lập kết nối.
+Tham khảo <Link path="/guides/connection/react-agui">hướng dẫn generator `connection`</Link> để biết chi tiết về cách kết nối được thiết lập.
 </OptionFilter>
 
 ## Bảo mật Agent của bạn
@@ -665,7 +674,7 @@ Xem tài liệu [`ChatBedrockConverse`](https://docs.langchain.com/oss/python/in
 
 ## Kết nối
 
-Sử dụng generator <Link path="vi/guides/connection">`connection`</Link> để tích hợp project này với các project khác trong workspace của bạn. Các kết nối sau liên quan đến project này:
+Sử dụng generator <Link path="guides/connection">`connection`</Link> để tích hợp dự án này với các dự án khác trong workspace của bạn. Các kết nối sau liên quan đến dự án này:
 
 <CardGrid>
   <ConnectionCard

--- a/docs/src/content/docs/zh/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/zh/get_started/tutorials/dungeon-game/1.mdx
@@ -1,6 +1,6 @@
 ---
-title: 设置 monorepo
-description: "使用 @aws/nx-plugin 构建 AI 驱动的地牢冒险游戏的演练。"
+title: 搭建 monorepo
+description: "使用 @aws/nx-plugin 构建一个由 AI 驱动的地牢冒险游戏的完整演练。"
 ---
 
 import { Aside, Code, FileTree, Steps, Tabs, TabItem } from '@astrojs/starlight/components';
@@ -24,53 +24,53 @@ import gameConversationPng from '@assets/game-conversation.png'
 
 ## 任务 1：创建 monorepo
 
-要创建新的 monorepo，在所需目录中运行以下命令：
+要创建一个新的 monorepo，请在您希望的目录中运行以下命令：
 
 <CreateNxWorkspaceCommand workspace="dungeon-adventure" iac="cdk" />
 
 :::note[CDK 作为 IaC 提供商]
-我们使用 `--iac=cdk`，因为在本教程中我们将使用 CDK 作为基础设施即代码。Nx Plugin for AWS 也支持 `terraform`。
+我们使用 `--iac=cdk`，因为在本教程中我们将使用 CDK 作为基础设施即代码工具。Nx Plugin for AWS 同样支持 `terraform`。
 :::
 
-这将在 `dungeon-adventure` 目录中设置一个 NX monorepo。当您在 VSCode 中打开该目录时，您将看到以下文件结构：
+这将在 `dungeon-adventure` 目录中创建一个 NX monorepo。在 VSCode 中打开该目录后，您将看到如下文件结构：
 
 <FileTree>
 - .nx/
 - .vscode/
 - node_modules/
-- packages/ 这是您的子项目所在的位置
+- packages/ 子项目将存放于此
 - .gitignore
-- biome.json 配置 Biome 用于代码检查和格式化
+- biome.json 配置 Biome 的代码检查与格式化
 - nx.json 配置 Nx CLI 和 monorepo 默认值
-- package.json 所有 node 依赖项都在这里定义
+- package.json 所有 node 依赖均在此定义
 - pnpm-lock.yaml 或 bun.lock、yarn.lock、package-lock.json，取决于包管理器
-- pnpm-workspace.yaml 如果使用 pnpm
+- pnpm-workspace.yaml 使用 pnpm 时存在
 - README.md
-- tsconfig.base.json 所有基于 node 的子项目都扩展此文件
+- tsconfig.base.json 所有基于 node 的子项目均继承此配置
 - tsconfig.json
-- aws-nx-plugin.config.mts Nx Plugin for AWS 的配置
+- aws-nx-plugin.config.mts Nx Plugin for AWS 的配置文件
 </FileTree>
 
-<Aside type="tip" title="经常提交">最佳实践是在运行任何生成器之前确保所有未暂存的文件都已在 Git 中提交。这样您可以通过 `git diff` 查看运行生成器后发生了什么变化。</Aside>
+<Aside type="tip" title="频繁提交">最佳实践是在运行任何生成器之前，确保所有未暂存的文件都已提交到 Git。这样您可以通过 `git diff` 查看运行生成器后发生了哪些变化。</Aside>
 
 ## 任务 2：搭建地牢冒险游戏
 
-有了工作空间后，我们搭建游戏的子项目——Game API、Story Agent、Inventory MCP 服务器、游戏数据库和网站——以及将它们连接在一起的连接。有两种方法可以做到这一点：
+有了工作区后，我们来搭建游戏的各个子项目——Game API、Story Agent、Inventory MCP 服务器、游戏数据库和网站——以及将它们连接在一起的配置。有两种方式可以完成：
 
-- **快速** — 直接从下面的图表中复制命令并运行它们。这是达到相同起点的最快方法。
-- **逐步** — 展开下面的部分，自己运行每个生成器并准确检查每个生成器产生的内容。
+- **快速方式** — 直接从下方的图表中复制命令并运行。这是到达相同起点的最快方式。
+- **逐步方式** — 展开下方的章节，逐个运行每个生成器，并仔细查看每个生成器的产出。
 
-下面的图表_就是_地牢冒险工作空间：您将在本模块中构建的每个项目、组件和连接。点击**复制命令**获取整个系列，然后从您在任务 1 中创建的 `dungeon-adventure` 目录中运行它们。
+下方的图表_就是_地牢冒险工作区：您将在本模块中构建的每个项目、组件和连接。点击 **Copy commands** 获取完整命令序列，然后在任务 1 中创建的 `dungeon-adventure` 目录中运行它们。
 
 <EmbeddedGraph preset="dungeon-adventure" workspace="dungeon-adventure" iac="cdk" skipWorkspace />
 
-<Drawer title="逐步" trigger="逐步：自己运行每个生成器并查看它产生的内容">
+<Drawer title="逐步方式" trigger="逐步方式：自行运行每个生成器并查看其产出">
 
-与其一次性复制所有命令，您可以单独运行每个生成器。这是了解每个生成器向工作空间添加什么的最佳方法。依次运行每个生成器，从您在任务 1 中创建的 `dungeon-adventure` 目录中运行。
+您可以逐个运行每个生成器，而不是一次性复制所有命令。这是了解每个生成器为工作区添加了什么内容的最佳方式。请在任务 1 中创建的 `dungeon-adventure` 目录中依次运行每个生成器。
 
 ##### 创建 Game API
 
-首先，让我们创建 Game API。为此，使用以下步骤创建一个名为 `GameApi` 的 tRPC API：
+首先，让我们创建 Game API。为此，请按照以下步骤创建一个名为 `GameApi` 的 tRPC API：
 
 <RunGenerator generator="ts#api" requiredParameters={{ name: "GameApi", framework: "trpc" }} noInteractive />
 
@@ -78,31 +78,31 @@ import gameConversationPng from '@assets/game-conversation.png'
 
 您将看到文件树中出现一些新文件。
 
-<Aside title="根依赖项">
-根 `package.json` 现在配置了 `type` 为 `module`，这意味着 ESM 是 `@aws/nx-plugin` 提供的所有基于 node 的子项目的默认模块类型。
-有关使用 TypeScript 项目的更多详细信息，请参阅 <Link path="guides/typescript-project">ts#project 生成器指南</Link>。
+<Aside title="根依赖">
+根目录的 `package.json` 现在配置了 `type` 为 `module`，这意味着 ESM 是 `@aws/nx-plugin` 提供的所有基于 node 的子项目的默认模块类型。
+有关使用 TypeScript 项目的更多详情，请参阅 <Link path="guides/typescript-project">ts#project 生成器指南</Link>。
 </Aside>
 
 <details>
-<summary>详细检查生成的 `ts#api` 文件</summary>
+<summary>详细查看生成的 `ts#api` 文件</summary>
 
-以下是 `ts#api` 生成器生成的所有文件的列表。我们将检查文件树中突出显示的一些关键文件：
+以下是 `ts#api` 生成器生成的所有文件列表。我们将检查文件树中高亮显示的一些关键文件：
 <FileTree>
 - packages/
   - common/
     - constructs/
       - src/
-        - app/ 应用特定的 cdk 构造
+        - app/ 应用特定的 cdk 构件
           - apis/
-            - **game-api.ts** 创建 tRPC API 的 cdk 构造
+            - **game-api.ts** 用于创建 tRPC API 的 cdk 构件
             - index.ts
             - ...
           - index.ts
-        - core/ 通用 cdk 构造
+        - core/ 通用 cdk 构件
           - api/
-            - rest-api.ts API Gateway Rest API 的基础 cdk 构造
-            - trpc-utils.ts trpc API CDK 构造的实用程序
-            - utils.ts API 构造的实用程序
+            - rest-api.ts API Gateway Rest API 的基础 cdk 构件
+            - trpc-utils.ts trpc API CDK 构件的工具函数
+            - utils.ts API 构件的工具函数
           - index.ts
           - runtime-config.ts
         - index.ts
@@ -110,23 +110,23 @@ import gameConversationPng from '@assets/game-conversation.png'
       - ...
   - game-api/ tRPC API
     - src/
-      - client/ 通常用于 ts 机器对机器调用的原生客户端
+      - client/ 通常用于 ts 机器间调用的普通客户端
         - index.ts
-      - middleware/ powertools 仪表化
+      - middleware/ powertools 插桩
         - error.ts
         - index.ts
         - logger.ts
         - metrics.ts
         - tracer.ts
-      - schema/ API 输入和输出的定义
+      - schema/ API 输入输出的定义
         - index.ts
-        - **echo.ts** 示例输入和输出模式
-        - z-async-iterable.ts tRPC 订阅输出的包装 Zod 模式
-      - procedures/ API 过程/路由的特定实现
+        - **echo.ts** 示例输入输出 schema
+        - z-async-iterable.ts tRPC 订阅输出的 Zod schema 包装器
+      - procedures/ API 过程/路由的具体实现
         - **echo.ts** 示例过程实现
       - index.ts
       - init.ts 设置上下文和中间件
-      - handler.ts Lambda 处理程序入口点（对 REST API 使用响应流）
+      - handler.ts Lambda 处理器入口点（REST API 使用响应流）
       - local-server.ts 本地运行 tRPC 服务器时使用
       - **router.ts** 定义 tRPC 路由器和所有过程
     - project.json
@@ -134,7 +134,7 @@ import gameConversationPng from '@assets/game-conversation.png'
 - vitest.workspace.ts
 </FileTree>
 
-让我们看看这些关键文件：
+让我们查看这些关键文件：
 
 ```ts {7}
 // packages/game-api/src/router.ts
@@ -149,7 +149,7 @@ export const appRouter = router({
 
 export type AppRouter = typeof appRouter;
 ```
-路由器定义了 API 的 tRPC 路由器，是您声明所有 API 方法的地方。如上所示，我们有一个名为 `echo` 的方法，其实现在 `./procedures/echo.ts` 文件中。Lambda 处理程序入口点在 `handler.ts` 中，由生成器自动配置。
+路由器定义了 API 的 tRPC 路由器，是您声明所有 API 方法的地方。如上所示，我们有一个名为 `echo` 的方法，其实现位于 `./procedures/echo.ts` 文件中。Lambda 处理器入口点位于 `handler.ts`，由生成器自动配置。
 
 ```ts {7-10}
 // packages/game-api/src/procedures/echo.ts
@@ -165,7 +165,7 @@ export const echo = publicProcedure
   .query((opts) => ({ message: opts.input.message }));
 ```
 
-此文件是 `echo` 方法的实现，如您所见，通过声明其输入和输出数据结构进行强类型化。
+该文件是 `echo` 方法的实现，通过声明输入和输出数据结构实现了强类型约束。
 
 ```ts
 // packages/game-api/src/schema/echo.ts
@@ -184,7 +184,7 @@ export const EchoOutputSchema = z.object({
 export type IEchoOutput = z.TypeOf<typeof EchoOutputSchema>;
 ```
 
-所有 tRPC 架构定义都使用 [Zod](https://zod.dev/) 定义，并通过 `z.TypeOf` 语法导出为 typescript 类型。
+所有 tRPC schema 定义均使用 [Zod](https://zod.dev/) 定义，并通过 `z.TypeOf` 语法导出为 TypeScript 类型。
 
 ```ts
 // packages/common/constructs/src/app/apis/game-api.ts
@@ -390,7 +390,7 @@ export class GameApi<
 }
 ```
 
-这是定义我们 `GameApi` 的 CDK 构造。它提供了一个 `defaultIntegrations` 方法，该方法自动为 tRPC API 中的每个过程创建一个 Lambda 函数，指向捆绑的 API 实现。这意味着在 `cdk synth` 时不会发生捆绑（与使用 [NodeJsFunction](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_lambda_nodejs.NodejsFunction.html) 相反），因为我们已经将其作为后端项目构建目标的一部分进行了捆绑。
+这是定义 `GameApi` 的 CDK 构件。它提供了一个 `defaultIntegrations` 方法，该方法会自动为 tRPC API 中的每个过程创建一个 Lambda 函数，并指向已打包的 API 实现。这意味着在 `cdk synth` 时不会发生打包（与使用 [NodeJsFunction](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_lambda_nodejs.NodejsFunction.html) 相反），因为我们已经在后端项目的构建目标中完成了打包。
 
 </details>
 
@@ -400,18 +400,18 @@ export class GameApi<
 
 ###### Story agent：Python 项目
 
-要创建 Python 项目：
+创建一个 Python 项目：
 
 <RunGenerator generator="py#project" requiredParameters={{name:"story"}} noInteractive />
 
 您将看到文件树中出现一些新文件。
 <details>
-<summary>详细检查生成的 `py#project` 文件</summary>
+<summary>详细查看生成的 `py#project` 文件</summary>
 
-`py#project` 生成这些文件：
+`py#project` 生成以下文件：
 
 <FileTree>
-- .venv/ 单体仓库的单个虚拟环境
+- .venv/ monorepo 的单一虚拟环境
 - packages/
   - story/
     - dungeon_adventure_story/ python 模块
@@ -430,19 +430,19 @@ export class GameApi<
 
 ###### Story agent
 
-要使用 `py#agent` 生成器向项目添加 Strands agent：
+使用 `py#agent` 生成器向项目添加 Strands agent：
 
 <RunGenerator generator="py#agent" requiredParameters={{project:"story", auth:"cognito", protocol:"ag-ui"}} noInteractive />
 
 :::note[AG-UI 协议]
-我们选择 `--protocol=ag-ui`，以便 agent 使用 [Agent-User Interaction 协议](https://docs.copilotkit.ai/aws-strands/protocol) — 这让我们的 React 网站可以通过 [CopilotKit](https://docs.copilotkit.ai/) 直接与其通信，流式传输、工具调用和对话历史由协议处理，而不是手工编写的 HTTP 客户端。
+我们选择 `--protocol=ag-ui`，使 agent 使用 [Agent-User Interaction 协议](https://docs.copilotkit.ai/aws-strands/protocol)——这让我们的 React 网站可以通过 [CopilotKit](https://docs.copilotkit.ai/) 直接与其通信，流式传输、工具调用和对话历史均由协议处理，无需手写 HTTP 客户端。
 :::
 
 您将看到文件树中出现一些新文件。
 <details>
-<summary>详细检查生成的 `py#agent` 文件</summary>
+<summary>详细查看生成的 `py#agent` 文件</summary>
 
-`py#agent` 生成这些文件：
+`py#agent` 生成以下文件：
 
 <FileTree>
 - packages/
@@ -452,11 +452,13 @@ export class GameApi<
         - main.py Bedrock AgentCore Runtime 中 agent 的入口点
         - agent.py 定义示例 agent 和工具
         - session.py 解析用于持久化对话状态的 SessionManager
-        - Dockerfile 定义用于部署到 AgentCore Runtime 的 docker 镜像
+        - middleware/
+          - session_id_middleware.py 为请求绑定入站 AgentCore 会话 ID
+        - Dockerfile 定义部署到 AgentCore Runtime 的 Docker 镜像
   - common/constructs/
     - src
       - app/agents/story-agent/
-        - story-agent.ts 用于将 Story agent 部署到 AgentCore Runtime 的构造
+        - story-agent.ts 将 Story agent 部署到 AgentCore Runtime 的构件
 </FileTree>
 
 让我们详细查看一些文件：
@@ -490,7 +492,30 @@ Refer to tools as your 'spellbook'.
     )
 ```
 
-这创建了一个示例 Strands agent 并定义了一个减法工具。`log_model_errors` 和 `log_tool_errors` 是来自共享 `dungeon_adventure_agent_connection` 项目的钩子，它们记录模型/工具失败，而不是让它们静默失败。
+这创建了一个示例 Strands agent 并定义了一个减法工具。`log_model_errors` 和 `log_tool_errors` 是来自共享 `dungeon_adventure_agent_connection` 项目的钩子，用于记录模型/工具失败而不是让它们静默失败。
+
+```python
+# agent/middleware/session_id_middleware.py
+import uuid
+
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from dungeon_adventure_agent_connection import session_id_context
+
+SESSION_ID_HEADER = "x-amzn-bedrock-agentcore-runtime-session-id"
+
+
+class SessionIdMiddleware(BaseHTTPMiddleware):
+    """Bind the session ID for this request so downstream MCP / A2A clients forward it on outbound calls."""
+
+    async def dispatch(self, request: Request, call_next):
+        session_id = request.headers.get(SESSION_ID_HEADER) or str(uuid.uuid4())
+        with session_id_context(session_id):
+            return await call_next(request)
+```
+
+`SessionIdMiddleware` 将入站 AgentCore 运行时会话 ID 绑定到请求期间的 `ContextVar` 上。
 
 ```python
 # agent/main.py
@@ -505,14 +530,12 @@ from dungeon_adventure_agent_connection import get_current_session_id, session_i
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import StreamingResponse
-from starlette.middleware.base import BaseHTTPMiddleware
 
 from .agent import get_agent
+from .middleware.session_id_middleware import SESSION_ID_HEADER, SessionIdMiddleware
 from .session import get_session_manager
 
 logging.basicConfig(level=logging.INFO)
-
-SESSION_ID_HEADER = "x-amzn-bedrock-agentcore-runtime-session-id"
 
 
 @asynccontextmanager
@@ -529,15 +552,6 @@ async def lifespan(app: FastAPI):
         yield
 
 
-class _SessionIdMiddleware(BaseHTTPMiddleware):
-    """Bind the session ID for this request so downstream MCP / A2A clients forward it on outbound calls."""
-
-    async def dispatch(self, request: Request, call_next):
-        session_id = request.headers.get(SESSION_ID_HEADER) or str(uuid.uuid4())
-        with session_id_context(session_id):
-            return await call_next(request)
-
-
 app = FastAPI(title="AWS Strands - StoryAgent", lifespan=lifespan)
 app.add_middleware(
     CORSMiddleware,
@@ -546,7 +560,7 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
-app.add_middleware(_SessionIdMiddleware)
+app.add_middleware(SessionIdMiddleware)
 
 
 @app.post("/invocations")
@@ -589,7 +603,7 @@ async def ping():
     return {"status": "healthy"}
 ```
 
-这是 agent 的入口点。因为我们选择了 `--protocol=ag-ui`，生成器使用 [`ag_ui_strands`](https://docs.copilotkit.ai/aws-strands/integration) 中的 `StrandsAgent` 包装我们的 Strands `Agent`，并将其挂载在使用 [AG-UI 协议](https://docs.copilotkit.ai/aws-strands/protocol) 的 FastAPI 应用程序上 — 这是 CopilotKit 将从 React 网站与之通信的内容。agent 在 `lifespan` 处理程序内构建 — 而不是在导入时 — 因此容器启动（而不是模块导入）拥有构造，每个 AgentCore 会话都有自己的容器。`_SessionIdMiddleware` 将入站 AgentCore 运行时会话 ID 绑定到 `ContextVar` 上，以便我们稍后连接的任何下游 MCP/A2A 客户端（例如 <Link path="zh/get_started/tutorials/dungeon-game/2">模块 2</Link> 中的 Inventory MCP 服务器）自动在其出站调用上转发它。由于 AG-UI 为每个 `thread_id` 缓存一个 Strands agent，我们插入一个 `session_manager_provider` 而不是模板 agent 自己的会话管理器 — 这为每个线程提供了自己的 `SessionManager`，以便对话历史在回合之间持久化。该 `get_session_manager()` 函数来自生成的 `session.py` 同级文件：部署时，它返回由生成器自动配置的 S3 存储桶支持的 `strands.session.S3SessionManager`；在 `agent-dev` 下（`LOCAL_DEV=true`），无论部署配置如何，它始终返回写入本地临时目录的 `FileSessionManager`。
+这是 agent 的入口点。由于我们选择了 `--protocol=ag-ui`，生成器将我们的 Strands `Agent` 用 [`ag_ui_strands`](https://docs.copilotkit.ai/aws-strands/integration) 中的 `StrandsAgent` 包装，并将其挂载到一个使用 [AG-UI 协议](https://docs.copilotkit.ai/aws-strands/protocol) 的 FastAPI 应用上——这就是 CopilotKit 从 React 网站与之通信的方式。agent 在 `lifespan` 处理器中构建，而非在导入时，因此容器启动（而非模块导入）拥有构建所有权，每个 AgentCore 会话都有自己的容器。上面看到的 `SessionIdMiddleware` 转发入站 AgentCore 运行时会话 ID，以便我们稍后连接的任何下游 MCP/A2A 客户端（例如 <Link path="get_started/tutorials/dungeon-game/2">模块 2</Link> 中的 Inventory MCP 服务器）在其出站调用中自动转发它。由于 AG-UI 为每个 `thread_id` 缓存一个 Strands agent，我们插入了一个 `session_manager_provider` 而不是模板 agent 自己的会话管理器——这为每个线程提供了自己的 `SessionManager`，使对话历史在轮次间持久化。`get_session_manager()` 函数来自生成的 `session.py` 同级文件：部署时，它返回一个由生成器自动配置的 S3 存储桶支持的 `strands.session.S3SessionManager`；在 `agent-dev`（`LOCAL_DEV=true`）下，它始终返回一个写入本地临时目录的 `FileSessionManager`，而不管部署配置如何。
 
 ```ts
 // common/constructs/src/app/agents/story-agent/story-agent.ts
@@ -877,7 +891,7 @@ export class StoryAgent extends Construct implements IGrantable, IConnectable {
 }
 ```
 
-这配置了一个 CDK `AgentRuntimeArtifact`，它将您的 agent Docker 镜像上传到 ECR，并使用 AgentCore Runtime 托管它。因为我们选择了 `--auth=cognito`，构造需要用户池/客户端身份，并通过 Cognito 授权 AgentCore Runtime 调用，转发调用者的 `Authorization` 标头。它还配置了 Story Agent 的 `session.py` 在运行时读取的会话存储桶 — 一个 KMS 加密的 S3 存储桶，服务器访问日志传送到 CloudWatch Logs — 授予 agent 对其的读写访问权限，授予它调用 Bedrock 模型的访问权限，并在 `RuntimeConfig` 中注册其 ARN 和存储桶名称，以便 agent（在运行时，通过 AppConfig）和 Game API（在合成时，通过 `invocationUrl`）都可以找到它。
+这配置了一个 CDK `AgentRuntimeArtifact`，将您的 agent Docker 镜像上传到 ECR，并使用 AgentCore Runtime 托管它。由于我们选择了 `--auth=cognito`，该构件需要用户池/客户端身份，并通过 Cognito 授权 AgentCore Runtime 调用，转发调用者的 `Authorization` 标头。它还配置了 Story Agent 的 `session.py` 在运行时读取的会话存储桶——一个使用 KMS 加密的 S3 存储桶，服务器访问日志传送到 CloudWatch Logs——授予 agent 对其的读写访问权限，授予其调用 Bedrock 模型的权限，并在 `RuntimeConfig` 中注册其 ARN 和存储桶名称，以便 agent（运行时通过 AppConfig）和 Game API（合成时通过 `invocationUrl`）都能找到它。
 
 您可能会注意到一个额外的 `Dockerfile`，它引用了 `story` 项目中的 Docker 镜像，允许我们将 Dockerfile 和 agent 源代码放在一起。
 
@@ -887,7 +901,7 @@ export class StoryAgent extends Construct implements IGrantable, IConnectable {
 
 ###### Inventory：TypeScript 项目
 
-让我们创建一个 MCP 服务器，为我们的 Story Agent 提供管理玩家库存的工具。
+让我们创建一个 MCP 服务器，为 Story Agent 提供管理玩家库存的工具。
 
 首先，我们创建一个 TypeScript 项目：
 
@@ -896,21 +910,21 @@ export class StoryAgent extends Construct implements IGrantable, IConnectable {
 这将创建一个空的 TypeScript 项目。
 
 <details>
-<summary>详细检查生成的 `ts#project` 文件</summary>
+<summary>详细查看生成的 `ts#project` 文件</summary>
 
-`ts#project` 生成器生成这些文件。
+`ts#project` 生成器生成以下文件。
 
 <FileTree>
 - packages/
   - inventory/
     - src/
-      - index.ts 带有示例函数的入口点
+      - index.ts 包含示例函数的入口点
     - project.json 项目配置
     - vitest.config.mts 测试配置
-    - tsconfig.json 项目的基础 typescript 配置
-    - tsconfig.lib.json 针对编译和捆绑的项目的 typescript 配置
-    - tsconfig.spec.json 测试的 typescript 配置
-- tsconfig.base.json 更新以配置其他项目引用此项目的别名
+    - tsconfig.json 项目的基础 TypeScript 配置
+    - tsconfig.lib.json 针对编译和打包的项目 TypeScript 配置
+    - tsconfig.spec.json 测试的 TypeScript 配置
+- tsconfig.base.json 已更新，为其他项目配置引用此项目的别名
 </FileTree>
 
 </details>
@@ -923,15 +937,15 @@ export class StoryAgent extends Construct implements IGrantable, IConnectable {
 
 这将添加一个 MCP 服务器。
 <details>
-<summary>详细检查生成的 `ts#mcp-server` 文件</summary>
+<summary>详细查看生成的 `ts#mcp-server` 文件</summary>
 
-`ts#mcp-server` 生成器生成这些文件。
+`ts#mcp-server` 生成器生成以下文件。
 
 <FileTree>
 - packages/
   - inventory/
     - src/mcp-server/
-      - index.ts barrel 导出
+      - index.ts 桶形导出
       - server.ts 创建 MCP 服务器
       - tools/
         - divide.ts 示例工具
@@ -939,31 +953,31 @@ export class StoryAgent extends Construct implements IGrantable, IConnectable {
         - sample-guidance.ts 示例资源
       - stdio.ts 使用 STDIO 传输的 MCP 入口点
       - http.ts 使用 Streamable HTTP 传输的 MCP 入口点
-      - Dockerfile 构建用于部署到 AgentCore Runtime 的镜像
-    - rolldown.config.ts 用于捆绑 MCP 服务器以部署到 AgentCore 的配置
+      - Dockerfile 构建部署到 AgentCore Runtime 的镜像
+    - rolldown.config.ts 用于将 MCP 服务器打包以部署到 AgentCore 的配置
   - common/constructs/
     - src
       - app/mcp-servers/inventory-mcp-server/
-        - inventory-mcp-server.ts 将 inventory MCP 服务器部署到 AgentCore Runtime 的构造
+        - inventory-mcp-server.ts 将 inventory MCP 服务器部署到 AgentCore Runtime 的构件
 </FileTree>
 
 </details>
 
 ##### 创建游戏数据库
 
-我们的游戏状态——保存的游戏和每个玩家的库存——存储在 [Amazon DynamoDB](https://aws.amazon.com/dynamodb/) 中。使用 `ts#dynamodb` 生成器创建一个名为 `DungeonDb` 的 DynamoDB 项目：
+我们的游戏状态——已保存的游戏和每个玩家的库存——存储在 [Amazon DynamoDB](https://aws.amazon.com/dynamodb/) 中。使用 `ts#dynamodb` 生成器创建一个名为 `DungeonDb` 的 DynamoDB 项目：
 
 <RunGenerator generator="ts#dynamodb" requiredParameters={{name:"DungeonDb"}} noInteractive />
 
 :::tip[本地优先开发]
-`ts#dynamodb` 生成器提供了一个 `dev` 目标，该目标在容器中运行 [DynamoDB Local](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html)。结合 `connection` 生成器（我们在下面运行），这意味着**整个游戏在您的机器上运行，无需部署**，直到教程结束。
+`ts#dynamodb` 生成器提供了一个 `dev` 目标，在容器中运行 [DynamoDB Local](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html)。结合 `connection` 生成器（我们在下面运行），这意味着**整个游戏可以在您的机器上运行，无需部署**，直到教程结束。
 :::
 
 您将看到文件树中出现一些新文件。
 <details>
-<summary>详细检查生成的 `ts#dynamodb` 文件</summary>
+<summary>详细查看生成的 `ts#dynamodb` 文件</summary>
 
-`ts#dynamodb` 生成器生成这些文件。
+`ts#dynamodb` 生成器生成以下文件。
 
 <FileTree>
 - packages/
@@ -986,69 +1000,69 @@ export class StoryAgent extends Construct implements IGrantable, IConnectable {
     - constructs/
       - src/
         - app/dynamodb/
-          - dungeon-db.ts 配置表的构造
+          - dungeon-db.ts 用于配置表的构件
         - core/
-          - dynamodb.ts 通用 DynamoDB 表构造
+          - dynamodb.ts 通用 DynamoDB 表构件
 </FileTree>
 
-生成的 `src/client.ts` 导出 `getDynamoDBClient()` 和 `resolveTableName()`。当 `LOCAL_DEV=true`（由 `dev` 目标自动设置）时，这些连接到 DynamoDB Local；否则它们连接到 AWS 并从 <Link path="guides/runtime-config">运行时配置</Link> 解析已部署的表名。我们将在 <Link path="zh/get_started/tutorials/dungeon-game/2">模块 2</Link> 中在此项目中建模我们的 `Game` 和 `Inventory` 实体。
+生成的 `src/client.ts` 导出 `getDynamoDBClient()` 和 `resolveTableName()`。当 `LOCAL_DEV=true`（由 `dev` 目标自动设置）时，这些函数连接到 DynamoDB Local；否则它们连接到 AWS 并从<Link path="guides/runtime-config">运行时配置</Link>解析已部署的表名。我们将在<Link path="get_started/tutorials/dungeon-game/2">模块 2</Link> 中在此项目中建模我们的 `Game` 和 `Inventory` 实体。
 
-有关更多详细信息，请参阅 <Link path="guides/ts-dynamodb">ts#dynamodb 生成器指南</Link>。
+有关更多详情，请参阅 <Link path="guides/ts-dynamodb">ts#dynamodb 生成器指南</Link>。
 
 </details>
 
-##### 创建用户界面 (UI)
+##### 创建用户界面（UI）
 
 接下来，我们将创建允许您与游戏交互的 UI。
 
 ###### Game UI：网站
 
-要创建 UI，使用以下步骤创建一个名为 `GameUI` 的网站：
+要创建 UI，请按照以下步骤创建一个名为 `GameUI` 的网站：
 
 <RunGenerator generator="ts#website" requiredParameters={{name:"GameUI", ux:"shadcn"}} noInteractive />
 
 :::note[Shadcn UI]
-我们选择 `--ux=shadcn`，以便生成的网站使用 [shadcn/ui](https://ui.shadcn.com/) 组件，使用 Tailwind 样式 — 我们所有的路由代码都使用 shadcn 原语，如 `Card`、`Button` 和 `Input`，稍后的 `connection` 生成器会连接一个匹配的 shadcn 主题的 [CopilotKit](https://docs.copilotkit.ai/) 聊天界面。
+我们选择 `--ux=shadcn`，使生成的网站使用以 Tailwind 样式化的 [shadcn/ui](https://ui.shadcn.com/) 组件——我们所有的路由代码都使用 `Card`、`Button` 和 `Input` 等 shadcn 原语，`connection` 生成器稍后会连接一个匹配 shadcn 主题的 [CopilotKit](https://docs.copilotkit.ai/) 聊天界面。
 :::
 
 您将看到文件树中出现一些新文件。
 
 <details>
-<summary>详细检查生成的 `ts#website` 文件</summary>
+<summary>详细查看生成的 `ts#website` 文件</summary>
 
-`ts#website` 生成这些文件。让我们检查文件树中突出显示的一些关键文件：
+`ts#website` 生成以下文件。让我们检查文件树中高亮显示的一些关键文件：
 
 <FileTree>
 - packages/
   - common/
     - constructs/
       - src/
-        - app/ 应用特定的 cdk 构造
+        - app/ 应用特定的 cdk 构件
           - static-websites/
-            - **game-ui.ts** 创建 Game UI 的 cdk 构造
+            - **game-ui.ts** 用于创建 Game UI 的 cdk 构件
         - core/
-          - static-website.ts 通用静态网站构造
+          - static-website.ts 通用静态网站构件
   - game-ui/
     - public/
     - src/
       - components/
         - AppLayout/
-          - index.tsx 使用 shadcn `SidebarProvider` + 标题的整体页面布局
-        - app-sidebar.tsx 带有导航项的默认 shadcn 侧边栏
-        - alert.tsx、spinner.tsx shadcn 包装的反馈原语
+          - index.tsx 使用 shadcn `SidebarProvider` + 标头的整体页面布局
+        - app-sidebar.tsx 带导航项的默认 shadcn 侧边栏
+        - alert.tsx, spinner.tsx shadcn 包装的反馈原语
       - routes/ @tanstack/react-router 基于文件的路由
         - **index.tsx** 根 '/' 页面
-        - __root.tsx 所有页面都使用此组件作为基础
+        - __root.tsx 所有页面都以此组件为基础
       - config.ts
       - **main.tsx** React 入口点
       - routeTree.gen.ts 由 @tanstack/react-router 自动更新
-      - styles.css 导入共享的 shadcn 全局变量（Tailwind v4）
+      - styles.css 导入共享 shadcn 全局样式（Tailwind v4）
     - index.html
     - project.json
     - vite.config.mts
     - ...
   - common/
-    - shadcn/ 共享的 shadcn/ui 库（主题令牌、`Button`、`Card`、`Input`、`Sidebar`、...）由每个 `ux=shadcn` 网站导入
+    - shadcn/ 共享 shadcn/ui 库（主题令牌、`Button`、`Card`、`Input`、`Sidebar`……），由每个 `ux=shadcn` 网站导入
       - src/components/ui/*
       - src/styles/globals.css Tailwind + shadcn 设计令牌
     - ...
@@ -1075,7 +1089,7 @@ export class GameUI extends StaticWebsite {
 }
 ```
 
-这是定义我们 GameUI 的 CDK 构造。它已经配置了基于 Vite 的 UI 生成的捆绑包的文件路径。这意味着在 `build` 时，捆绑发生在 game-ui 项目的构建目标内，输出在此处使用。
+这是定义 GameUI 的 CDK 构件。它已经配置了指向我们基于 Vite 的 UI 生成包的文件路径。这意味着在 `build` 时，打包发生在 game-ui 项目的构建目标中，输出在此处使用。
 
 ```tsx
 // packages/game-ui/src/main.tsx
@@ -1106,7 +1120,7 @@ root &&
   );
 ```
 
-这是挂载 React 的入口点。样式来自通过 `styles.css` 导入的 Tailwind v4 令牌。`@tanstack/react-router` 配置为[基于文件的路由](https://tanstack.com/router/v1/docs/framework/react/routing/file-based-routing)模式：只要开发服务器正在运行，您在 `routes/` 下创建的任何文件都会自动被拾取，路由树会重新生成。稍后的生成器（auth、connection）将 AST 修补此文件，以在 `<App />` 中包装其他提供者。
+这是挂载 React 的入口点。样式来自通过 `styles.css` 导入的 Tailwind v4 令牌。`@tanstack/react-router` 配置为[基于文件的路由](https://tanstack.com/router/v1/docs/framework/react/routing/file-based-routing)模式：只要开发服务器正在运行，您在 `routes/` 下创建的任何文件都会被自动拾取，路由树会重新生成。后续生成器（auth、connection）将通过 AST 补丁修改此文件，将 `<App />` 包装在额外的提供者中。
 
 ```tsx
 // packages/game-ui/src/routes/index.tsx
@@ -1128,22 +1142,22 @@ function RouteComponent() {
 }
 ```
 
-导航到 `/` 路由时将呈现一个组件。只要开发服务器正在运行，`@tanstack/react-router` 将在您创建/移动此文件时为您管理 `Route`。
+导航到 `/` 路由时将渲染此组件。只要您创建/移动此文件（只要开发服务器正在运行），`@tanstack/react-router` 就会为您管理 `Route`。
 
 </details>
 
-###### Game UI：身份验证
+###### Game UI：认证
 
-让我们配置 Game UI，通过 Amazon Cognito 要求经过身份验证的访问，使用以下步骤：
+让我们使用以下步骤配置 Game UI，通过 Amazon Cognito 要求经过身份验证的访问：
 
 <RunGenerator generator="ts#website#auth" requiredParameters={{cognitoDomain:"game-ui", project:"@dungeon-adventure/game-ui", allowSignup:true}} noInteractive />
 
 您将看到文件树中出现/更改一些新文件。
 
 <details>
-<summary>详细检查生成的 `ts#website#auth` 文件</summary>
+<summary>详细查看生成的 `ts#website#auth` 文件</summary>
 
-`ts#website#auth` 生成器更新/生成这些文件。让我们检查文件树中突出显示的一些关键文件：
+`ts#website#auth` 生成器更新/生成以下文件。让我们检查文件树中高亮显示的一些关键文件：
 
 <FileTree>
 - packages/
@@ -1151,19 +1165,19 @@ function RouteComponent() {
     - constructs/
       - src/
         - core/
-          - user-identity.ts 用于创建用户/身份池的 cdk 构造
+          - user-identity.ts 用于创建用户/身份池的 cdk 构件
   - game-ui/
     - src/
       - components/
         - AppLayout/
-          - index.tsx 将登录用户/注销添加到标题
+          - index.tsx 在标头中添加已登录用户/注销功能
         - CognitoAuth/
           - index.tsx 管理登录到 Cognito
         - RuntimeConfig/
           - index.tsx 获取 `runtime-config.json` 并通过上下文提供给子组件
       - hooks/
         - useRuntimeConfig.tsx
-      - **main.tsx** 更新以添加 Cognito
+      - **main.tsx** 已更新以添加 Cognito
 </FileTree>
 
 ```diff lang="tsx"
@@ -1212,7 +1226,7 @@ root &&
   );
 ```
 
-`RuntimeConfigProvider` 和 `CognitoAuth` 组件已通过 AST 转换添加到 `main.tsx` 文件中。这允许 `CognitoAuth` 组件通过获取包含所需 cognito 连接配置的 `runtime-config.json` 来向 Amazon Cognito 进行身份验证，以便向正确的目标进行后端调用。
+`RuntimeConfigProvider` 和 `CognitoAuth` 组件已通过 AST 转换添加到 `main.tsx` 文件中。这允许 `CognitoAuth` 组件通过获取包含所需 Cognito 连接配置的 `runtime-config.json` 来向 Amazon Cognito 进行身份验证，以便向正确的目标发出后端调用。
 
 </details>
 
@@ -1225,9 +1239,9 @@ root &&
 您将看到文件树中出现/更改一些新文件。
 
 <details>
-<summary>检查 UI → tRPC 连接文件</summary>
+<summary>查看 UI → tRPC 连接文件</summary>
 
-`connection` 生成器生成/更新这些文件。让我们检查文件树中突出显示的一些关键文件：
+`connection` 生成器生成/更新以下文件。让我们检查文件树中高亮显示的一些关键文件：
 
 <FileTree>
 - packages/
@@ -1268,8 +1282,8 @@ export const useGameApiClient = () => {
 
 此钩子提供对用于调用 GameApi 的 tRPC 客户端的访问。有关如何调用 tRPC API 的示例，请参阅 <Link path="guides/connection/react-trpc#using-the-generated-code">使用 tRPC 钩子指南</Link>。
 
-<Aside title="类型安全钩子">
-由于 tRPC 的 [Typescript 推断](https://trpc.io/docs/concepts)，`useGameApi` 不需要构建步骤即可将后端更改传递到前端 — 对路由器或任何过程的编辑会立即被类型检查器拾取。
+<Aside title="类型安全的钩子">
+得益于 tRPC 的 [TypeScript 推断](https://trpc.io/docs/concepts)，`useGameApi` 不需要构建步骤就能将后端更改传递到前端——对路由器或任何过程的编辑都会被类型检查器立即捕获。
 </Aside>
 
 ```diff lang="tsx"
@@ -1303,20 +1317,20 @@ root &&
   );
 ```
 
-`main.tsx` 文件已通过 AST 转换更新以注入 tRPC 提供者。
+`main.tsx` 文件已通过 AST 转换更新，注入了 tRPC 提供者。
 
 </details>
 
 ###### Story Agent：连接到 Inventory MCP 服务器
 
-让我们将 Story Agent 连接到 Inventory MCP 服务器，以便 agent 可以发现和调用 MCP 服务器的工具。
+让我们将 Story Agent 连接到 Inventory MCP 服务器，使 agent 能够发现并调用 MCP 服务器的工具。
 
 <RunGenerator generator="connection" requiredParameters={{sourceProject:"story", targetProject:"inventory"}} noInteractive />
 
 <details>
-<summary>检查 Story Agent → Inventory MCP 连接文件</summary>
+<summary>查看 Story Agent → Inventory MCP 连接文件</summary>
 
-`connection` 生成器生成/更新这些文件：
+`connection` 生成器生成/更新以下文件：
 
 <FileTree>
 - packages/
@@ -1329,68 +1343,68 @@ root &&
           - **agentcore\_mcp\_client\_strands.py** 包装传输的 Strands MCP 客户端
           - auth/ 框架无关的 SigV4 / 会话转发 `httpx.Auth`
         - app/
-          - **inventory\_mcp\_server\_client\_strands.py** 连接库存 MCP 服务器的 Strands 客户端
-        - **\_\_init\_\_.py** 重新导出各连接客户端
+          - **inventory\_mcp\_server\_client\_strands.py** 连接到 Inventory MCP 服务器的 Strands 客户端
+        - **\_\_init\_\_.py** 重新导出每个连接的客户端
   - story/
     - dungeon\_adventure\_story/agent/
-      - **agent.py** 修改以导入和使用 MCP 客户端
+      - **agent.py** 已修改以导入和使用 MCP 客户端
 
 </FileTree>
 
 生成器：
-- 创建一个共享的 `agent_connection` Python 项目（如果尚不存在），其中包含核心 `AgentCoreMCPClientStrands`
-- 生成一个 `InventoryMcpServerClientStrands` 类，该类处理本地（直接 HTTP）和部署时（通过 AgentCore 使用 IAM 身份验证）连接到 MCP 服务器
-- 转换 `agent.py` 以导入客户端、创建实例并将 MCP 服务器的工具连接到 agent
-- 将 `agent_connection` 项目添加为 story 项目的工作空间依赖项
+- 创建一个共享的 `agent_connection` Python 项目（如果尚不存在），包含核心 `AgentCoreMCPClientStrands`
+- 生成一个 `InventoryMcpServerClientStrands` 类，处理本地（直接 HTTP）和部署时（通过带 IAM 认证的 AgentCore）连接到 MCP 服务器
+- 转换 `agent.py` 以导入客户端、创建实例，并将 MCP 服务器的工具连接到 agent
+- 将 `agent_connection` 项目添加为 story 项目的工作区依赖
 - 更新 `dev` 目标以在本地运行时自动启动 MCP 服务器
 
-有关更多详细信息，请参阅 <Link path="guides/connection/py-agent-mcp">Python Agent 到 MCP 连接指南</Link>。
+有关更多详情，请参阅 <Link path="guides/connection/py-agent-mcp">Python Agent 到 MCP 连接指南</Link>。
 </details>
 
 ###### Game UI：连接到 Story Agent
 
-让我们将 Game UI 连接到 Story Agent。由于 agent 使用 AG-UI，`connection` 生成器会连接 [CopilotKit](https://docs.copilotkit.ai/)：一个主题化的聊天组件和一个准备渲染的 `@ag-ui/client` `HttpAgent`。
+让我们将 Game UI 连接到 Story Agent。由于 agent 使用 AG-UI 协议，`connection` 生成器会连接 [CopilotKit](https://docs.copilotkit.ai/)：一个主题化的聊天组件和一个准备好渲染的 `@ag-ui/client` `HttpAgent`。
 
 <RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-ui", targetProject:"story"}} noInteractive />
 
 <details>
-<summary>检查 UI → Story Agent 连接文件</summary>
+<summary>查看 UI → Story Agent 连接文件</summary>
 
-`connection` 生成器生成/更新这些文件：
+`connection` 生成器生成/更新以下文件：
 
 <FileTree>
 - packages/
   - game-ui/
     - src/
       - components/
-        - **AguiProvider.tsx** 注册了每个连接的 AG-UI agent 的 `CopilotKitProvider`
+        - **AguiProvider.tsx** 注册了所有已连接 AG-UI agent 的 `CopilotKitProvider`
         - copilot/
           - **index.tsx** Shadcn 主题的 `CopilotChat` / `CopilotSidebar` / `CopilotPopup`
-          - ShadcnAssistantMessage.tsx、ShadcnUserMessage.tsx、ShadcnChatInput.tsx、ShadcnCursor.tsx、copilot.css
+          - ShadcnAssistantMessage.tsx, ShadcnUserMessage.tsx, ShadcnChatInput.tsx, ShadcnCursor.tsx, copilot.css
       - hooks/
-        - **useAguiStoryAgent.tsx** 构建 `HttpAgent`，注入 Cognito bearer 令牌，并将 `threadId` 填充到 AgentCore 的 33 字符会话 id
-    - **main.tsx** 在 `<AguiProvider>` 中包装 `<App />`
+        - **useAguiStoryAgent.tsx** 构建 `HttpAgent`，注入 Cognito 承载令牌，并将 `threadId` 填充到 AgentCore 的 33 字符会话 ID
+    - **main.tsx** 将 `<App />` 包装在 `<AguiProvider>` 中
 
 </FileTree>
 
 生成器：
-- 检测 React 网站的 `ux`（这里是 Shadcn）并提供匹配的聊天组件。
-- 在单个 `CopilotKitProvider` 上注册每个连接的 agent — 为另一个 agent 重新运行只会添加另一个钩子。
-- 从运行时配置读取 agent 的运行时 ARN，构建 AgentCore 调用 URL，并附加 Cognito bearer 令牌加上 AgentCore 会话 id 标头。
+- 检测 React 网站的 `ux`（此处为 Shadcn）并提供匹配的聊天组件。
+- 在单个 `CopilotKitProvider` 上注册每个已连接的 agent——为另一个 agent 重新运行只需添加另一个钩子。
+- 从运行时配置读取 agent 的运行时 ARN，构建 AgentCore 调用 URL，并附加 Cognito 承载令牌和 AgentCore 会话 ID 标头。
 
-有关更多详细信息，请参阅 <Link path="guides/connection/react-agui">React 到 AG-UI 连接指南</Link>。
+有关更多详情，请参阅 <Link path="guides/connection/react-agui">React 到 AG-UI 连接指南</Link>。
 </details>
 
 ###### 将 Game API 和 Inventory MCP 服务器连接到数据库
 
-Game API 和 Inventory MCP 服务器都读取和写入我们的 DynamoDB 表，因此让我们将它们连接到 `DungeonDb` 项目。`connection` 生成器检测到目标是 `ts#dynamodb` 项目，并将每个源项目的 `dev` 目标连接到自动启动 DynamoDB Local。
+Game API 和 Inventory MCP 服务器都读写我们的 DynamoDB 表，因此让我们将它们连接到 `DungeonDb` 项目。`connection` 生成器检测到目标是 `ts#dynamodb` 项目，并将每个源项目的 `dev` 目标配置为自动启动 DynamoDB Local。
 
 <RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-api", targetProject:"@dungeon-adventure/dungeon-db"}} noInteractive />
 
 <RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/inventory", targetProject:"@dungeon-adventure/dungeon-db"}} noInteractive />
 
-<Aside type="tip" title="一个命令在本地启动整个堆栈">
-因为 Story Agent 的 `agent-dev` 已经依赖于 Inventory MCP 服务器的 `mcp-server-dev`（通过上面的 `story → inventory` 连接），并且 Game API 和 MCP 服务器现在都依赖于 `dungeon-db:dev`，运行任何一个项目的 `dev` 目标都会以正确的顺序启动它需要的每个依赖项。
+<Aside type="tip" title="一条命令启动整个本地堆栈">
+因为 Story Agent 的 `agent-dev` 已经依赖于 Inventory MCP 服务器的 `mcp-server-dev`（通过上面的 `story → inventory` 连接），而 Game API 和 MCP 服务器现在都依赖于 `dungeon-db:dev`，运行任何一个项目的 `dev` 目标都会按正确顺序启动它所需的每个依赖项。
 </Aside>
 
 ###### Game UI：基础设施
@@ -1402,9 +1416,9 @@ Game API 和 Inventory MCP 服务器都读取和写入我们的 DynamoDB 表，�
 您将看到文件树中出现/更改一些新文件。
 
 <details>
-<summary>详细检查生成的 `ts#infra` 文件</summary>
+<summary>详细查看生成的 `ts#infra` 文件</summary>
 
-`ts#infra` 生成器生成/更新这些。让我们检查文件树中突出显示的一些关键文件：
+`ts#infra` 生成器生成/更新以下内容。让我们检查文件树中高亮显示的一些关键文件：
 
 <FileTree>
 - packages/
@@ -1449,9 +1463,9 @@ new ApplicationStage(app, 'dungeon-adventure-infra-sandbox', {
 app.synth();
 ```
 
-<Aside type="tip" title="修复导入错误">如果您在 IDE 中看到导入错误，这是因为我们的基础设施项目尚未在 `tsconfig.json` 中设置 typescript 引用。Nx 已[配置](https://nx.dev/nx-api/js/generators/typescript-sync)为在运行构建/编译时*动态*创建这些引用，或者如果您手动运行 `nx sync` 命令。有关更多信息，请参阅 <Link path="guides/typescript-project#importing-your-library-code-in-other-projects">Typescript 指南</Link>。</Aside>
+<Aside type="tip" title="修复导入错误">如果您在 IDE 中看到导入错误，这是因为我们的基础设施项目尚未在 `tsconfig.json` 中设置 TypeScript 引用。Nx 已被[配置](https://nx.dev/nx-api/js/generators/typescript-sync)为在运行构建/编译时或手动运行 `nx sync` 命令时*动态*创建这些引用。有关更多信息，请参阅 <Link path="guides/typescript-project#importing-your-library-code-in-other-projects">TypeScript 指南</Link>。</Aside>
 
-这是 CDK 应用程序的入口点。
+这是您的 CDK 应用程序的入口点。
 
 ```ts
 // packages/infra/src/stacks/application-stack.ts
@@ -1467,41 +1481,41 @@ export class ApplicationStack extends Stack {
 }
 ```
 
-让我们实例化 CDK 构造来构建我们的地牢冒险游戏。
+让我们实例化我们的 CDK 构件来构建地牢冒险游戏。
 
 </details>
 
 </Drawer>
 
-## 任务 3：更新我们的基础设施
+## 任务 3：更新基础设施
 
-让我们更新 `packages/infra/src/stacks/application-stack.ts` 以实例化一些生成的构造：
+让我们更新 `packages/infra/src/stacks/application-stack.ts` 以实例化一些生成的构件：
 
 <E2EDiff before="dungeon-adventure/1/application-stack.ts.original.template" after="dungeon-adventure/1/application-stack.ts.template" lang="ts" />
 
 :::note[默认集成]
-我们为 Game API 提供默认集成。默认情况下，API 中的每个操作都映射到一个单独的 Lambda 函数来处理该操作。
+我们为 Game API 提供了默认集成。默认情况下，API 中的每个操作都映射到一个单独的 Lambda 函数来处理该操作。
 :::
 
 ## 任务 4：构建代码
 
 <Drawer title="Nx 命令" trigger="现在是我们第一次构建代码的时候了">
 
-###### 单个与多个目标
+###### 单目标与多目标
 
-`run-many` 命令将在多个列出的子项目上运行目标（`--all` 将针对所有子项目）。这确保依赖项以正确的顺序执行。
+`run-many` 命令将在多个列出的子项目上运行目标（`--all` 将针对所有项目）。这确保依赖项以正确的顺序执行。
 
-您还可以通过直接在项目上运行目标来触发单个项目目标的构建（或任何其他任务）。例如，要构建 `@dungeon-adventure/infra` 项目，请运行以下命令：
-
-<NxCommands commands={['build infra']} />
-
-如果您愿意，也可以省略作用域并使用 Nx 简写语法：
+您也可以通过直接在项目上运行目标来触发单个项目目标的构建（或任何其他任务）。例如，要构建 `@dungeon-adventure/infra` 项目，请运行以下命令：
 
 <NxCommands commands={['build infra']} />
 
-###### 可视化您的依赖项
+您也可以省略范围，如果您愿意，可以使用 Nx 简写语法：
 
-要可视化您的依赖项，请运行：
+<NxCommands commands={['build infra']} />
+
+###### 可视化依赖关系
+
+要可视化您的依赖关系，请运行：
 
 <NxCommands commands={['graph']} />
 <br/>
@@ -1510,16 +1524,16 @@ export class ApplicationStack extends Stack {
 
 ###### 缓存
 
-Nx 依赖于[缓存](https://nx.dev/concepts/how-caching-works)，以便您可以重用以前构建的工件以加快开发速度。需要进行一些配置才能使其正常工作，并且在某些情况下您可能希望执行**不使用缓存**的构建。为此，只需将 `--skip-nx-cache` 参数附加到您的命令。例如：
+Nx 依赖[缓存](https://nx.dev/concepts/how-caching-works)，以便您可以重用之前构建的产物来加速开发。需要一些配置才能使其正常工作，在某些情况下您可能希望在**不使用缓存**的情况下执行构建。为此，只需在命令中附加 `--skip-nx-cache` 参数。例如：
 
 <NxCommands commands={['build infra --skip-nx-cache']} />
-如果出于某种原因您想清除缓存（存储在 `.nx` 文件夹中），可以运行以下命令：
+如果出于任何原因您想清除缓存（存储在 `.nx` 文件夹中），可以运行以下命令：
 
 <NxCommands commands={['reset']} />
 
 </Drawer>
 
-使用命令行，运行以下命令首先修复任何 lint 问题：
+使用命令行，首先运行以下命令修复任何 lint 问题：
 
 <PackageManagerShortCommand commands={["lint"]} />
 
@@ -1527,7 +1541,7 @@ Nx 依赖于[缓存](https://nx.dev/concepts/how-caching-works)，以便您可�
 
 <PackageManagerShortCommand commands={["build"]} />
 
-您将收到以下提示：
+您将看到以下提示：
 
 ```bash
  NX   The workspace is out of sync
@@ -1541,10 +1555,10 @@ Yes, sync the changes and run the tasks
 No, run the tasks without syncing the changes
 ```
 
-此消息表示 NX 检测到一些可以自动为您更新的文件。在这种情况下，它指的是 `tsconfig.json` 文件，这些文件没有在引用项目上设置 Typescript 引用。
+此消息表明 NX 检测到一些可以自动为您更新的文件。在这种情况下，它指的是没有在引用项目上设置 TypeScript 引用的 `tsconfig.json` 文件。
 
-选择 **Yes, sync the changes and run the tasks** 选项以继续。您应该注意到所有与 IDE 相关的导入错误都会自动解决，因为同步生成器会自动添加缺少的 typescript 引用！
+选择 **Yes, sync the changes and run the tasks** 选项继续。您应该会注意到所有与 IDE 相关的导入错误都会自动解决，因为同步生成器会自动添加缺失的 TypeScript 引用！
 
-所有构建的工件现在都可以在位于 monorepo 根目录的 `dist/` 文件夹中找到。这是使用 `@aws/nx-plugin` 生成的项目时的标准做法，因为它不会用生成的文件污染您的文件树。如果您想清理文件，请删除 `dist/` 文件夹，而不必担心构建工件散布在整个文件树中。
+所有构建产物现在都可以在位于 monorepo 根目录的 `dist/` 文件夹中找到。这是使用 `@aws/nx-plugin` 生成的项目时的标准做法，因为它不会用生成的文件污染您的文件树。如果您想清理文件，只需删除 `dist/` 文件夹，无需担心构建产物散落在整个文件树中。
 
 恭喜！您已经创建了开始实现 AI 地牢冒险游戏核心所需的所有子项目。🎉🎉🎉

--- a/docs/src/content/docs/zh/guides/py-agent.mdx
+++ b/docs/src/content/docs/zh/guides/py-agent.mdx
@@ -51,6 +51,9 @@ import OptionFilter from '@components/option-filter.astro';
         - init.py FastAPI application setup with CORS and error handling middleware
         - agent.py Main agent definition with sample tools
         - session.py Resolves the framework-specific session persistence implementation
+        - middleware/
+          - \_\_init\_\_.py Python package initialization
+          - session_id_middleware.py Binds the inbound AgentCore session ID for the request
         - main.py FastAPI entry point for Bedrock AgentCore Runtime
         - Dockerfile Entry point for hosting your agent (excluded when `infra` is set to `None`)
     - pyproject.toml Updated with Strands dependencies
@@ -70,6 +73,9 @@ import OptionFilter from '@components/option-filter.astro';
         - \_\_init\_\_.py Python package initialization
         - agent.py Main agent definition with sample tools
         - session.py Resolves the framework-specific session persistence implementation
+        - middleware/
+          - \_\_init\_\_.py Python package initialization
+          - session_id_middleware.py Binds the inbound AgentCore session ID for the request
         - main.py A2A server entry point
         - Dockerfile Entry point for hosting your agent (excluded when `infra` is set to `None`)
     - pyproject.toml Updated with framework and A2A dependencies
@@ -89,6 +95,9 @@ import OptionFilter from '@components/option-filter.astro';
         - \_\_init\_\_.py Python package initialization
         - agent.py Main agent definition with sample tools
         - session.py Resolves the framework-specific session persistence implementation
+        - middleware/
+          - \_\_init\_\_.py Python package initialization
+          - session_id_middleware.py Binds the inbound AgentCore session ID for the request
         - main.py AG-UI server entry point
         - Dockerfile Entry point for hosting your agent (excluded when `infra` is set to `None`)
     - pyproject.toml Updated with framework and AG-UI dependencies
@@ -502,14 +511,6 @@ aws cognito-idp admin-initiate-auth \
 
 这在生成的 `session.py` 中实现，它导出一个 `get_session_manager()` 函数，为当前会话解析 `SessionManager`。
 
-<OptionFilter when={{ protocol: 'ag-ui' }} description="AG-UI session wiring">
-由于 AG-UI 的 `ag-ui-strands` 适配器为每个对话线程克隆一个模板 `Agent`，因此 `get_session_manager` 作为 `session_manager_provider` 连接到传递给 `main.py` 中的 `StrandsAgent` 的 `StrandsAgentConfig` 上，因此为每个线程解析一个新的 `SessionManager`，而不是烘焙到共享模板代理中。
-</OptionFilter>
-
-<OptionFilter when={{ protocol: ['http', 'a2a'] }} description="HTTP/A2A session wiring">
-由于 `with_session_id` 已经为每个会话缓存一个 `Agent` 实例，因此 `get_session_manager` 直接在 `agent.py` 中的 `get_agent` 的 `Agent(session_manager=get_session_manager())` 调用内调用。
-</OptionFilter>
-
 会话 ID 本身来自 AgentCore Runtime 会话（通过 `x-amzn-bedrock-agentcore-runtime-session-id` 标头传播），并绑定到基于 [`contextvars.ContextVar`](https://docs.python.org/3/library/contextvars.html) 的上下文，因此 `get_current_session_id()` 可以在请求中的任何位置解析它 — 包括通过 <Link path="/guides/connection">`connection` 生成器</Link>连接的任何下游 MCP 或 A2A 客户端，因此整个调用链共享一致的会话。
 
 :::note[本地开发]
@@ -566,7 +567,7 @@ acurl <region> bedrock-agentcore -N -X POST \
 -H 'Content-Type: application/json'
 ```
 
-<Drawer title="Sigv4 enabled curl" trigger="单击此处了解有关配置上述 acurl 命令的更多详细信息">
+<Drawer title="Sigv4 enabled curl" trigger="Click here for more details on configuring the above acurl command">
 <Snippet name="tools/acurl" />
 </Drawer>
 </TabItem>
@@ -678,7 +679,7 @@ model = ChatBedrockConverse(
 <CardGrid>
   <ConnectionCard
     title="React to Python Agent"
-    description="从 React 网站调用 Python Agent"
+    description="Call a Python Agent from a React website"
     href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/react-py-agent`}
     source="react"
     target="strands"
@@ -686,14 +687,14 @@ model = ChatBedrockConverse(
   />
   <ConnectionCard
     title="React to AG-UI Agent"
-    description="通过 CopilotKit 从 React 网站调用公开 AG-UI 协议的 Agent"
+    description="Call an Agent exposing the AG-UI protocol from a React website via CopilotKit"
     href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/react-agui`}
     source="react"
     target="copilotkit"
   />
   <ConnectionCard
     title="Python Agent to MCP"
-    description="将 Python Agent 连接到 MCP 服务器"
+    description="Connect a Python Agent to an MCP server"
     href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/py-agent-mcp`}
     source="strands"
     sourceBadge="python"
@@ -701,7 +702,7 @@ model = ChatBedrockConverse(
   />
   <ConnectionCard
     title="Python Agent to A2A Agent"
-    description="将 Python Agent 连接到远程 A2A 代理"
+    description="Connect a Python Agent to a remote A2A agent"
     href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/py-agent-a2a`}
     source="strands"
     sourceBadge="python"
@@ -709,7 +710,7 @@ model = ChatBedrockConverse(
   />
   <ConnectionCard
     title="TypeScript Agent to A2A Agent"
-    description="将 TypeScript Agent 连接到远程 A2A 代理"
+    description="Connect a TypeScript Agent to a remote A2A agent"
     href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/ts-agent-a2a`}
     source="strands"
     sourceBadge="typescript"
@@ -717,7 +718,7 @@ model = ChatBedrockConverse(
   />
   <ConnectionCard
     title="Python Agent to Python DynamoDB"
-    description="将 Python Agent 连接到 DynamoDB 表"
+    description="Connect a Python Agent to a DynamoDB table"
     href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/py-agent-dynamodb`}
     source="strands"
     sourceBadge="python"
@@ -726,7 +727,7 @@ model = ChatBedrockConverse(
   />
   <ConnectionCard
     title="Python Agent to AgentCore Gateway"
-    description="将 Python Agent 连接到 AgentCore Gateway"
+    description="Connect a Python Agent to an AgentCore Gateway"
     href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/py-agent-gateway`}
     source="strands"
     sourceBadge="python"
@@ -734,7 +735,7 @@ model = ChatBedrockConverse(
   />
   <ConnectionCard
     title="AgentCore Gateway to Agent"
-    description="使用 AgentCore Gateway 作为运行时目标来前置代理"
+    description="Front an agent with an AgentCore Gateway as a runtime target"
     href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/agentcore-gateway-agent`}
     source="agentcore"
     target="strands"

--- a/packages/nx-plugin/src/migrations/latest/py-agent-session-id-middleware-extraction/metadata.json
+++ b/packages/nx-plugin/src/migrations/latest/py-agent-session-id-middleware-extraction/metadata.json
@@ -1,0 +1,3 @@
+{
+  "description": "Extract the duplicated _SessionIdMiddleware class in py#agent's main.py into a shared middleware/session_id_middleware.py module"
+}

--- a/packages/nx-plugin/src/migrations/latest/py-agent-session-id-middleware-extraction/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/latest/py-agent-session-id-middleware-extraction/migration.spec.ts
@@ -1,0 +1,411 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { addProjectConfiguration, type Tree } from '@nx/devkit';
+import { PY_AGENT_GENERATOR_INFO } from '../../../py/agent/generator';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test';
+import migration from './migration';
+
+const PROJECT_ROOT = 'apps/test-project';
+const AGENT_DIR = `${PROJECT_ROOT}/proj_test_project/agent`;
+const MAIN_PY = `${AGENT_DIR}/main.py`;
+const MIDDLEWARE_INIT_PY = `${AGENT_DIR}/middleware/__init__.py`;
+const MIDDLEWARE_PY = `${AGENT_DIR}/middleware/session_id_middleware.py`;
+
+const setUpProject = (
+  tree: Tree,
+  options: {
+    path?: string;
+    protocol?: 'http' | 'a2a' | 'ag-ui';
+    framework?: 'strands' | 'langchain';
+  } = {},
+) => {
+  addProjectConfiguration(tree, 'test-project', {
+    root: PROJECT_ROOT,
+    sourceRoot: `${PROJECT_ROOT}/proj_test_project`,
+    targets: {},
+    metadata: {
+      components: [
+        {
+          generator: PY_AGENT_GENERATOR_INFO.id,
+          path: options.path ?? 'proj_test_project/agent',
+          protocol: options.protocol ?? 'http',
+          framework: options.framework ?? 'strands',
+          rc: 'SnapshotAgent',
+        },
+      ],
+    } as any,
+  });
+};
+
+const OLD_STRANDS_HTTP_MAIN = `import uuid
+
+import uvicorn
+from bedrock_agentcore.runtime.models import PingStatus
+from fastapi import Request
+from pydantic import BaseModel, Field
+from starlette.middleware.base import BaseHTTPMiddleware
+from proj_agent_connection import session_id_context
+
+from .init import JsonStreamingResponse, app
+
+SESSION_ID_HEADER = "x-amzn-bedrock-agentcore-runtime-session-id"
+
+
+class InvokeInput(BaseModel):
+    prompt: str = Field(max_length=100000)
+
+
+class StreamChunk(BaseModel):
+    content: str
+
+
+async def handle_invoke(input: InvokeInput):
+    """Streaming handler for agent invocation"""
+    stream = app.state.agent.stream_async(input.prompt)
+    async for event in stream:
+        text = event.get("event", {}).get("contentBlockDelta", {}).get("delta", {}).get("text")
+        if text is not None:
+            yield StreamChunk(content=text)
+
+
+@app.post("/invocations")
+async def invoke(input: InvokeInput) -> JsonStreamingResponse:
+    """Entry point for agent invocation"""
+    return JsonStreamingResponse(handle_invoke(input))
+
+
+class _SessionIdMiddleware(BaseHTTPMiddleware):
+    """Bind the inbound session (or a fresh UUID) to async context."""
+
+    async def dispatch(self, request: Request, call_next):
+        session_id = request.headers.get(SESSION_ID_HEADER) or str(uuid.uuid4())
+        with session_id_context(session_id):
+            return await call_next(request)
+
+
+app.add_middleware(_SessionIdMiddleware)
+
+
+@app.get("/ping")
+def ping() -> str:
+    return PingStatus.HEALTHY
+
+
+if __name__ == "__main__":
+    uvicorn.run("proj_test_project.agent.main:app", port=8080)
+`;
+
+const OLD_STRANDS_A2A_MAIN = `import logging
+import os
+import uuid
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from typing import cast
+
+from fastapi import FastAPI, Request
+from starlette.middleware.base import BaseHTTPMiddleware
+from strands import Agent
+from strands.multiagent.a2a import A2AServer
+from proj_agent_connection import session_id_context, with_session_id
+
+from .agent import get_agent
+
+logging.basicConfig(level=logging.INFO)
+
+PORT = int(os.environ.get("PORT", "9000"))
+RUNTIME_URL = os.environ.get("AGENTCORE_RUNTIME_URL", f"http://localhost:{PORT}/")
+SESSION_ID_HEADER = "x-amzn-bedrock-agentcore-runtime-session-id"
+AGENT_NAME = "SnapshotAgent"
+AGENT_DESCRIPTION = "A Strands Agent exposed via the Agent-to-Agent (A2A) protocol."
+
+_card_placeholder = cast(
+    Agent, SimpleNamespace(name=AGENT_NAME, description=AGENT_DESCRIPTION)
+)
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    with with_session_id(
+        get_agent,
+        name=AGENT_NAME,
+        description=AGENT_DESCRIPTION,
+    ) as agent:
+        app.state.agent = agent
+        yield
+
+
+class _SessionIdMiddleware(BaseHTTPMiddleware):
+    """Bind the inbound session (or a fresh UUID) to async context."""
+
+    async def dispatch(self, request: Request, call_next):
+        session_id = request.headers.get(SESSION_ID_HEADER) or str(uuid.uuid4())
+        with session_id_context(session_id):
+            return await call_next(request)
+
+
+app = FastAPI(lifespan=lifespan)
+app.add_middleware(_SessionIdMiddleware)
+
+
+@app.get("/ping")
+def ping() -> dict[str, str]:
+    return {"status": "Healthy"}
+
+
+a2a_server = A2AServer(
+    agent_factory=lambda _context_id: getattr(app.state, "agent", _card_placeholder),
+    port=PORT,
+    http_url=RUNTIME_URL,
+    serve_at_root=True,
+    skills=[],
+)
+
+app.mount("/", a2a_server.to_fastapi_app())
+`;
+
+const OLD_STRANDS_AGUI_MAIN = `import logging
+import uuid
+from contextlib import asynccontextmanager
+
+from ag_ui.core import EventType, RunAgentInput, RunErrorEvent
+from ag_ui.encoder import EventEncoder
+from ag_ui_strands import StrandsAgent, StrandsAgentConfig
+from fastapi import FastAPI, Request
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import StreamingResponse
+from proj_agent_connection import get_current_session_id, session_id_context
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from .agent import get_agent
+from .session import get_session_manager
+
+logging.basicConfig(level=logging.INFO)
+
+SESSION_ID_HEADER = "x-amzn-bedrock-agentcore-runtime-session-id"
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    with get_agent() as agent:
+        app.state.agui_agent = StrandsAgent(
+            agent=agent,
+            name="SnapshotAgent",
+            description="A Strands Agent exposed via the AG-UI protocol.",
+            config=StrandsAgentConfig(session_manager_provider=lambda _input_data: get_session_manager()),
+        )
+        yield
+
+
+class _SessionIdMiddleware(BaseHTTPMiddleware):
+    """Bind the session ID for this request so downstream MCP / A2A clients forward it on outbound calls."""
+
+    async def dispatch(self, request: Request, call_next):
+        session_id = request.headers.get(SESSION_ID_HEADER) or str(uuid.uuid4())
+        with session_id_context(session_id):
+            return await call_next(request)
+
+
+app = FastAPI(title="AWS Strands - SnapshotAgent", lifespan=lifespan)
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+app.add_middleware(_SessionIdMiddleware)
+
+
+@app.post("/invocations")
+async def invocations(request: Request):
+    encoder = EventEncoder(accept=request.headers.get("accept") or "")
+    raw = await request.body()
+    input_data = RunAgentInput.model_validate_json(raw)
+
+    session_id = request.headers.get(SESSION_ID_HEADER) or get_current_session_id()
+
+    async def event_generator():
+        with session_id_context(session_id or str(uuid.uuid4())):
+            async for event in request.app.state.agui_agent.run(input_data):
+                yield encoder.encode(event)
+
+    return StreamingResponse(event_generator(), media_type=encoder.get_content_type())
+
+
+@app.get("/ping")
+async def ping():
+    return {"status": "healthy"}
+`;
+
+describe('py-agent-session-id-middleware-extraction migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeUsingTsSolutionSetup();
+  });
+
+  it('should do nothing when no projects contain Python agents', async () => {
+    await expect(migration(tree)).resolves.toEqual({ nextSteps: [] });
+  });
+
+  describe('Strands HTTP', () => {
+    it('should extract the middleware into a shared module', async () => {
+      setUpProject(tree, { protocol: 'http' });
+      tree.write(MAIN_PY, OLD_STRANDS_HTTP_MAIN);
+
+      const result = await migration(tree);
+      const migrated = tree.read(MAIN_PY, 'utf-8') ?? '';
+
+      expect(result.nextSteps).toEqual([]);
+      expect(migrated).not.toContain('class _SessionIdMiddleware');
+      expect(migrated).not.toContain(
+        'SESSION_ID_HEADER = "x-amzn-bedrock-agentcore-runtime-session-id"',
+      );
+      expect(migrated).toContain('app.add_middleware(SessionIdMiddleware)');
+      expect(migrated).toContain(
+        'from .middleware.session_id_middleware import SessionIdMiddleware',
+      );
+      // ruff's F401 pass prunes every import that only existed to support the
+      // now-deleted class.
+      expect(migrated).not.toContain('import uuid');
+      expect(migrated).not.toContain('Request');
+      expect(migrated).not.toContain('BaseHTTPMiddleware');
+      expect(migrated).not.toContain('session_id_context');
+
+      expect(tree.exists(MIDDLEWARE_INIT_PY)).toBe(true);
+      expect(tree.read(MIDDLEWARE_INIT_PY, 'utf-8')).toEqual('');
+
+      const middleware = tree.read(MIDDLEWARE_PY, 'utf-8') ?? '';
+      expect(middleware).toContain(
+        'class SessionIdMiddleware(BaseHTTPMiddleware):',
+      );
+      expect(middleware).toContain(
+        'from proj_agent_connection import session_id_context',
+      );
+      expect(middleware).toContain(
+        'SESSION_ID_HEADER = "x-amzn-bedrock-agentcore-runtime-session-id"',
+      );
+    });
+
+    it('should support legacy component paths ending in agent.py', async () => {
+      setUpProject(tree, {
+        protocol: 'http',
+        path: 'proj_test_project/agent/agent.py',
+      });
+      tree.write(MAIN_PY, OLD_STRANDS_HTTP_MAIN);
+
+      await migration(tree);
+
+      expect(tree.exists(MIDDLEWARE_PY)).toBe(true);
+      expect(tree.read(MAIN_PY, 'utf-8')).toContain(
+        'app.add_middleware(SessionIdMiddleware)',
+      );
+    });
+
+    it('should report a diverged generated shape without partially rewriting it', async () => {
+      setUpProject(tree, { protocol: 'http' });
+      const diverged = OLD_STRANDS_HTTP_MAIN.replace(
+        '"""Bind the inbound session (or a fresh UUID) to async context."""',
+        '"""My custom docstring."""',
+      );
+      tree.write(MAIN_PY, diverged);
+
+      const result = await migration(tree);
+      const contents = tree.read(MAIN_PY, 'utf-8') ?? '';
+
+      expect(result.nextSteps).toHaveLength(1);
+      expect(result.nextSteps[0]).toContain(MAIN_PY);
+      expect(contents).toContain('class _SessionIdMiddleware');
+      expect(contents).toContain('My custom docstring.');
+      expect(tree.exists(MIDDLEWARE_PY)).toBe(false);
+    });
+
+    it('should be idempotent', async () => {
+      setUpProject(tree, { protocol: 'http' });
+      tree.write(MAIN_PY, OLD_STRANDS_HTTP_MAIN);
+
+      await migration(tree);
+      const once = {
+        main: tree.read(MAIN_PY, 'utf-8'),
+        middleware: tree.read(MIDDLEWARE_PY, 'utf-8'),
+      };
+      const result = await migration(tree);
+
+      expect(result.nextSteps).toEqual([]);
+      expect(tree.read(MAIN_PY, 'utf-8')).toEqual(once.main);
+      expect(tree.read(MIDDLEWARE_PY, 'utf-8')).toEqual(once.middleware);
+    });
+  });
+
+  describe('Strands A2A', () => {
+    it('should extract the middleware into a shared module', async () => {
+      setUpProject(tree, { protocol: 'a2a' });
+      tree.write(MAIN_PY, OLD_STRANDS_A2A_MAIN);
+
+      const result = await migration(tree);
+      const migrated = tree.read(MAIN_PY, 'utf-8') ?? '';
+
+      expect(result.nextSteps).toEqual([]);
+      expect(migrated).not.toContain('class _SessionIdMiddleware');
+      expect(migrated).toContain('app.add_middleware(SessionIdMiddleware)');
+      expect(migrated).toContain('with_session_id(');
+      expect(tree.exists(MIDDLEWARE_PY)).toBe(true);
+    });
+  });
+
+  describe('Strands AG-UI', () => {
+    it('should extract the middleware while keeping SESSION_ID_HEADER usable', async () => {
+      setUpProject(tree, { protocol: 'ag-ui' });
+      tree.write(MAIN_PY, OLD_STRANDS_AGUI_MAIN);
+
+      const result = await migration(tree);
+      const migrated = tree.read(MAIN_PY, 'utf-8') ?? '';
+
+      expect(result.nextSteps).toEqual([]);
+      expect(migrated).not.toContain('class _SessionIdMiddleware');
+      expect(migrated).not.toContain(
+        'SESSION_ID_HEADER = "x-amzn-bedrock-agentcore-runtime-session-id"',
+      );
+      expect(migrated).toContain('app.add_middleware(SessionIdMiddleware)');
+      // Still referenced directly in the /invocations handler, so the import
+      // must survive ruff's unused-import pass, unlike HTTP/A2A above.
+      expect(migrated).toContain(
+        'from .middleware.session_id_middleware import SESSION_ID_HEADER, SessionIdMiddleware',
+      );
+      expect(migrated).toContain(
+        'session_id = request.headers.get(SESSION_ID_HEADER) or get_current_session_id()',
+      );
+
+      const middleware = tree.read(MIDDLEWARE_PY, 'utf-8') ?? '';
+      expect(middleware).toContain(
+        'Bind the session ID for this request so downstream MCP / A2A clients forward it on outbound calls.',
+      );
+    });
+
+    it('should be idempotent', async () => {
+      setUpProject(tree, { protocol: 'ag-ui' });
+      tree.write(MAIN_PY, OLD_STRANDS_AGUI_MAIN);
+
+      await migration(tree);
+      const once = tree.read(MAIN_PY, 'utf-8');
+      const result = await migration(tree);
+
+      expect(result.nextSteps).toEqual([]);
+      expect(tree.read(MAIN_PY, 'utf-8')).toEqual(once);
+    });
+  });
+
+  it('should not overwrite an already-customised shared middleware module', async () => {
+    setUpProject(tree, { protocol: 'http' });
+    tree.write(MAIN_PY, OLD_STRANDS_HTTP_MAIN);
+    tree.write(MIDDLEWARE_PY, '# customised by the user\n');
+
+    await migration(tree);
+
+    expect(tree.read(MIDDLEWARE_PY, 'utf-8')).toEqual(
+      '# customised by the user\n',
+    );
+  });
+});

--- a/packages/nx-plugin/src/migrations/latest/py-agent-session-id-middleware-extraction/migration.ts
+++ b/packages/nx-plugin/src/migrations/latest/py-agent-session-id-middleware-extraction/migration.ts
@@ -1,0 +1,211 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  getProjects,
+  joinPathFragments,
+  type MigrationReturnObject,
+  type Tree,
+} from '@nx/devkit';
+import { PY_AGENT_GENERATOR_INFO } from '../../../py/agent/generator';
+import {
+  addPythonDestructuredImport,
+  applyGritQL,
+  captureGritQLVariable,
+  matchGritQL,
+} from '../../../utils/ast';
+import { formatFilesInSubtree } from '../../../utils/format';
+import type { ComponentMetadata } from '../../../utils/nx';
+
+/**
+ * Extract the `_SessionIdMiddleware` class - previously duplicated verbatim
+ * in every py#agent `main.py` (one copy per framework/protocol combination) -
+ * into a shared `middleware/session_id_middleware.py` module sitting beside
+ * `main.py`, mirroring the http#/a2a#/ag-ui#'s own `common/agent.py` and
+ * `common/session.py` sharing pattern.
+ *
+ * The transform is protocol/framework-agnostic: every generated `main.py`
+ * duplicated the exact same `dispatch` body (only the docstring differs
+ * between AG-UI and HTTP/A2A), so one rewrite handles all six shapes. Imports
+ * that only existed to support the inlined class (`uuid`, `Request`,
+ * `BaseHTTPMiddleware`, `session_id_context`) are left for the trailing
+ * `formatFilesInSubtree` ruff pass to prune if they've gone unused - AG-UI's
+ * `main.py` still uses several of them directly, so nothing here can safely
+ * assume any one of them is dead.
+ */
+const pyMatch = (snippet: string) => `language python\n\`${snippet}\``;
+
+const pyDelete = (snippet: string) => `${pyMatch(snippet)} => .`;
+
+const pyRewrite = (from: string, to: string): string => {
+  const replacement = to.includes('\n') ? `raw\`${to}\`` : `\`${to}\``;
+  return `${pyMatch(from)} => ${replacement}`;
+};
+
+// Both frameworks import `session_id_context` from the shared agent-connection
+// module alongside other names, so this both confirms the old shape is
+// present and recovers the module name to import the new middleware from.
+const SESSION_ID_CONTEXT_MOD_CAPTURE =
+  'language python\n`from $mod import $names` where { $names <: contains `session_id_context` }';
+
+const SESSION_ID_HEADER_LINE =
+  'SESSION_ID_HEADER = "x-amzn-bedrock-agentcore-runtime-session-id"';
+
+const ADD_MIDDLEWARE_OLD = 'app.add_middleware(_SessionIdMiddleware)';
+const ADD_MIDDLEWARE_NEW = 'app.add_middleware(SessionIdMiddleware)';
+
+// HTTP and A2A share this docstring verbatim; AG-UI's differs (see below).
+const OLD_CLASS_INBOUND = `class _SessionIdMiddleware(BaseHTTPMiddleware):
+    """Bind the inbound session (or a fresh UUID) to async context."""
+
+    async def dispatch(self, request: Request, call_next):
+        session_id = request.headers.get(SESSION_ID_HEADER) or str(uuid.uuid4())
+        with session_id_context(session_id):
+            return await call_next(request)`;
+
+const OLD_CLASS_DOWNSTREAM = `class _SessionIdMiddleware(BaseHTTPMiddleware):
+    """Bind the session ID for this request so downstream MCP / A2A clients forward it on outbound calls."""
+
+    async def dispatch(self, request: Request, call_next):
+        session_id = request.headers.get(SESSION_ID_HEADER) or str(uuid.uuid4())
+        with session_id_context(session_id):
+            return await call_next(request)`;
+
+// Both framework common/ dirs vend byte-identical middleware content (the
+// LangChain copy would work equally well); this one is read as the single
+// source of truth rather than hand-duplicating it here.
+const SESSION_ID_MIDDLEWARE_TEMPLATE = readFileSync(
+  join(
+    import.meta.dirname,
+    '../../../py/agent/files/strands/common/middleware/session_id_middleware.py.template',
+  ),
+  'utf-8',
+);
+
+const sessionIdMiddlewareContent = (agentConnectionModule: string): string =>
+  SESSION_ID_MIDDLEWARE_TEMPLATE.replace(
+    '<%- agentConnectionModuleName %>',
+    agentConnectionModule,
+  );
+
+const findAgentComponents = (
+  components: ComponentMetadata[] | undefined,
+): ComponentMetadata[] =>
+  (components ?? []).filter(
+    (component) => component.generator === PY_AGENT_GENERATOR_INFO.id,
+  );
+
+const migrateMain = async (
+  tree: Tree,
+  mainPath: string,
+  component: ComponentMetadata,
+  nextSteps: string[],
+): Promise<void> => {
+  if (!tree.exists(mainPath)) return;
+
+  const contents = tree.read(mainPath, 'utf-8') ?? '';
+  if (!contents.includes('class _SessionIdMiddleware(')) return;
+
+  const oldClass = contents.includes(
+    'Bind the session ID for this request so downstream MCP / A2A clients forward it on outbound calls.',
+  )
+    ? OLD_CLASS_DOWNSTREAM
+    : OLD_CLASS_INBOUND;
+
+  const ready =
+    (await matchGritQL(tree, mainPath, pyMatch(oldClass))) &&
+    (await matchGritQL(tree, mainPath, pyMatch(SESSION_ID_HEADER_LINE))) &&
+    (await matchGritQL(tree, mainPath, pyMatch(ADD_MIDDLEWARE_OLD))) &&
+    (await matchGritQL(tree, mainPath, SESSION_ID_CONTEXT_MOD_CAPTURE));
+
+  const diverged = () => {
+    const shape = [component.framework, component.protocol]
+      .filter(Boolean)
+      .join('/');
+    nextSteps.push(
+      `${mainPath}: diverged from the generated ${shape || 'py#agent'} shape - left untouched. Manually move \`_SessionIdMiddleware\` into a sibling \`middleware/session_id_middleware.py\` module and import it from there (see the py#agent generator's template).`,
+    );
+  };
+
+  if (!ready) {
+    diverged();
+    return;
+  }
+
+  const mod = await captureGritQLVariable(
+    tree,
+    mainPath,
+    SESSION_ID_CONTEXT_MOD_CAPTURE,
+    'mod',
+  );
+  if (!mod) {
+    diverged();
+    return;
+  }
+
+  const dir = mainPath.split('/').slice(0, -1).join('/');
+  const middlewareInitPath = joinPathFragments(
+    dir,
+    'middleware',
+    '__init__.py',
+  );
+  const middlewarePath = joinPathFragments(
+    dir,
+    'middleware',
+    'session_id_middleware.py',
+  );
+
+  if (!tree.exists(middlewareInitPath)) {
+    tree.write(middlewareInitPath, '');
+  }
+  if (!tree.exists(middlewarePath)) {
+    tree.write(middlewarePath, sessionIdMiddlewareContent(mod));
+  }
+
+  await applyGritQL(tree, mainPath, pyDelete(SESSION_ID_HEADER_LINE));
+  await applyGritQL(tree, mainPath, pyDelete(oldClass));
+  await applyGritQL(
+    tree,
+    mainPath,
+    pyRewrite(ADD_MIDDLEWARE_OLD, ADD_MIDDLEWARE_NEW),
+  );
+  // Imported unconditionally - SESSION_ID_HEADER is only still referenced by
+  // AG-UI's main.py after the class is gone; the ruff pass below prunes it
+  // from HTTP/A2A's now-unused import list.
+  await addPythonDestructuredImport(
+    tree,
+    mainPath,
+    ['SESSION_ID_HEADER', 'SessionIdMiddleware'],
+    '.middleware.session_id_middleware',
+  );
+};
+
+export default async function migration(
+  tree: Tree,
+): Promise<MigrationReturnObject> {
+  const nextSteps: string[] = [];
+
+  for (const project of getProjects(tree).values()) {
+    const components = findAgentComponents(
+      (project.metadata as { components?: ComponentMetadata[] })?.components,
+    );
+
+    for (const component of components) {
+      if (!component.path) continue;
+
+      const componentDir = component.path.endsWith('/agent.py')
+        ? component.path.slice(0, -'/agent.py'.length)
+        : component.path;
+      const mainPath = joinPathFragments(project.root, componentDir, 'main.py');
+
+      await migrateMain(tree, mainPath, component, nextSteps);
+    }
+  }
+
+  await formatFilesInSubtree(tree);
+
+  return { nextSteps };
+}

--- a/packages/nx-plugin/src/py/agent/__snapshots__/generator.constructs.spec.ts.snap
+++ b/packages/nx-plugin/src/py/agent/__snapshots__/generator.constructs.spec.ts.snap
@@ -693,18 +693,12 @@ Refer to tools as your 'spellbook'.
 `;
 
 exports[`py#agent generator > should match snapshot for generated files > agent-main.py 1`] = `
-"import uuid
-
-import uvicorn
+"import uvicorn
 from bedrock_agentcore.runtime.models import PingStatus
-from fastapi import Request
-from proj_agent_connection import session_id_context
 from pydantic import BaseModel, Field
-from starlette.middleware.base import BaseHTTPMiddleware
 
 from .init import JsonStreamingResponse, app
-
-SESSION_ID_HEADER = "x-amzn-bedrock-agentcore-runtime-session-id"
+from .middleware.session_id_middleware import SessionIdMiddleware
 
 
 class InvokeInput(BaseModel):
@@ -745,16 +739,7 @@ async def invoke(input: InvokeInput) -> JsonStreamingResponse:
     return JsonStreamingResponse(handle_invoke(input))
 
 
-class _SessionIdMiddleware(BaseHTTPMiddleware):
-    """Bind the inbound session (or a fresh UUID) to async context."""
-
-    async def dispatch(self, request: Request, call_next):
-        session_id = request.headers.get(SESSION_ID_HEADER) or str(uuid.uuid4())
-        with session_id_context(session_id):
-            return await call_next(request)
-
-
-app.add_middleware(_SessionIdMiddleware)
+app.add_middleware(SessionIdMiddleware)
 
 
 @app.get("/ping")

--- a/packages/nx-plugin/src/py/agent/__snapshots__/generator.frameworks.spec.ts.snap
+++ b/packages/nx-plugin/src/py/agent/__snapshots__/generator.frameworks.spec.ts.snap
@@ -618,13 +618,11 @@ from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse, StreamingResponse
 from proj_agent_connection import get_current_session_id, session_id_context
-from starlette.middleware.base import BaseHTTPMiddleware
 
 from .agent import get_agent
+from .middleware.session_id_middleware import SESSION_ID_HEADER, SessionIdMiddleware
 
 logging.basicConfig(level=logging.INFO)
-
-SESSION_ID_HEADER = "x-amzn-bedrock-agentcore-runtime-session-id"
 
 
 @asynccontextmanager
@@ -638,15 +636,6 @@ async def lifespan(app: FastAPI):
     yield
 
 
-class _SessionIdMiddleware(BaseHTTPMiddleware):
-    """Bind the session ID for this request so downstream MCP / A2A clients forward it on outbound calls."""
-
-    async def dispatch(self, request: Request, call_next):
-        session_id = request.headers.get(SESSION_ID_HEADER) or str(uuid.uuid4())
-        with session_id_context(session_id):
-            return await call_next(request)
-
-
 app = FastAPI(title="SnapshotAgent", lifespan=lifespan)
 # Allow browser-based AG-UI clients (e.g. a connected React website) to call
 # this agent cross-origin, including the CORS preflight.
@@ -657,7 +646,7 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
-app.add_middleware(_SessionIdMiddleware)
+app.add_middleware(SessionIdMiddleware)
 
 
 @app.post("/invocations")

--- a/packages/nx-plugin/src/py/agent/files/langchain/a2a/main.py.template
+++ b/packages/nx-plugin/src/py/agent/files/langchain/a2a/main.py.template
@@ -1,6 +1,5 @@
 import logging
 import os
-import uuid
 from contextlib import asynccontextmanager
 
 from a2a.server.agent_execution import AgentExecutor, RequestContext
@@ -10,18 +9,17 @@ from a2a.server.request_handlers import DefaultRequestHandler
 from a2a.server.tasks import InMemoryTaskStore, TaskUpdater
 from a2a.types import AgentCapabilities, AgentCard, Part, TextPart
 from a2a.utils import new_task
-from fastapi import FastAPI, Request
-from starlette.middleware.base import BaseHTTPMiddleware
+from fastapi import FastAPI
 
-from <%- agentConnectionModuleName %> import get_current_session_id, session_id_context
+from <%- agentConnectionModuleName %> import get_current_session_id
 
 from .agent import get_agent
+from .middleware.session_id_middleware import SessionIdMiddleware
 
 logging.basicConfig(level=logging.INFO)
 
 PORT = int(os.environ.get("PORT", "9000"))
 RUNTIME_URL = os.environ.get("AGENTCORE_RUNTIME_URL", f"http://localhost:{PORT}/")
-SESSION_ID_HEADER = "x-amzn-bedrock-agentcore-runtime-session-id"
 DEFAULT_MODES = ["text/plain"]
 
 
@@ -73,17 +71,8 @@ _agent_card = AgentCard(
 a2a_app = A2AStarletteApplication(agent_card=_agent_card, http_handler=_handler).build()
 
 
-class _SessionIdMiddleware(BaseHTTPMiddleware):
-    """Bind the inbound session (or a fresh UUID) to async context."""
-
-    async def dispatch(self, request: Request, call_next):
-        session_id = request.headers.get(SESSION_ID_HEADER) or str(uuid.uuid4())
-        with session_id_context(session_id):
-            return await call_next(request)
-
-
 app = FastAPI(title="<%= agentNameClassName %>", lifespan=lifespan)
-app.add_middleware(_SessionIdMiddleware)
+app.add_middleware(SessionIdMiddleware)
 
 
 @app.get("/ping")

--- a/packages/nx-plugin/src/py/agent/files/langchain/ag-ui/main.py.template
+++ b/packages/nx-plugin/src/py/agent/files/langchain/ag-ui/main.py.template
@@ -10,13 +10,11 @@ from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse, StreamingResponse
 from <%- agentConnectionModuleName %> import get_current_session_id, session_id_context
-from starlette.middleware.base import BaseHTTPMiddleware
 
 from .agent import get_agent
+from .middleware.session_id_middleware import SESSION_ID_HEADER, SessionIdMiddleware
 
 logging.basicConfig(level=logging.INFO)
-
-SESSION_ID_HEADER = "x-amzn-bedrock-agentcore-runtime-session-id"
 
 
 @asynccontextmanager
@@ -30,15 +28,6 @@ async def lifespan(app: FastAPI):
     yield
 
 
-class _SessionIdMiddleware(BaseHTTPMiddleware):
-    """Bind the session ID for this request so downstream MCP / A2A clients forward it on outbound calls."""
-
-    async def dispatch(self, request: Request, call_next):
-        session_id = request.headers.get(SESSION_ID_HEADER) or str(uuid.uuid4())
-        with session_id_context(session_id):
-            return await call_next(request)
-
-
 app = FastAPI(title="<%= agentNameClassName %>", lifespan=lifespan)
 # Allow browser-based AG-UI clients (e.g. a connected React website) to call
 # this agent cross-origin, including the CORS preflight.
@@ -49,7 +38,7 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
-app.add_middleware(_SessionIdMiddleware)
+app.add_middleware(SessionIdMiddleware)
 
 
 @app.post("/invocations")

--- a/packages/nx-plugin/src/py/agent/files/langchain/common/middleware/session_id_middleware.py.template
+++ b/packages/nx-plugin/src/py/agent/files/langchain/common/middleware/session_id_middleware.py.template
@@ -1,0 +1,17 @@
+import uuid
+
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from <%- agentConnectionModuleName %> import session_id_context
+
+SESSION_ID_HEADER = "x-amzn-bedrock-agentcore-runtime-session-id"
+
+
+class SessionIdMiddleware(BaseHTTPMiddleware):
+    """Bind the session ID for this request so downstream MCP / A2A clients forward it on outbound calls."""
+
+    async def dispatch(self, request: Request, call_next):
+        session_id = request.headers.get(SESSION_ID_HEADER) or str(uuid.uuid4())
+        with session_id_context(session_id):
+            return await call_next(request)

--- a/packages/nx-plugin/src/py/agent/files/langchain/http/main.py.template
+++ b/packages/nx-plugin/src/py/agent/files/langchain/http/main.py.template
@@ -2,14 +2,11 @@ import uuid
 
 import uvicorn
 from bedrock_agentcore.runtime.models import PingStatus
-from fastapi import Request
 from pydantic import BaseModel, Field
-from starlette.middleware.base import BaseHTTPMiddleware
 from <%- agentConnectionModuleName %> import get_current_session_id, session_id_context
 
 from .init import JsonStreamingResponse, app
-
-SESSION_ID_HEADER = "x-amzn-bedrock-agentcore-runtime-session-id"
+from .middleware.session_id_middleware import SessionIdMiddleware
 
 
 class InvokeInput(BaseModel):
@@ -59,16 +56,7 @@ async def invoke(input: InvokeInput) -> JsonStreamingResponse:
     return JsonStreamingResponse(handle_invoke(input, session_id))
 
 
-class _SessionIdMiddleware(BaseHTTPMiddleware):
-    """Bind the inbound session (or a fresh UUID) to async context."""
-
-    async def dispatch(self, request: Request, call_next):
-        session_id = request.headers.get(SESSION_ID_HEADER) or str(uuid.uuid4())
-        with session_id_context(session_id):
-            return await call_next(request)
-
-
-app.add_middleware(_SessionIdMiddleware)
+app.add_middleware(SessionIdMiddleware)
 
 
 @app.get("/ping")

--- a/packages/nx-plugin/src/py/agent/files/strands/a2a/main.py.template
+++ b/packages/nx-plugin/src/py/agent/files/strands/a2a/main.py.template
@@ -1,23 +1,21 @@
 import logging
 import os
-import uuid
 from contextlib import asynccontextmanager
 from types import SimpleNamespace
 from typing import cast
 
-from fastapi import FastAPI, Request
-from starlette.middleware.base import BaseHTTPMiddleware
+from fastapi import FastAPI
 from strands import Agent
 from strands.multiagent.a2a import A2AServer
-from <%- agentConnectionModuleName %> import session_id_context, with_session_id
+from <%- agentConnectionModuleName %> import with_session_id
 
 from .agent import get_agent
+from .middleware.session_id_middleware import SessionIdMiddleware
 
 logging.basicConfig(level=logging.INFO)
 
 PORT = int(os.environ.get("PORT", "9000"))
 RUNTIME_URL = os.environ.get("AGENTCORE_RUNTIME_URL", f"http://localhost:{PORT}/")
-SESSION_ID_HEADER = "x-amzn-bedrock-agentcore-runtime-session-id"
 AGENT_NAME = "<%= agentNameClassName %>"
 AGENT_DESCRIPTION = "A Strands Agent exposed via the Agent-to-Agent (A2A) protocol."
 
@@ -41,17 +39,8 @@ async def lifespan(app: FastAPI):
         yield
 
 
-class _SessionIdMiddleware(BaseHTTPMiddleware):
-    """Bind the inbound session (or a fresh UUID) to async context."""
-
-    async def dispatch(self, request: Request, call_next):
-        session_id = request.headers.get(SESSION_ID_HEADER) or str(uuid.uuid4())
-        with session_id_context(session_id):
-            return await call_next(request)
-
-
 app = FastAPI(lifespan=lifespan)
-app.add_middleware(_SessionIdMiddleware)
+app.add_middleware(SessionIdMiddleware)
 
 
 @app.get("/ping")

--- a/packages/nx-plugin/src/py/agent/files/strands/ag-ui/main.py.template
+++ b/packages/nx-plugin/src/py/agent/files/strands/ag-ui/main.py.template
@@ -9,14 +9,12 @@ from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import StreamingResponse
 from <%- agentConnectionModuleName %> import get_current_session_id, session_id_context
-from starlette.middleware.base import BaseHTTPMiddleware
 
 from .agent import get_agent
+from .middleware.session_id_middleware import SESSION_ID_HEADER, SessionIdMiddleware
 from .session import get_session_manager
 
 logging.basicConfig(level=logging.INFO)
-
-SESSION_ID_HEADER = "x-amzn-bedrock-agentcore-runtime-session-id"
 
 
 @asynccontextmanager
@@ -33,15 +31,6 @@ async def lifespan(app: FastAPI):
         yield
 
 
-class _SessionIdMiddleware(BaseHTTPMiddleware):
-    """Bind the session ID for this request so downstream MCP / A2A clients forward it on outbound calls."""
-
-    async def dispatch(self, request: Request, call_next):
-        session_id = request.headers.get(SESSION_ID_HEADER) or str(uuid.uuid4())
-        with session_id_context(session_id):
-            return await call_next(request)
-
-
 app = FastAPI(title="AWS Strands - <%= agentNameClassName %>", lifespan=lifespan)
 app.add_middleware(
     CORSMiddleware,
@@ -50,7 +39,7 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
-app.add_middleware(_SessionIdMiddleware)
+app.add_middleware(SessionIdMiddleware)
 
 
 @app.post("/invocations")

--- a/packages/nx-plugin/src/py/agent/files/strands/common/middleware/session_id_middleware.py.template
+++ b/packages/nx-plugin/src/py/agent/files/strands/common/middleware/session_id_middleware.py.template
@@ -1,0 +1,17 @@
+import uuid
+
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from <%- agentConnectionModuleName %> import session_id_context
+
+SESSION_ID_HEADER = "x-amzn-bedrock-agentcore-runtime-session-id"
+
+
+class SessionIdMiddleware(BaseHTTPMiddleware):
+    """Bind the session ID for this request so downstream MCP / A2A clients forward it on outbound calls."""
+
+    async def dispatch(self, request: Request, call_next):
+        session_id = request.headers.get(SESSION_ID_HEADER) or str(uuid.uuid4())
+        with session_id_context(session_id):
+            return await call_next(request)

--- a/packages/nx-plugin/src/py/agent/files/strands/http/main.py.template
+++ b/packages/nx-plugin/src/py/agent/files/strands/http/main.py.template
@@ -1,15 +1,9 @@
-import uuid
-
 import uvicorn
 from bedrock_agentcore.runtime.models import PingStatus
-from fastapi import Request
 from pydantic import BaseModel, Field
-from starlette.middleware.base import BaseHTTPMiddleware
-from <%- agentConnectionModuleName %> import session_id_context
 
 from .init import JsonStreamingResponse, app
-
-SESSION_ID_HEADER = "x-amzn-bedrock-agentcore-runtime-session-id"
+from .middleware.session_id_middleware import SessionIdMiddleware
 
 
 class InvokeInput(BaseModel):
@@ -41,16 +35,7 @@ async def invoke(input: InvokeInput) -> JsonStreamingResponse:
     return JsonStreamingResponse(handle_invoke(input))
 
 
-class _SessionIdMiddleware(BaseHTTPMiddleware):
-    """Bind the inbound session (or a fresh UUID) to async context."""
-
-    async def dispatch(self, request: Request, call_next):
-        session_id = request.headers.get(SESSION_ID_HEADER) or str(uuid.uuid4())
-        with session_id_context(session_id):
-            return await call_next(request)
-
-
-app.add_middleware(_SessionIdMiddleware)
+app.add_middleware(SessionIdMiddleware)
 
 
 @app.get("/ping")

--- a/packages/nx-plugin/src/py/agent/generator.frameworks.spec.ts
+++ b/packages/nx-plugin/src/py/agent/generator.frameworks.spec.ts
@@ -70,9 +70,17 @@ dev-dependencies = []
     // so downstream MCP / A2A connection clients forward it on outbound
     // calls. (AG-UI handles its own per-thread conversation isolation, so
     // we don't wrap the agent in `with_session_id` here — only the
-    // downstream forwarding path matters.)
+    // downstream forwarding path matters.) The binding middleware itself
+    // lives in a shared module rather than being defined inline.
     expect(mainContent).toContain('session_id_context');
     expect(mainContent).toContain(
+      'from .middleware.session_id_middleware import SESSION_ID_HEADER, SessionIdMiddleware',
+    );
+    const middlewareContent = tree.read(
+      'apps/test-project/proj_test_project/agent/middleware/session_id_middleware.py',
+      'utf-8',
+    );
+    expect(middlewareContent).toContain(
       'x-amzn-bedrock-agentcore-runtime-session-id',
     );
 
@@ -381,9 +389,17 @@ dev-dependencies = []
       expect(mainContent).not.toContain('create_strands_app');
       expect(mainContent).not.toContain('StrandsAgent');
 
-      // The session ID is still bound for downstream forwarding.
+      // The session ID is still bound for downstream forwarding, via the
+      // shared middleware module rather than an inline class.
       expect(mainContent).toContain('session_id_context');
       expect(mainContent).toContain(
+        'from .middleware.session_id_middleware import SESSION_ID_HEADER, SessionIdMiddleware',
+      );
+      const middlewareContent = tree.read(
+        'apps/test-project/proj_test_project/agent/middleware/session_id_middleware.py',
+        'utf-8',
+      );
+      expect(middlewareContent).toContain(
         'x-amzn-bedrock-agentcore-runtime-session-id',
       );
 
@@ -500,10 +516,12 @@ dev-dependencies = []
       );
       expect(mainContent).toContain('get_agent');
       expect(mainContent).toContain('/ping');
-      expect(mainContent).toContain('session_id_context');
+      // The session-binding middleware itself lives in a shared module (see
+      // below), imported rather than defined inline.
       expect(mainContent).toContain(
-        'x-amzn-bedrock-agentcore-runtime-session-id',
+        'from .middleware.session_id_middleware import SessionIdMiddleware',
       );
+      expect(mainContent).toContain('app.add_middleware(SessionIdMiddleware)');
       // The graph reply is published as a task artifact so streaming A2A clients
       // (e.g. the chat CLI) render it.
       expect(mainContent).toContain('add_artifact');
@@ -512,6 +530,20 @@ dev-dependencies = []
       expect(mainContent).not.toContain('strands.multiagent.a2a');
       expect(mainContent).not.toContain('A2AServer');
       expect(mainContent).not.toContain('from strands');
+
+      // The shared middleware module binds the inbound session (or a fresh
+      // UUID) to async context for every framework/protocol combination.
+      const middlewareContent = tree.read(
+        'apps/test-project/proj_test_project/agent/middleware/session_id_middleware.py',
+        'utf-8',
+      );
+      expect(middlewareContent).toContain('session_id_context');
+      expect(middlewareContent).toContain(
+        'x-amzn-bedrock-agentcore-runtime-session-id',
+      );
+      expect(middlewareContent).toContain(
+        'class SessionIdMiddleware(BaseHTTPMiddleware):',
+      );
     });
 
     it('should add per-protocol langchain dependencies', async () => {


### PR DESCRIPTION
### Reason for this change

The `py#agent` generator's templates defined an identical `_SessionIdMiddleware` class inline across all six framework/protocol combinations (Strands/LangChain × HTTP/A2A/AG-UI) — byte-for-byte the same `dispatch` body, only the docstring differed for AG-UI. Refactor it into one shared module in each framework's `common/` folder to reduce the duplication.

### Description of changes

- Extracted the middleware into a new `middleware/session_id_middleware.py` module (with a sibling `__init__.py`), generated once per framework's `common/` dir alongside `agent.py`/`session.py`, so it's shared across all three protocols within a framework.
- Renamed `_SessionIdMiddleware` → `SessionIdMiddleware` now that it's a proper shared export, and standardized the docstring.
- Updated all six `main.py.template` files to import `SessionIdMiddleware` (and `SESSION_ID_HEADER` where still referenced directly, i.e. AG-UI) from the new module instead of defining the class inline.
- Added a deterministic migration (`py-agent-session-id-middleware-extraction`) so existing workspaces get the same shape. It's a single protocol/framework-agnostic transform: back-fills the shared module, deletes the old class/`SESSION_ID_HEADER` assignment, rewrites `app.add_middleware(...)`, and adds the new import — leaving the trailing ruff format pass to prune whichever of `uuid`/`Request`/`BaseHTTPMiddleware`/`session_id_context` end up unused per shape. Diverged files are reported via `nextSteps`, not rewritten.
- Updated docs: `py-agent.mdx`'s generated-file trees for all three protocols, and the dungeon-game tutorial (Module 1) code sample, file tree, and prose — translated into all configured locales (jp, ko, es, pt, fr, it, zh, vi).

### Description of how you validated changes

- Added `migration.spec.ts` (9 tests): Strands HTTP/A2A/AG-UI extraction, legacy `component.path` support, divergence detection, idempotency, and not clobbering an already-customized middleware module.
- Updated `generator.frameworks.spec.ts` assertions that checked for `session_id_context`/the header literal directly in `main.py` to check the new middleware module instead (`session_id_context`/header now live there for HTTP/A2A; AG-UI still references `SESSION_ID_HEADER` via the new import).
- `generator.frameworks.spec.ts` (22 tests) and `generator.constructs.spec.ts` (28 tests) pass.
- Confirmed the dungeon-game e2e smoke test needs no changes — it has no pinned `main.py` fixture, and its live `/invocations` HTTP check exercises the same (unchanged) runtime behavior.
- Validated end-to-end in a real project: [`862d120`](https://github.com/AlexTo/py-agent-session-manager/commit/862d1205813b6130d68150256048ada9ebcb1117)

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*