### PR TITLE
test(internal#test-matrix): cover smithy#project and agentcore-harness

### DIFF
--- a/packages/nx-plugin/src/internal/test-matrix/generator.ts
+++ b/packages/nx-plugin/src/internal/test-matrix/generator.ts
@@ -4,6 +4,7 @@
  */
 import type { GeneratorCallback, Tree } from '@nx/devkit';
 import { agentcoreGatewayGenerator } from '../../sdk/agentcore-gateway';
+import { agentcoreHarnessGenerator } from '../../sdk/agentcore-harness';
 import {
   type ConnectionGeneratorSchema,
   connectionGenerator,
@@ -21,6 +22,7 @@ import {
   pyProjectGenerator,
   pyRdbGenerator,
 } from '../../sdk/py';
+import { smithyProjectGenerator } from '../../sdk/smithy';
 import { terraformProjectGenerator } from '../../sdk/terraform';
 import {
   type TsAgentGeneratorSchema,
@@ -157,6 +159,13 @@ export const internalTestMatrixGenerator = async (
   for (const api of tsApis) {
     await tsApiGenerator(tree, { ...api, ...projectDefaults });
   }
+
+  // A Smithy shape library; `my-smithy-api` covers consuming one.
+  await smithyProjectGenerator(tree, {
+    name: 'my-shapes',
+    type: 'shapes',
+    ...projectDefaults,
+  });
 
   // Python FastAPI — REST + HTTP, with Cognito and custom auth.
   const pyApis: PyApiGeneratorSchema[] = [
@@ -353,6 +362,14 @@ export const internalTestMatrixGenerator = async (
   await agentcoreGatewayGenerator(tree, {
     name: 'agent-gateway',
     protocol: 'http',
+    iac: 'inherit',
+    ...projectDefaults,
+  });
+
+  // AgentCore Harness — a standalone invocation project.
+  await agentcoreHarnessGenerator(tree, {
+    name: 'my-harness',
+    infra: 'agentcore',
     iac: 'inherit',
     ...projectDefaults,
   });

--- a/packages/nx-plugin/src/sdk/agentcore-harness.ts
+++ b/packages/nx-plugin/src/sdk/agentcore-harness.ts
@@ -1,0 +1,8 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// AgentCore Harness Generator
+export { agentcoreHarnessGenerator } from '../agentcore-harness/generator';
+export type { AgentcoreHarnessGeneratorSchema } from '../agentcore-harness/schema';

--- a/packages/nx-plugin/src/sdk/smithy.ts
+++ b/packages/nx-plugin/src/sdk/smithy.ts
@@ -1,0 +1,8 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Smithy Project Generator
+export { smithyProjectGenerator } from '../smithy/project/generator';
+export type { SmithyProjectGeneratorSchema } from '../smithy/project/schema';


### PR DESCRIPTION
### Reason for this change

[CONTRIBUTING.md](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md#end-to-end-tests) requires every new generator to be added to **both** generator matrices, but two generators were only present in one of them.

`e2e/src/smoke-tests/generator-matrix.ts` exercises these; `packages/nx-plugin/src/internal/test-matrix/generator.ts` did not:

- `smithy#project --type=shapes` — the standalone Smithy shapes library. (`ts#api --framework=smithy` covers the *service* case, so what was uncovered is specifically the shapes library project.)
- `agentcore-harness` — not covered at all.

Since `internal#test-matrix` ships with the plugin and is what upgrade/migration tests scaffold with, a released version's matrix silently omitted both generators — so migrations touching them were never exercised across a version hop.

Nothing enforces parity between the two matrices, so this drift was only visible by diffing them by hand.

### Description of changes

- Added `packages/nx-plugin/src/sdk/smithy.ts` and `packages/nx-plugin/src/sdk/agentcore-harness.ts`. Neither generator was re-exported from the SDK surface, which is where `internal#test-matrix` composes its generators from, so the calls weren't expressible without them. These follow the existing single-generator SDK entry points (`agentcore-gateway.ts`, `terraform.ts`).
- Added the two composed calls to `internal#test-matrix`, matching the names and options the CLI matrix uses (`my-shapes` / `type: 'shapes'`, and `my-harness`), so both lanes scaffold the same workspace.

Harness -> Gateway and Harness -> MCP connections are separate generators and remain out of both matrices, unchanged by this PR.

### Description of how you validated changes

- `pnpm nx run @aws/nx-plugin:build` — passes, including the full unit suite (3563 tests, 190 files). The matrix options are typed against each generator's schema, so the composed calls are checked at build time.
- Re-diffed both matrices programmatically: all 43 `connection` invocations and every per-generator invocation count now correspond one-for-one in both directions, with only the documented intentional asymmetries remaining (the test-matrix generates its own `ts#infra`/`terraform#project` because it composes onto a bare tree; the CLI matrix additionally runs the *generated* `@e2e-test/plugin:my#generator`, which has no in-process equivalent).
- `pnpm nx run-many --target lint --projects=@aws/nx-plugin --fix` — clean.
- The behavioural check for this change is the `test-matrix` smoke test, which runs `internal#test-matrix` in a real workspace and builds it. It takes tens of minutes and is part of the CI matrix in `pr.yml`, so I am relying on CI for it rather than a local run, and will iterate on failures.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*