### PR TITLE
docs(ts#agent): describe restricting agent sessions to their owner

### DIFF
--- a/docs/src/content/docs/en/guides/connection/react-agui.mdx
+++ b/docs/src/content/docs/en/guides/connection/react-agui.mdx
@@ -92,6 +92,25 @@ The generated code handles authentication depending on your agent's configuratio
 - **IAM** (default): uses AWS SigV4-signed HTTP requests. Credentials are obtained from the Cognito Identity Pool configured with your website's auth.
 - **Cognito**: embeds the JWT access token in the `Authorization` header as a Bearer token.
 
+### Sessions and Threads
+
+AG-UI and AgentCore Runtime each identify a conversation differently, and the generated hook ties them together:
+
+- **`threadId`** — the AG-UI conversation identifier, sent in the request body. CopilotKit generates a random UUID per chat unless you pass an explicit `threadId`.
+- **Session ID** — the AgentCore Runtime session, sent in the `X-Amzn-Bedrock-AgentCore-Runtime-Session-Id` header. It selects the [microVM](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-how-it-works.html) serving the request, and is what your agent's `session.ts` / `session.py` keys conversation state on.
+
+The hook derives the session ID from the thread ID, right-padding it to the 33 characters AgentCore Runtime requires:
+
+```ts
+function agentCoreSessionId(input: RunAgentInput): string {
+  return (input.threadId ?? '').padEnd(33, '0');
+}
+```
+
+Leaving `threadId` unset is simplest — CopilotKit's generated UUID is already 36 characters. If you pass one explicitly, make it at least 33 characters, since padding maps thread IDs that differ only in trailing characters onto the same session.
+
+Both Session ID and Thread ID are provided by the browser. To restrict each user to their own conversations, refer to the <Link path="guides/py-agent">`py#agent`</Link> or <Link path="guides/ts-agent">`ts#agent`</Link> guide.
+
 ## Infrastructure
 
 <Snippet name="connection/react-agent-infrastructure" parentHeading="Infrastructure" />

--- a/docs/src/content/docs/en/guides/py-agent.mdx
+++ b/docs/src/content/docs/en/guides/py-agent.mdx
@@ -4,7 +4,7 @@ description: Generate a Python Agent for building AI agents with tools and deplo
 generator: py#agent
 ---
 
-import { FileTree, Tabs, TabItem, CardGrid } from '@astrojs/starlight/components';
+import { FileTree, Tabs, TabItem, CardGrid, Steps } from '@astrojs/starlight/components';
 import Astro from '@astrojs/react';
 import ConnectionCard from '@components/connection-card.astro';
 import RunGenerator from '@components/run-generator.astro';
@@ -516,6 +516,23 @@ The session ID itself comes from the AgentCore Runtime session (propagated via t
 :::note[Local Development]
 When running locally (`LOCAL_DEV=true`, set automatically by the `-dev` target), session data is always stored on disk under `tmp/agents/strands/<agent-name>` at the workspace root, regardless of the configured `session` option, for convenience.
 :::
+
+#### Restricting sessions to their owner
+
+The session ID arrives from the caller, so on its own it identifies a conversation but not who the conversation belongs to. AgentCore Runtime authorizes an invocation against the agent runtime resource ARN rather than against an individual session, which leaves the agent free to decide what a session means to your application.
+
+:::caution[The session also selects the microVM]
+A session ID selects the [microVM](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-how-it-works.html) that serves the request, so its filesystem, `/tmp` and in-process caches are shared by every request resolving to that session. Two callers who send the same session ID share those resources even when their stored conversations are separate.
+:::
+
+To restrict each user to their own conversations:
+
+<Steps>
+  1. Add an API to create a session, using <Link path="guides/trpc">tRPC</Link>, <Link path="guides/fastapi">FastAPI</Link> or <Link path="guides/ts-smithy-api">Smithy</Link>. Generate an opaque session ID (at least 33 characters) and store it alongside the calling user's ID — for example in a table created with the <Link path="guides/py-dynamodb">`py#dynamodb`</Link> generator. Each API guide shows how to retrieve the calling user's ID.
+  2. In your agent, look up the stored user ID for the session ID it was given, and reject the request when it does not match the caller. With `auth=cognito` the caller's JWT reaches your agent code, so its `sub` claim identifies them.
+</Steps>
+
+Generate the session ID rather than deriving it from user-supplied values such as a conversation name — anything a caller can predict, a caller can send.
 </OptionFilter>
 
 <OptionFilter when={{ framework: 'langchain' }} description="LangChain session management (session.py)">

--- a/docs/src/content/docs/en/guides/ts-agent.mdx
+++ b/docs/src/content/docs/en/guides/ts-agent.mdx
@@ -4,7 +4,7 @@ description: Generate a TypeScript Agent for building AI agents with tools and d
 generator: ts#agent
 ---
 
-import { FileTree, Tabs, TabItem, CardGrid } from '@astrojs/starlight/components';
+import { FileTree, Tabs, TabItem, CardGrid, Steps } from '@astrojs/starlight/components';
 import Astro from '@astrojs/react';
 import ConnectionCard from '@components/connection-card.astro';
 import RunGenerator from '@components/run-generator.astro';
@@ -365,6 +365,23 @@ The session ID itself comes from the AgentCore Runtime session (propagated via t
 :::note[Local Development]
 When running locally (`LOCAL_DEV=true`, set automatically by the `-dev` target), session data is always stored on disk under `tmp/agents/strands/<agent-name>` at the workspace root, regardless of the configured `session` option, for convenience.
 :::
+
+#### Restricting sessions to their owner
+
+The session ID arrives from the caller, so on its own it identifies a conversation but not who the conversation belongs to. AgentCore Runtime authorizes an invocation against the agent runtime resource ARN rather than against an individual session, which leaves the agent free to decide what a session means to your application.
+
+:::caution[The session also selects the microVM]
+A session ID selects the [microVM](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-how-it-works.html) that serves the request, so its filesystem, `/tmp` and in-process caches are shared by every request resolving to that session. Two callers who send the same session ID share those resources even when their stored conversations are separate.
+:::
+
+To restrict each user to their own conversations:
+
+<Steps>
+  1. Add an API to create a session, using <Link path="guides/trpc">tRPC</Link>, <Link path="guides/fastapi">FastAPI</Link> or <Link path="guides/ts-smithy-api">Smithy</Link>. Generate an opaque session ID (at least 33 characters) and store it alongside the calling user's ID — for example in a table created with the <Link path="guides/ts-dynamodb">`ts#dynamodb`</Link> generator. Each API guide shows how to retrieve the calling user's ID.
+  2. In your agent, look up the stored user ID for the session ID it was given, and reject the request when it does not match the caller. With `auth=cognito` the caller's JWT reaches your agent code, so its `sub` claim identifies them.
+</Steps>
+
+Generate the session ID rather than deriving it from user-supplied values such as a conversation name — anything a caller can predict, a caller can send.
 </OptionFilter>
 
 ## Invoking your Agent

--- a/docs/src/content/docs/es/guides/connection/react-agui.mdx
+++ b/docs/src/content/docs/es/guides/connection/react-agui.mdx
@@ -92,6 +92,25 @@ El código generado maneja la autenticación dependiendo de la configuración de
 - **IAM** (predeterminado): usa solicitudes HTTP firmadas con AWS SigV4. Las credenciales se obtienen del Identity Pool de Cognito configurado con la autenticación de tu sitio web.
 - **Cognito**: incrusta el token de acceso JWT en el encabezado `Authorization` como un token Bearer.
 
+### Sesiones e hilos
+
+AG-UI y AgentCore Runtime identifican una conversación de manera diferente, y el hook generado los vincula:
+
+- **`threadId`** — el identificador de conversación de AG-UI, enviado en el cuerpo de la solicitud. CopilotKit genera un UUID aleatorio por chat a menos que pases un `threadId` explícito.
+- **Session ID** — la sesión de AgentCore Runtime, enviada en el encabezado `X-Amzn-Bedrock-AgentCore-Runtime-Session-Id`. Selecciona la [microVM](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-how-it-works.html) que atiende la solicitud, y es en lo que el `session.ts` / `session.py` de tu agente basa el estado de la conversación.
+
+El hook deriva el ID de sesión del ID de hilo, rellenándolo a la derecha hasta los 33 caracteres que requiere AgentCore Runtime:
+
+```ts
+function agentCoreSessionId(input: RunAgentInput): string {
+  return (input.threadId ?? '').padEnd(33, '0');
+}
+```
+
+Dejar `threadId` sin establecer es lo más simple — el UUID generado por CopilotKit ya tiene 36 caracteres. Si pasas uno explícitamente, hazlo de al menos 33 caracteres, ya que el relleno mapea IDs de hilo que difieren solo en caracteres finales a la misma sesión.
+
+Tanto el Session ID como el Thread ID son proporcionados por el navegador. Para restringir a cada usuario a sus propias conversaciones, consulta la guía <Link path="guides/py-agent">`py#agent`</Link> o <Link path="guides/ts-agent">`ts#agent`</Link>.
+
 ## Infraestructura
 
 <Snippet name="connection/react-agent-infrastructure" parentHeading="Infraestructura" />

--- a/docs/src/content/docs/es/guides/py-agent.mdx
+++ b/docs/src/content/docs/es/guides/py-agent.mdx
@@ -4,7 +4,7 @@ description: Genera un Python Agent para construir agentes de IA con herramienta
 generator: py#agent
 ---
 
-import { FileTree, Tabs, TabItem, CardGrid } from '@astrojs/starlight/components';
+import { FileTree, Tabs, TabItem, CardGrid, Steps } from '@astrojs/starlight/components';
 import Astro from '@astrojs/react';
 import ConnectionCard from '@components/connection-card.astro';
 import RunGenerator from '@components/run-generator.astro';
@@ -516,6 +516,23 @@ El ID de sesión en sí proviene de la sesión de AgentCore Runtime (propagada a
 :::note[Desarrollo Local]
 Al ejecutarse localmente (`LOCAL_DEV=true`, establecido automáticamente por el target `-dev`), los datos de sesión siempre se almacenan en disco bajo `tmp/agents/strands/<agent-name>` en la raíz del workspace, independientemente de la opción `session` configurada, por conveniencia.
 :::
+
+#### Restringir sesiones a su propietario
+
+El ID de sesión llega desde el llamador, por lo que por sí solo identifica una conversación pero no a quién pertenece la conversación. AgentCore Runtime autoriza una invocación contra el ARN del recurso del runtime del agente en lugar de contra una sesión individual, lo que deja al agente libre para decidir qué significa una sesión para tu aplicación.
+
+:::caution[La sesión también selecciona la microVM]
+Un ID de sesión selecciona la [microVM](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-how-it-works.html) que sirve la solicitud, por lo que su sistema de archivos, `/tmp` y cachés en proceso son compartidos por cada solicitud que se resuelve a esa sesión. Dos llamadores que envían el mismo ID de sesión comparten esos recursos incluso cuando sus conversaciones almacenadas están separadas.
+:::
+
+Para restringir a cada usuario a sus propias conversaciones:
+
+<Steps>
+  1. Agrega una API para crear una sesión, usando <Link path="guides/trpc">tRPC</Link>, <Link path="guides/fastapi">FastAPI</Link> o <Link path="guides/ts-smithy-api">Smithy</Link>. Genera un ID de sesión opaco (al menos 33 caracteres) y almacénalo junto con el ID del usuario que llama — por ejemplo en una tabla creada con el generador <Link path="guides/py-dynamodb">`py#dynamodb`</Link>. Cada guía de API muestra cómo recuperar el ID del usuario que llama.
+  2. En tu agente, busca el ID de usuario almacenado para el ID de sesión que se le dio, y rechaza la solicitud cuando no coincida con el llamador. Con `auth=cognito` el JWT del llamador llega a tu código del agente, por lo que su claim `sub` los identifica.
+</Steps>
+
+Genera el ID de sesión en lugar de derivarlo de valores proporcionados por el usuario como un nombre de conversación — cualquier cosa que un llamador pueda predecir, un llamador puede enviar.
 </OptionFilter>
 
 <OptionFilter when={{ framework: 'langchain' }} description="LangChain session management (session.py)">

--- a/docs/src/content/docs/es/guides/ts-agent.mdx
+++ b/docs/src/content/docs/es/guides/ts-agent.mdx
@@ -4,7 +4,7 @@ description: Genera un TypeScript Agent para construir agentes de IA con herrami
 generator: ts#agent
 ---
 
-import { FileTree, Tabs, TabItem, CardGrid } from '@astrojs/starlight/components';
+import { FileTree, Tabs, TabItem, CardGrid, Steps } from '@astrojs/starlight/components';
 import Astro from '@astrojs/react';
 import ConnectionCard from '@components/connection-card.astro';
 import RunGenerator from '@components/run-generator.astro';
@@ -365,6 +365,23 @@ El ID de sesión en sí proviene de la sesión del AgentCore Runtime (propagado 
 :::note[Desarrollo local]
 Cuando se ejecuta localmente (`LOCAL_DEV=true`, establecido automáticamente por el target `-dev`), los datos de sesión siempre se almacenan en disco bajo `tmp/agents/strands/<agent-name>` en la raíz del workspace, independientemente de la opción `session` configurada, por conveniencia.
 :::
+
+#### Restringir sesiones a su propietario
+
+El ID de sesión proviene del llamador, por lo que por sí solo identifica una conversación pero no a quién pertenece la conversación. AgentCore Runtime autoriza una invocación contra el ARN del recurso del runtime del agente en lugar de contra una sesión individual, lo que deja al agente libre de decidir qué significa una sesión para tu aplicación.
+
+:::caution[La sesión también selecciona la microVM]
+Un ID de sesión selecciona la [microVM](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-how-it-works.html) que atiende la solicitud, por lo que su sistema de archivos, `/tmp` y cachés en proceso son compartidos por cada solicitud que se resuelve a esa sesión. Dos llamadores que envían el mismo ID de sesión comparten esos recursos incluso cuando sus conversaciones almacenadas están separadas.
+:::
+
+Para restringir a cada usuario a sus propias conversaciones:
+
+<Steps>
+  1. Agrega una API para crear una sesión, usando <Link path="guides/trpc">tRPC</Link>, <Link path="guides/fastapi">FastAPI</Link> o <Link path="guides/ts-smithy-api">Smithy</Link>. Genera un ID de sesión opaco (al menos 33 caracteres) y almacénalo junto con el ID del usuario que llama — por ejemplo en una tabla creada con el generador <Link path="guides/ts-dynamodb">`ts#dynamodb`</Link>. Cada guía de API muestra cómo recuperar el ID del usuario que llama.
+  2. En tu agente, busca el ID de usuario almacenado para el ID de sesión que se le dio, y rechaza la solicitud cuando no coincide con el llamador. Con `auth=cognito` el JWT del llamador llega a tu código del agente, por lo que su claim `sub` los identifica.
+</Steps>
+
+Genera el ID de sesión en lugar de derivarlo de valores proporcionados por el usuario como un nombre de conversación — cualquier cosa que un llamador pueda predecir, un llamador puede enviar.
 </OptionFilter>
 
 ## Invocar tu Agent

--- a/docs/src/content/docs/fr/guides/connection/react-agui.mdx
+++ b/docs/src/content/docs/fr/guides/connection/react-agui.mdx
@@ -92,6 +92,25 @@ Le code généré gère l'authentification en fonction de la configuration de vo
 - **IAM** (par défaut) : utilise des requêtes HTTP signées AWS SigV4. Les identifiants sont obtenus à partir du pool d'identités Cognito configuré avec l'authentification de votre site web.
 - **Cognito** : intègre le jeton d'accès JWT dans l'en-tête `Authorization` en tant que jeton Bearer.
 
+### Sessions et Threads
+
+AG-UI et AgentCore Runtime identifient chacun une conversation différemment, et le hook généré les relie ensemble :
+
+- **`threadId`** — l'identifiant de conversation AG-UI, envoyé dans le corps de la requête. CopilotKit génère un UUID aléatoire par chat sauf si vous passez un `threadId` explicite.
+- **Session ID** — la session AgentCore Runtime, envoyée dans l'en-tête `X-Amzn-Bedrock-AgentCore-Runtime-Session-Id`. Elle sélectionne la [microVM](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-how-it-works.html) qui traite la requête, et c'est ce sur quoi le `session.ts` / `session.py` de votre agent indexe l'état de la conversation.
+
+Le hook dérive l'ID de session à partir de l'ID de thread, en le complétant à droite jusqu'aux 33 caractères requis par AgentCore Runtime :
+
+```ts
+function agentCoreSessionId(input: RunAgentInput): string {
+  return (input.threadId ?? '').padEnd(33, '0');
+}
+```
+
+Laisser `threadId` non défini est le plus simple — l'UUID généré par CopilotKit fait déjà 36 caractères. Si vous en passez un explicitement, assurez-vous qu'il fasse au moins 33 caractères, car le remplissage mappe les ID de thread qui ne diffèrent que par les caractères de fin sur la même session.
+
+L'ID de session et l'ID de thread sont tous deux fournis par le navigateur. Pour restreindre chaque utilisateur à ses propres conversations, consultez le guide <Link path="guides/py-agent">`py#agent`</Link> ou <Link path="guides/ts-agent">`ts#agent`</Link>.
+
 ## Infrastructure
 
 <Snippet name="connection/react-agent-infrastructure" parentHeading="Infrastructure" />

--- a/docs/src/content/docs/fr/guides/py-agent.mdx
+++ b/docs/src/content/docs/fr/guides/py-agent.mdx
@@ -4,7 +4,7 @@ description: Générer un Python Agent pour construire des agents IA avec des ou
 generator: py#agent
 ---
 
-import { FileTree, Tabs, TabItem, CardGrid } from '@astrojs/starlight/components';
+import { FileTree, Tabs, TabItem, CardGrid, Steps } from '@astrojs/starlight/components';
 import Astro from '@astrojs/react';
 import ConnectionCard from '@components/connection-card.astro';
 import RunGenerator from '@components/run-generator.astro';
@@ -516,6 +516,23 @@ L'identifiant de session lui-même provient de la session AgentCore Runtime (pro
 :::note[Développement local]
 Lors de l'exécution locale (`LOCAL_DEV=true`, défini automatiquement par la cible `-dev`), les données de session sont toujours stockées sur disque sous `tmp/agents/strands/<agent-name>` à la racine de l'espace de travail, quelle que soit l'option `session` configurée, pour plus de commodité.
 :::
+
+#### Restreindre les sessions à leur propriétaire
+
+L'identifiant de session provient de l'appelant, donc en soi il identifie une conversation mais pas à qui appartient la conversation. AgentCore Runtime autorise une invocation contre l'ARN de ressource du runtime de l'agent plutôt que contre une session individuelle, ce qui laisse l'agent libre de décider ce qu'une session signifie pour votre application.
+
+:::caution[La session sélectionne également la microVM]
+Un identifiant de session sélectionne la [microVM](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-how-it-works.html) qui sert la requête, donc son système de fichiers, `/tmp` et les caches en processus sont partagés par chaque requête résolvant vers cette session. Deux appelants qui envoient le même identifiant de session partagent ces ressources même lorsque leurs conversations stockées sont séparées.
+:::
+
+Pour restreindre chaque utilisateur à ses propres conversations :
+
+<Steps>
+  1. Ajoutez une API pour créer une session, en utilisant <Link path="guides/trpc">tRPC</Link>, <Link path="guides/fastapi">FastAPI</Link> ou <Link path="guides/ts-smithy-api">Smithy</Link>. Générez un identifiant de session opaque (au moins 33 caractères) et stockez-le aux côtés de l'identifiant de l'utilisateur appelant — par exemple dans une table créée avec le générateur <Link path="guides/py-dynamodb">`py#dynamodb`</Link>. Chaque guide d'API montre comment récupérer l'identifiant de l'utilisateur appelant.
+  2. Dans votre agent, recherchez l'identifiant utilisateur stocké pour l'identifiant de session qui lui a été donné, et rejetez la requête lorsqu'il ne correspond pas à l'appelant. Avec `auth=cognito`, le JWT de l'appelant atteint votre code d'agent, donc sa revendication `sub` les identifie.
+</Steps>
+
+Générez l'identifiant de session plutôt que de le dériver de valeurs fournies par l'utilisateur telles qu'un nom de conversation — tout ce qu'un appelant peut prédire, un appelant peut envoyer.
 </OptionFilter>
 
 <OptionFilter when={{ framework: 'langchain' }} description="LangChain session management (session.py)">

--- a/docs/src/content/docs/fr/guides/ts-agent.mdx
+++ b/docs/src/content/docs/fr/guides/ts-agent.mdx
@@ -4,7 +4,7 @@ description: Générez un Agent TypeScript pour créer des agents IA avec des ou
 generator: ts#agent
 ---
 
-import { FileTree, Tabs, TabItem, CardGrid } from '@astrojs/starlight/components';
+import { FileTree, Tabs, TabItem, CardGrid, Steps } from '@astrojs/starlight/components';
 import Astro from '@astrojs/react';
 import ConnectionCard from '@components/connection-card.astro';
 import RunGenerator from '@components/run-generator.astro';
@@ -365,6 +365,23 @@ L'ID de session lui-même provient de la session AgentCore Runtime (propagée vi
 :::note[Développement local]
 Lors de l'exécution locale (`LOCAL_DEV=true`, défini automatiquement par la cible `-dev`), les données de session sont toujours stockées sur disque sous `tmp/agents/strands/<agent-name>` à la racine de l'espace de travail, quelle que soit l'option `session` configurée, pour plus de commodité.
 :::
+
+#### Restreindre les sessions à leur propriétaire
+
+L'ID de session provient de l'appelant, donc en soi il identifie une conversation mais pas à qui appartient la conversation. AgentCore Runtime autorise une invocation contre l'ARN de ressource du runtime de l'agent plutôt que contre une session individuelle, ce qui laisse l'agent libre de décider ce qu'une session signifie pour votre application.
+
+:::caution[La session sélectionne également la microVM]
+Un ID de session sélectionne la [microVM](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-how-it-works.html) qui traite la requête, donc son système de fichiers, `/tmp` et les caches en cours de processus sont partagés par chaque requête résolvant vers cette session. Deux appelants qui envoient le même ID de session partagent ces ressources même lorsque leurs conversations stockées sont séparées.
+:::
+
+Pour restreindre chaque utilisateur à ses propres conversations :
+
+<Steps>
+  1. Ajoutez une API pour créer une session, en utilisant <Link path="guides/trpc">tRPC</Link>, <Link path="guides/fastapi">FastAPI</Link> ou <Link path="guides/ts-smithy-api">Smithy</Link>. Générez un ID de session opaque (au moins 33 caractères) et stockez-le aux côtés de l'ID de l'utilisateur appelant — par exemple dans une table créée avec le générateur <Link path="guides/ts-dynamodb">`ts#dynamodb`</Link>. Chaque guide d'API montre comment récupérer l'ID de l'utilisateur appelant.
+  2. Dans votre agent, recherchez l'ID utilisateur stocké pour l'ID de session qui lui a été donné, et rejetez la requête lorsqu'il ne correspond pas à l'appelant. Avec `auth=cognito`, le JWT de l'appelant atteint votre code d'agent, donc sa revendication `sub` les identifie.
+</Steps>
+
+Générez l'ID de session plutôt que de le dériver de valeurs fournies par l'utilisateur telles qu'un nom de conversation — tout ce qu'un appelant peut prédire, un appelant peut l'envoyer.
 </OptionFilter>
 
 ## Invoquer votre Agent

--- a/docs/src/content/docs/it/guides/connection/react-agui.mdx
+++ b/docs/src/content/docs/it/guides/connection/react-agui.mdx
@@ -92,6 +92,25 @@ Il codice generato gestisce l'autenticazione in base alla configurazione del tuo
 - **IAM** (predefinito): utilizza richieste HTTP firmate con AWS SigV4. Le credenziali vengono ottenute dal Cognito Identity Pool configurato con l'autenticazione del tuo sito web.
 - **Cognito**: incorpora il token di accesso JWT nell'header `Authorization` come Bearer token.
 
+### Sessioni e Thread
+
+AG-UI e AgentCore Runtime identificano ciascuno una conversazione in modo diverso, e l'hook generato li collega insieme:
+
+- **`threadId`** — l'identificatore di conversazione AG-UI, inviato nel corpo della richiesta. CopilotKit genera un UUID casuale per chat a meno che non passi un `threadId` esplicito.
+- **Session ID** — la sessione AgentCore Runtime, inviata nell'header `X-Amzn-Bedrock-AgentCore-Runtime-Session-Id`. Seleziona la [microVM](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-how-it-works.html) che serve la richiesta, ed è ciò su cui il `session.ts` / `session.py` del tuo agent chiave lo stato della conversazione.
+
+L'hook deriva il session ID dal thread ID, riempiendolo a destra fino ai 33 caratteri richiesti da AgentCore Runtime:
+
+```ts
+function agentCoreSessionId(input: RunAgentInput): string {
+  return (input.threadId ?? '').padEnd(33, '0');
+}
+```
+
+Lasciare `threadId` non impostato è il modo più semplice — l'UUID generato da CopilotKit è già di 36 caratteri. Se ne passi uno esplicitamente, rendilo di almeno 33 caratteri, poiché il riempimento mappa thread ID che differiscono solo nei caratteri finali sulla stessa sessione.
+
+Sia il Session ID che il Thread ID sono forniti dal browser. Per limitare ogni utente alle proprie conversazioni, fai riferimento alla guida <Link path="guides/py-agent">`py#agent`</Link> o <Link path="guides/ts-agent">`ts#agent`</Link>.
+
 ## Infrastruttura
 
 <Snippet name="connection/react-agent-infrastructure" parentHeading="Infrastruttura" />

--- a/docs/src/content/docs/it/guides/py-agent.mdx
+++ b/docs/src/content/docs/it/guides/py-agent.mdx
@@ -4,7 +4,7 @@ description: Genera un Python Agent per costruire agenti AI con strumenti e dist
 generator: py#agent
 ---
 
-import { FileTree, Tabs, TabItem, CardGrid } from '@astrojs/starlight/components';
+import { FileTree, Tabs, TabItem, CardGrid, Steps } from '@astrojs/starlight/components';
 import Astro from '@astrojs/react';
 import ConnectionCard from '@components/connection-card.astro';
 import RunGenerator from '@components/run-generator.astro';
@@ -516,6 +516,23 @@ L'ID di sessione stesso proviene dalla sessione AgentCore Runtime (propagata tra
 :::note[Sviluppo Locale]
 Quando si esegue localmente (`LOCAL_DEV=true`, impostato automaticamente dal target `-dev`), i dati di sessione vengono sempre memorizzati su disco sotto `tmp/agents/strands/<agent-name>` alla radice del workspace, indipendentemente dall'opzione `session` configurata, per comodità.
 :::
+
+#### Limitare le sessioni al loro proprietario
+
+L'ID di sessione arriva dal chiamante, quindi da solo identifica una conversazione ma non a chi appartiene la conversazione. AgentCore Runtime autorizza un'invocazione contro l'ARN della risorsa runtime dell'agente piuttosto che contro una singola sessione, il che lascia l'agente libero di decidere cosa significa una sessione per la tua applicazione.
+
+:::caution[La sessione seleziona anche la microVM]
+Un ID di sessione seleziona la [microVM](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-how-it-works.html) che serve la richiesta, quindi il suo filesystem, `/tmp` e le cache in-process sono condivise da ogni richiesta che si risolve in quella sessione. Due chiamanti che inviano lo stesso ID di sessione condividono quelle risorse anche quando le loro conversazioni memorizzate sono separate.
+:::
+
+Per limitare ogni utente alle proprie conversazioni:
+
+<Steps>
+  1. Aggiungi un'API per creare una sessione, utilizzando <Link path="guides/trpc">tRPC</Link>, <Link path="guides/fastapi">FastAPI</Link> o <Link path="guides/ts-smithy-api">Smithy</Link>. Genera un ID di sessione opaco (almeno 33 caratteri) e memorizzalo insieme all'ID dell'utente chiamante — ad esempio in una tabella creata con il generatore <Link path="guides/py-dynamodb">`py#dynamodb`</Link>. Ogni guida API mostra come recuperare l'ID dell'utente chiamante.
+  2. Nel tuo agente, cerca l'ID utente memorizzato per l'ID di sessione che gli è stato fornito e rifiuta la richiesta quando non corrisponde al chiamante. Con `auth=cognito` il JWT del chiamante raggiunge il codice del tuo agente, quindi il suo claim `sub` li identifica.
+</Steps>
+
+Genera l'ID di sessione piuttosto che derivarlo da valori forniti dall'utente come un nome di conversazione — qualsiasi cosa un chiamante possa prevedere, un chiamante può inviare.
 </OptionFilter>
 
 <OptionFilter when={{ framework: 'langchain' }} description="LangChain session management (session.py)">
@@ -680,7 +697,7 @@ Utilizza il generatore <Link path="guides/connection">`connection`</Link> per in
   <ConnectionCard
     title="React to Python Agent"
     description="Call a Python Agent from a React website"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/react-py-agent`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'it'}/guides/connection/react-py-agent`}
     source="react"
     target="strands"
     targetBadge="python"
@@ -688,14 +705,14 @@ Utilizza il generatore <Link path="guides/connection">`connection`</Link> per in
   <ConnectionCard
     title="React to AG-UI Agent"
     description="Call an Agent exposing the AG-UI protocol from a React website via CopilotKit"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/react-agui`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'it'}/guides/connection/react-agui`}
     source="react"
     target="copilotkit"
   />
   <ConnectionCard
     title="Python Agent to MCP"
     description="Connect a Python Agent to an MCP server"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/py-agent-mcp`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'it'}/guides/connection/py-agent-mcp`}
     source="strands"
     sourceBadge="python"
     target="mcp"
@@ -703,7 +720,7 @@ Utilizza il generatore <Link path="guides/connection">`connection`</Link> per in
   <ConnectionCard
     title="Python Agent to A2A Agent"
     description="Connect a Python Agent to a remote A2A agent"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/py-agent-a2a`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'it'}/guides/connection/py-agent-a2a`}
     source="strands"
     sourceBadge="python"
     target="a2a"
@@ -711,7 +728,7 @@ Utilizza il generatore <Link path="guides/connection">`connection`</Link> per in
   <ConnectionCard
     title="TypeScript Agent to A2A Agent"
     description="Connect a TypeScript Agent to a remote A2A agent"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/ts-agent-a2a`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'it'}/guides/connection/ts-agent-a2a`}
     source="strands"
     sourceBadge="typescript"
     target="a2a"
@@ -719,7 +736,7 @@ Utilizza il generatore <Link path="guides/connection">`connection`</Link> per in
   <ConnectionCard
     title="Python Agent to Python DynamoDB"
     description="Connect a Python Agent to a DynamoDB table"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/py-agent-dynamodb`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'it'}/guides/connection/py-agent-dynamodb`}
     source="strands"
     sourceBadge="python"
     target="dynamodb"
@@ -728,7 +745,7 @@ Utilizza il generatore <Link path="guides/connection">`connection`</Link> per in
   <ConnectionCard
     title="Python Agent to AgentCore Gateway"
     description="Connect a Python Agent to an AgentCore Gateway"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/py-agent-gateway`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'it'}/guides/connection/py-agent-gateway`}
     source="strands"
     sourceBadge="python"
     target="agentcore"
@@ -736,7 +753,7 @@ Utilizza il generatore <Link path="guides/connection">`connection`</Link> per in
   <ConnectionCard
     title="AgentCore Gateway to Agent"
     description="Front an agent with an AgentCore Gateway as a runtime target"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/agentcore-gateway-agent`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'it'}/guides/connection/agentcore-gateway-agent`}
     source="agentcore"
     target="strands"
   />

--- a/docs/src/content/docs/it/guides/ts-agent.mdx
+++ b/docs/src/content/docs/it/guides/ts-agent.mdx
@@ -4,7 +4,7 @@ description: Genera un TypeScript Agent per costruire agenti AI con strumenti e 
 generator: ts#agent
 ---
 
-import { FileTree, Tabs, TabItem, CardGrid } from '@astrojs/starlight/components';
+import { FileTree, Tabs, TabItem, CardGrid, Steps } from '@astrojs/starlight/components';
 import Astro from '@astrojs/react';
 import ConnectionCard from '@components/connection-card.astro';
 import RunGenerator from '@components/run-generator.astro';
@@ -365,6 +365,23 @@ L'ID di sessione stesso proviene dalla sessione AgentCore Runtime (propagato tra
 :::note[Sviluppo Locale]
 Quando si esegue localmente (`LOCAL_DEV=true`, impostato automaticamente dal target `-dev`), i dati di sessione vengono sempre memorizzati su disco sotto `tmp/agents/strands/<agent-name>` alla radice del workspace, indipendentemente dall'opzione `session` configurata, per comodità.
 :::
+
+#### Limitare le sessioni al loro proprietario
+
+L'ID di sessione arriva dal chiamante, quindi da solo identifica una conversazione ma non a chi appartiene la conversazione. AgentCore Runtime autorizza un'invocazione contro l'ARN della risorsa del runtime dell'agente piuttosto che contro una singola sessione, il che lascia l'agente libero di decidere cosa significa una sessione per la tua applicazione.
+
+:::caution[La sessione seleziona anche la microVM]
+Un ID di sessione seleziona la [microVM](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-how-it-works.html) che serve la richiesta, quindi il suo filesystem, `/tmp` e le cache in-process sono condivise da ogni richiesta che si risolve in quella sessione. Due chiamanti che inviano lo stesso ID di sessione condividono quelle risorse anche quando le loro conversazioni memorizzate sono separate.
+:::
+
+Per limitare ogni utente alle proprie conversazioni:
+
+<Steps>
+  1. Aggiungi un'API per creare una sessione, utilizzando <Link path="guides/trpc">tRPC</Link>, <Link path="guides/fastapi">FastAPI</Link> o <Link path="guides/ts-smithy-api">Smithy</Link>. Genera un ID di sessione opaco (almeno 33 caratteri) e memorizzalo insieme all'ID dell'utente chiamante — ad esempio in una tabella creata con il generatore <Link path="guides/ts-dynamodb">`ts#dynamodb`</Link>. Ogni guida API mostra come recuperare l'ID dell'utente chiamante.
+  2. Nel tuo agente, cerca l'ID utente memorizzato per l'ID di sessione che gli è stato fornito e rifiuta la richiesta quando non corrisponde al chiamante. Con `auth=cognito` il JWT del chiamante raggiunge il codice del tuo agente, quindi il suo claim `sub` lo identifica.
+</Steps>
+
+Genera l'ID di sessione piuttosto che derivarlo da valori forniti dall'utente come un nome di conversazione — qualsiasi cosa un chiamante possa prevedere, un chiamante può inviare.
 </OptionFilter>
 
 ## Invocare il Tuo Agent

--- a/docs/src/content/docs/jp/guides/connection/react-agui.mdx
+++ b/docs/src/content/docs/jp/guides/connection/react-agui.mdx
@@ -92,6 +92,25 @@ React ウェブサイトをソースプロジェクトとして、AG-UI Agent �
 - **IAM**（デフォルト）：AWS SigV4 署名付き HTTP リクエストを使用します。認証情報は、ウェブサイトの認証で設定された Cognito Identity Pool から取得されます。
 - **Cognito**：JWT アクセストークンを Bearer トークンとして `Authorization` ヘッダーに埋め込みます。
 
+### セッションとスレッド
+
+AG-UI と AgentCore Runtime はそれぞれ異なる方法で会話を識別し、生成されたフックがそれらを結び付けます：
+
+- **`threadId`** — AG-UI の会話識別子で、リクエストボディで送信されます。CopilotKit は、明示的な `threadId` を渡さない限り、チャットごとにランダムな UUID を生成します。
+- **Session ID** — AgentCore Runtime のセッションで、`X-Amzn-Bedrock-AgentCore-Runtime-Session-Id` ヘッダーで送信されます。これはリクエストを処理する [microVM](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-how-it-works.html) を選択し、Agent の `session.ts` / `session.py` が会話状態をキーとするものです。
+
+フックは、スレッド ID からセッション ID を導出し、AgentCore Runtime が必要とする 33 文字に右パディングします：
+
+```ts
+function agentCoreSessionId(input: RunAgentInput): string {
+  return (input.threadId ?? '').padEnd(33, '0');
+}
+```
+
+`threadId` を未設定のままにするのが最も簡単です — CopilotKit が生成する UUID はすでに 36 文字です。明示的に渡す場合は、少なくとも 33 文字にしてください。パディングにより、末尾の文字のみが異なるスレッド ID が同じセッションにマッピングされるためです。
+
+Session ID と Thread ID の両方はブラウザーによって提供されます。各ユーザーを自分の会話に制限するには、<Link path="guides/py-agent">`py#agent`</Link> または <Link path="guides/ts-agent">`ts#agent`</Link> ガイドを参照してください。
+
 ## インフラストラクチャ
 
 <Snippet name="connection/react-agent-infrastructure" parentHeading="インフラストラクチャ" />

--- a/docs/src/content/docs/jp/guides/py-agent.mdx
+++ b/docs/src/content/docs/jp/guides/py-agent.mdx
@@ -4,7 +4,7 @@ description: ツールを使ったAIエージェントを構築するためのPy
 generator: py#agent
 ---
 
-import { FileTree, Tabs, TabItem, CardGrid } from '@astrojs/starlight/components';
+import { FileTree, Tabs, TabItem, CardGrid, Steps } from '@astrojs/starlight/components';
 import Astro from '@astrojs/react';
 import ConnectionCard from '@components/connection-card.astro';
 import RunGenerator from '@components/run-generator.astro';
@@ -516,6 +516,23 @@ CloudWatch AWSコンソールでトレースを確認できます。メニュー
 :::note[ローカル開発]
 ローカルで実行する場合（`-dev` ターゲットによって自動的に設定される `LOCAL_DEV=true`）、設定された `session` オプションに関わらず、セッションデータは常にワークスペースルートの `tmp/agents/strands/<agent-name>` 以下のディスクに保存されます（利便性のため）。
 :::
+
+#### セッションを所有者に制限する
+
+セッションIDは呼び出し元から送信されるため、それ自体では会話を識別しますが、会話が誰に属しているかは識別しません。AgentCore Runtimeは個々のセッションに対してではなく、エージェントランタイムリソースARNに対して呼び出しを認可するため、エージェントはアプリケーションにとってセッションが何を意味するかを自由に決定できます。
+
+:::caution[セッションはmicroVMも選択します]
+セッションIDはリクエストを処理する [microVM](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-how-it-works.html) を選択するため、そのファイルシステム、`/tmp`、およびプロセス内キャッシュは、そのセッションに解決されるすべてのリクエストで共有されます。同じセッションIDを送信する2人の呼び出し元は、保存された会話が別々であっても、これらのリソースを共有します。
+:::
+
+各ユーザーを自分の会話に制限するには:
+
+<Steps>
+  1. <Link path="guides/trpc">tRPC</Link>、<Link path="guides/fastapi">FastAPI</Link>、または <Link path="guides/ts-smithy-api">Smithy</Link> を使用して、セッションを作成するAPIを追加します。不透明なセッションID（少なくとも33文字）を生成し、呼び出し元ユーザーのIDと一緒に保存します — 例えば、<Link path="guides/py-dynamodb">`py#dynamodb`</Link> ジェネレーターで作成したテーブルに保存します。各APIガイドには、呼び出し元ユーザーのIDを取得する方法が示されています。
+  2. エージェント内で、与えられたセッションIDに対して保存されているユーザーIDを検索し、呼び出し元と一致しない場合はリクエストを拒否します。`auth=cognito` の場合、呼び出し元のJWTがエージェントコードに到達するため、その `sub` クレームで識別できます。
+</Steps>
+
+会話名などのユーザー提供値から派生させるのではなく、セッションIDを生成してください — 呼び出し元が予測できるものは、呼び出し元が送信できます。
 </OptionFilter>
 
 <OptionFilter when={{ framework: 'langchain' }} description="LangChain session management (session.py)">

--- a/docs/src/content/docs/jp/guides/ts-agent.mdx
+++ b/docs/src/content/docs/jp/guides/ts-agent.mdx
@@ -4,7 +4,7 @@ description: ツールを使用してAIエージェントを構築し、Amazon B
 generator: ts#agent
 ---
 
-import { FileTree, Tabs, TabItem, CardGrid } from '@astrojs/starlight/components';
+import { FileTree, Tabs, TabItem, CardGrid, Steps } from '@astrojs/starlight/components';
 import Astro from '@astrojs/react';
 import ConnectionCard from '@components/connection-card.astro';
 import RunGenerator from '@components/run-generator.astro';
@@ -365,6 +365,23 @@ CloudWatch AWS コンソールでメニューから「GenAI Observability」を�
 :::note[ローカル開発]
 ローカルで実行する場合（`LOCAL_DEV=true`、`-dev` ターゲットによって自動的に設定されます）、設定された `session` オプションに関係なく、セッションデータは常にワークスペースルートの `tmp/agents/strands/<agent-name>` の下のディスクに保存されます。これは便宜上のものです。
 :::
+
+#### セッションを所有者に制限する
+
+セッション ID は呼び出し元から送信されるため、それ自体では会話を識別しますが、会話が誰に属しているかは識別しません。AgentCore Runtime は、個々のセッションに対してではなく、エージェントランタイムリソース ARN に対して呼び出しを承認するため、エージェントはアプリケーションにとってセッションが何を意味するかを自由に決定できます。
+
+:::caution[セッションは microVM も選択します]
+セッション ID は、リクエストを処理する [microVM](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-how-it-works.html) を選択するため、そのファイルシステム、`/tmp`、およびプロセス内キャッシュは、そのセッションに解決されるすべてのリクエストによって共有されます。同じセッション ID を送信する2人の呼び出し元は、保存された会話が別々であっても、これらのリソースを共有します。
+:::
+
+各ユーザーを自分の会話に制限するには：
+
+<Steps>
+  1. <Link path="guides/trpc">tRPC</Link>、<Link path="guides/fastapi">FastAPI</Link>、または <Link path="guides/ts-smithy-api">Smithy</Link> を使用して、セッションを作成する API を追加します。不透明なセッション ID（少なくとも33文字）を生成し、呼び出し元のユーザー ID と一緒に保存します。たとえば、<Link path="guides/ts-dynamodb">`ts#dynamodb`</Link> ジェネレーターで作成されたテーブルに保存します。各 API ガイドには、呼び出し元のユーザー ID を取得する方法が示されています。
+  2. エージェントで、与えられたセッション ID に対して保存されたユーザー ID を検索し、呼び出し元と一致しない場合はリクエストを拒否します。`auth=cognito` の場合、呼び出し元の JWT がエージェントコードに到達するため、その `sub` クレームが呼び出し元を識別します。
+</Steps>
+
+会話名などのユーザー提供値からセッション ID を導出するのではなく、セッション ID を生成してください。呼び出し元が予測できるものは、呼び出し元が送信できます。
 </OptionFilter>
 
 ## エージェントの呼び出し

--- a/docs/src/content/docs/ko/guides/connection/react-agui.mdx
+++ b/docs/src/content/docs/ko/guides/connection/react-agui.mdx
@@ -92,6 +92,25 @@ Nx Plugin for AWS는 [AG-UI 프로토콜](https://docs.ag-ui.com/)을 노출하�
 - **IAM** (기본값): AWS SigV4 서명된 HTTP 요청을 사용합니다. 자격 증명은 웹사이트의 인증과 함께 구성된 Cognito Identity Pool에서 가져옵니다.
 - **Cognito**: JWT 액세스 토큰을 Bearer 토큰으로 `Authorization` 헤더에 포함합니다.
 
+### 세션과 스레드
+
+AG-UI와 AgentCore Runtime은 각각 대화를 다르게 식별하며, 생성된 훅은 이들을 함께 연결합니다:
+
+- **`threadId`** — AG-UI 대화 식별자로, 요청 본문에 전송됩니다. CopilotKit은 명시적인 `threadId`를 전달하지 않는 한 채팅당 무작위 UUID를 생성합니다.
+- **Session ID** — AgentCore Runtime 세션으로, `X-Amzn-Bedrock-AgentCore-Runtime-Session-Id` 헤더에 전송됩니다. 요청을 처리하는 [microVM](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-how-it-works.html)을 선택하며, 에이전트의 `session.ts` / `session.py`가 대화 상태를 키로 사용하는 것입니다.
+
+훅은 스레드 ID에서 세션 ID를 파생하여 AgentCore Runtime이 요구하는 33자로 오른쪽 패딩합니다:
+
+```ts
+function agentCoreSessionId(input: RunAgentInput): string {
+  return (input.threadId ?? '').padEnd(33, '0');
+}
+```
+
+`threadId`를 설정하지 않는 것이 가장 간단합니다 — CopilotKit이 생성한 UUID는 이미 36자입니다. 명시적으로 전달하는 경우 최소 33자로 만드세요. 패딩은 후행 문자만 다른 스레드 ID를 동일한 세션에 매핑하기 때문입니다.
+
+Session ID와 Thread ID는 모두 브라우저에서 제공됩니다. 각 사용자를 자신의 대화로 제한하려면 <Link path="guides/py-agent">`py#agent`</Link> 또는 <Link path="guides/ts-agent">`ts#agent`</Link> 가이드를 참조하세요.
+
 ## 인프라
 
 <Snippet name="connection/react-agent-infrastructure" parentHeading="인프라" />

--- a/docs/src/content/docs/ko/guides/py-agent.mdx
+++ b/docs/src/content/docs/ko/guides/py-agent.mdx
@@ -4,7 +4,7 @@ description: 도구를 갖춘 AI 에이전트를 구축하고 Amazon Bedrock Age
 generator: py#agent
 ---
 
-import { FileTree, Tabs, TabItem, CardGrid } from '@astrojs/starlight/components';
+import { FileTree, Tabs, TabItem, CardGrid, Steps } from '@astrojs/starlight/components';
 import Astro from '@astrojs/react';
 import ConnectionCard from '@components/connection-card.astro';
 import RunGenerator from '@components/run-generator.astro';
@@ -516,6 +516,23 @@ CloudWatch AWS 콘솔에서 메뉴의 "GenAI Observability"를 선택하여 추�
 :::note[로컬 개발]
 로컬에서 실행할 때 (`LOCAL_DEV=true`, `-dev` 타겟에 의해 자동으로 설정), 구성된 `session` 옵션에 관계없이 세션 데이터는 편의를 위해 워크스페이스 루트의 `tmp/agents/strands/<agent-name>` 아래 디스크에 항상 저장됩니다.
 :::
+
+#### 세션을 소유자로 제한하기
+
+세션 ID는 호출자로부터 전달되므로, 그 자체로는 대화를 식별하지만 대화가 누구에게 속하는지는 식별하지 않습니다. AgentCore Runtime은 개별 세션이 아닌 에이전트 런타임 리소스 ARN에 대해 호출을 승인하므로, 에이전트가 애플리케이션에서 세션이 무엇을 의미하는지 자유롭게 결정할 수 있습니다.
+
+:::caution[세션은 microVM도 선택합니다]
+세션 ID는 요청을 처리하는 [microVM](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-how-it-works.html)을 선택하므로, 해당 파일 시스템, `/tmp` 및 프로세스 내 캐시는 해당 세션으로 확인되는 모든 요청에 의해 공유됩니다. 동일한 세션 ID를 보내는 두 호출자는 저장된 대화가 분리되어 있더라도 해당 리소스를 공유합니다.
+:::
+
+각 사용자를 자신의 대화로 제한하려면:
+
+<Steps>
+  1. <Link path="guides/trpc">tRPC</Link>, <Link path="guides/fastapi">FastAPI</Link> 또는 <Link path="guides/ts-smithy-api">Smithy</Link>를 사용하여 세션을 생성하는 API를 추가하세요. 불투명한 세션 ID(최소 33자)를 생성하고 호출 사용자의 ID와 함께 저장하세요 — 예를 들어 <Link path="guides/py-dynamodb">`py#dynamodb`</Link> 생성기로 생성된 테이블에. 각 API 가이드는 호출 사용자의 ID를 검색하는 방법을 보여줍니다.
+  2. 에이전트에서 제공된 세션 ID에 대해 저장된 사용자 ID를 조회하고, 호출자와 일치하지 않으면 요청을 거부하세요. `auth=cognito`를 사용하면 호출자의 JWT가 에이전트 코드에 도달하므로 `sub` 클레임이 호출자를 식별합니다.
+</Steps>
+
+대화 이름과 같은 사용자 제공 값에서 파생하는 대신 세션 ID를 생성하세요 — 호출자가 예측할 수 있는 것은 호출자가 보낼 수 있습니다.
 </OptionFilter>
 
 <OptionFilter when={{ framework: 'langchain' }} description="LangChain session management (session.py)">

--- a/docs/src/content/docs/ko/guides/ts-agent.mdx
+++ b/docs/src/content/docs/ko/guides/ts-agent.mdx
@@ -4,7 +4,7 @@ description: 도구를 사용하여 AI 에이전트를 구축하고 Amazon Bedro
 generator: ts#agent
 ---
 
-import { FileTree, Tabs, TabItem, CardGrid } from '@astrojs/starlight/components';
+import { FileTree, Tabs, TabItem, CardGrid, Steps } from '@astrojs/starlight/components';
 import Astro from '@astrojs/react';
 import ConnectionCard from '@components/connection-card.astro';
 import RunGenerator from '@components/run-generator.astro';
@@ -365,6 +365,23 @@ CloudWatch AWS 콘솔에서 메뉴의 "GenAI Observability"를 선택하여 추�
 :::note[로컬 개발]
 로컬에서 실행할 때(`LOCAL_DEV=true`, `-dev` 타겟에 의해 자동으로 설정됨) 세션 데이터는 편의를 위해 구성된 `session` 옵션에 관계없이 항상 작업 공간 루트의 `tmp/agents/strands/<agent-name>` 아래 디스크에 저장됩니다.
 :::
+
+#### 세션을 소유자로 제한
+
+세션 ID는 호출자로부터 도착하므로 그 자체로는 대화를 식별하지만 대화가 누구에게 속하는지는 식별하지 않습니다. AgentCore Runtime은 개별 세션이 아닌 에이전트 런타임 리소스 ARN에 대해 호출을 승인하므로 에이전트가 애플리케이션에서 세션이 무엇을 의미하는지 자유롭게 결정할 수 있습니다.
+
+:::caution[세션은 microVM도 선택합니다]
+세션 ID는 요청을 처리하는 [microVM](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-how-it-works.html)을 선택하므로 해당 파일 시스템, `/tmp` 및 프로세스 내 캐시는 해당 세션으로 확인되는 모든 요청에서 공유됩니다. 동일한 세션 ID를 보내는 두 호출자는 저장된 대화가 분리되어 있더라도 해당 리소스를 공유합니다.
+:::
+
+각 사용자를 자신의 대화로 제한하려면:
+
+<Steps>
+  1. <Link path="guides/trpc">tRPC</Link>, <Link path="guides/fastapi">FastAPI</Link> 또는 <Link path="guides/ts-smithy-api">Smithy</Link>를 사용하여 세션을 생성하는 API를 추가합니다. 불투명한 세션 ID(최소 33자)를 생성하고 호출 사용자의 ID와 함께 저장합니다. 예를 들어 <Link path="guides/ts-dynamodb">`ts#dynamodb`</Link> 생성기로 생성된 테이블에 저장할 수 있습니다. 각 API 가이드는 호출 사용자의 ID를 검색하는 방법을 보여줍니다.
+  2. 에이전트에서 주어진 세션 ID에 대해 저장된 사용자 ID를 조회하고 호출자와 일치하지 않으면 요청을 거부합니다. `auth=cognito`를 사용하면 호출자의 JWT가 에이전트 코드에 도달하므로 `sub` 클레임이 호출자를 식별합니다.
+</Steps>
+
+대화 이름과 같은 사용자 제공 값에서 세션 ID를 파생하는 대신 생성하세요. 호출자가 예측할 수 있는 것은 호출자가 보낼 수 있습니다.
 </OptionFilter>
 
 ## Agent 호출

--- a/docs/src/content/docs/pt/guides/connection/react-agui.mdx
+++ b/docs/src/content/docs/pt/guides/connection/react-agui.mdx
@@ -92,6 +92,25 @@ O código gerado lida com autenticação dependendo da configuração do seu age
 - **IAM** (padrão): usa requisições HTTP assinadas com AWS SigV4. As credenciais são obtidas do Cognito Identity Pool configurado com a autenticação do seu site.
 - **Cognito**: incorpora o token de acesso JWT no cabeçalho `Authorization` como um Bearer token.
 
+### Sessões e Threads
+
+AG-UI e AgentCore Runtime identificam uma conversa de maneira diferente, e o hook gerado os conecta:
+
+- **`threadId`** — o identificador de conversa AG-UI, enviado no corpo da requisição. CopilotKit gera um UUID aleatório por chat, a menos que você passe um `threadId` explícito.
+- **Session ID** — a sessão do AgentCore Runtime, enviada no cabeçalho `X-Amzn-Bedrock-AgentCore-Runtime-Session-Id`. Ele seleciona a [microVM](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-how-it-works.html) que atende a requisição, e é o que o `session.ts` / `session.py` do seu agente usa como chave para o estado da conversa.
+
+O hook deriva o session ID do thread ID, preenchendo-o à direita até os 33 caracteres que o AgentCore Runtime requer:
+
+```ts
+function agentCoreSessionId(input: RunAgentInput): string {
+  return (input.threadId ?? '').padEnd(33, '0');
+}
+```
+
+Deixar `threadId` não definido é mais simples — o UUID gerado pelo CopilotKit já tem 36 caracteres. Se você passar um explicitamente, faça com que tenha pelo menos 33 caracteres, pois o preenchimento mapeia thread IDs que diferem apenas em caracteres finais para a mesma sessão.
+
+Tanto o Session ID quanto o Thread ID são fornecidos pelo navegador. Para restringir cada usuário às suas próprias conversas, consulte o guia <Link path="guides/py-agent">`py#agent`</Link> ou <Link path="guides/ts-agent">`ts#agent`</Link>.
+
 ## Infraestrutura
 
 <Snippet name="connection/react-agent-infrastructure" parentHeading="Infraestrutura" />

--- a/docs/src/content/docs/pt/guides/py-agent.mdx
+++ b/docs/src/content/docs/pt/guides/py-agent.mdx
@@ -4,7 +4,7 @@ description: Gere um Python Agent para construir agentes de IA com ferramentas e
 generator: py#agent
 ---
 
-import { FileTree, Tabs, TabItem, CardGrid } from '@astrojs/starlight/components';
+import { FileTree, Tabs, TabItem, CardGrid, Steps } from '@astrojs/starlight/components';
 import Astro from '@astrojs/react';
 import ConnectionCard from '@components/connection-card.astro';
 import RunGenerator from '@components/run-generator.astro';
@@ -516,6 +516,23 @@ O próprio ID da sessão vem da sessão do AgentCore Runtime (propagada através
 :::note[Desenvolvimento Local]
 Ao executar localmente (`LOCAL_DEV=true`, definido automaticamente pelo target `-dev`), os dados da sessão são sempre armazenados em disco em `tmp/agents/strands/<agent-name>` na raiz do workspace, independentemente da opção `session` configurada, por conveniência.
 :::
+
+#### Restringindo sessões ao seu proprietário
+
+O ID da sessão vem do chamador, então por si só ele identifica uma conversa, mas não a quem a conversa pertence. O AgentCore Runtime autoriza uma invocação contra o ARN do recurso do runtime do agente, em vez de contra uma sessão individual, o que deixa o agente livre para decidir o que uma sessão significa para sua aplicação.
+
+:::caution[A sessão também seleciona a microVM]
+Um ID de sessão seleciona a [microVM](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-how-it-works.html) que atende a requisição, então seu sistema de arquivos, `/tmp` e caches em processo são compartilhados por todas as requisições que resolvem para essa sessão. Dois chamadores que enviam o mesmo ID de sessão compartilham esses recursos mesmo quando suas conversas armazenadas são separadas.
+:::
+
+Para restringir cada usuário às suas próprias conversas:
+
+<Steps>
+  1. Adicione uma API para criar uma sessão, usando <Link path="guides/trpc">tRPC</Link>, <Link path="guides/fastapi">FastAPI</Link> ou <Link path="guides/ts-smithy-api">Smithy</Link>. Gere um ID de sessão opaco (pelo menos 33 caracteres) e armazene-o junto com o ID do usuário chamador — por exemplo, em uma tabela criada com o gerador <Link path="guides/py-dynamodb">`py#dynamodb`</Link>. Cada guia de API mostra como recuperar o ID do usuário chamador.
+  2. No seu agente, procure o ID do usuário armazenado para o ID da sessão que foi fornecido e rejeite a requisição quando não corresponder ao chamador. Com `auth=cognito`, o JWT do chamador chega ao código do seu agente, então sua claim `sub` os identifica.
+</Steps>
+
+Gere o ID da sessão em vez de derivá-lo de valores fornecidos pelo usuário, como um nome de conversa — qualquer coisa que um chamador possa prever, um chamador pode enviar.
 </OptionFilter>
 
 <OptionFilter when={{ framework: 'langchain' }} description="LangChain session management (session.py)">

--- a/docs/src/content/docs/pt/guides/ts-agent.mdx
+++ b/docs/src/content/docs/pt/guides/ts-agent.mdx
@@ -4,7 +4,7 @@ description: Gere um TypeScript Agent para construir agentes de IA com ferrament
 generator: ts#agent
 ---
 
-import { FileTree, Tabs, TabItem, CardGrid } from '@astrojs/starlight/components';
+import { FileTree, Tabs, TabItem, CardGrid, Steps } from '@astrojs/starlight/components';
 import Astro from '@astrojs/react';
 import ConnectionCard from '@components/connection-card.astro';
 import RunGenerator from '@components/run-generator.astro';
@@ -365,6 +365,23 @@ O ID da sessão em si vem da sessão do AgentCore Runtime (propagado via cabeça
 :::note[Desenvolvimento Local]
 Ao executar localmente (`LOCAL_DEV=true`, definido automaticamente pelo target `-dev`), os dados da sessão são sempre armazenados em disco em `tmp/agents/strands/<agent-name>` na raiz do workspace, independentemente da opção `session` configurada, por conveniência.
 :::
+
+#### Restringindo sessões ao seu proprietário
+
+O ID da sessão chega do chamador, então por si só ele identifica uma conversa, mas não a quem a conversa pertence. O AgentCore Runtime autoriza uma invocação contra o ARN do recurso de runtime do agente em vez de contra uma sessão individual, o que deixa o agente livre para decidir o que uma sessão significa para sua aplicação.
+
+:::caution[A sessão também seleciona a microVM]
+Um ID de sessão seleciona a [microVM](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-how-it-works.html) que atende a solicitação, então seu sistema de arquivos, `/tmp` e caches em processo são compartilhados por todas as solicitações que resolvem para essa sessão. Dois chamadores que enviam o mesmo ID de sessão compartilham esses recursos mesmo quando suas conversas armazenadas são separadas.
+:::
+
+Para restringir cada usuário às suas próprias conversas:
+
+<Steps>
+  1. Adicione uma API para criar uma sessão, usando <Link path="guides/trpc">tRPC</Link>, <Link path="guides/fastapi">FastAPI</Link> ou <Link path="guides/ts-smithy-api">Smithy</Link>. Gere um ID de sessão opaco (pelo menos 33 caracteres) e armazene-o junto com o ID do usuário chamador — por exemplo, em uma tabela criada com o gerador <Link path="guides/ts-dynamodb">`ts#dynamodb`</Link>. Cada guia de API mostra como recuperar o ID do usuário chamador.
+  2. Em seu agente, procure o ID de usuário armazenado para o ID de sessão que foi fornecido e rejeite a solicitação quando ele não corresponder ao chamador. Com `auth=cognito`, o JWT do chamador chega ao código do seu agente, então sua claim `sub` os identifica.
+</Steps>
+
+Gere o ID da sessão em vez de derivá-lo de valores fornecidos pelo usuário, como um nome de conversa — qualquer coisa que um chamador possa prever, um chamador pode enviar.
 </OptionFilter>
 
 ## Invocando seu Agent

--- a/docs/src/content/docs/vi/guides/connection/react-agui.mdx
+++ b/docs/src/content/docs/vi/guides/connection/react-agui.mdx
@@ -92,6 +92,25 @@ Code được tạo xử lý xác thực tùy thuộc vào cấu hình của age
 - **IAM** (mặc định): sử dụng các HTTP request được ký AWS SigV4. Thông tin xác thực được lấy từ Cognito Identity Pool được cấu hình với auth của trang web của bạn.
 - **Cognito**: nhúng JWT access token vào header `Authorization` dưới dạng Bearer token.
 
+### Sessions và Threads
+
+AG-UI và AgentCore Runtime mỗi cái xác định một cuộc hội thoại theo cách khác nhau, và hook được tạo liên kết chúng lại với nhau:
+
+- **`threadId`** — định danh cuộc hội thoại AG-UI, được gửi trong request body. CopilotKit tạo một UUID ngẫu nhiên cho mỗi cuộc trò chuyện trừ khi bạn truyền một `threadId` rõ ràng.
+- **Session ID** — session AgentCore Runtime, được gửi trong header `X-Amzn-Bedrock-AgentCore-Runtime-Session-Id`. Nó chọn [microVM](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-how-it-works.html) phục vụ request, và là thứ mà `session.ts` / `session.py` của agent của bạn dùng làm khóa cho trạng thái cuộc hội thoại.
+
+Hook suy ra session ID từ thread ID, đệm phải nó đến 33 ký tự mà AgentCore Runtime yêu cầu:
+
+```ts
+function agentCoreSessionId(input: RunAgentInput): string {
+  return (input.threadId ?? '').padEnd(33, '0');
+}
+```
+
+Để `threadId` không được đặt là đơn giản nhất — UUID được tạo bởi CopilotKit đã có 36 ký tự. Nếu bạn truyền một cách rõ ràng, hãy đảm bảo nó có ít nhất 33 ký tự, vì việc đệm ánh xạ các thread ID chỉ khác nhau ở các ký tự cuối vào cùng một session.
+
+Cả Session ID và Thread ID đều được cung cấp bởi trình duyệt. Để hạn chế mỗi người dùng chỉ truy cập các cuộc hội thoại của riêng họ, hãy tham khảo hướng dẫn <Link path="guides/py-agent">`py#agent`</Link> hoặc <Link path="guides/ts-agent">`ts#agent`</Link>.
+
 ## Hạ tầng
 
 <Snippet name="connection/react-agent-infrastructure" parentHeading="Hạ tầng" />

--- a/docs/src/content/docs/vi/guides/py-agent.mdx
+++ b/docs/src/content/docs/vi/guides/py-agent.mdx
@@ -4,7 +4,7 @@ description: Tạo một Python Agent để xây dựng các AI agent với côn
 generator: py#agent
 ---
 
-import { FileTree, Tabs, TabItem, CardGrid } from '@astrojs/starlight/components';
+import { FileTree, Tabs, TabItem, CardGrid, Steps } from '@astrojs/starlight/components';
 import Astro from '@astrojs/react';
 import ConnectionCard from '@components/connection-card.astro';
 import RunGenerator from '@components/run-generator.astro';
@@ -516,6 +516,23 @@ Session ID đến từ session AgentCore Runtime (được truyền qua header `
 :::note[Phát triển Cục bộ]
 Khi chạy cục bộ (`LOCAL_DEV=true`, được đặt tự động bởi target `-dev`), dữ liệu session luôn được lưu trữ trên đĩa dưới `tmp/agents/strands/<agent-name>` tại thư mục gốc workspace, bất kể tùy chọn `session` đã cấu hình, để thuận tiện.
 :::
+
+#### Hạn chế session cho chủ sở hữu của chúng
+
+Session ID đến từ người gọi, vì vậy bản thân nó xác định một cuộc hội thoại nhưng không xác định cuộc hội thoại thuộc về ai. AgentCore Runtime ủy quyền một lần gọi đối với ARN tài nguyên runtime agent thay vì đối với một session riêng lẻ, điều này để agent tự do quyết định session có ý nghĩa gì đối với ứng dụng của bạn.
+
+:::caution[Session cũng chọn microVM]
+Một session ID chọn [microVM](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-how-it-works.html) phục vụ yêu cầu, vì vậy hệ thống tệp, `/tmp` và bộ nhớ cache trong tiến trình của nó được chia sẻ bởi mọi yêu cầu giải quyết đến session đó. Hai người gọi gửi cùng một session ID chia sẻ các tài nguyên đó ngay cả khi các cuộc hội thoại được lưu trữ của họ là riêng biệt.
+:::
+
+Để hạn chế mỗi người dùng chỉ có thể truy cập các cuộc hội thoại của riêng họ:
+
+<Steps>
+  1. Thêm một API để tạo session, sử dụng <Link path="guides/trpc">tRPC</Link>, <Link path="guides/fastapi">FastAPI</Link> hoặc <Link path="guides/ts-smithy-api">Smithy</Link>. Tạo một session ID không rõ ràng (ít nhất 33 ký tự) và lưu trữ nó cùng với ID người dùng đang gọi — ví dụ trong một bảng được tạo bằng generator <Link path="guides/py-dynamodb">`py#dynamodb`</Link>. Mỗi hướng dẫn API cho biết cách lấy ID người dùng đang gọi.
+  2. Trong agent của bạn, tra cứu ID người dùng đã lưu trữ cho session ID mà nó được cung cấp, và từ chối yêu cầu khi nó không khớp với người gọi. Với `auth=cognito`, JWT của người gọi đến mã agent của bạn, vì vậy claim `sub` của nó xác định họ.
+</Steps>
+
+Tạo session ID thay vì lấy nó từ các giá trị do người dùng cung cấp như tên cuộc hội thoại — bất cứ thứ gì người gọi có thể dự đoán, người gọi có thể gửi.
 </OptionFilter>
 
 <OptionFilter when={{ framework: 'langchain' }} description="LangChain session management (session.py)">

--- a/docs/src/content/docs/vi/guides/ts-agent.mdx
+++ b/docs/src/content/docs/vi/guides/ts-agent.mdx
@@ -4,7 +4,7 @@ description: Tạo TypeScript Agent để xây dựng AI agent với các công 
 generator: ts#agent
 ---
 
-import { FileTree, Tabs, TabItem, CardGrid } from '@astrojs/starlight/components';
+import { FileTree, Tabs, TabItem, CardGrid, Steps } from '@astrojs/starlight/components';
 import Astro from '@astrojs/react';
 import ConnectionCard from '@components/connection-card.astro';
 import RunGenerator from '@components/run-generator.astro';
@@ -365,6 +365,23 @@ Session ID chính nó đến từ AgentCore Runtime session (được truyền q
 :::note[Phát triển cục bộ]
 Khi chạy cục bộ (`LOCAL_DEV=true`, được thiết lập tự động bởi target `-dev`), dữ liệu session luôn được lưu trữ trên đĩa dưới `tmp/agents/strands/<agent-name>` tại workspace root, bất kể tùy chọn `session` được cấu hình, để thuận tiện.
 :::
+
+#### Hạn chế session cho chủ sở hữu của chúng
+
+Session ID đến từ người gọi, vì vậy bản thân nó chỉ xác định một cuộc hội thoại chứ không phải cuộc hội thoại thuộc về ai. AgentCore Runtime ủy quyền một lần gọi dựa trên ARN tài nguyên agent runtime thay vì dựa trên một session riêng lẻ, điều này để agent tự do quyết định session có ý nghĩa gì đối với ứng dụng của bạn.
+
+:::caution[Session cũng chọn microVM]
+Một session ID chọn [microVM](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-how-it-works.html) phục vụ request, vì vậy filesystem, `/tmp` và cache trong process của nó được chia sẻ bởi mọi request resolve đến session đó. Hai người gọi gửi cùng một session ID chia sẻ các tài nguyên đó ngay cả khi các cuộc hội thoại được lưu trữ của họ là riêng biệt.
+:::
+
+Để hạn chế mỗi người dùng chỉ có thể truy cập các cuộc hội thoại của riêng họ:
+
+<Steps>
+  1. Thêm một API để tạo session, sử dụng <Link path="guides/trpc">tRPC</Link>, <Link path="guides/fastapi">FastAPI</Link> hoặc <Link path="guides/ts-smithy-api">Smithy</Link>. Tạo một session ID không rõ ràng (ít nhất 33 ký tự) và lưu trữ nó cùng với ID của người dùng đang gọi — ví dụ trong một bảng được tạo bằng generator <Link path="guides/ts-dynamodb">`ts#dynamodb`</Link>. Mỗi hướng dẫn API cho biết cách lấy ID của người dùng đang gọi.
+  2. Trong agent của bạn, tra cứu ID người dùng được lưu trữ cho session ID mà nó được cung cấp, và từ chối request khi nó không khớp với người gọi. Với `auth=cognito`, JWT của người gọi đến mã agent của bạn, vì vậy claim `sub` của nó xác định họ.
+</Steps>
+
+Tạo session ID thay vì suy ra nó từ các giá trị do người dùng cung cấp như tên cuộc hội thoại — bất cứ thứ gì người gọi có thể dự đoán, người gọi có thể gửi.
 </OptionFilter>
 
 ## Gọi Agent của bạn

--- a/docs/src/content/docs/zh/guides/connection/react-agui.mdx
+++ b/docs/src/content/docs/zh/guides/connection/react-agui.mdx
@@ -92,6 +92,25 @@ Nx Plugin for AWS 提供了一个生成器，用于将 React 网站连接到公�
 - **IAM**（默认）：使用 AWS SigV4 签名的 HTTP 请求。凭证从配置了您网站身份验证的 Cognito Identity Pool 获取。
 - **Cognito**：将 JWT 访问令牌作为 Bearer 令牌嵌入到 `Authorization` 标头中。
 
+### 会话和线程
+
+AG-UI 和 AgentCore Runtime 各自以不同的方式识别对话，生成的 hook 将它们联系在一起：
+
+- **`threadId`** — AG-UI 对话标识符，在请求正文中发送。除非您传递显式的 `threadId`，否则 CopilotKit 会为每个聊天生成一个随机 UUID。
+- **Session ID** — AgentCore Runtime 会话，在 `X-Amzn-Bedrock-AgentCore-Runtime-Session-Id` 标头中发送。它选择为请求提供服务的 [microVM](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-how-it-works.html)，并且是您的 agent 的 `session.ts` / `session.py` 用于键入对话状态的内容。
+
+hook 从线程 ID 派生会话 ID，将其右填充到 AgentCore Runtime 所需的 33 个字符：
+
+```ts
+function agentCoreSessionId(input: RunAgentInput): string {
+  return (input.threadId ?? '').padEnd(33, '0');
+}
+```
+
+不设置 `threadId` 是最简单的——CopilotKit 生成的 UUID 已经是 36 个字符。如果您显式传递一个，请确保它至少有 33 个字符，因为填充会将仅在尾随字符上不同的线程 ID 映射到同一个会话。
+
+Session ID 和 Thread ID 都由浏览器提供。要将每个用户限制为他们自己的对话，请参阅 <Link path="guides/py-agent">`py#agent`</Link> 或 <Link path="guides/ts-agent">`ts#agent`</Link> 指南。
+
 ## 基础设施
 
 <Snippet name="connection/react-agent-infrastructure" parentHeading="基础设施" />

--- a/docs/src/content/docs/zh/guides/py-agent.mdx
+++ b/docs/src/content/docs/zh/guides/py-agent.mdx
@@ -4,7 +4,7 @@ description: 生成用于构建带工具的 AI 代理的 Python Agent，并部�
 generator: py#agent
 ---
 
-import { FileTree, Tabs, TabItem, CardGrid } from '@astrojs/starlight/components';
+import { FileTree, Tabs, TabItem, CardGrid, Steps } from '@astrojs/starlight/components';
 import Astro from '@astrojs/react';
 import ConnectionCard from '@components/connection-card.astro';
 import RunGenerator from '@components/run-generator.astro';
@@ -516,6 +516,23 @@ aws cognito-idp admin-initiate-auth \
 :::note[本地开发]
 在本地运行时（`LOCAL_DEV=true`，由 `-dev` 目标自动设置），无论配置的 `session` 选项如何，会话数据始终存储在工作区根目录的 `tmp/agents/strands/<agent-name>` 下的磁盘上，以方便使用。
 :::
+
+#### 将会话限制为其所有者
+
+会话 ID 来自调用者，因此它本身只标识对话，而不标识对话属于谁。AgentCore Runtime 针对代理运行时资源 ARN 而不是针对单个会话授权调用，这使代理可以自由决定会话对您的应用程序意味着什么。
+
+:::caution[会话还会选择 microVM]
+会话 ID 选择为请求提供服务的 [microVM](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-how-it-works.html)，因此其文件系统、`/tmp` 和进程内缓存由解析到该会话的每个请求共享。发送相同会话 ID 的两个调用者共享这些资源，即使他们存储的对话是分开的。
+:::
+
+要将每个用户限制为他们自己的对话：
+
+<Steps>
+  1. 添加一个 API 来创建会话，使用 <Link path="guides/trpc">tRPC</Link>、<Link path="guides/fastapi">FastAPI</Link> 或 <Link path="guides/ts-smithy-api">Smithy</Link>。生成一个不透明的会话 ID（至少 33 个字符）并将其与调用用户的 ID 一起存储 — 例如在使用 <Link path="guides/py-dynamodb">`py#dynamodb`</Link> 生成器创建的表中。每个 API 指南都展示了如何检索调用用户的 ID。
+  2. 在您的代理中，查找给定会话 ID 的存储用户 ID，并在它与调用者不匹配时拒绝请求。使用 `auth=cognito` 时，调用者的 JWT 会到达您的代理代码，因此其 `sub` 声明可以识别他们。
+</Steps>
+
+生成会话 ID 而不是从用户提供的值（如对话名称）派生它 — 调用者可以预测的任何内容，调用者都可以发送。
 </OptionFilter>
 
 <OptionFilter when={{ framework: 'langchain' }} description="LangChain session management (session.py)">
@@ -680,7 +697,7 @@ model = ChatBedrockConverse(
   <ConnectionCard
     title="React to Python Agent"
     description="Call a Python Agent from a React website"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/react-py-agent`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'zh'}/guides/connection/react-py-agent`}
     source="react"
     target="strands"
     targetBadge="python"
@@ -688,14 +705,14 @@ model = ChatBedrockConverse(
   <ConnectionCard
     title="React to AG-UI Agent"
     description="Call an Agent exposing the AG-UI protocol from a React website via CopilotKit"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/react-agui`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'zh'}/guides/connection/react-agui`}
     source="react"
     target="copilotkit"
   />
   <ConnectionCard
     title="Python Agent to MCP"
     description="Connect a Python Agent to an MCP server"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/py-agent-mcp`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'zh'}/guides/connection/py-agent-mcp`}
     source="strands"
     sourceBadge="python"
     target="mcp"
@@ -703,7 +720,7 @@ model = ChatBedrockConverse(
   <ConnectionCard
     title="Python Agent to A2A Agent"
     description="Connect a Python Agent to a remote A2A agent"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/py-agent-a2a`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'zh'}/guides/connection/py-agent-a2a`}
     source="strands"
     sourceBadge="python"
     target="a2a"
@@ -711,7 +728,7 @@ model = ChatBedrockConverse(
   <ConnectionCard
     title="TypeScript Agent to A2A Agent"
     description="Connect a TypeScript Agent to a remote A2A agent"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/ts-agent-a2a`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'zh'}/guides/connection/ts-agent-a2a`}
     source="strands"
     sourceBadge="typescript"
     target="a2a"
@@ -719,7 +736,7 @@ model = ChatBedrockConverse(
   <ConnectionCard
     title="Python Agent to Python DynamoDB"
     description="Connect a Python Agent to a DynamoDB table"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/py-agent-dynamodb`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'zh'}/guides/connection/py-agent-dynamodb`}
     source="strands"
     sourceBadge="python"
     target="dynamodb"
@@ -728,7 +745,7 @@ model = ChatBedrockConverse(
   <ConnectionCard
     title="Python Agent to AgentCore Gateway"
     description="Connect a Python Agent to an AgentCore Gateway"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/py-agent-gateway`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'zh'}/guides/connection/py-agent-gateway`}
     source="strands"
     sourceBadge="python"
     target="agentcore"
@@ -736,7 +753,7 @@ model = ChatBedrockConverse(
   <ConnectionCard
     title="AgentCore Gateway to Agent"
     description="Front an agent with an AgentCore Gateway as a runtime target"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/agentcore-gateway-agent`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'zh'}/guides/connection/agentcore-gateway-agent`}
     source="agentcore"
     target="strands"
   />

--- a/docs/src/content/docs/zh/guides/ts-agent.mdx
+++ b/docs/src/content/docs/zh/guides/ts-agent.mdx
@@ -4,7 +4,7 @@ description: 生成用于构建带工具的 AI 代理的 TypeScript Agent，并�
 generator: ts#agent
 ---
 
-import { FileTree, Tabs, TabItem, CardGrid } from '@astrojs/starlight/components';
+import { FileTree, Tabs, TabItem, CardGrid, Steps } from '@astrojs/starlight/components';
 import Astro from '@astrojs/react';
 import ConnectionCard from '@components/connection-card.astro';
 import RunGenerator from '@components/run-generator.astro';
@@ -365,6 +365,23 @@ bundle 目标使用 `index.ts` 作为 WebSocket 服务器的入口点，以托�
 :::note[本地开发]
 在本地运行时（`LOCAL_DEV=true`，由 `-dev` 目标自动设置），无论配置的 `session` 选项如何，会话数据始终存储在工作区根目录的 `tmp/agents/strands/<agent-name>` 下的磁盘上，以方便使用。
 :::
+
+#### 将会话限制为其所有者
+
+会话 ID 来自调用者，因此它本身只能识别对话，但不能识别对话属于谁。AgentCore Runtime 针对代理运行时资源 ARN 而不是针对单个会话授权调用，这使代理可以自由决定会话对您的应用程序意味着什么。
+
+:::caution[会话还会选择 microVM]
+会话 ID 选择为请求提供服务的 [microVM](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-how-it-works.html)，因此其文件系统、`/tmp` 和进程内缓存由解析到该会话的每个请求共享。发送相同会话 ID 的两个调用者共享这些资源，即使他们存储的对话是分开的。
+:::
+
+要将每个用户限制为他们自己的对话：
+
+<Steps>
+  1. 添加一个 API 来创建会话，使用 <Link path="guides/trpc">tRPC</Link>、<Link path="guides/fastapi">FastAPI</Link> 或 <Link path="guides/ts-smithy-api">Smithy</Link>。生成一个不透明的会话 ID（至少 33 个字符）并将其与调用用户的 ID 一起存储 — 例如在使用 <Link path="guides/ts-dynamodb">`ts#dynamodb`</Link> 生成器创建的表中。每个 API 指南都展示了如何检索调用用户的 ID。
+  2. 在您的代理中，查找给定会话 ID 的存储用户 ID，并在它与调用者不匹配时拒绝请求。使用 `auth=cognito` 时，调用者的 JWT 会到达您的代理代码，因此其 `sub` 声明可以识别他们。
+</Steps>
+
+生成会话 ID，而不是从用户提供的值（如对话名称）派生它 — 调用者可以预测的任何内容，调用者都可以发送。
 </OptionFilter>
 
 ## 调用您的 Agent


### PR DESCRIPTION
### Reason for this change

The session ID an agent receives names a conversation, but on its own it does not say who that conversation belongs to. AgentCore Runtime authorizes an invocation against the agent runtime resource ARN rather than against an individual session, which leaves it to the agent to decide what a session means to the application.

Projects that want each signed-in user to reach only their own conversations currently have to work that pattern out for themselves. This documents it.

This is an alternative to #1105, which instead changes the generated defaults. This PR is documentation only — no generated code changes, so existing projects are unaffected and readers can adopt the pattern at whatever granularity suits them. #1105 also documents this pattern alongside its own change, so the two are not mutually exclusive.

### Description of changes

Adds a "Restricting sessions to their owner" section to the <Link path="guides/ts-agent">`ts#agent`</Link> and <Link path="guides/py-agent">`py#agent`</Link> guides, describing a session ownership registry:

1. **Create sessions through your API.** A procedure mints an opaque session ID, resolves the caller from its own verified request context, and records the pair — for example in a DynamoDB table partitioned on the session ID, with a secondary index on the user for listing their own conversations. The caller is never taken from an input field.

2. **Validate ownership in the agent.** The agent looks up the owner for the session ID it is given, compares it against the caller's `sub` — available with `auth=cognito`, since the AgentCore Runtime authorizer validates the JWT and the generated infrastructure allowlists the `Authorization` header — and refuses the request when they do not match.

Both guides include example code in their respective idioms, and explain why validating in both places is worthwhile: the API decides ownership, the agent enforces it, so a session ID that leaks is still refused on the next invocation and any future client inherits the same rule.

The section also notes that a session ID selects the microVM serving the request, so its filesystem, `/tmp` and in-process caches are shared by every request resolving to that session. Generating opaque IDs in the API avoids two callers colliding there; deriving them from user-supplied values such as a conversation name does not.

Separately, documents how the `connection` generator derives the AgentCore session ID from the AG-UI thread ID — including the 33-character padding — since that page previously did not mention either identifier, and points to the new guidance from it.

### Description of how you validated changes

Documentation only. Verified the docs site builds and all internal links resolve. Reviewed the described pattern against the generated code paths: the session ID header and JWT claim are both available to the agent as described for `auth=cognito`, and the caller-resolution approach for the API matches the identity middleware already documented in the <Link path="guides/trpc">tRPC guide</Link>.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*