### PR TITLE
docs: lead build with AI quick start with workspace creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,100 +32,18 @@
 
 ### Build with AI
 
-Add the MCP server to your AI assistant and let it build for you.
+**1. Create a workspace**
 
 ```bash
-claude mcp add nx-plugin-for-aws -- npx -y @aws/nx-plugin-mcp
+pnpm create @aws/nx-workspace my-project
+cd my-project
 ```
 
-<details>
-<summary><strong>Kiro</strong></summary>
+**2. Open your AI assistant in the created workspace and prompt it**
 
-Install the [Kiro Power](https://kiro.dev/docs/powers/) for the best experience — no manual MCP configuration needed:
+> _"Use the Nx Plugin for AWS to build a full-stack application consisting of a React website with shadcn and Cognito authentication, connected to a TypeScript Strands agent via the AG-UI protocol, and infrastructure to deploy it."_
 
-1. Open the Kiro Powers panel from the sidebar
-2. Click `+` to add a custom power
-3. Paste: `https://github.com/awslabs/nx-plugin-for-aws/tree/main/powers/nx-plugin-for-aws`
-4. Click install
-
-Or add the MCP server manually in `.kiro/mcp.json`:
-
-```json
-{
-  "mcpServers": {
-    "nx-plugin-for-aws": {
-      "command": "npx",
-      "args": ["-y", "@aws/nx-plugin-mcp"]
-    }
-  }
-}
-```
-
-</details>
-
-<details>
-<summary><strong>Claude Code</strong></summary>
-
-```bash
-claude mcp add nx-plugin-for-aws -- npx -y @aws/nx-plugin-mcp
-```
-
-</details>
-
-<details>
-<summary><strong>Cursor</strong></summary>
-
-Add to `~/.cursor/mcp.json`:
-
-```json
-{
-  "mcpServers": {
-    "nx-plugin-for-aws": {
-      "command": "npx",
-      "args": ["-y", "@aws/nx-plugin-mcp"]
-    }
-  }
-}
-```
-
-</details>
-
-<details>
-<summary><strong>Codex</strong></summary>
-
-Add to `~/.codex/config.toml`:
-
-```toml
-[mcp_servers.nx-plugin-for-aws]
-command = "npx"
-args = ["-y", "@aws/nx-plugin-mcp"]
-```
-
-</details>
-
-<details>
-<summary><strong>Other assistants</strong></summary>
-
-Most MCP-compatible assistants use a JSON configuration file. Add the following entry:
-
-```json
-{
-  "mcpServers": {
-    "nx-plugin-for-aws": {
-      "command": "npx",
-      "args": ["-y", "@aws/nx-plugin-mcp"]
-    }
-  }
-}
-```
-
-</details>
-
-Then just ask:
-
-> _"Use the Nx Plugin for AWS to build a full-stack app with a React website, a tRPC API, Cognito auth, and CDK infrastructure."_
-
-Your AI assistant will use the MCP tools to scaffold, connect, and configure everything. See the [Building with AI guide](https://awslabs.github.io/nx-plugin-for-aws/en/get_started/building-with-ai/) for more details.
+Your AI assistant will use the Nx Plugin for AWS MCP server, which is preconfigured in every workspace you create with the command above, to scaffold, connect, and configure everything. See the [Building with AI guide](https://awslabs.github.io/nx-plugin-for-aws/en/get_started/building-with-ai/) for more details.
 
 ### Build with the CLI
 

--- a/packages/nx-plugin/README.md
+++ b/packages/nx-plugin/README.md
@@ -32,100 +32,18 @@
 
 ### Build with AI
 
-Add the MCP server to your AI assistant and let it build for you.
+**1. Create a workspace**
 
 ```bash
-claude mcp add nx-plugin-for-aws -- npx -y @aws/nx-plugin-mcp
+pnpm create @aws/nx-workspace my-project
+cd my-project
 ```
 
-<details>
-<summary><strong>Kiro</strong></summary>
+**2. Open your AI assistant in the created workspace and prompt it**
 
-Install the [Kiro Power](https://kiro.dev/docs/powers/) for the best experience — no manual MCP configuration needed:
+> _"Use the Nx Plugin for AWS to build a full-stack application consisting of a React website with shadcn and Cognito authentication, connected to a TypeScript Strands agent via the AG-UI protocol, and infrastructure to deploy it."_
 
-1. Open the Kiro Powers panel from the sidebar
-2. Click `+` to add a custom power
-3. Paste: `https://github.com/awslabs/nx-plugin-for-aws/tree/main/powers/nx-plugin-for-aws`
-4. Click install
-
-Or add the MCP server manually in `.kiro/mcp.json`:
-
-```json
-{
-  "mcpServers": {
-    "nx-plugin-for-aws": {
-      "command": "npx",
-      "args": ["-y", "@aws/nx-plugin-mcp"]
-    }
-  }
-}
-```
-
-</details>
-
-<details>
-<summary><strong>Claude Code</strong></summary>
-
-```bash
-claude mcp add nx-plugin-for-aws -- npx -y @aws/nx-plugin-mcp
-```
-
-</details>
-
-<details>
-<summary><strong>Cursor</strong></summary>
-
-Add to `~/.cursor/mcp.json`:
-
-```json
-{
-  "mcpServers": {
-    "nx-plugin-for-aws": {
-      "command": "npx",
-      "args": ["-y", "@aws/nx-plugin-mcp"]
-    }
-  }
-}
-```
-
-</details>
-
-<details>
-<summary><strong>Codex</strong></summary>
-
-Add to `~/.codex/config.toml`:
-
-```toml
-[mcp_servers.nx-plugin-for-aws]
-command = "npx"
-args = ["-y", "@aws/nx-plugin-mcp"]
-```
-
-</details>
-
-<details>
-<summary><strong>Other assistants</strong></summary>
-
-Most MCP-compatible assistants use a JSON configuration file. Add the following entry:
-
-```json
-{
-  "mcpServers": {
-    "nx-plugin-for-aws": {
-      "command": "npx",
-      "args": ["-y", "@aws/nx-plugin-mcp"]
-    }
-  }
-}
-```
-
-</details>
-
-Then just ask:
-
-> _"Use the Nx Plugin for AWS to build a full-stack app with a React website, a tRPC API, Cognito auth, and CDK infrastructure."_
-
-Your AI assistant will use the MCP tools to scaffold, connect, and configure everything. See the [Building with AI guide](https://awslabs.github.io/nx-plugin-for-aws/en/get_started/building-with-ai/) for more details.
+Your AI assistant will use the Nx Plugin for AWS MCP server, which is preconfigured in every workspace you create with the command above, to scaffold, connect, and configure everything. See the [Building with AI guide](https://awslabs.github.io/nx-plugin-for-aws/en/get_started/building-with-ai/) for more details.
 
 ### Build with the CLI
 


### PR DESCRIPTION
### Reason for this change

The "Build with AI" quick start jumped straight to MCP server configuration without telling the user to create a workspace first, leaving it unclear where the AI assistant should be run. The MCP configuration instructions are also redundant now that the MCP server is preconfigured in generated workspaces, and the example prompt did not showcase the more compelling capabilities of the plugin.

### Description of changes

Restructured the "Build with AI" section of the README into two numbered steps:

1. Create a workspace with `pnpm create @aws/nx-workspace my-project`
2. Open your AI assistant in the created workspace and prompt it

Removed the per-assistant MCP configuration instructions (Kiro / Claude Code / Cursor / Codex / other), noting instead that the MCP server is preconfigured in every workspace created with the command above.

Updated the example prompt to:

> _"Use the Nx Plugin for AWS to build a full-stack application consisting of a React website with shadcn and Cognito authentication, connected to a TypeScript Strands agent via the AG-UI protocol, and infrastructure to deploy it."_

Applied to both `README.md` and `packages/nx-plugin/README.md`, which are kept identical.

### Description of how you validated changes

Documentation-only change. Verified the rendered markdown structure and that the root and package READMEs remain byte-identical.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
