### PR TITLE
fix(ts#agent): match reordered express import specifiers in session-id middleware migration

### DIFF
--- a/packages/nx-plugin/src/migrations/latest/ts-agent-session-id-middleware-extraction/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/latest/ts-agent-session-id-middleware-extraction/migration.spec.ts
@@ -184,6 +184,29 @@ describe('ts#agent session-id middleware extraction migration', () => {
     expect(middlewareContent).toContain('export const sessionIdMiddleware');
   });
 
+  it('should extract A2A middleware when the express import specifiers were reordered (e.g. alphabetized by the consumer repo formatter)', async () => {
+    const tree = createTreeUsingTsSolutionSetup();
+    registerAgentProject(tree, 'agents', 'packages/agents', 'a2a', 'src/a2a');
+    const reordered = OLD_A2A_INDEX.replace(
+      "import express, {\n  type Request,\n  type Response,\n  type NextFunction,\n} from 'express';",
+      "import express, {\n  type NextFunction,\n  type Request,\n  type Response,\n} from 'express';",
+    );
+    tree.write('packages/agents/src/a2a/index.ts', reordered);
+
+    const result = await migration(tree);
+
+    expect(result.nextSteps).toEqual([]);
+
+    const indexContent = tree.read('packages/agents/src/a2a/index.ts', 'utf-8');
+    expect(indexContent).toContain("import express from 'express';");
+    expect(indexContent).toContain('app.use(sessionIdMiddleware);');
+    expect(
+      tree.exists(
+        'packages/agents/src/a2a/middleware/session-id-middleware.ts',
+      ),
+    ).toBe(true);
+  });
+
   it('should extract AG-UI middleware into a shared module', async () => {
     const tree = createTreeUsingTsSolutionSetup();
     registerAgentProject(

--- a/packages/nx-plugin/src/migrations/latest/ts-agent-session-id-middleware-extraction/migration.ts
+++ b/packages/nx-plugin/src/migrations/latest/ts-agent-session-id-middleware-extraction/migration.ts
@@ -42,9 +42,20 @@ import type { ComponentMetadata } from '../../../utils/nx';
  * - Idempotent: re-running is a no-op once migrated.
  */
 
-const EXPRESS_IMPORT_OLD =
-  "import express, { type Request, type Response, type NextFunction } from 'express';";
-const EXPRESS_IMPORT_NEW = "import express from 'express';";
+// The consuming repo's formatter/linter (e.g. Biome, ESLint import/order) may
+// alphabetize these three named type imports, so match/rewrite any of their
+// orderings rather than only the literal order the generator emits. Fixed-
+// arity destructuring (`[$a, $b, $c]`) pins the specifier count to exactly
+// three - so a 4th merged-in specifier fails to match - while constraining
+// each slot independently makes the check order-independent.
+const EXPRESS_IMPORT_OLD_WHERE = `{
+  $clause <: import_clause(default=\`express\`, name=named_imports(imports=[$a, $b, $c])),
+  $a <: or { \`type Request\`, \`type Response\`, \`type NextFunction\` },
+  $b <: or { \`type Request\`, \`type Response\`, \`type NextFunction\` },
+  $c <: or { \`type Request\`, \`type Response\`, \`type NextFunction\` }
+}`;
+const EXPRESS_IMPORT_OLD_MATCH = `\`import $clause from 'express';\` where ${EXPRESS_IMPORT_OLD_WHERE}`;
+const EXPRESS_IMPORT_OLD_REWRITE = `\`import $clause from 'express';\` => \`import express from 'express';\` where ${EXPRESS_IMPORT_OLD_WHERE}`;
 
 const RANDOM_UUID_IMPORT = "import { randomUUID } from 'node:crypto';";
 
@@ -138,7 +149,7 @@ const migrateIndex = async (
   };
 
   const ready =
-    (await matchGritQL(tree, indexPath, `\`${EXPRESS_IMPORT_OLD}\``)) &&
+    (await matchGritQL(tree, indexPath, EXPRESS_IMPORT_OLD_MATCH)) &&
     (await matchGritQL(tree, indexPath, `\`${RANDOM_UUID_IMPORT}\``)) &&
     (await matchGritQL(tree, indexPath, `\`${SESSION_ID_HEADER_LINE}\``)) &&
     (await matchGritQL(tree, indexPath, `\`${MIDDLEWARE_LEADING_COMMENT}\``)) &&
@@ -172,11 +183,7 @@ const migrateIndex = async (
     tree.write(middlewarePath, sessionIdMiddlewareContent(mod));
   }
 
-  await applyGritQL(
-    tree,
-    indexPath,
-    `\`${EXPRESS_IMPORT_OLD}\` => \`${EXPRESS_IMPORT_NEW}\``,
-  );
+  await applyGritQL(tree, indexPath, EXPRESS_IMPORT_OLD_REWRITE);
   await applyGritQL(tree, indexPath, `\`${RANDOM_UUID_IMPORT}\` => .`);
   await applyGritQL(tree, indexPath, `\`${SESSION_ID_HEADER_LINE}\` => .`);
   await applyGritQL(tree, indexPath, REMOVE_RUNWITHSESSIONID_IMPORT_PATTERN);


### PR DESCRIPTION
### Reason for this change

The `ts-agent-session-id-middleware-extraction` migration (from #1103) matched the old-shape `import express, { type Request, type Response, type NextFunction } from 'express';` line as a literal, order-sensitive GritQL pattern. In a workspace where a formatter/linter (e.g. Biome, ESLint `import/order`) alphabetizes named specifiers to `NextFunction, Request, Response`, that single check failed, and the migration reported the file as "diverged" and left it untouched — even though every other part of the old shape matched exactly and the file was otherwise perfectly migratable.

### Description of changes

- Replaced the literal `EXPRESS_IMPORT_OLD` string with `EXPRESS_IMPORT_OLD_WHERE`, a GritQL `where` clause that decomposes the import via `import_clause(default=\`express\`, name=named_imports(imports=[$a, $b, $c]))` and constrains each of the three fixed positions independently to one of `Request`/`Response`/`NextFunction`.
- Fixed-arity destructuring (`[$a, $b, $c]`) pins the specifier count to exactly three, so it still correctly rejects divergence (a merged-in 4th specifier, a missing specifier, or a non-`express` default import) rather than silently over-matching — same guardrail behavior as before, just order-independent.
- `EXPRESS_IMPORT_OLD_MATCH` / `EXPRESS_IMPORT_OLD_REWRITE` compose that clause for the two existing call sites (the `ready` check and the actual rewrite).

### Description of how you validated changes

- Added a regression test reproducing the exact alphabetized-import shape (`should extract A2A middleware when the express import specifiers were reordered...`).
- Ran the full migration spec (`migration.spec.ts`, 6 tests, all passing).
- Verified end-to-end against two real-world files pulled from a downstream workspace that were hitting this exact divergence — both now migrate cleanly with empty `nextSteps`.

### Issue # (if applicable)

None filed — found while debugging a downstream workspace migration.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*