### PR TITLE
refactor(ts#agent): extract session-id middleware into a shared module

### DIFF
--- a/packages/nx-plugin/src/migrations/latest/ts-agent-session-id-middleware-extraction/metadata.json
+++ b/packages/nx-plugin/src/migrations/latest/ts-agent-session-id-middleware-extraction/metadata.json
@@ -1,0 +1,3 @@
+{
+  "description": "Extract the duplicated session-id Express middleware in ts#agent's ag-ui/a2a index.ts into a shared middleware/session-id-middleware.ts module"
+}

--- a/packages/nx-plugin/src/migrations/latest/ts-agent-session-id-middleware-extraction/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/latest/ts-agent-session-id-middleware-extraction/migration.spec.ts
@@ -1,0 +1,296 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { addProjectConfiguration, type Tree } from '@nx/devkit';
+import { TS_AGENT_GENERATOR_INFO } from '../../../ts/agent/generator';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test';
+import migration from './migration';
+
+const registerAgentProject = (
+  tree: Tree,
+  name: string,
+  root: string,
+  protocol: string,
+  agentDir = 'src/agent',
+) =>
+  addProjectConfiguration(tree, name, {
+    root,
+    metadata: {
+      components: [
+        {
+          generator: TS_AGENT_GENERATOR_INFO.id,
+          path: agentDir,
+          rc: 'MyAgent',
+          protocol,
+        },
+      ],
+    } as any,
+  });
+
+// Exact shape produced by biome's formatter on the previously-generated
+// (pre-extraction) template, wrapped onto multiple lines.
+const OLD_A2A_INDEX = `import { A2AExpressServer } from '@strands-agents/sdk/a2a/express';
+import express, {
+  type Request,
+  type Response,
+  type NextFunction,
+} from 'express';
+import { randomUUID } from 'node:crypto';
+import {
+  runWithSessionId,
+  withSessionId,
+} from '@my-ts-agents/agent-connection';
+import { getAgent } from './agent.js';
+
+const PORT = parseInt(process.env.PORT || '9000');
+const HOST = '0.0.0.0';
+
+const SESSION_ID_HEADER = 'x-amzn-bedrock-agentcore-runtime-session-id';
+
+void (async () => {
+  const httpUrl =
+    process.env.AGENTCORE_RUNTIME_URL ?? \`http://localhost:\${PORT}/\`;
+
+  const server = new A2AExpressServer({
+    agent: withSessionId(getAgent),
+    name: 'A2a',
+    description:
+      'A Strands Agent exposed via the Agent-to-Agent (A2A) protocol.',
+    host: HOST,
+    port: PORT,
+    httpUrl,
+  });
+
+  const app = express();
+  app.get('/ping', (_req, res) => res.status(200).json({ status: 'Healthy' }));
+  // Bind the inbound session (or a fresh UUID) for downstream MCP / A2A calls.
+  app.use((req: Request, _res: Response, next: NextFunction) => {
+    const header = req.headers[SESSION_ID_HEADER];
+    const sessionId =
+      (Array.isArray(header) ? header[0] : header) ?? randomUUID();
+    runWithSessionId(sessionId, () => next());
+  });
+  app.use(server.createMiddleware());
+  app.listen(PORT, HOST, () => {
+    console.log(\`A2A server listening on \${HOST}:\${PORT}\`);
+  });
+})();
+`;
+
+const OLD_AGUI_INDEX = `import { StrandsAgent } from '@ag-ui/aws-strands';
+import {
+  addStrandsExpressEndpoint,
+  addPing,
+  addCapabilities,
+} from '@ag-ui/aws-strands/server';
+import express, {
+  type Request,
+  type Response,
+  type NextFunction,
+} from 'express';
+import cors from 'cors';
+import { randomUUID } from 'node:crypto';
+import {
+  ModelErrorLoggingPlugin,
+  ToolErrorLoggingPlugin,
+  runWithSessionId,
+} from '@my-ts-agents/agent-connection';
+import { getAgent } from './agent.js';
+import { getSessionManager } from './session.js';
+
+const PORT = parseInt(process.env.PORT || '8080');
+const HOST = '0.0.0.0';
+
+const SESSION_ID_HEADER = 'x-amzn-bedrock-agentcore-runtime-session-id';
+
+// Bind the inbound session (or a fresh UUID) for downstream MCP / A2A calls.
+const sessionIdMiddleware = (
+  req: Request,
+  _res: Response,
+  next: NextFunction,
+) => {
+  const header = req.headers[SESSION_ID_HEADER];
+  const sessionId =
+    (Array.isArray(header) ? header[0] : header) ?? randomUUID();
+  runWithSessionId(sessionId, () => next());
+};
+
+void (async () => {
+  const agent = await getAgent();
+
+  // Connect MCP clients and register their tools so StrandsAgent can discover them.
+  await agent.initialize();
+
+  const aguiAgent = new StrandsAgent({
+    agent,
+    name: 'Agui',
+    description: 'A Strands Agent exposed via the AG-UI protocol.',
+    plugins: [new ModelErrorLoggingPlugin(), new ToolErrorLoggingPlugin()],
+    config: {
+      sessionManagerProvider: getSessionManager,
+    },
+  });
+
+  // Built up manually (mirroring createStrandsApp's defaults) rather than via createStrandsApp
+  // https://github.com/ag-ui-protocol/ag-ui/blob/main/integrations/aws-strands/typescript/src/server.ts
+  const app = express();
+  app.use(cors({ origin: '*', credentials: true }));
+  app.use(express.json({ limit: '50mb' }));
+
+  addPing(app, '/ping');
+  addCapabilities(app, '/capabilities', { agent: aguiAgent });
+
+  app.use(sessionIdMiddleware);
+
+  addStrandsExpressEndpoint(app, aguiAgent, { path: '/invocations' });
+
+  app.listen(PORT, HOST, () => {
+    console.log(\`AG-UI server listening on \${HOST}:\${PORT}\`);
+  });
+})();
+`;
+
+describe('ts#agent session-id middleware extraction migration', () => {
+  it('should extract A2A middleware into a shared module', async () => {
+    const tree = createTreeUsingTsSolutionSetup();
+    registerAgentProject(tree, 'agents', 'packages/agents', 'a2a', 'src/a2a');
+    tree.write('packages/agents/src/a2a/index.ts', OLD_A2A_INDEX);
+
+    const result = await migration(tree);
+
+    expect(result.nextSteps).toEqual([]);
+
+    const indexContent = tree.read('packages/agents/src/a2a/index.ts', 'utf-8');
+    expect(indexContent).toContain(
+      "import { sessionIdMiddleware } from './middleware/session-id-middleware.js';",
+    );
+    expect(indexContent).toContain("import express from 'express';");
+    expect(indexContent).toContain('app.use(sessionIdMiddleware);');
+    expect(indexContent).not.toContain('SESSION_ID_HEADER');
+    expect(indexContent).not.toContain('randomUUID');
+    expect(indexContent).not.toContain('runWithSessionId');
+    expect(indexContent).toContain(
+      "import { withSessionId } from '@my-ts-agents/agent-connection';",
+    );
+
+    const middlewareContent = tree.read(
+      'packages/agents/src/a2a/middleware/session-id-middleware.ts',
+      'utf-8',
+    );
+    expect(middlewareContent).toContain(
+      "import { runWithSessionId } from '@my-ts-agents/agent-connection';",
+    );
+    expect(middlewareContent).toContain('export const sessionIdMiddleware');
+  });
+
+  it('should extract AG-UI middleware into a shared module', async () => {
+    const tree = createTreeUsingTsSolutionSetup();
+    registerAgentProject(
+      tree,
+      'agents',
+      'packages/agents',
+      'ag-ui',
+      'src/agui',
+    );
+    tree.write('packages/agents/src/agui/index.ts', OLD_AGUI_INDEX);
+
+    const result = await migration(tree);
+
+    expect(result.nextSteps).toEqual([]);
+
+    const indexContent = tree.read(
+      'packages/agents/src/agui/index.ts',
+      'utf-8',
+    );
+    expect(indexContent).toContain(
+      "import { sessionIdMiddleware } from './middleware/session-id-middleware.js';",
+    );
+    expect(indexContent).toContain("import express from 'express';");
+    expect(indexContent).toContain('app.use(sessionIdMiddleware);');
+    expect(indexContent).not.toContain('SESSION_ID_HEADER');
+    expect(indexContent).not.toContain('randomUUID');
+    expect(indexContent).not.toContain('runWithSessionId');
+    expect(indexContent).toContain(
+      "import {\n  ModelErrorLoggingPlugin,\n  ToolErrorLoggingPlugin,\n} from '@my-ts-agents/agent-connection';",
+    );
+
+    const middlewareContent = tree.read(
+      'packages/agents/src/agui/middleware/session-id-middleware.ts',
+      'utf-8',
+    );
+    expect(middlewareContent).toContain(
+      "import { runWithSessionId } from '@my-ts-agents/agent-connection';",
+    );
+    expect(middlewareContent).toContain('export const sessionIdMiddleware');
+  });
+
+  it('should be idempotent when re-run on an already-migrated file', async () => {
+    const tree = createTreeUsingTsSolutionSetup();
+    registerAgentProject(tree, 'agents', 'packages/agents', 'a2a', 'src/a2a');
+    tree.write('packages/agents/src/a2a/index.ts', OLD_A2A_INDEX);
+
+    await migration(tree);
+    const onceMigrated = tree.read('packages/agents/src/a2a/index.ts', 'utf-8');
+    const onceMiddleware = tree.read(
+      'packages/agents/src/a2a/middleware/session-id-middleware.ts',
+      'utf-8',
+    );
+
+    const result = await migration(tree);
+
+    expect(result.nextSteps).toEqual([]);
+    expect(tree.read('packages/agents/src/a2a/index.ts', 'utf-8')).toEqual(
+      onceMigrated,
+    );
+    expect(
+      tree.read(
+        'packages/agents/src/a2a/middleware/session-id-middleware.ts',
+        'utf-8',
+      ),
+    ).toEqual(onceMiddleware);
+  });
+
+  it('should leave HTTP protocol agents untouched', async () => {
+    const tree = createTreeUsingTsSolutionSetup();
+    registerAgentProject(tree, 'agents', 'packages/agents', 'http', 'src/http');
+    const httpIndex = `import { createServer } from 'http';\nexport const server = createServer();\n`;
+    tree.write('packages/agents/src/http/index.ts', httpIndex);
+
+    const result = await migration(tree);
+
+    expect(result.nextSteps).toEqual([]);
+    expect(tree.read('packages/agents/src/http/index.ts', 'utf-8')).toEqual(
+      httpIndex,
+    );
+    expect(
+      tree.exists(
+        'packages/agents/src/http/middleware/session-id-middleware.ts',
+      ),
+    ).toBe(false);
+  });
+
+  it('should report divergence and leave a customised middleware body untouched', async () => {
+    const tree = createTreeUsingTsSolutionSetup();
+    registerAgentProject(tree, 'agents', 'packages/agents', 'a2a', 'src/a2a');
+    const diverged = OLD_A2A_INDEX.replace(
+      'runWithSessionId(sessionId, () => next());',
+      "console.log('custom logging');\n    runWithSessionId(sessionId, () => next());",
+    );
+    tree.write('packages/agents/src/a2a/index.ts', diverged);
+
+    const result = await migration(tree);
+
+    expect(result.nextSteps).toHaveLength(1);
+    expect(result.nextSteps[0]).toContain('packages/agents/src/a2a/index.ts');
+    expect(result.nextSteps[0]).toContain('diverged');
+    expect(tree.read('packages/agents/src/a2a/index.ts', 'utf-8')).toEqual(
+      diverged,
+    );
+    expect(
+      tree.exists(
+        'packages/agents/src/a2a/middleware/session-id-middleware.ts',
+      ),
+    ).toBe(false);
+  });
+});

--- a/packages/nx-plugin/src/migrations/latest/ts-agent-session-id-middleware-extraction/migration.ts
+++ b/packages/nx-plugin/src/migrations/latest/ts-agent-session-id-middleware-extraction/migration.ts
@@ -1,0 +1,238 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  getProjects,
+  joinPathFragments,
+  type MigrationReturnObject,
+  type Tree,
+} from '@nx/devkit';
+import { TS_AGENT_GENERATOR_INFO } from '../../../ts/agent/generator';
+import {
+  addDestructuredImport,
+  applyGritQL,
+  captureGritQLVariable,
+  matchGritQL,
+} from '../../../utils/ast';
+import { formatFilesInSubtree } from '../../../utils/format';
+import type { ComponentMetadata } from '../../../utils/nx';
+
+/**
+ * Extract the inline session-id Express middleware - previously duplicated
+ * verbatim in every ts#agent AG-UI/A2A `index.ts` - into a shared
+ * `middleware/session-id-middleware.ts` module sitting beside `index.ts`,
+ * mirroring how `agent.ts`/`session.ts` are already shared siblings.
+ *
+ * HTTP is untouched: its one procedure is a tRPC subscription served over
+ * WebSocket, which bypasses Express entirely, so it never had this middleware
+ * to begin with (see `enterSessionContext` in its `router.ts` instead).
+ *
+ * AG-UI and A2A wire the same logic up differently - AG-UI binds it to a
+ * named `sessionIdMiddleware` const before use, while A2A inlines it directly
+ * at the `app.use` call site - so each gets its own old-shape pattern below,
+ * even though both resolve to the same shared middleware content.
+ *
+ * Guardrails:
+ * - Pattern-match before writing: skip files that have diverged from the
+ *   generated shape and report them via `nextSteps`, rather than clobbering
+ *   the user's changes.
+ * - Idempotent: re-running is a no-op once migrated.
+ */
+
+const EXPRESS_IMPORT_OLD =
+  "import express, { type Request, type Response, type NextFunction } from 'express';";
+const EXPRESS_IMPORT_NEW = "import express from 'express';";
+
+const RANDOM_UUID_IMPORT = "import { randomUUID } from 'node:crypto';";
+
+const SESSION_ID_HEADER_LINE =
+  "const SESSION_ID_HEADER = 'x-amzn-bedrock-agentcore-runtime-session-id';";
+
+// The leading comment sits directly above both shapes below. GritQL can only
+// match it as its own comment node - folding it into the same backtick
+// snippet as the statement that follows fails to parse as one construct - so
+// it's matched/deleted as a separate step from the statement/expression.
+const MIDDLEWARE_LEADING_COMMENT =
+  '// Bind the inbound session (or a fresh UUID) for downstream MCP / A2A calls.';
+
+// AG-UI binds the middleware to a named const, used later via `app.use(sessionIdMiddleware)`.
+const AGUI_MIDDLEWARE_DEFINITION_OLD = `const sessionIdMiddleware = (req: Request, _res: Response, next: NextFunction) => {
+  const header = req.headers[SESSION_ID_HEADER];
+  const sessionId = (Array.isArray(header) ? header[0] : header) ?? randomUUID();
+  runWithSessionId(sessionId, () => next());
+};`;
+
+// A2A inlines the same logic directly at the `app.use` call site instead.
+const A2A_MIDDLEWARE_USE_OLD = `app.use((req: Request, _res: Response, next: NextFunction) => {
+    const header = req.headers[SESSION_ID_HEADER];
+    const sessionId = (Array.isArray(header) ? header[0] : header) ?? randomUUID();
+    runWithSessionId(sessionId, () => next());
+  });`;
+const A2A_MIDDLEWARE_USE_NEW = 'app.use(sessionIdMiddleware);';
+
+// Captures the agent-connection package specifier so the new middleware
+// module targets the same one. Generic over `$names` since a connection
+// generator may have merged its own import into this same statement.
+const RUNWITHSESSIONID_IMPORT_CAPTURE =
+  "`import { $names } from '$mod';` where { $names <: contains `runWithSessionId` }";
+
+// Removes `runWithSessionId` from the named import, preserving any other
+// merged specifiers (or the whole statement if it was the only one).
+// Decomposed via `import_clause(name=named_imports($imports))` since a naive
+// `$rest`-based rewrite silently fails once other specifiers are involved.
+const REMOVE_RUNWITHSESSIONID_IMPORT_PATTERN = `\`import $clause from '$mod';\` as $import where {
+  $clause <: import_clause(name=named_imports($imports)),
+  $imports <: contains \`runWithSessionId\`,
+  if ($imports <: [\`runWithSessionId\`]) { $import => . } else { $imports <: some import_specifier(name=\`runWithSessionId\`) => . }
+}`;
+
+// Both protocols' `common-express/` dir vends byte-identical middleware
+// content; read as the single source of truth rather than hand-duplicating
+// it here.
+const SESSION_ID_MIDDLEWARE_TEMPLATE = readFileSync(
+  join(
+    import.meta.dirname,
+    '../../../ts/agent/files/common-express/middleware/session-id-middleware.ts.template',
+  ),
+  'utf-8',
+);
+
+const sessionIdMiddlewareContent = (agentConnectionImport: string): string =>
+  SESSION_ID_MIDDLEWARE_TEMPLATE.replace(
+    '<%- agentConnectionImport %>',
+    agentConnectionImport,
+  );
+
+const findAgentComponents = (
+  components: ComponentMetadata[] | undefined,
+): ComponentMetadata[] =>
+  (components ?? []).filter(
+    (component) =>
+      component.generator === TS_AGENT_GENERATOR_INFO.id &&
+      (component.protocol === 'ag-ui' || component.protocol === 'a2a'),
+  );
+
+const migrateIndex = async (
+  tree: Tree,
+  indexPath: string,
+  protocol: 'ag-ui' | 'a2a',
+  nextSteps: string[],
+): Promise<void> => {
+  if (!tree.exists(indexPath)) return;
+
+  const contents = tree.read(indexPath, 'utf-8') ?? '';
+  if (!contents.includes(SESSION_ID_HEADER_LINE)) return;
+
+  const middlewarePattern =
+    protocol === 'ag-ui'
+      ? AGUI_MIDDLEWARE_DEFINITION_OLD
+      : A2A_MIDDLEWARE_USE_OLD;
+
+  const diverged = () => {
+    nextSteps.push(
+      `${indexPath}: diverged from the generated ts#agent ${protocol} shape - left untouched. Manually move the inline session-id middleware into a sibling \`middleware/session-id-middleware.ts\` module and import \`sessionIdMiddleware\` from there (see the ts#agent generator's template).`,
+    );
+  };
+
+  const ready =
+    (await matchGritQL(tree, indexPath, `\`${EXPRESS_IMPORT_OLD}\``)) &&
+    (await matchGritQL(tree, indexPath, `\`${RANDOM_UUID_IMPORT}\``)) &&
+    (await matchGritQL(tree, indexPath, `\`${SESSION_ID_HEADER_LINE}\``)) &&
+    (await matchGritQL(tree, indexPath, `\`${MIDDLEWARE_LEADING_COMMENT}\``)) &&
+    (await matchGritQL(tree, indexPath, `\`${middlewarePattern}\``)) &&
+    (await matchGritQL(tree, indexPath, RUNWITHSESSIONID_IMPORT_CAPTURE));
+
+  if (!ready) {
+    diverged();
+    return;
+  }
+
+  const mod = await captureGritQLVariable(
+    tree,
+    indexPath,
+    RUNWITHSESSIONID_IMPORT_CAPTURE,
+    'mod',
+  );
+  if (!mod) {
+    diverged();
+    return;
+  }
+
+  const dir = indexPath.split('/').slice(0, -1).join('/');
+  const middlewarePath = joinPathFragments(
+    dir,
+    'middleware',
+    'session-id-middleware.ts',
+  );
+
+  if (!tree.exists(middlewarePath)) {
+    tree.write(middlewarePath, sessionIdMiddlewareContent(mod));
+  }
+
+  await applyGritQL(
+    tree,
+    indexPath,
+    `\`${EXPRESS_IMPORT_OLD}\` => \`${EXPRESS_IMPORT_NEW}\``,
+  );
+  await applyGritQL(tree, indexPath, `\`${RANDOM_UUID_IMPORT}\` => .`);
+  await applyGritQL(tree, indexPath, `\`${SESSION_ID_HEADER_LINE}\` => .`);
+  await applyGritQL(tree, indexPath, REMOVE_RUNWITHSESSIONID_IMPORT_PATTERN);
+  await applyGritQL(tree, indexPath, `\`${MIDDLEWARE_LEADING_COMMENT}\` => .`);
+
+  if (protocol === 'ag-ui') {
+    await applyGritQL(
+      tree,
+      indexPath,
+      `\`${AGUI_MIDDLEWARE_DEFINITION_OLD}\` => .`,
+    );
+  } else {
+    await applyGritQL(
+      tree,
+      indexPath,
+      `\`${A2A_MIDDLEWARE_USE_OLD}\` => \`${A2A_MIDDLEWARE_USE_NEW}\``,
+    );
+  }
+
+  await addDestructuredImport(
+    tree,
+    indexPath,
+    ['sessionIdMiddleware'],
+    './middleware/session-id-middleware.js',
+  );
+};
+
+export default async function migration(
+  tree: Tree,
+): Promise<MigrationReturnObject> {
+  const nextSteps: string[] = [];
+
+  for (const project of getProjects(tree).values()) {
+    const components = findAgentComponents(
+      (project.metadata as { components?: ComponentMetadata[] })?.components,
+    );
+
+    for (const component of components) {
+      if (!component.path) continue;
+
+      const indexPath = joinPathFragments(
+        project.root,
+        component.path,
+        'index.ts',
+      );
+
+      await migrateIndex(
+        tree,
+        indexPath,
+        component.protocol as 'ag-ui' | 'a2a',
+        nextSteps,
+      );
+    }
+  }
+
+  await formatFilesInSubtree(tree);
+
+  return { nextSteps };
+}

--- a/packages/nx-plugin/src/ts/agent/files/a2a/index.ts.template
+++ b/packages/nx-plugin/src/ts/agent/files/a2a/index.ts.template
@@ -1,13 +1,11 @@
 import { A2AExpressServer } from '@strands-agents/sdk/a2a/express';
-import express, { type Request, type Response, type NextFunction } from 'express';
-import { randomUUID } from 'node:crypto';
-import { runWithSessionId, withSessionId } from '<%- agentConnectionImport %>';
+import express from 'express';
+import { withSessionId } from '<%- agentConnectionImport %>';
 import { getAgent } from './agent<% if (esm) { %>.js<% } %>';
+import { sessionIdMiddleware } from './middleware/session-id-middleware<% if (esm) { %>.js<% } %>';
 
 const PORT = parseInt(process.env.PORT || '9000');
 const HOST = '0.0.0.0';
-
-const SESSION_ID_HEADER = 'x-amzn-bedrock-agentcore-runtime-session-id';
 
 void (async () => {
   const httpUrl =
@@ -25,12 +23,7 @@ void (async () => {
 
   const app = express();
   app.get('/ping', (_req, res) => res.status(200).json({ status: 'Healthy' }));
-  // Bind the inbound session (or a fresh UUID) for downstream MCP / A2A calls.
-  app.use((req: Request, _res: Response, next: NextFunction) => {
-    const header = req.headers[SESSION_ID_HEADER];
-    const sessionId = (Array.isArray(header) ? header[0] : header) ?? randomUUID();
-    runWithSessionId(sessionId, () => next());
-  });
+  app.use(sessionIdMiddleware);
   app.use(server.createMiddleware());
   app.listen(PORT, HOST, () => {
     console.log(`A2A server listening on ${HOST}:${PORT}`);

--- a/packages/nx-plugin/src/ts/agent/files/ag-ui/index.ts.template
+++ b/packages/nx-plugin/src/ts/agent/files/ag-ui/index.ts.template
@@ -4,28 +4,18 @@ import {
   addPing,
   addCapabilities,
 } from '@ag-ui/aws-strands/server';
-import express, { type Request, type Response, type NextFunction } from 'express';
+import express from 'express';
 import cors from 'cors';
-import { randomUUID } from 'node:crypto';
 import {
   ModelErrorLoggingPlugin,
   ToolErrorLoggingPlugin,
-  runWithSessionId,
 } from '<%- agentConnectionImport %>';
 import { getAgent } from './agent<% if (esm) { %>.js<% } %>';
 import { getSessionManager } from './session<% if (esm) { %>.js<% } %>';
+import { sessionIdMiddleware } from './middleware/session-id-middleware<% if (esm) { %>.js<% } %>';
 
 const PORT = parseInt(process.env.PORT || '8080');
 const HOST = '0.0.0.0';
-
-const SESSION_ID_HEADER = 'x-amzn-bedrock-agentcore-runtime-session-id';
-
-// Bind the inbound session (or a fresh UUID) for downstream MCP / A2A calls.
-const sessionIdMiddleware = (req: Request, _res: Response, next: NextFunction) => {
-  const header = req.headers[SESSION_ID_HEADER];
-  const sessionId = (Array.isArray(header) ? header[0] : header) ?? randomUUID();
-  runWithSessionId(sessionId, () => next());
-};
 
 void (async () => {
   const agent = await getAgent();

--- a/packages/nx-plugin/src/ts/agent/files/common-express/middleware/session-id-middleware.ts.template
+++ b/packages/nx-plugin/src/ts/agent/files/common-express/middleware/session-id-middleware.ts.template
@@ -1,0 +1,16 @@
+import { randomUUID } from 'node:crypto';
+import type { NextFunction, Request, Response } from 'express';
+import { runWithSessionId } from '<%- agentConnectionImport %>';
+
+export const SESSION_ID_HEADER = 'x-amzn-bedrock-agentcore-runtime-session-id';
+
+// Bind the inbound session (or a fresh UUID) for downstream MCP / A2A calls.
+export const sessionIdMiddleware = (
+  req: Request,
+  _res: Response,
+  next: NextFunction,
+) => {
+  const header = req.headers[SESSION_ID_HEADER];
+  const sessionId = (Array.isArray(header) ? header[0] : header) ?? randomUUID();
+  runWithSessionId(sessionId, () => next());
+};

--- a/packages/nx-plugin/src/ts/agent/generator.ts
+++ b/packages/nx-plugin/src/ts/agent/generator.ts
@@ -232,6 +232,19 @@ export const tsAgentGenerator = async (
     { overwriteStrategy: OverwriteStrategy.KeepExisting },
   );
 
+  // AG-UI and A2A both mount an Express app and share the same session-id
+  // middleware; HTTP relies on tRPC's createContext instead and has no
+  // Express dependency to support it.
+  if (protocol === 'ag-ui' || protocol === 'a2a') {
+    generateFiles(
+      tree,
+      joinPathFragments(import.meta.dirname, 'files', 'common-express'),
+      targetSourceDir,
+      templateContext,
+      { overwriteStrategy: OverwriteStrategy.KeepExisting },
+    );
+  }
+
   if (infra === 'agentcore') {
     const containers = await resolveContainers(tree, 'inherit');
     const dockerImageTag = `${getNpmScope(tree)}-${name}:latest`;


### PR DESCRIPTION
### Reason for this change

Mirrors #1094 (py#agent). ts#agent's AG-UI and A2A `index.ts` templates each inlined a byte-identical Express middleware for binding the inbound AgentCore session ID to async context. HTTP was never part of this duplication — its one procedure is a tRPC subscription served over WebSocket, which bypasses Express entirely, so it uses `enterSessionContext` in `router.ts` instead.

### Description of changes

- Added `files/common-express/middleware/session-id-middleware.ts.template`, generated only when `protocol === 'ag-ui' || protocol === 'a2a'` (explicit checks rather than `!== 'http'`, so a future third protocol doesn't silently inherit an Express dependency it may not have).
- Updated the AG-UI and A2A `index.ts` templates to import `sessionIdMiddleware` from the shared module instead of defining it inline.
- Added an Nx migration (`ts-agent-session-id-middleware-extraction`) that rewrites existing workspaces to the same shape via GritQL, reporting `nextSteps` for any file that has diverged from the generated shape rather than clobbering it.

### Description of how you validated changes

- `migration.spec.ts`: extraction for both AG-UI and A2A, idempotency on re-run, HTTP left untouched, and divergence detection/reporting for a customised middleware body.
- Ran the existing `ts#agent` generator spec; all tests touching AG-UI/A2A/HTTP protocol generation pass.
- Validated the migration against a real generated workspace.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*