### PR TITLE
feat(ts#website): make WAF, encryption and KMS key rotation configurable on the static website construct/module

### DIFF
--- a/docs/src/content/docs/en/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/en/get_started/tutorials/dungeon-game/1.mdx
@@ -1072,11 +1072,17 @@ The `ts#website` generates these files. Let us examine some of the key files hig
 // packages/common/constructs/src/app/static-websites/game-ui.ts
 import * as url from 'url';
 import { Construct } from 'constructs';
-import { StaticWebsite } from '../../core/index.js';
+import { StaticWebsite, StaticWebsiteProps } from '../../core/index.js';
+
+export type GameUIProps = Omit<
+  StaticWebsiteProps,
+  'websiteName' | 'websiteFilePath'
+>;
 
 export class GameUI extends StaticWebsite {
-  constructor(scope: Construct, id: string) {
+  constructor(scope: Construct, id: string, props?: GameUIProps) {
     super(scope, id, {
+      ...props,
       websiteName: 'GameUI',
       websiteFilePath: url.fileURLToPath(
         new URL(

--- a/docs/src/content/docs/en/guides/react-website.mdx
+++ b/docs/src/content/docs/en/guides/react-website.mdx
@@ -334,6 +334,22 @@ export class ApplicationStack extends Stack {
 }
 ```
 
+:::caution[Suppress CKV_AWS_158 when using S3_MANAGED]
+Choosing `BucketEncryption.S3_MANAGED` means the access log group is no longer KMS encrypted, which fails the `checkov` security scan with `CKV_AWS_158`. Suppress it:
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { LogGroup } from 'aws-cdk-lib/aws-logs';
+import { suppressRules } from '@my-scope/common-constructs';
+
+suppressRules(
+  website,
+  ['CKV_AWS_158'],
+  'Access log group is not KMS encrypted when encryption is S3_MANAGED',
+  (c) => c instanceof LogGroup,
+);
+```
+:::
+
 To use your own KMS key instead of one created automatically, pass `encryptionKey`:
 
 ```ts {2}
@@ -342,10 +358,36 @@ new MyWebsite(this, 'MyWebsite', {
 });
 ```
 
-`enableKeyRotation` (default `true`) only applies to the automatically created key, i.e. when `encryption` is `BucketEncryption.KMS` (the default) and no `encryptionKey` is supplied.
+:::caution[Imported keys need their own permissions]
+A key imported via `Key.fromKeyArn` must already grant the CloudWatch Logs, S3 and CloudFront service principals the permissions they need in its own key policy. `addToResourcePolicy` is a no-op on an imported key, so this construct can't grant them for you, and `cdk synth` won't warn you - the failure only shows up at deploy time. A key created in the same app (`new Key(this, 'WebsiteKey')`) doesn't have this problem, since CDK can update its policy directly.
+:::
+
+`enableKeyRotation` (default `true`) only applies to the automatically created key, i.e. when `encryption` is `BucketEncryption.KMS` (the default) and no `encryptionKey` is supplied:
+
+```ts {2}
+new MyWebsite(this, 'MyWebsite', {
+  enableKeyRotation: false,
+});
+```
+
+:::caution[Suppress CKV_AWS_7 when disabling key rotation]
+Disabling key rotation on the automatically created key fails the `checkov` security scan with `CKV_AWS_7`. Suppress it:
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { Key } from 'aws-cdk-lib/aws-kms';
+import { suppressRules } from '@my-scope/common-constructs';
+
+suppressRules(
+  website,
+  ['CKV_AWS_7'],
+  'Key rotation is managed externally',
+  (c) => c instanceof Key,
+);
+```
+:::
 </Fragment>
 <Fragment slot="terraform">
-If you want to use a different encryption configuration, set the `encryption`, `kms_key_arn` and `enable_key_rotation` variables:
+If you want to use a different encryption configuration, set the `encryption`, `kms_key_arn`, `create_kms_key` and `enable_key_rotation` variables:
 
 ```hcl title="packages/infra/src/main.tf" {7}
 module "my_website" {
@@ -358,9 +400,52 @@ module "my_website" {
 }
 ```
 
-To use your own KMS key instead of one created automatically, pass `kms_key_arn`. A customer-supplied key must already grant the CloudWatch Logs, S3 and CloudFront service principals the permissions they need in its own key policy.
+:::caution[Checkov: S3_MANAGED]
+Choosing `S3_MANAGED` fails the `checkov` security scan with `CKV_AWS_145` on the website and distribution log buckets. The vended `test` target doesn't accept a `--config-file`, but `checkov` auto-discovers a `.checkov.yaml` in its working directory, so drop one in `packages/infra/src`:
 
-`enable_key_rotation` (default `true`) only applies to the automatically created key, i.e. when `encryption` is `"KMS"` (the default) and no `kms_key_arn` is supplied.
+```yaml title="packages/infra/src/.checkov.yaml"
+skip-check:
+  - CKV_AWS_145
+```
+:::
+
+To use your own KMS key instead of one created automatically, pass `kms_key_arn` and set `create_kms_key` to `false`:
+
+```hcl title="packages/infra/src/main.tf" {7-8}
+module "my_website" {
+  source = "../../common/terraform/src/app/static-websites/my-website"
+
+  providers = {
+    aws.us_east_1 = aws.us_east_1
+  }
+  kms_key_arn    = aws_kms_key.website.arn
+  create_kms_key = false
+}
+```
+
+A customer-supplied key must already grant the CloudWatch Logs, S3 and CloudFront service principals the permissions they need in its own key policy.
+
+`enable_key_rotation` (default `true`) only applies to the automatically created key, i.e. when `encryption` is `"KMS"` (the default) and `create_kms_key` is `true`:
+
+```hcl title="packages/infra/src/main.tf" {7}
+module "my_website" {
+  source = "../../common/terraform/src/app/static-websites/my-website"
+
+  providers = {
+    aws.us_east_1 = aws.us_east_1
+  }
+  enable_key_rotation = false
+}
+```
+
+:::caution[Checkov: key rotation disabled]
+Disabling key rotation on the automatically created key fails the `checkov` security scan with `CKV_AWS_7`. Add it to the same `.checkov.yaml`:
+
+```yaml title="packages/infra/src/.checkov.yaml"
+skip-check:
+  - CKV_AWS_7
+```
+:::
 </Fragment>
 </Infrastructure>
 

--- a/docs/src/content/docs/en/guides/react-website.mdx
+++ b/docs/src/content/docs/en/guides/react-website.mdx
@@ -129,58 +129,7 @@ waf -> cloudfront
 cloudfront -> s3
 ```
 
-#### Security Headers
-
-The CloudFront distribution applies a response headers policy that sets `Strict-Transport-Security`, `X-Content-Type-Options`, `X-Frame-Options: DENY`, `Referrer-Policy` and a `Content-Security-Policy` on all responses.
-
-A default `Content-Security-Policy` is enforced. It restricts scripts and framing to mitigate XSS and clickjacking, while permitting HTTPS and WSS connections so the website can call AWS service endpoints (such as API Gateway, Cognito and Bedrock AgentCore) whose URLs are only known at deploy time. To adjust the policy (for example to tighten `connect-src` to your specific origins), edit the `content_security_policy` value in your generated `static-website.ts` (CDK) or `static-website.tf` (Terraform).
-
-`runtime-config.json` is served with `Cache-Control: no-cache` so that browsers always fetch the latest configuration after a redeploy, rather than using a stale cached copy.
-
-#### Custom Domain & TLS
-
-By default the distribution uses the default CloudFront domain name (`*.cloudfront.net`) and its default certificate, which does not support enforcing a minimum TLS version of 1.2. To serve your website from your own domain, supply an [ACM certificate](https://docs.aws.amazon.com/acm/latest/userguide/acm-overview.html) (which must reside in `us-east-1` for use with CloudFront) and your domain names — a minimum TLS version of 1.2 is then enforced for viewers:
-
-<Infrastructure>
-<Fragment slot="cdk">
-Pass the `certificate` and `domainNames` props through in your generated website construct in `packages/common/constructs/src/app/static-websites`:
-
-```ts {6-8}
-export class MyWebsite extends StaticWebsite {
-  constructor(scope: Construct, id: string) {
-    super(scope, id, {
-      websiteName: 'MyWebsite',
-      websiteFilePath: ...,
-      domainNames: ['www.example.com'],
-      certificate: Certificate.fromCertificateArn(scope, 'Cert',
-        'arn:aws:acm:us-east-1:123456789012:certificate/...'),
-    });
-  }
-}
-```
-</Fragment>
-<Fragment slot="terraform">
-Set the `custom_domain_names` and `acm_certificate_arn` variables in your generated website module in `packages/common/terraform/src/app/static-websites`:
-
-```hcl {5-6}
-module "static_website" {
-  source            = "../../../core/static-website"
-  website_name      = "my-website"
-  website_file_path = ...
-  custom_domain_names = ["www.example.com"]
-  acm_certificate_arn = "arn:aws:acm:us-east-1:123456789012:certificate/..."
-
-  providers = {
-    aws.us_east_1 = aws.us_east_1
-  }
-}
-```
-</Fragment>
-</Infrastructure>
-
-You will also need to create DNS records (for example in Route 53) pointing your domain at the CloudFront distribution.
-
-## Implementing your React Website
+## Implementing your Website
 
 The [React documentation](https://react.dev/learn) is a good place to start to learn the basics of building with React.
 
@@ -231,6 +180,236 @@ export const MyComponent = () => {
 
 For more details, check out the [TanStack Router](https://tanstack.com/router/latest/docs/framework/react/overview) documentation.
 
+## Deploying your Website
+
+The React website generator creates CDK or Terraform infrastructure as code based on your selected `iac`. You can use this to deploy your website.
+
+<Infrastructure>
+<Fragment slot="cdk">
+To deploy your website, we recommend using the <Link path="guides/typescript-infrastructure">`ts#infra` generator</Link> to create a CDK application.
+
+You can use the CDK construct generated for you in `packages/common/constructs` to deploy your website.
+
+```ts title="packages/infra/src/stacks/application-stack.ts" {3, 9}
+import { Stack } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { MyWebsite } from '@my-scope/common-constructs';
+
+export class ApplicationStack extends Stack {
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+
+    new MyWebsite(this, 'MyWebsite');
+  }
+}
+```
+
+This sets up:
+
+1. An S3 bucket for hosting your static website files
+2. CloudFront distribution for global content delivery
+3. WAF Web ACL for security protection
+4. Origin Access Control for secure S3 access
+5. Automatic deployment of website files and runtime configuration
+</Fragment>
+<Fragment slot="terraform">
+To deploy your website, we recommend using the <Link path="/guides/terraform-project">`terraform#project` generator</Link> to create a Terraform project.
+
+You can use the Terraform module generated for you in `packages/common/terraform` to deploy your website.
+
+```hcl title="packages/infra/src/main.tf" {3}
+# Deploy website
+module "my_website" {
+  source = "../../common/terraform/src/app/static-websites/my-website"
+
+  providers = {
+    aws.us_east_1 = aws.us_east_1
+  }
+}
+```
+
+This sets up:
+
+1. An S3 bucket for hosting your static website files
+2. CloudFront distribution for global content delivery
+3. WAF Web ACL for security protection (deployed in us-east-1)
+4. Origin Access Control for secure S3 access
+5. Automatic deployment of website files and runtime configuration
+
+:::note[WAF Provider Region]
+The `aws.us_east_1` provider is required for CloudFront and WAF resources, which must be deployed in the us-east-1 region. Make sure your Terraform configuration includes this provider:
+
+```hcl title="packages/infra/src/providers.tf"
+provider "aws" {
+  alias  = "us_east_1"
+  region = "us-east-1"
+}
+```
+:::
+</Fragment>
+</Infrastructure>
+
+### Security Headers
+
+The CloudFront distribution applies a response headers policy that sets `Strict-Transport-Security`, `X-Content-Type-Options`, `X-Frame-Options: DENY`, `Referrer-Policy` and a `Content-Security-Policy` on all responses.
+
+A default `Content-Security-Policy` is enforced. It restricts scripts and framing to mitigate XSS and clickjacking, while permitting HTTPS and WSS connections so the website can call AWS service endpoints (such as API Gateway, Cognito and Bedrock AgentCore) whose URLs are only known at deploy time. To adjust the policy (for example to tighten `connect-src` to your specific origins), edit the `content_security_policy` value in your generated `static-website.ts` (CDK) or `static-website.tf` (Terraform).
+
+`runtime-config.json` is served with `Cache-Control: no-cache` so that browsers always fetch the latest configuration after a redeploy, rather than using a stale cached copy.
+
+### WAF
+
+The CloudFront distribution is protected by an [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACL by default. The Web ACL uses the AWS managed default ruleset ([`AWSManagedRulesCommonRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs) and [`AWSManagedRulesKnownBadInputsRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs)), providing protection against common web exploits including the OWASP Top 10.
+
+<Infrastructure>
+<Fragment slot="cdk">
+To opt out, set `enableWaf` to `false` when you create your website:
+
+```ts title="packages/infra/src/stacks/application-stack.ts" {10,15-18}
+import { Stack } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { MyWebsite, suppressRules } from '@my-scope/common-constructs';
+
+export class ApplicationStack extends Stack {
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+
+    const website = new MyWebsite(this, 'MyWebsite', {
+      enableWaf: false,
+    });
+
+    // Disabling WAF fails the checkov CKV_AWS_68 check ("CloudFront
+    // Distribution should have WAF enabled"). Suppress it explicitly.
+    suppressRules(
+      website.cloudFrontDistribution,
+      ['CKV_AWS_68'],
+      'WAF is intentionally disabled for this distribution',
+    );
+  }
+}
+```
+
+:::caution[Suppress CKV_AWS_68 when disabling WAF]
+Disabling WAF means the synthesized CloudFront distribution has no Web ACL associated, which fails the `checkov` security scan with `CKV_AWS_68: "CloudFront Distribution should have WAF enabled"` unless suppressed as shown above.
+:::
+</Fragment>
+<Fragment slot="terraform">
+To opt out, set `enable_waf` to `false`:
+
+```hcl title="packages/infra/src/main.tf" {7}
+module "my_website" {
+  source = "../../common/terraform/src/app/static-websites/my-website"
+
+  providers = {
+    aws.us_east_1 = aws.us_east_1
+  }
+  enable_waf = false
+}
+```
+</Fragment>
+</Infrastructure>
+
+### Bucket Encryption
+
+The website bucket, the CloudFront distribution log bucket, and the CloudWatch Logs group receiving their server access logs are encrypted with a customer-managed [AWS KMS](https://aws.amazon.com/kms/) key by default. This key is created for you automatically, with key rotation enabled.
+
+<Infrastructure>
+<Fragment slot="cdk">
+If you want to use a different encryption configuration, pass the `encryption`, `encryptionKey` and `enableKeyRotation` props when you create your website:
+
+```ts title="packages/infra/src/stacks/application-stack.ts" {11}
+import { Stack } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { BucketEncryption } from 'aws-cdk-lib/aws-s3';
+import { MyWebsite } from '@my-scope/common-constructs';
+
+export class ApplicationStack extends Stack {
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+
+    new MyWebsite(this, 'MyWebsite', {
+      encryption: BucketEncryption.S3_MANAGED,
+    });
+  }
+}
+```
+
+To use your own KMS key instead of one created automatically, pass `encryptionKey`:
+
+```ts {2}
+new MyWebsite(this, 'MyWebsite', {
+  encryptionKey: myKey,
+});
+```
+
+`enableKeyRotation` (default `true`) only applies to the automatically created key, i.e. when `encryption` is `BucketEncryption.KMS` (the default) and no `encryptionKey` is supplied.
+</Fragment>
+<Fragment slot="terraform">
+If you want to use a different encryption configuration, set the `encryption`, `kms_key_arn` and `enable_key_rotation` variables:
+
+```hcl title="packages/infra/src/main.tf" {7}
+module "my_website" {
+  source = "../../common/terraform/src/app/static-websites/my-website"
+
+  providers = {
+    aws.us_east_1 = aws.us_east_1
+  }
+  encryption = "S3_MANAGED"
+}
+```
+
+To use your own KMS key instead of one created automatically, pass `kms_key_arn`. A customer-supplied key must already grant the CloudWatch Logs, S3 and CloudFront service principals the permissions they need in its own key policy.
+
+`enable_key_rotation` (default `true`) only applies to the automatically created key, i.e. when `encryption` is `"KMS"` (the default) and no `kms_key_arn` is supplied.
+</Fragment>
+</Infrastructure>
+
+### Custom Domain & TLS
+
+By default the distribution uses the default CloudFront domain name (`*.cloudfront.net`) and its default certificate, which does not support enforcing a minimum TLS version of 1.2. To serve your website from your own domain, supply an [ACM certificate](https://docs.aws.amazon.com/acm/latest/userguide/acm-overview.html) (which must reside in `us-east-1` for use with CloudFront) and your domain names. A minimum TLS version of 1.2 is then enforced for viewers:
+
+<Infrastructure>
+<Fragment slot="cdk">
+Pass the `certificate` and `domainNames` props when you create your website:
+
+```ts title="packages/infra/src/stacks/application-stack.ts" {11-13}
+import { Stack } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { Certificate } from 'aws-cdk-lib/aws-certificatemanager';
+import { MyWebsite } from '@my-scope/common-constructs';
+
+export class ApplicationStack extends Stack {
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+
+    new MyWebsite(this, 'MyWebsite', {
+      domainNames: ['www.example.com'],
+      certificate: Certificate.fromCertificateArn(this, 'Cert',
+        'arn:aws:acm:us-east-1:123456789012:certificate/...'),
+    });
+  }
+}
+```
+</Fragment>
+<Fragment slot="terraform">
+Set the `custom_domain_names` and `acm_certificate_arn` variables:
+
+```hcl title="packages/infra/src/main.tf" {7-8}
+module "my_website" {
+  source = "../../common/terraform/src/app/static-websites/my-website"
+
+  providers = {
+    aws.us_east_1 = aws.us_east_1
+  }
+  custom_domain_names = ["www.example.com"]
+  acm_certificate_arn = "arn:aws:acm:us-east-1:123456789012:certificate/..."
+}
+```
+</Fragment>
+</Infrastructure>
+
+You will also need to create DNS records (for example in Route 53) pointing your domain at the CloudFront distribution.
+
 ## Runtime Configuration
 
 Configuration from your infrastructure is provided to your website via <Link href="guides/runtime-config">Runtime Configuration</Link>. This allows your website to access details such as API URLs which are not known until your application is deployed.
@@ -252,7 +431,7 @@ export class ApplicationStack extends Stack {
   constructor(scope: Construct, id: string) {
     super(scope, id);
 
-    // Website can be declared at any point — runtime config is resolved lazily
+    // Website can be declared at any point, since runtime config is resolved lazily
     new MyWebsite(this, 'MyWebsite');
 
     // Automatically adds values to the RuntimeConfig
@@ -414,75 +593,6 @@ For React specific testing, React Testing Library is already installed and avail
 You can run your tests using the `test` target:
 
 <NxCommands commands={['test <my-website>']} />
-
-## Deploying Your Website
-
-The React website generator creates CDK or Terraform infrastructure as code based on your selected `iac`. You can use this to deploy your website.
-
-<Infrastructure>
-<Fragment slot="cdk">
-To deploy your website, we recommend using the <Link path="guides/typescript-infrastructure">`ts#infra` generator</Link> to create a CDK application.
-
-You can use the CDK construct generated for you in `packages/common/constructs` to deploy your website.
-
-```ts title="packages/infra/src/stacks/application-stack.ts" {3, 9}
-import { Stack } from 'aws-cdk-lib';
-import { Construct } from 'constructs';
-import { MyWebsite } from '@my-scope/common-constructs';
-
-export class ApplicationStack extends Stack {
-  constructor(scope: Construct, id: string) {
-    super(scope, id);
-
-    new MyWebsite(this, 'MyWebsite');
-  }
-}
-```
-
-This sets up:
-
-1. An S3 bucket for hosting your static website files
-2. CloudFront distribution for global content delivery
-3. WAF Web ACL for security protection
-4. Origin Access Control for secure S3 access
-5. Automatic deployment of website files and runtime configuration
-</Fragment>
-<Fragment slot="terraform">
-To deploy your website, we recommend using the <Link path="/guides/terraform-project">`terraform#project` generator</Link> to create a Terraform project.
-
-You can use the Terraform module generated for you in `packages/common/terraform` to deploy your website.
-
-```hcl title="packages/infra/src/main.tf" {3}
-# Deploy website
-module "my_website" {
-  source = "../../common/terraform/src/app/static-websites/my-website"
-
-  providers = {
-    aws.us_east_1 = aws.us_east_1
-  }
-}
-```
-
-This sets up:
-
-1. An S3 bucket for hosting your static website files
-2. CloudFront distribution for global content delivery
-3. WAF Web ACL for security protection (deployed in us-east-1)
-4. Origin Access Control for secure S3 access
-5. Automatic deployment of website files and runtime configuration
-
-:::note[WAF Provider Region]
-The `aws.us_east_1` provider is required for CloudFront and WAF resources, which must be deployed in the us-east-1 region. Make sure your Terraform configuration includes this provider:
-
-```hcl title="packages/infra/src/providers.tf"
-provider "aws" {
-  alias  = "us_east_1"
-  region = "us-east-1"
-}
-```
-:::
-</Fragment>
-</Infrastructure>
 
 ## Connections
 

--- a/docs/src/content/docs/es/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/es/get_started/tutorials/dungeon-game/1.mdx
@@ -1072,11 +1072,17 @@ El `ts#website` genera estos archivos. Examinemos algunos de los archivos clave 
 // packages/common/constructs/src/app/static-websites/game-ui.ts
 import * as url from 'url';
 import { Construct } from 'constructs';
-import { StaticWebsite } from '../../core/index.js';
+import { StaticWebsite, StaticWebsiteProps } from '../../core/index.js';
+
+export type GameUIProps = Omit<
+  StaticWebsiteProps,
+  'websiteName' | 'websiteFilePath'
+>;
 
 export class GameUI extends StaticWebsite {
-  constructor(scope: Construct, id: string) {
+  constructor(scope: Construct, id: string, props?: GameUIProps) {
     super(scope, id, {
+      ...props,
       websiteName: 'GameUI',
       websiteFilePath: url.fileURLToPath(
         new URL(

--- a/docs/src/content/docs/es/guides/react-website.mdx
+++ b/docs/src/content/docs/es/guides/react-website.mdx
@@ -18,11 +18,11 @@ import Infrastructure from '@components/infrastructure.astro';
 import Snippet from '@components/snippet.astro';
 import OptionFilter from '@components/option-filter.astro';
 
-Este generador crea un nuevo sitio web [React](https://react.dev/) con [shadcn/ui](https://ui.shadcn.com/) configurado por defecto, junto con la infraestructura AWS CDK o Terraform para desplegar tu sitio web en la nube como un sitio web estático alojado en [S3](https://aws.amazon.com/s3/), servido por [CloudFront](https://aws.amazon.com/cloudfront/) y protegido por [WAF](https://aws.amazon.com/waf/).
+Este generador crea un nuevo sitio web [React](https://react.dev/) con [shadcn/ui](https://ui.shadcn.com/) configurado por defecto, junto con la infraestructura de AWS CDK o Terraform para desplegar tu sitio web en la nube como un sitio web estático alojado en [S3](https://aws.amazon.com/s3/), servido por [CloudFront](https://aws.amazon.com/cloudfront/) y protegido por [WAF](https://aws.amazon.com/waf/).
 
 La aplicación generada utiliza [Vite](https://vite.dev/) como herramienta de construcción y empaquetador. Utiliza [TanStack Router](https://tanstack.com/router/v1) para enrutamiento con seguridad de tipos.
 
-:::note[Proveedor de UX]
+:::note[Proveedor UX]
 El `ux` predeterminado es [shadcn/ui](https://ui.shadcn.com/). También puedes seleccionar [Cloudscape](http://cloudscape.design/) o `none` (trae tu propia biblioteca de componentes).
 :::
 
@@ -129,58 +129,7 @@ waf -> cloudfront
 cloudfront -> s3
 ```
 
-#### Encabezados de Seguridad
-
-La distribución CloudFront aplica una política de encabezados de respuesta que establece `Strict-Transport-Security`, `X-Content-Type-Options`, `X-Frame-Options: DENY`, `Referrer-Policy` y una `Content-Security-Policy` en todas las respuestas.
-
-Se aplica una `Content-Security-Policy` predeterminada. Restringe scripts y enmarcado para mitigar XSS y clickjacking, mientras permite conexiones HTTPS y WSS para que el sitio web pueda llamar a endpoints de servicios AWS (como API Gateway, Cognito y Bedrock AgentCore) cuyas URLs solo se conocen en el momento del despliegue. Para ajustar la política (por ejemplo, para restringir `connect-src` a tus orígenes específicos), edita el valor `content_security_policy` en tu `static-website.ts` (CDK) o `static-website.tf` (Terraform) generado.
-
-`runtime-config.json` se sirve con `Cache-Control: no-cache` para que los navegadores siempre obtengan la configuración más reciente después de un redespliegue, en lugar de usar una copia en caché obsoleta.
-
-#### Dominio Personalizado y TLS
-
-Por defecto, la distribución utiliza el nombre de dominio predeterminado de CloudFront (`*.cloudfront.net`) y su certificado predeterminado, que no admite la aplicación de una versión mínima de TLS de 1.2. Para servir tu sitio web desde tu propio dominio, proporciona un [certificado ACM](https://docs.aws.amazon.com/acm/latest/userguide/acm-overview.html) (que debe residir en `us-east-1` para su uso con CloudFront) y tus nombres de dominio — entonces se aplica una versión mínima de TLS de 1.2 para los visitantes:
-
-<Infrastructure>
-<Fragment slot="cdk">
-Pasa las propiedades `certificate` y `domainNames` en tu construcción de sitio web generada en `packages/common/constructs/src/app/static-websites`:
-
-```ts {6-8}
-export class MyWebsite extends StaticWebsite {
-  constructor(scope: Construct, id: string) {
-    super(scope, id, {
-      websiteName: 'MyWebsite',
-      websiteFilePath: ...,
-      domainNames: ['www.example.com'],
-      certificate: Certificate.fromCertificateArn(scope, 'Cert',
-        'arn:aws:acm:us-east-1:123456789012:certificate/...'),
-    });
-  }
-}
-```
-</Fragment>
-<Fragment slot="terraform">
-Establece las variables `custom_domain_names` y `acm_certificate_arn` en tu módulo de sitio web generado en `packages/common/terraform/src/app/static-websites`:
-
-```hcl {5-6}
-module "static_website" {
-  source            = "../../../core/static-website"
-  website_name      = "my-website"
-  website_file_path = ...
-  custom_domain_names = ["www.example.com"]
-  acm_certificate_arn = "arn:aws:acm:us-east-1:123456789012:certificate/..."
-
-  providers = {
-    aws.us_east_1 = aws.us_east_1
-  }
-}
-```
-</Fragment>
-</Infrastructure>
-
-También necesitarás crear registros DNS (por ejemplo, en Route 53) apuntando tu dominio a la distribución CloudFront.
-
-## Implementando tu Sitio Web React
+## Implementando tu Sitio Web
 
 La [documentación de React](https://react.dev/learn) es un buen lugar para comenzar a aprender los conceptos básicos de construcción con React.
 
@@ -199,7 +148,7 @@ Puedes consultar la [documentación de shadcn/ui](https://ui.shadcn.com/docs) pa
 Tu sitio web viene con [TanStack Router](https://tanstack.com/router/v1) configurado por defecto. Esto facilita agregar nuevas rutas:
 
 <Steps>
-  1. [Ejecuta el Servidor de Desarrollo Local](#servidor-de-desarrollo-local)
+  1. [Ejecutar el Servidor de Desarrollo Local](#servidor-de-desarrollo-local)
   2. Crea un nuevo archivo `<page-name>.tsx` en `src/routes`, con su posición en el árbol de archivos representando la ruta
   3. ¡Observa que se generan automáticamente un `Route` y `RouteComponent` para ti. Puedes comenzar a construir tu página aquí!
 </Steps>
@@ -231,6 +180,236 @@ export const MyComponent = () => {
 
 Para más detalles, consulta la documentación de [TanStack Router](https://tanstack.com/router/latest/docs/framework/react/overview).
 
+## Desplegando tu Sitio Web
+
+El generador de sitios web React crea infraestructura como código CDK o Terraform basándose en tu `iac` seleccionado. Puedes usar esto para desplegar tu sitio web.
+
+<Infrastructure>
+<Fragment slot="cdk">
+Para desplegar tu sitio web, recomendamos usar el <Link path="guides/typescript-infrastructure">generador `ts#infra`</Link> para crear una aplicación CDK.
+
+Puedes usar el constructo CDK generado para ti en `packages/common/constructs` para desplegar tu sitio web.
+
+```ts title="packages/infra/src/stacks/application-stack.ts" {3, 9}
+import { Stack } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { MyWebsite } from '@my-scope/common-constructs';
+
+export class ApplicationStack extends Stack {
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+
+    new MyWebsite(this, 'MyWebsite');
+  }
+}
+```
+
+Esto configura:
+
+1. Un bucket S3 para alojar los archivos de tu sitio web estático
+2. Distribución CloudFront para entrega de contenido global
+3. WAF Web ACL para protección de seguridad
+4. Origin Access Control para acceso seguro a S3
+5. Despliegue automático de archivos del sitio web y configuración en tiempo de ejecución
+</Fragment>
+<Fragment slot="terraform">
+Para desplegar tu sitio web, recomendamos usar el <Link path="/guides/terraform-project">generador `terraform#project`</Link> para crear un proyecto Terraform.
+
+Puedes usar el módulo Terraform generado para ti en `packages/common/terraform` para desplegar tu sitio web.
+
+```hcl title="packages/infra/src/main.tf" {3}
+# Deploy website
+module "my_website" {
+  source = "../../common/terraform/src/app/static-websites/my-website"
+
+  providers = {
+    aws.us_east_1 = aws.us_east_1
+  }
+}
+```
+
+Esto configura:
+
+1. Un bucket S3 para alojar los archivos de tu sitio web estático
+2. Distribución CloudFront para entrega de contenido global
+3. WAF Web ACL para protección de seguridad (desplegado en us-east-1)
+4. Origin Access Control para acceso seguro a S3
+5. Despliegue automático de archivos del sitio web y configuración en tiempo de ejecución
+
+:::note[Región del Proveedor WAF]
+El proveedor `aws.us_east_1` es requerido para los recursos de CloudFront y WAF, que deben desplegarse en la región us-east-1. Asegúrate de que tu configuración de Terraform incluya este proveedor:
+
+```hcl title="packages/infra/src/providers.tf"
+provider "aws" {
+  alias  = "us_east_1"
+  region = "us-east-1"
+}
+```
+:::
+</Fragment>
+</Infrastructure>
+
+### Encabezados de Seguridad
+
+La distribución CloudFront aplica una política de encabezados de respuesta que establece `Strict-Transport-Security`, `X-Content-Type-Options`, `X-Frame-Options: DENY`, `Referrer-Policy` y una `Content-Security-Policy` en todas las respuestas.
+
+Se aplica una `Content-Security-Policy` predeterminada. Restringe scripts y framing para mitigar XSS y clickjacking, mientras permite conexiones HTTPS y WSS para que el sitio web pueda llamar a endpoints de servicios de AWS (como API Gateway, Cognito y Bedrock AgentCore) cuyas URLs solo se conocen en tiempo de despliegue. Para ajustar la política (por ejemplo, para restringir `connect-src` a tus orígenes específicos), edita el valor `content_security_policy` en tu `static-website.ts` (CDK) o `static-website.tf` (Terraform) generado.
+
+`runtime-config.json` se sirve con `Cache-Control: no-cache` para que los navegadores siempre obtengan la configuración más reciente después de un redespliegue, en lugar de usar una copia en caché obsoleta.
+
+### WAF
+
+La distribución CloudFront está protegida por un Web ACL de [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) por defecto. El Web ACL utiliza el conjunto de reglas predeterminado administrado por AWS ([`AWSManagedRulesCommonRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs) y [`AWSManagedRulesKnownBadInputsRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs)), proporcionando protección contra exploits web comunes incluyendo el OWASP Top 10.
+
+<Infrastructure>
+<Fragment slot="cdk">
+Para optar por no usarlo, establece `enableWaf` en `false` cuando crees tu sitio web:
+
+```ts title="packages/infra/src/stacks/application-stack.ts" {10,15-18}
+import { Stack } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { MyWebsite, suppressRules } from '@my-scope/common-constructs';
+
+export class ApplicationStack extends Stack {
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+
+    const website = new MyWebsite(this, 'MyWebsite', {
+      enableWaf: false,
+    });
+
+    // Disabling WAF fails the checkov CKV_AWS_68 check ("CloudFront
+    // Distribution should have WAF enabled"). Suppress it explicitly.
+    suppressRules(
+      website.cloudFrontDistribution,
+      ['CKV_AWS_68'],
+      'WAF is intentionally disabled for this distribution',
+    );
+  }
+}
+```
+
+:::caution[Suprimir CKV_AWS_68 al deshabilitar WAF]
+Deshabilitar WAF significa que la distribución CloudFront sintetizada no tiene un Web ACL asociado, lo que falla el escaneo de seguridad `checkov` con `CKV_AWS_68: "CloudFront Distribution should have WAF enabled"` a menos que se suprima como se muestra arriba.
+:::
+</Fragment>
+<Fragment slot="terraform">
+Para optar por no usarlo, establece `enable_waf` en `false`:
+
+```hcl title="packages/infra/src/main.tf" {7}
+module "my_website" {
+  source = "../../common/terraform/src/app/static-websites/my-website"
+
+  providers = {
+    aws.us_east_1 = aws.us_east_1
+  }
+  enable_waf = false
+}
+```
+</Fragment>
+</Infrastructure>
+
+### Cifrado de Bucket
+
+El bucket del sitio web, el bucket de logs de la distribución CloudFront y el grupo de CloudWatch Logs que recibe sus logs de acceso al servidor están cifrados con una clave [AWS KMS](https://aws.amazon.com/kms/) administrada por el cliente por defecto. Esta clave se crea automáticamente para ti, con rotación de claves habilitada.
+
+<Infrastructure>
+<Fragment slot="cdk">
+Si deseas usar una configuración de cifrado diferente, pasa las props `encryption`, `encryptionKey` y `enableKeyRotation` cuando crees tu sitio web:
+
+```ts title="packages/infra/src/stacks/application-stack.ts" {11}
+import { Stack } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { BucketEncryption } from 'aws-cdk-lib/aws-s3';
+import { MyWebsite } from '@my-scope/common-constructs';
+
+export class ApplicationStack extends Stack {
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+
+    new MyWebsite(this, 'MyWebsite', {
+      encryption: BucketEncryption.S3_MANAGED,
+    });
+  }
+}
+```
+
+Para usar tu propia clave KMS en lugar de una creada automáticamente, pasa `encryptionKey`:
+
+```ts {2}
+new MyWebsite(this, 'MyWebsite', {
+  encryptionKey: myKey,
+});
+```
+
+`enableKeyRotation` (predeterminado `true`) solo se aplica a la clave creada automáticamente, es decir, cuando `encryption` es `BucketEncryption.KMS` (el predeterminado) y no se proporciona `encryptionKey`.
+</Fragment>
+<Fragment slot="terraform">
+Si deseas usar una configuración de cifrado diferente, establece las variables `encryption`, `kms_key_arn` y `enable_key_rotation`:
+
+```hcl title="packages/infra/src/main.tf" {7}
+module "my_website" {
+  source = "../../common/terraform/src/app/static-websites/my-website"
+
+  providers = {
+    aws.us_east_1 = aws.us_east_1
+  }
+  encryption = "S3_MANAGED"
+}
+```
+
+Para usar tu propia clave KMS en lugar de una creada automáticamente, pasa `kms_key_arn`. Una clave proporcionada por el cliente ya debe otorgar a los principales de servicio de CloudWatch Logs, S3 y CloudFront los permisos que necesitan en su propia política de clave.
+
+`enable_key_rotation` (predeterminado `true`) solo se aplica a la clave creada automáticamente, es decir, cuando `encryption` es `"KMS"` (el predeterminado) y no se proporciona `kms_key_arn`.
+</Fragment>
+</Infrastructure>
+
+### Dominio Personalizado y TLS
+
+Por defecto, la distribución usa el nombre de dominio predeterminado de CloudFront (`*.cloudfront.net`) y su certificado predeterminado, que no admite la aplicación de una versión TLS mínima de 1.2. Para servir tu sitio web desde tu propio dominio, proporciona un [certificado ACM](https://docs.aws.amazon.com/acm/latest/userguide/acm-overview.html) (que debe residir en `us-east-1` para su uso con CloudFront) y tus nombres de dominio. Entonces se aplica una versión TLS mínima de 1.2 para los espectadores:
+
+<Infrastructure>
+<Fragment slot="cdk">
+Pasa las props `certificate` y `domainNames` cuando crees tu sitio web:
+
+```ts title="packages/infra/src/stacks/application-stack.ts" {11-13}
+import { Stack } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { Certificate } from 'aws-cdk-lib/aws-certificatemanager';
+import { MyWebsite } from '@my-scope/common-constructs';
+
+export class ApplicationStack extends Stack {
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+
+    new MyWebsite(this, 'MyWebsite', {
+      domainNames: ['www.example.com'],
+      certificate: Certificate.fromCertificateArn(this, 'Cert',
+        'arn:aws:acm:us-east-1:123456789012:certificate/...'),
+    });
+  }
+}
+```
+</Fragment>
+<Fragment slot="terraform">
+Establece las variables `custom_domain_names` y `acm_certificate_arn`:
+
+```hcl title="packages/infra/src/main.tf" {7-8}
+module "my_website" {
+  source = "../../common/terraform/src/app/static-websites/my-website"
+
+  providers = {
+    aws.us_east_1 = aws.us_east_1
+  }
+  custom_domain_names = ["www.example.com"]
+  acm_certificate_arn = "arn:aws:acm:us-east-1:123456789012:certificate/..."
+}
+```
+</Fragment>
+</Infrastructure>
+
+También necesitarás crear registros DNS (por ejemplo, en Route 53) apuntando tu dominio a la distribución CloudFront.
+
 ## Configuración en Tiempo de Ejecución
 
 La configuración de tu infraestructura se proporciona a tu sitio web a través de <Link href="guides/runtime-config">Configuración en Tiempo de Ejecución</Link>. Esto permite que tu sitio web acceda a detalles como URLs de API que no se conocen hasta que tu aplicación está desplegada.
@@ -239,9 +418,9 @@ La configuración de tu infraestructura se proporciona a tu sitio web a través 
 
 <Infrastructure>
 <Fragment slot="cdk">
-La construcción CDK `RuntimeConfig` se puede usar para agregar y recuperar configuración en tu infraestructura CDK. Las construcciones CDK generadas por los generadores de `@aws/nx-plugin` (como <Link path="guides/trpc">`ts#api`</Link> y <Link path="guides/fastapi">`py#api`</Link>) agregarán automáticamente valores apropiados al `RuntimeConfig`.
+El constructo CDK `RuntimeConfig` se puede usar para agregar y recuperar configuración en tu infraestructura CDK. Los constructos CDK generados por los generadores de `@aws/nx-plugin` (como <Link path="guides/trpc">`ts#api`</Link> y <Link path="guides/fastapi">`py#api`</Link>) agregarán automáticamente valores apropiados al `RuntimeConfig`.
 
-Tu construcción CDK de sitio web desplegará el espacio de nombres `connection` de la configuración en tiempo de ejecución como un archivo `runtime-config.json` en la raíz de tu bucket S3.
+Tu constructo CDK del sitio web desplegará el namespace `connection` de la configuración en tiempo de ejecución como un archivo `runtime-config.json` en la raíz de tu bucket S3.
 
 ```ts title="packages/infra/src/stacks/application-stack.ts"
 import { Stack } from 'aws-cdk-lib';
@@ -252,7 +431,7 @@ export class ApplicationStack extends Stack {
   constructor(scope: Construct, id: string) {
     super(scope, id);
 
-    // Website can be declared at any point — runtime config is resolved lazily
+    // Website can be declared at any point, since runtime config is resolved lazily
     new MyWebsite(this, 'MyWebsite');
 
     // Automatically adds values to the RuntimeConfig
@@ -263,14 +442,14 @@ export class ApplicationStack extends Stack {
 }
 ```
 
-:::note[Construcción de Sitio Web CDK]
-Con CDK, la construcción del sitio web se puede declarar en cualquier punto de tu stack. La configuración en tiempo de ejecución se resuelve de forma diferida en el momento de la síntesis, por lo que todos los valores se incluirán independientemente del orden de declaración.
+:::note[Constructo CDK del Sitio Web]
+Con CDK, el constructo del sitio web puede declararse en cualquier punto de tu stack. La configuración en tiempo de ejecución se resuelve de forma perezosa en tiempo de síntesis, por lo que todos los valores se incluirán independientemente del orden de declaración.
 :::
 </Fragment>
 <Fragment slot="terraform">
 Con Terraform, la configuración en tiempo de ejecución se gestiona a través de los módulos runtime-config. Los módulos Terraform generados por los generadores de `@aws/nx-plugin` (como <Link path="guides/trpc">`ts#api`</Link> y <Link path="guides/fastapi">`py#api`</Link>) agregarán automáticamente valores apropiados a la configuración en tiempo de ejecución.
 
-Tu módulo Terraform de sitio web desplegará el espacio de nombres `connection` de la configuración en tiempo de ejecución como un archivo `runtime-config.json` en la raíz de tu bucket S3.
+Tu módulo Terraform del sitio web desplegará el namespace `connection` de la configuración en tiempo de ejecución como un archivo `runtime-config.json` en la raíz de tu bucket S3.
 
 ```hcl title="packages/infra/src/main.tf" {20-21}
 module "asset_bucket" {
@@ -298,7 +477,7 @@ module "my_website" {
 ```
 
 :::caution[Orden de Módulos]
-Debes asegurarte de declarar tu módulo de sitio web _después_ de cualquier módulo que agregue a la configuración en tiempo de ejecución y configurar el `depends_on` apropiado para garantizar el orden, de lo contrario faltarán en tu archivo `runtime-config.json`.
+Debes asegurarte de declarar tu módulo de sitio web _después_ de cualquier módulo que agregue a la configuración en tiempo de ejecución y configurar el `depends_on` apropiado para asegurar el orden, de lo contrario faltarán en tu archivo `runtime-config.json`.
 :::
 </Fragment>
 </Infrastructure>
@@ -324,84 +503,84 @@ Para obtener detalles sobre cómo se almacena la configuración en tiempo de eje
 
 ### Configuración en Tiempo de Ejecución Local
 
-Al ejecutar el [servidor de desarrollo local](#servidor-de-desarrollo-local), necesitarás un archivo `runtime-config.json` en tu directorio `public` para que tu sitio web local conozca las URLs del backend, la configuración de identidad, etc.
+Al ejecutar el [servidor de desarrollo local](#servidor-de-desarrollo-local), necesitarás un archivo `runtime-config.json` en tu directorio `public` para que tu sitio web local conozca las URLs del backend, configuración de identidad, etc.
 
-Tu proyecto de sitio web está configurado con un objetivo `load-runtime-config` que puedes usar para descargar el archivo `runtime-config.json` de una aplicación desplegada:
+Tu proyecto de sitio web está configurado con un target `load-runtime-config` que puedes usar para descargar el archivo `runtime-config.json` de una aplicación desplegada:
 
 <NxCommands commands={['load-runtime-config <my-website>']} />
 
-:::note[Nombres de Etapa Personalizados]
+:::note[Nombres de Stage Personalizados]
 <Infrastructure>
 <Fragment slot="cdk">
-Si cambias el prefijo para los nombres de tus etapas en el `src/main.ts` de tu proyecto de infraestructura, necesitarás actualizar el objetivo `load-runtime-config` en el archivo `project.json` de tu sitio web en consecuencia.
+Si cambias el prefijo para los nombres de tus stages en el `src/main.ts` de tu proyecto de infraestructura, necesitarás actualizar el target `load-runtime-config` en el archivo `project.json` de tu sitio web en consecuencia.
 
-Además, vale la pena señalar que el objetivo `load-runtime-config` asume que una sola etapa de tu aplicación está desplegada en el entorno para el que tienes credenciales de AWS. Necesitarás ajustar el comando si despliegas múltiples etapas en la misma cuenta y región.
+Además, vale la pena señalar que el target `load-runtime-config` asume que un solo stage de tu aplicación está desplegado en el entorno para el que tienes credenciales de AWS. Necesitarás ajustar el comando si despliegas múltiples stages en la misma cuenta y región.
 </Fragment>
 <Fragment slot="terraform">
-Para proyectos Terraform, el objetivo `load-runtime-config` copia el archivo `runtime-config.json` que se creó después de tu `terraform apply` local más reciente.
+Para proyectos Terraform, el target `load-runtime-config` copia el archivo `runtime-config.json` que se creó después de tu `terraform apply` local más reciente.
 </Fragment>
 </Infrastructure>
 :::
 
 ## Servidor de Desarrollo Local
 
-El comando canónico para el desarrollo local es `dev`, que inicia tu sitio web (y cualquier servidor local para APIs a las que lo hayas conectado) con un solo comando:
+El comando canónico para desarrollo local es `dev`, que inicia tu sitio web (y cualquier servidor local para APIs que hayas conectado) con un solo comando:
 
 <NxCommands commands={['dev <my-website>']} />
 
-El objetivo `serve` también está disponible para cuando necesites controlar cuánto de tu aplicación se ejecuta localmente versus apuntando a la infraestructura AWS desplegada. Para una descripción general más amplia del desarrollo local en proyectos conectados, incluido cómo se comporta `dev` para proyectos con múltiples componentes, consulta la guía de <Link path="guides/local-development">Desarrollo Local</Link>.
+El target `serve` también está disponible para cuando necesites controlar cuánto de tu aplicación se ejecuta localmente versus apuntando a infraestructura de AWS desplegada. Para una visión más amplia del desarrollo local a través de proyectos conectados, incluyendo cómo se comporta `dev` para proyectos con múltiples componentes, consulta la guía de <Link path="guides/local-development">Desarrollo Local</Link>.
 
-### Objetivo Serve
+### Target Serve
 
-El objetivo `serve` inicia un servidor de desarrollo local para tu sitio web. Este objetivo requiere que hayas desplegado cualquier infraestructura de soporte con la que el sitio web interactúe, y que hayas [cargado la configuración en tiempo de ejecución local](#configuración-en-tiempo-de-ejecución-local).
+El target `serve` inicia un servidor de desarrollo local para tu sitio web. Este target requiere que hayas desplegado cualquier infraestructura de soporte con la que el sitio web interactúa, y que hayas [cargado la configuración en tiempo de ejecución local](#configuración-en-tiempo-de-ejecución-local).
 
-Puedes ejecutar este objetivo con el siguiente comando:
+Puedes ejecutar este target con el siguiente comando:
 
 <NxCommands commands={['serve <my-website>']} />
 
-Este objetivo es útil para trabajar en cambios del sitio web mientras apuntas a APIs "reales" desplegadas y otra infraestructura.
+Este target es útil para trabajar en cambios del sitio web mientras apuntas a APIs "reales" desplegadas y otra infraestructura.
 
-### Objetivo Dev
+### Target Dev
 
-El objetivo `dev` inicia un servidor de desarrollo local para tu sitio web (con [Vite `MODE`](https://vite.dev/guide/env-and-mode) establecido en `local-dev`), así como también inicia cualquier servidor local para APIs a las que hayas conectado tu sitio web a través del <Link path="/guides/connection">Generador de Conexión</Link>.
+El target `dev` inicia un servidor de desarrollo local para tu sitio web (con [Vite `MODE`](https://vite.dev/guide/env-and-mode) establecido en `local-dev`), así como iniciando cualquier servidor local para APIs que hayas conectado a tu sitio web a través del <Link path="/guides/connection">generador Connection</Link>.
 
-Cuando tu servidor de sitio web local se ejecuta a través de este objetivo, `runtime-config.json` se sobrescribe automáticamente para apuntar a las URLs de tu API que se ejecutan localmente.
+Cuando tu servidor de sitio web local se ejecuta a través de este target, `runtime-config.json` se sobrescribe automáticamente para apuntar a las urls de tu API ejecutándose localmente.
 
-Puedes ejecutar este objetivo con el siguiente comando:
+Puedes ejecutar este target con el siguiente comando:
 
 <NxCommands commands={['dev <my-website>']} />
 
-Este objetivo es útil cuando estás trabajando en tu sitio web y API y deseas iterar rápidamente sin desplegar tu infraestructura.
+Este target es útil cuando estás trabajando en tu sitio web y API y deseas iterar rápidamente sin desplegar tu infraestructura.
 
-:::note[Script `dev` del Espacio de Trabajo]
-El `package.json` raíz de tu espacio de trabajo incluye un script `dev` que ejecuta el objetivo `dev` para cada proyecto que lo tenga:
+:::note[Script `dev` del Workspace]
+El `package.json` raíz de tu workspace incluye un script `dev` que ejecuta el target `dev` para cada proyecto que lo tenga:
 
 <PackageManagerShortCommand commands={["dev"]} />
 
-Esto inicia el servidor de desarrollo local para tu sitio web (y cualquier otro proyecto con un objetivo `dev`) en un solo comando. Para ejecutar solo este sitio web, usa su propio objetivo `dev` (por ejemplo, `nx dev <my-website>`).
+Esto inicia el servidor de desarrollo local para tu sitio web (y cualquier otro proyecto con un target `dev`) en un solo comando. Para ejecutar solo este sitio web, usa su propio target `dev` (por ejemplo, `nx dev <my-website>`).
 :::
 
 :::warning[Autenticación Simulada]
-Cuando se ejecuta en este modo y no hay `runtime-config.json` presente, si has configurado Autenticación Cognito (a través del <Link path="/guides/react-website-auth">generador `ts#website#auth`</Link>), se omitirá el inicio de sesión y las solicitudes a tus servidores locales no incluirán encabezados de autenticación.
+Cuando se ejecuta en este modo y no hay `runtime-config.json` presente, si has configurado Autenticación Cognito (a través del <Link path="/guides/react-website-auth">generador `ts#website#auth`</Link>), el inicio de sesión se omitirá y las solicitudes a tus servidores locales no incluirán encabezados de autenticación.
 
 Para habilitar el inicio de sesión y la autenticación para `dev`, despliega tu infraestructura y carga la configuración en tiempo de ejecución.
 :::
 
 :::tip[Comportamiento de Dev]
-Al ejecutar con `dev`, puedes especificar cualquier variable de entorno requerida por tus APIs para apuntar a otros recursos AWS desplegados, por ejemplo:
+Al ejecutar con `dev`, puedes especificar cualquier variable de entorno requerida por tus APIs para apuntar a otros recursos de AWS desplegados, por ejemplo:
 
 <NxCommands env={{DYNAMODB_TABLE_NAME: 'xxxxx'}} commands={['dev <my-website>']} />
 
-Ten en cuenta que tus servidores de API locales se ejecutarán con las credenciales de AWS que hayas configurado localmente.
+Ten en cuenta que tus servidores API locales se ejecutarán con las credenciales de AWS que hayas configurado localmente.
 :::
 
 ## Construcción
 
-Puedes construir tu sitio web usando el objetivo `build`. Esto ejecuta los objetivos `bundle`, `compile`, `test` y `lint`, verificando tipos, empaquetando, probando y lintando tu sitio web.
+Puedes construir tu sitio web usando el target `build`. Esto ejecuta los targets `bundle`, `compile`, `test` y `lint`, verificando tipos, empaquetando, probando y lintando tu sitio web.
 
 <NxCommands commands={['build <my-website>']} />
 
-El objetivo `bundle` usa Vite para crear un paquete de producción en el directorio raíz `dist/packages/<my-website>/bundle`. Este es el artefacto desplegable consumido por tu infraestructura de sitio web. Puedes ejecutarlo por sí solo:
+El target `bundle` usa Vite para crear un bundle de producción en el directorio raíz `dist/packages/<my-website>/bundle`. Este es el artefacto desplegable consumido por tu infraestructura del sitio web. Puedes ejecutarlo por sí solo:
 
 <NxCommands commands={['bundle <my-website>']} />
 
@@ -411,82 +590,13 @@ Probar tu sitio web es muy similar a escribir pruebas en un proyecto TypeScript 
 
 Para pruebas específicas de React, React Testing Library ya está instalado y disponible para que lo uses para escribir pruebas. Para más detalles sobre su uso, consulta la [documentación de React Testing Library](https://testing-library.com/docs/react-testing-library/example-intro).
 
-Puedes ejecutar tus pruebas usando el objetivo `test`:
+Puedes ejecutar tus pruebas usando el target `test`:
 
 <NxCommands commands={['test <my-website>']} />
 
-## Desplegando tu Sitio Web
-
-El generador de sitio web React crea infraestructura como código CDK o Terraform basándose en tu `iac` seleccionado. Puedes usar esto para desplegar tu sitio web.
-
-<Infrastructure>
-<Fragment slot="cdk">
-Para desplegar tu sitio web, recomendamos usar el <Link path="guides/typescript-infrastructure">generador `ts#infra`</Link> para crear una aplicación CDK.
-
-Puedes usar la construcción CDK generada para ti en `packages/common/constructs` para desplegar tu sitio web.
-
-```ts title="packages/infra/src/stacks/application-stack.ts" {3, 9}
-import { Stack } from 'aws-cdk-lib';
-import { Construct } from 'constructs';
-import { MyWebsite } from '@my-scope/common-constructs';
-
-export class ApplicationStack extends Stack {
-  constructor(scope: Construct, id: string) {
-    super(scope, id);
-
-    new MyWebsite(this, 'MyWebsite');
-  }
-}
-```
-
-Esto configura:
-
-1. Un bucket S3 para alojar tus archivos de sitio web estático
-2. Distribución CloudFront para entrega de contenido global
-3. WAF Web ACL para protección de seguridad
-4. Origin Access Control para acceso seguro a S3
-5. Despliegue automático de archivos del sitio web y configuración en tiempo de ejecución
-</Fragment>
-<Fragment slot="terraform">
-Para desplegar tu sitio web, recomendamos usar el <Link path="/guides/terraform-project">generador `terraform#project`</Link> para crear un proyecto Terraform.
-
-Puedes usar el módulo Terraform generado para ti en `packages/common/terraform` para desplegar tu sitio web.
-
-```hcl title="packages/infra/src/main.tf" {3}
-# Deploy website
-module "my_website" {
-  source = "../../common/terraform/src/app/static-websites/my-website"
-
-  providers = {
-    aws.us_east_1 = aws.us_east_1
-  }
-}
-```
-
-Esto configura:
-
-1. Un bucket S3 para alojar tus archivos de sitio web estático
-2. Distribución CloudFront para entrega de contenido global
-3. WAF Web ACL para protección de seguridad (desplegado en us-east-1)
-4. Origin Access Control para acceso seguro a S3
-5. Despliegue automático de archivos del sitio web y configuración en tiempo de ejecución
-
-:::note[Región del Proveedor WAF]
-El proveedor `aws.us_east_1` es requerido para los recursos CloudFront y WAF, que deben desplegarse en la región us-east-1. Asegúrate de que tu configuración Terraform incluya este proveedor:
-
-```hcl title="packages/infra/src/providers.tf"
-provider "aws" {
-  alias  = "us_east_1"
-  region = "us-east-1"
-}
-```
-:::
-</Fragment>
-</Infrastructure>
-
 ## Conexiones
 
-Usa el generador <Link path="guides/connection">`connection`</Link> para integrar este proyecto con otros en tu espacio de trabajo. Las siguientes conexiones involucran este proyecto:
+Usa el generador <Link path="guides/connection">`connection`</Link> para integrar este proyecto con otros en tu workspace. Las siguientes conexiones involucran este proyecto:
 
 <CardGrid>
   <ConnectionCard

--- a/docs/src/content/docs/es/guides/react-website.mdx
+++ b/docs/src/content/docs/es/guides/react-website.mdx
@@ -18,11 +18,11 @@ import Infrastructure from '@components/infrastructure.astro';
 import Snippet from '@components/snippet.astro';
 import OptionFilter from '@components/option-filter.astro';
 
-Este generador crea un nuevo sitio web [React](https://react.dev/) con [shadcn/ui](https://ui.shadcn.com/) configurado por defecto, junto con la infraestructura de AWS CDK o Terraform para desplegar tu sitio web en la nube como un sitio web estático alojado en [S3](https://aws.amazon.com/s3/), servido por [CloudFront](https://aws.amazon.com/cloudfront/) y protegido por [WAF](https://aws.amazon.com/waf/).
+Este generador crea un nuevo sitio web [React](https://react.dev/) con [shadcn/ui](https://ui.shadcn.com/) configurado por defecto, junto con la infraestructura AWS CDK o Terraform para desplegar tu sitio web en la nube como un sitio web estático alojado en [S3](https://aws.amazon.com/s3/), servido por [CloudFront](https://aws.amazon.com/cloudfront/) y protegido por [WAF](https://aws.amazon.com/waf/).
 
 La aplicación generada utiliza [Vite](https://vite.dev/) como herramienta de construcción y empaquetador. Utiliza [TanStack Router](https://tanstack.com/router/v1) para enrutamiento con seguridad de tipos.
 
-:::note[Proveedor UX]
+:::note[Proveedor de UX]
 El `ux` predeterminado es [shadcn/ui](https://ui.shadcn.com/). También puedes seleccionar [Cloudscape](http://cloudscape.design/) o `none` (trae tu propia biblioteca de componentes).
 :::
 
@@ -129,7 +129,7 @@ waf -> cloudfront
 cloudfront -> s3
 ```
 
-## Implementando tu Sitio Web
+## Implementar tu Sitio Web
 
 La [documentación de React](https://react.dev/learn) es un buen lugar para comenzar a aprender los conceptos básicos de construcción con React.
 
@@ -150,7 +150,7 @@ Tu sitio web viene con [TanStack Router](https://tanstack.com/router/v1) configu
 <Steps>
   1. [Ejecutar el Servidor de Desarrollo Local](#servidor-de-desarrollo-local)
   2. Crea un nuevo archivo `<page-name>.tsx` en `src/routes`, con su posición en el árbol de archivos representando la ruta
-  3. ¡Observa que se generan automáticamente un `Route` y `RouteComponent` para ti. Puedes comenzar a construir tu página aquí!
+  3. Observa que un `Route` y `RouteComponent` se generan automáticamente para ti. ¡Puedes comenzar a construir tu página aquí!
 </Steps>
 
 #### Navegar Entre Páginas
@@ -180,7 +180,7 @@ export const MyComponent = () => {
 
 Para más detalles, consulta la documentación de [TanStack Router](https://tanstack.com/router/latest/docs/framework/react/overview).
 
-## Desplegando tu Sitio Web
+## Desplegar tu Sitio Web
 
 El generador de sitios web React crea infraestructura como código CDK o Terraform basándose en tu `iac` seleccionado. Puedes usar esto para desplegar tu sitio web.
 
@@ -208,8 +208,8 @@ Esto configura:
 
 1. Un bucket S3 para alojar los archivos de tu sitio web estático
 2. Distribución CloudFront para entrega de contenido global
-3. WAF Web ACL para protección de seguridad
-4. Origin Access Control para acceso seguro a S3
+3. Web ACL de WAF para protección de seguridad
+4. Control de Acceso de Origen para acceso seguro a S3
 5. Despliegue automático de archivos del sitio web y configuración en tiempo de ejecución
 </Fragment>
 <Fragment slot="terraform">
@@ -232,12 +232,12 @@ Esto configura:
 
 1. Un bucket S3 para alojar los archivos de tu sitio web estático
 2. Distribución CloudFront para entrega de contenido global
-3. WAF Web ACL para protección de seguridad (desplegado en us-east-1)
-4. Origin Access Control para acceso seguro a S3
+3. Web ACL de WAF para protección de seguridad (desplegado en us-east-1)
+4. Control de Acceso de Origen para acceso seguro a S3
 5. Despliegue automático de archivos del sitio web y configuración en tiempo de ejecución
 
 :::note[Región del Proveedor WAF]
-El proveedor `aws.us_east_1` es requerido para los recursos de CloudFront y WAF, que deben desplegarse en la región us-east-1. Asegúrate de que tu configuración de Terraform incluya este proveedor:
+El proveedor `aws.us_east_1` es requerido para los recursos CloudFront y WAF, que deben desplegarse en la región us-east-1. Asegúrate de que tu configuración Terraform incluya este proveedor:
 
 ```hcl title="packages/infra/src/providers.tf"
 provider "aws" {
@@ -253,7 +253,7 @@ provider "aws" {
 
 La distribución CloudFront aplica una política de encabezados de respuesta que establece `Strict-Transport-Security`, `X-Content-Type-Options`, `X-Frame-Options: DENY`, `Referrer-Policy` y una `Content-Security-Policy` en todas las respuestas.
 
-Se aplica una `Content-Security-Policy` predeterminada. Restringe scripts y framing para mitigar XSS y clickjacking, mientras permite conexiones HTTPS y WSS para que el sitio web pueda llamar a endpoints de servicios de AWS (como API Gateway, Cognito y Bedrock AgentCore) cuyas URLs solo se conocen en tiempo de despliegue. Para ajustar la política (por ejemplo, para restringir `connect-src` a tus orígenes específicos), edita el valor `content_security_policy` en tu `static-website.ts` (CDK) o `static-website.tf` (Terraform) generado.
+Se aplica una `Content-Security-Policy` predeterminada. Restringe scripts y framing para mitigar XSS y clickjacking, mientras permite conexiones HTTPS y WSS para que el sitio web pueda llamar a endpoints de servicios AWS (como API Gateway, Cognito y Bedrock AgentCore) cuyas URLs solo se conocen en tiempo de despliegue. Para ajustar la política (por ejemplo, para restringir `connect-src` a tus orígenes específicos), edita el valor `content_security_policy` en tu `static-website.ts` (CDK) o `static-website.tf` (Terraform) generado.
 
 `runtime-config.json` se sirve con `Cache-Control: no-cache` para que los navegadores siempre obtengan la configuración más reciente después de un redespliegue, en lugar de usar una copia en caché obsoleta.
 
@@ -311,11 +311,11 @@ module "my_website" {
 
 ### Cifrado de Bucket
 
-El bucket del sitio web, el bucket de logs de la distribución CloudFront y el grupo de CloudWatch Logs que recibe sus logs de acceso al servidor están cifrados con una clave [AWS KMS](https://aws.amazon.com/kms/) administrada por el cliente por defecto. Esta clave se crea automáticamente para ti, con rotación de claves habilitada.
+El bucket del sitio web, el bucket de logs de la distribución CloudFront y el grupo CloudWatch Logs que recibe sus logs de acceso al servidor están cifrados con una clave [AWS KMS](https://aws.amazon.com/kms/) administrada por el cliente por defecto. Esta clave se crea automáticamente para ti, con rotación de clave habilitada.
 
 <Infrastructure>
 <Fragment slot="cdk">
-Si deseas usar una configuración de cifrado diferente, pasa las props `encryption`, `encryptionKey` y `enableKeyRotation` cuando crees tu sitio web:
+Si deseas usar una configuración de cifrado diferente, pasa las propiedades `encryption`, `encryptionKey` y `enableKeyRotation` cuando crees tu sitio web:
 
 ```ts title="packages/infra/src/stacks/application-stack.ts" {11}
 import { Stack } from 'aws-cdk-lib';
@@ -334,6 +334,22 @@ export class ApplicationStack extends Stack {
 }
 ```
 
+:::caution[Suprimir CKV_AWS_158 al usar S3_MANAGED]
+Elegir `BucketEncryption.S3_MANAGED` significa que el grupo de logs de acceso ya no está cifrado con KMS, lo que falla el escaneo de seguridad `checkov` con `CKV_AWS_158`. Suprímelo:
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { LogGroup } from 'aws-cdk-lib/aws-logs';
+import { suppressRules } from '@my-scope/common-constructs';
+
+suppressRules(
+  website,
+  ['CKV_AWS_158'],
+  'Access log group is not KMS encrypted when encryption is S3_MANAGED',
+  (c) => c instanceof LogGroup,
+);
+```
+:::
+
 Para usar tu propia clave KMS en lugar de una creada automáticamente, pasa `encryptionKey`:
 
 ```ts {2}
@@ -342,10 +358,36 @@ new MyWebsite(this, 'MyWebsite', {
 });
 ```
 
-`enableKeyRotation` (predeterminado `true`) solo se aplica a la clave creada automáticamente, es decir, cuando `encryption` es `BucketEncryption.KMS` (el predeterminado) y no se proporciona `encryptionKey`.
+:::caution[Las claves importadas necesitan sus propios permisos]
+Una clave importada a través de `Key.fromKeyArn` ya debe otorgar a los principales de servicio CloudWatch Logs, S3 y CloudFront los permisos que necesitan en su propia política de clave. `addToResourcePolicy` es un no-op en una clave importada, por lo que este constructo no puede otorgarlos por ti, y `cdk synth` no te advertirá - el fallo solo aparece en tiempo de despliegue. Una clave creada en la misma aplicación (`new Key(this, 'WebsiteKey')`) no tiene este problema, ya que CDK puede actualizar su política directamente.
+:::
+
+`enableKeyRotation` (predeterminado `true`) solo se aplica a la clave creada automáticamente, es decir, cuando `encryption` es `BucketEncryption.KMS` (el predeterminado) y no se proporciona `encryptionKey`:
+
+```ts {2}
+new MyWebsite(this, 'MyWebsite', {
+  enableKeyRotation: false,
+});
+```
+
+:::caution[Suprimir CKV_AWS_7 al deshabilitar la rotación de clave]
+Deshabilitar la rotación de clave en la clave creada automáticamente falla el escaneo de seguridad `checkov` con `CKV_AWS_7`. Suprímelo:
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { Key } from 'aws-cdk-lib/aws-kms';
+import { suppressRules } from '@my-scope/common-constructs';
+
+suppressRules(
+  website,
+  ['CKV_AWS_7'],
+  'Key rotation is managed externally',
+  (c) => c instanceof Key,
+);
+```
+:::
 </Fragment>
 <Fragment slot="terraform">
-Si deseas usar una configuración de cifrado diferente, establece las variables `encryption`, `kms_key_arn` y `enable_key_rotation`:
+Si deseas usar una configuración de cifrado diferente, establece las variables `encryption`, `kms_key_arn`, `create_kms_key` y `enable_key_rotation`:
 
 ```hcl title="packages/infra/src/main.tf" {7}
 module "my_website" {
@@ -358,19 +400,62 @@ module "my_website" {
 }
 ```
 
-Para usar tu propia clave KMS en lugar de una creada automáticamente, pasa `kms_key_arn`. Una clave proporcionada por el cliente ya debe otorgar a los principales de servicio de CloudWatch Logs, S3 y CloudFront los permisos que necesitan en su propia política de clave.
+:::caution[Checkov: S3_MANAGED]
+Elegir `S3_MANAGED` falla el escaneo de seguridad `checkov` con `CKV_AWS_145` en los buckets del sitio web y de logs de distribución. El objetivo `test` proporcionado no acepta un `--config-file`, pero `checkov` descubre automáticamente un `.checkov.yaml` en su directorio de trabajo, así que coloca uno en `packages/infra/src`:
 
-`enable_key_rotation` (predeterminado `true`) solo se aplica a la clave creada automáticamente, es decir, cuando `encryption` es `"KMS"` (el predeterminado) y no se proporciona `kms_key_arn`.
+```yaml title="packages/infra/src/.checkov.yaml"
+skip-check:
+  - CKV_AWS_145
+```
+:::
+
+Para usar tu propia clave KMS en lugar de una creada automáticamente, pasa `kms_key_arn` y establece `create_kms_key` en `false`:
+
+```hcl title="packages/infra/src/main.tf" {7-8}
+module "my_website" {
+  source = "../../common/terraform/src/app/static-websites/my-website"
+
+  providers = {
+    aws.us_east_1 = aws.us_east_1
+  }
+  kms_key_arn    = aws_kms_key.website.arn
+  create_kms_key = false
+}
+```
+
+Una clave proporcionada por el cliente ya debe otorgar a los principales de servicio CloudWatch Logs, S3 y CloudFront los permisos que necesitan en su propia política de clave.
+
+`enable_key_rotation` (predeterminado `true`) solo se aplica a la clave creada automáticamente, es decir, cuando `encryption` es `"KMS"` (el predeterminado) y `create_kms_key` es `true`:
+
+```hcl title="packages/infra/src/main.tf" {7}
+module "my_website" {
+  source = "../../common/terraform/src/app/static-websites/my-website"
+
+  providers = {
+    aws.us_east_1 = aws.us_east_1
+  }
+  enable_key_rotation = false
+}
+```
+
+:::caution[Checkov: rotación de clave deshabilitada]
+Deshabilitar la rotación de clave en la clave creada automáticamente falla el escaneo de seguridad `checkov` con `CKV_AWS_7`. Agrégalo al mismo `.checkov.yaml`:
+
+```yaml title="packages/infra/src/.checkov.yaml"
+skip-check:
+  - CKV_AWS_7
+```
+:::
 </Fragment>
 </Infrastructure>
 
 ### Dominio Personalizado y TLS
 
-Por defecto, la distribución usa el nombre de dominio predeterminado de CloudFront (`*.cloudfront.net`) y su certificado predeterminado, que no admite la aplicación de una versión TLS mínima de 1.2. Para servir tu sitio web desde tu propio dominio, proporciona un [certificado ACM](https://docs.aws.amazon.com/acm/latest/userguide/acm-overview.html) (que debe residir en `us-east-1` para su uso con CloudFront) y tus nombres de dominio. Entonces se aplica una versión TLS mínima de 1.2 para los espectadores:
+Por defecto, la distribución usa el nombre de dominio CloudFront predeterminado (`*.cloudfront.net`) y su certificado predeterminado, que no admite la aplicación de una versión TLS mínima de 1.2. Para servir tu sitio web desde tu propio dominio, proporciona un [certificado ACM](https://docs.aws.amazon.com/acm/latest/userguide/acm-overview.html) (que debe residir en `us-east-1` para su uso con CloudFront) y tus nombres de dominio. Entonces se aplica una versión TLS mínima de 1.2 para los espectadores:
 
 <Infrastructure>
 <Fragment slot="cdk">
-Pasa las props `certificate` y `domainNames` cuando crees tu sitio web:
+Pasa las propiedades `certificate` y `domainNames` cuando crees tu sitio web:
 
 ```ts title="packages/infra/src/stacks/application-stack.ts" {11-13}
 import { Stack } from 'aws-cdk-lib';
@@ -408,7 +493,7 @@ module "my_website" {
 </Fragment>
 </Infrastructure>
 
-También necesitarás crear registros DNS (por ejemplo, en Route 53) apuntando tu dominio a la distribución CloudFront.
+También necesitarás crear registros DNS (por ejemplo en Route 53) apuntando tu dominio a la distribución CloudFront.
 
 ## Configuración en Tiempo de Ejecución
 
@@ -420,7 +505,7 @@ La configuración de tu infraestructura se proporciona a tu sitio web a través 
 <Fragment slot="cdk">
 El constructo CDK `RuntimeConfig` se puede usar para agregar y recuperar configuración en tu infraestructura CDK. Los constructos CDK generados por los generadores de `@aws/nx-plugin` (como <Link path="guides/trpc">`ts#api`</Link> y <Link path="guides/fastapi">`py#api`</Link>) agregarán automáticamente valores apropiados al `RuntimeConfig`.
 
-Tu constructo CDK del sitio web desplegará el namespace `connection` de la configuración en tiempo de ejecución como un archivo `runtime-config.json` en la raíz de tu bucket S3.
+Tu constructo CDK de sitio web desplegará el namespace `connection` de la configuración en tiempo de ejecución como un archivo `runtime-config.json` en la raíz de tu bucket S3.
 
 ```ts title="packages/infra/src/stacks/application-stack.ts"
 import { Stack } from 'aws-cdk-lib';
@@ -442,14 +527,14 @@ export class ApplicationStack extends Stack {
 }
 ```
 
-:::note[Constructo CDK del Sitio Web]
-Con CDK, el constructo del sitio web puede declararse en cualquier punto de tu stack. La configuración en tiempo de ejecución se resuelve de forma perezosa en tiempo de síntesis, por lo que todos los valores se incluirán independientemente del orden de declaración.
+:::note[Constructo de Sitio Web CDK]
+Con CDK, el constructo del sitio web se puede declarar en cualquier punto de tu stack. La configuración en tiempo de ejecución se resuelve de forma perezosa en tiempo de síntesis, por lo que todos los valores se incluirán independientemente del orden de declaración.
 :::
 </Fragment>
 <Fragment slot="terraform">
 Con Terraform, la configuración en tiempo de ejecución se gestiona a través de los módulos runtime-config. Los módulos Terraform generados por los generadores de `@aws/nx-plugin` (como <Link path="guides/trpc">`ts#api`</Link> y <Link path="guides/fastapi">`py#api`</Link>) agregarán automáticamente valores apropiados a la configuración en tiempo de ejecución.
 
-Tu módulo Terraform del sitio web desplegará el namespace `connection` de la configuración en tiempo de ejecución como un archivo `runtime-config.json` en la raíz de tu bucket S3.
+Tu módulo Terraform de sitio web desplegará el namespace `connection` de la configuración en tiempo de ejecución como un archivo `runtime-config.json` en la raíz de tu bucket S3.
 
 ```hcl title="packages/infra/src/main.tf" {20-21}
 module "asset_bucket" {
@@ -505,19 +590,19 @@ Para obtener detalles sobre cómo se almacena la configuración en tiempo de eje
 
 Al ejecutar el [servidor de desarrollo local](#servidor-de-desarrollo-local), necesitarás un archivo `runtime-config.json` en tu directorio `public` para que tu sitio web local conozca las URLs del backend, configuración de identidad, etc.
 
-Tu proyecto de sitio web está configurado con un target `load-runtime-config` que puedes usar para descargar el archivo `runtime-config.json` de una aplicación desplegada:
+Tu proyecto de sitio web está configurado con un objetivo `load-runtime-config` que puedes usar para descargar el archivo `runtime-config.json` de una aplicación desplegada:
 
 <NxCommands commands={['load-runtime-config <my-website>']} />
 
-:::note[Nombres de Stage Personalizados]
+:::note[Nombres de Etapa Personalizados]
 <Infrastructure>
 <Fragment slot="cdk">
-Si cambias el prefijo para los nombres de tus stages en el `src/main.ts` de tu proyecto de infraestructura, necesitarás actualizar el target `load-runtime-config` en el archivo `project.json` de tu sitio web en consecuencia.
+Si cambias el prefijo para los nombres de tus etapas en el `src/main.ts` de tu proyecto de infraestructura, necesitarás actualizar el objetivo `load-runtime-config` en el archivo `project.json` de tu sitio web en consecuencia.
 
-Además, vale la pena señalar que el target `load-runtime-config` asume que un solo stage de tu aplicación está desplegado en el entorno para el que tienes credenciales de AWS. Necesitarás ajustar el comando si despliegas múltiples stages en la misma cuenta y región.
+Además, vale la pena señalar que el objetivo `load-runtime-config` asume que una sola etapa de tu aplicación está desplegada en el entorno para el que tienes credenciales AWS. Necesitarás ajustar el comando si despliegas múltiples etapas en la misma cuenta y región.
 </Fragment>
 <Fragment slot="terraform">
-Para proyectos Terraform, el target `load-runtime-config` copia el archivo `runtime-config.json` que se creó después de tu `terraform apply` local más reciente.
+Para proyectos Terraform, el objetivo `load-runtime-config` copia el archivo `runtime-config.json` que se creó después de tu `terraform apply` local más reciente.
 </Fragment>
 </Infrastructure>
 :::
@@ -528,36 +613,36 @@ El comando canónico para desarrollo local es `dev`, que inicia tu sitio web (y 
 
 <NxCommands commands={['dev <my-website>']} />
 
-El target `serve` también está disponible para cuando necesites controlar cuánto de tu aplicación se ejecuta localmente versus apuntando a infraestructura de AWS desplegada. Para una visión más amplia del desarrollo local a través de proyectos conectados, incluyendo cómo se comporta `dev` para proyectos con múltiples componentes, consulta la guía de <Link path="guides/local-development">Desarrollo Local</Link>.
+El objetivo `serve` también está disponible para cuando necesites controlar cuánto de tu aplicación se ejecuta localmente versus apuntando a infraestructura AWS desplegada. Para una descripción general más amplia del desarrollo local en proyectos conectados, incluyendo cómo se comporta `dev` para proyectos con múltiples componentes, consulta la guía de <Link path="guides/local-development">Desarrollo Local</Link>.
 
-### Target Serve
+### Objetivo Serve
 
-El target `serve` inicia un servidor de desarrollo local para tu sitio web. Este target requiere que hayas desplegado cualquier infraestructura de soporte con la que el sitio web interactúa, y que hayas [cargado la configuración en tiempo de ejecución local](#configuración-en-tiempo-de-ejecución-local).
+El objetivo `serve` inicia un servidor de desarrollo local para tu sitio web. Este objetivo requiere que hayas desplegado cualquier infraestructura de soporte con la que el sitio web interactúe, y que hayas [cargado la configuración en tiempo de ejecución local](#configuración-en-tiempo-de-ejecución-local).
 
-Puedes ejecutar este target con el siguiente comando:
+Puedes ejecutar este objetivo con el siguiente comando:
 
 <NxCommands commands={['serve <my-website>']} />
 
-Este target es útil para trabajar en cambios del sitio web mientras apuntas a APIs "reales" desplegadas y otra infraestructura.
+Este objetivo es útil para trabajar en cambios del sitio web mientras apuntas a APIs "reales" desplegadas y otra infraestructura.
 
-### Target Dev
+### Objetivo Dev
 
-El target `dev` inicia un servidor de desarrollo local para tu sitio web (con [Vite `MODE`](https://vite.dev/guide/env-and-mode) establecido en `local-dev`), así como iniciando cualquier servidor local para APIs que hayas conectado a tu sitio web a través del <Link path="/guides/connection">generador Connection</Link>.
+El objetivo `dev` inicia un servidor de desarrollo local para tu sitio web (con [Vite `MODE`](https://vite.dev/guide/env-and-mode) establecido en `local-dev`), así como iniciando cualquier servidor local para APIs que hayas conectado a tu sitio web a través del <Link path="/guides/connection">Generador de Conexión</Link>.
 
-Cuando tu servidor de sitio web local se ejecuta a través de este target, `runtime-config.json` se sobrescribe automáticamente para apuntar a las urls de tu API ejecutándose localmente.
+Cuando tu servidor de sitio web local se ejecuta a través de este objetivo, `runtime-config.json` se sobrescribe automáticamente para apuntar a las URLs de tu API ejecutándose localmente.
 
-Puedes ejecutar este target con el siguiente comando:
+Puedes ejecutar este objetivo con el siguiente comando:
 
 <NxCommands commands={['dev <my-website>']} />
 
-Este target es útil cuando estás trabajando en tu sitio web y API y deseas iterar rápidamente sin desplegar tu infraestructura.
+Este objetivo es útil cuando estás trabajando en tu sitio web y API y deseas iterar rápidamente sin desplegar tu infraestructura.
 
 :::note[Script `dev` del Workspace]
-El `package.json` raíz de tu workspace incluye un script `dev` que ejecuta el target `dev` para cada proyecto que lo tenga:
+El `package.json` raíz de tu workspace incluye un script `dev` que ejecuta el objetivo `dev` para cada proyecto que lo tenga:
 
 <PackageManagerShortCommand commands={["dev"]} />
 
-Esto inicia el servidor de desarrollo local para tu sitio web (y cualquier otro proyecto con un target `dev`) en un solo comando. Para ejecutar solo este sitio web, usa su propio target `dev` (por ejemplo, `nx dev <my-website>`).
+Esto inicia el servidor de desarrollo local para tu sitio web (y cualquier otro proyecto con un objetivo `dev`) en un solo comando. Para ejecutar solo este sitio web, usa su propio objetivo `dev` (por ejemplo, `nx dev <my-website>`).
 :::
 
 :::warning[Autenticación Simulada]
@@ -567,20 +652,20 @@ Para habilitar el inicio de sesión y la autenticación para `dev`, despliega tu
 :::
 
 :::tip[Comportamiento de Dev]
-Al ejecutar con `dev`, puedes especificar cualquier variable de entorno requerida por tus APIs para apuntar a otros recursos de AWS desplegados, por ejemplo:
+Al ejecutar con `dev`, puedes especificar cualquier variable de entorno requerida por tus APIs para apuntar a otros recursos AWS desplegados, por ejemplo:
 
 <NxCommands env={{DYNAMODB_TABLE_NAME: 'xxxxx'}} commands={['dev <my-website>']} />
 
-Ten en cuenta que tus servidores API locales se ejecutarán con las credenciales de AWS que hayas configurado localmente.
+Ten en cuenta que tus servidores API locales se ejecutarán con las credenciales AWS que hayas configurado localmente.
 :::
 
 ## Construcción
 
-Puedes construir tu sitio web usando el target `build`. Esto ejecuta los targets `bundle`, `compile`, `test` y `lint`, verificando tipos, empaquetando, probando y lintando tu sitio web.
+Puedes construir tu sitio web usando el objetivo `build`. Esto ejecuta los objetivos `bundle`, `compile`, `test` y `lint`, verificando tipos, empaquetando, probando y lintando tu sitio web.
 
 <NxCommands commands={['build <my-website>']} />
 
-El target `bundle` usa Vite para crear un bundle de producción en el directorio raíz `dist/packages/<my-website>/bundle`. Este es el artefacto desplegable consumido por tu infraestructura del sitio web. Puedes ejecutarlo por sí solo:
+El objetivo `bundle` usa Vite para crear un paquete de producción en el directorio raíz `dist/packages/<my-website>/bundle`. Este es el artefacto desplegable consumido por tu infraestructura de sitio web. Puedes ejecutarlo por sí solo:
 
 <NxCommands commands={['bundle <my-website>']} />
 
@@ -590,7 +675,7 @@ Probar tu sitio web es muy similar a escribir pruebas en un proyecto TypeScript 
 
 Para pruebas específicas de React, React Testing Library ya está instalado y disponible para que lo uses para escribir pruebas. Para más detalles sobre su uso, consulta la [documentación de React Testing Library](https://testing-library.com/docs/react-testing-library/example-intro).
 
-Puedes ejecutar tus pruebas usando el target `test`:
+Puedes ejecutar tus pruebas usando el objetivo `test`:
 
 <NxCommands commands={['test <my-website>']} />
 

--- a/docs/src/content/docs/fr/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/fr/get_started/tutorials/dungeon-game/1.mdx
@@ -1,6 +1,6 @@
 ---
 title: Configurer un monorepo
-description: "Une présentation de la création d'un jeu d'aventure dans un donjon propulsé par une IA agentique, en utilisant le @aws/nx-plugin."
+description: "Un guide pas à pas pour construire un jeu d'aventure de donjon alimenté par une IA agentique en utilisant le @aws/nx-plugin."
 ---
 
 import { Aside, Code, FileTree, Steps, Tabs, TabItem } from '@astrojs/starlight/components';
@@ -24,7 +24,7 @@ import gameConversationPng from '@assets/game-conversation.png'
 
 ## Tâche 1 : Créer un monorepo
 
-Pour créer un nouveau monorepo, depuis le répertoire souhaité, exécutez la commande suivante :
+Pour créer un nouveau monorepo, depuis le répertoire de votre choix, exécutez la commande suivante :
 
 <CreateNxWorkspaceCommand workspace="dungeon-adventure" iac="cdk" />
 
@@ -1072,11 +1072,17 @@ Le `ts#website` génère ces fichiers. Examinons certains des fichiers clés mis
 // packages/common/constructs/src/app/static-websites/game-ui.ts
 import * as url from 'url';
 import { Construct } from 'constructs';
-import { StaticWebsite } from '../../core/index.js';
+import { StaticWebsite, StaticWebsiteProps } from '../../core/index.js';
+
+export type GameUIProps = Omit<
+  StaticWebsiteProps,
+  'websiteName' | 'websiteFilePath'
+>;
 
 export class GameUI extends StaticWebsite {
-  constructor(scope: Construct, id: string) {
+  constructor(scope: Construct, id: string, props?: GameUIProps) {
     super(scope, id, {
+      ...props,
       websiteName: 'GameUI',
       websiteFilePath: url.fileURLToPath(
         new URL(

--- a/docs/src/content/docs/fr/guides/react-website.mdx
+++ b/docs/src/content/docs/fr/guides/react-website.mdx
@@ -70,7 +70,7 @@ Si vous avez choisi de ne pas utiliser [TanStack Router](https://tanstack.com/ro
 
 <Snippet name="shared-constructs" />
 
-Le générateur crée l'infrastructure en tant que code pour déployer votre site Web en fonction de votre `iac` sélectionné :
+Le générateur crée l'infrastructure as code pour déployer votre site Web en fonction de votre `iac` sélectionné :
 
 <Infrastructure>
 <Fragment slot="cdk">
@@ -182,7 +182,7 @@ Pour plus de détails, consultez la documentation [TanStack Router](https://tans
 
 ## Déployer votre site Web
 
-Le générateur de site Web React crée l'infrastructure en tant que code CDK ou Terraform en fonction de votre `iac` sélectionné. Vous pouvez l'utiliser pour déployer votre site Web.
+Le générateur de site Web React crée l'infrastructure as code CDK ou Terraform en fonction de votre `iac` sélectionné. Vous pouvez l'utiliser pour déployer votre site Web.
 
 <Infrastructure>
 <Fragment slot="cdk">
@@ -207,9 +207,9 @@ export class ApplicationStack extends Stack {
 Cela configure :
 
 1. Un bucket S3 pour héberger vos fichiers de site Web statique
-2. Une distribution CloudFront pour la diffusion de contenu mondiale
+2. Une distribution CloudFront pour la diffusion de contenu globale
 3. Une Web ACL WAF pour la protection de sécurité
-4. Un contrôle d'accès à l'origine pour un accès S3 sécurisé
+4. Un contrôle d'accès d'origine pour un accès S3 sécurisé
 5. Le déploiement automatique des fichiers du site Web et de la configuration d'exécution
 </Fragment>
 <Fragment slot="terraform">
@@ -231,9 +231,9 @@ module "my_website" {
 Cela configure :
 
 1. Un bucket S3 pour héberger vos fichiers de site Web statique
-2. Une distribution CloudFront pour la diffusion de contenu mondiale
+2. Une distribution CloudFront pour la diffusion de contenu globale
 3. Une Web ACL WAF pour la protection de sécurité (déployée dans us-east-1)
-4. Un contrôle d'accès à l'origine pour un accès S3 sécurisé
+4. Un contrôle d'accès d'origine pour un accès S3 sécurisé
 5. Le déploiement automatique des fichiers du site Web et de la configuration d'exécution
 
 :::note[Région du fournisseur WAF]
@@ -290,7 +290,7 @@ export class ApplicationStack extends Stack {
 ```
 
 :::caution[Supprimer CKV_AWS_68 lors de la désactivation de WAF]
-La désactivation de WAF signifie que la distribution CloudFront synthétisée n'a pas de Web ACL associée, ce qui fait échouer l'analyse de sécurité `checkov` avec `CKV_AWS_68: "CloudFront Distribution should have WAF enabled"` sauf si elle est supprimée comme indiqué ci-dessus.
+La désactivation de WAF signifie que la distribution CloudFront synthétisée n'a pas de Web ACL associée, ce qui échoue l'analyse de sécurité `checkov` avec `CKV_AWS_68: "CloudFront Distribution should have WAF enabled"` sauf si elle est supprimée comme indiqué ci-dessus.
 :::
 </Fragment>
 <Fragment slot="terraform">
@@ -311,7 +311,7 @@ module "my_website" {
 
 ### Chiffrement du bucket
 
-Le bucket du site Web, le bucket de journaux de la distribution CloudFront et le groupe CloudWatch Logs recevant leurs journaux d'accès au serveur sont chiffrés avec une clé [AWS KMS](https://aws.amazon.com/kms/) gérée par le client par défaut. Cette clé est créée automatiquement pour vous, avec la rotation de clé activée.
+Le bucket du site Web, le bucket de logs de la distribution CloudFront et le groupe CloudWatch Logs recevant leurs logs d'accès au serveur sont chiffrés avec une clé [AWS KMS](https://aws.amazon.com/kms/) gérée par le client par défaut. Cette clé est créée automatiquement pour vous, avec la rotation de clé activée.
 
 <Infrastructure>
 <Fragment slot="cdk">
@@ -334,6 +334,22 @@ export class ApplicationStack extends Stack {
 }
 ```
 
+:::caution[Supprimer CKV_AWS_158 lors de l'utilisation de S3_MANAGED]
+Choisir `BucketEncryption.S3_MANAGED` signifie que le groupe de logs d'accès n'est plus chiffré par KMS, ce qui échoue l'analyse de sécurité `checkov` avec `CKV_AWS_158`. Supprimez-le :
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { LogGroup } from 'aws-cdk-lib/aws-logs';
+import { suppressRules } from '@my-scope/common-constructs';
+
+suppressRules(
+  website,
+  ['CKV_AWS_158'],
+  'Access log group is not KMS encrypted when encryption is S3_MANAGED',
+  (c) => c instanceof LogGroup,
+);
+```
+:::
+
 Pour utiliser votre propre clé KMS au lieu d'une créée automatiquement, passez `encryptionKey` :
 
 ```ts {2}
@@ -342,10 +358,36 @@ new MyWebsite(this, 'MyWebsite', {
 });
 ```
 
-`enableKeyRotation` (par défaut `true`) s'applique uniquement à la clé créée automatiquement, c'est-à-dire lorsque `encryption` est `BucketEncryption.KMS` (par défaut) et qu'aucune `encryptionKey` n'est fournie.
+:::caution[Les clés importées ont besoin de leurs propres permissions]
+Une clé importée via `Key.fromKeyArn` doit déjà accorder aux principaux de service CloudWatch Logs, S3 et CloudFront les permissions dont ils ont besoin dans sa propre politique de clé. `addToResourcePolicy` est un no-op sur une clé importée, donc ce construct ne peut pas les accorder pour vous, et `cdk synth` ne vous avertira pas - l'échec n'apparaît qu'au moment du déploiement. Une clé créée dans la même application (`new Key(this, 'WebsiteKey')`) n'a pas ce problème, car CDK peut mettre à jour sa politique directement.
+:::
+
+`enableKeyRotation` (par défaut `true`) ne s'applique qu'à la clé créée automatiquement, c'est-à-dire lorsque `encryption` est `BucketEncryption.KMS` (par défaut) et qu'aucune `encryptionKey` n'est fournie :
+
+```ts {2}
+new MyWebsite(this, 'MyWebsite', {
+  enableKeyRotation: false,
+});
+```
+
+:::caution[Supprimer CKV_AWS_7 lors de la désactivation de la rotation de clé]
+La désactivation de la rotation de clé sur la clé créée automatiquement échoue l'analyse de sécurité `checkov` avec `CKV_AWS_7`. Supprimez-le :
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { Key } from 'aws-cdk-lib/aws-kms';
+import { suppressRules } from '@my-scope/common-constructs';
+
+suppressRules(
+  website,
+  ['CKV_AWS_7'],
+  'Key rotation is managed externally',
+  (c) => c instanceof Key,
+);
+```
+:::
 </Fragment>
 <Fragment slot="terraform">
-Si vous souhaitez utiliser une configuration de chiffrement différente, définissez les variables `encryption`, `kms_key_arn` et `enable_key_rotation` :
+Si vous souhaitez utiliser une configuration de chiffrement différente, définissez les variables `encryption`, `kms_key_arn`, `create_kms_key` et `enable_key_rotation` :
 
 ```hcl title="packages/infra/src/main.tf" {7}
 module "my_website" {
@@ -358,9 +400,52 @@ module "my_website" {
 }
 ```
 
-Pour utiliser votre propre clé KMS au lieu d'une créée automatiquement, passez `kms_key_arn`. Une clé fournie par le client doit déjà accorder aux principaux de service CloudWatch Logs, S3 et CloudFront les permissions dont ils ont besoin dans sa propre politique de clé.
+:::caution[Checkov: S3_MANAGED]
+Choisir `S3_MANAGED` échoue l'analyse de sécurité `checkov` avec `CKV_AWS_145` sur les buckets du site Web et des logs de distribution. La cible `test` fournie n'accepte pas de `--config-file`, mais `checkov` découvre automatiquement un `.checkov.yaml` dans son répertoire de travail, donc déposez-en un dans `packages/infra/src` :
 
-`enable_key_rotation` (par défaut `true`) s'applique uniquement à la clé créée automatiquement, c'est-à-dire lorsque `encryption` est `"KMS"` (par défaut) et qu'aucun `kms_key_arn` n'est fourni.
+```yaml title="packages/infra/src/.checkov.yaml"
+skip-check:
+  - CKV_AWS_145
+```
+:::
+
+Pour utiliser votre propre clé KMS au lieu d'une créée automatiquement, passez `kms_key_arn` et définissez `create_kms_key` sur `false` :
+
+```hcl title="packages/infra/src/main.tf" {7-8}
+module "my_website" {
+  source = "../../common/terraform/src/app/static-websites/my-website"
+
+  providers = {
+    aws.us_east_1 = aws.us_east_1
+  }
+  kms_key_arn    = aws_kms_key.website.arn
+  create_kms_key = false
+}
+```
+
+Une clé fournie par le client doit déjà accorder aux principaux de service CloudWatch Logs, S3 et CloudFront les permissions dont ils ont besoin dans sa propre politique de clé.
+
+`enable_key_rotation` (par défaut `true`) ne s'applique qu'à la clé créée automatiquement, c'est-à-dire lorsque `encryption` est `"KMS"` (par défaut) et que `create_kms_key` est `true` :
+
+```hcl title="packages/infra/src/main.tf" {7}
+module "my_website" {
+  source = "../../common/terraform/src/app/static-websites/my-website"
+
+  providers = {
+    aws.us_east_1 = aws.us_east_1
+  }
+  enable_key_rotation = false
+}
+```
+
+:::caution[Checkov: rotation de clé désactivée]
+La désactivation de la rotation de clé sur la clé créée automatiquement échoue l'analyse de sécurité `checkov` avec `CKV_AWS_7`. Ajoutez-le au même `.checkov.yaml` :
+
+```yaml title="packages/infra/src/.checkov.yaml"
+skip-check:
+  - CKV_AWS_7
+```
+:::
 </Fragment>
 </Infrastructure>
 
@@ -477,7 +562,7 @@ module "my_website" {
 ```
 
 :::caution[Ordre des modules]
-Vous devez vous assurer de déclarer votre module de site Web _après_ tous les modules qui ajoutent à la configuration d'exécution et de configurer le `depends_on` approprié pour garantir l'ordre, sinon ils seront manquants dans votre fichier `runtime-config.json`.
+Vous devez vous assurer de déclarer votre module de site Web _après_ tous les modules qui ajoutent à la configuration d'exécution et configurer le `depends_on` approprié pour garantir l'ordre, sinon ils seront manquants dans votre fichier `runtime-config.json`.
 :::
 </Fragment>
 </Infrastructure>
@@ -503,7 +588,7 @@ Pour plus de détails sur la façon dont la configuration d'exécution est stock
 
 ### Configuration d'exécution locale
 
-Lors de l'exécution du [serveur de développement local](#serveur-de-développement-local), vous aurez besoin d'un fichier `runtime-config.json` dans votre répertoire `public` pour que votre site Web local connaisse les URL backend, la configuration d'identité, etc.
+Lors de l'exécution du [serveur de développement local](#serveur-de-développement-local), vous aurez besoin d'un fichier `runtime-config.json` dans votre répertoire `public` afin que votre site Web local connaisse les URL backend, la configuration d'identité, etc.
 
 Votre projet de site Web est configuré avec une cible `load-runtime-config` que vous pouvez utiliser pour télécharger le fichier `runtime-config.json` depuis une application déployée :
 
@@ -542,9 +627,9 @@ Cette cible est utile pour travailler sur les modifications du site Web tout en 
 
 ### Cible Dev
 
-La cible `dev` démarre un serveur de développement local pour votre site Web (avec [Vite `MODE`](https://vite.dev/guide/env-and-mode) défini sur `local-dev`), ainsi que le démarrage de tous les serveurs locaux pour les API auxquelles vous avez connecté votre site Web via le <Link path="/guides/connection">générateur de connexion</Link>.
+La cible `dev` démarre un serveur de développement local pour votre site Web (avec [Vite `MODE`](https://vite.dev/guide/env-and-mode) défini sur `local-dev`), ainsi que le démarrage de tous les serveurs locaux pour les API auxquelles vous avez connecté votre site Web via le <Link path="/guides/connection">générateur Connection</Link>.
 
-Lorsque votre serveur de site Web local est exécuté via cette cible, `runtime-config.json` est automatiquement remplacé pour pointer vers vos URL d'API s'exécutant localement.
+Lorsque votre serveur de site Web local est exécuté via cette cible, `runtime-config.json` est automatiquement remplacé pour pointer vers vos URL d'API en cours d'exécution localement.
 
 Vous pouvez exécuter cette cible avec la commande suivante :
 
@@ -574,7 +659,7 @@ Lors de l'exécution avec `dev`, vous pouvez spécifier toutes les variables d'e
 Notez que vos serveurs d'API locaux s'exécuteront avec les informations d'identification AWS que vous avez configurées localement.
 :::
 
-## Construction
+## Building
 
 Vous pouvez construire votre site Web en utilisant la cible `build`. Cela exécute les cibles `bundle`, `compile`, `test` et `lint`, vérifiant les types, regroupant, testant et lintant votre site Web.
 
@@ -584,7 +669,7 @@ La cible `bundle` utilise Vite pour créer un bundle de production dans le répe
 
 <NxCommands commands={['bundle <my-website>']} />
 
-## Tests
+## Testing
 
 Tester votre site Web ressemble beaucoup à l'écriture de tests dans un projet TypeScript standard, veuillez donc vous référer au <Link path="guides/typescript-project#testing">guide du projet TypeScript</Link> pour plus de détails.
 

--- a/docs/src/content/docs/fr/guides/react-website.mdx
+++ b/docs/src/content/docs/fr/guides/react-website.mdx
@@ -129,58 +129,7 @@ waf -> cloudfront
 cloudfront -> s3
 ```
 
-#### En-têtes de sécurité
-
-La distribution CloudFront applique une politique d'en-têtes de réponse qui définit `Strict-Transport-Security`, `X-Content-Type-Options`, `X-Frame-Options: DENY`, `Referrer-Policy` et une `Content-Security-Policy` sur toutes les réponses.
-
-Une `Content-Security-Policy` par défaut est appliquée. Elle restreint les scripts et le framing pour atténuer les attaques XSS et de clickjacking, tout en permettant les connexions HTTPS et WSS afin que le site Web puisse appeler les points de terminaison des services AWS (tels que API Gateway, Cognito et Bedrock AgentCore) dont les URL ne sont connues qu'au moment du déploiement. Pour ajuster la politique (par exemple pour restreindre `connect-src` à vos origines spécifiques), modifiez la valeur `content_security_policy` dans votre `static-website.ts` (CDK) ou `static-website.tf` (Terraform) généré.
-
-`runtime-config.json` est servi avec `Cache-Control: no-cache` afin que les navigateurs récupèrent toujours la dernière configuration après un redéploiement, plutôt que d'utiliser une copie en cache obsolète.
-
-#### Domaine personnalisé et TLS
-
-Par défaut, la distribution utilise le nom de domaine CloudFront par défaut (`*.cloudfront.net`) et son certificat par défaut, qui ne prend pas en charge l'application d'une version TLS minimale de 1.2. Pour servir votre site Web depuis votre propre domaine, fournissez un [certificat ACM](https://docs.aws.amazon.com/acm/latest/userguide/acm-overview.html) (qui doit résider dans `us-east-1` pour une utilisation avec CloudFront) et vos noms de domaine — une version TLS minimale de 1.2 est alors appliquée pour les visiteurs :
-
-<Infrastructure>
-<Fragment slot="cdk">
-Passez les props `certificate` et `domainNames` dans votre construct de site Web généré dans `packages/common/constructs/src/app/static-websites` :
-
-```ts {6-8}
-export class MyWebsite extends StaticWebsite {
-  constructor(scope: Construct, id: string) {
-    super(scope, id, {
-      websiteName: 'MyWebsite',
-      websiteFilePath: ...,
-      domainNames: ['www.example.com'],
-      certificate: Certificate.fromCertificateArn(scope, 'Cert',
-        'arn:aws:acm:us-east-1:123456789012:certificate/...'),
-    });
-  }
-}
-```
-</Fragment>
-<Fragment slot="terraform">
-Définissez les variables `custom_domain_names` et `acm_certificate_arn` dans votre module de site Web généré dans `packages/common/terraform/src/app/static-websites` :
-
-```hcl {5-6}
-module "static_website" {
-  source            = "../../../core/static-website"
-  website_name      = "my-website"
-  website_file_path = ...
-  custom_domain_names = ["www.example.com"]
-  acm_certificate_arn = "arn:aws:acm:us-east-1:123456789012:certificate/..."
-
-  providers = {
-    aws.us_east_1 = aws.us_east_1
-  }
-}
-```
-</Fragment>
-</Infrastructure>
-
-Vous devrez également créer des enregistrements DNS (par exemple dans Route 53) pointant votre domaine vers la distribution CloudFront.
-
-## Implémenter votre site Web React
+## Implémenter votre site Web
 
 La [documentation React](https://react.dev/learn) est un bon point de départ pour apprendre les bases de la construction avec React.
 
@@ -199,8 +148,8 @@ Vous pouvez vous référer à la [documentation shadcn/ui](https://ui.shadcn.com
 Votre site Web est livré avec [TanStack Router](https://tanstack.com/router/v1) configuré par défaut. Cela facilite l'ajout de nouvelles routes :
 
 <Steps>
-  1. [Exécutez le serveur de développement local](#serveur-de-développement-local)
-  2. Créez un nouveau fichier `<page-name>.tsx` dans `src/routes`, avec sa position dans l'arborescence de fichiers représentant le chemin
+  1. [Exécuter le serveur de développement local](#serveur-de-développement-local)
+  2. Créer un nouveau fichier `<page-name>.tsx` dans `src/routes`, avec sa position dans l'arborescence de fichiers représentant le chemin
   3. Remarquez qu'une `Route` et un `RouteComponent` sont automatiquement générés pour vous. Vous pouvez commencer à construire votre page ici !
 </Steps>
 
@@ -231,6 +180,236 @@ export const MyComponent = () => {
 
 Pour plus de détails, consultez la documentation [TanStack Router](https://tanstack.com/router/latest/docs/framework/react/overview).
 
+## Déployer votre site Web
+
+Le générateur de site Web React crée l'infrastructure en tant que code CDK ou Terraform en fonction de votre `iac` sélectionné. Vous pouvez l'utiliser pour déployer votre site Web.
+
+<Infrastructure>
+<Fragment slot="cdk">
+Pour déployer votre site Web, nous recommandons d'utiliser le <Link path="guides/typescript-infrastructure">générateur `ts#infra`</Link> pour créer une application CDK.
+
+Vous pouvez utiliser le construct CDK généré pour vous dans `packages/common/constructs` pour déployer votre site Web.
+
+```ts title="packages/infra/src/stacks/application-stack.ts" {3, 9}
+import { Stack } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { MyWebsite } from '@my-scope/common-constructs';
+
+export class ApplicationStack extends Stack {
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+
+    new MyWebsite(this, 'MyWebsite');
+  }
+}
+```
+
+Cela configure :
+
+1. Un bucket S3 pour héberger vos fichiers de site Web statique
+2. Une distribution CloudFront pour la diffusion de contenu mondiale
+3. Une Web ACL WAF pour la protection de sécurité
+4. Un contrôle d'accès à l'origine pour un accès S3 sécurisé
+5. Le déploiement automatique des fichiers du site Web et de la configuration d'exécution
+</Fragment>
+<Fragment slot="terraform">
+Pour déployer votre site Web, nous recommandons d'utiliser le <Link path="/guides/terraform-project">générateur `terraform#project`</Link> pour créer un projet Terraform.
+
+Vous pouvez utiliser le module Terraform généré pour vous dans `packages/common/terraform` pour déployer votre site Web.
+
+```hcl title="packages/infra/src/main.tf" {3}
+# Deploy website
+module "my_website" {
+  source = "../../common/terraform/src/app/static-websites/my-website"
+
+  providers = {
+    aws.us_east_1 = aws.us_east_1
+  }
+}
+```
+
+Cela configure :
+
+1. Un bucket S3 pour héberger vos fichiers de site Web statique
+2. Une distribution CloudFront pour la diffusion de contenu mondiale
+3. Une Web ACL WAF pour la protection de sécurité (déployée dans us-east-1)
+4. Un contrôle d'accès à l'origine pour un accès S3 sécurisé
+5. Le déploiement automatique des fichiers du site Web et de la configuration d'exécution
+
+:::note[Région du fournisseur WAF]
+Le fournisseur `aws.us_east_1` est requis pour les ressources CloudFront et WAF, qui doivent être déployées dans la région us-east-1. Assurez-vous que votre configuration Terraform inclut ce fournisseur :
+
+```hcl title="packages/infra/src/providers.tf"
+provider "aws" {
+  alias  = "us_east_1"
+  region = "us-east-1"
+}
+```
+:::
+</Fragment>
+</Infrastructure>
+
+### En-têtes de sécurité
+
+La distribution CloudFront applique une politique d'en-têtes de réponse qui définit `Strict-Transport-Security`, `X-Content-Type-Options`, `X-Frame-Options: DENY`, `Referrer-Policy` et une `Content-Security-Policy` sur toutes les réponses.
+
+Une `Content-Security-Policy` par défaut est appliquée. Elle restreint les scripts et le framing pour atténuer XSS et le clickjacking, tout en permettant les connexions HTTPS et WSS afin que le site Web puisse appeler les points de terminaison de service AWS (tels que API Gateway, Cognito et Bedrock AgentCore) dont les URL ne sont connues qu'au moment du déploiement. Pour ajuster la politique (par exemple pour resserrer `connect-src` à vos origines spécifiques), modifiez la valeur `content_security_policy` dans votre `static-website.ts` (CDK) ou `static-website.tf` (Terraform) généré.
+
+`runtime-config.json` est servi avec `Cache-Control: no-cache` afin que les navigateurs récupèrent toujours la dernière configuration après un redéploiement, plutôt que d'utiliser une copie en cache obsolète.
+
+### WAF
+
+La distribution CloudFront est protégée par une Web ACL [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) par défaut. La Web ACL utilise l'ensemble de règles par défaut géré par AWS ([`AWSManagedRulesCommonRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs) et [`AWSManagedRulesKnownBadInputsRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs)), offrant une protection contre les exploits Web courants, y compris le Top 10 OWASP.
+
+<Infrastructure>
+<Fragment slot="cdk">
+Pour désactiver, définissez `enableWaf` sur `false` lorsque vous créez votre site Web :
+
+```ts title="packages/infra/src/stacks/application-stack.ts" {10,15-18}
+import { Stack } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { MyWebsite, suppressRules } from '@my-scope/common-constructs';
+
+export class ApplicationStack extends Stack {
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+
+    const website = new MyWebsite(this, 'MyWebsite', {
+      enableWaf: false,
+    });
+
+    // Disabling WAF fails the checkov CKV_AWS_68 check ("CloudFront
+    // Distribution should have WAF enabled"). Suppress it explicitly.
+    suppressRules(
+      website.cloudFrontDistribution,
+      ['CKV_AWS_68'],
+      'WAF is intentionally disabled for this distribution',
+    );
+  }
+}
+```
+
+:::caution[Supprimer CKV_AWS_68 lors de la désactivation de WAF]
+La désactivation de WAF signifie que la distribution CloudFront synthétisée n'a pas de Web ACL associée, ce qui fait échouer l'analyse de sécurité `checkov` avec `CKV_AWS_68: "CloudFront Distribution should have WAF enabled"` sauf si elle est supprimée comme indiqué ci-dessus.
+:::
+</Fragment>
+<Fragment slot="terraform">
+Pour désactiver, définissez `enable_waf` sur `false` :
+
+```hcl title="packages/infra/src/main.tf" {7}
+module "my_website" {
+  source = "../../common/terraform/src/app/static-websites/my-website"
+
+  providers = {
+    aws.us_east_1 = aws.us_east_1
+  }
+  enable_waf = false
+}
+```
+</Fragment>
+</Infrastructure>
+
+### Chiffrement du bucket
+
+Le bucket du site Web, le bucket de journaux de la distribution CloudFront et le groupe CloudWatch Logs recevant leurs journaux d'accès au serveur sont chiffrés avec une clé [AWS KMS](https://aws.amazon.com/kms/) gérée par le client par défaut. Cette clé est créée automatiquement pour vous, avec la rotation de clé activée.
+
+<Infrastructure>
+<Fragment slot="cdk">
+Si vous souhaitez utiliser une configuration de chiffrement différente, passez les props `encryption`, `encryptionKey` et `enableKeyRotation` lorsque vous créez votre site Web :
+
+```ts title="packages/infra/src/stacks/application-stack.ts" {11}
+import { Stack } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { BucketEncryption } from 'aws-cdk-lib/aws-s3';
+import { MyWebsite } from '@my-scope/common-constructs';
+
+export class ApplicationStack extends Stack {
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+
+    new MyWebsite(this, 'MyWebsite', {
+      encryption: BucketEncryption.S3_MANAGED,
+    });
+  }
+}
+```
+
+Pour utiliser votre propre clé KMS au lieu d'une créée automatiquement, passez `encryptionKey` :
+
+```ts {2}
+new MyWebsite(this, 'MyWebsite', {
+  encryptionKey: myKey,
+});
+```
+
+`enableKeyRotation` (par défaut `true`) s'applique uniquement à la clé créée automatiquement, c'est-à-dire lorsque `encryption` est `BucketEncryption.KMS` (par défaut) et qu'aucune `encryptionKey` n'est fournie.
+</Fragment>
+<Fragment slot="terraform">
+Si vous souhaitez utiliser une configuration de chiffrement différente, définissez les variables `encryption`, `kms_key_arn` et `enable_key_rotation` :
+
+```hcl title="packages/infra/src/main.tf" {7}
+module "my_website" {
+  source = "../../common/terraform/src/app/static-websites/my-website"
+
+  providers = {
+    aws.us_east_1 = aws.us_east_1
+  }
+  encryption = "S3_MANAGED"
+}
+```
+
+Pour utiliser votre propre clé KMS au lieu d'une créée automatiquement, passez `kms_key_arn`. Une clé fournie par le client doit déjà accorder aux principaux de service CloudWatch Logs, S3 et CloudFront les permissions dont ils ont besoin dans sa propre politique de clé.
+
+`enable_key_rotation` (par défaut `true`) s'applique uniquement à la clé créée automatiquement, c'est-à-dire lorsque `encryption` est `"KMS"` (par défaut) et qu'aucun `kms_key_arn` n'est fourni.
+</Fragment>
+</Infrastructure>
+
+### Domaine personnalisé et TLS
+
+Par défaut, la distribution utilise le nom de domaine CloudFront par défaut (`*.cloudfront.net`) et son certificat par défaut, qui ne prend pas en charge l'application d'une version TLS minimale de 1.2. Pour servir votre site Web depuis votre propre domaine, fournissez un [certificat ACM](https://docs.aws.amazon.com/acm/latest/userguide/acm-overview.html) (qui doit résider dans `us-east-1` pour une utilisation avec CloudFront) et vos noms de domaine. Une version TLS minimale de 1.2 est alors appliquée pour les visiteurs :
+
+<Infrastructure>
+<Fragment slot="cdk">
+Passez les props `certificate` et `domainNames` lorsque vous créez votre site Web :
+
+```ts title="packages/infra/src/stacks/application-stack.ts" {11-13}
+import { Stack } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { Certificate } from 'aws-cdk-lib/aws-certificatemanager';
+import { MyWebsite } from '@my-scope/common-constructs';
+
+export class ApplicationStack extends Stack {
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+
+    new MyWebsite(this, 'MyWebsite', {
+      domainNames: ['www.example.com'],
+      certificate: Certificate.fromCertificateArn(this, 'Cert',
+        'arn:aws:acm:us-east-1:123456789012:certificate/...'),
+    });
+  }
+}
+```
+</Fragment>
+<Fragment slot="terraform">
+Définissez les variables `custom_domain_names` et `acm_certificate_arn` :
+
+```hcl title="packages/infra/src/main.tf" {7-8}
+module "my_website" {
+  source = "../../common/terraform/src/app/static-websites/my-website"
+
+  providers = {
+    aws.us_east_1 = aws.us_east_1
+  }
+  custom_domain_names = ["www.example.com"]
+  acm_certificate_arn = "arn:aws:acm:us-east-1:123456789012:certificate/..."
+}
+```
+</Fragment>
+</Infrastructure>
+
+Vous devrez également créer des enregistrements DNS (par exemple dans Route 53) pointant votre domaine vers la distribution CloudFront.
+
 ## Configuration d'exécution
 
 La configuration de votre infrastructure est fournie à votre site Web via la <Link href="guides/runtime-config">Configuration d'exécution</Link>. Cela permet à votre site Web d'accéder à des détails tels que les URL d'API qui ne sont pas connus avant le déploiement de votre application.
@@ -252,7 +431,7 @@ export class ApplicationStack extends Stack {
   constructor(scope: Construct, id: string) {
     super(scope, id);
 
-    // Website can be declared at any point — runtime config is resolved lazily
+    // Website can be declared at any point, since runtime config is resolved lazily
     new MyWebsite(this, 'MyWebsite');
 
     // Automatically adds values to the RuntimeConfig
@@ -263,8 +442,8 @@ export class ApplicationStack extends Stack {
 }
 ```
 
-:::note[Construct de site Web CDK]
-Avec CDK, le construct de site Web peut être déclaré à n'importe quel moment dans votre stack. La configuration d'exécution est résolue de manière paresseuse au moment de la synthèse, donc toutes les valeurs seront incluses quel que soit l'ordre de déclaration.
+:::note[Construct CDK de site Web]
+Avec CDK, le construct de site Web peut être déclaré à n'importe quel point de votre stack. La configuration d'exécution est résolue paresseusement au moment de la synthèse, donc toutes les valeurs seront incluses quel que soit l'ordre de déclaration.
 :::
 </Fragment>
 <Fragment slot="terraform">
@@ -298,7 +477,7 @@ module "my_website" {
 ```
 
 :::caution[Ordre des modules]
-Vous devez vous assurer de déclarer votre module de site Web _après_ tous les modules qui ajoutent à la configuration d'exécution et configurer le `depends_on` approprié pour garantir l'ordre, sinon ils seront manquants dans votre fichier `runtime-config.json`.
+Vous devez vous assurer de déclarer votre module de site Web _après_ tous les modules qui ajoutent à la configuration d'exécution et de configurer le `depends_on` approprié pour garantir l'ordre, sinon ils seront manquants dans votre fichier `runtime-config.json`.
 :::
 </Fragment>
 </Infrastructure>
@@ -335,7 +514,7 @@ Votre projet de site Web est configuré avec une cible `load-runtime-config` que
 <Fragment slot="cdk">
 Si vous modifiez le préfixe de vos noms de stage dans le `src/main.ts` de votre projet d'infrastructure, vous devrez mettre à jour la cible `load-runtime-config` dans le fichier `project.json` de votre site Web en conséquence.
 
-De plus, il convient de noter que la cible `load-runtime-config` suppose qu'un seul stage de votre application est déployé dans l'environnement pour lequel vous avez des identifiants AWS. Vous devrez ajuster la commande si vous déployez plusieurs stages dans le même compte et la même région.
+De plus, il convient de noter que la cible `load-runtime-config` suppose qu'un seul stage de votre application est déployé dans l'environnement pour lequel vous avez des informations d'identification AWS. Vous devrez ajuster la commande si vous déployez plusieurs stages dans le même compte et la même région.
 </Fragment>
 <Fragment slot="terraform">
 Pour les projets Terraform, la cible `load-runtime-config` copie le fichier `runtime-config.json` qui a été créé après votre `terraform apply` local le plus récent.
@@ -349,7 +528,7 @@ La commande canonique pour le développement local est `dev`, qui démarre votre
 
 <NxCommands commands={['dev <my-website>']} />
 
-La cible `serve` est également disponible lorsque vous devez contrôler quelle partie de votre application s'exécute localement par rapport à pointer vers l'infrastructure AWS déployée. Pour un aperçu plus large du développement local à travers les projets connectés, y compris comment `dev` se comporte pour les projets avec plusieurs composants, consultez le guide <Link path="guides/local-development">Développement local</Link>.
+La cible `serve` est également disponible lorsque vous devez contrôler quelle partie de votre application s'exécute localement par rapport au pointage vers l'infrastructure AWS déployée. Pour un aperçu plus large du développement local à travers les projets connectés, y compris comment `dev` se comporte pour les projets avec plusieurs composants, consultez le guide <Link path="guides/local-development">Développement local</Link>.
 
 ### Cible Serve
 
@@ -363,7 +542,7 @@ Cette cible est utile pour travailler sur les modifications du site Web tout en 
 
 ### Cible Dev
 
-La cible `dev` démarre un serveur de développement local pour votre site Web (avec [Vite `MODE`](https://vite.dev/guide/env-and-mode) défini sur `local-dev`), ainsi que le démarrage de tous les serveurs locaux pour les API auxquelles vous avez connecté votre site Web via le <Link path="/guides/connection">générateur Connection</Link>.
+La cible `dev` démarre un serveur de développement local pour votre site Web (avec [Vite `MODE`](https://vite.dev/guide/env-and-mode) défini sur `local-dev`), ainsi que le démarrage de tous les serveurs locaux pour les API auxquelles vous avez connecté votre site Web via le <Link path="/guides/connection">générateur de connexion</Link>.
 
 Lorsque votre serveur de site Web local est exécuté via cette cible, `runtime-config.json` est automatiquement remplacé pour pointer vers vos URL d'API s'exécutant localement.
 
@@ -392,12 +571,12 @@ Lors de l'exécution avec `dev`, vous pouvez spécifier toutes les variables d'e
 
 <NxCommands env={{DYNAMODB_TABLE_NAME: 'xxxxx'}} commands={['dev <my-website>']} />
 
-Notez que vos serveurs d'API locaux s'exécuteront avec les identifiants AWS que vous avez configurés localement.
+Notez que vos serveurs d'API locaux s'exécuteront avec les informations d'identification AWS que vous avez configurées localement.
 :::
 
 ## Construction
 
-Vous pouvez construire votre site Web en utilisant la cible `build`. Cela exécute les cibles `bundle`, `compile`, `test` et `lint`, en vérifiant les types, en regroupant, en testant et en lintant votre site Web.
+Vous pouvez construire votre site Web en utilisant la cible `build`. Cela exécute les cibles `bundle`, `compile`, `test` et `lint`, vérifiant les types, regroupant, testant et lintant votre site Web.
 
 <NxCommands commands={['build <my-website>']} />
 
@@ -407,82 +586,13 @@ La cible `bundle` utilise Vite pour créer un bundle de production dans le répe
 
 ## Tests
 
-Tester votre site Web est très similaire à l'écriture de tests dans un projet TypeScript standard, veuillez donc vous référer au <Link path="guides/typescript-project#testing">guide du projet TypeScript</Link> pour plus de détails.
+Tester votre site Web ressemble beaucoup à l'écriture de tests dans un projet TypeScript standard, veuillez donc vous référer au <Link path="guides/typescript-project#testing">guide du projet TypeScript</Link> pour plus de détails.
 
 Pour les tests spécifiques à React, React Testing Library est déjà installé et disponible pour que vous puissiez l'utiliser pour écrire des tests. Pour plus de détails sur son utilisation, veuillez vous référer à la [documentation React Testing Library](https://testing-library.com/docs/react-testing-library/example-intro).
 
 Vous pouvez exécuter vos tests en utilisant la cible `test` :
 
 <NxCommands commands={['test <my-website>']} />
-
-## Déployer votre site Web
-
-Le générateur de site Web React crée l'infrastructure en tant que code CDK ou Terraform en fonction de votre `iac` sélectionné. Vous pouvez l'utiliser pour déployer votre site Web.
-
-<Infrastructure>
-<Fragment slot="cdk">
-Pour déployer votre site Web, nous recommandons d'utiliser le <Link path="guides/typescript-infrastructure">générateur `ts#infra`</Link> pour créer une application CDK.
-
-Vous pouvez utiliser le construct CDK généré pour vous dans `packages/common/constructs` pour déployer votre site Web.
-
-```ts title="packages/infra/src/stacks/application-stack.ts" {3, 9}
-import { Stack } from 'aws-cdk-lib';
-import { Construct } from 'constructs';
-import { MyWebsite } from '@my-scope/common-constructs';
-
-export class ApplicationStack extends Stack {
-  constructor(scope: Construct, id: string) {
-    super(scope, id);
-
-    new MyWebsite(this, 'MyWebsite');
-  }
-}
-```
-
-Cela configure :
-
-1. Un bucket S3 pour héberger vos fichiers de site Web statique
-2. Une distribution CloudFront pour la diffusion de contenu mondiale
-3. Une Web ACL WAF pour la protection de sécurité
-4. Un contrôle d'accès d'origine pour un accès S3 sécurisé
-5. Le déploiement automatique des fichiers du site Web et de la configuration d'exécution
-</Fragment>
-<Fragment slot="terraform">
-Pour déployer votre site Web, nous recommandons d'utiliser le <Link path="/guides/terraform-project">générateur `terraform#project`</Link> pour créer un projet Terraform.
-
-Vous pouvez utiliser le module Terraform généré pour vous dans `packages/common/terraform` pour déployer votre site Web.
-
-```hcl title="packages/infra/src/main.tf" {3}
-# Deploy website
-module "my_website" {
-  source = "../../common/terraform/src/app/static-websites/my-website"
-
-  providers = {
-    aws.us_east_1 = aws.us_east_1
-  }
-}
-```
-
-Cela configure :
-
-1. Un bucket S3 pour héberger vos fichiers de site Web statique
-2. Une distribution CloudFront pour la diffusion de contenu mondiale
-3. Une Web ACL WAF pour la protection de sécurité (déployée dans us-east-1)
-4. Un contrôle d'accès d'origine pour un accès S3 sécurisé
-5. Le déploiement automatique des fichiers du site Web et de la configuration d'exécution
-
-:::note[Région du fournisseur WAF]
-Le fournisseur `aws.us_east_1` est requis pour les ressources CloudFront et WAF, qui doivent être déployées dans la région us-east-1. Assurez-vous que votre configuration Terraform inclut ce fournisseur :
-
-```hcl title="packages/infra/src/providers.tf"
-provider "aws" {
-  alias  = "us_east_1"
-  region = "us-east-1"
-}
-```
-:::
-</Fragment>
-</Infrastructure>
 
 ## Connexions
 

--- a/docs/src/content/docs/it/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/it/get_started/tutorials/dungeon-game/1.mdx
@@ -1,6 +1,6 @@
 ---
 title: Configurare un monorepo
-description: "Una guida su come costruire un gioco d'avventura nel dungeon basato su AI agente usando il @aws/nx-plugin."
+description: "Una guida passo-passo su come costruire un gioco di avventura in un dungeon basato su AI agentica utilizzando @aws/nx-plugin."
 ---
 
 import { Aside, Code, FileTree, Steps, Tabs, TabItem } from '@astrojs/starlight/components';
@@ -80,7 +80,7 @@ Vedrai alcuni nuovi file apparire nel tuo albero dei file.
 
 <Aside title="Dipendenze root">
 Il `package.json` root è ora configurato con un `type` di `module`, il che significa che ESM è il tipo di modulo predefinito per tutti i sotto-progetti basati su node forniti da `@aws/nx-plugin`.
-Per maggiori dettagli sul lavoro con progetti TypeScript, fai riferimento alla <Link path="guides/typescript-project">guida del generatore ts#project</Link>.
+Per maggiori dettagli sul lavoro con progetti TypeScript, consulta la <Link path="guides/typescript-project">guida al generatore ts#project</Link>.
 </Aside>
 
 <details>
@@ -149,7 +149,7 @@ export const appRouter = router({
 
 export type AppRouter = typeof appRouter;
 ```
-Il router definisce il router tRPC per la tua API ed è il luogo in cui dichiarerai tutti i metodi della tua API. Come puoi vedere sopra, abbiamo un metodo chiamato `echo` con la sua implementazione nel file `./procedures/echo.ts`. Il punto di ingresso del gestore Lambda è in `handler.ts`, che è configurato automaticamente dal generatore.
+Il router definisce il router tRPC per la tua API ed è il posto dove dichiarerai tutti i tuoi metodi API. Come puoi vedere sopra, abbiamo un metodo chiamato `echo` con la sua implementazione nel file `./procedures/echo.ts`. L'entrypoint del handler Lambda è in `handler.ts`, che viene configurato automaticamente dal generatore.
 
 ```ts {7-10}
 // packages/game-api/src/procedures/echo.ts
@@ -390,7 +390,7 @@ export class GameApi<
 }
 ```
 
-Questo è il costrutto CDK che definisce la nostra `GameApi`. Fornisce un metodo `defaultIntegrations` che crea automaticamente una funzione Lambda per ogni procedura nella nostra API tRPC, puntando all'implementazione dell'API bundled. Ciò significa che al momento di `cdk synth`, il bundling non avviene (a differenza dell'uso di [NodeJsFunction](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_lambda_nodejs.NodejsFunction.html)) poiché abbiamo già effettuato il bundle come parte del target di build del progetto backend.
+Questo è il costrutto CDK che definisce la nostra `GameApi`. Fornisce un metodo `defaultIntegrations` che crea automaticamente una funzione Lambda per ogni procedura nella nostra API tRPC, puntando all'implementazione dell'API bundled. Questo significa che al momento di `cdk synth`, il bundling non avviene (al contrario dell'uso di [NodeJsFunction](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_lambda_nodejs.NodejsFunction.html)) poiché abbiamo già effettuato il bundle come parte del target di build del progetto backend.
 
 </details>
 
@@ -398,7 +398,7 @@ Questo è il costrutto CDK che definisce la nostra `GameApi`. Fornisce un metodo
 
 Ora creiamo il nostro Story Agent.
 
-###### Story agent: Progetto Python
+###### Story agent: progetto Python
 
 Per creare un progetto Python:
 
@@ -603,7 +603,7 @@ async def ping():
     return {"status": "healthy"}
 ```
 
-Questo è il punto di ingresso per l'agente. Poiché abbiamo selezionato `--protocol=ag-ui`, il generatore avvolge il nostro `Agent` Strands con `StrandsAgent` da [`ag_ui_strands`](https://docs.copilotkit.ai/aws-strands/integration) e lo monta su un'app FastAPI che parla il [protocollo AG-UI](https://docs.copilotkit.ai/aws-strands/protocol) — questo è ciò con cui CopilotKit comunicherà dal sito web React. L'agente viene costruito all'interno di un handler `lifespan` — non al momento dell'importazione — quindi l'avvio del container, non l'importazione del modulo, gestisce la costruzione, e ogni sessione AgentCore ottiene il proprio container. Il `SessionIdMiddleware` che abbiamo visto sopra inoltra l'ID sessione del runtime AgentCore in entrata in modo che qualsiasi client MCP/A2A downstream che colleghiamo in seguito (ad es. il server MCP Inventory nel <Link path="get_started/tutorials/dungeon-game/2">Modulo 2</Link>) lo inoltri automaticamente nelle sue chiamate in uscita. Poiché AG-UI memorizza nella cache un agente Strands per `thread_id`, colleghiamo un `session_manager_provider` invece del session manager dell'agente template — questo dà a ogni thread il proprio `SessionManager` in modo che la cronologia delle conversazioni persista tra i turni. Quella funzione `get_session_manager()` proviene da un `session.py` generato: quando deployato, restituisce un `strands.session.S3SessionManager` supportato da un bucket S3 che il generatore fornisce automaticamente; sotto `agent-dev` (`LOCAL_DEV=true`) restituisce sempre un `FileSessionManager` che scrive in una directory temporanea locale, indipendentemente dalla configurazione deployata.
+Questo è l'entrypoint per l'agente. Poiché abbiamo selezionato `--protocol=ag-ui`, il generatore avvolge il nostro `Agent` Strands con `StrandsAgent` da [`ag_ui_strands`](https://docs.copilotkit.ai/aws-strands/integration) e lo monta su un'app FastAPI che parla il [protocollo AG-UI](https://docs.copilotkit.ai/aws-strands/protocol) — questo è ciò con cui CopilotKit comunicherà dal sito web React. L'agente è costruito all'interno di un handler `lifespan` — non al momento dell'import — quindi l'avvio del container, non l'import del modulo, possiede la costruzione, e ogni sessione AgentCore ottiene il proprio container. Il `SessionIdMiddleware` che abbiamo visto sopra inoltra l'ID di sessione runtime AgentCore in entrata in modo che qualsiasi client MCP/A2A downstream che colleghiamo successivamente (ad es. il server MCP Inventory nel <Link path="get_started/tutorials/dungeon-game/2">Modulo 2</Link>) lo inoltri automaticamente sulle sue chiamate in uscita. Poiché AG-UI memorizza nella cache un agente Strands per `thread_id`, inseriamo un `session_manager_provider` invece del session manager proprio dell'agente template — questo dà a ogni thread il proprio `SessionManager` in modo che la cronologia delle conversazioni persista tra i turni. Quella funzione `get_session_manager()` proviene da un `session.py` sibling generato: quando deployato, restituisce un `strands.session.S3SessionManager` supportato da un bucket S3 che il generatore fornisce automaticamente; sotto `agent-dev` (`LOCAL_DEV=true`) restituisce sempre un `FileSessionManager` che scrive in una directory temporanea locale invece, indipendentemente dalla configurazione deployata.
 
 ```ts
 // common/constructs/src/app/agents/story-agent/story-agent.ts
@@ -899,7 +899,7 @@ Potresti notare un `Dockerfile` extra, che fa riferimento all'immagine Docker da
 
 ##### Configurare gli strumenti Inventory
 
-###### Inventory: Progetto TypeScript
+###### Inventory: progetto TypeScript
 
 Creiamo un server MCP per fornire strumenti al nostro Story Agent per gestire l'inventario di un giocatore.
 
@@ -929,7 +929,7 @@ Il generatore `ts#project` genera questi file.
 
 </details>
 
-###### Inventory: Server MCP
+###### Inventory: server MCP
 
 Successivamente, aggiungeremo un server MCP al nostro progetto TypeScript:
 
@@ -1005,9 +1005,9 @@ Il generatore `ts#dynamodb` genera questi file.
           - dynamodb.ts costrutto tabella DynamoDB generico
 </FileTree>
 
-Il `src/client.ts` generato esporta `getDynamoDBClient()` e `resolveTableName()`. Quando `LOCAL_DEV=true` (impostato automaticamente dai target `dev`) questi si connettono a DynamoDB Local; altrimenti si connettono ad AWS e risolvono il nome della tabella deployata dalla <Link path="guides/runtime-config">Runtime Configuration</Link>. Modelleremo le nostre entità `Game` e `Inventory` in questo progetto nel <Link path="get_started/tutorials/dungeon-game/2">Modulo 2</Link>.
+Il `src/client.ts` generato esporta `getDynamoDBClient()` e `resolveTableName()`. Quando `LOCAL_DEV=true` (impostato automaticamente dai target `dev`) questi si connettono a DynamoDB Local; altrimenti si connettono ad AWS e risolvono il nome della tabella deployata da <Link path="guides/runtime-config">Runtime Configuration</Link>. Modelleremo le nostre entità `Game` e `Inventory` in questo progetto nel <Link path="get_started/tutorials/dungeon-game/2">Modulo 2</Link>.
 
-Per maggiori dettagli, fai riferimento alla <Link path="guides/ts-dynamodb">guida del generatore ts#dynamodb</Link>.
+Per maggiori dettagli, consulta la <Link path="guides/ts-dynamodb">guida al generatore ts#dynamodb</Link>.
 
 </details>
 
@@ -1015,7 +1015,7 @@ Per maggiori dettagli, fai riferimento alla <Link path="guides/ts-dynamodb">guid
 
 Successivamente, creeremo l'UI che ti permetterà di interagire con il gioco.
 
-###### Game UI: Website
+###### Game UI: sito web
 
 Per creare l'UI, crea un sito web chiamato `GameUI` usando questi passaggi:
 
@@ -1072,11 +1072,17 @@ Il `ts#website` genera questi file. Esaminiamo alcuni dei file chiave evidenziat
 // packages/common/constructs/src/app/static-websites/game-ui.ts
 import * as url from 'url';
 import { Construct } from 'constructs';
-import { StaticWebsite } from '../../core/index.js';
+import { StaticWebsite, StaticWebsiteProps } from '../../core/index.js';
+
+export type GameUIProps = Omit<
+  StaticWebsiteProps,
+  'websiteName' | 'websiteFilePath'
+>;
 
 export class GameUI extends StaticWebsite {
-  constructor(scope: Construct, id: string) {
+  constructor(scope: Construct, id: string, props?: GameUIProps) {
     super(scope, id, {
+      ...props,
       websiteName: 'GameUI',
       websiteFilePath: url.fileURLToPath(
         new URL(
@@ -1089,7 +1095,7 @@ export class GameUI extends StaticWebsite {
 }
 ```
 
-Questo è il costrutto CDK che definisce la nostra GameUI. Ha già configurato il percorso del file al bundle generato per la nostra UI basata su Vite. Ciò significa che al momento del `build`, il bundling avviene all'interno del target di build del progetto game-ui e l'output viene utilizzato qui.
+Questo è il costrutto CDK che definisce la nostra GameUI. Ha già configurato il percorso del file al bundle generato per la nostra UI basata su Vite. Questo significa che al momento del `build`, il bundling avviene all'interno del target di build del progetto game-ui e l'output viene utilizzato qui.
 
 ```tsx
 // packages/game-ui/src/main.tsx
@@ -1120,7 +1126,7 @@ root &&
   );
 ```
 
-Questo è il punto di ingresso dove React viene montato. Lo stile proviene dai token Tailwind v4 importati tramite `styles.css`. `@tanstack/react-router` è configurato in modalità [file-based routing](https://tanstack.com/router/v1/docs/framework/react/routing/file-based-routing): finché il server di sviluppo è in esecuzione, qualsiasi file che crei sotto `routes/` viene rilevato automaticamente e l'albero delle route viene rigenerato. I generatori successivi (auth, connection) patcheranno questo file con AST per avvolgere `<App />` in provider aggiuntivi.
+Questo è l'entry point dove React viene montato. Lo stile proviene dai token Tailwind v4 importati tramite `styles.css`. `@tanstack/react-router` è configurato in modalità [file-based routing](https://tanstack.com/router/v1/docs/framework/react/routing/file-based-routing): finché il server di sviluppo è in esecuzione, qualsiasi file che crei sotto `routes/` viene rilevato automaticamente e l'albero delle route viene rigenerato. I generatori successivi (auth, connection) patcheranno questo file tramite AST per avvolgere `<App />` in provider aggiuntivi.
 
 ```tsx
 // packages/game-ui/src/routes/index.tsx
@@ -1146,7 +1152,7 @@ Un componente verrà renderizzato quando si naviga verso la route `/`. `@tanstac
 
 </details>
 
-###### Game UI: Auth
+###### Game UI: autenticazione
 
 Configuriamo la nostra Game UI per richiedere l'accesso autenticato tramite Amazon Cognito usando questi passaggi:
 
@@ -1230,7 +1236,7 @@ I componenti `RuntimeConfigProvider` e `CognitoAuth` sono stati aggiunti al file
 
 </details>
 
-###### Game UI: Connettere alla Game API
+###### Game UI: connessione alla Game API
 
 Configuriamo la nostra Game UI per connettersi alla nostra Game API creata in precedenza.
 
@@ -1280,7 +1286,7 @@ export const useGameApiClient = () => {
 };
 ```
 
-Questo hook fornisce accesso al client tRPC per chiamare la GameApi. Per esempi su come chiamare le API tRPC, fai riferimento alla <Link path="guides/connection/react-trpc#using-the-generated-code">guida all'uso dell'hook tRPC</Link>.
+Questo hook fornisce accesso al client tRPC per chiamare la GameApi. Per esempi su come chiamare le API tRPC, consulta la <Link path="guides/connection/react-trpc#using-the-generated-code">guida all'uso dell'hook tRPC</Link>.
 
 <Aside title="Hook type-safe">
 Grazie all'[inferenza TypeScript](https://trpc.io/docs/concepts) di tRPC, `useGameApi` non ha bisogno di un passo di build per far arrivare le modifiche del backend al frontend — le modifiche al router o a qualsiasi procedura vengono rilevate dal type checker istantaneamente.
@@ -1321,7 +1327,7 @@ Il file `main.tsx` è stato aggiornato tramite una trasformazione AST per iniett
 
 </details>
 
-###### Story Agent: Connettere al server MCP Inventory
+###### Story Agent: connessione al server MCP Inventory
 
 Connettiamo il nostro Story Agent al server MCP Inventory in modo che l'agente possa scoprire e invocare gli strumenti del server MCP.
 
@@ -1358,10 +1364,10 @@ Il generatore:
 - Aggiunge il progetto `agent_connection` come dipendenza workspace del progetto story
 - Aggiorna il target `dev` per avviare automaticamente il server MCP quando si esegue localmente
 
-Per maggiori dettagli, fai riferimento alla <Link path="guides/connection/py-agent-mcp">guida alla connessione Python Agent a MCP</Link>.
+Per maggiori dettagli, consulta la <Link path="guides/connection/py-agent-mcp">guida alla connessione Python Agent a MCP</Link>.
 </details>
 
-###### Game UI: Connettere allo Story Agent
+###### Game UI: connessione allo Story Agent
 
 Connettiamo la nostra Game UI allo Story Agent. Poiché l'agente parla AG-UI, il generatore `connection` collega [CopilotKit](https://docs.copilotkit.ai/): un componente chat con tema e un `HttpAgent` `@ag-ui/client` pronto per il rendering.
 
@@ -1392,7 +1398,7 @@ Il generatore:
 - Registra ogni agente connesso su un singolo `CopilotKitProvider` — rieseguire per un altro agente aggiunge semplicemente un altro hook.
 - Legge l'ARN runtime dell'agente dalla Runtime Configuration, costruisce l'URL di invocazione AgentCore e allega il token bearer Cognito più l'header id sessione AgentCore.
 
-Per maggiori dettagli, fai riferimento alla <Link path="guides/connection/react-agui">guida alla connessione React a AG-UI</Link>.
+Per maggiori dettagli, consulta la <Link path="guides/connection/react-agui">guida alla connessione React a AG-UI</Link>.
 </details>
 
 ###### Connettere la Game API e il server MCP Inventory al database
@@ -1407,7 +1413,7 @@ Sia la Game API che il server MCP Inventory leggono e scrivono la nostra tabella
 Poiché l'`agent-dev` dello Story Agent dipende già dal `mcp-server-dev` del server MCP Inventory (tramite la connessione `story → inventory` sopra), e sia la Game API che il server MCP ora dipendono da `dungeon-db:dev`, eseguire il target `dev` di qualsiasi progetto avvia ogni dipendenza di cui ha bisogno nell'ordine giusto.
 </Aside>
 
-###### Game UI: Infrastruttura
+###### Game UI: infrastruttura
 
 Creiamo il sotto-progetto finale per l'infrastruttura CDK.
 
@@ -1463,7 +1469,7 @@ new ApplicationStage(app, 'dungeon-adventure-infra-sandbox', {
 app.synth();
 ```
 
-<Aside type="tip" title="Correggere errori di import">Se vedi un errore di import all'interno del tuo IDE, questo è perché il nostro progetto infrastruttura non ha ancora un riferimento typescript configurato nel `tsconfig.json`. Nx è stato [configurato](https://nx.dev/nx-api/js/generators/typescript-sync) per creare questi riferimenti *dinamicamente* ogni volta che viene eseguita una build/compilazione o se esegui manualmente il comando `nx sync`. Per maggiori informazioni fai riferimento alla <Link path="guides/typescript-project#importing-your-library-code-in-other-projects">guida TypeScript</Link>.</Aside>
+<Aside type="tip" title="Correggere gli errori di import">Se vedi un errore di import all'interno del tuo IDE, questo è perché il nostro progetto infrastruttura non ha ancora un riferimento typescript configurato nel `tsconfig.json`. Nx è stato [configurato](https://nx.dev/nx-api/js/generators/typescript-sync) per creare questi riferimenti *dinamicamente* ogni volta che viene eseguita una build/compilazione o se esegui manualmente il comando `nx sync`. Per maggiori informazioni consulta la <Link path="guides/typescript-project#importing-your-library-code-in-other-projects">guida TypeScript</Link>.</Aside>
 
 Questo è il punto di ingresso per la tua applicazione CDK.
 
@@ -1497,15 +1503,15 @@ Aggiorniamo `packages/infra/src/stacks/application-stack.ts` per istanziare alcu
 Forniamo integrazioni predefinite per la nostra Game API. Per impostazione predefinita, ogni operazione nella nostra API è mappata a una singola funzione Lambda per gestire quell'operazione.
 :::
 
-## Task 4: Costruire il codice
+## Task 4: Compilare il codice
 
-<Drawer title="Comandi Nx" trigger="Ora è il momento di costruire il nostro codice per la prima volta">
+<Drawer title="Comandi Nx" trigger="Ora è il momento di compilare il nostro codice per la prima volta">
 
 ###### Target singoli vs multipli
 
 Il comando `run-many` eseguirà un target su più sotto-progetti elencati (`--all` li targetizzerà tutti). Questo assicura che le dipendenze vengano eseguite nell'ordine corretto.
 
-Puoi anche attivare una build (o qualsiasi altro task) per un singolo target di progetto eseguendo il target sul progetto direttamente. Ad esempio, per costruire il progetto `@dungeon-adventure/infra`, esegui il seguente comando:
+Puoi anche attivare una build (o qualsiasi altro task) per un singolo target di progetto eseguendo il target sul progetto direttamente. Ad esempio, per compilare il progetto `@dungeon-adventure/infra`, esegui il seguente comando:
 
 <NxCommands commands={['build infra']} />
 
@@ -1524,7 +1530,7 @@ Per visualizzare le tue dipendenze, esegui:
 
 ###### Caching
 
-Nx si basa sul [caching](https://nx.dev/concepts/how-caching-works) in modo da poter riutilizzare gli artefatti dalle build precedenti per velocizzare lo sviluppo. C'è una certa configurazione richiesta per far funzionare correttamente questo e potrebbero esserci casi in cui vuoi eseguire una build **senza usare la cache**. Per farlo, aggiungi semplicemente l'argomento `--skip-nx-cache` al tuo comando. Ad esempio:
+Nx si basa sulla [cache](https://nx.dev/concepts/how-caching-works) in modo da poter riutilizzare gli artefatti dalle build precedenti per velocizzare lo sviluppo. È necessaria una certa configurazione per far funzionare correttamente questo e potrebbero esserci casi in cui vuoi eseguire una build **senza usare la cache**. Per farlo, aggiungi semplicemente l'argomento `--skip-nx-cache` al tuo comando. Ad esempio:
 
 <NxCommands commands={['build infra --skip-nx-cache']} />
 Se per qualsiasi motivo volessi mai cancellare la tua cache (memorizzata nella cartella `.nx`), puoi eseguire il seguente comando:
@@ -1557,8 +1563,8 @@ No, run the tasks without syncing the changes
 
 Questo messaggio indica che NX ha rilevato alcuni file che possono essere aggiornati automaticamente per te. In questo caso, si riferisce ai file `tsconfig.json` che non hanno riferimenti TypeScript configurati sui progetti di riferimento.
 
-Seleziona l'opzione **Yes, sync the changes and run the tasks** per procedere. Dovresti notare che tutti gli errori di import relativi all'IDE vengono risolti automaticamente poiché il generatore di sincronizzazione aggiungerà automaticamente i riferimenti TypeScript mancanti!
+Seleziona l'opzione **Yes, sync the changes and run the tasks** per procedere. Dovresti notare che tutti gli errori di import relativi all'IDE vengono risolti automaticamente poiché il generatore di sincronizzazione aggiungerà automaticamente i riferimenti typescript mancanti!
 
-Tutti gli artefatti costruiti sono ora disponibili all'interno della cartella `dist/` situata alla radice del monorepo. Questa è una pratica standard quando si utilizzano progetti generati da `@aws/nx-plugin` poiché non inquina il tuo albero dei file con file generati. Nel caso in cui tu voglia pulire i tuoi file, elimina la cartella `dist/` senza preoccuparti che gli artefatti di build siano sparsi in tutto l'albero dei file.
+Tutti gli artefatti compilati sono ora disponibili all'interno della cartella `dist/` situata alla radice del monorepo. Questa è una pratica standard quando si utilizzano progetti generati da `@aws/nx-plugin` poiché non inquina il tuo albero dei file con file generati. Nel caso in cui tu voglia pulire i tuoi file, elimina la cartella `dist/` senza preoccuparti che gli artefatti di build siano sparsi in tutto l'albero dei file.
 
-Congratulazioni! Hai creato tutti i sotto-progetti richiesti per iniziare a implementare il nucleo del nostro gioco AI Dungeon Adventure.  🎉🎉🎉
+Congratulazioni! Hai creato tutti i sotto-progetti necessari per iniziare a implementare il nucleo del nostro gioco AI Dungeon Adventure.  🎉🎉🎉

--- a/docs/src/content/docs/it/guides/react-website.mdx
+++ b/docs/src/content/docs/it/guides/react-website.mdx
@@ -129,58 +129,7 @@ waf -> cloudfront
 cloudfront -> s3
 ```
 
-#### Header di sicurezza
-
-La distribuzione CloudFront applica una policy di header di risposta che imposta `Strict-Transport-Security`, `X-Content-Type-Options`, `X-Frame-Options: DENY`, `Referrer-Policy` e una `Content-Security-Policy` su tutte le risposte.
-
-Viene applicata una `Content-Security-Policy` predefinita. Essa limita gli script e il framing per mitigare XSS e clickjacking, consentendo al contempo connessioni HTTPS e WSS in modo che il sito web possa chiamare gli endpoint dei servizi AWS (come API Gateway, Cognito e Bedrock AgentCore) i cui URL sono noti solo al momento della distribuzione. Per regolare la policy (ad esempio per restringere `connect-src` alle tue origini specifiche), modifica il valore `content_security_policy` nel tuo `static-website.ts` (CDK) o `static-website.tf` (Terraform) generato.
-
-`runtime-config.json` viene servito con `Cache-Control: no-cache` in modo che i browser recuperino sempre la configurazione più recente dopo una ridistribuzione, anziché utilizzare una copia cache obsoleta.
-
-#### Dominio personalizzato e TLS
-
-Per impostazione predefinita, la distribuzione utilizza il nome di dominio CloudFront predefinito (`*.cloudfront.net`) e il suo certificato predefinito, che non supporta l'applicazione di una versione TLS minima di 1.2. Per servire il tuo sito web dal tuo dominio, fornisci un [certificato ACM](https://docs.aws.amazon.com/acm/latest/userguide/acm-overview.html) (che deve risiedere in `us-east-1` per l'uso con CloudFront) e i tuoi nomi di dominio — viene quindi applicata una versione TLS minima di 1.2 per i visualizzatori:
-
-<Infrastructure>
-<Fragment slot="cdk">
-Passa le props `certificate` e `domainNames` nel tuo costrutto del sito web generato in `packages/common/constructs/src/app/static-websites`:
-
-```ts {6-8}
-export class MyWebsite extends StaticWebsite {
-  constructor(scope: Construct, id: string) {
-    super(scope, id, {
-      websiteName: 'MyWebsite',
-      websiteFilePath: ...,
-      domainNames: ['www.example.com'],
-      certificate: Certificate.fromCertificateArn(scope, 'Cert',
-        'arn:aws:acm:us-east-1:123456789012:certificate/...'),
-    });
-  }
-}
-```
-</Fragment>
-<Fragment slot="terraform">
-Imposta le variabili `custom_domain_names` e `acm_certificate_arn` nel tuo modulo del sito web generato in `packages/common/terraform/src/app/static-websites`:
-
-```hcl {5-6}
-module "static_website" {
-  source            = "../../../core/static-website"
-  website_name      = "my-website"
-  website_file_path = ...
-  custom_domain_names = ["www.example.com"]
-  acm_certificate_arn = "arn:aws:acm:us-east-1:123456789012:certificate/..."
-
-  providers = {
-    aws.us_east_1 = aws.us_east_1
-  }
-}
-```
-</Fragment>
-</Infrastructure>
-
-Dovrai anche creare record DNS (ad esempio in Route 53) che puntano il tuo dominio alla distribuzione CloudFront.
-
-## Implementare il tuo sito web React
+## Implementare il tuo sito web
 
 La [documentazione React](https://react.dev/learn) è un buon punto di partenza per imparare le basi della costruzione con React.
 
@@ -231,197 +180,13 @@ export const MyComponent = () => {
 
 Per maggiori dettagli, consulta la documentazione di [TanStack Router](https://tanstack.com/router/latest/docs/framework/react/overview).
 
-## Configurazione runtime
-
-La configurazione dalla tua infrastruttura viene fornita al tuo sito web tramite <Link href="guides/runtime-config">Configurazione runtime</Link>. Questo consente al tuo sito web di accedere a dettagli come gli URL delle API che non sono noti fino a quando la tua applicazione non viene distribuita.
-
-### Infrastruttura
-
-<Infrastructure>
-<Fragment slot="cdk">
-Il costrutto CDK `RuntimeConfig` può essere utilizzato per aggiungere e recuperare la configurazione nella tua infrastruttura CDK. I costrutti CDK generati dai generatori `@aws/nx-plugin` (come <Link path="guides/trpc">`ts#api`</Link> e <Link path="guides/fastapi">`py#api`</Link>) aggiungeranno automaticamente i valori appropriati al `RuntimeConfig`.
-
-Il tuo costrutto CDK del sito web distribuirà il namespace `connection` della configurazione runtime come file `runtime-config.json` nella radice del tuo bucket S3.
-
-```ts title="packages/infra/src/stacks/application-stack.ts"
-import { Stack } from 'aws-cdk-lib';
-import { Construct } from 'constructs';
-import { MyWebsite, MyApi } from '@my-scope/common-constructs';
-
-export class ApplicationStack extends Stack {
-  constructor(scope: Construct, id: string) {
-    super(scope, id);
-
-    // Website can be declared at any point — runtime config is resolved lazily
-    new MyWebsite(this, 'MyWebsite');
-
-    // Automatically adds values to the RuntimeConfig
-    new MyApi(this, 'MyApi', {
-      integrations: MyApi.defaultIntegrations(this).build(),
-    });
-  }
-}
-```
-
-:::note[Costrutto CDK del sito web]
-Con CDK, il costrutto del sito web può essere dichiarato in qualsiasi punto del tuo stack. La configurazione runtime viene risolta in modo lazy al momento della sintesi, quindi tutti i valori saranno inclusi indipendentemente dall'ordine di dichiarazione.
-:::
-</Fragment>
-<Fragment slot="terraform">
-Con Terraform, la configurazione runtime viene gestita tramite i moduli runtime-config. I moduli Terraform generati dai generatori `@aws/nx-plugin` (come <Link path="guides/trpc">`ts#api`</Link> e <Link path="guides/fastapi">`py#api`</Link>) aggiungeranno automaticamente i valori appropriati alla configurazione runtime.
-
-Il tuo modulo Terraform del sito web distribuirà il namespace `connection` della configurazione runtime come file `runtime-config.json` nella radice del tuo bucket S3.
-
-```hcl title="packages/infra/src/main.tf" {20-21}
-module "asset_bucket" {
-  source = "../../common/terraform/src/core/asset-bucket"
-}
-
-# Automatically adds values to runtime config
-module "my_api" {
-  source = "../../common/terraform/src/app/apis/my-api"
-
-  asset_bucket_name = module.asset_bucket.bucket_name
-}
-
-# Automatically deploys the runtime config to runtime-config.json
-module "my_website" {
-  source = "../../common/terraform/src/app/static-websites/my-website"
-
-  providers = {
-    aws.us_east_1 = aws.us_east_1
-  }
-
-  # Ensure API is deployed first to add to runtime config
-  depends_on = [module.my_api]
-}
-```
-
-:::caution[Ordinamento dei moduli]
-Devi assicurarti di dichiarare il tuo modulo del sito web _dopo_ qualsiasi modulo che aggiunge alla configurazione runtime e configurare l'appropriato `depends_on` per garantire l'ordinamento, altrimenti mancheranno nel tuo file `runtime-config.json`.
-:::
-</Fragment>
-</Infrastructure>
-
-### Codice del sito web
-
-Nel tuo sito web, puoi utilizzare l'hook `useRuntimeConfig` per recuperare i valori dalla configurazione runtime:
-
-```tsx {1,4}
-import { useRuntimeConfig } from '../hooks/useRuntimeConfig';
-
-const MyComponent = () => {
-  const runtimeConfig = useRuntimeConfig();
-
-  // Access values in the runtime config here
-  const apiUrl = runtimeConfig.apis.MyApi;
-};
-```
-
-:::note[Configurazione runtime]
-Per dettagli su come la configurazione runtime viene memorizzata in AWS AppConfig e su come i consumatori lato server (funzioni Lambda, agenti) possono recuperarla, consulta la guida <Link path="guides/runtime-config">Configurazione runtime</Link>.
-:::
-
-### Configurazione runtime locale
-
-Quando esegui il [server di sviluppo locale](#server-di-sviluppo-locale), avrai bisogno di un file `runtime-config.json` nella tua directory `public` affinché il tuo sito web locale conosca gli URL del backend, la configurazione dell'identità, ecc.
-
-Il tuo progetto del sito web è configurato con un target `load-runtime-config` che puoi utilizzare per scaricare il file `runtime-config.json` da un'applicazione distribuita:
-
-<NxCommands commands={['load-runtime-config <my-website>']} />
-
-:::note[Nomi di stage personalizzati]
-<Infrastructure>
-<Fragment slot="cdk">
-Se modifichi il prefisso per i nomi degli stage nel file `src/main.ts` del tuo progetto di infrastruttura, dovrai aggiornare di conseguenza il target `load-runtime-config` nel file `project.json` del tuo sito web.
-
-Inoltre, vale la pena notare che il target `load-runtime-config` presuppone che un singolo stage della tua applicazione sia distribuito nell'ambiente per cui hai le credenziali AWS. Dovrai regolare il comando se distribuisci più stage nello stesso account e regione.
-</Fragment>
-<Fragment slot="terraform">
-Per i progetti Terraform, il target `load-runtime-config` copia il file `runtime-config.json` che è stato creato dopo il tuo più recente `terraform apply` locale.
-</Fragment>
-</Infrastructure>
-:::
-
-## Server di sviluppo locale
-
-Il comando canonico per lo sviluppo locale è `dev`, che avvia il tuo sito web (e qualsiasi server locale per le API a cui lo hai connesso) con un solo comando:
-
-<NxCommands commands={['dev <my-website>']} />
-
-Il target `serve` è anche disponibile per quando hai bisogno di controllare quanto della tua applicazione viene eseguito localmente rispetto al puntamento all'infrastruttura AWS distribuita. Per una panoramica più ampia dello sviluppo locale tra progetti connessi, incluso come si comporta `dev` per progetti con più componenti, consulta la guida <Link path="guides/local-development">Sviluppo locale</Link>.
-
-### Target Serve
-
-Il target `serve` avvia un server di sviluppo locale per il tuo sito web. Questo target richiede che tu abbia distribuito qualsiasi infrastruttura di supporto con cui il sito web interagisce e che tu abbia [caricato la configurazione runtime locale](#configurazione-runtime-locale).
-
-Puoi eseguire questo target con il seguente comando:
-
-<NxCommands commands={['serve <my-website>']} />
-
-Questo target è utile per lavorare sulle modifiche del sito web puntando a API "reali" distribuite e ad altra infrastruttura.
-
-### Target Dev
-
-Il target `dev` avvia un server di sviluppo locale per il tuo sito web (con [Vite `MODE`](https://vite.dev/guide/env-and-mode) impostato su `local-dev`), oltre ad avviare qualsiasi server locale per le API a cui hai connesso il tuo sito web tramite il <Link path="/guides/connection">generatore Connection</Link>.
-
-Quando il tuo server del sito web locale viene eseguito tramite questo target, `runtime-config.json` viene automaticamente sovrascritto per puntare agli URL delle tue API in esecuzione locale.
-
-Puoi eseguire questo target con il seguente comando:
-
-<NxCommands commands={['dev <my-website>']} />
-
-Questo target è utile quando stai lavorando sul tuo sito web e sulla tua API e desideri iterare rapidamente senza distribuire la tua infrastruttura.
-
-:::note[Script `dev` del workspace]
-Il `package.json` radice del tuo workspace include uno script `dev` che esegue il target `dev` per ogni progetto che ne ha uno:
-
-<PackageManagerShortCommand commands={["dev"]} />
-
-Questo avvia il server di sviluppo locale per il tuo sito web (e qualsiasi altro progetto con un target `dev`) con un solo comando. Per eseguire solo questo sito web, usa il suo proprio target `dev` (ad es. `nx dev <my-website>`).
-:::
-
-:::warning[Autenticazione simulata]
-Quando viene eseguito in questa modalità e non è presente alcun `runtime-config.json`, se hai configurato l'autenticazione Cognito (tramite il <Link path="/guides/react-website-auth">generatore `ts#website#auth`</Link>), il login verrà saltato e le richieste ai tuoi server locali non includeranno gli header di autenticazione.
-
-Per abilitare il login e l'autenticazione per `dev`, distribuisci la tua infrastruttura e carica la configurazione runtime.
-:::
-
-:::tip[Comportamento di Dev]
-Quando esegui con `dev`, puoi specificare qualsiasi variabile d'ambiente richiesta dalle tue API per puntare ad altre risorse AWS distribuite, ad esempio:
-
-<NxCommands env={{DYNAMODB_TABLE_NAME: 'xxxxx'}} commands={['dev <my-website>']} />
-
-Nota che i tuoi server API locali verranno eseguiti con le credenziali AWS che hai configurato localmente.
-:::
-
-## Build
-
-Puoi costruire il tuo sito web utilizzando il target `build`. Questo esegue i target `bundle`, `compile`, `test` e `lint`, effettuando il type-checking, il bundling, il testing e il linting del tuo sito web.
-
-<NxCommands commands={['build <my-website>']} />
-
-Il target `bundle` utilizza Vite per creare un bundle di produzione nella directory radice `dist/packages/<my-website>/bundle`. Questo è l'artefatto distribuibile consumato dalla tua infrastruttura del sito web. Puoi eseguirlo da solo:
-
-<NxCommands commands={['bundle <my-website>']} />
-
-## Testing
-
-Testare il tuo sito web è molto simile a scrivere test in un progetto TypeScript standard, quindi fai riferimento alla <Link path="guides/typescript-project#testing">guida al progetto TypeScript</Link> per maggiori dettagli.
-
-Per il testing specifico di React, React Testing Library è già installato e disponibile per scrivere test. Per maggiori dettagli sul suo utilizzo, fai riferimento alla [documentazione di React Testing Library](https://testing-library.com/docs/react-testing-library/example-intro).
-
-Puoi eseguire i tuoi test utilizzando il target `test`:
-
-<NxCommands commands={['test <my-website>']} />
-
 ## Distribuire il tuo sito web
 
-Il generatore del sito web React crea l'infrastruttura come codice CDK o Terraform in base al tuo `iac` selezionato. Puoi utilizzarlo per distribuire il tuo sito web.
+Il generatore di siti web React crea l'infrastruttura come codice CDK o Terraform in base al tuo `iac` selezionato. Puoi utilizzarla per distribuire il tuo sito web.
 
 <Infrastructure>
 <Fragment slot="cdk">
-Per distribuire il tuo sito web, ti consigliamo di utilizzare il <Link path="guides/typescript-infrastructure">generatore `ts#infra`</Link> per creare un'applicazione CDK.
+Per distribuire il tuo sito web, consigliamo di utilizzare il <Link path="guides/typescript-infrastructure">generatore `ts#infra`</Link> per creare un'applicazione CDK.
 
 Puoi utilizzare il costrutto CDK generato per te in `packages/common/constructs` per distribuire il tuo sito web.
 
@@ -448,7 +213,7 @@ Questo configura:
 5. Distribuzione automatica dei file del sito web e della configurazione runtime
 </Fragment>
 <Fragment slot="terraform">
-Per distribuire il tuo sito web, ti consigliamo di utilizzare il <Link path="/guides/terraform-project">generatore `terraform#project`</Link> per creare un progetto Terraform.
+Per distribuire il tuo sito web, consigliamo di utilizzare il <Link path="/guides/terraform-project">generatore `terraform#project`</Link> per creare un progetto Terraform.
 
 Puoi utilizzare il modulo Terraform generato per te in `packages/common/terraform` per distribuire il tuo sito web.
 
@@ -484,6 +249,351 @@ provider "aws" {
 </Fragment>
 </Infrastructure>
 
+### Header di sicurezza
+
+La distribuzione CloudFront applica una policy di header di risposta che imposta `Strict-Transport-Security`, `X-Content-Type-Options`, `X-Frame-Options: DENY`, `Referrer-Policy` e una `Content-Security-Policy` su tutte le risposte.
+
+Viene applicata una `Content-Security-Policy` predefinita. Limita gli script e il framing per mitigare XSS e clickjacking, consentendo al contempo connessioni HTTPS e WSS in modo che il sito web possa chiamare gli endpoint dei servizi AWS (come API Gateway, Cognito e Bedrock AgentCore) i cui URL sono noti solo al momento della distribuzione. Per regolare la policy (ad esempio per restringere `connect-src` alle tue origini specifiche), modifica il valore `content_security_policy` nel tuo `static-website.ts` (CDK) o `static-website.tf` (Terraform) generato.
+
+`runtime-config.json` viene servito con `Cache-Control: no-cache` in modo che i browser recuperino sempre la configurazione più recente dopo una ridistribuzione, anziché utilizzare una copia cache obsoleta.
+
+### WAF
+
+La distribuzione CloudFront è protetta da un Web ACL [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) di default. Il Web ACL utilizza il ruleset predefinito gestito da AWS ([`AWSManagedRulesCommonRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs) e [`AWSManagedRulesKnownBadInputsRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs)), fornendo protezione contro exploit web comuni inclusi OWASP Top 10.
+
+<Infrastructure>
+<Fragment slot="cdk">
+Per disattivare, imposta `enableWaf` su `false` quando crei il tuo sito web:
+
+```ts title="packages/infra/src/stacks/application-stack.ts" {10,15-18}
+import { Stack } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { MyWebsite, suppressRules } from '@my-scope/common-constructs';
+
+export class ApplicationStack extends Stack {
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+
+    const website = new MyWebsite(this, 'MyWebsite', {
+      enableWaf: false,
+    });
+
+    // Disabling WAF fails the checkov CKV_AWS_68 check ("CloudFront
+    // Distribution should have WAF enabled"). Suppress it explicitly.
+    suppressRules(
+      website.cloudFrontDistribution,
+      ['CKV_AWS_68'],
+      'WAF is intentionally disabled for this distribution',
+    );
+  }
+}
+```
+
+:::caution[Sopprimere CKV_AWS_68 quando si disabilita WAF]
+La disabilitazione di WAF significa che la distribuzione CloudFront sintetizzata non ha un Web ACL associato, il che fa fallire la scansione di sicurezza `checkov` con `CKV_AWS_68: "CloudFront Distribution should have WAF enabled"` a meno che non venga soppresso come mostrato sopra.
+:::
+</Fragment>
+<Fragment slot="terraform">
+Per disattivare, imposta `enable_waf` su `false`:
+
+```hcl title="packages/infra/src/main.tf" {7}
+module "my_website" {
+  source = "../../common/terraform/src/app/static-websites/my-website"
+
+  providers = {
+    aws.us_east_1 = aws.us_east_1
+  }
+  enable_waf = false
+}
+```
+</Fragment>
+</Infrastructure>
+
+### Crittografia del bucket
+
+Il bucket del sito web, il bucket dei log della distribuzione CloudFront e il gruppo CloudWatch Logs che riceve i loro log di accesso al server sono crittografati con una chiave [AWS KMS](https://aws.amazon.com/kms/) gestita dal cliente di default. Questa chiave viene creata automaticamente per te, con la rotazione delle chiavi abilitata.
+
+<Infrastructure>
+<Fragment slot="cdk">
+Se desideri utilizzare una configurazione di crittografia diversa, passa le props `encryption`, `encryptionKey` e `enableKeyRotation` quando crei il tuo sito web:
+
+```ts title="packages/infra/src/stacks/application-stack.ts" {11}
+import { Stack } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { BucketEncryption } from 'aws-cdk-lib/aws-s3';
+import { MyWebsite } from '@my-scope/common-constructs';
+
+export class ApplicationStack extends Stack {
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+
+    new MyWebsite(this, 'MyWebsite', {
+      encryption: BucketEncryption.S3_MANAGED,
+    });
+  }
+}
+```
+
+Per utilizzare la tua chiave KMS invece di una creata automaticamente, passa `encryptionKey`:
+
+```ts {2}
+new MyWebsite(this, 'MyWebsite', {
+  encryptionKey: myKey,
+});
+```
+
+`enableKeyRotation` (default `true`) si applica solo alla chiave creata automaticamente, cioè quando `encryption` è `BucketEncryption.KMS` (il default) e non viene fornita alcuna `encryptionKey`.
+</Fragment>
+<Fragment slot="terraform">
+Se desideri utilizzare una configurazione di crittografia diversa, imposta le variabili `encryption`, `kms_key_arn` e `enable_key_rotation`:
+
+```hcl title="packages/infra/src/main.tf" {7}
+module "my_website" {
+  source = "../../common/terraform/src/app/static-websites/my-website"
+
+  providers = {
+    aws.us_east_1 = aws.us_east_1
+  }
+  encryption = "S3_MANAGED"
+}
+```
+
+Per utilizzare la tua chiave KMS invece di una creata automaticamente, passa `kms_key_arn`. Una chiave fornita dal cliente deve già concedere ai principal dei servizi CloudWatch Logs, S3 e CloudFront le autorizzazioni di cui hanno bisogno nella propria policy della chiave.
+
+`enable_key_rotation` (default `true`) si applica solo alla chiave creata automaticamente, cioè quando `encryption` è `"KMS"` (il default) e non viene fornito alcun `kms_key_arn`.
+</Fragment>
+</Infrastructure>
+
+### Dominio personalizzato e TLS
+
+Di default, la distribuzione utilizza il nome di dominio CloudFront predefinito (`*.cloudfront.net`) e il suo certificato predefinito, che non supporta l'applicazione di una versione TLS minima di 1.2. Per servire il tuo sito web dal tuo dominio, fornisci un [certificato ACM](https://docs.aws.amazon.com/acm/latest/userguide/acm-overview.html) (che deve risiedere in `us-east-1` per l'uso con CloudFront) e i tuoi nomi di dominio. Viene quindi applicata una versione TLS minima di 1.2 per i visualizzatori:
+
+<Infrastructure>
+<Fragment slot="cdk">
+Passa le props `certificate` e `domainNames` quando crei il tuo sito web:
+
+```ts title="packages/infra/src/stacks/application-stack.ts" {11-13}
+import { Stack } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { Certificate } from 'aws-cdk-lib/aws-certificatemanager';
+import { MyWebsite } from '@my-scope/common-constructs';
+
+export class ApplicationStack extends Stack {
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+
+    new MyWebsite(this, 'MyWebsite', {
+      domainNames: ['www.example.com'],
+      certificate: Certificate.fromCertificateArn(this, 'Cert',
+        'arn:aws:acm:us-east-1:123456789012:certificate/...'),
+    });
+  }
+}
+```
+</Fragment>
+<Fragment slot="terraform">
+Imposta le variabili `custom_domain_names` e `acm_certificate_arn`:
+
+```hcl title="packages/infra/src/main.tf" {7-8}
+module "my_website" {
+  source = "../../common/terraform/src/app/static-websites/my-website"
+
+  providers = {
+    aws.us_east_1 = aws.us_east_1
+  }
+  custom_domain_names = ["www.example.com"]
+  acm_certificate_arn = "arn:aws:acm:us-east-1:123456789012:certificate/..."
+}
+```
+</Fragment>
+</Infrastructure>
+
+Dovrai anche creare record DNS (ad esempio in Route 53) che puntano il tuo dominio alla distribuzione CloudFront.
+
+## Configurazione runtime
+
+La configurazione dalla tua infrastruttura viene fornita al tuo sito web tramite <Link href="guides/runtime-config">Configurazione runtime</Link>. Questo consente al tuo sito web di accedere a dettagli come gli URL delle API che non sono noti fino a quando la tua applicazione non viene distribuita.
+
+### Infrastruttura
+
+<Infrastructure>
+<Fragment slot="cdk">
+Il costrutto CDK `RuntimeConfig` può essere utilizzato per aggiungere e recuperare la configurazione nella tua infrastruttura CDK. I costrutti CDK generati dai generatori `@aws/nx-plugin` (come <Link path="guides/trpc">`ts#api`</Link> e <Link path="guides/fastapi">`py#api`</Link>) aggiungeranno automaticamente valori appropriati al `RuntimeConfig`.
+
+Il tuo costrutto CDK del sito web distribuirà il namespace `connection` della configurazione runtime come file `runtime-config.json` nella radice del tuo bucket S3.
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { Stack } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { MyWebsite, MyApi } from '@my-scope/common-constructs';
+
+export class ApplicationStack extends Stack {
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+
+    // Website can be declared at any point, since runtime config is resolved lazily
+    new MyWebsite(this, 'MyWebsite');
+
+    // Automatically adds values to the RuntimeConfig
+    new MyApi(this, 'MyApi', {
+      integrations: MyApi.defaultIntegrations(this).build(),
+    });
+  }
+}
+```
+
+:::note[Costrutto CDK del sito web]
+Con CDK, il costrutto del sito web può essere dichiarato in qualsiasi punto dello stack. La configurazione runtime viene risolta in modo lazy al momento della sintesi, quindi tutti i valori saranno inclusi indipendentemente dall'ordine di dichiarazione.
+:::
+</Fragment>
+<Fragment slot="terraform">
+Con Terraform, la configurazione runtime viene gestita tramite i moduli runtime-config. I moduli Terraform generati dai generatori `@aws/nx-plugin` (come <Link path="guides/trpc">`ts#api`</Link> e <Link path="guides/fastapi">`py#api`</Link>) aggiungeranno automaticamente valori appropriati alla configurazione runtime.
+
+Il tuo modulo Terraform del sito web distribuirà il namespace `connection` della configurazione runtime come file `runtime-config.json` nella radice del tuo bucket S3.
+
+```hcl title="packages/infra/src/main.tf" {20-21}
+module "asset_bucket" {
+  source = "../../common/terraform/src/core/asset-bucket"
+}
+
+# Automatically adds values to runtime config
+module "my_api" {
+  source = "../../common/terraform/src/app/apis/my-api"
+
+  asset_bucket_name = module.asset_bucket.bucket_name
+}
+
+# Automatically deploys the runtime config to runtime-config.json
+module "my_website" {
+  source = "../../common/terraform/src/app/static-websites/my-website"
+
+  providers = {
+    aws.us_east_1 = aws.us_east_1
+  }
+
+  # Ensure API is deployed first to add to runtime config
+  depends_on = [module.my_api]
+}
+```
+
+:::caution[Ordinamento dei moduli]
+Devi assicurarti di dichiarare il modulo del tuo sito web _dopo_ qualsiasi modulo che aggiunge alla configurazione runtime e configurare il `depends_on` appropriato per garantire l'ordinamento, altrimenti mancheranno nel tuo file `runtime-config.json`.
+:::
+</Fragment>
+</Infrastructure>
+
+### Codice del sito web
+
+Nel tuo sito web, puoi utilizzare l'hook `useRuntimeConfig` per recuperare i valori dalla configurazione runtime:
+
+```tsx {1,4}
+import { useRuntimeConfig } from '../hooks/useRuntimeConfig';
+
+const MyComponent = () => {
+  const runtimeConfig = useRuntimeConfig();
+
+  // Access values in the runtime config here
+  const apiUrl = runtimeConfig.apis.MyApi;
+};
+```
+
+:::note[Configurazione runtime]
+Per dettagli su come la configurazione runtime viene memorizzata in AWS AppConfig e su come i consumatori lato server (funzioni Lambda, agenti) possono recuperarla, consulta la guida <Link path="guides/runtime-config">Configurazione runtime</Link>.
+:::
+
+### Configurazione runtime locale
+
+Quando esegui il [server di sviluppo locale](#server-di-sviluppo-locale), avrai bisogno di un file `runtime-config.json` nella tua directory `public` affinché il tuo sito web locale conosca gli URL del backend, la configurazione dell'identità, ecc.
+
+Il tuo progetto del sito web è configurato con un target `load-runtime-config` che puoi utilizzare per scaricare il file `runtime-config.json` da un'applicazione distribuita:
+
+<NxCommands commands={['load-runtime-config <my-website>']} />
+
+:::note[Nomi di stage personalizzati]
+<Infrastructure>
+<Fragment slot="cdk">
+Se modifichi il prefisso per i nomi degli stage nel `src/main.ts` del tuo progetto di infrastruttura, dovrai aggiornare di conseguenza il target `load-runtime-config` nel file `project.json` del tuo sito web.
+
+Inoltre, vale la pena notare che il target `load-runtime-config` presuppone che un singolo stage della tua applicazione sia distribuito nell'ambiente per cui hai le credenziali AWS. Dovrai regolare il comando se distribuisci più stage nello stesso account e regione.
+</Fragment>
+<Fragment slot="terraform">
+Per i progetti Terraform, il target `load-runtime-config` copia il file `runtime-config.json` che è stato creato dopo il tuo più recente `terraform apply` locale.
+</Fragment>
+</Infrastructure>
+:::
+
+## Server di sviluppo locale
+
+Il comando canonico per lo sviluppo locale è `dev`, che avvia il tuo sito web (e qualsiasi server locale per le API a cui lo hai connesso) con un solo comando:
+
+<NxCommands commands={['dev <my-website>']} />
+
+Il target `serve` è disponibile anche per quando hai bisogno di controllare quanto della tua applicazione viene eseguito localmente rispetto al puntamento all'infrastruttura AWS distribuita. Per una panoramica più ampia dello sviluppo locale tra progetti connessi, incluso come si comporta `dev` per progetti con più componenti, consulta la guida <Link path="guides/local-development">Sviluppo locale</Link>.
+
+### Target Serve
+
+Il target `serve` avvia un server di sviluppo locale per il tuo sito web. Questo target richiede che tu abbia distribuito qualsiasi infrastruttura di supporto con cui il sito web interagisce e che tu abbia [caricato la configurazione runtime locale](#configurazione-runtime-locale).
+
+Puoi eseguire questo target con il seguente comando:
+
+<NxCommands commands={['serve <my-website>']} />
+
+Questo target è utile per lavorare sulle modifiche del sito web puntando a API "reali" distribuite e ad altra infrastruttura.
+
+### Target Dev
+
+Il target `dev` avvia un server di sviluppo locale per il tuo sito web (con [Vite `MODE`](https://vite.dev/guide/env-and-mode) impostato su `local-dev`), oltre ad avviare qualsiasi server locale per le API a cui hai connesso il tuo sito web tramite il <Link path="/guides/connection">generatore Connection</Link>.
+
+Quando il server del tuo sito web locale viene eseguito tramite questo target, `runtime-config.json` viene automaticamente sovrascritto per puntare agli URL delle tue API in esecuzione localmente.
+
+Puoi eseguire questo target con il seguente comando:
+
+<NxCommands commands={['dev <my-website>']} />
+
+Questo target è utile quando lavori sul tuo sito web e sulla tua API e desideri iterare rapidamente senza distribuire la tua infrastruttura.
+
+:::note[Script `dev` del workspace]
+Il `package.json` radice del tuo workspace include uno script `dev` che esegue il target `dev` per ogni progetto che ne ha uno:
+
+<PackageManagerShortCommand commands={["dev"]} />
+
+Questo avvia il server di sviluppo locale per il tuo sito web (e qualsiasi altro progetto con un target `dev`) in un solo comando. Per eseguire solo questo sito web, usa il suo target `dev` (ad es. `nx dev <my-website>`).
+:::
+
+:::warning[Autenticazione simulata]
+Quando viene eseguito in questa modalità e non è presente alcun `runtime-config.json`, se hai configurato l'autenticazione Cognito (tramite il <Link path="/guides/react-website-auth">generatore `ts#website#auth`</Link>), il login verrà saltato e le richieste ai tuoi server locali non includeranno header di autenticazione.
+
+Per abilitare il login e l'autenticazione per `dev`, distribuisci la tua infrastruttura e carica la configurazione runtime.
+:::
+
+:::tip[Comportamento di Dev]
+Quando esegui con `dev`, puoi specificare qualsiasi variabile d'ambiente richiesta dalle tue API per puntare ad altre risorse AWS distribuite, ad esempio:
+
+<NxCommands env={{DYNAMODB_TABLE_NAME: 'xxxxx'}} commands={['dev <my-website>']} />
+
+Nota che i tuoi server API locali verranno eseguiti con le credenziali AWS che hai configurato localmente.
+:::
+
+## Build
+
+Puoi costruire il tuo sito web utilizzando il target `build`. Questo esegue i target `bundle`, `compile`, `test` e `lint`, effettuando il type-checking, il bundling, il testing e il linting del tuo sito web.
+
+<NxCommands commands={['build <my-website>']} />
+
+Il target `bundle` utilizza Vite per creare un bundle di produzione nella directory radice `dist/packages/<my-website>/bundle`. Questo è l'artefatto distribuibile consumato dalla tua infrastruttura del sito web. Puoi eseguirlo da solo:
+
+<NxCommands commands={['bundle <my-website>']} />
+
+## Testing
+
+Testare il tuo sito web è molto simile a scrivere test in un progetto TypeScript standard, quindi fai riferimento alla <Link path="guides/typescript-project#testing">guida al progetto TypeScript</Link> per maggiori dettagli.
+
+Per i test specifici di React, React Testing Library è già installato e disponibile per scrivere test. Per maggiori dettagli sul suo utilizzo, fai riferimento alla [documentazione di React Testing Library](https://testing-library.com/docs/react-testing-library/example-intro).
+
+Puoi eseguire i tuoi test utilizzando il target `test`:
+
+<NxCommands commands={['test <my-website>']} />
+
 ## Connessioni
 
 Utilizza il generatore <Link path="guides/connection">`connection`</Link> per integrare questo progetto con altri nel tuo workspace. Le seguenti connessioni coinvolgono questo progetto:
@@ -492,28 +602,28 @@ Utilizza il generatore <Link path="guides/connection">`connection`</Link> per in
   <ConnectionCard
     title="React to tRPC"
     description="Call a tRPC API from a React website"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'it'}/guides/connection/react-trpc`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/react-trpc`}
     source="react"
     target="trpc"
   />
   <ConnectionCard
     title="React to FastAPI"
     description="Call a Python FastAPI from a React website"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'it'}/guides/connection/react-fastapi`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/react-fastapi`}
     source="react"
     target="fastapi"
   />
   <ConnectionCard
     title="React to Smithy API"
     description="Call a Smithy API from a React website"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'it'}/guides/connection/react-smithy`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/react-smithy`}
     source="react"
     target="smithy"
   />
   <ConnectionCard
     title="React to Python Agent"
     description="Call a Python Agent from a React website"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'it'}/guides/connection/react-py-agent`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/react-py-agent`}
     source="react"
     target="strands"
     targetBadge="python"
@@ -521,7 +631,7 @@ Utilizza il generatore <Link path="guides/connection">`connection`</Link> per in
   <ConnectionCard
     title="React to TypeScript Agent"
     description="Call a TypeScript Agent from a React website"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'it'}/guides/connection/react-ts-agent`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/react-ts-agent`}
     source="react"
     target="strands"
     targetBadge="typescript"
@@ -529,14 +639,14 @@ Utilizza il generatore <Link path="guides/connection">`connection`</Link> per in
   <ConnectionCard
     title="React to AG-UI Agent"
     description="Call an Agent exposing the AG-UI protocol from a React website via CopilotKit"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'it'}/guides/connection/react-agui`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/react-agui`}
     source="react"
     target="copilotkit"
   />
   <ConnectionCard
     title="React Website to AgentCore Gateway"
     description="Connect a React website to agents through an AgentCore Gateway"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'it'}/guides/connection/react-agentcore-gateway`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/react-agentcore-gateway`}
     source="react"
     target="agentcore"
   />

--- a/docs/src/content/docs/it/guides/react-website.mdx
+++ b/docs/src/content/docs/it/guides/react-website.mdx
@@ -70,7 +70,7 @@ Se hai scelto di non utilizzare [TanStack Router](https://tanstack.com/router/v1
 
 <Snippet name="shared-constructs" />
 
-Il generatore crea l'infrastruttura come codice per distribuire il tuo sito web in base al tuo `iac` selezionato:
+Il generatore crea infrastruttura come codice per distribuire il tuo sito web in base al tuo `iac` selezionato:
 
 <Infrastructure>
 <Fragment slot="cdk">
@@ -150,7 +150,7 @@ Il tuo sito web viene fornito con [TanStack Router](https://tanstack.com/router/
 <Steps>
   1. [Esegui il server di sviluppo locale](#server-di-sviluppo-locale)
   2. Crea un nuovo file `<page-name>.tsx` in `src/routes`, con la sua posizione nell'albero dei file che rappresenta il percorso
-  3. Nota che una `Route` e un `RouteComponent` vengono generati automaticamente per te. Puoi iniziare a costruire la tua pagina qui!
+  3. Nota che un `Route` e `RouteComponent` vengono generati automaticamente per te. Puoi iniziare a costruire la tua pagina qui!
 </Steps>
 
 #### Navigare tra le pagine
@@ -182,7 +182,7 @@ Per maggiori dettagli, consulta la documentazione di [TanStack Router](https://t
 
 ## Distribuire il tuo sito web
 
-Il generatore di siti web React crea l'infrastruttura come codice CDK o Terraform in base al tuo `iac` selezionato. Puoi utilizzarla per distribuire il tuo sito web.
+Il generatore di siti web React crea infrastruttura come codice CDK o Terraform in base al tuo `iac` selezionato. Puoi utilizzarla per distribuire il tuo sito web.
 
 <Infrastructure>
 <Fragment slot="cdk">
@@ -253,13 +253,13 @@ provider "aws" {
 
 La distribuzione CloudFront applica una policy di header di risposta che imposta `Strict-Transport-Security`, `X-Content-Type-Options`, `X-Frame-Options: DENY`, `Referrer-Policy` e una `Content-Security-Policy` su tutte le risposte.
 
-Viene applicata una `Content-Security-Policy` predefinita. Limita gli script e il framing per mitigare XSS e clickjacking, consentendo al contempo connessioni HTTPS e WSS in modo che il sito web possa chiamare gli endpoint dei servizi AWS (come API Gateway, Cognito e Bedrock AgentCore) i cui URL sono noti solo al momento della distribuzione. Per regolare la policy (ad esempio per restringere `connect-src` alle tue origini specifiche), modifica il valore `content_security_policy` nel tuo `static-website.ts` (CDK) o `static-website.tf` (Terraform) generato.
+Viene applicata una `Content-Security-Policy` predefinita. Essa limita gli script e il framing per mitigare XSS e clickjacking, consentendo al contempo connessioni HTTPS e WSS in modo che il sito web possa chiamare gli endpoint dei servizi AWS (come API Gateway, Cognito e Bedrock AgentCore) i cui URL sono noti solo al momento della distribuzione. Per regolare la policy (ad esempio per restringere `connect-src` alle tue origini specifiche), modifica il valore `content_security_policy` nel tuo `static-website.ts` (CDK) o `static-website.tf` (Terraform) generato.
 
 `runtime-config.json` viene servito con `Cache-Control: no-cache` in modo che i browser recuperino sempre la configurazione più recente dopo una ridistribuzione, anziché utilizzare una copia cache obsoleta.
 
 ### WAF
 
-La distribuzione CloudFront è protetta da un Web ACL [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) di default. Il Web ACL utilizza il ruleset predefinito gestito da AWS ([`AWSManagedRulesCommonRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs) e [`AWSManagedRulesKnownBadInputsRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs)), fornendo protezione contro exploit web comuni inclusi OWASP Top 10.
+La distribuzione CloudFront è protetta da un [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACL di default. Il Web ACL utilizza il set di regole predefinito gestito da AWS ([`AWSManagedRulesCommonRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs) e [`AWSManagedRulesKnownBadInputsRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs)), fornendo protezione contro exploit web comuni inclusi OWASP Top 10.
 
 <Infrastructure>
 <Fragment slot="cdk">
@@ -290,7 +290,7 @@ export class ApplicationStack extends Stack {
 ```
 
 :::caution[Sopprimere CKV_AWS_68 quando si disabilita WAF]
-La disabilitazione di WAF significa che la distribuzione CloudFront sintetizzata non ha un Web ACL associato, il che fa fallire la scansione di sicurezza `checkov` con `CKV_AWS_68: "CloudFront Distribution should have WAF enabled"` a meno che non venga soppresso come mostrato sopra.
+Disabilitare WAF significa che la distribuzione CloudFront sintetizzata non ha un Web ACL associato, il che fa fallire la scansione di sicurezza `checkov` con `CKV_AWS_68: "CloudFront Distribution should have WAF enabled"` a meno che non venga soppresso come mostrato sopra.
 :::
 </Fragment>
 <Fragment slot="terraform">
@@ -315,7 +315,7 @@ Il bucket del sito web, il bucket dei log della distribuzione CloudFront e il gr
 
 <Infrastructure>
 <Fragment slot="cdk">
-Se desideri utilizzare una configurazione di crittografia diversa, passa le props `encryption`, `encryptionKey` e `enableKeyRotation` quando crei il tuo sito web:
+Se desideri utilizzare una configurazione di crittografia diversa, passa le proprietà `encryption`, `encryptionKey` e `enableKeyRotation` quando crei il tuo sito web:
 
 ```ts title="packages/infra/src/stacks/application-stack.ts" {11}
 import { Stack } from 'aws-cdk-lib';
@@ -334,6 +334,22 @@ export class ApplicationStack extends Stack {
 }
 ```
 
+:::caution[Sopprimere CKV_AWS_158 quando si utilizza S3_MANAGED]
+Scegliere `BucketEncryption.S3_MANAGED` significa che il gruppo di log di accesso non è più crittografato con KMS, il che fa fallire la scansione di sicurezza `checkov` con `CKV_AWS_158`. Sopprimilo:
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { LogGroup } from 'aws-cdk-lib/aws-logs';
+import { suppressRules } from '@my-scope/common-constructs';
+
+suppressRules(
+  website,
+  ['CKV_AWS_158'],
+  'Access log group is not KMS encrypted when encryption is S3_MANAGED',
+  (c) => c instanceof LogGroup,
+);
+```
+:::
+
 Per utilizzare la tua chiave KMS invece di una creata automaticamente, passa `encryptionKey`:
 
 ```ts {2}
@@ -342,10 +358,36 @@ new MyWebsite(this, 'MyWebsite', {
 });
 ```
 
-`enableKeyRotation` (default `true`) si applica solo alla chiave creata automaticamente, cioè quando `encryption` è `BucketEncryption.KMS` (il default) e non viene fornita alcuna `encryptionKey`.
+:::caution[Le chiavi importate necessitano delle proprie autorizzazioni]
+Una chiave importata tramite `Key.fromKeyArn` deve già concedere ai principali dei servizi CloudWatch Logs, S3 e CloudFront le autorizzazioni di cui hanno bisogno nella propria policy della chiave. `addToResourcePolicy` è un no-op su una chiave importata, quindi questo costrutto non può concederle per te, e `cdk synth` non ti avviserà - il fallimento si manifesta solo al momento della distribuzione. Una chiave creata nella stessa app (`new Key(this, 'WebsiteKey')`) non ha questo problema, poiché CDK può aggiornare direttamente la sua policy.
+:::
+
+`enableKeyRotation` (default `true`) si applica solo alla chiave creata automaticamente, cioè quando `encryption` è `BucketEncryption.KMS` (il default) e non viene fornita alcuna `encryptionKey`:
+
+```ts {2}
+new MyWebsite(this, 'MyWebsite', {
+  enableKeyRotation: false,
+});
+```
+
+:::caution[Sopprimere CKV_AWS_7 quando si disabilita la rotazione delle chiavi]
+Disabilitare la rotazione delle chiavi sulla chiave creata automaticamente fa fallire la scansione di sicurezza `checkov` con `CKV_AWS_7`. Sopprimilo:
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { Key } from 'aws-cdk-lib/aws-kms';
+import { suppressRules } from '@my-scope/common-constructs';
+
+suppressRules(
+  website,
+  ['CKV_AWS_7'],
+  'Key rotation is managed externally',
+  (c) => c instanceof Key,
+);
+```
+:::
 </Fragment>
 <Fragment slot="terraform">
-Se desideri utilizzare una configurazione di crittografia diversa, imposta le variabili `encryption`, `kms_key_arn` e `enable_key_rotation`:
+Se desideri utilizzare una configurazione di crittografia diversa, imposta le variabili `encryption`, `kms_key_arn`, `create_kms_key` e `enable_key_rotation`:
 
 ```hcl title="packages/infra/src/main.tf" {7}
 module "my_website" {
@@ -358,9 +400,52 @@ module "my_website" {
 }
 ```
 
-Per utilizzare la tua chiave KMS invece di una creata automaticamente, passa `kms_key_arn`. Una chiave fornita dal cliente deve già concedere ai principal dei servizi CloudWatch Logs, S3 e CloudFront le autorizzazioni di cui hanno bisogno nella propria policy della chiave.
+:::caution[Checkov: S3_MANAGED]
+Scegliere `S3_MANAGED` fa fallire la scansione di sicurezza `checkov` con `CKV_AWS_145` sui bucket del sito web e dei log di distribuzione. Il target `test` fornito non accetta un `--config-file`, ma `checkov` scopre automaticamente un `.checkov.yaml` nella sua directory di lavoro, quindi inseriscine uno in `packages/infra/src`:
 
-`enable_key_rotation` (default `true`) si applica solo alla chiave creata automaticamente, cioè quando `encryption` è `"KMS"` (il default) e non viene fornito alcun `kms_key_arn`.
+```yaml title="packages/infra/src/.checkov.yaml"
+skip-check:
+  - CKV_AWS_145
+```
+:::
+
+Per utilizzare la tua chiave KMS invece di una creata automaticamente, passa `kms_key_arn` e imposta `create_kms_key` su `false`:
+
+```hcl title="packages/infra/src/main.tf" {7-8}
+module "my_website" {
+  source = "../../common/terraform/src/app/static-websites/my-website"
+
+  providers = {
+    aws.us_east_1 = aws.us_east_1
+  }
+  kms_key_arn    = aws_kms_key.website.arn
+  create_kms_key = false
+}
+```
+
+Una chiave fornita dal cliente deve già concedere ai principali dei servizi CloudWatch Logs, S3 e CloudFront le autorizzazioni di cui hanno bisogno nella propria policy della chiave.
+
+`enable_key_rotation` (default `true`) si applica solo alla chiave creata automaticamente, cioè quando `encryption` è `"KMS"` (il default) e `create_kms_key` è `true`:
+
+```hcl title="packages/infra/src/main.tf" {7}
+module "my_website" {
+  source = "../../common/terraform/src/app/static-websites/my-website"
+
+  providers = {
+    aws.us_east_1 = aws.us_east_1
+  }
+  enable_key_rotation = false
+}
+```
+
+:::caution[Checkov: rotazione delle chiavi disabilitata]
+Disabilitare la rotazione delle chiavi sulla chiave creata automaticamente fa fallire la scansione di sicurezza `checkov` con `CKV_AWS_7`. Aggiungilo allo stesso `.checkov.yaml`:
+
+```yaml title="packages/infra/src/.checkov.yaml"
+skip-check:
+  - CKV_AWS_7
+```
+:::
 </Fragment>
 </Infrastructure>
 
@@ -370,7 +455,7 @@ Di default, la distribuzione utilizza il nome di dominio CloudFront predefinito 
 
 <Infrastructure>
 <Fragment slot="cdk">
-Passa le props `certificate` e `domainNames` quando crei il tuo sito web:
+Passa le proprietà `certificate` e `domainNames` quando crei il tuo sito web:
 
 ```ts title="packages/infra/src/stacks/application-stack.ts" {11-13}
 import { Stack } from 'aws-cdk-lib';
@@ -443,7 +528,7 @@ export class ApplicationStack extends Stack {
 ```
 
 :::note[Costrutto CDK del sito web]
-Con CDK, il costrutto del sito web può essere dichiarato in qualsiasi punto dello stack. La configurazione runtime viene risolta in modo lazy al momento della sintesi, quindi tutti i valori saranno inclusi indipendentemente dall'ordine di dichiarazione.
+Con CDK, il costrutto del sito web può essere dichiarato in qualsiasi punto del tuo stack. La configurazione runtime viene risolta in modo lazy al momento della sintesi, quindi tutti i valori saranno inclusi indipendentemente dall'ordine di dichiarazione.
 :::
 </Fragment>
 <Fragment slot="terraform">
@@ -477,14 +562,14 @@ module "my_website" {
 ```
 
 :::caution[Ordinamento dei moduli]
-Devi assicurarti di dichiarare il modulo del tuo sito web _dopo_ qualsiasi modulo che aggiunge alla configurazione runtime e configurare il `depends_on` appropriato per garantire l'ordinamento, altrimenti mancheranno nel tuo file `runtime-config.json`.
+Devi assicurarti di dichiarare il modulo del tuo sito web _dopo_ qualsiasi modulo che aggiunge alla configurazione runtime e configurare l'appropriato `depends_on` per garantire l'ordinamento, altrimenti mancheranno nel tuo file `runtime-config.json`.
 :::
 </Fragment>
 </Infrastructure>
 
 ### Codice del sito web
 
-Nel tuo sito web, puoi utilizzare l'hook `useRuntimeConfig` per recuperare i valori dalla configurazione runtime:
+Nel tuo sito web, puoi utilizzare l'hook `useRuntimeConfig` per recuperare valori dalla configurazione runtime:
 
 ```tsx {1,4}
 import { useRuntimeConfig } from '../hooks/useRuntimeConfig';
@@ -512,9 +597,9 @@ Il tuo progetto del sito web è configurato con un target `load-runtime-config` 
 :::note[Nomi di stage personalizzati]
 <Infrastructure>
 <Fragment slot="cdk">
-Se modifichi il prefisso per i nomi degli stage nel `src/main.ts` del tuo progetto di infrastruttura, dovrai aggiornare di conseguenza il target `load-runtime-config` nel file `project.json` del tuo sito web.
+Se modifichi il prefisso per i nomi dei tuoi stage nel file `src/main.ts` del tuo progetto di infrastruttura, dovrai aggiornare di conseguenza il target `load-runtime-config` nel file `project.json` del tuo sito web.
 
-Inoltre, vale la pena notare che il target `load-runtime-config` presuppone che un singolo stage della tua applicazione sia distribuito nell'ambiente per cui hai le credenziali AWS. Dovrai regolare il comando se distribuisci più stage nello stesso account e regione.
+Inoltre, vale la pena notare che il target `load-runtime-config` presuppone che un singolo stage della tua applicazione sia distribuito nell'ambiente per cui hai credenziali AWS. Dovrai regolare il comando se distribuisci più stage nello stesso account e regione.
 </Fragment>
 <Fragment slot="terraform">
 Per i progetti Terraform, il target `load-runtime-config` copia il file `runtime-config.json` che è stato creato dopo il tuo più recente `terraform apply` locale.
@@ -524,7 +609,7 @@ Per i progetti Terraform, il target `load-runtime-config` copia il file `runtime
 
 ## Server di sviluppo locale
 
-Il comando canonico per lo sviluppo locale è `dev`, che avvia il tuo sito web (e qualsiasi server locale per le API a cui lo hai connesso) con un solo comando:
+Il comando canonico per lo sviluppo locale è `dev`, che avvia il tuo sito web (e qualsiasi server locale per le API a cui lo hai connesso) con un unico comando:
 
 <NxCommands commands={['dev <my-website>']} />
 
@@ -550,14 +635,14 @@ Puoi eseguire questo target con il seguente comando:
 
 <NxCommands commands={['dev <my-website>']} />
 
-Questo target è utile quando lavori sul tuo sito web e sulla tua API e desideri iterare rapidamente senza distribuire la tua infrastruttura.
+Questo target è utile quando stai lavorando sul tuo sito web e sulla tua API e desideri iterare rapidamente senza distribuire la tua infrastruttura.
 
 :::note[Script `dev` del workspace]
 Il `package.json` radice del tuo workspace include uno script `dev` che esegue il target `dev` per ogni progetto che ne ha uno:
 
 <PackageManagerShortCommand commands={["dev"]} />
 
-Questo avvia il server di sviluppo locale per il tuo sito web (e qualsiasi altro progetto con un target `dev`) in un solo comando. Per eseguire solo questo sito web, usa il suo target `dev` (ad es. `nx dev <my-website>`).
+Questo avvia il server di sviluppo locale per il tuo sito web (e qualsiasi altro progetto con un target `dev`) in un unico comando. Per eseguire solo questo sito web, utilizza il suo target `dev` (ad es. `nx dev <my-website>`).
 :::
 
 :::warning[Autenticazione simulata]
@@ -574,9 +659,9 @@ Quando esegui con `dev`, puoi specificare qualsiasi variabile d'ambiente richies
 Nota che i tuoi server API locali verranno eseguiti con le credenziali AWS che hai configurato localmente.
 :::
 
-## Build
+## Building
 
-Puoi costruire il tuo sito web utilizzando il target `build`. Questo esegue i target `bundle`, `compile`, `test` e `lint`, effettuando il type-checking, il bundling, il testing e il linting del tuo sito web.
+Puoi compilare il tuo sito web utilizzando il target `build`. Questo esegue i target `bundle`, `compile`, `test` e `lint`, effettuando il controllo dei tipi, il bundling, il testing e il linting del tuo sito web.
 
 <NxCommands commands={['build <my-website>']} />
 
@@ -600,54 +685,55 @@ Utilizza il generatore <Link path="guides/connection">`connection`</Link> per in
 
 <CardGrid>
   <ConnectionCard
-    title="React to tRPC"
-    description="Call a tRPC API from a React website"
+    title="React a tRPC"
+    description="Chiama un'API tRPC da un sito web React"
     href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/react-trpc`}
     source="react"
     target="trpc"
   />
   <ConnectionCard
-    title="React to FastAPI"
-    description="Call a Python FastAPI from a React website"
+    title="React a FastAPI"
+    description="Chiama una FastAPI Python da un sito web React"
     href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/react-fastapi`}
     source="react"
     target="fastapi"
   />
   <ConnectionCard
-    title="React to Smithy API"
-    description="Call a Smithy API from a React website"
+    title="React a Smithy API"
+    description="Chiama un'API Smithy da un sito web React"
     href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/react-smithy`}
     source="react"
     target="smithy"
   />
   <ConnectionCard
-    title="React to Python Agent"
-    description="Call a Python Agent from a React website"
+    title="React a Python Agent"
+    description="Chiama un agente Python da un sito web React"
     href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/react-py-agent`}
     source="react"
     target="strands"
     targetBadge="python"
   />
   <ConnectionCard
-    title="React to TypeScript Agent"
-    description="Call a TypeScript Agent from a React website"
+    title="React a TypeScript Agent"
+    description="Chiama un agente TypeScript da un sito web React"
     href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/react-ts-agent`}
     source="react"
     target="strands"
     targetBadge="typescript"
   />
   <ConnectionCard
-    title="React to AG-UI Agent"
-    description="Call an Agent exposing the AG-UI protocol from a React website via CopilotKit"
+    title="React a AG-UI Agent"
+    description="Chiama un agente che espone il protocollo AG-UI da un sito web React tramite CopilotKit"
     href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/react-agui`}
     source="react"
     target="copilotkit"
   />
   <ConnectionCard
-    title="React Website to AgentCore Gateway"
-    description="Connect a React website to agents through an AgentCore Gateway"
+    title="Sito web React a AgentCore Gateway"
+    description="Connetti un sito web React agli agenti tramite un AgentCore Gateway"
     href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/react-agentcore-gateway`}
     source="react"
     target="agentcore"
   />
 </CardGrid>
+

--- a/docs/src/content/docs/jp/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/jp/get_started/tutorials/dungeon-game/1.mdx
@@ -1,6 +1,6 @@
 ---
 title: モノレポのセットアップ
-description: "@aws/nx-plugin を使ってエージェント型 AI ダンジョンアドベンチャーゲームを構築するウォークスルー。"
+description: "@aws/nx-pluginを使用してエージェント型AI搭載のダンジョンアドベンチャーゲームを構築する方法のチュートリアル。"
 ---
 
 import { Aside, Code, FileTree, Steps, Tabs, TabItem } from '@astrojs/starlight/components';
@@ -22,17 +22,17 @@ import nxGraphPng from '@assets/nx-graph.png'
 import gameSelectPng from '@assets/game-select.png'
 import gameConversationPng from '@assets/game-conversation.png'
 
-## タスク 1: モノレポを作成する
+## タスク1: モノレポの作成
 
-新しいモノレポを作成するには、任意のディレクトリ内で次のコマンドを実行します:
+新しいモノレポを作成するには、目的のディレクトリ内で次のコマンドを実行します:
 
 <CreateNxWorkspaceCommand workspace="dungeon-adventure" iac="cdk" />
 
-:::note[IaC プロバイダーとしての CDK]
-このチュートリアルではインフラストラクチャーコードに CDK を使用するため、`--iac=cdk` を指定します。AWS 向け Nx Plugin は `terraform` もサポートしています。
+:::note[IaCプロバイダーとしてのCDK]
+このチュートリアルではインフラストラクチャをコードとして管理するためにCDKを使用するため、`--iac=cdk`を使用します。Nx Plugin for AWSは`terraform`もサポートしています。
 :::
 
-これにより `dungeon-adventure` ディレクトリ内に NX モノレポがセットアップされます。VSCode でそのディレクトリを開くと、次のファイル構造が表示されます:
+これにより、`dungeon-adventure`ディレクトリ内にNXモノレポがセットアップされます。VSCodeでディレクトリを開くと、次のファイル構造が表示されます:
 
 <FileTree>
 - .nx/
@@ -40,37 +40,37 @@ import gameConversationPng from '@assets/game-conversation.png'
 - node_modules/
 - packages/ サブプロジェクトが配置される場所
 - .gitignore
-- biome.json リントとフォーマットのための Biome 設定
-- nx.json Nx CLI とモノレポのデフォルト設定
-- package.json すべての node 依存関係はここで定義
-- pnpm-lock.yaml パッケージマネージャーによって bun.lock、yarn.lock、package-lock.json になる場合もある
-- pnpm-workspace.yaml pnpm を使用する場合
+- biome.json Biomeのリントとフォーマット設定
+- nx.json Nx CLIとモノレポのデフォルト設定
+- package.json すべてのnode依存関係がここで定義されます
+- pnpm-lock.yaml または bun.lock、yarn.lock、package-lock.json（パッケージマネージャーによる）
+- pnpm-workspace.yaml pnpmを使用する場合
 - README.md
-- tsconfig.base.json すべての node ベースのサブプロジェクトはこれを継承する
+- tsconfig.base.json すべてのnodeベースのサブプロジェクトがこれを拡張します
 - tsconfig.json
-- aws-nx-plugin.config.mts AWS 向け Nx Plugin の設定
+- aws-nx-plugin.config.mts Nx Plugin for AWSの設定
 </FileTree>
 
-<Aside type="tip" title="こまめにコミットしよう">ジェネレーターを実行する前に、すべてのステージングされていないファイルを Git にコミットしておくことがベストプラクティスです。これにより、`git diff` でジェネレーター実行後の変更を確認できます。</Aside>
+<Aside type="tip" title="頻繁にコミット">ジェネレーターを実行する前に、すべてのステージングされていないファイルをGitにコミットしておくことがベストプラクティスです。これにより、ジェネレーター実行後に`git diff`で何が変更されたかを確認できます。</Aside>
 
-## タスク 2: ダンジョンアドベンチャーゲームのスキャフォールド
+## タスク2: ダンジョンアドベンチャーゲームのスキャフォールディング
 
-ワークスペースが整ったら、ゲームのサブプロジェクト（Game API、Story Agent、Inventory MCP サーバー、ゲームデータベース、ウェブサイト）と、それらを繋ぐ接続をスキャフォールドします。方法は 2 つあります:
+ワークスペースが整ったら、ゲームのサブプロジェクト（Game API、Story Agent、Inventory MCPサーバー、ゲームデータベース、ウェブサイト）と、それらを接続するコネクションをスキャフォールディングします。これには2つの方法があります:
 
-- **クイック** — 下の図からコマンドをそのままコピーして実行します。同じ出発点に最速で到達できます。
-- **ステップバイステップ** — 下のセクションを展開して、各ジェネレーターを自分で実行し、それぞれが何を生成するかを詳しく確認します。
+- **クイック** — 以下の図からコマンドを直接コピーして実行します。同じ開始点に到達する最速の方法です。
+- **ステップバイステップ** — 以下のセクションを展開して、各ジェネレーターを自分で実行し、それぞれが何を生成するかを正確に確認します。
 
-下の図はダンジョンアドベンチャーワークスペースそのものです: このモジュールで構築するすべてのプロジェクト、コンポーネント、接続が含まれています。**コマンドをコピー** をクリックしてシリーズ全体を取得し、タスク 1 で作成した `dungeon-adventure` ディレクトリ内から実行してください。
+以下の図は、ダンジョンアドベンチャーワークスペース_そのもの_です: このモジュールで構築するすべてのプロジェクト、コンポーネント、コネクションが含まれています。**Copy commands**をクリックしてシリーズ全体を取得し、タスク1で作成した`dungeon-adventure`ディレクトリ内から実行してください。
 
 <EmbeddedGraph preset="dungeon-adventure" workspace="dungeon-adventure" iac="cdk" skipWorkspace />
 
-<Drawer title="ステップバイステップ" trigger="ステップバイステップ: 各ジェネレーターを自分で実行して何が生成されるか確認する">
+<Drawer title="ステップバイステップ" trigger="ステップバイステップ: 各ジェネレーターを自分で実行して、何が生成されるかを確認する">
 
-コマンドを一度にコピーする代わりに、各ジェネレーターを個別に実行できます。これは各ジェネレーターがワークスペースに何を追加するかを理解する最良の方法です。タスク 1 で作成した `dungeon-adventure` ディレクトリ内から、各ジェネレーターを順番に実行してください。
+コマンドを一度にコピーするのではなく、各ジェネレーターを個別に実行できます。これは、各ジェネレーターがワークスペースに何を追加するかを理解する最良の方法です。タスク1で作成した`dungeon-adventure`ディレクトリ内から、各ジェネレーターを順番に実行してください。
 
-##### Game API を作成する
+##### Game APIの作成
 
-まず、Game API を作成しましょう。次の手順で `GameApi` という名前の tRPC API を作成します:
+まず、Game APIを作成しましょう。これを行うには、次の手順で`GameApi`というtRPC APIを作成します:
 
 <RunGenerator generator="ts#api" requiredParameters={{ name: "GameApi", framework: "trpc" }} noInteractive />
 
@@ -79,30 +79,30 @@ import gameConversationPng from '@assets/game-conversation.png'
 ファイルツリーに新しいファイルが表示されます。
 
 <Aside title="ルート依存関係">
-ルートの `package.json` には `module` タイプが設定されており、これは `@aws/nx-plugin` が提供するすべての node ベースのサブプロジェクトのデフォルトモジュールタイプが ESM であることを意味します。
-TypeScript プロジェクトの操作の詳細については、<Link path="guides/typescript-project">ts#project ジェネレーターガイド</Link>を参照してください。
+ルートの`package.json`は`type`が`module`に設定されており、これは`@aws/nx-plugin`によって提供されるすべてのnodeベースのサブプロジェクトのデフォルトモジュールタイプがESMであることを意味します。
+TypeScriptプロジェクトの操作の詳細については、<Link path="guides/typescript-project">ts#projectジェネレーターガイド</Link>を参照してください。
 </Aside>
 
 <details>
-<summary>生成された `ts#api` ファイルを詳しく確認する</summary>
+<summary>生成された`ts#api`ファイルを詳しく確認する</summary>
 
-以下は `ts#api` ジェネレーターによって生成されたすべてのファイルの一覧です。ファイルツリーでハイライトされているいくつかの重要なファイルを確認します:
+以下は、`ts#api`ジェネレーターによって生成されたすべてのファイルのリストです。ファイルツリーで強調表示されている主要なファイルのいくつかを確認します:
 <FileTree>
 - packages/
   - common/
     - constructs/
       - src/
-        - app/ アプリ固有の cdk コンストラクト
+        - app/ アプリ固有のcdkコンストラクト
           - apis/
-            - **game-api.ts** tRPC API を作成する cdk コンストラクト
+            - **game-api.ts** tRPC APIを作成するためのcdkコンストラクト
             - index.ts
             - ...
           - index.ts
-        - core/ 汎用 cdk コンストラクト
+        - core/ 汎用cdkコンストラクト
           - api/
-            - rest-api.ts API Gateway Rest API のベース cdk コンストラクト
-            - trpc-utils.ts trpc API CDK コンストラクトのユーティリティ
-            - utils.ts API コンストラクトのユーティリティ
+            - rest-api.ts API Gateway Rest APIの基本cdkコンストラクト
+            - trpc-utils.ts trpc API CDKコンストラクト用のユーティリティ
+            - utils.ts APIコンストラクト用のユーティリティ
           - index.ts
           - runtime-config.ts
         - index.ts
@@ -110,31 +110,31 @@ TypeScript プロジェクトの操作の詳細については、<Link path="gui
       - ...
   - game-api/ tRPC API
     - src/
-      - client/ ts のマシン間通信に使用するバニラクライアント
+      - client/ 通常tsマシン間呼び出しに使用されるバニラクライアント
         - index.ts
-      - middleware/ powertools インストルメンテーション
+      - middleware/ powertoolsインストルメンテーション
         - error.ts
         - index.ts
         - logger.ts
         - metrics.ts
         - tracer.ts
-      - schema/ API の入出力定義
+      - schema/ APIの入力と出力の定義
         - index.ts
-        - **echo.ts** サンプルの入出力スキーマ
-        - z-async-iterable.ts tRPC サブスクリプション出力用のラッパー Zod スキーマ
-      - procedures/ API プロシージャ/ルートの具体的な実装
-        - **echo.ts** サンプルプロシージャの実装
+        - **echo.ts** サンプル入出力スキーマ
+        - z-async-iterable.ts tRPCサブスクリプション出力用のラッパーZodスキーマ
+      - procedures/ APIプロシージャ/ルートの具体的な実装
+        - **echo.ts** サンプルプロシージャ実装
       - index.ts
-      - init.ts コンテキストとミドルウェアのセットアップ
-      - handler.ts Lambda ハンドラーエントリーポイント（REST API にはレスポンスストリーミングを使用）
-      - local-server.ts tRPC サーバーをローカルで実行する際に使用
-      - **router.ts** tRPC ルーターとすべてのプロシージャを定義
+      - init.ts コンテキストとミドルウェアをセットアップ
+      - handler.ts Lambdaハンドラーエントリーポイント（REST APIにレスポンスストリーミングを使用）
+      - local-server.ts tRPCサーバーをローカルで実行する際に使用
+      - **router.ts** tRPCルーターとすべてのプロシージャを定義
     - project.json
     - ...
 - vitest.workspace.ts
 </FileTree>
 
-これらの重要なファイルを見てみましょう:
+これらの主要なファイルを見てみましょう:
 
 ```ts {7}
 // packages/game-api/src/router.ts
@@ -149,7 +149,7 @@ export const appRouter = router({
 
 export type AppRouter = typeof appRouter;
 ```
-ルーターは API の tRPC ルーターを定義し、すべての API メソッドを宣言する場所です。上記のように、`echo` というメソッドがあり、その実装は `./procedures/echo.ts` ファイルにあります。Lambda ハンドラーエントリーポイントは `handler.ts` にあり、ジェネレーターによって自動的に設定されます。
+ルーターはAPIのtRPCルーターを定義し、すべてのAPIメソッドを宣言する場所です。上記のように、`echo`というメソッドがあり、その実装は`./procedures/echo.ts`ファイルにあります。Lambdaハンドラーエントリーポイントは`handler.ts`にあり、ジェネレーターによって自動的に設定されます。
 
 ```ts {7-10}
 // packages/game-api/src/procedures/echo.ts
@@ -165,7 +165,7 @@ export const echo = publicProcedure
   .query((opts) => ({ message: opts.input.message }));
 ```
 
-このファイルは `echo` メソッドの実装であり、入出力データ構造を宣言することで強く型付けされています。
+このファイルは`echo`メソッドの実装であり、入力と出力のデータ構造を宣言することで強く型付けされています。
 
 ```ts
 // packages/game-api/src/schema/echo.ts
@@ -184,7 +184,7 @@ export const EchoOutputSchema = z.object({
 export type IEchoOutput = z.TypeOf<typeof EchoOutputSchema>;
 ```
 
-すべての tRPC スキーマ定義は [Zod](https://zod.dev/) を使用して定義され、`z.TypeOf` 構文を通じて TypeScript 型としてエクスポートされます。
+すべてのtRPCスキーマ定義は[Zod](https://zod.dev/)を使用して定義され、`z.TypeOf`構文を介してTypeScript型としてエクスポートされます。
 
 ```ts
 // packages/common/constructs/src/app/apis/game-api.ts
@@ -390,75 +390,75 @@ export class GameApi<
 }
 ```
 
-これは `GameApi` を定義する CDK コンストラクトです。`defaultIntegrations` メソッドを提供し、tRPC API の各プロシージャに対して Lambda 関数を自動的に作成し、バンドルされた API 実装を指定します。これは `cdk synth` 時にバンドルが発生しないことを意味します（[NodeJsFunction](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_lambda_nodejs.NodejsFunction.html) を使用する場合とは異なり）。バックエンドプロジェクトのビルドターゲットの一部としてすでにバンドルされているためです。
+これは`GameApi`を定義するCDKコンストラクトです。`defaultIntegrations`メソッドを提供し、tRPC APIの各プロシージャに対してLambda関数を自動的に作成し、バンドルされたAPI実装を指します。これは、`cdk synth`時にバンドルが発生しないことを意味します（[NodeJsFunction](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_lambda_nodejs.NodejsFunction.html)を使用する場合とは対照的）。バックエンドプロジェクトのビルドターゲットの一部として既にバンドルされているためです。
 
 </details>
 
-##### Story Agent を作成する
+##### Story Agentの作成
 
-次に Story Agent を作成しましょう。
+次に、Story Agentを作成しましょう。
 
-###### Story agent: Python プロジェクト
+###### Story agent: Pythonプロジェクト
 
-Python プロジェクトを作成するには:
+Pythonプロジェクトを作成するには:
 
 <RunGenerator generator="py#project" requiredParameters={{name:"story"}} noInteractive />
 
 ファイルツリーに新しいファイルが表示されます。
 <details>
-<summary>生成された `py#project` ファイルを詳しく確認する</summary>
+<summary>生成された`py#project`ファイルを詳しく確認する</summary>
 
-`py#project` は次のファイルを生成します:
+`py#project`は次のファイルを生成します:
 
 <FileTree>
 - .venv/ モノレポ用の単一仮想環境
 - packages/
   - story/
-    - dungeon_adventure_story/ Python モジュール
+    - dungeon_adventure_story/ pythonモジュール
     - tests/
     - .python-version
     - pyproject.toml
     - project.json
-- .python-version ピン留めされた uv Python バージョン
+- .python-version 固定されたuv pythonバージョン
 - pyproject.toml
 - uv.lock
 </FileTree>
 
-これにより、Python プロジェクトと共有仮想環境を持つ [UV Workspace](https://docs.astral.sh/uv/concepts/projects/workspaces/) が設定されます。
+これにより、共有仮想環境を持つPythonプロジェクトと[UV Workspace](https://docs.astral.sh/uv/concepts/projects/workspaces/)が設定されました。
 
 </details>
 
 ###### Story agent
 
-`py#agent` ジェネレーターでプロジェクトに Strands エージェントを追加するには:
+`py#agent`ジェネレーターを使用してプロジェクトにStrandsエージェントを追加するには:
 
 <RunGenerator generator="py#agent" requiredParameters={{project:"story", auth:"cognito", protocol:"ag-ui"}} noInteractive />
 
-:::note[AG-UI プロトコル]
-`--protocol=ag-ui` を選択することで、エージェントが [Agent-User Interaction プロトコル](https://docs.copilotkit.ai/aws-strands/protocol) を話すようになります。これにより、React ウェブサイトが [CopilotKit](https://docs.copilotkit.ai/) を通じて直接エージェントと通信でき、ストリーミング、ツール呼び出し、会話履歴がプロトコルによって処理されます（手作りの HTTP クライアントは不要）。
+:::note[AG-UIプロトコル]
+`--protocol=ag-ui`を選択することで、エージェントが[Agent-User Interactionプロトコル](https://docs.copilotkit.ai/aws-strands/protocol)を話すようになります。これにより、Reactウェブサイトが[CopilotKit](https://docs.copilotkit.ai/)を介して直接通信でき、ストリーミング、ツール呼び出し、会話履歴がプロトコルによって処理され、手作りのHTTPクライアントは不要になります。
 :::
 
 ファイルツリーに新しいファイルが表示されます。
 <details>
-<summary>生成された `py#agent` ファイルを詳しく確認する</summary>
+<summary>生成された`py#agent`ファイルを詳しく確認する</summary>
 
-`py#agent` は次のファイルを生成します:
+`py#agent`は次のファイルを生成します:
 
 <FileTree>
 - packages/
   - story/
-    - dungeon_adventure_story/ Python モジュール
+    - dungeon_adventure_story/ pythonモジュール
       - agent/
-        - main.py Bedrock AgentCore Runtime でのエージェントのエントリーポイント
+        - main.py Bedrock AgentCore Runtimeでのエージェントのエントリーポイント
         - agent.py サンプルエージェントとツールを定義
-        - session.py 会話状態を永続化するための SessionManager を解決
+        - session.py 会話状態を永続化するためのSessionManagerを解決
         - middleware/
-          - session_id_middleware.py リクエストの受信 AgentCore セッション ID をバインド
-        - Dockerfile AgentCore Runtime へのデプロイ用 Docker イメージを定義
+          - session_id_middleware.py リクエストのインバウンドAgentCoreセッションIDをバインド
+        - Dockerfile AgentCore Runtimeへのデプロイ用のDockerイメージを定義
   - common/constructs/
     - src
       - app/agents/story-agent/
-        - story-agent.ts Story エージェントを AgentCore Runtime にデプロイするコンストラクト
+        - story-agent.ts StoryエージェントをAgentCore Runtimeにデプロイするためのコンストラクト
 </FileTree>
 
 いくつかのファイルを詳しく見てみましょう:
@@ -492,7 +492,7 @@ Refer to tools as your 'spellbook'.
     )
 ```
 
-これはサンプルの Strands エージェントを作成し、減算ツールを定義します。`log_model_errors` と `log_tool_errors` は共有の `dungeon_adventure_agent_connection` プロジェクトのフックで、モデル/ツールの失敗をサイレントに失敗させる代わりにログに記録します。
+これはサンプルのStrandsエージェントを作成し、減算ツールを定義します。`log_model_errors`と`log_tool_errors`は、共有の`dungeon_adventure_agent_connection`プロジェクトからのフックで、モデル/ツールの失敗を静かに失敗させるのではなくログに記録します。
 
 ```python
 # agent/middleware/session_id_middleware.py
@@ -515,7 +515,7 @@ class SessionIdMiddleware(BaseHTTPMiddleware):
             return await call_next(request)
 ```
 
-`SessionIdMiddleware` はリクエストの期間中、受信した AgentCore ランタイムセッション ID を `ContextVar` にバインドします。
+`SessionIdMiddleware`は、インバウンドAgentCoreランタイムセッションIDをリクエストの期間中`ContextVar`にバインドします。
 
 ```python
 # agent/main.py
@@ -603,7 +603,7 @@ async def ping():
     return {"status": "healthy"}
 ```
 
-これはエージェントのエントリーポイントです。`--protocol=ag-ui` を選択したため、ジェネレーターは Strands の `Agent` を [`ag_ui_strands`](https://docs.copilotkit.ai/aws-strands/integration) の `StrandsAgent` でラップし、[AG-UI プロトコル](https://docs.copilotkit.ai/aws-strands/protocol) を話す FastAPI アプリにマウントします。これが React ウェブサイトから CopilotKit が通信する相手です。エージェントはインポート時ではなく `lifespan` ハンドラー内で構築されるため、コンテナの起動（モジュールのインポートではなく）が構築を担い、各 AgentCore セッションは独自のコンテナを取得します。上記の `SessionIdMiddleware` は受信した AgentCore ランタイムセッション ID を転送するため、後でワイヤーアップするダウンストリームの MCP/A2A クライアント（例: <Link path="get_started/tutorials/dungeon-game/2">モジュール 2</Link> の Inventory MCP サーバー）が送信呼び出し時に自動的に転送します。AG-UI は `thread_id` ごとに 1 つの Strands エージェントをキャッシュするため、テンプレートエージェント自身のセッションマネージャーではなく `session_manager_provider` を接続します。これにより各スレッドが独自の `SessionManager` を持ち、会話履歴がターン間で永続化されます。その `get_session_manager()` 関数は生成された `session.py` の兄弟ファイルから来ています: デプロイ時はジェネレーターが自動的にプロビジョニングする S3 バケットに裏付けられた `strands.session.S3SessionManager` を返し、`agent-dev`（`LOCAL_DEV=true`）では、デプロイ設定に関わらず常にローカルの一時ディレクトリに書き込む `FileSessionManager` を返します。
+これはエージェントのエントリーポイントです。`--protocol=ag-ui`を選択したため、ジェネレーターはStrandsの`Agent`を[`ag_ui_strands`](https://docs.copilotkit.ai/aws-strands/integration)の`StrandsAgent`でラップし、[AG-UIプロトコル](https://docs.copilotkit.ai/aws-strands/protocol)を話すFastAPIアプリにマウントします。これがReactウェブサイトからCopilotKitが通信する対象です。エージェントは`lifespan`ハンドラー内で構築されます（インポート時ではありません）。これにより、モジュールインポートではなくコンテナ起動が構築を所有し、各AgentCoreセッションが独自のコンテナを取得します。上で見た`SessionIdMiddleware`は、インバウンドAgentCoreランタイムセッションIDを転送するため、後で接続する下流のMCP/A2Aクライアント（<Link path="get_started/tutorials/dungeon-game/2">モジュール2</Link>のInventory MCPサーバーなど）がアウトバウンド呼び出しで自動的に転送します。AG-UIは`thread_id`ごとに1つのStrandsエージェントをキャッシュするため、テンプレートエージェント自身のセッションマネージャーではなく`session_manager_provider`をプラグインします。これにより、各スレッドが独自の`SessionManager`を取得し、会話履歴がターン間で永続化されます。その`get_session_manager()`関数は生成された`session.py`の兄弟から来ます: デプロイされると、ジェネレーターが自動的にプロビジョニングするS3バケットに支えられた`strands.session.S3SessionManager`を返します。`agent-dev`（`LOCAL_DEV=true`）では、デプロイされた設定に関係なく、常にローカルの一時ディレクトリに書き込む`FileSessionManager`を返します。
 
 ```ts
 // common/constructs/src/app/agents/story-agent/story-agent.ts
@@ -891,28 +891,28 @@ export class StoryAgent extends Construct implements IGrantable, IConnectable {
 }
 ```
 
-これは CDK の `AgentRuntimeArtifact` を設定し、エージェントの Docker イメージを ECR にアップロードして AgentCore Runtime でホストします。`--auth=cognito` を選択したため、コンストラクトはユーザープール/クライアントの ID を必要とし、Cognito を通じて AgentCore Runtime の呼び出しを認可し、呼び出し元の `Authorization` ヘッダーを転送します。また、Story Agent の `session.py` がランタイムで読み取るセッションバケット（CloudWatch Logs にサーバーアクセスログを配信する KMS 暗号化 S3 バケット）をプロビジョニングし、エージェントへの読み書きアクセスを付与し、Bedrock モデルを呼び出すアクセスを付与し、エージェント（ランタイム時、AppConfig 経由）と Game API（synth 時、`invocationUrl` 経由）の両方が見つけられるように ARN とバケット名を `RuntimeConfig` に登録します。
+これは、エージェントDockerイメージをECRにアップロードし、AgentCore Runtimeを使用してホストするCDK `AgentRuntimeArtifact`を設定します。`--auth=cognito`を選択したため、コンストラクトはユーザープール/クライアントIDを必要とし、Cognitoを通じてAgentCore Runtime呼び出しを認証し、呼び出し元の`Authorization`ヘッダーを転送します。また、Story Agentの`session.py`が実行時に読み取るセッションバケット（CloudWatch Logsに配信されるサーバーアクセスログを持つKMS暗号化S3バケット）をプロビジョニングし、エージェントに読み取り/書き込みアクセスを付与し、Bedrockモデルを呼び出すアクセスを付与し、そのARNとバケット名を`RuntimeConfig`に登録して、エージェント（実行時、AppConfig経由）とGame API（synth時、`invocationUrl`経由）の両方が見つけられるようにします。
 
-`story` プロジェクトの Docker イメージを参照する追加の `Dockerfile` があることに気づくかもしれません。これにより Dockerfile とエージェントのソースコードを同じ場所に配置できます。
+エージェントソースコードと同じ場所に配置できるように、`story`プロジェクトからDockerイメージを参照する追加の`Dockerfile`があることに気付くかもしれません。
 
 </details>
 
-##### Inventory ツールのセットアップ
+##### Inventoryツールのセットアップ
 
-###### Inventory: TypeScript プロジェクト
+###### Inventory: TypeScriptプロジェクト
 
-Story Agent がプレイヤーのインベントリを管理するためのツールを提供する MCP サーバーを作成しましょう。
+Story Agentがプレイヤーのインベントリを管理するためのツールを提供するMCPサーバーを作成しましょう。
 
-まず、TypeScript プロジェクトを作成します:
+まず、TypeScriptプロジェクトを作成します:
 
 <RunGenerator generator="ts#project" requiredParameters={{name:"inventory"}} noInteractive />
 
-これにより空の TypeScript プロジェクトが作成されます。
+これにより、空のTypeScriptプロジェクトが作成されます。
 
 <details>
-<summary>生成された `ts#project` ファイルを詳しく確認する</summary>
+<summary>生成された`ts#project`ファイルを詳しく確認する</summary>
 
-`ts#project` ジェネレーターはこれらのファイルを生成します。
+`ts#project`ジェネレーターは次のファイルを生成します。
 
 <FileTree>
 - packages/
@@ -921,125 +921,125 @@ Story Agent がプレイヤーのインベントリを管理するためのツ�
       - index.ts サンプル関数を含むエントリーポイント
     - project.json プロジェクト設定
     - vitest.config.mts テスト設定
-    - tsconfig.json プロジェクトのベース TypeScript 設定
-    - tsconfig.lib.json コンパイルとバンドル向けの TypeScript 設定
-    - tsconfig.spec.json テスト用の TypeScript 設定
-- tsconfig.base.json 他のプロジェクトがこれを参照するためのエイリアスを設定するよう更新
+    - tsconfig.json プロジェクトの基本typescript設定
+    - tsconfig.lib.json コンパイルとバンドル用のプロジェクトのtypescript設定
+    - tsconfig.spec.json テスト用のtypescript設定
+- tsconfig.base.json 他のプロジェクトがこれを参照するためのエイリアスを設定するように更新
 </FileTree>
 
 </details>
 
-###### Inventory: MCP サーバー
+###### Inventory: MCPサーバー
 
-次に、TypeScript プロジェクトに MCP サーバーを追加します:
+次に、TypeScriptプロジェクトにMCPサーバーを追加します:
 
 <RunGenerator generator="ts#mcp-server" requiredParameters={{project:"inventory"}} noInteractive />
 
-これにより MCP サーバーが追加されます。
+これによりMCPサーバーが追加されます。
 <details>
-<summary>生成された `ts#mcp-server` ファイルを詳しく確認する</summary>
+<summary>生成された`ts#mcp-server`ファイルを詳しく確認する</summary>
 
-`ts#mcp-server` ジェネレーターはこれらのファイルを生成します。
+`ts#mcp-server`ジェネレーターは次のファイルを生成します。
 
 <FileTree>
 - packages/
   - inventory/
     - src/mcp-server/
       - index.ts バレルエクスポート
-      - server.ts MCP サーバーを作成
+      - server.ts MCPサーバーを作成
       - tools/
         - divide.ts サンプルツール
       - resources/
         - sample-guidance.ts サンプルリソース
-      - stdio.ts STDIO トランスポートを使用した MCP のエントリーポイント
-      - http.ts Streamable HTTP トランスポートを使用した MCP のエントリーポイント
-      - Dockerfile AgentCore Runtime へのデプロイ用イメージをビルド
-    - rolldown.config.ts AgentCore へのデプロイ用 MCP サーバーバンドルの設定
+      - stdio.ts STDIOトランスポートを使用したMCPのエントリーポイント
+      - http.ts ストリーマブルHTTPトランスポートを使用したMCPのエントリーポイント
+      - Dockerfile AgentCore Runtimeへのデプロイ用のイメージをビルド
+    - rolldown.config.ts AgentCore Runtimeへのデプロイ用にMCPサーバーをバンドルするための設定
   - common/constructs/
     - src
       - app/mcp-servers/inventory-mcp-server/
-        - inventory-mcp-server.ts inventory MCP サーバーを AgentCore Runtime にデプロイするコンストラクト
+        - inventory-mcp-server.ts inventory MCPサーバーをAgentCore Runtimeにデプロイするためのコンストラクト
 </FileTree>
 
 </details>
 
-##### ゲームデータベースを作成する
+##### ゲームデータベースの作成
 
-ゲームの状態（セーブデータと各プレイヤーのインベントリ）は [Amazon DynamoDB](https://aws.amazon.com/dynamodb/) に保存されます。`ts#dynamodb` ジェネレーターで `DungeonDb` という名前の DynamoDB プロジェクトを作成します:
+ゲームの状態（保存されたゲームと各プレイヤーのインベントリ）は[Amazon DynamoDB](https://aws.amazon.com/dynamodb/)に保存されます。`ts#dynamodb`ジェネレーターを使用して`DungeonDb`というDynamoDBプロジェクトを作成します:
 
 <RunGenerator generator="ts#dynamodb" requiredParameters={{name:"DungeonDb"}} noInteractive />
 
 :::tip[ローカルファースト開発]
-`ts#dynamodb` ジェネレーターはコンテナ内で [DynamoDB Local](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html) を実行する `dev` ターゲットを提供します。`connection` ジェネレーター（以下で実行）と組み合わせることで、チュートリアルの終わりまで**デプロイなしでゲーム全体がマシン上で動作します**。
+`ts#dynamodb`ジェネレーターは、コンテナ内で[DynamoDB Local](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html)を実行する`dev`ターゲットを提供します。`connection`ジェネレーター（以下で実行します）と組み合わせることで、**チュートリアルの最後までデプロイなしでゲーム全体がマシン上で実行されます**。
 :::
 
 ファイルツリーに新しいファイルが表示されます。
 <details>
-<summary>生成された `ts#dynamodb` ファイルを詳しく確認する</summary>
+<summary>生成された`ts#dynamodb`ファイルを詳しく確認する</summary>
 
-`ts#dynamodb` ジェネレーターはこれらのファイルを生成します。
+`ts#dynamodb`ジェネレーターは次のファイルを生成します。
 
 <FileTree>
 - packages/
   - dungeon-db/
-    - config.json ポート、テーブル名、コンテナ設定、グローバルセカンダリインデックスを含む DynamoDB 設定
+    - config.json ポート、テーブル名、コンテナ設定、グローバルセカンダリインデックスを含むDynamoDB設定
     - src/
       - index.ts エントリーポイントとエクスポート
-      - client.ts DynamoDB クライアントシングルトンとテーブル名解決
+      - client.ts DynamoDBクライアントシングルトンとテーブル名解決
       - entities/
-        - example.ts サンプル ElectroDB エンティティ（後で置き換えます）
+        - example.ts サンプルElectroDBエンティティ（これを置き換えます）
         - index.ts エンティティエクスポート
-    - project.json `dev` と `pull-image` ターゲットを追加
+    - project.json `dev`と`pull-image`ターゲットを追加
   - common/
     - scripts/
       - src/
         - dynamodb/
-          - create-local-table.ts DynamoDB Local にテーブルを作成
-          - pull-image.ts DynamoDB Local イメージをプル
-          - start-container.ts DynamoDB Local コンテナを起動
+          - create-local-table.ts DynamoDB Localにテーブルを作成
+          - pull-image.ts DynamoDB Localイメージをプル
+          - start-container.ts DynamoDB Localコンテナを起動
     - constructs/
       - src/
         - app/dynamodb/
-          - dungeon-db.ts テーブルをプロビジョニングするコンストラクト
+          - dungeon-db.ts テーブルをプロビジョニングするためのコンストラクト
         - core/
-          - dynamodb.ts 汎用 DynamoDB テーブルコンストラクト
+          - dynamodb.ts 汎用DynamoDBテーブルコンストラクト
 </FileTree>
 
-生成された `src/client.ts` は `getDynamoDBClient()` と `resolveTableName()` をエクスポートします。`LOCAL_DEV=true`（`dev` ターゲットによって自動的に設定）の場合は DynamoDB Local に接続し、それ以外の場合は AWS に接続して<Link path="guides/runtime-config">ランタイム設定</Link>からデプロイされたテーブル名を解決します。`Game` と `Inventory` エンティティは<Link path="get_started/tutorials/dungeon-game/2">モジュール 2</Link> でこのプロジェクトにモデル化します。
+生成された`src/client.ts`は`getDynamoDBClient()`と`resolveTableName()`をエクスポートします。`LOCAL_DEV=true`（`dev`ターゲットによって自動的に設定）の場合、これらはDynamoDB Localに接続します。それ以外の場合は、AWSに接続し、<Link path="guides/runtime-config">Runtime Configuration</Link>からデプロイされたテーブル名を解決します。<Link path="get_started/tutorials/dungeon-game/2">モジュール2</Link>でこのプロジェクトに`Game`と`Inventory`エンティティをモデル化します。
 
-詳細については、<Link path="guides/ts-dynamodb">ts#dynamodb ジェネレーターガイド</Link>を参照してください。
+詳細については、<Link path="guides/ts-dynamodb">ts#dynamodbジェネレーターガイド</Link>を参照してください。
 
 </details>
 
-##### ユーザーインターフェース（UI）を作成する
+##### ユーザーインターフェース（UI）の作成
 
-次に、ゲームと対話するための UI を作成します。
+次に、ゲームと対話できるUIを作成します。
 
 ###### Game UI: ウェブサイト
 
-UI を作成するには、次の手順で `GameUI` という名前のウェブサイトを作成します:
+UIを作成するには、次の手順で`GameUI`というウェブサイトを作成します:
 
 <RunGenerator generator="ts#website" requiredParameters={{name:"GameUI", ux:"shadcn"}} noInteractive />
 
 :::note[Shadcn UI]
-`--ux=shadcn` を選択することで、生成されたウェブサイトが Tailwind でスタイリングされた [shadcn/ui](https://ui.shadcn.com/) コンポーネントを使用します。すべてのルートコードは `Card`、`Button`、`Input` などの shadcn プリミティブを使用し、`connection` ジェネレーターは後で一致する shadcn テーマの [CopilotKit](https://docs.copilotkit.ai/) チャットサーフェスをワイヤーアップします。
+生成されたウェブサイトがTailwindでスタイル設定された[shadcn/ui](https://ui.shadcn.com/)コンポーネントを使用するように、`--ux=shadcn`を選択します。すべてのルートコードは`Card`、`Button`、`Input`などのshadcnプリミティブを使用し、後の`connection`ジェネレーターは、一致するshadcnテーマの[CopilotKit](https://docs.copilotkit.ai/)チャットサーフェスを接続します。
 :::
 
 ファイルツリーに新しいファイルが表示されます。
 
 <details>
-<summary>生成された `ts#website` ファイルを詳しく確認する</summary>
+<summary>生成された`ts#website`ファイルを詳しく確認する</summary>
 
-`ts#website` はこれらのファイルを生成します。ファイルツリーでハイライトされているいくつかの重要なファイルを確認しましょう:
+`ts#website`は次のファイルを生成します。ファイルツリーで強調表示されている主要なファイルのいくつかを確認しましょう:
 
 <FileTree>
 - packages/
   - common/
     - constructs/
       - src/
-        - app/ アプリ固有の cdk コンストラクト
+        - app/ アプリ固有のcdkコンストラクト
           - static-websites/
-            - **game-ui.ts** Game UI を作成する cdk コンストラクト
+            - **game-ui.ts** Game UIを作成するためのcdkコンストラクト
         - core/
           - static-website.ts 汎用静的ウェブサイトコンストラクト
   - game-ui/
@@ -1047,24 +1047,24 @@ UI を作成するには、次の手順で `GameUI` という名前のウェブ�
     - src/
       - components/
         - AppLayout/
-          - index.tsx shadcn `SidebarProvider` + ヘッダーを使用した全体ページレイアウト
-        - app-sidebar.tsx ナビゲーション項目を持つデフォルト shadcn サイドバー
-        - alert.tsx, spinner.tsx shadcn でラップされたフィードバックプリミティブ
-      - routes/ @tanstack/react-router ファイルベースルート
-        - **index.tsx** ルート '/' ページ
+          - index.tsx shadcnの`SidebarProvider` + ヘッダーを使用した全体的なページレイアウト
+        - app-sidebar.tsx ナビゲーション項目を含むデフォルトのshadcnサイドバー
+        - alert.tsx, spinner.tsx shadcnでラップされたフィードバックプリミティブ
+      - routes/ @tanstack/react-routerファイルベースルート
+        - **index.tsx** ルート'/'ページ
         - __root.tsx すべてのページがこのコンポーネントをベースとして使用
       - config.ts
-      - **main.tsx** React エントリーポイント
-      - routeTree.gen.ts @tanstack/react-router によって自動更新される
-      - styles.css 共有 shadcn グローバルをインポート（Tailwind v4）
+      - **main.tsx** Reactエントリーポイント
+      - routeTree.gen.ts @tanstack/react-routerによって自動的に更新されます
+      - styles.css 共有shadcnグローバル（Tailwind v4）をインポート
     - index.html
     - project.json
     - vite.config.mts
     - ...
   - common/
-    - shadcn/ 共有 shadcn/ui ライブラリ（テーマトークン、`Button`、`Card`、`Input`、`Sidebar`、…）すべての `ux=shadcn` ウェブサイトがインポート
+    - shadcn/ すべての`ux=shadcn`ウェブサイトによってインポートされる共有shadcn/uiライブラリ（テーマトークン、`Button`、`Card`、`Input`、`Sidebar`など）
       - src/components/ui/*
-      - src/styles/globals.css Tailwind + shadcn デザイントークン
+      - src/styles/globals.css Tailwind + shadcnデザイントークン
     - ...
 </FileTree>
 
@@ -1072,11 +1072,17 @@ UI を作成するには、次の手順で `GameUI` という名前のウェブ�
 // packages/common/constructs/src/app/static-websites/game-ui.ts
 import * as url from 'url';
 import { Construct } from 'constructs';
-import { StaticWebsite } from '../../core/index.js';
+import { StaticWebsite, StaticWebsiteProps } from '../../core/index.js';
+
+export type GameUIProps = Omit<
+  StaticWebsiteProps,
+  'websiteName' | 'websiteFilePath'
+>;
 
 export class GameUI extends StaticWebsite {
-  constructor(scope: Construct, id: string) {
+  constructor(scope: Construct, id: string, props?: GameUIProps) {
     super(scope, id, {
+      ...props,
       websiteName: 'GameUI',
       websiteFilePath: url.fileURLToPath(
         new URL(
@@ -1089,7 +1095,7 @@ export class GameUI extends StaticWebsite {
 }
 ```
 
-これは GameUI を定義する CDK コンストラクトです。Vite ベースの UI の生成されたバンドルへのファイルパスがすでに設定されています。これは `build` 時に game-ui プロジェクトのビルドターゲット内でバンドルが発生し、その出力がここで使用されることを意味します。
+これはGameUIを定義するCDKコンストラクトです。ViteベースのUI用に生成されたバンドルへのファイルパスが既に設定されています。これは、`build`時にgame-uiプロジェクトのビルドターゲット内でバンドルが発生し、その出力がここで使用されることを意味します。
 
 ```tsx
 // packages/game-ui/src/main.tsx
@@ -1120,7 +1126,7 @@ root &&
   );
 ```
 
-これは React がマウントされるエントリーポイントです。スタイリングは `styles.css` 経由でインポートされた Tailwind v4 トークンから来ています。`@tanstack/react-router` は[ファイルベースルーティング](https://tanstack.com/router/v1/docs/framework/react/routing/file-based-routing)モードで設定されています: 開発サーバーが実行中である限り、`routes/` 以下に作成したファイルは自動的に検出され、ルートツリーが再生成されます。後のジェネレーター（auth、connection）はこのファイルを AST パッチして `<App />` を追加のプロバイダーでラップします。
+これはReactがマウントされるエントリーポイントです。スタイリングは`styles.css`を介してインポートされたTailwind v4トークンから来ます。`@tanstack/react-router`は[ファイルベースルーティング](https://tanstack.com/router/v1/docs/framework/react/routing/file-based-routing)モードで設定されています: 開発サーバーが実行されている限り、`routes/`の下に作成したファイルは自動的に検出され、ルートツリーが再生成されます。後のジェネレーター（auth、connection）は、このファイルをAST変換して`<App />`を追加のプロバイダーでラップします。
 
 ```tsx
 // packages/game-ui/src/routes/index.tsx
@@ -1142,22 +1148,22 @@ function RouteComponent() {
 }
 ```
 
-`/` ルートに移動するとこのコンポーネントがレンダリングされます。`@tanstack/react-router` はこのファイルを作成/移動するたびに（開発サーバーが実行中である限り）`Route` を管理します。
+`/`ルートにナビゲートすると、コンポーネントがレンダリングされます。`@tanstack/react-router`は、このファイルを作成/移動するたびに（開発サーバーが実行されている限り）`Route`を管理します。
 
 </details>
 
 ###### Game UI: 認証
 
-Amazon Cognito を通じた認証アクセスを必要とするよう Game UI を設定しましょう:
+Amazon Cognitoを介した認証アクセスを必要とするようにGame UIを設定しましょう:
 
 <RunGenerator generator="ts#website#auth" requiredParameters={{cognitoDomain:"game-ui", project:"@dungeon-adventure/game-ui", allowSignup:true}} noInteractive />
 
 ファイルツリーに新しいファイルが表示/変更されます。
 
 <details>
-<summary>生成された `ts#website#auth` ファイルを詳しく確認する</summary>
+<summary>生成された`ts#website#auth`ファイルを詳しく確認する</summary>
 
-`ts#website#auth` ジェネレーターはこれらのファイルを更新/生成します。ファイルツリーでハイライトされているいくつかの重要なファイルを確認しましょう:
+`ts#website#auth`ジェネレーターは次のファイルを更新/生成します。ファイルツリーで強調表示されている主要なファイルのいくつかを確認しましょう:
 
 <FileTree>
 - packages/
@@ -1165,19 +1171,19 @@ Amazon Cognito を通じた認証アクセスを必要とするよう Game UI �
     - constructs/
       - src/
         - core/
-          - user-identity.ts ユーザー/ID プールを作成する cdk コンストラクト
+          - user-identity.ts ユーザー/IDプールを作成するためのcdkコンストラクト
   - game-ui/
     - src/
       - components/
         - AppLayout/
-          - index.tsx ヘッダーにログインユーザー/ログアウトを追加
+          - index.tsx ログインユーザー/ログアウトをヘッダーに追加
         - CognitoAuth/
-          - index.tsx Cognito へのログインを管理
+          - index.tsx Cognitoへのログインを管理
         - RuntimeConfig/
-          - index.tsx `runtime-config.json` を取得してコンテキスト経由で子に提供
+          - index.tsx `runtime-config.json`を取得し、コンテキスト経由で子に提供
       - hooks/
         - useRuntimeConfig.tsx
-      - **main.tsx** Cognito を追加するよう更新
+      - **main.tsx** Cognitoを追加するように更新
 </FileTree>
 
 ```diff lang="tsx"
@@ -1226,32 +1232,32 @@ root &&
   );
 ```
 
-`RuntimeConfigProvider` と `CognitoAuth` コンポーネントが AST 変換を通じて `main.tsx` ファイルに追加されました。これにより `CognitoAuth` コンポーネントが `runtime-config.json` を取得して Amazon Cognito で認証できるようになります。`runtime-config.json` には、バックエンド呼び出しを正しい宛先に向けるために必要な Cognito 接続設定が含まれています。
+`RuntimeConfigProvider`と`CognitoAuth`コンポーネントがAST変換を介して`main.tsx`ファイルに追加されました。これにより、`CognitoAuth`コンポーネントは、正しい宛先へのバックエンド呼び出しを行うために必要なcognito接続設定を含む`runtime-config.json`を取得することで、Amazon Cognitoで認証できます。
 
 </details>
 
-###### Game UI: Game API への接続
+###### Game UI: Game APIへの接続
 
-以前に作成した Game API に接続するよう Game UI を設定しましょう。
+以前に作成したGame APIに接続するようにGame UIを設定しましょう。
 
 <RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-ui", targetProject:"@dungeon-adventure/game-api"}} noInteractive />
 
 ファイルツリーに新しいファイルが表示/変更されます。
 
 <details>
-<summary>UI → tRPC 接続ファイルを確認する</summary>
+<summary>UI → tRPC接続ファイルを確認する</summary>
 
-`connection` ジェネレーターはこれらのファイルを生成/更新します。ファイルツリーでハイライトされているいくつかの重要なファイルを確認しましょう:
+`connection`ジェネレーターは次のファイルを生成/更新します。ファイルツリーで強調表示されている主要なファイルのいくつかを確認しましょう:
 
 <FileTree>
 - packages/
   - game-ui/
     - src/
       - components/
-        - GameApiClientProvider.tsx GameAPI クライアントをセットアップ
+        - GameApiClientProvider.tsx GameAPIクライアントをセットアップ
       - hooks/
-        - **useGameApi.tsx** GameApi を呼び出すフック
-      - **main.tsx** trpc クライアントプロバイダーを注入
+        - **useGameApi.tsx** GameApiを呼び出すためのフック
+      - **main.tsx** trpcクライアントプロバイダーを注入
 - package.json
 
 </FileTree>
@@ -1280,10 +1286,10 @@ export const useGameApiClient = () => {
 };
 ```
 
-このフックは GameApi を呼び出すための tRPC クライアントへのアクセスを提供します。tRPC API の呼び出し方法の例については、<Link path="guides/connection/react-trpc#using-the-generated-code">tRPC フックガイドの使用方法</Link>を参照してください。
+このフックは、GameApiを呼び出すためのtRPCクライアントへのアクセスを提供します。tRPC APIの呼び出し方法の例については、<Link path="guides/connection/react-trpc#using-the-generated-code">tRPCフックの使用ガイド</Link>を参照してください。
 
 <Aside title="型安全なフック">
-tRPC の [TypeScript 推論](https://trpc.io/docs/concepts) のおかげで、`useGameApi` はバックエンドの変更がフロントエンドに反映されるためのビルドステップを必要としません。ルーターやプロシージャへの編集は型チェッカーによって即座に検出されます。
+tRPCの[Typescript推論](https://trpc.io/docs/concepts)のおかげで、`useGameApi`はバックエンドの変更がフロントエンドに到達するためのビルドステップを必要としません。ルーターまたは任意のプロシージャへの編集は、型チェッカーによって即座に検出されます。
 </Aside>
 
 ```diff lang="tsx"
@@ -1317,20 +1323,20 @@ root &&
   );
 ```
 
-`main.tsx` ファイルは AST 変換を通じて tRPC プロバイダーを注入するよう更新されました。
+`main.tsx`ファイルがAST変換を介して更新され、tRPCプロバイダーが注入されました。
 
 </details>
 
-###### Story Agent: Inventory MCP サーバーへの接続
+###### Story Agent: Inventory MCPサーバーへの接続
 
-Story Agent が MCP サーバーのツールを検出して呼び出せるよう、Story Agent を Inventory MCP サーバーに接続しましょう。
+Story AgentをInventory MCPサーバーに接続して、エージェントがMCPサーバーのツールを検出して呼び出せるようにしましょう。
 
 <RunGenerator generator="connection" requiredParameters={{sourceProject:"story", targetProject:"inventory"}} noInteractive />
 
 <details>
-<summary>Story Agent → Inventory MCP 接続ファイルを確認する</summary>
+<summary>Story Agent → Inventory MCP接続ファイルを確認する</summary>
 
-`connection` ジェネレーターはこれらのファイルを生成/更新します:
+`connection`ジェネレーターは次のファイルを生成/更新します:
 
 <FileTree>
 - packages/
@@ -1338,87 +1344,87 @@ Story Agent が MCP サーバーのツールを検出して呼び出せるよう
     - agent\_connection/
       - dungeon\_adventure\_agent\_connection/
         - core/
-          - **agentcore\_endpoints.py** フレームワーク非依存の ARN/URL 解決
-          - **agentcore\_mcp\_transport.py** フレームワーク非依存の MCP トランスポート
-          - **agentcore\_mcp\_client\_strands.py** トランスポートをラップする Strands MCP クライアント
-          - auth/ フレームワーク非依存の SigV4 / セッション転送 `httpx.Auth`
+          - **agentcore\_endpoints.py** フレームワークに依存しないARN/URL解決
+          - **agentcore\_mcp\_transport.py** フレームワークに依存しないMCPトランスポート
+          - **agentcore\_mcp\_client\_strands.py** トランスポートをラップするStrands MCPクライアント
+          - auth/ フレームワークに依存しないSigV4 / セッション転送`httpx.Auth`
         - app/
-          - **inventory\_mcp\_server\_client\_strands.py** Inventory MCP サーバーに接続するための Strands クライアント
+          - **inventory\_mcp\_server\_client\_strands.py** Inventory MCPサーバーに接続するためのStrandsクライアント
         - **\_\_init\_\_.py** 接続ごとのクライアントを再エクスポート
   - story/
     - dungeon\_adventure\_story/agent/
-      - **agent.py** MCP クライアントをインポートして使用するよう変更
+      - **agent.py** MCPクライアントをインポートして使用するように変更
 
 </FileTree>
 
 ジェネレーターは:
-- コア `AgentCoreMCPClientStrands` を持つ共有 `agent_connection` Python プロジェクトを作成します（まだ存在しない場合）
-- ローカル（直接 HTTP）とデプロイ時（IAM 認証を使用した AgentCore 経由）の両方で MCP サーバーへの接続を処理する `InventoryMcpServerClientStrands` クラスを生成します
-- クライアントをインポートし、インスタンスを作成し、MCP サーバーのツールをエージェントにワイヤーアップするよう `agent.py` を変換します
-- `agent_connection` プロジェクトを story プロジェクトのワークスペース依存関係として追加します
-- ローカルで実行する際に MCP サーバーを自動的に起動するよう `dev` ターゲットを更新します
+- コアの`AgentCoreMCPClientStrands`を持つ共有`agent_connection` Pythonプロジェクトを作成します（まだ存在しない場合）
+- ローカル（直接HTTP）とデプロイ時（IAM認証を使用したAgentCore経由）の両方でMCPサーバーへの接続を処理する`InventoryMcpServerClientStrands`クラスを生成します
+- `agent.py`を変換してクライアントをインポートし、インスタンスを作成し、MCPサーバーのツールをエージェントに接続します
+- `agent_connection`プロジェクトをstoryプロジェクトのワークスペース依存関係として追加します
+- ローカルで実行する際にMCPサーバーを自動的に起動するように`dev`ターゲットを更新します
 
-詳細については、<Link path="guides/connection/py-agent-mcp">Python Agent から MCP への接続ガイド</Link>を参照してください。
+詳細については、<Link path="guides/connection/py-agent-mcp">Python AgentからMCP接続ガイド</Link>を参照してください。
 </details>
 
-###### Game UI: Story Agent への接続
+###### Game UI: Story Agentへの接続
 
-Game UI を Story Agent に接続しましょう。エージェントが AG-UI を話すため、`connection` ジェネレーターは [CopilotKit](https://docs.copilotkit.ai/) をワイヤーアップします: テーマ付きチャットコンポーネントとレンダリング準備済みの `@ag-ui/client` `HttpAgent` です。
+Game UIをStory Agentに接続しましょう。エージェントがAG-UIを話すため、`connection`ジェネレーターは[CopilotKit](https://docs.copilotkit.ai/)を接続します: テーマ付きチャットコンポーネントと、レンダリング準備ができた`@ag-ui/client` `HttpAgent`です。
 
 <RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-ui", targetProject:"story"}} noInteractive />
 
 <details>
-<summary>UI → Story Agent 接続ファイルを確認する</summary>
+<summary>UI → Story Agent接続ファイルを確認する</summary>
 
-`connection` ジェネレーターはこれらのファイルを生成/更新します:
+`connection`ジェネレーターは次のファイルを生成/更新します:
 
 <FileTree>
 - packages/
   - game-ui/
     - src/
       - components/
-        - **AguiProvider.tsx** 接続されたすべての AG-UI エージェントが登録された `CopilotKitProvider`
+        - **AguiProvider.tsx** 接続されたすべてのAG-UIエージェントが登録された`CopilotKitProvider`
         - copilot/
-          - **index.tsx** Shadcn テーマの `CopilotChat` / `CopilotSidebar` / `CopilotPopup`
+          - **index.tsx** Shadcnテーマの`CopilotChat` / `CopilotSidebar` / `CopilotPopup`
           - ShadcnAssistantMessage.tsx, ShadcnUserMessage.tsx, ShadcnChatInput.tsx, ShadcnCursor.tsx, copilot.css
       - hooks/
-        - **useAguiStoryAgent.tsx** `HttpAgent` を構築し、Cognito ベアラートークンを注入し、`threadId` を AgentCore の 33 文字セッション ID にパディング
-    - **main.tsx** `<App />` を `<AguiProvider>` でラップ
+        - **useAguiStoryAgent.tsx** `HttpAgent`を構築し、Cognitoベアラートークンを注入し、`threadId`をAgentCoreの33文字のセッションIDにパディング
+    - **main.tsx** `<App />`を`<AguiProvider>`でラップ
 
 </FileTree>
 
 ジェネレーターは:
-- React ウェブサイトの `ux`（ここでは Shadcn）を検出し、一致するチャットコンポーネントを提供します。
-- 接続されたすべてのエージェントを単一の `CopilotKitProvider` に登録します。別のエージェントのために再実行すると、別のフックが追加されるだけです。
-- ランタイム設定からエージェントのランタイム ARN を読み取り、AgentCore 呼び出し URL を構築し、Cognito ベアラートークンと AgentCore セッション ID ヘッダーを添付します。
+- Reactウェブサイトの`ux`（ここではShadcn）を検出し、一致するチャットコンポーネントを提供します。
+- 単一の`CopilotKitProvider`にすべての接続されたエージェントを登録します。別のエージェントに対して再実行すると、別のフックが追加されるだけです。
+- Runtime ConfigurationからエージェントのランタイムARNを読み取り、AgentCore呼び出しURLを構築し、CognitoベアラートークンとAgentCoreセッションIDヘッダーを添付します。
 
-詳細については、<Link path="guides/connection/react-agui">React から AG-UI への接続ガイド</Link>を参照してください。
+詳細については、<Link path="guides/connection/react-agui">ReactからAG-UI接続ガイド</Link>を参照してください。
 </details>
 
-###### Game API と Inventory MCP サーバーをデータベースに接続する
+###### Game APIとInventory MCPサーバーをデータベースに接続
 
-両方が DynamoDB テーブルを読み書きするため、それらを `DungeonDb` プロジェクトに接続しましょう。`connection` ジェネレーターはターゲットが `ts#dynamodb` プロジェクトであることを検出し、各ソースプロジェクトの `dev` ターゲットが DynamoDB Local を自動的に起動するようにワイヤーアップします。
+Game APIとInventory MCPサーバーの両方がDynamoDBテーブルを読み書きするため、`DungeonDb`プロジェクトに接続しましょう。`connection`ジェネレーターは、ターゲットが`ts#dynamodb`プロジェクトであることを検出し、各ソースプロジェクトの`dev`ターゲットを接続してDynamoDB Localを自動的に起動します。
 
 <RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-api", targetProject:"@dungeon-adventure/dungeon-db"}} noInteractive />
 
 <RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/inventory", targetProject:"@dungeon-adventure/dungeon-db"}} noInteractive />
 
-<Aside type="tip" title="1 つのコマンドでスタック全体をローカルで起動">
-Story Agent の `agent-dev` はすでに Inventory MCP サーバーの `mcp-server-dev` に依存しており（上記の `story → inventory` 接続経由）、Game API と MCP サーバーの両方が `dungeon-db:dev` に依存しているため、任意のプロジェクトの `dev` ターゲットを実行するだけで、必要なすべての依存関係が正しい順序で起動されます。
+<Aside type="tip" title="1つのコマンドでスタック全体をローカルで起動">
+Story Agentの`agent-dev`は既にInventory MCPサーバーの`mcp-server-dev`に依存しており（上記の`story → inventory`接続経由）、Game APIとMCPサーバーの両方が`dungeon-db:dev`に依存しているため、任意の1つのプロジェクトの`dev`ターゲットを実行すると、必要なすべての依存関係が正しい順序で起動します。
 </Aside>
 
-###### Game UI: インフラストラクチャー
+###### Game UI: インフラストラクチャ
 
-CDK インフラストラクチャーの最終サブプロジェクトを作成しましょう。
+CDKインフラストラクチャ用の最終サブプロジェクトを作成しましょう。
 
 <RunGenerator generator="ts#infra" requiredParameters={{name:"infra"}} noInteractive />
 
 ファイルツリーに新しいファイルが表示/変更されます。
 
 <details>
-<summary>生成された `ts#infra` ファイルを詳しく確認する</summary>
+<summary>生成された`ts#infra`ファイルを詳しく確認する</summary>
 
-`ts#infra` ジェネレーターはこれらを生成/更新します。ファイルツリーでハイライトされているいくつかの重要なファイルを確認しましょう:
+`ts#infra`ジェネレーターは次を生成/更新します。ファイルツリーで強調表示されている主要なファイルのいくつかを確認しましょう:
 
 <FileTree>
 - packages/
@@ -1431,9 +1437,9 @@ CDK インフラストラクチャーの最終サブプロジェクトを作成�
   - infra
     - src/
       - stages/
-        - **application-stage.ts** cdk スタックはここで定義
+        - **application-stage.ts** cdkスタックがここで定義されます
       - stacks/
-        - **application-stack.ts** cdk リソースはここで定義
+        - **application-stack.ts** cdkリソースがここで定義されます
       - **main.ts** すべてのステージを定義するエントリーポイント
     - cdk.json
     - checkov.yml
@@ -1463,9 +1469,9 @@ new ApplicationStage(app, 'dungeon-adventure-infra-sandbox', {
 app.synth();
 ```
 
-<Aside type="tip" title="インポートエラーの修正">IDE 内でインポートエラーが表示される場合、これはインフラストラクチャープロジェクトの `tsconfig.json` にまだ TypeScript 参照が設定されていないためです。Nx はビルド/コンパイルが実行されるたびに、または `nx sync` コマンドを手動で実行したときに、これらの参照を*動的に*作成するよう[設定](https://nx.dev/nx-api/js/generators/typescript-sync)されています。詳細については、<Link path="guides/typescript-project#importing-your-library-code-in-other-projects">TypeScript ガイド</Link>を参照してください。</Aside>
+<Aside type="tip" title="インポートエラーの修正">IDE内でインポートエラーが表示される場合、これはインフラストラクチャプロジェクトが`tsconfig.json`にまだTypeScript参照が設定されていないためです。Nxは、ビルド/コンパイルが実行されるたびに、または`nx sync`コマンドを手動で実行した場合に、これらの参照を*動的に*作成するように[設定](https://nx.dev/nx-api/js/generators/typescript-sync)されています。詳細については、<Link path="guides/typescript-project#importing-your-library-code-in-other-projects">Typescriptガイド</Link>を参照してください。</Aside>
 
-これは CDK アプリケーションのエントリーポイントです。
+これはCDKアプリケーションのエントリーポイントです。
 
 ```ts
 // packages/infra/src/stacks/application-stack.ts
@@ -1481,35 +1487,35 @@ export class ApplicationStack extends Stack {
 }
 ```
 
-ダンジョンアドベンチャーゲームを構築するために CDK コンストラクトをインスタンス化しましょう。
+CDKコンストラクトをインスタンス化して、ダンジョンアドベンチャーゲームを構築しましょう。
 
 </details>
 
 </Drawer>
 
-## タスク 3: インフラストラクチャーを更新する
+## タスク3: インフラストラクチャの更新
 
-生成されたコンストラクトの一部をインスタンス化するために `packages/infra/src/stacks/application-stack.ts` を更新しましょう:
+`packages/infra/src/stacks/application-stack.ts`を更新して、生成されたコンストラクトのいくつかをインスタンス化しましょう:
 
 <E2EDiff before="dungeon-adventure/1/application-stack.ts.original.template" after="dungeon-adventure/1/application-stack.ts.template" lang="ts" />
 
 :::note[デフォルトインテグレーション]
-Game API にデフォルトインテグレーションを提供します。デフォルトでは、API の各オペレーションはそのオペレーションを処理する個別の Lambda 関数にマッピングされます。
+Game APIにデフォルトのインテグレーションを提供します。デフォルトでは、APIの各オペレーションは、そのオペレーションを処理する個別のLambda関数にマッピングされます。
 :::
 
-## タスク 4: コードをビルドする
+## タスク4: コードのビルド
 
-<Drawer title="Nx コマンド" trigger="コードを初めてビルドする時が来ました">
+<Drawer title="Nxコマンド" trigger="初めてコードをビルドする時が来ました">
 
-###### 単一 vs 複数ターゲット
+###### 単一vs複数ターゲット
 
-`run-many` コマンドは複数のリストされたサブプロジェクトでターゲットを実行します（`--all` はすべてをターゲットにします）。これにより依存関係が正しい順序で実行されます。
+`run-many`コマンドは、リストされた複数のサブプロジェクトでターゲットを実行します（`--all`はすべてを対象とします）。これにより、依存関係が正しい順序で実行されます。
 
-また、プロジェクトのターゲットを直接実行することで、単一プロジェクトのビルド（または他のタスク）をトリガーすることもできます。例えば、`@dungeon-adventure/infra` プロジェクトをビルドするには、次のコマンドを実行します:
+また、プロジェクトで直接ターゲットを実行することで、単一のプロジェクトターゲットのビルド（または他のタスク）をトリガーすることもできます。たとえば、`@dungeon-adventure/infra`プロジェクトをビルドするには、次のコマンドを実行します:
 
 <NxCommands commands={['build infra']} />
 
-スコープを省略して、好みに応じて Nx の短縮構文を使用することもできます:
+スコープを省略して、Nxの短縮構文を使用することもできます:
 
 <NxCommands commands={['build infra']} />
 
@@ -1524,16 +1530,16 @@ Game API にデフォルトインテグレーションを提供します。デ�
 
 ###### キャッシング
 
-Nx は[キャッシング](https://nx.dev/concepts/how-caching-works)に依存しており、以前のビルドのアーティファクトを再利用して開発を高速化できます。これを正しく機能させるためにいくつかの設定が必要であり、**キャッシュを使用せずに**ビルドを実行したい場合があります。その場合は、コマンドに `--skip-nx-cache` 引数を追加するだけです。例えば:
+Nxは[キャッシング](https://nx.dev/concepts/how-caching-works)に依存しているため、以前のビルドからアーティファクトを再利用して開発を高速化できます。これを正しく機能させるにはいくつかの設定が必要であり、**キャッシュを使用せずに**ビルドを実行したい場合があります。そのためには、コマンドに`--skip-nx-cache`引数を追加するだけです。例:
 
 <NxCommands commands={['build infra --skip-nx-cache']} />
-何らかの理由でキャッシュ（`.nx` フォルダーに保存）をクリアしたい場合は、次のコマンドを実行できます:
+何らかの理由でキャッシュ（`.nx`フォルダーに保存）をクリアしたい場合は、次のコマンドを実行できます:
 
 <NxCommands commands={['reset']} />
 
 </Drawer>
 
-コマンドラインを使用して、まず次のコマンドでリントの問題を修正します:
+コマンドラインを使用して、まずリントの問題を修正するために次のコマンドを実行します:
 
 <PackageManagerShortCommand commands={["lint"]} />
 
@@ -1555,10 +1561,10 @@ Yes, sync the changes and run the tasks
 No, run the tasks without syncing the changes
 ```
 
-このメッセージは、NX が自動的に更新できるファイルを検出したことを示しています。この場合、参照プロジェクトに TypeScript 参照が設定されていない `tsconfig.json` ファイルを指しています。
+このメッセージは、NXが自動的に更新できるファイルを検出したことを示しています。この場合、参照プロジェクトにTypeScript参照が設定されていない`tsconfig.json`ファイルを指しています。
 
-**Yes, sync the changes and run the tasks** オプションを選択して続行します。sync ジェネレーターが不足している TypeScript 参照を自動的に追加するため、IDE 関連のインポートエラーがすべて自動的に解決されることに気づくでしょう！
+**Yes, sync the changes and run the tasks**オプションを選択して続行します。syncジェネレーターが欠落しているTypeScript参照を自動的に追加するため、すべてのIDE関連のインポートエラーが自動的に解決されることに気付くはずです！
 
-すべてのビルドアーティファクトは、モノレポのルートにある `dist/` フォルダー内で利用可能になります。これは `@aws/nx-plugin` によって生成されたプロジェクトを使用する際の標準的な慣行であり、生成されたファイルでファイルツリーを汚染しません。ファイルをクリーンアップしたい場合は、ビルドアーティファクトがファイルツリー全体に散らばることを心配せずに `dist/` フォルダーを削除できます。
+すべてのビルドアーティファクトは、モノレポのルートにある`dist/`フォルダー内で利用できるようになりました。これは、`@aws/nx-plugin`によって生成されたプロジェクトを使用する際の標準的な慣行であり、生成されたファイルでファイルツリーを汚染しません。ファイルをクリーンアップしたい場合は、ビルドアーティファクトがファイルツリー全体に散らばることを心配せずに`dist/`フォルダーを削除してください。
 
-おめでとうございます！AI ダンジョンアドベンチャーゲームのコアを実装するために必要なすべてのサブプロジェクトを作成しました。🎉🎉🎉
+おめでとうございます！AI Dungeon Adventureゲームのコアの実装を開始するために必要なすべてのサブプロジェクトを作成しました。🎉🎉🎉

--- a/docs/src/content/docs/jp/guides/react-website.mdx
+++ b/docs/src/content/docs/jp/guides/react-website.mdx
@@ -18,7 +18,7 @@ import Infrastructure from '@components/infrastructure.astro';
 import Snippet from '@components/snippet.astro';
 import OptionFilter from '@components/option-filter.astro';
 
-このジェネレーターは、デフォルトで[shadcn/ui](https://ui.shadcn.com/)が設定された新しい[React](https://react.dev/)ウェブサイトと、[S3](https://aws.amazon.com/s3/)でホストされる静的ウェブサイトとしてクラウドにデプロイし、[CloudFront](https://aws.amazon.com/cloudfront/)で配信し、[WAF](https://aws.amazon.com/waf/)で保護するためのAWS CDKまたはTerraformインフラストラクチャを作成します。
+このジェネレーターは、デフォルトで[shadcn/ui](https://ui.shadcn.com/)が設定された新しい[React](https://react.dev/)ウェブサイトと、[S3](https://aws.amazon.com/s3/)でホストされ、[CloudFront](https://aws.amazon.com/cloudfront/)で配信され、[WAF](https://aws.amazon.com/waf/)で保護される静的ウェブサイトとしてクラウドにデプロイするためのAWS CDKまたはTerraformインフラストラクチャを作成します。
 
 生成されたアプリケーションは、ビルドツールおよびバンドラーとして[Vite](https://vite.dev/)を使用します。型安全なルーティングには[TanStack Router](https://tanstack.com/router/v1)を使用します。
 
@@ -30,7 +30,7 @@ import OptionFilter from '@components/option-filter.astro';
 
 ### React Websiteの生成
 
-React Websiteは2つの方法で生成できます：
+新しいReact Websiteは2つの方法で生成できます：
 
 <RunGenerator generator="ts#website" requiredParameters={{ framework: 'react' }} />
 
@@ -43,34 +43,34 @@ React Websiteは2つの方法で生成できます：
 ジェネレーターは`<directory>/<name>`ディレクトリに以下のプロジェクト構造を作成します：
 
 <FileTree>
-  - index.html HTML entry point
-  - public Static assets
+  - index.html HTMLエントリーポイント
+  - public 静的アセット
   - src
-    - main.tsx Application entry point with React setup
-    - config.ts Application configuration (eg. logo)
+    - main.tsx Reactセットアップを含むアプリケーションエントリーポイント
+    - config.ts アプリケーション設定（例：ロゴ）
     - components
-      - AppLayout Components for the overall layout and navigation bar
+      - AppLayout 全体のレイアウトとナビゲーションバーのコンポーネント
     - hooks
-      - useAppLayout.tsx Hook for adjusting the AppLayout from nested components (Cloudscape only)
+      - useAppLayout.tsx ネストされたコンポーネントからAppLayoutを調整するためのフック（Cloudscapeのみ）
     - routes
-      - index.tsx Example route (or page) for TanStack Router
-    - styles.css Global styles
-  - vite.config.mts Vite and Vitest configuration
-  - tsconfig.json Base TypeScript configuration for source and tests
-  - tsconfig.app.json TypeScript configuration for source code
-  - tsconfig.spec.json TypeScript configuration for tests
-  - package.json Project manifest defining the project's package name and dependencies
+      - index.tsx TanStack Routerのルート（またはページ）の例
+    - styles.css グローバルスタイル
+  - vite.config.mts ViteとVitestの設定
+  - tsconfig.json ソースとテストのベースTypeScript設定
+  - tsconfig.app.json ソースコード用のTypeScript設定
+  - tsconfig.spec.json テスト用のTypeScript設定
+  - package.json プロジェクトのパッケージ名と依存関係を定義するプロジェクトマニフェスト
 </FileTree>
 
 :::note[TanStack Routerを使用しない場合]
-[TanStack Router](https://tanstack.com/router/v1)を使用しないことを選択した場合、`routes`ディレクトリの代わりに、アプリケーションのエントリーポイントとしてシンプルな`src/app.tsx`ファイルが提供されます。
+[TanStack Router](https://tanstack.com/router/v1)を使用しないことを選択した場合、`routes`ディレクトリの代わりに、アプリケーションエントリーポイントとしてシンプルな`src/app.tsx`ファイルが提供されます。
 :::
 
 ### インフラストラクチャ
 
 <Snippet name="shared-constructs" />
 
-ジェネレーターは、選択した`iac`に基づいてウェブサイトをデプロイするためのInfrastructure as Codeを作成します：
+ジェネレーターは、選択した`iac`に基づいてウェブサイトをデプロイするためのコードとしてのインフラストラクチャを作成します：
 
 <Infrastructure>
 <Fragment slot="cdk">
@@ -78,9 +78,9 @@ React Websiteは2つの方法で生成できます：
   - packages/common/constructs/src
     - app
       - static-websites
-        - \<name>.ts Infrastructure specific to your website
+        - \<name>.ts ウェブサイト固有のインフラストラクチャ
     - core
-      - static-website.ts Generic StaticWebsite construct
+      - static-website.ts 汎用StaticWebsiteコンストラクト
 </FileTree>
 </Fragment>
 <Fragment slot="terraform">
@@ -89,10 +89,10 @@ React Websiteは2つの方法で生成できます：
     - app
       - static-websites
         - \<name>
-          - \<name>.tf Module specific to your website
+          - \<name>.tf ウェブサイト固有のモジュール
     - core
       - static-website
-        - static-website.tf Generic static website module
+        - static-website.tf 汎用静的ウェブサイトモジュール
 </FileTree>
 </Fragment>
 </Infrastructure>
@@ -178,11 +178,11 @@ export const MyComponent = () => {
 };
 ```
 
-詳細については、[TanStack Router](https://tanstack.com/router/latest/docs/framework/react/overview)ドキュメントを参照してください。
+詳細については、[TanStack Router](https://tanstack.com/router/latest/docs/framework/react/overview)ドキュメントを確認してください。
 
 ## ウェブサイトのデプロイ
 
-React websiteジェネレーターは、選択した`iac`に基づいてCDKまたはTerraformのInfrastructure as Codeを作成します。これを使用してウェブサイトをデプロイできます。
+React websiteジェネレーターは、選択した`iac`に基づいてCDKまたはTerraformのコードとしてのインフラストラクチャを作成します。これを使用してウェブサイトをデプロイできます。
 
 <Infrastructure>
 <Fragment slot="cdk">
@@ -253,9 +253,9 @@ provider "aws" {
 
 CloudFrontディストリビューションは、すべてのレスポンスに`Strict-Transport-Security`、`X-Content-Type-Options`、`X-Frame-Options: DENY`、`Referrer-Policy`、および`Content-Security-Policy`を設定するレスポンスヘッダーポリシーを適用します。
 
-デフォルトの`Content-Security-Policy`が適用されます。これは、XSSやクリックジャッキングを軽減するためにスクリプトとフレーミングを制限しながら、HTTPS接続とWSS接続を許可するため、ウェブサイトはデプロイ時にのみURLが判明するAWSサービスエンドポイント（API Gateway、Cognito、Bedrock AgentCoreなど）を呼び出すことができます。ポリシーを調整する（例えば、`connect-src`を特定のオリジンに絞り込む）には、生成された`static-website.ts`（CDK）または`static-website.tf`（Terraform）の`content_security_policy`値を編集してください。
+デフォルトの`Content-Security-Policy`が適用されます。これは、XSSやクリックジャッキングを軽減するためにスクリプトとフレーミングを制限しながら、ウェブサイトがデプロイ時にのみURLが判明するAWSサービスエンドポイント（API Gateway、Cognito、Bedrock AgentCoreなど）を呼び出せるようにHTTPSおよびWSS接続を許可します。ポリシーを調整する（例えば、`connect-src`を特定のオリジンに絞り込む）には、生成された`static-website.ts`（CDK）または`static-website.tf`（Terraform）の`content_security_policy`値を編集してください。
 
-`runtime-config.json`は`Cache-Control: no-cache`で配信されるため、ブラウザは再デプロイ後に古いキャッシュされたコピーを使用するのではなく、常に最新の設定を取得します。
+`runtime-config.json`は`Cache-Control: no-cache`で提供されるため、ブラウザは再デプロイ後に古いキャッシュされたコピーを使用するのではなく、常に最新の設定を取得します。
 
 ### WAF
 
@@ -334,6 +334,22 @@ export class ApplicationStack extends Stack {
 }
 ```
 
+:::caution[S3_MANAGEDを使用する場合はCKV_AWS_158を抑制]
+`BucketEncryption.S3_MANAGED`を選択すると、アクセスログ群がKMS暗号化されなくなるため、`checkov`セキュリティスキャンが`CKV_AWS_158`で失敗します。抑制してください：
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { LogGroup } from 'aws-cdk-lib/aws-logs';
+import { suppressRules } from '@my-scope/common-constructs';
+
+suppressRules(
+  website,
+  ['CKV_AWS_158'],
+  'Access log group is not KMS encrypted when encryption is S3_MANAGED',
+  (c) => c instanceof LogGroup,
+);
+```
+:::
+
 自動的に作成されるキーの代わりに独自のKMSキーを使用するには、`encryptionKey`を渡します：
 
 ```ts {2}
@@ -342,10 +358,36 @@ new MyWebsite(this, 'MyWebsite', {
 });
 ```
 
-`enableKeyRotation`（デフォルト`true`）は、自動的に作成されるキーにのみ適用されます。つまり、`encryption`が`BucketEncryption.KMS`（デフォルト）で、`encryptionKey`が提供されていない場合です。
+:::caution[インポートされたキーには独自の権限が必要]
+`Key.fromKeyArn`経由でインポートされたキーは、独自のキーポリシーでCloudWatch Logs、S3、CloudFrontサービスプリンシパルに必要な権限を既に付与している必要があります。`addToResourcePolicy`はインポートされたキーでは何も行わないため、このコンストラクトはそれらを付与できず、`cdk synth`は警告しません - 失敗はデプロイ時にのみ表示されます。同じアプリで作成されたキー（`new Key(this, 'WebsiteKey')`）にはこの問題はありません。CDKがそのポリシーを直接更新できるためです。
+:::
+
+`enableKeyRotation`（デフォルト`true`）は、自動的に作成されたキーにのみ適用されます。つまり、`encryption`が`BucketEncryption.KMS`（デフォルト）で、`encryptionKey`が提供されていない場合です：
+
+```ts {2}
+new MyWebsite(this, 'MyWebsite', {
+  enableKeyRotation: false,
+});
+```
+
+:::caution[キーローテーションを無効にする場合はCKV_AWS_7を抑制]
+自動的に作成されたキーでキーローテーションを無効にすると、`checkov`セキュリティスキャンが`CKV_AWS_7`で失敗します。抑制してください：
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { Key } from 'aws-cdk-lib/aws-kms';
+import { suppressRules } from '@my-scope/common-constructs';
+
+suppressRules(
+  website,
+  ['CKV_AWS_7'],
+  'Key rotation is managed externally',
+  (c) => c instanceof Key,
+);
+```
+:::
 </Fragment>
 <Fragment slot="terraform">
-異なる暗号化設定を使用する場合は、`encryption`、`kms_key_arn`、および`enable_key_rotation`変数を設定します：
+異なる暗号化設定を使用する場合は、`encryption`、`kms_key_arn`、`create_kms_key`、および`enable_key_rotation`変数を設定します：
 
 ```hcl title="packages/infra/src/main.tf" {7}
 module "my_website" {
@@ -358,19 +400,62 @@ module "my_website" {
 }
 ```
 
-自動的に作成されるキーの代わりに独自のKMSキーを使用するには、`kms_key_arn`を渡します。顧客提供のキーは、CloudWatch Logs、S3、およびCloudFrontサービスプリンシパルに必要な権限を独自のキーポリシーで既に付与している必要があります。
+:::caution[Checkov: S3_MANAGED]
+`S3_MANAGED`を選択すると、ウェブサイトおよびディストリビューションログバケットで`checkov`セキュリティスキャンが`CKV_AWS_145`で失敗します。提供された`test`ターゲットは`--config-file`を受け入れませんが、`checkov`は作業ディレクトリ内の`.checkov.yaml`を自動検出するため、`packages/infra/src`に配置してください：
 
-`enable_key_rotation`（デフォルト`true`）は、自動的に作成されるキーにのみ適用されます。つまり、`encryption`が`"KMS"`（デフォルト）で、`kms_key_arn`が提供されていない場合です。
+```yaml title="packages/infra/src/.checkov.yaml"
+skip-check:
+  - CKV_AWS_145
+```
+:::
+
+自動的に作成されるキーの代わりに独自のKMSキーを使用するには、`kms_key_arn`を渡し、`create_kms_key`を`false`に設定します：
+
+```hcl title="packages/infra/src/main.tf" {7-8}
+module "my_website" {
+  source = "../../common/terraform/src/app/static-websites/my-website"
+
+  providers = {
+    aws.us_east_1 = aws.us_east_1
+  }
+  kms_key_arn    = aws_kms_key.website.arn
+  create_kms_key = false
+}
+```
+
+顧客提供のキーは、独自のキーポリシーでCloudWatch Logs、S3、CloudFrontサービスプリンシパルに必要な権限を既に付与している必要があります。
+
+`enable_key_rotation`（デフォルト`true`）は、自動的に作成されたキーにのみ適用されます。つまり、`encryption`が`"KMS"`（デフォルト）で、`create_kms_key`が`true`の場合です：
+
+```hcl title="packages/infra/src/main.tf" {7}
+module "my_website" {
+  source = "../../common/terraform/src/app/static-websites/my-website"
+
+  providers = {
+    aws.us_east_1 = aws.us_east_1
+  }
+  enable_key_rotation = false
+}
+```
+
+:::caution[Checkov: キーローテーション無効]
+自動的に作成されたキーでキーローテーションを無効にすると、`checkov`セキュリティスキャンが`CKV_AWS_7`で失敗します。同じ`.checkov.yaml`に追加してください：
+
+```yaml title="packages/infra/src/.checkov.yaml"
+skip-check:
+  - CKV_AWS_7
+```
+:::
 </Fragment>
 </Infrastructure>
 
 ### カスタムドメインとTLS
 
-デフォルトでは、ディストリビューションはデフォルトのCloudFrontドメイン名（`*.cloudfront.net`）とそのデフォルト証明書を使用します。これは、最小TLSバージョン1.2の強制をサポートしていません。独自のドメインからウェブサイトを提供するには、[ACM証明書](https://docs.aws.amazon.com/acm/latest/userguide/acm-overview.html)（CloudFrontで使用するには`us-east-1`に存在する必要があります）とドメイン名を提供します。その後、ビューアーに対して最小TLSバージョン1.2が強制されます：
+デフォルトでは、ディストリビューションはデフォルトのCloudFrontドメイン名（`*.cloudfront.net`）とそのデフォルト証明書を使用します。これは最小TLSバージョン1.2の強制をサポートしていません。独自のドメインからウェブサイトを提供するには、[ACM証明書](https://docs.aws.amazon.com/acm/latest/userguide/acm-overview.html)（CloudFrontで使用するには`us-east-1`に存在する必要があります）とドメイン名を提供します。その後、ビューアーに対して最小TLSバージョン1.2が強制されます：
 
 <Infrastructure>
 <Fragment slot="cdk">
-ウェブサイトを作成する際に`certificate`および`domainNames`プロパティを渡します：
+ウェブサイトを作成する際に`certificate`と`domainNames`プロパティを渡します：
 
 ```ts title="packages/infra/src/stacks/application-stack.ts" {11-13}
 import { Stack } from 'aws-cdk-lib';
@@ -392,7 +477,7 @@ export class ApplicationStack extends Stack {
 ```
 </Fragment>
 <Fragment slot="terraform">
-`custom_domain_names`および`acm_certificate_arn`変数を設定します：
+`custom_domain_names`と`acm_certificate_arn`変数を設定します：
 
 ```hcl title="packages/infra/src/main.tf" {7-8}
 module "my_website" {
@@ -408,7 +493,7 @@ module "my_website" {
 </Fragment>
 </Infrastructure>
 
-また、ドメインをCloudFrontディストリビューションに向けるDNSレコード（例：Route 53）を作成する必要があります。
+また、CloudFrontディストリビューションを指すDNSレコード（例：Route 53）を作成する必要があります。
 
 ## ランタイム設定
 
@@ -420,7 +505,7 @@ module "my_website" {
 <Fragment slot="cdk">
 `RuntimeConfig` CDKコンストラクトを使用して、CDKインフラストラクチャで設定を追加および取得できます。`@aws/nx-plugin`ジェネレーター（<Link path="guides/trpc">`ts#api`</Link>や<Link path="guides/fastapi">`py#api`</Link>など）によって生成されたCDKコンストラクトは、自動的に適切な値を`RuntimeConfig`に追加します。
 
-ウェブサイトのCDKコンストラクトは、ランタイム設定の`connection`名前空間を`runtime-config.json`ファイルとしてS3バケットのルートにデプロイします。
+ウェブサイトCDKコンストラクトは、ランタイム設定の`connection`名前空間を`runtime-config.json`ファイルとしてS3バケットのルートにデプロイします。
 
 ```ts title="packages/infra/src/stacks/application-stack.ts"
 import { Stack } from 'aws-cdk-lib';
@@ -449,7 +534,7 @@ CDKでは、ウェブサイトコンストラクトはスタック内の任意�
 <Fragment slot="terraform">
 Terraformでは、ランタイム設定はruntime-configモジュールを通じて管理されます。`@aws/nx-plugin`ジェネレーター（<Link path="guides/trpc">`ts#api`</Link>や<Link path="guides/fastapi">`py#api`</Link>など）によって生成されたTerraformモジュールは、自動的に適切な値をランタイム設定に追加します。
 
-ウェブサイトのTerraformモジュールは、ランタイム設定の`connection`名前空間を`runtime-config.json`ファイルとしてS3バケットのルートにデプロイします。
+ウェブサイトTerraformモジュールは、ランタイム設定の`connection`名前空間を`runtime-config.json`ファイルとしてS3バケットのルートにデプロイします。
 
 ```hcl title="packages/infra/src/main.tf" {20-21}
 module "asset_bucket" {
@@ -477,7 +562,7 @@ module "my_website" {
 ```
 
 :::caution[モジュールの順序]
-ウェブサイトモジュールは、ランタイム設定に追加するモジュールの_後_に宣言し、順序を保証するために適切な`depends_on`を設定する必要があります。そうしないと、`runtime-config.json`ファイルに含まれません。
+ランタイム設定に追加するモジュールの_後_にウェブサイトモジュールを宣言し、順序を保証するために適切な`depends_on`を設定する必要があります。そうしないと、`runtime-config.json`ファイルに欠落します。
 :::
 </Fragment>
 </Infrastructure>
@@ -498,12 +583,12 @@ const MyComponent = () => {
 ```
 
 :::note[ランタイム設定]
-ランタイム設定がAWS AppConfigにどのように保存されるか、およびサーバー側のコンシューマー（Lambda関数、エージェント）がそれを取得する方法の詳細については、<Link path="guides/runtime-config">ランタイム設定</Link>ガイドを参照してください。
+ランタイム設定がAWS AppConfigにどのように保存されるか、およびサーバーサイドコンシューマー（Lambda関数、エージェント）がそれを取得する方法の詳細については、<Link path="guides/runtime-config">ランタイム設定</Link>ガイドを参照してください。
 :::
 
 ### ローカルランタイム設定
 
-[ローカル開発サーバー](#local-development-server)を実行する場合、ローカルウェブサイトがバックエンドURL、アイデンティティ設定などを知るために、`public`ディレクトリに`runtime-config.json`ファイルが必要です。
+[ローカル開発サーバー](#local-development-server)を実行する場合、ローカルウェブサイトがバックエンドURL、ID設定などを知るために、`public`ディレクトリに`runtime-config.json`ファイルが必要です。
 
 ウェブサイトプロジェクトには、デプロイされたアプリケーションから`runtime-config.json`ファイルをダウンロードするために使用できる`load-runtime-config`ターゲットが設定されています：
 
@@ -512,7 +597,7 @@ const MyComponent = () => {
 :::note[カスタムステージ名]
 <Infrastructure>
 <Fragment slot="cdk">
-インフラストラクチャプロジェクトの`src/main.ts`でステージ名のプレフィックスを変更した場合、それに応じてウェブサイトの`project.json`ファイルの`load-runtime-config`ターゲットを更新する必要があります。
+インフラストラクチャプロジェクトの`src/main.ts`でステージ名のプレフィックスを変更する場合は、ウェブサイトの`project.json`ファイルの`load-runtime-config`ターゲットを適宜更新する必要があります。
 
 また、`load-runtime-config`ターゲットは、AWS認証情報を持つ環境にアプリケーションの単一のステージがデプロイされていることを前提としていることに注意してください。同じアカウントとリージョンに複数のステージをデプロイする場合は、コマンドを調整する必要があります。
 </Fragment>
@@ -524,11 +609,11 @@ Terraformプロジェクトの場合、`load-runtime-config`ターゲットは�
 
 ## ローカル開発サーバー
 
-ローカル開発の標準的なコマンドは`dev`で、これはウェブサイト（および接続したAPIのローカルサーバー）を1つのコマンドで起動します：
+ローカル開発の標準的なコマンドは`dev`で、1つのコマンドでウェブサイト（および接続したAPIのローカルサーバー）を起動します：
 
 <NxCommands commands={['dev <my-website>']} />
 
-`serve`ターゲットは、デプロイされたAWSインフラストラクチャを指すのではなく、アプリケーションのどの部分をローカルで実行するかを制御する必要がある場合にも利用できます。複数のコンポーネントを持つプロジェクトでの`dev`の動作を含む、接続されたプロジェクト全体でのローカル開発の広範な概要については、<Link path="guides/local-development">ローカル開発</Link>ガイドを参照してください。
+`serve`ターゲットは、デプロイされたAWSインフラストラクチャを指すのではなく、アプリケーションのどの部分をローカルで実行するかを制御する必要がある場合にも利用できます。複数のコンポーネントを持つプロジェクト全体でのローカル開発の広範な概要（`dev`が複数のコンポーネントでどのように動作するかを含む）については、<Link path="guides/local-development">ローカル開発</Link>ガイドを参照してください。
 
 ### Serveターゲット
 
@@ -544,7 +629,7 @@ Terraformプロジェクトの場合、`load-runtime-config`ターゲットは�
 
 `dev`ターゲットは、ウェブサイトのローカル開発サーバー（[Vite `MODE`](https://vite.dev/guide/env-and-mode)を`local-dev`に設定）を起動し、<Link path="/guides/connection">Connectionジェネレーター</Link>を介してウェブサイトに接続したAPIのローカルサーバーも起動します。
 
-このターゲットを介してローカルウェブサイトサーバーが実行されると、`runtime-config.json`は自動的にオーバーライドされ、ローカルで実行されているAPI URLを指すようになります。
+このターゲットを介してローカルウェブサイトサーバーを実行すると、`runtime-config.json`は自動的にローカルで実行されているAPI URLを指すようにオーバーライドされます。
 
 このターゲットは以下のコマンドで実行できます：
 
@@ -571,12 +656,12 @@ Terraformプロジェクトの場合、`load-runtime-config`ターゲットは�
 
 <NxCommands env={{DYNAMODB_TABLE_NAME: 'xxxxx'}} commands={['dev <my-website>']} />
 
-ローカルAPIサーバーは、ローカルで設定したAWS認証情報で実行されることに注意してください。
+ローカルAPIサーバーは、ローカルに設定したAWS認証情報で実行されることに注意してください。
 :::
 
 ## ビルド
 
-`build`ターゲットを使用してウェブサイトをビルドできます。これは`bundle`、`compile`、`test`、および`lint`ターゲットを実行し、ウェブサイトの型チェック、バンドル、テスト、およびリントを行います。
+`build`ターゲットを使用してウェブサイトをビルドできます。これにより、`bundle`、`compile`、`test`、および`lint`ターゲットが実行され、ウェブサイトの型チェック、バンドル、テスト、およびリントが行われます。
 
 <NxCommands commands={['build <my-website>']} />
 
@@ -645,7 +730,7 @@ React固有のテストについては、React Testing Libraryが既にインス
   />
   <ConnectionCard
     title="React Website to AgentCore Gateway"
-    description="ReactウェブサイトをAgentCore Gatewayを通じてエージェントに接続する"
+    description="AgentCore Gateway経由でReactウェブサイトをエージェントに接続する"
     href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/react-agentcore-gateway`}
     source="react"
     target="agentcore"

--- a/docs/src/content/docs/jp/guides/react-website.mdx
+++ b/docs/src/content/docs/jp/guides/react-website.mdx
@@ -18,7 +18,7 @@ import Infrastructure from '@components/infrastructure.astro';
 import Snippet from '@components/snippet.astro';
 import OptionFilter from '@components/option-filter.astro';
 
-このジェネレーターは、デフォルトで[shadcn/ui](https://ui.shadcn.com/)が設定された新しい[React](https://react.dev/)ウェブサイトと、[S3](https://aws.amazon.com/s3/)でホストされ、[CloudFront](https://aws.amazon.com/cloudfront/)で配信され、[WAF](https://aws.amazon.com/waf/)で保護される静的ウェブサイトとしてクラウドにデプロイするためのAWS CDKまたはTerraformインフラストラクチャを作成します。
+このジェネレーターは、デフォルトで[shadcn/ui](https://ui.shadcn.com/)が設定された新しい[React](https://react.dev/)ウェブサイトと、[S3](https://aws.amazon.com/s3/)でホストされる静的ウェブサイトとしてクラウドにデプロイし、[CloudFront](https://aws.amazon.com/cloudfront/)で配信し、[WAF](https://aws.amazon.com/waf/)で保護するためのAWS CDKまたはTerraformインフラストラクチャを作成します。
 
 生成されたアプリケーションは、ビルドツールおよびバンドラーとして[Vite](https://vite.dev/)を使用します。型安全なルーティングには[TanStack Router](https://tanstack.com/router/v1)を使用します。
 
@@ -62,7 +62,7 @@ React Websiteは2つの方法で生成できます：
   - package.json Project manifest defining the project's package name and dependencies
 </FileTree>
 
-:::note[TanStack Routerなしの場合]
+:::note[TanStack Routerを使用しない場合]
 [TanStack Router](https://tanstack.com/router/v1)を使用しないことを選択した場合、`routes`ディレクトリの代わりに、アプリケーションのエントリーポイントとしてシンプルな`src/app.tsx`ファイルが提供されます。
 :::
 
@@ -129,58 +129,7 @@ waf -> cloudfront
 cloudfront -> s3
 ```
 
-#### セキュリティヘッダー
-
-CloudFrontディストリビューションは、すべてのレスポンスに`Strict-Transport-Security`、`X-Content-Type-Options`、`X-Frame-Options: DENY`、`Referrer-Policy`、および`Content-Security-Policy`を設定するレスポンスヘッダーポリシーを適用します。
-
-デフォルトの`Content-Security-Policy`が適用されます。これはXSSやクリックジャッキングを軽減するためにスクリプトとフレーミングを制限しますが、デプロイ時にのみURLが判明するAWSサービスエンドポイント（API Gateway、Cognito、Bedrock AgentCoreなど）をウェブサイトが呼び出せるようにHTTPSおよびWSS接続を許可します。ポリシーを調整する（例えば、`connect-src`を特定のオリジンに厳格化する）には、生成された`static-website.ts`（CDK）または`static-website.tf`（Terraform）の`content_security_policy`値を編集してください。
-
-`runtime-config.json`は`Cache-Control: no-cache`で配信されるため、ブラウザは再デプロイ後に古いキャッシュされたコピーを使用するのではなく、常に最新の設定を取得します。
-
-#### カスタムドメインとTLS
-
-デフォルトでは、ディストリビューションはデフォルトのCloudFrontドメイン名（`*.cloudfront.net`）とそのデフォルト証明書を使用しますが、これは最小TLSバージョン1.2の強制をサポートしていません。独自のドメインからウェブサイトを配信するには、[ACM証明書](https://docs.aws.amazon.com/acm/latest/userguide/acm-overview.html)（CloudFrontで使用するには`us-east-1`に存在する必要があります）とドメイン名を指定してください。これにより、ビューアーに対して最小TLSバージョン1.2が強制されます：
-
-<Infrastructure>
-<Fragment slot="cdk">
-`packages/common/constructs/src/app/static-websites`にある生成されたウェブサイトコンストラクトで`certificate`と`domainNames`プロパティを渡します：
-
-```ts {6-8}
-export class MyWebsite extends StaticWebsite {
-  constructor(scope: Construct, id: string) {
-    super(scope, id, {
-      websiteName: 'MyWebsite',
-      websiteFilePath: ...,
-      domainNames: ['www.example.com'],
-      certificate: Certificate.fromCertificateArn(scope, 'Cert',
-        'arn:aws:acm:us-east-1:123456789012:certificate/...'),
-    });
-  }
-}
-```
-</Fragment>
-<Fragment slot="terraform">
-`packages/common/terraform/src/app/static-websites`にある生成されたウェブサイトモジュールで`custom_domain_names`と`acm_certificate_arn`変数を設定します：
-
-```hcl {5-6}
-module "static_website" {
-  source            = "../../../core/static-website"
-  website_name      = "my-website"
-  website_file_path = ...
-  custom_domain_names = ["www.example.com"]
-  acm_certificate_arn = "arn:aws:acm:us-east-1:123456789012:certificate/..."
-
-  providers = {
-    aws.us_east_1 = aws.us_east_1
-  }
-}
-```
-</Fragment>
-</Infrastructure>
-
-また、ドメインをCloudFrontディストリビューションに向けるDNSレコード（例：Route 53）を作成する必要があります。
-
-## React Websiteの実装
+## ウェブサイトの実装
 
 [Reactドキュメント](https://react.dev/learn)は、Reactでの構築の基本を学ぶための良い出発点です。
 
@@ -206,7 +155,7 @@ module "static_website" {
 
 #### ページ間のナビゲーション
 
-`Link`コンポーネントまたは`useNavigate`フックを使用してページ間を移動できます：
+ページ間を移動するには、`Link`コンポーネントまたは`useNavigate`フックを使用できます：
 
 ```tsx {1, 4, 8-9, 14}
 import { Link, useNavigate } from '@tanstack/react-router';
@@ -231,199 +180,15 @@ export const MyComponent = () => {
 
 詳細については、[TanStack Router](https://tanstack.com/router/latest/docs/framework/react/overview)ドキュメントを参照してください。
 
-## ランタイム設定
-
-インフラストラクチャからの設定は、<Link href="guides/runtime-config">ランタイム設定</Link>を介してウェブサイトに提供されます。これにより、ウェブサイトはアプリケーションがデプロイされるまで不明なAPI URLなどの詳細にアクセスできます。
-
-### インフラストラクチャ
-
-<Infrastructure>
-<Fragment slot="cdk">
-`RuntimeConfig` CDKコンストラクトを使用して、CDKインフラストラクチャで設定を追加および取得できます。`@aws/nx-plugin`ジェネレーター（<Link path="guides/trpc">`ts#api`</Link>や<Link path="guides/fastapi">`py#api`</Link>など）によって生成されたCDKコンストラクトは、自動的に適切な値を`RuntimeConfig`に追加します。
-
-ウェブサイトCDKコンストラクトは、ランタイム設定の`connection`名前空間を`runtime-config.json`ファイルとしてS3バケットのルートにデプロイします。
-
-```ts title="packages/infra/src/stacks/application-stack.ts"
-import { Stack } from 'aws-cdk-lib';
-import { Construct } from 'constructs';
-import { MyWebsite, MyApi } from '@my-scope/common-constructs';
-
-export class ApplicationStack extends Stack {
-  constructor(scope: Construct, id: string) {
-    super(scope, id);
-
-    // Website can be declared at any point — runtime config is resolved lazily
-    new MyWebsite(this, 'MyWebsite');
-
-    // Automatically adds values to the RuntimeConfig
-    new MyApi(this, 'MyApi', {
-      integrations: MyApi.defaultIntegrations(this).build(),
-    });
-  }
-}
-```
-
-:::note[CDK Websiteコンストラクト]
-CDKでは、ウェブサイトコンストラクトはスタック内の任意の時点で宣言できます。ランタイム設定はsynth時に遅延解決されるため、宣言順序に関係なくすべての値が含まれます。
-:::
-</Fragment>
-<Fragment slot="terraform">
-Terraformでは、ランタイム設定はruntime-configモジュールを通じて管理されます。`@aws/nx-plugin`ジェネレーター（<Link path="guides/trpc">`ts#api`</Link>や<Link path="guides/fastapi">`py#api`</Link>など）によって生成されたTerraformモジュールは、自動的に適切な値をランタイム設定に追加します。
-
-ウェブサイトTerraformモジュールは、ランタイム設定の`connection`名前空間を`runtime-config.json`ファイルとしてS3バケットのルートにデプロイします。
-
-```hcl title="packages/infra/src/main.tf" {20-21}
-module "asset_bucket" {
-  source = "../../common/terraform/src/core/asset-bucket"
-}
-
-# Automatically adds values to runtime config
-module "my_api" {
-  source = "../../common/terraform/src/app/apis/my-api"
-
-  asset_bucket_name = module.asset_bucket.bucket_name
-}
-
-# Automatically deploys the runtime config to runtime-config.json
-module "my_website" {
-  source = "../../common/terraform/src/app/static-websites/my-website"
-
-  providers = {
-    aws.us_east_1 = aws.us_east_1
-  }
-
-  # Ensure API is deployed first to add to runtime config
-  depends_on = [module.my_api]
-}
-```
-
-:::caution[モジュールの順序]
-ランタイム設定に追加するモジュールの_後_にウェブサイトモジュールを宣言し、順序を保証するために適切な`depends_on`を設定する必要があります。そうしないと、`runtime-config.json`ファイルに欠落が生じます。
-:::
-</Fragment>
-</Infrastructure>
-
-### ウェブサイトコード
-
-ウェブサイトでは、`useRuntimeConfig`フックを使用してランタイム設定から値を取得できます：
-
-```tsx {1,4}
-import { useRuntimeConfig } from '../hooks/useRuntimeConfig';
-
-const MyComponent = () => {
-  const runtimeConfig = useRuntimeConfig();
-
-  // Access values in the runtime config here
-  const apiUrl = runtimeConfig.apis.MyApi;
-};
-```
-
-:::note[ランタイム設定]
-ランタイム設定がAWS AppConfigにどのように保存され、サーバーサイドのコンシューマー（Lambda関数、エージェント）がどのように取得できるかの詳細については、<Link path="guides/runtime-config">ランタイム設定</Link>ガイドを参照してください。
-:::
-
-### ローカルランタイム設定
-
-[ローカル開発サーバー](#local-development-server)を実行する際、ローカルウェブサイトがバックエンドURL、ID設定などを知るために、`public`ディレクトリに`runtime-config.json`ファイルが必要です。
-
-ウェブサイトプロジェクトには`load-runtime-config`ターゲットが設定されており、デプロイされたアプリケーションから`runtime-config.json`ファイルをダウンロードするために使用できます：
-
-<NxCommands commands={['load-runtime-config <my-website>']} />
-
-:::note[カスタムステージ名]
-<Infrastructure>
-<Fragment slot="cdk">
-インフラストラクチャプロジェクトの`src/main.ts`でステージ名のプレフィックスを変更した場合、ウェブサイトの`project.json`ファイルの`load-runtime-config`ターゲットを適宜更新する必要があります。
-
-また、`load-runtime-config`ターゲットは、AWS認証情報を持つ環境にアプリケーションの単一ステージがデプロイされていることを前提としていることに注意してください。同じアカウントとリージョンに複数のステージをデプロイする場合は、コマンドを調整する必要があります。
-</Fragment>
-<Fragment slot="terraform">
-Terraformプロジェクトの場合、`load-runtime-config`ターゲットは、最新のローカル`terraform apply`後に作成された`runtime-config.json`ファイルをコピーします。
-</Fragment>
-</Infrastructure>
-:::
-
-## ローカル開発サーバー
-
-ローカル開発の標準的なコマンドは`dev`で、1つのコマンドでウェブサイト（および接続したAPIのローカルサーバー）を起動します：
-
-<NxCommands commands={['dev <my-website>']} />
-
-`serve`ターゲットは、ローカルで実行するアプリケーションの範囲とデプロイされたAWSインフラストラクチャを指す範囲を制御する必要がある場合にも利用できます。複数のコンポーネントを持つプロジェクトで`dev`がどのように動作するかを含む、接続されたプロジェクト全体のローカル開発の広範な概要については、<Link path="guides/local-development">ローカル開発</Link>ガイドを参照してください。
-
-### Serveターゲット
-
-`serve`ターゲットは、ウェブサイトのローカル開発サーバーを起動します。このターゲットは、ウェブサイトが対話するサポートインフラストラクチャをデプロイし、[ローカルランタイム設定をロード](#local-runtime-config)している必要があります。
-
-このターゲットは以下のコマンドで実行できます：
-
-<NxCommands commands={['serve <my-website>']} />
-
-このターゲットは、「実際の」デプロイされたAPIやその他のインフラストラクチャを指しながらウェブサイトの変更を行う際に便利です。
-
-### Devターゲット
-
-`dev`ターゲットは、ウェブサイトのローカル開発サーバー（[Vite `MODE`](https://vite.dev/guide/env-and-mode)を`local-dev`に設定）を起動し、<Link path="/guides/connection">Connectionジェネレーター</Link>を介してウェブサイトに接続したAPIのローカルサーバーも起動します。
-
-このターゲットを介してローカルウェブサイトサーバーを実行すると、`runtime-config.json`は自動的にローカルで実行されているAPI URLを指すようにオーバーライドされます。
-
-このターゲットは以下のコマンドで実行できます：
-
-<NxCommands commands={['dev <my-website>']} />
-
-このターゲットは、ウェブサイトとAPIを横断して作業し、インフラストラクチャをデプロイせずに迅速に反復したい場合に便利です。
-
-:::note[ワークスペース`dev`スクリプト]
-ワークスペースのルート`package.json`には、`dev`ターゲットを持つすべてのプロジェクトに対して`dev`ターゲットを実行する`dev`スクリプトが含まれています：
-
-<PackageManagerShortCommand commands={["dev"]} />
-
-これにより、1つのコマンドでウェブサイト（および`dev`ターゲットを持つその他のプロジェクト）のローカル開発サーバーが起動します。このウェブサイトのみを実行するには、独自の`dev`ターゲット（例：`nx dev <my-website>`）を使用してください。
-:::
-
-:::warning[モック認証]
-このモードで実行され、`runtime-config.json`が存在しない場合、Cognito認証を設定している場合（<Link path="/guides/react-website-auth">`ts#website#auth`ジェネレーター</Link>経由）、ログインはスキップされ、ローカルサーバーへのリクエストには認証ヘッダーが含まれません。
-
-`dev`でログインと認証を有効にするには、インフラストラクチャをデプロイしてランタイム設定をロードしてください。
-:::
-
-:::tip[Dev動作]
-`dev`で実行する場合、APIが他のデプロイされたAWSリソースを指すために必要な環境変数を指定できます。例：
-
-<NxCommands env={{DYNAMODB_TABLE_NAME: 'xxxxx'}} commands={['dev <my-website>']} />
-
-ローカルAPIサーバーは、ローカルで設定したAWS認証情報で実行されることに注意してください。
-:::
-
-## ビルド
-
-`build`ターゲットを使用してウェブサイトをビルドできます。これは`bundle`、`compile`、`test`、`lint`ターゲットを実行し、ウェブサイトの型チェック、バンドル、テスト、リントを行います。
-
-<NxCommands commands={['build <my-website>']} />
-
-`bundle`ターゲットはViteを使用して、ルートの`dist/packages/<my-website>/bundle`ディレクトリにプロダクションバンドルを作成します。これは、ウェブサイトインフラストラクチャによって消費されるデプロイ可能なアーティファクトです。単独で実行できます：
-
-<NxCommands commands={['bundle <my-website>']} />
-
-## テスト
-
-ウェブサイトのテストは、標準的なTypeScriptプロジェクトでテストを書くのとよく似ているため、詳細については<Link path="guides/typescript-project#testing">TypeScriptプロジェクトガイド</Link>を参照してください。
-
-React固有のテストについては、React Testing Libraryがすでにインストールされており、テストを書くために使用できます。使用方法の詳細については、[React Testing Libraryドキュメント](https://testing-library.com/docs/react-testing-library/example-intro)を参照してください。
-
-`test`ターゲットを使用してテストを実行できます：
-
-<NxCommands commands={['test <my-website>']} />
-
 ## ウェブサイトのデプロイ
 
-React websiteジェネレーターは、選択した`iac`に基づいてCDKまたはTerraform Infrastructure as Codeを作成します。これを使用してウェブサイトをデプロイできます。
+React websiteジェネレーターは、選択した`iac`に基づいてCDKまたはTerraformのInfrastructure as Codeを作成します。これを使用してウェブサイトをデプロイできます。
 
 <Infrastructure>
 <Fragment slot="cdk">
 ウェブサイトをデプロイするには、<Link path="guides/typescript-infrastructure">`ts#infra`ジェネレーター</Link>を使用してCDKアプリケーションを作成することをお勧めします。
 
-`packages/common/constructs`で生成されたCDKコンストラクトを使用してウェブサイトをデプロイできます。
+`packages/common/constructs`に生成されたCDKコンストラクトを使用してウェブサイトをデプロイできます。
 
 ```ts title="packages/infra/src/stacks/application-stack.ts" {3, 9}
 import { Stack } from 'aws-cdk-lib';
@@ -450,7 +215,7 @@ export class ApplicationStack extends Stack {
 <Fragment slot="terraform">
 ウェブサイトをデプロイするには、<Link path="/guides/terraform-project">`terraform#project`ジェネレーター</Link>を使用してTerraformプロジェクトを作成することをお勧めします。
 
-`packages/common/terraform`で生成されたTerraformモジュールを使用してウェブサイトをデプロイできます。
+`packages/common/terraform`に生成されたTerraformモジュールを使用してウェブサイトをデプロイできます。
 
 ```hcl title="packages/infra/src/main.tf" {3}
 # Deploy website
@@ -484,9 +249,354 @@ provider "aws" {
 </Fragment>
 </Infrastructure>
 
+### セキュリティヘッダー
+
+CloudFrontディストリビューションは、すべてのレスポンスに`Strict-Transport-Security`、`X-Content-Type-Options`、`X-Frame-Options: DENY`、`Referrer-Policy`、および`Content-Security-Policy`を設定するレスポンスヘッダーポリシーを適用します。
+
+デフォルトの`Content-Security-Policy`が適用されます。これは、XSSやクリックジャッキングを軽減するためにスクリプトとフレーミングを制限しながら、HTTPS接続とWSS接続を許可するため、ウェブサイトはデプロイ時にのみURLが判明するAWSサービスエンドポイント（API Gateway、Cognito、Bedrock AgentCoreなど）を呼び出すことができます。ポリシーを調整する（例えば、`connect-src`を特定のオリジンに絞り込む）には、生成された`static-website.ts`（CDK）または`static-website.tf`（Terraform）の`content_security_policy`値を編集してください。
+
+`runtime-config.json`は`Cache-Control: no-cache`で配信されるため、ブラウザは再デプロイ後に古いキャッシュされたコピーを使用するのではなく、常に最新の設定を取得します。
+
+### WAF
+
+CloudFrontディストリビューションは、デフォルトで[AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACLによって保護されています。Web ACLは、AWSマネージドデフォルトルールセット（[`AWSManagedRulesCommonRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs)および[`AWSManagedRulesKnownBadInputsRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs)）を使用し、OWASP Top 10を含む一般的なWebエクスプロイトに対する保護を提供します。
+
+<Infrastructure>
+<Fragment slot="cdk">
+オプトアウトするには、ウェブサイトを作成する際に`enableWaf`を`false`に設定します：
+
+```ts title="packages/infra/src/stacks/application-stack.ts" {10,15-18}
+import { Stack } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { MyWebsite, suppressRules } from '@my-scope/common-constructs';
+
+export class ApplicationStack extends Stack {
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+
+    const website = new MyWebsite(this, 'MyWebsite', {
+      enableWaf: false,
+    });
+
+    // Disabling WAF fails the checkov CKV_AWS_68 check ("CloudFront
+    // Distribution should have WAF enabled"). Suppress it explicitly.
+    suppressRules(
+      website.cloudFrontDistribution,
+      ['CKV_AWS_68'],
+      'WAF is intentionally disabled for this distribution',
+    );
+  }
+}
+```
+
+:::caution[WAFを無効にする場合はCKV_AWS_68を抑制]
+WAFを無効にすると、合成されたCloudFrontディストリビューションにWeb ACLが関連付けられないため、上記のように抑制しない限り、`checkov`セキュリティスキャンが`CKV_AWS_68: "CloudFront Distribution should have WAF enabled"`で失敗します。
+:::
+</Fragment>
+<Fragment slot="terraform">
+オプトアウトするには、`enable_waf`を`false`に設定します：
+
+```hcl title="packages/infra/src/main.tf" {7}
+module "my_website" {
+  source = "../../common/terraform/src/app/static-websites/my-website"
+
+  providers = {
+    aws.us_east_1 = aws.us_east_1
+  }
+  enable_waf = false
+}
+```
+</Fragment>
+</Infrastructure>
+
+### バケット暗号化
+
+ウェブサイトバケット、CloudFrontディストリビューションログバケット、およびそれらのサーバーアクセスログを受信するCloudWatch Logsグループは、デフォルトで顧客管理の[AWS KMS](https://aws.amazon.com/kms/)キーで暗号化されます。このキーは自動的に作成され、キーローテーションが有効になっています。
+
+<Infrastructure>
+<Fragment slot="cdk">
+異なる暗号化設定を使用する場合は、ウェブサイトを作成する際に`encryption`、`encryptionKey`、および`enableKeyRotation`プロパティを渡します：
+
+```ts title="packages/infra/src/stacks/application-stack.ts" {11}
+import { Stack } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { BucketEncryption } from 'aws-cdk-lib/aws-s3';
+import { MyWebsite } from '@my-scope/common-constructs';
+
+export class ApplicationStack extends Stack {
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+
+    new MyWebsite(this, 'MyWebsite', {
+      encryption: BucketEncryption.S3_MANAGED,
+    });
+  }
+}
+```
+
+自動的に作成されるキーの代わりに独自のKMSキーを使用するには、`encryptionKey`を渡します：
+
+```ts {2}
+new MyWebsite(this, 'MyWebsite', {
+  encryptionKey: myKey,
+});
+```
+
+`enableKeyRotation`（デフォルト`true`）は、自動的に作成されるキーにのみ適用されます。つまり、`encryption`が`BucketEncryption.KMS`（デフォルト）で、`encryptionKey`が提供されていない場合です。
+</Fragment>
+<Fragment slot="terraform">
+異なる暗号化設定を使用する場合は、`encryption`、`kms_key_arn`、および`enable_key_rotation`変数を設定します：
+
+```hcl title="packages/infra/src/main.tf" {7}
+module "my_website" {
+  source = "../../common/terraform/src/app/static-websites/my-website"
+
+  providers = {
+    aws.us_east_1 = aws.us_east_1
+  }
+  encryption = "S3_MANAGED"
+}
+```
+
+自動的に作成されるキーの代わりに独自のKMSキーを使用するには、`kms_key_arn`を渡します。顧客提供のキーは、CloudWatch Logs、S3、およびCloudFrontサービスプリンシパルに必要な権限を独自のキーポリシーで既に付与している必要があります。
+
+`enable_key_rotation`（デフォルト`true`）は、自動的に作成されるキーにのみ適用されます。つまり、`encryption`が`"KMS"`（デフォルト）で、`kms_key_arn`が提供されていない場合です。
+</Fragment>
+</Infrastructure>
+
+### カスタムドメインとTLS
+
+デフォルトでは、ディストリビューションはデフォルトのCloudFrontドメイン名（`*.cloudfront.net`）とそのデフォルト証明書を使用します。これは、最小TLSバージョン1.2の強制をサポートしていません。独自のドメインからウェブサイトを提供するには、[ACM証明書](https://docs.aws.amazon.com/acm/latest/userguide/acm-overview.html)（CloudFrontで使用するには`us-east-1`に存在する必要があります）とドメイン名を提供します。その後、ビューアーに対して最小TLSバージョン1.2が強制されます：
+
+<Infrastructure>
+<Fragment slot="cdk">
+ウェブサイトを作成する際に`certificate`および`domainNames`プロパティを渡します：
+
+```ts title="packages/infra/src/stacks/application-stack.ts" {11-13}
+import { Stack } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { Certificate } from 'aws-cdk-lib/aws-certificatemanager';
+import { MyWebsite } from '@my-scope/common-constructs';
+
+export class ApplicationStack extends Stack {
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+
+    new MyWebsite(this, 'MyWebsite', {
+      domainNames: ['www.example.com'],
+      certificate: Certificate.fromCertificateArn(this, 'Cert',
+        'arn:aws:acm:us-east-1:123456789012:certificate/...'),
+    });
+  }
+}
+```
+</Fragment>
+<Fragment slot="terraform">
+`custom_domain_names`および`acm_certificate_arn`変数を設定します：
+
+```hcl title="packages/infra/src/main.tf" {7-8}
+module "my_website" {
+  source = "../../common/terraform/src/app/static-websites/my-website"
+
+  providers = {
+    aws.us_east_1 = aws.us_east_1
+  }
+  custom_domain_names = ["www.example.com"]
+  acm_certificate_arn = "arn:aws:acm:us-east-1:123456789012:certificate/..."
+}
+```
+</Fragment>
+</Infrastructure>
+
+また、ドメインをCloudFrontディストリビューションに向けるDNSレコード（例：Route 53）を作成する必要があります。
+
+## ランタイム設定
+
+インフラストラクチャからの設定は、<Link href="guides/runtime-config">ランタイム設定</Link>を介してウェブサイトに提供されます。これにより、ウェブサイトはアプリケーションがデプロイされるまで不明なAPI URLなどの詳細にアクセスできます。
+
+### インフラストラクチャ
+
+<Infrastructure>
+<Fragment slot="cdk">
+`RuntimeConfig` CDKコンストラクトを使用して、CDKインフラストラクチャで設定を追加および取得できます。`@aws/nx-plugin`ジェネレーター（<Link path="guides/trpc">`ts#api`</Link>や<Link path="guides/fastapi">`py#api`</Link>など）によって生成されたCDKコンストラクトは、自動的に適切な値を`RuntimeConfig`に追加します。
+
+ウェブサイトのCDKコンストラクトは、ランタイム設定の`connection`名前空間を`runtime-config.json`ファイルとしてS3バケットのルートにデプロイします。
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { Stack } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { MyWebsite, MyApi } from '@my-scope/common-constructs';
+
+export class ApplicationStack extends Stack {
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+
+    // Website can be declared at any point, since runtime config is resolved lazily
+    new MyWebsite(this, 'MyWebsite');
+
+    // Automatically adds values to the RuntimeConfig
+    new MyApi(this, 'MyApi', {
+      integrations: MyApi.defaultIntegrations(this).build(),
+    });
+  }
+}
+```
+
+:::note[CDK Websiteコンストラクト]
+CDKでは、ウェブサイトコンストラクトはスタック内の任意の時点で宣言できます。ランタイム設定は合成時に遅延解決されるため、宣言順序に関係なくすべての値が含まれます。
+:::
+</Fragment>
+<Fragment slot="terraform">
+Terraformでは、ランタイム設定はruntime-configモジュールを通じて管理されます。`@aws/nx-plugin`ジェネレーター（<Link path="guides/trpc">`ts#api`</Link>や<Link path="guides/fastapi">`py#api`</Link>など）によって生成されたTerraformモジュールは、自動的に適切な値をランタイム設定に追加します。
+
+ウェブサイトのTerraformモジュールは、ランタイム設定の`connection`名前空間を`runtime-config.json`ファイルとしてS3バケットのルートにデプロイします。
+
+```hcl title="packages/infra/src/main.tf" {20-21}
+module "asset_bucket" {
+  source = "../../common/terraform/src/core/asset-bucket"
+}
+
+# Automatically adds values to runtime config
+module "my_api" {
+  source = "../../common/terraform/src/app/apis/my-api"
+
+  asset_bucket_name = module.asset_bucket.bucket_name
+}
+
+# Automatically deploys the runtime config to runtime-config.json
+module "my_website" {
+  source = "../../common/terraform/src/app/static-websites/my-website"
+
+  providers = {
+    aws.us_east_1 = aws.us_east_1
+  }
+
+  # Ensure API is deployed first to add to runtime config
+  depends_on = [module.my_api]
+}
+```
+
+:::caution[モジュールの順序]
+ウェブサイトモジュールは、ランタイム設定に追加するモジュールの_後_に宣言し、順序を保証するために適切な`depends_on`を設定する必要があります。そうしないと、`runtime-config.json`ファイルに含まれません。
+:::
+</Fragment>
+</Infrastructure>
+
+### ウェブサイトコード
+
+ウェブサイトでは、`useRuntimeConfig`フックを使用してランタイム設定から値を取得できます：
+
+```tsx {1,4}
+import { useRuntimeConfig } from '../hooks/useRuntimeConfig';
+
+const MyComponent = () => {
+  const runtimeConfig = useRuntimeConfig();
+
+  // Access values in the runtime config here
+  const apiUrl = runtimeConfig.apis.MyApi;
+};
+```
+
+:::note[ランタイム設定]
+ランタイム設定がAWS AppConfigにどのように保存されるか、およびサーバー側のコンシューマー（Lambda関数、エージェント）がそれを取得する方法の詳細については、<Link path="guides/runtime-config">ランタイム設定</Link>ガイドを参照してください。
+:::
+
+### ローカルランタイム設定
+
+[ローカル開発サーバー](#local-development-server)を実行する場合、ローカルウェブサイトがバックエンドURL、アイデンティティ設定などを知るために、`public`ディレクトリに`runtime-config.json`ファイルが必要です。
+
+ウェブサイトプロジェクトには、デプロイされたアプリケーションから`runtime-config.json`ファイルをダウンロードするために使用できる`load-runtime-config`ターゲットが設定されています：
+
+<NxCommands commands={['load-runtime-config <my-website>']} />
+
+:::note[カスタムステージ名]
+<Infrastructure>
+<Fragment slot="cdk">
+インフラストラクチャプロジェクトの`src/main.ts`でステージ名のプレフィックスを変更した場合、それに応じてウェブサイトの`project.json`ファイルの`load-runtime-config`ターゲットを更新する必要があります。
+
+また、`load-runtime-config`ターゲットは、AWS認証情報を持つ環境にアプリケーションの単一のステージがデプロイされていることを前提としていることに注意してください。同じアカウントとリージョンに複数のステージをデプロイする場合は、コマンドを調整する必要があります。
+</Fragment>
+<Fragment slot="terraform">
+Terraformプロジェクトの場合、`load-runtime-config`ターゲットは、最新のローカル`terraform apply`後に作成された`runtime-config.json`ファイルをコピーします。
+</Fragment>
+</Infrastructure>
+:::
+
+## ローカル開発サーバー
+
+ローカル開発の標準的なコマンドは`dev`で、これはウェブサイト（および接続したAPIのローカルサーバー）を1つのコマンドで起動します：
+
+<NxCommands commands={['dev <my-website>']} />
+
+`serve`ターゲットは、デプロイされたAWSインフラストラクチャを指すのではなく、アプリケーションのどの部分をローカルで実行するかを制御する必要がある場合にも利用できます。複数のコンポーネントを持つプロジェクトでの`dev`の動作を含む、接続されたプロジェクト全体でのローカル開発の広範な概要については、<Link path="guides/local-development">ローカル開発</Link>ガイドを参照してください。
+
+### Serveターゲット
+
+`serve`ターゲットは、ウェブサイトのローカル開発サーバーを起動します。このターゲットでは、ウェブサイトが対話するサポートインフラストラクチャをデプロイし、[ローカルランタイム設定をロード](#local-runtime-config)している必要があります。
+
+このターゲットは以下のコマンドで実行できます：
+
+<NxCommands commands={['serve <my-website>']} />
+
+このターゲットは、「実際の」デプロイされたAPIやその他のインフラストラクチャを指しながらウェブサイトの変更を行う場合に便利です。
+
+### Devターゲット
+
+`dev`ターゲットは、ウェブサイトのローカル開発サーバー（[Vite `MODE`](https://vite.dev/guide/env-and-mode)を`local-dev`に設定）を起動し、<Link path="/guides/connection">Connectionジェネレーター</Link>を介してウェブサイトに接続したAPIのローカルサーバーも起動します。
+
+このターゲットを介してローカルウェブサイトサーバーが実行されると、`runtime-config.json`は自動的にオーバーライドされ、ローカルで実行されているAPI URLを指すようになります。
+
+このターゲットは以下のコマンドで実行できます：
+
+<NxCommands commands={['dev <my-website>']} />
+
+このターゲットは、ウェブサイトとAPIを横断して作業し、インフラストラクチャをデプロイせずに迅速に反復したい場合に便利です。
+
+:::note[ワークスペース`dev`スクリプト]
+ワークスペースのルート`package.json`には、`dev`ターゲットを持つすべてのプロジェクトに対して`dev`ターゲットを実行する`dev`スクリプトが含まれています：
+
+<PackageManagerShortCommand commands={["dev"]} />
+
+これにより、1つのコマンドでウェブサイト（および`dev`ターゲットを持つその他のプロジェクト）のローカル開発サーバーが起動します。このウェブサイトだけを実行するには、独自の`dev`ターゲット（例：`nx dev <my-website>`）を使用してください。
+:::
+
+:::warning[モック認証]
+このモードで実行され、`runtime-config.json`が存在しない場合、Cognito認証を設定している場合（<Link path="/guides/react-website-auth">`ts#website#auth`ジェネレーター</Link>経由）、ログインはスキップされ、ローカルサーバーへのリクエストには認証ヘッダーが含まれません。
+
+`dev`でログインと認証を有効にするには、インフラストラクチャをデプロイしてランタイム設定をロードしてください。
+:::
+
+:::tip[Dev動作]
+`dev`で実行する場合、APIが他のデプロイされたAWSリソースを指すために必要な環境変数を指定できます。例：
+
+<NxCommands env={{DYNAMODB_TABLE_NAME: 'xxxxx'}} commands={['dev <my-website>']} />
+
+ローカルAPIサーバーは、ローカルで設定したAWS認証情報で実行されることに注意してください。
+:::
+
+## ビルド
+
+`build`ターゲットを使用してウェブサイトをビルドできます。これは`bundle`、`compile`、`test`、および`lint`ターゲットを実行し、ウェブサイトの型チェック、バンドル、テスト、およびリントを行います。
+
+<NxCommands commands={['build <my-website>']} />
+
+`bundle`ターゲットは、Viteを使用してルート`dist/packages/<my-website>/bundle`ディレクトリに本番バンドルを作成します。これは、ウェブサイトインフラストラクチャによって消費されるデプロイ可能なアーティファクトです。単独で実行できます：
+
+<NxCommands commands={['bundle <my-website>']} />
+
+## テスト
+
+ウェブサイトのテストは、標準的なTypeScriptプロジェクトでのテストの記述とよく似ているため、詳細については<Link path="guides/typescript-project#testing">TypeScriptプロジェクトガイド</Link>を参照してください。
+
+React固有のテストについては、React Testing Libraryが既にインストールされており、テストを記述するために使用できます。使用方法の詳細については、[React Testing Libraryドキュメント](https://testing-library.com/docs/react-testing-library/example-intro)を参照してください。
+
+`test`ターゲットを使用してテストを実行できます：
+
+<NxCommands commands={['test <my-website>']} />
+
 ## 接続
 
-<Link path="guides/connection">`connection`</Link>ジェネレーターを使用して、このプロジェクトをワークスペース内の他のプロジェクトと統合します。以下の接続がこのプロジェクトに関連します：
+<Link path="guides/connection">`connection`</Link>ジェネレーターを使用して、このプロジェクトをワークスペース内の他のプロジェクトと統合します。このプロジェクトに関連する接続は以下の通りです：
 
 <CardGrid>
   <ConnectionCard

--- a/docs/src/content/docs/ko/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/ko/get_started/tutorials/dungeon-game/1.mdx
@@ -1,6 +1,6 @@
 ---
 title: 모노레포 설정하기
-description: "@aws/nx-plugin을 사용하여 에이전트 AI 기반 던전 어드벤처 게임을 만드는 방법을 안내합니다."
+description: "@aws/nx-plugin을 사용하여 에이전트 AI 기반 던전 어드벤처 게임을 구축하는 방법에 대한 안내입니다."
 ---
 
 import { Aside, Code, FileTree, Steps, Tabs, TabItem } from '@astrojs/starlight/components';
@@ -22,55 +22,55 @@ import nxGraphPng from '@assets/nx-graph.png'
 import gameSelectPng from '@assets/game-select.png'
 import gameConversationPng from '@assets/game-conversation.png'
 
-## 작업 1: 모노레포 생성
+## 작업 1: 모노레포 생성하기
 
-새 모노레포를 생성하려면 원하는 디렉터리 안에서 다음 명령어를 실행하세요:
+새 모노레포를 생성하려면 원하는 디렉토리 내에서 다음 명령을 실행하세요:
 
 <CreateNxWorkspaceCommand workspace="dungeon-adventure" iac="cdk" />
 
-:::note[CDK as IaC Provider]
-이 튜토리얼에서는 인프라 코드로 CDK를 사용하므로 `--iac=cdk`를 사용합니다. Nx Plugin for AWS는 `terraform`도 지원합니다.
+:::note[IaC 제공자로서의 CDK]
+이 튜토리얼에서는 인프라를 코드로 관리하기 위해 CDK를 사용하므로 `--iac=cdk`를 사용합니다. Nx Plugin for AWS는 `terraform`도 지원합니다.
 :::
 
-이 명령어는 `dungeon-adventure` 디렉터리 안에 NX 모노레포를 설정합니다. VSCode에서 해당 디렉터리를 열면 다음과 같은 파일 구조를 볼 수 있습니다:
+이렇게 하면 `dungeon-adventure` 디렉토리 내에 NX 모노레포가 설정됩니다. VSCode에서 디렉토리를 열면 다음과 같은 파일 구조를 볼 수 있습니다:
 
 <FileTree>
 - .nx/
 - .vscode/
 - node_modules/
-- packages/ 서브 프로젝트가 위치하는 곳
+- packages/ 하위 프로젝트가 위치할 곳
 - .gitignore
-- biome.json 린팅 및 포맷팅을 위한 Biome 설정
-- nx.json Nx CLI 및 모노레포 기본값 설정
-- package.json 모든 node 의존성이 정의된 곳
+- biome.json Biome을 린팅 및 포맷팅을 위해 구성
+- nx.json Nx CLI 및 모노레포 기본값 구성
+- package.json 모든 node 의존성이 여기에 정의됨
 - pnpm-lock.yaml 또는 패키지 매니저에 따라 bun.lock, yarn.lock, package-lock.json
 - pnpm-workspace.yaml pnpm 사용 시
 - README.md
-- tsconfig.base.json 모든 node 기반 서브 프로젝트가 이를 확장
+- tsconfig.base.json 모든 node 기반 하위 프로젝트가 이를 확장함
 - tsconfig.json
-- aws-nx-plugin.config.mts Nx Plugin for AWS 설정
+- aws-nx-plugin.config.mts Nx Plugin for AWS 구성
 </FileTree>
 
-<Aside type="tip" title="자주 커밋하세요">제너레이터를 실행하기 전에 스테이징되지 않은 모든 파일을 Git에 커밋해 두는 것이 좋습니다. 이렇게 하면 `git diff`를 통해 제너레이터 실행 후 변경된 내용을 확인할 수 있습니다.</Aside>
+<Aside type="tip" title="자주 커밋하기">제너레이터를 실행하기 전에 스테이징되지 않은 모든 파일을 Git에 커밋하는 것이 좋습니다. 이렇게 하면 제너레이터 실행 후 `git diff`를 통해 변경된 내용을 확인할 수 있습니다.</Aside>
 
-## 작업 2: 던전 어드벤처 게임 스캐폴딩
+## 작업 2: 던전 어드벤처 게임 스캐폴딩하기
 
-워크스페이스가 준비되었으면 게임의 서브 프로젝트들 — Game API, Story Agent, Inventory MCP 서버, 게임 데이터베이스, 웹사이트 — 과 이들을 연결하는 연결 설정을 스캐폴딩합니다. 두 가지 방법이 있습니다:
+워크스페이스가 준비되면 게임의 하위 프로젝트들(Game API, Story Agent, Inventory MCP 서버, 게임 데이터베이스, 웹사이트)과 이들을 연결하는 연결을 스캐폴딩합니다. 두 가지 방법이 있습니다:
 
-- **빠른 방법** — 아래 다이어그램에서 명령어를 바로 복사하여 실행합니다. 동일한 시작점에 가장 빠르게 도달하는 방법입니다.
-- **단계별 방법** — 아래 섹션을 펼쳐 각 제너레이터를 직접 실행하고 각각이 무엇을 생성하는지 확인합니다.
+- **빠른 방법** — 아래 다이어그램에서 명령을 직접 복사하여 실행합니다. 동일한 시작점에 도달하는 가장 빠른 방법입니다.
+- **단계별 방법** — 아래 섹션을 펼쳐 각 제너레이터를 직접 실행하고 각각이 생성하는 것을 정확히 확인합니다.
 
-아래 다이어그램은 던전 어드벤처 워크스페이스 그 자체입니다: 이 모듈에서 빌드할 모든 프로젝트, 컴포넌트, 연결이 포함되어 있습니다. **명령어 복사**를 클릭하여 전체 시리즈를 가져온 다음, 작업 1에서 생성한 `dungeon-adventure` 디렉터리 안에서 실행하세요.
+아래 다이어그램은 던전 어드벤처 워크스페이스 그 자체입니다: 이 모듈에서 구축할 모든 프로젝트, 컴포넌트, 연결이 포함되어 있습니다. **명령 복사**를 눌러 전체 시리즈를 가져온 다음, 작업 1에서 생성한 `dungeon-adventure` 디렉토리 내에서 실행하세요.
 
 <EmbeddedGraph preset="dungeon-adventure" workspace="dungeon-adventure" iac="cdk" skipWorkspace />
 
-<Drawer title="단계별 방법" trigger="단계별 방법: 각 제너레이터를 직접 실행하고 결과 확인하기">
+<Drawer title="단계별" trigger="단계별: 각 제너레이터를 직접 실행하고 생성되는 것을 확인하기">
 
-명령어를 한꺼번에 복사하는 대신, 각 제너레이터를 개별적으로 실행할 수 있습니다. 이 방법은 각 제너레이터가 워크스페이스에 무엇을 추가하는지 이해하는 가장 좋은 방법입니다. 작업 1에서 생성한 `dungeon-adventure` 디렉터리 안에서 각 제너레이터를 순서대로 실행하세요.
+명령을 한 번에 복사하는 대신 각 제너레이터를 개별적으로 실행할 수 있습니다. 이는 각 제너레이터가 워크스페이스에 추가하는 것을 이해하는 가장 좋은 방법입니다. 작업 1에서 생성한 `dungeon-adventure` 디렉토리 내에서 각 제너레이터를 차례로 실행하세요.
 
-##### Game API 생성
+##### Game API 생성하기
 
-먼저 Game API를 생성해 보겠습니다. 이를 위해 다음 단계를 따라 `GameApi`라는 tRPC API를 생성합니다:
+먼저 Game API를 생성하겠습니다. 이를 위해 다음 단계를 사용하여 `GameApi`라는 tRPC API를 생성합니다:
 
 <RunGenerator generator="ts#api" requiredParameters={{ name: "GameApi", framework: "trpc" }} noInteractive />
 
@@ -79,20 +79,20 @@ import gameConversationPng from '@assets/game-conversation.png'
 파일 트리에 새 파일들이 나타나는 것을 볼 수 있습니다.
 
 <Aside title="루트 의존성">
-루트 `package.json`은 이제 `module` 타입으로 설정되어 있으며, 이는 `@aws/nx-plugin`이 제공하는 모든 node 기반 서브 프로젝트의 기본 모듈 타입이 ESM임을 의미합니다.
+루트 `package.json`은 이제 `type`이 `module`로 구성되어 있으며, 이는 ESM이 `@aws/nx-plugin`에서 제공하는 모든 node 기반 하위 프로젝트의 기본 모듈 타입임을 의미합니다.
 TypeScript 프로젝트 작업에 대한 자세한 내용은 <Link path="guides/typescript-project">ts#project 제너레이터 가이드</Link>를 참조하세요.
 </Aside>
 
 <details>
-<summary>생성된 `ts#api` 파일 자세히 살펴보기</summary>
+<summary>생성된 `ts#api` 파일을 자세히 살펴보기</summary>
 
-아래는 `ts#api` 제너레이터가 생성한 모든 파일 목록입니다. 파일 트리에서 강조 표시된 주요 파일들을 살펴보겠습니다:
+다음은 `ts#api` 제너레이터에 의해 생성된 모든 파일의 목록입니다. 파일 트리에서 강조 표시된 주요 파일 중 일부를 살펴보겠습니다:
 <FileTree>
 - packages/
   - common/
     - constructs/
       - src/
-        - app/ 앱별 cdk 구성
+        - app/ 앱 특정 cdk 구성
           - apis/
             - **game-api.ts** tRPC API를 생성하는 cdk 구성
             - index.ts
@@ -100,7 +100,7 @@ TypeScript 프로젝트 작업에 대한 자세한 내용은 <Link path="guides/
           - index.ts
         - core/ 일반 cdk 구성
           - api/
-            - rest-api.ts API Gateway Rest API의 기본 cdk 구성
+            - rest-api.ts API Gateway Rest API를 위한 기본 cdk 구성
             - trpc-utils.ts trpc API CDK 구성을 위한 유틸리티
             - utils.ts API 구성을 위한 유틸리티
           - index.ts
@@ -110,7 +110,7 @@ TypeScript 프로젝트 작업에 대한 자세한 내용은 <Link path="guides/
       - ...
   - game-api/ tRPC API
     - src/
-      - client/ 일반적으로 ts 머신 간 호출에 사용되는 바닐라 클라이언트
+      - client/ ts 머신 간 호출에 일반적으로 사용되는 바닐라 클라이언트
         - index.ts
       - middleware/ powertools 계측
         - error.ts
@@ -122,11 +122,11 @@ TypeScript 프로젝트 작업에 대한 자세한 내용은 <Link path="guides/
         - index.ts
         - **echo.ts** 샘플 입력 및 출력 스키마
         - z-async-iterable.ts tRPC 구독 출력을 위한 래퍼 Zod 스키마
-      - procedures/ API 프로시저/라우트의 구체적인 구현
+      - procedures/ API 프로시저/라우트의 특정 구현
         - **echo.ts** 샘플 프로시저 구현
       - index.ts
       - init.ts 컨텍스트 및 미들웨어 설정
-      - handler.ts Lambda 핸들러 진입점 (REST API에 응답 스트리밍 사용)
+      - handler.ts Lambda 핸들러 진입점 (REST API를 위한 응답 스트리밍 사용)
       - local-server.ts tRPC 서버를 로컬에서 실행할 때 사용
       - **router.ts** tRPC 라우터 및 모든 프로시저 정의
     - project.json
@@ -149,7 +149,7 @@ export const appRouter = router({
 
 export type AppRouter = typeof appRouter;
 ```
-라우터는 API의 tRPC 라우터를 정의하며 모든 API 메서드를 선언하는 곳입니다. 위에서 볼 수 있듯이, `./procedures/echo.ts` 파일에 구현이 있는 `echo`라는 메서드가 있습니다. Lambda 핸들러 진입점은 `handler.ts`에 있으며, 제너레이터에 의해 자동으로 설정됩니다.
+라우터는 API의 tRPC 라우터를 정의하며 모든 API 메서드를 선언할 곳입니다. 위에서 볼 수 있듯이 `./procedures/echo.ts` 파일에 구현이 있는 `echo`라는 메서드가 있습니다. Lambda 핸들러 진입점은 `handler.ts`에 있으며, 제너레이터에 의해 자동으로 구성됩니다.
 
 ```ts {7-10}
 // packages/game-api/src/procedures/echo.ts
@@ -165,7 +165,7 @@ export const echo = publicProcedure
   .query((opts) => ({ message: opts.input.message }));
 ```
 
-이 파일은 `echo` 메서드의 구현이며, 입력 및 출력 데이터 구조를 선언하여 강력한 타입 검사를 제공합니다.
+이 파일은 `echo` 메서드의 구현이며, 입력 및 출력 데이터 구조를 선언하여 강력하게 타입이 지정되어 있습니다.
 
 ```ts
 // packages/game-api/src/schema/echo.ts
@@ -390,13 +390,13 @@ export class GameApi<
 }
 ```
 
-이것은 `GameApi`를 정의하는 CDK 구성입니다. tRPC API의 각 프로시저에 대해 자동으로 Lambda 함수를 생성하는 `defaultIntegrations` 메서드를 제공하며, 번들된 API 구현을 가리킵니다. 이는 `cdk synth` 시점에 번들링이 발생하지 않음을 의미합니다([NodeJsFunction](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_lambda_nodejs.NodejsFunction.html) 사용과 달리), 백엔드 프로젝트의 빌드 타겟의 일부로 이미 번들링이 완료되었기 때문입니다.
+이것은 `GameApi`를 정의하는 CDK 구성입니다. tRPC API의 각 프로시저에 대해 Lambda 함수를 자동으로 생성하는 `defaultIntegrations` 메서드를 제공하며, 번들된 API 구현을 가리킵니다. 이는 백엔드 프로젝트의 빌드 타겟의 일부로 이미 번들링했기 때문에 `cdk synth` 시점에 번들링이 발생하지 않음을 의미합니다([NodeJsFunction](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_lambda_nodejs.NodejsFunction.html) 사용과 반대).
 
 </details>
 
-##### Story Agent 생성
+##### Story Agent 생성하기
 
-이제 Story Agent를 생성해 보겠습니다.
+이제 Story Agent를 생성하겠습니다.
 
 ###### Story agent: Python 프로젝트
 
@@ -406,7 +406,7 @@ Python 프로젝트를 생성하려면:
 
 파일 트리에 새 파일들이 나타나는 것을 볼 수 있습니다.
 <details>
-<summary>생성된 `py#project` 파일 자세히 살펴보기</summary>
+<summary>생성된 `py#project` 파일을 자세히 살펴보기</summary>
 
 `py#project`는 다음 파일들을 생성합니다:
 
@@ -424,23 +424,23 @@ Python 프로젝트를 생성하려면:
 - uv.lock
 </FileTree>
 
-이는 공유 가상 환경을 가진 Python 프로젝트와 [UV Workspace](https://docs.astral.sh/uv/concepts/projects/workspaces/)를 설정합니다.
+이것은 공유 가상 환경을 가진 Python 프로젝트와 [UV Workspace](https://docs.astral.sh/uv/concepts/projects/workspaces/)를 구성했습니다.
 
 </details>
 
 ###### Story agent
 
-`py#agent` 제너레이터로 프로젝트에 Strands 에이전트를 추가하려면:
+`py#agent` 제너레이터를 사용하여 프로젝트에 Strands 에이전트를 추가하려면:
 
 <RunGenerator generator="py#agent" requiredParameters={{project:"story", auth:"cognito", protocol:"ag-ui"}} noInteractive />
 
 :::note[AG-UI 프로토콜]
-`--protocol=ag-ui`를 선택하면 에이전트가 [Agent-User Interaction 프로토콜](https://docs.copilotkit.ai/aws-strands/protocol)을 사용합니다 — 이를 통해 React 웹사이트가 [CopilotKit](https://docs.copilotkit.ai/)을 통해 직접 에이전트와 통신할 수 있으며, 스트리밍, 도구 호출, 대화 기록이 직접 만든 HTTP 클라이언트 대신 프로토콜에 의해 처리됩니다.
+`--protocol=ag-ui`를 선택하여 에이전트가 [Agent-User Interaction 프로토콜](https://docs.copilotkit.ai/aws-strands/protocol)을 사용하도록 합니다. 이를 통해 React 웹사이트가 [CopilotKit](https://docs.copilotkit.ai/)를 통해 직접 통신할 수 있으며, 스트리밍, 도구 호출, 대화 기록이 수동으로 작성한 HTTP 클라이언트 대신 프로토콜에 의해 처리됩니다.
 :::
 
 파일 트리에 새 파일들이 나타나는 것을 볼 수 있습니다.
 <details>
-<summary>생성된 `py#agent` 파일 자세히 살펴보기</summary>
+<summary>생성된 `py#agent` 파일을 자세히 살펴보기</summary>
 
 `py#agent`는 다음 파일들을 생성합니다:
 
@@ -450,18 +450,18 @@ Python 프로젝트를 생성하려면:
     - dungeon_adventure_story/ python 모듈
       - agent/
         - main.py Bedrock AgentCore Runtime에서 에이전트의 진입점
-        - agent.py 예시 에이전트 및 도구 정의
-        - session.py 대화 상태 유지를 위한 SessionManager 해결
+        - agent.py 예제 에이전트 및 도구 정의
+        - session.py 대화 상태를 유지하기 위한 SessionManager 해결
         - middleware/
           - session_id_middleware.py 요청에 대한 인바운드 AgentCore 세션 ID 바인딩
-        - Dockerfile AgentCore Runtime에 배포하기 위한 docker 이미지 정의
+        - Dockerfile AgentCore Runtime에 배포하기 위한 도커 이미지 정의
   - common/constructs/
     - src
       - app/agents/story-agent/
         - story-agent.ts Story 에이전트를 AgentCore Runtime에 배포하기 위한 구성
 </FileTree>
 
-일부 파일을 자세히 살펴보겠습니다:
+파일 중 일부를 자세히 살펴보겠습니다:
 
 ```python
 # agent/agent.py
@@ -492,7 +492,7 @@ Refer to tools as your 'spellbook'.
     )
 ```
 
-이는 예시 Strands 에이전트를 생성하고 빼기 도구를 정의합니다. `log_model_errors`와 `log_tool_errors`는 공유 `dungeon_adventure_agent_connection` 프로젝트의 훅으로, 모델/도구 실패를 자동으로 실패하게 두지 않고 로깅합니다.
+이것은 예제 Strands 에이전트를 생성하고 빼기 도구를 정의합니다. `log_model_errors`와 `log_tool_errors`는 공유 `dungeon_adventure_agent_connection` 프로젝트의 훅으로, 모델/도구 실패를 조용히 실패하도록 두는 대신 로깅합니다.
 
 ```python
 # agent/middleware/session_id_middleware.py
@@ -603,7 +603,7 @@ async def ping():
     return {"status": "healthy"}
 ```
 
-이것은 에이전트의 진입점입니다. `--protocol=ag-ui`를 선택했기 때문에, 제너레이터는 Strands `Agent`를 [`ag_ui_strands`](https://docs.copilotkit.ai/aws-strands/integration)의 `StrandsAgent`로 래핑하고 [AG-UI 프로토콜](https://docs.copilotkit.ai/aws-strands/protocol)을 사용하는 FastAPI 앱에 마운트합니다 — 이것이 React 웹사이트의 CopilotKit이 통신하는 대상입니다. 에이전트는 임포트 시점이 아닌 `lifespan` 핸들러 내부에서 빌드됩니다 — 따라서 컨테이너 시작이 구성을 소유하며, 각 AgentCore 세션은 자체 컨테이너를 갖습니다. 위에서 본 `SessionIdMiddleware`는 인바운드 AgentCore 런타임 세션 ID를 전달하므로 나중에 연결하는 다운스트림 MCP/A2A 클라이언트(예: <Link path="get_started/tutorials/dungeon-game/2">모듈 2</Link>의 Inventory MCP 서버)가 아웃바운드 호출 시 자동으로 전달합니다. AG-UI는 `thread_id`당 하나의 Strands 에이전트를 캐시하므로, 템플릿 에이전트의 자체 세션 매니저 대신 `session_manager_provider`를 연결합니다 — 이렇게 하면 각 스레드가 자체 `SessionManager`를 가져 대화 기록이 턴 간에 유지됩니다. 해당 `get_session_manager()` 함수는 생성된 `session.py` 형제 파일에서 옵니다: 배포 시에는 제너레이터가 자동으로 프로비저닝하는 S3 버킷을 기반으로 하는 `strands.session.S3SessionManager`를 반환하고, `agent-dev`(`LOCAL_DEV=true`) 하에서는 배포 설정에 관계없이 항상 로컬 임시 디렉터리에 쓰는 `FileSessionManager`를 반환합니다.
+이것은 에이전트의 진입점입니다. `--protocol=ag-ui`를 선택했기 때문에 제너레이터는 Strands `Agent`를 [`ag_ui_strands`](https://docs.copilotkit.ai/aws-strands/integration)의 `StrandsAgent`로 래핑하고 [AG-UI 프로토콜](https://docs.copilotkit.ai/aws-strands/protocol)을 사용하는 FastAPI 앱에 마운트합니다. 이것이 React 웹사이트에서 CopilotKit가 통신할 대상입니다. 에이전트는 `lifespan` 핸들러 내부에서 빌드되며 임포트 시점이 아닙니다. 따라서 컨테이너 시작이 구성을 소유하며 각 AgentCore 세션은 자체 컨테이너를 가집니다. 위에서 본 `SessionIdMiddleware`는 인바운드 AgentCore 런타임 세션 ID를 전달하므로 나중에 연결할 다운스트림 MCP/A2A 클라이언트(예: <Link path="get_started/tutorials/dungeon-game/2">모듈 2</Link>의 Inventory MCP 서버)가 아웃바운드 호출에서 자동으로 전달합니다. AG-UI는 `thread_id`당 하나의 Strands 에이전트를 캐시하므로 템플릿 에이전트 자체의 세션 매니저가 아닌 `session_manager_provider`를 연결합니다. 이렇게 하면 각 스레드가 자체 `SessionManager`를 가지므로 대화 기록이 턴 간에 유지됩니다. 그 `get_session_manager()` 함수는 생성된 `session.py` 형제에서 가져옵니다: 배포 시 제너레이터가 자동으로 프로비저닝하는 S3 버킷으로 백업되는 `strands.session.S3SessionManager`를 반환합니다. `agent-dev`(`LOCAL_DEV=true`) 하에서는 배포된 구성과 관계없이 항상 로컬 임시 디렉토리에 쓰는 `FileSessionManager`를 반환합니다.
 
 ```ts
 // common/constructs/src/app/agents/story-agent/story-agent.ts
@@ -891,17 +891,17 @@ export class StoryAgent extends Construct implements IGrantable, IConnectable {
 }
 ```
 
-이는 에이전트 Docker 이미지를 ECR에 업로드하고 AgentCore Runtime을 사용하여 호스팅하는 CDK `AgentRuntimeArtifact`를 설정합니다. `--auth=cognito`를 선택했기 때문에, 구성은 사용자 풀/클라이언트 ID를 요구하고 Cognito를 통해 AgentCore Runtime 호출을 인증하며, 호출자의 `Authorization` 헤더를 전달합니다. 또한 Story Agent의 `session.py`가 런타임에 읽는 세션 버킷 — CloudWatch Logs에 서버 액세스 로그가 전달되는 KMS 암호화된 S3 버킷 — 을 프로비저닝하고, 에이전트에 읽기/쓰기 액세스를 부여하고, Bedrock 모델을 호출할 수 있는 액세스를 부여하며, ARN과 버킷 이름을 `RuntimeConfig`에 등록하여 에이전트(런타임에 AppConfig를 통해)와 Game API(synth 시점에 `invocationUrl`을 통해) 모두 찾을 수 있게 합니다.
+이것은 CDK `AgentRuntimeArtifact`를 구성하여 에이전트 Docker 이미지를 ECR에 업로드하고 AgentCore Runtime을 사용하여 호스팅합니다. `--auth=cognito`를 선택했기 때문에 구성은 사용자 풀/클라이언트 identity를 요구하고 Cognito를 통해 AgentCore Runtime 호출을 인증하며 호출자의 `Authorization` 헤더를 전달합니다. 또한 Story Agent의 `session.py`가 런타임에 읽는 세션 버킷(CloudWatch Logs로 전달되는 서버 액세스 로그가 있는 KMS 암호화 S3 버킷)을 프로비저닝하고, 에이전트에 읽기/쓰기 액세스 권한을 부여하고, Bedrock 모델 호출 액세스 권한을 부여하며, ARN과 버킷 이름을 `RuntimeConfig`에 등록하여 에이전트(런타임에 AppConfig를 통해)와 Game API(synth 시점에 `invocationUrl`을 통해) 모두 찾을 수 있도록 합니다.
 
 `story` 프로젝트의 Docker 이미지를 참조하는 추가 `Dockerfile`이 있어 Dockerfile과 에이전트 소스 코드를 함께 배치할 수 있습니다.
 
 </details>
 
-##### Inventory 도구 설정
+##### Inventory 도구 설정하기
 
 ###### Inventory: TypeScript 프로젝트
 
-Story Agent가 플레이어의 인벤토리를 관리하는 도구를 제공하는 MCP 서버를 생성해 보겠습니다.
+Story Agent가 플레이어의 인벤토리를 관리할 수 있도록 도구를 제공하는 MCP 서버를 생성하겠습니다.
 
 먼저 TypeScript 프로젝트를 생성합니다:
 
@@ -910,7 +910,7 @@ Story Agent가 플레이어의 인벤토리를 관리하는 도구를 제공하�
 이렇게 하면 빈 TypeScript 프로젝트가 생성됩니다.
 
 <details>
-<summary>생성된 `ts#project` 파일 자세히 살펴보기</summary>
+<summary>생성된 `ts#project` 파일을 자세히 살펴보기</summary>
 
 `ts#project` 제너레이터는 다음 파일들을 생성합니다.
 
@@ -918,26 +918,26 @@ Story Agent가 플레이어의 인벤토리를 관리하는 도구를 제공하�
 - packages/
   - inventory/
     - src/
-      - index.ts 예시 함수가 있는 진입점
-    - project.json 프로젝트 설정
-    - vitest.config.mts 테스트 설정
-    - tsconfig.json 프로젝트의 기본 TypeScript 설정
-    - tsconfig.lib.json 컴파일 및 번들링을 위한 TypeScript 설정
-    - tsconfig.spec.json 테스트를 위한 TypeScript 설정
-- tsconfig.base.json 다른 프로젝트가 이를 참조할 수 있도록 별칭 설정 업데이트
+      - index.ts 예제 함수가 있는 진입점
+    - project.json 프로젝트 구성
+    - vitest.config.mts 테스트 구성
+    - tsconfig.json 프로젝트의 기본 typescript 구성
+    - tsconfig.lib.json 컴파일 및 번들링을 위한 typescript 구성
+    - tsconfig.spec.json 테스트를 위한 typescript 구성
+- tsconfig.base.json 다른 프로젝트가 이를 참조할 수 있도록 별칭 구성 업데이트
 </FileTree>
 
 </details>
 
 ###### Inventory: MCP 서버
 
-다음으로 TypeScript 프로젝트에 MCP 서버를 추가합니다:
+다음으로 TypeScript 프로젝트에 MCP 서버를 추가하겠습니다:
 
 <RunGenerator generator="ts#mcp-server" requiredParameters={{project:"inventory"}} noInteractive />
 
 이렇게 하면 MCP 서버가 추가됩니다.
 <details>
-<summary>생성된 `ts#mcp-server` 파일 자세히 살펴보기</summary>
+<summary>생성된 `ts#mcp-server` 파일을 자세히 살펴보기</summary>
 
 `ts#mcp-server` 제너레이터는 다음 파일들을 생성합니다.
 
@@ -948,13 +948,13 @@ Story Agent가 플레이어의 인벤토리를 관리하는 도구를 제공하�
       - index.ts 배럴 내보내기
       - server.ts MCP 서버 생성
       - tools/
-        - divide.ts 예시 도구
+        - divide.ts 예제 도구
       - resources/
-        - sample-guidance.ts 예시 리소스
+        - sample-guidance.ts 예제 리소스
       - stdio.ts STDIO 전송을 사용하는 MCP 진입점
       - http.ts Streamable HTTP 전송을 사용하는 MCP 진입점
       - Dockerfile AgentCore Runtime에 배포하기 위한 이미지 빌드
-    - rolldown.config.ts AgentCore에 배포하기 위한 MCP 서버 번들링 설정
+    - rolldown.config.ts AgentCore에 배포하기 위한 MCP 서버 번들링 구성
   - common/constructs/
     - src
       - app/mcp-servers/inventory-mcp-server/
@@ -963,31 +963,31 @@ Story Agent가 플레이어의 인벤토리를 관리하는 도구를 제공하�
 
 </details>
 
-##### 게임 데이터베이스 생성
+##### 게임 데이터베이스 생성하기
 
-게임 상태 — 저장된 게임과 각 플레이어의 인벤토리 — 는 [Amazon DynamoDB](https://aws.amazon.com/dynamodb/)에 저장됩니다. `ts#dynamodb` 제너레이터로 `DungeonDb`라는 DynamoDB 프로젝트를 생성합니다:
+게임 상태(저장된 게임 및 각 플레이어의 인벤토리)는 [Amazon DynamoDB](https://aws.amazon.com/dynamodb/)에 저장됩니다. `ts#dynamodb` 제너레이터를 사용하여 `DungeonDb`라는 DynamoDB 프로젝트를 생성합니다:
 
 <RunGenerator generator="ts#dynamodb" requiredParameters={{name:"DungeonDb"}} noInteractive />
 
 :::tip[로컬 우선 개발]
-`ts#dynamodb` 제너레이터는 컨테이너에서 [DynamoDB Local](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html)을 실행하는 `dev` 타겟을 제공합니다. 아래에서 실행하는 `connection` 제너레이터와 결합하면, **튜토리얼 끝까지 배포 없이 전체 게임이 로컬 머신에서 실행됩니다**.
+`ts#dynamodb` 제너레이터는 컨테이너에서 [DynamoDB Local](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html)을 실행하는 `dev` 타겟을 제공합니다. 아래에서 실행할 `connection` 제너레이터와 결합하면 **튜토리얼 끝까지 배포 없이 전체 게임이 로컬 머신에서 실행됩니다**.
 :::
 
 파일 트리에 새 파일들이 나타나는 것을 볼 수 있습니다.
 <details>
-<summary>생성된 `ts#dynamodb` 파일 자세히 살펴보기</summary>
+<summary>생성된 `ts#dynamodb` 파일을 자세히 살펴보기</summary>
 
 `ts#dynamodb` 제너레이터는 다음 파일들을 생성합니다.
 
 <FileTree>
 - packages/
   - dungeon-db/
-    - config.json 포트, 테이블 이름, 컨테이너 설정 및 글로벌 보조 인덱스를 포함한 DynamoDB 설정
+    - config.json 포트, 테이블 이름, 컨테이너 설정 및 Global Secondary Indexes를 포함한 DynamoDB 구성
     - src/
       - index.ts 진입점 및 내보내기
       - client.ts DynamoDB 클라이언트 싱글톤 및 테이블 이름 해결
       - entities/
-        - example.ts 예시 ElectroDB 엔티티 (이것을 교체할 예정)
+        - example.ts 예제 ElectroDB 엔티티 (이것을 교체할 예정)
         - index.ts 엔티티 내보내기
     - project.json `dev` 및 `pull-image` 타겟 추가
   - common/
@@ -995,7 +995,7 @@ Story Agent가 플레이어의 인벤토리를 관리하는 도구를 제공하�
       - src/
         - dynamodb/
           - create-local-table.ts DynamoDB Local에 테이블 생성
-          - pull-image.ts DynamoDB Local 이미지 풀
+          - pull-image.ts DynamoDB Local 이미지 가져오기
           - start-container.ts DynamoDB Local 컨테이너 시작
     - constructs/
       - src/
@@ -1005,39 +1005,39 @@ Story Agent가 플레이어의 인벤토리를 관리하는 도구를 제공하�
           - dynamodb.ts 일반 DynamoDB 테이블 구성
 </FileTree>
 
-생성된 `src/client.ts`는 `getDynamoDBClient()`와 `resolveTableName()`을 내보냅니다. `LOCAL_DEV=true`(`dev` 타겟에 의해 자동으로 설정됨)일 때는 DynamoDB Local에 연결하고, 그렇지 않으면 AWS에 연결하여 <Link path="guides/runtime-config">런타임 설정</Link>에서 배포된 테이블 이름을 해결합니다. <Link path="get_started/tutorials/dungeon-game/2">모듈 2</Link>에서 이 프로젝트에 `Game` 및 `Inventory` 엔티티를 모델링할 것입니다.
+생성된 `src/client.ts`는 `getDynamoDBClient()`와 `resolveTableName()`을 내보냅니다. `LOCAL_DEV=true`(자동으로 `dev` 타겟에 의해 설정됨)일 때 이들은 DynamoDB Local에 연결하고, 그렇지 않으면 AWS에 연결하고 <Link path="guides/runtime-config">Runtime Configuration</Link>에서 배포된 테이블 이름을 해결합니다. <Link path="get_started/tutorials/dungeon-game/2">모듈 2</Link>에서 이 프로젝트에 `Game` 및 `Inventory` 엔티티를 모델링할 것입니다.
 
 자세한 내용은 <Link path="guides/ts-dynamodb">ts#dynamodb 제너레이터 가이드</Link>를 참조하세요.
 
 </details>
 
-##### 사용자 인터페이스(UI) 생성
+##### 사용자 인터페이스(UI) 생성하기
 
-다음으로 게임과 상호작용할 수 있는 UI를 생성합니다.
+다음으로 게임과 상호 작용할 수 있는 UI를 생성하겠습니다.
 
 ###### Game UI: 웹사이트
 
-UI를 생성하려면 다음 단계를 따라 `GameUI`라는 웹사이트를 생성합니다:
+UI를 생성하려면 다음 단계를 사용하여 `GameUI`라는 웹사이트를 생성합니다:
 
 <RunGenerator generator="ts#website" requiredParameters={{name:"GameUI", ux:"shadcn"}} noInteractive />
 
 :::note[Shadcn UI]
-`--ux=shadcn`을 선택하면 생성된 웹사이트가 Tailwind로 스타일링된 [shadcn/ui](https://ui.shadcn.com/) 컴포넌트를 사용합니다 — 모든 라우트 코드는 `Card`, `Button`, `Input`과 같은 shadcn 프리미티브를 사용하며, 나중에 `connection` 제너레이터가 일치하는 shadcn 테마의 [CopilotKit](https://docs.copilotkit.ai/) 채팅 인터페이스를 연결합니다.
+`--ux=shadcn`을 선택하여 생성된 웹사이트가 Tailwind로 스타일이 지정된 [shadcn/ui](https://ui.shadcn.com/) 컴포넌트를 사용하도록 합니다. 모든 라우트 코드는 `Card`, `Button`, `Input`과 같은 shadcn 프리미티브를 사용하며, 나중에 `connection` 제너레이터가 일치하는 shadcn 테마의 [CopilotKit](https://docs.copilotkit.ai/) 채팅 표면을 연결합니다.
 :::
 
 파일 트리에 새 파일들이 나타나는 것을 볼 수 있습니다.
 
 <details>
-<summary>생성된 `ts#website` 파일 자세히 살펴보기</summary>
+<summary>생성된 `ts#website` 파일을 자세히 살펴보기</summary>
 
-`ts#website`는 다음 파일들을 생성합니다. 파일 트리에서 강조 표시된 주요 파일들을 살펴보겠습니다:
+`ts#website`는 다음 파일들을 생성합니다. 파일 트리에서 강조 표시된 주요 파일 중 일부를 살펴보겠습니다:
 
 <FileTree>
 - packages/
   - common/
     - constructs/
       - src/
-        - app/ 앱별 cdk 구성
+        - app/ 앱 특정 cdk 구성
           - static-websites/
             - **game-ui.ts** Game UI를 생성하는 cdk 구성
         - core/
@@ -1047,12 +1047,12 @@ UI를 생성하려면 다음 단계를 따라 `GameUI`라는 웹사이트를 생
     - src/
       - components/
         - AppLayout/
-          - index.tsx shadcn `SidebarProvider` + 헤더를 사용하는 전체 페이지 레이아웃
-        - app-sidebar.tsx 탐색 항목이 있는 기본 shadcn 사이드바
+          - index.tsx shadcn `SidebarProvider` + 헤더를 사용한 전체 페이지 레이아웃
+        - app-sidebar.tsx 네비게이션 항목이 있는 기본 shadcn 사이드바
         - alert.tsx, spinner.tsx shadcn으로 래핑된 피드백 프리미티브
       - routes/ @tanstack/react-router 파일 기반 라우트
         - **index.tsx** 루트 '/' 페이지
-        - __root.tsx 모든 페이지가 이 컴포넌트를 기반으로 사용
+        - __root.tsx 모든 페이지가 이 컴포넌트를 기본으로 사용
       - config.ts
       - **main.tsx** React 진입점
       - routeTree.gen.ts @tanstack/react-router에 의해 자동으로 업데이트됨
@@ -1062,7 +1062,7 @@ UI를 생성하려면 다음 단계를 따라 `GameUI`라는 웹사이트를 생
     - vite.config.mts
     - ...
   - common/
-    - shadcn/ 공유 shadcn/ui 라이브러리 (테마 토큰, `Button`, `Card`, `Input`, `Sidebar`, …) 모든 `ux=shadcn` 웹사이트에서 임포트
+    - shadcn/ 모든 `ux=shadcn` 웹사이트에서 임포트하는 공유 shadcn/ui 라이브러리 (테마 토큰, `Button`, `Card`, `Input`, `Sidebar`, …)
       - src/components/ui/*
       - src/styles/globals.css Tailwind + shadcn 디자인 토큰
     - ...
@@ -1072,11 +1072,17 @@ UI를 생성하려면 다음 단계를 따라 `GameUI`라는 웹사이트를 생
 // packages/common/constructs/src/app/static-websites/game-ui.ts
 import * as url from 'url';
 import { Construct } from 'constructs';
-import { StaticWebsite } from '../../core/index.js';
+import { StaticWebsite, StaticWebsiteProps } from '../../core/index.js';
+
+export type GameUIProps = Omit<
+  StaticWebsiteProps,
+  'websiteName' | 'websiteFilePath'
+>;
 
 export class GameUI extends StaticWebsite {
-  constructor(scope: Construct, id: string) {
+  constructor(scope: Construct, id: string, props?: GameUIProps) {
     super(scope, id, {
+      ...props,
       websiteName: 'GameUI',
       websiteFilePath: url.fileURLToPath(
         new URL(
@@ -1089,7 +1095,7 @@ export class GameUI extends StaticWebsite {
 }
 ```
 
-이것은 GameUI를 정의하는 CDK 구성입니다. Vite 기반 UI의 생성된 번들에 대한 파일 경로가 이미 설정되어 있습니다. 이는 `build` 시점에 game-ui 프로젝트의 빌드 타겟 내에서 번들링이 발생하고 그 출력이 여기서 사용됨을 의미합니다.
+이것은 GameUI를 정의하는 CDK 구성입니다. Vite 기반 UI의 생성된 번들에 대한 파일 경로가 이미 구성되어 있습니다. 이는 `build` 시점에 game-ui 프로젝트의 빌드 타겟 내에서 번들링이 발생하고 출력이 여기에서 사용됨을 의미합니다.
 
 ```tsx
 // packages/game-ui/src/main.tsx
@@ -1120,7 +1126,7 @@ root &&
   );
 ```
 
-이것은 React가 마운트되는 진입점입니다. 스타일링은 `styles.css`를 통해 임포트된 Tailwind v4 토큰에서 옵니다. `@tanstack/react-router`는 [파일 기반 라우팅](https://tanstack.com/router/v1/docs/framework/react/routing/file-based-routing) 모드로 설정됩니다: 개발 서버가 실행 중인 한, `routes/` 아래에 생성하는 모든 파일이 자동으로 감지되고 라우트 트리가 재생성됩니다. 이후 제너레이터(auth, connection)는 AST 패치를 통해 이 파일을 수정하여 `<App />`을 추가 프로바이더로 래핑합니다.
+이것은 React가 마운트되는 진입점입니다. 스타일링은 `styles.css`를 통해 임포트된 Tailwind v4 토큰에서 가져옵니다. `@tanstack/react-router`는 [파일 기반 라우팅](https://tanstack.com/router/v1/docs/framework/react/routing/file-based-routing) 모드로 구성됩니다: 개발 서버가 실행 중인 한 `routes/` 아래에 생성하는 모든 파일이 자동으로 선택되고 라우트 트리가 재생성됩니다. 나중 제너레이터(auth, connection)는 이 파일을 AST 패치하여 `<App />`를 추가 프로바이더로 래핑합니다.
 
 ```tsx
 // packages/game-ui/src/routes/index.tsx
@@ -1142,22 +1148,22 @@ function RouteComponent() {
 }
 ```
 
-`/` 라우트로 이동할 때 렌더링될 컴포넌트입니다. `@tanstack/react-router`는 이 파일을 생성/이동할 때마다(개발 서버가 실행 중인 한) `Route`를 관리합니다.
+`/` 라우트로 이동할 때 컴포넌트가 렌더링됩니다. `@tanstack/react-router`는 이 파일을 생성/이동할 때마다 `Route`를 관리합니다(개발 서버가 실행 중인 한).
 
 </details>
 
 ###### Game UI: 인증
 
-다음 단계를 따라 Amazon Cognito를 통한 인증된 액세스를 요구하도록 Game UI를 설정합니다:
+Amazon Cognito를 통한 인증된 액세스를 요구하도록 Game UI를 구성하겠습니다:
 
 <RunGenerator generator="ts#website#auth" requiredParameters={{cognitoDomain:"game-ui", project:"@dungeon-adventure/game-ui", allowSignup:true}} noInteractive />
 
 파일 트리에 새 파일들이 나타나거나 변경되는 것을 볼 수 있습니다.
 
 <details>
-<summary>생성된 `ts#website#auth` 파일 자세히 살펴보기</summary>
+<summary>생성된 `ts#website#auth` 파일을 자세히 살펴보기</summary>
 
-`ts#website#auth` 제너레이터는 다음 파일들을 업데이트/생성합니다. 파일 트리에서 강조 표시된 주요 파일들을 살펴보겠습니다:
+`ts#website#auth` 제너레이터는 다음 파일들을 업데이트/생성합니다. 파일 트리에서 강조 표시된 주요 파일 중 일부를 살펴보겠습니다:
 
 <FileTree>
 - packages/
@@ -1226,13 +1232,13 @@ root &&
   );
 ```
 
-`RuntimeConfigProvider`와 `CognitoAuth` 컴포넌트가 AST 변환을 통해 `main.tsx` 파일에 추가되었습니다. 이를 통해 `CognitoAuth` 컴포넌트가 백엔드 호출을 올바른 대상으로 보내기 위해 필요한 Cognito 연결 설정이 포함된 `runtime-config.json`을 가져와 Amazon Cognito로 인증할 수 있습니다.
+`RuntimeConfigProvider`와 `CognitoAuth` 컴포넌트가 AST 변환을 통해 `main.tsx` 파일에 추가되었습니다. 이를 통해 `CognitoAuth` 컴포넌트가 백엔드 호출을 올바른 대상으로 보내기 위해 필요한 cognito 연결 구성이 포함된 `runtime-config.json`을 가져와 Amazon Cognito로 인증할 수 있습니다.
 
 </details>
 
-###### Game UI: Game API 연결
+###### Game UI: Game API에 연결하기
 
-이전에 생성한 Game API에 Game UI를 연결합니다.
+이전에 생성한 Game API에 연결하도록 Game UI를 구성하겠습니다.
 
 <RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-ui", targetProject:"@dungeon-adventure/game-api"}} noInteractive />
 
@@ -1241,7 +1247,7 @@ root &&
 <details>
 <summary>UI → tRPC 연결 파일 살펴보기</summary>
 
-`connection` 제너레이터는 다음 파일들을 생성/업데이트합니다. 파일 트리에서 강조 표시된 주요 파일들을 살펴보겠습니다:
+`connection` 제너레이터는 다음 파일들을 생성/업데이트합니다. 파일 트리에서 강조 표시된 주요 파일 중 일부를 살펴보겠습니다:
 
 <FileTree>
 - packages/
@@ -1280,10 +1286,10 @@ export const useGameApiClient = () => {
 };
 ```
 
-이 훅은 GameApi를 호출하기 위한 tRPC 클라이언트에 대한 액세스를 제공합니다. tRPC API 호출 예시는 <Link path="guides/connection/react-trpc#using-the-generated-code">tRPC 훅 사용 가이드</Link>를 참조하세요.
+이 훅은 GameApi를 호출하기 위한 tRPC 클라이언트에 대한 액세스를 제공합니다. tRPC API 호출 예제는 <Link path="guides/connection/react-trpc#using-the-generated-code">tRPC 훅 사용 가이드</Link>를 참조하세요.
 
 <Aside title="타입 안전 훅">
-tRPC의 [TypeScript 추론](https://trpc.io/docs/concepts) 덕분에, `useGameApi`는 백엔드 변경 사항이 프론트엔드에 반영되기 위한 빌드 단계가 필요하지 않습니다 — 라우터나 프로시저에 대한 편집이 타입 검사기에 즉시 반영됩니다.
+tRPC의 [Typescript 추론](https://trpc.io/docs/concepts) 덕분에 `useGameApi`는 백엔드 변경 사항이 프론트엔드에 도달하기 위한 빌드 단계가 필요하지 않습니다. 라우터나 프로시저에 대한 편집은 타입 체커에 의해 즉시 선택됩니다.
 </Aside>
 
 ```diff lang="tsx"
@@ -1317,13 +1323,13 @@ root &&
   );
 ```
 
-`main.tsx` 파일이 AST 변환을 통해 tRPC 프로바이더를 주입하도록 업데이트되었습니다.
+`main.tsx` 파일이 AST 변환을 통해 업데이트되어 trpc 프로바이더를 주입합니다.
 
 </details>
 
-###### Story Agent: Inventory MCP 서버 연결
+###### Story Agent: Inventory MCP 서버에 연결하기
 
-에이전트가 MCP 서버의 도구를 발견하고 호출할 수 있도록 Story Agent를 Inventory MCP 서버에 연결합니다.
+에이전트가 MCP 서버의 도구를 발견하고 호출할 수 있도록 Story Agent를 Inventory MCP 서버에 연결하겠습니다.
 
 <RunGenerator generator="connection" requiredParameters={{sourceProject:"story", targetProject:"inventory"}} noInteractive />
 
@@ -1352,18 +1358,18 @@ root &&
 </FileTree>
 
 제너레이터는:
-- 핵심 `AgentCoreMCPClientStrands`를 포함하는 공유 `agent_connection` Python 프로젝트를 생성합니다(아직 없는 경우)
-- 로컬(직접 HTTP)과 배포 시(IAM 인증을 통한 AgentCore) 모두에서 MCP 서버에 연결하는 `InventoryMcpServerClientStrands` 클래스를 생성합니다
-- `agent.py`를 변환하여 클라이언트를 임포트하고, 인스턴스를 생성하고, MCP 서버의 도구를 에이전트에 연결합니다
-- `agent_connection` 프로젝트를 story 프로젝트의 워크스페이스 의존성으로 추가합니다
+- 핵심 `AgentCoreMCPClientStrands`를 포함하는 공유 `agent_connection` Python 프로젝트를 생성합니다(아직 존재하지 않는 경우)
+- 로컬(직접 HTTP) 및 배포 시(IAM 인증을 통한 AgentCore) 모두에서 MCP 서버에 연결하는 것을 처리하는 `InventoryMcpServerClientStrands` 클래스를 생성합니다
+- `agent.py`를 변환하여 클라이언트를 임포트하고 인스턴스를 생성하며 MCP 서버의 도구를 에이전트에 연결합니다
+- story 프로젝트의 워크스페이스 의존성으로 `agent_connection` 프로젝트를 추가합니다
 - 로컬에서 실행할 때 MCP 서버를 자동으로 시작하도록 `dev` 타겟을 업데이트합니다
 
 자세한 내용은 <Link path="guides/connection/py-agent-mcp">Python Agent to MCP 연결 가이드</Link>를 참조하세요.
 </details>
 
-###### Game UI: Story Agent 연결
+###### Game UI: Story Agent에 연결하기
 
-Game UI를 Story Agent에 연결합니다. 에이전트가 AG-UI를 사용하므로, `connection` 제너레이터는 [CopilotKit](https://docs.copilotkit.ai/)을 연결합니다: 테마가 적용된 채팅 컴포넌트와 렌더링 준비가 된 `@ag-ui/client` `HttpAgent`.
+Game UI를 Story Agent에 연결하겠습니다. 에이전트가 AG-UI를 사용하므로 `connection` 제너레이터는 [CopilotKit](https://docs.copilotkit.ai/)를 연결합니다: 테마가 적용된 채팅 컴포넌트와 렌더링할 준비가 된 `@ag-ui/client` `HttpAgent`.
 
 <RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-ui", targetProject:"story"}} noInteractive />
 
@@ -1382,43 +1388,43 @@ Game UI를 Story Agent에 연결합니다. 에이전트가 AG-UI를 사용하므
           - **index.tsx** Shadcn 테마의 `CopilotChat` / `CopilotSidebar` / `CopilotPopup`
           - ShadcnAssistantMessage.tsx, ShadcnUserMessage.tsx, ShadcnChatInput.tsx, ShadcnCursor.tsx, copilot.css
       - hooks/
-        - **useAguiStoryAgent.tsx** `HttpAgent`를 빌드하고, Cognito 베어러 토큰을 주입하며, `threadId`를 AgentCore의 33자 세션 ID로 패딩
+        - **useAguiStoryAgent.tsx** `HttpAgent`를 빌드하고 Cognito 베어러 토큰을 주입하며 `threadId`를 AgentCore의 33자 세션 id로 패딩
     - **main.tsx** `<App />`을 `<AguiProvider>`로 래핑
 
 </FileTree>
 
 제너레이터는:
 - React 웹사이트의 `ux`(여기서는 Shadcn)를 감지하고 일치하는 채팅 컴포넌트를 제공합니다.
-- 연결된 모든 에이전트를 단일 `CopilotKitProvider`에 등록합니다 — 다른 에이전트에 대해 다시 실행하면 다른 훅이 추가됩니다.
-- 런타임 설정에서 에이전트의 런타임 ARN을 읽고, AgentCore 호출 URL을 빌드하며, Cognito 베어러 토큰과 AgentCore 세션 ID 헤더를 첨부합니다.
+- 연결된 모든 에이전트를 단일 `CopilotKitProvider`에 등록합니다. 다른 에이전트에 대해 다시 실행하면 다른 훅만 추가됩니다.
+- Runtime Configuration에서 에이전트의 런타임 ARN을 읽고 AgentCore 호출 URL을 빌드하며 Cognito 베어러 토큰과 AgentCore 세션 id 헤더를 첨부합니다.
 
 자세한 내용은 <Link path="guides/connection/react-agui">React to AG-UI 연결 가이드</Link>를 참조하세요.
 </details>
 
-###### Game API와 Inventory MCP 서버를 데이터베이스에 연결
+###### Game API와 Inventory MCP 서버를 데이터베이스에 연결하기
 
-Game API와 Inventory MCP 서버 모두 DynamoDB 테이블을 읽고 씁니다. 따라서 이들을 `DungeonDb` 프로젝트에 연결합니다. `connection` 제너레이터는 대상이 `ts#dynamodb` 프로젝트임을 감지하고 각 소스 프로젝트의 `dev` 타겟이 DynamoDB Local을 자동으로 시작하도록 연결합니다.
+Game API와 Inventory MCP 서버 모두 DynamoDB 테이블을 읽고 쓰므로 `DungeonDb` 프로젝트에 연결하겠습니다. `connection` 제너레이터는 대상이 `ts#dynamodb` 프로젝트임을 감지하고 각 소스 프로젝트의 `dev` 타겟을 DynamoDB Local을 자동으로 시작하도록 연결합니다.
 
 <RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-api", targetProject:"@dungeon-adventure/dungeon-db"}} noInteractive />
 
 <RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/inventory", targetProject:"@dungeon-adventure/dungeon-db"}} noInteractive />
 
-<Aside type="tip" title="하나의 명령으로 전체 스택을 로컬에서 시작">
-Story Agent의 `agent-dev`는 이미 Inventory MCP 서버의 `mcp-server-dev`에 의존하고 있으며(`story → inventory` 연결을 통해), Game API와 MCP 서버 모두 이제 `dungeon-db:dev`에 의존합니다. 따라서 어떤 프로젝트의 `dev` 타겟을 실행하든 필요한 모든 의존성이 올바른 순서로 시작됩니다.
+<Aside type="tip" title="하나의 명령으로 전체 스택을 로컬에서 부팅">
+Story Agent의 `agent-dev`는 이미 Inventory MCP 서버의 `mcp-server-dev`에 의존하고(위의 `story → inventory` 연결을 통해), Game API와 MCP 서버 모두 이제 `dungeon-db:dev`에 의존하므로 어떤 프로젝트의 `dev` 타겟을 실행하든 필요한 모든 의존성을 올바른 순서로 시작합니다.
 </Aside>
 
 ###### Game UI: 인프라
 
-CDK 인프라를 위한 최종 서브 프로젝트를 생성합니다.
+CDK 인프라를 위한 최종 하위 프로젝트를 생성하겠습니다.
 
 <RunGenerator generator="ts#infra" requiredParameters={{name:"infra"}} noInteractive />
 
 파일 트리에 새 파일들이 나타나거나 변경되는 것을 볼 수 있습니다.
 
 <details>
-<summary>생성된 `ts#infra` 파일 자세히 살펴보기</summary>
+<summary>생성된 `ts#infra` 파일을 자세히 살펴보기</summary>
 
-`ts#infra` 제너레이터는 다음 파일들을 생성/업데이트합니다. 파일 트리에서 강조 표시된 주요 파일들을 살펴보겠습니다:
+`ts#infra` 제너레이터는 다음을 생성/업데이트합니다. 파일 트리에서 강조 표시된 주요 파일 중 일부를 살펴보겠습니다:
 
 <FileTree>
 - packages/
@@ -1431,9 +1437,9 @@ CDK 인프라를 위한 최종 서브 프로젝트를 생성합니다.
   - infra
     - src/
       - stages/
-        - **application-stage.ts** cdk 스택이 정의되는 곳
+        - **application-stage.ts** cdk 스택이 여기에 정의됨
       - stacks/
-        - **application-stack.ts** cdk 리소스가 정의되는 곳
+        - **application-stack.ts** cdk 리소스가 여기에 정의됨
       - **main.ts** 모든 스테이지를 정의하는 진입점
     - cdk.json
     - checkov.yml
@@ -1463,7 +1469,7 @@ new ApplicationStage(app, 'dungeon-adventure-infra-sandbox', {
 app.synth();
 ```
 
-<Aside type="tip" title="임포트 오류 수정">IDE에서 임포트 오류가 표시되는 경우, 이는 인프라 프로젝트에 `tsconfig.json`에 TypeScript 참조가 아직 설정되지 않았기 때문입니다. Nx는 빌드/컴파일이 실행되거나 `nx sync` 명령을 수동으로 실행할 때마다 이러한 참조를 *동적으로* 생성하도록 [설정](https://nx.dev/nx-api/js/generators/typescript-sync)되어 있습니다. 자세한 내용은 <Link path="guides/typescript-project#importing-your-library-code-in-other-projects">TypeScript 가이드</Link>를 참조하세요.</Aside>
+<Aside type="tip" title="임포트 오류 수정">IDE 내에서 임포트 오류가 표시되면 인프라 프로젝트의 `tsconfig.json`에 아직 Typescript 참조가 설정되지 않았기 때문입니다. Nx는 빌드/컴파일이 실행될 때마다 또는 `nx sync` 명령을 수동으로 실행하면 이러한 참조를 *동적으로* 생성하도록 [구성](https://nx.dev/nx-api/js/generators/typescript-sync)되어 있습니다. 자세한 내용은 <Link path="guides/typescript-project#importing-your-library-code-in-other-projects">Typescript 가이드</Link>를 참조하세요.</Aside>
 
 이것은 CDK 애플리케이션의 진입점입니다.
 
@@ -1481,15 +1487,15 @@ export class ApplicationStack extends Stack {
 }
 ```
 
-던전 어드벤처 게임을 빌드하기 위해 CDK 구성을 인스턴스화해 보겠습니다.
+던전 어드벤처 게임을 구축하기 위해 CDK 구성을 인스턴스화하겠습니다.
 
 </details>
 
 </Drawer>
 
-## 작업 3: 인프라 업데이트
+## 작업 3: 인프라 업데이트하기
 
-생성된 구성 중 일부를 인스턴스화하기 위해 `packages/infra/src/stacks/application-stack.ts`를 업데이트해 보겠습니다:
+생성된 구성 중 일부를 인스턴스화하기 위해 `packages/infra/src/stacks/application-stack.ts`를 업데이트하겠습니다:
 
 <E2EDiff before="dungeon-adventure/1/application-stack.ts.original.template" after="dungeon-adventure/1/application-stack.ts.template" lang="ts" />
 
@@ -1497,25 +1503,25 @@ export class ApplicationStack extends Stack {
 Game API에 기본 통합을 제공합니다. 기본적으로 API의 각 작업은 해당 작업을 처리하는 개별 Lambda 함수에 매핑됩니다.
 :::
 
-## 작업 4: 코드 빌드
+## 작업 4: 코드 빌드하기
 
-<Drawer title="Nx 명령어" trigger="이제 처음으로 코드를 빌드할 시간입니다">
+<Drawer title="Nx 명령" trigger="이제 처음으로 코드를 빌드할 시간입니다">
 
 ###### 단일 vs 다중 타겟
 
-`run-many` 명령어는 여러 나열된 서브 프로젝트에서 타겟을 실행합니다(`--all`은 모두를 대상으로 합니다). 이렇게 하면 의존성이 올바른 순서로 실행됩니다.
+`run-many` 명령은 나열된 여러 하위 프로젝트에서 타겟을 실행합니다(`--all`은 모두를 대상으로 함). 이렇게 하면 의존성이 올바른 순서로 실행됩니다.
 
-단일 프로젝트 타겟에 대한 빌드(또는 다른 작업)를 직접 프로젝트에서 실행하여 트리거할 수도 있습니다. 예를 들어, `@dungeon-adventure/infra` 프로젝트를 빌드하려면 다음 명령어를 실행합니다:
-
-<NxCommands commands={['build infra']} />
-
-범위를 생략하고 원하는 경우 Nx 단축 구문을 사용할 수도 있습니다:
+프로젝트에서 직접 타겟을 실행하여 단일 프로젝트 타겟에 대한 빌드(또는 다른 작업)를 트리거할 수도 있습니다. 예를 들어 `@dungeon-adventure/infra` 프로젝트를 빌드하려면 다음 명령을 실행하세요:
 
 <NxCommands commands={['build infra']} />
 
-###### 의존성 시각화
+원하는 경우 스코프를 생략하고 Nx 단축 구문을 사용할 수도 있습니다:
 
-의존성을 시각화하려면 다음을 실행합니다:
+<NxCommands commands={['build infra']} />
+
+###### 의존성 시각화하기
+
+의존성을 시각화하려면 다음을 실행하세요:
 
 <NxCommands commands={['graph']} />
 <br/>
@@ -1524,20 +1530,20 @@ Game API에 기본 통합을 제공합니다. 기본적으로 API의 각 작업�
 
 ###### 캐싱
 
-Nx는 [캐싱](https://nx.dev/concepts/how-caching-works)을 사용하여 이전 빌드의 아티팩트를 재사용하여 개발 속도를 높입니다. 이를 올바르게 작동시키기 위한 일부 설정이 필요하며, **캐시를 사용하지 않고** 빌드를 수행하고 싶은 경우가 있을 수 있습니다. 그렇게 하려면 명령어에 `--skip-nx-cache` 인수를 추가하면 됩니다. 예를 들어:
+Nx는 [캐싱](https://nx.dev/concepts/how-caching-works)에 의존하여 이전 빌드의 아티팩트를 재사용하여 개발 속도를 높일 수 있습니다. 이것이 올바르게 작동하려면 일부 구성이 필요하며 **캐시를 사용하지 않고** 빌드를 수행하려는 경우가 있을 수 있습니다. 그렇게 하려면 명령에 `--skip-nx-cache` 인수를 추가하기만 하면 됩니다. 예를 들어:
 
 <NxCommands commands={['build infra --skip-nx-cache']} />
-어떤 이유로든 캐시(`.nx` 폴더에 저장됨)를 지우고 싶다면 다음 명령어를 실행할 수 있습니다:
+어떤 이유로든 캐시(`.nx` 폴더에 저장됨)를 지우려면 다음 명령을 실행할 수 있습니다:
 
 <NxCommands commands={['reset']} />
 
 </Drawer>
 
-명령줄을 사용하여 먼저 린트 문제를 수정하는 다음 명령어를 실행합니다:
+명령줄을 사용하여 다음 명령을 실행하여 먼저 린트 문제를 수정하세요:
 
 <PackageManagerShortCommand commands={["lint"]} />
 
-그런 다음 전체 빌드를 위해 다음 명령어를 실행합니다:
+그런 다음 전체 빌드를 위해 다음 명령을 실행하세요:
 
 <PackageManagerShortCommand commands={["build"]} />
 
@@ -1555,10 +1561,10 @@ Yes, sync the changes and run the tasks
 No, run the tasks without syncing the changes
 ```
 
-이 메시지는 NX가 자동으로 업데이트할 수 있는 일부 파일을 감지했음을 나타냅니다. 이 경우, 참조 프로젝트에 TypeScript 참조가 설정되지 않은 `tsconfig.json` 파일을 가리킵니다.
+이 메시지는 NX가 자동으로 업데이트할 수 있는 일부 파일을 감지했음을 나타냅니다. 이 경우 참조 프로젝트에 Typescript 참조가 설정되지 않은 `tsconfig.json` 파일을 가리킵니다.
 
-**Yes, sync the changes and run the tasks** 옵션을 선택하여 진행합니다. sync 제너레이터가 누락된 TypeScript 참조를 자동으로 추가하면서 IDE 관련 임포트 오류가 자동으로 해결되는 것을 볼 수 있습니다!
+**Yes, sync the changes and run the tasks** 옵션을 선택하여 진행하세요. sync 제너레이터가 누락된 typescript 참조를 자동으로 추가하면서 IDE 관련 임포트 오류가 자동으로 해결되는 것을 확인할 수 있습니다!
 
-모든 빌드 아티팩트는 이제 모노레포 루트에 위치한 `dist/` 폴더 내에서 사용 가능합니다. 이는 `@aws/nx-plugin`이 생성한 프로젝트를 사용할 때의 표준 관행으로, 파일 트리에 생성된 파일이 흩어지지 않습니다. 파일을 정리하고 싶다면 파일 트리 전체에 빌드 아티팩트가 흩어질 걱정 없이 `dist/` 폴더를 삭제하면 됩니다.
+모든 빌드 아티팩트는 이제 모노레포 루트에 위치한 `dist/ folder` 내에서 사용할 수 있습니다. 이는 `@aws/nx-plugin`에서 생성된 프로젝트를 사용할 때의 표준 관행으로 파일 트리에 생성된 파일이 흩어지지 않습니다. 파일을 정리하려는 경우 빌드 아티팩트가 파일 트리 전체에 흩어져 있는 것에 대해 걱정하지 않고 `dist/` 폴더를 삭제하세요.
 
-축하합니다! AI 던전 어드벤처 게임의 핵심을 구현하는 데 필요한 모든 하위 프로젝트를 생성했습니다. 🎉🎉🎉
+축하합니다! AI 던전 어드벤처 게임의 핵심을 구현하기 시작하는 데 필요한 모든 하위 프로젝트를 생성했습니다. 🎉🎉🎉

--- a/docs/src/content/docs/ko/guides/react-website.mdx
+++ b/docs/src/content/docs/ko/guides/react-website.mdx
@@ -22,7 +22,7 @@ import OptionFilter from '@components/option-filter.astro';
 
 생성된 애플리케이션은 빌드 도구 및 번들러로 [Vite](https://vite.dev/)를 사용합니다. 타입 안전 라우팅을 위해 [TanStack Router](https://tanstack.com/router/v1)를 사용합니다.
 
-:::note[UX Provider]
+:::note[UX 프로바이더]
 기본 `ux`는 [shadcn/ui](https://ui.shadcn.com/)입니다. [Cloudscape](http://cloudscape.design/) 또는 `none`(자체 컴포넌트 라이브러리 사용)을 선택할 수도 있습니다.
 :::
 
@@ -51,7 +51,7 @@ import OptionFilter from '@components/option-filter.astro';
     - components
       - AppLayout 전체 레이아웃 및 네비게이션 바를 위한 컴포넌트
     - hooks
-      - useAppLayout.tsx 중첩된 컴포넌트에서 AppLayout을 조정하기 위한 훅 (Cloudscape만 해당)
+      - useAppLayout.tsx 중첩된 컴포넌트에서 AppLayout을 조정하기 위한 훅 (Cloudscape 전용)
     - routes
       - index.tsx TanStack Router를 위한 예제 라우트 (또는 페이지)
     - styles.css 전역 스타일
@@ -70,7 +70,7 @@ import OptionFilter from '@components/option-filter.astro';
 
 <Snippet name="shared-constructs" />
 
-생성기는 선택한 `iac`에 따라 웹사이트를 배포하기 위한 코드형 인프라를 생성합니다:
+생성기는 선택한 `iac`에 따라 웹사이트 배포를 위한 코드형 인프라를 생성합니다:
 
 <Infrastructure>
 <Fragment slot="cdk">
@@ -80,7 +80,7 @@ import OptionFilter from '@components/option-filter.astro';
       - static-websites
         - \<name>.ts 웹사이트에 특화된 인프라
     - core
-      - static-website.ts 일반 StaticWebsite 구성
+      - static-website.ts 범용 StaticWebsite 구성
 </FileTree>
 </Fragment>
 <Fragment slot="terraform">
@@ -92,7 +92,7 @@ import OptionFilter from '@components/option-filter.astro';
           - \<name>.tf 웹사이트에 특화된 모듈
     - core
       - static-website
-        - static-website.tf 일반 정적 웹사이트 모듈
+        - static-website.tf 범용 정적 웹사이트 모듈
 </FileTree>
 </Fragment>
 </Infrastructure>
@@ -131,7 +131,7 @@ cloudfront -> s3
 
 ## 웹사이트 구현
 
-[React 문서](https://react.dev/learn)는 React로 빌드하는 기본 사항을 배우기 좋은 시작점입니다.
+[React 문서](https://react.dev/learn)는 React로 빌드하는 기본 사항을 배우기 좋은 출발점입니다.
 
 <OptionFilter when={{ ux: 'cloudscape' }} description="Cloudscape component docs pointer">
 사용 가능한 컴포넌트와 사용 방법에 대한 자세한 내용은 [Cloudscape 문서](https://cloudscape.design/components/)를 참조하세요.
@@ -155,7 +155,7 @@ cloudfront -> s3
 
 #### 페이지 간 탐색
 
-`Link` 컴포넌트 또는 `useNavigate` 훅을 사용하여 페이지 간 탐색할 수 있습니다:
+페이지 간 탐색을 위해 `Link` 컴포넌트 또는 `useNavigate` 훅을 사용할 수 있습니다:
 
 ```tsx {1, 4, 8-9, 14}
 import { Link, useNavigate } from '@tanstack/react-router';
@@ -206,7 +206,7 @@ export class ApplicationStack extends Stack {
 
 이는 다음을 설정합니다:
 
-1. 정적 웹사이트 파일을 호스팅하기 위한 S3 버킷
+1. 정적 웹사이트 파일 호스팅을 위한 S3 버킷
 2. 글로벌 콘텐츠 전송을 위한 CloudFront 배포
 3. 보안 보호를 위한 WAF Web ACL
 4. 안전한 S3 액세스를 위한 Origin Access Control
@@ -230,14 +230,14 @@ module "my_website" {
 
 이는 다음을 설정합니다:
 
-1. 정적 웹사이트 파일을 호스팅하기 위한 S3 버킷
+1. 정적 웹사이트 파일 호스팅을 위한 S3 버킷
 2. 글로벌 콘텐츠 전송을 위한 CloudFront 배포
 3. 보안 보호를 위한 WAF Web ACL (us-east-1에 배포)
 4. 안전한 S3 액세스를 위한 Origin Access Control
 5. 웹사이트 파일 및 런타임 구성의 자동 배포
 
-:::note[WAF Provider 리전]
-`aws.us_east_1` 프로바이더는 CloudFront 및 WAF 리소스에 필요하며, 이들은 us-east-1 리전에 배포되어야 합니다. Terraform 구성에 이 프로바이더가 포함되어 있는지 확인하세요:
+:::note[WAF 프로바이더 리전]
+`aws.us_east_1` 프로바이더는 CloudFront 및 WAF 리소스에 필요하며, us-east-1 리전에 배포되어야 합니다. Terraform 구성에 이 프로바이더가 포함되어 있는지 확인하세요:
 
 ```hcl title="packages/infra/src/providers.tf"
 provider "aws" {
@@ -253,13 +253,13 @@ provider "aws" {
 
 CloudFront 배포는 모든 응답에 `Strict-Transport-Security`, `X-Content-Type-Options`, `X-Frame-Options: DENY`, `Referrer-Policy` 및 `Content-Security-Policy`를 설정하는 응답 헤더 정책을 적용합니다.
 
-기본 `Content-Security-Policy`가 적용됩니다. 이는 XSS 및 클릭재킹을 완화하기 위해 스크립트와 프레이밍을 제한하면서, 배포 시점에만 알 수 있는 URL을 가진 AWS 서비스 엔드포인트(예: API Gateway, Cognito 및 Bedrock AgentCore)를 웹사이트가 호출할 수 있도록 HTTPS 및 WSS 연결을 허용합니다. 정책을 조정하려면(예: `connect-src`를 특정 출처로 강화) 생성된 `static-website.ts`(CDK) 또는 `static-website.tf`(Terraform)에서 `content_security_policy` 값을 편집하세요.
+기본 `Content-Security-Policy`가 적용됩니다. 이는 XSS 및 클릭재킹을 완화하기 위해 스크립트와 프레이밍을 제한하면서, 배포 시점에만 알 수 있는 URL을 가진 AWS 서비스 엔드포인트(API Gateway, Cognito, Bedrock AgentCore 등)를 웹사이트가 호출할 수 있도록 HTTPS 및 WSS 연결을 허용합니다. 정책을 조정하려면(예: `connect-src`를 특정 원본으로 강화) 생성된 `static-website.ts`(CDK) 또는 `static-website.tf`(Terraform)의 `content_security_policy` 값을 편집하세요.
 
 `runtime-config.json`은 `Cache-Control: no-cache`로 제공되어 브라우저가 재배포 후 캐시된 오래된 복사본을 사용하는 대신 항상 최신 구성을 가져오도록 합니다.
 
 ### WAF
 
-CloudFront 배포는 기본적으로 [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACL로 보호됩니다. Web ACL은 AWS 관리형 기본 규칙 세트([`AWSManagedRulesCommonRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs) 및 [`AWSManagedRulesKnownBadInputsRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs))를 사용하여 OWASP Top 10을 포함한 일반적인 웹 취약점에 대한 보호를 제공합니다.
+CloudFront 배포는 기본적으로 [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACL로 보호됩니다. Web ACL은 AWS 관리형 기본 규칙 세트([`AWSManagedRulesCommonRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs) 및 [`AWSManagedRulesKnownBadInputsRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs))를 사용하여 OWASP Top 10을 포함한 일반적인 웹 익스플로잇에 대한 보호를 제공합니다.
 
 <Infrastructure>
 <Fragment slot="cdk">
@@ -311,7 +311,7 @@ module "my_website" {
 
 ### 버킷 암호화
 
-웹사이트 버킷, CloudFront 배포 로그 버킷, 그리고 서버 액세스 로그를 수신하는 CloudWatch Logs 그룹은 기본적으로 고객 관리형 [AWS KMS](https://aws.amazon.com/kms/) 키로 암호화됩니다. 이 키는 키 교체가 활성화된 상태로 자동으로 생성됩니다.
+웹사이트 버킷, CloudFront 배포 로그 버킷, 서버 액세스 로그를 수신하는 CloudWatch Logs 그룹은 기본적으로 고객 관리형 [AWS KMS](https://aws.amazon.com/kms/) 키로 암호화됩니다. 이 키는 키 로테이션이 활성화된 상태로 자동으로 생성됩니다.
 
 <Infrastructure>
 <Fragment slot="cdk">
@@ -334,6 +334,22 @@ export class ApplicationStack extends Stack {
 }
 ```
 
+:::caution[S3_MANAGED 사용 시 CKV_AWS_158 억제]
+`BucketEncryption.S3_MANAGED`를 선택하면 액세스 로그 그룹이 더 이상 KMS로 암호화되지 않아 `checkov` 보안 스캔이 `CKV_AWS_158`로 실패합니다. 억제하세요:
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { LogGroup } from 'aws-cdk-lib/aws-logs';
+import { suppressRules } from '@my-scope/common-constructs';
+
+suppressRules(
+  website,
+  ['CKV_AWS_158'],
+  'Access log group is not KMS encrypted when encryption is S3_MANAGED',
+  (c) => c instanceof LogGroup,
+);
+```
+:::
+
 자동으로 생성되는 대신 자체 KMS 키를 사용하려면 `encryptionKey`를 전달하세요:
 
 ```ts {2}
@@ -342,10 +358,36 @@ new MyWebsite(this, 'MyWebsite', {
 });
 ```
 
-`enableKeyRotation`(기본값 `true`)은 자동으로 생성된 키에만 적용됩니다. 즉, `encryption`이 `BucketEncryption.KMS`(기본값)이고 `encryptionKey`가 제공되지 않은 경우입니다.
+:::caution[가져온 키에는 자체 권한이 필요]
+`Key.fromKeyArn`을 통해 가져온 키는 자체 키 정책에서 CloudWatch Logs, S3 및 CloudFront 서비스 주체에게 필요한 권한을 이미 부여해야 합니다. `addToResourcePolicy`는 가져온 키에서 no-op이므로 이 구성이 대신 권한을 부여할 수 없으며, `cdk synth`는 경고하지 않습니다 - 실패는 배포 시점에만 나타납니다. 동일한 앱에서 생성된 키(`new Key(this, 'WebsiteKey')`)는 CDK가 정책을 직접 업데이트할 수 있으므로 이 문제가 없습니다.
+:::
+
+`enableKeyRotation`(기본값 `true`)은 자동으로 생성된 키에만 적용됩니다. 즉, `encryption`이 `BucketEncryption.KMS`(기본값)이고 `encryptionKey`가 제공되지 않은 경우입니다:
+
+```ts {2}
+new MyWebsite(this, 'MyWebsite', {
+  enableKeyRotation: false,
+});
+```
+
+:::caution[키 로테이션 비활성화 시 CKV_AWS_7 억제]
+자동으로 생성된 키에서 키 로테이션을 비활성화하면 `checkov` 보안 스캔이 `CKV_AWS_7`로 실패합니다. 억제하세요:
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { Key } from 'aws-cdk-lib/aws-kms';
+import { suppressRules } from '@my-scope/common-constructs';
+
+suppressRules(
+  website,
+  ['CKV_AWS_7'],
+  'Key rotation is managed externally',
+  (c) => c instanceof Key,
+);
+```
+:::
 </Fragment>
 <Fragment slot="terraform">
-다른 암호화 구성을 사용하려면 `encryption`, `kms_key_arn` 및 `enable_key_rotation` 변수를 설정하세요:
+다른 암호화 구성을 사용하려면 `encryption`, `kms_key_arn`, `create_kms_key` 및 `enable_key_rotation` 변수를 설정하세요:
 
 ```hcl title="packages/infra/src/main.tf" {7}
 module "my_website" {
@@ -358,13 +400,56 @@ module "my_website" {
 }
 ```
 
-자동으로 생성되는 대신 자체 KMS 키를 사용하려면 `kms_key_arn`을 전달하세요. 고객이 제공한 키는 자체 키 정책에서 CloudWatch Logs, S3 및 CloudFront 서비스 주체에게 필요한 권한을 이미 부여해야 합니다.
+:::caution[Checkov: S3_MANAGED]
+`S3_MANAGED`를 선택하면 웹사이트 및 배포 로그 버킷에서 `checkov` 보안 스캔이 `CKV_AWS_145`로 실패합니다. 제공된 `test` 타겟은 `--config-file`을 허용하지 않지만, `checkov`는 작업 디렉토리에서 `.checkov.yaml`을 자동으로 발견하므로 `packages/infra/src`에 하나를 추가하세요:
 
-`enable_key_rotation`(기본값 `true`)은 자동으로 생성된 키에만 적용됩니다. 즉, `encryption`이 `"KMS"`(기본값)이고 `kms_key_arn`이 제공되지 않은 경우입니다.
+```yaml title="packages/infra/src/.checkov.yaml"
+skip-check:
+  - CKV_AWS_145
+```
+:::
+
+자동으로 생성되는 대신 자체 KMS 키를 사용하려면 `kms_key_arn`을 전달하고 `create_kms_key`를 `false`로 설정하세요:
+
+```hcl title="packages/infra/src/main.tf" {7-8}
+module "my_website" {
+  source = "../../common/terraform/src/app/static-websites/my-website"
+
+  providers = {
+    aws.us_east_1 = aws.us_east_1
+  }
+  kms_key_arn    = aws_kms_key.website.arn
+  create_kms_key = false
+}
+```
+
+고객이 제공한 키는 자체 키 정책에서 CloudWatch Logs, S3 및 CloudFront 서비스 주체에게 필요한 권한을 이미 부여해야 합니다.
+
+`enable_key_rotation`(기본값 `true`)은 자동으로 생성된 키에만 적용됩니다. 즉, `encryption`이 `"KMS"`(기본값)이고 `create_kms_key`가 `true`인 경우입니다:
+
+```hcl title="packages/infra/src/main.tf" {7}
+module "my_website" {
+  source = "../../common/terraform/src/app/static-websites/my-website"
+
+  providers = {
+    aws.us_east_1 = aws.us_east_1
+  }
+  enable_key_rotation = false
+}
+```
+
+:::caution[Checkov: 키 로테이션 비활성화]
+자동으로 생성된 키에서 키 로테이션을 비활성화하면 `checkov` 보안 스캔이 `CKV_AWS_7`로 실패합니다. 동일한 `.checkov.yaml`에 추가하세요:
+
+```yaml title="packages/infra/src/.checkov.yaml"
+skip-check:
+  - CKV_AWS_7
+```
+:::
 </Fragment>
 </Infrastructure>
 
-### 사용자 지정 도메인 및 TLS
+### 사용자 정의 도메인 및 TLS
 
 기본적으로 배포는 기본 CloudFront 도메인 이름(`*.cloudfront.net`)과 기본 인증서를 사용하며, 이는 최소 TLS 버전 1.2 적용을 지원하지 않습니다. 자체 도메인에서 웹사이트를 제공하려면 [ACM 인증서](https://docs.aws.amazon.com/acm/latest/userguide/acm-overview.html)(CloudFront와 함께 사용하려면 `us-east-1`에 있어야 함)와 도메인 이름을 제공하세요. 그러면 뷰어에 대해 최소 TLS 버전 1.2가 적용됩니다:
 
@@ -418,7 +503,7 @@ module "my_website" {
 
 <Infrastructure>
 <Fragment slot="cdk">
-`RuntimeConfig` CDK 구성을 사용하여 CDK 인프라에서 구성을 추가하고 검색할 수 있습니다. `@aws/nx-plugin` 생성기(<Link path="guides/trpc">`ts#api`</Link> 및 <Link path="guides/fastapi">`py#api`</Link>와 같은)가 생성한 CDK 구성은 자동으로 `RuntimeConfig`에 적절한 값을 추가합니다.
+`RuntimeConfig` CDK 구성을 사용하여 CDK 인프라에서 구성을 추가하고 검색할 수 있습니다. `@aws/nx-plugin` 생성기(<Link path="guides/trpc">`ts#api`</Link> 및 <Link path="guides/fastapi">`py#api`</Link> 등)가 생성한 CDK 구성은 자동으로 `RuntimeConfig`에 적절한 값을 추가합니다.
 
 웹사이트 CDK 구성은 런타임 구성의 `connection` 네임스페이스를 S3 버킷의 루트에 `runtime-config.json` 파일로 배포합니다.
 
@@ -443,11 +528,11 @@ export class ApplicationStack extends Stack {
 ```
 
 :::note[CDK 웹사이트 구성]
-CDK를 사용하면 웹사이트 구성을 스택의 어느 지점에서든 선언할 수 있습니다. 런타임 구성은 합성 시점에 지연 해결되므로 선언 순서에 관계없이 모든 값이 포함됩니다.
+CDK를 사용하면 웹사이트 구성을 스택의 어느 지점에서나 선언할 수 있습니다. 런타임 구성은 합성 시점에 지연 해결되므로 선언 순서에 관계없이 모든 값이 포함됩니다.
 :::
 </Fragment>
 <Fragment slot="terraform">
-Terraform을 사용하면 런타임 구성은 runtime-config 모듈을 통해 관리됩니다. `@aws/nx-plugin` 생성기(<Link path="guides/trpc">`ts#api`</Link> 및 <Link path="guides/fastapi">`py#api`</Link>와 같은)가 생성한 Terraform 모듈은 자동으로 런타임 구성에 적절한 값을 추가합니다.
+Terraform을 사용하면 런타임 구성은 runtime-config 모듈을 통해 관리됩니다. `@aws/nx-plugin` 생성기(<Link path="guides/trpc">`ts#api`</Link> 및 <Link path="guides/fastapi">`py#api`</Link> 등)가 생성한 Terraform 모듈은 자동으로 런타임 구성에 적절한 값을 추가합니다.
 
 웹사이트 Terraform 모듈은 런타임 구성의 `connection` 네임스페이스를 S3 버킷의 루트에 `runtime-config.json` 파일로 배포합니다.
 
@@ -503,21 +588,21 @@ const MyComponent = () => {
 
 ### 로컬 런타임 구성
 
-[로컬 개발 서버](#local-development-server)를 실행할 때 로컬 웹사이트가 백엔드 URL, ID 구성 등을 알 수 있도록 `public` 디렉토리에 `runtime-config.json` 파일이 필요합니다.
+[로컬 개발 서버](#local-development-server)를 실행할 때 로컬 웹사이트가 백엔드 URL, 신원 구성 등을 알 수 있도록 `public` 디렉토리에 `runtime-config.json` 파일이 필요합니다.
 
 웹사이트 프로젝트는 배포된 애플리케이션에서 `runtime-config.json` 파일을 가져오는 데 사용할 수 있는 `load-runtime-config` 타겟으로 구성되어 있습니다:
 
 <NxCommands commands={['load-runtime-config <my-website>']} />
 
-:::note[사용자 지정 스테이지 이름]
+:::note[사용자 정의 스테이지 이름]
 <Infrastructure>
 <Fragment slot="cdk">
-인프라 프로젝트의 `src/main.ts`에서 스테이지 이름의 접두사를 변경하는 경우, 웹사이트의 `project.json` 파일에서 `load-runtime-config` 타겟을 그에 맞게 업데이트해야 합니다.
+인프라 프로젝트의 `src/main.ts`에서 스테이지 이름의 접두사를 변경하는 경우 웹사이트의 `project.json` 파일에서 `load-runtime-config` 타겟을 그에 따라 업데이트해야 합니다.
 
-또한 `load-runtime-config` 타겟은 AWS 자격 증명이 있는 환경에 애플리케이션의 단일 스테이지가 배포되어 있다고 가정한다는 점에 유의할 가치가 있습니다. 동일한 계정과 리전에 여러 스테이지를 배포하는 경우 명령을 조정해야 합니다.
+또한 `load-runtime-config` 타겟은 AWS 자격 증명이 있는 환경에 애플리케이션의 단일 스테이지가 배포되어 있다고 가정합니다. 동일한 계정 및 리전에 여러 스테이지를 배포하는 경우 명령을 조정해야 합니다.
 </Fragment>
 <Fragment slot="terraform">
-Terraform 프로젝트의 경우 `load-runtime-config` 타겟은 가장 최근의 로컬 `terraform apply` 이후에 생성된 `runtime-config.json` 파일을 복사합니다.
+Terraform 프로젝트의 경우 `load-runtime-config` 타겟은 가장 최근의 로컬 `terraform apply` 후에 생성된 `runtime-config.json` 파일을 복사합니다.
 </Fragment>
 </Infrastructure>
 :::
@@ -528,11 +613,11 @@ Terraform 프로젝트의 경우 `load-runtime-config` 타겟은 가장 최근�
 
 <NxCommands commands={['dev <my-website>']} />
 
-`serve` 타겟은 로컬에서 실행되는 애플리케이션의 양과 배포된 AWS 인프라를 가리키는 양을 제어해야 할 때 사용할 수 있습니다. 여러 컴포넌트가 있는 프로젝트에서 `dev`가 어떻게 동작하는지를 포함하여 연결된 프로젝트 전체의 로컬 개발에 대한 광범위한 개요는 <Link path="guides/local-development">로컬 개발</Link> 가이드를 참조하세요.
+`serve` 타겟은 배포된 AWS 인프라를 가리키는 것과 로컬에서 실행되는 애플리케이션의 양을 제어해야 할 때 사용할 수 있습니다. 여러 구성 요소가 있는 프로젝트에서 `dev`가 동작하는 방식을 포함하여 연결된 프로젝트 전체의 로컬 개발에 대한 광범위한 개요는 <Link path="guides/local-development">로컬 개발</Link> 가이드를 참조하세요.
 
 ### Serve 타겟
 
-`serve` 타겟은 웹사이트를 위한 로컬 개발 서버를 시작합니다. 이 타겟은 웹사이트가 상호 작용하는 지원 인프라를 배포하고 [로컬 런타임 구성을 로드](#local-runtime-config)해야 합니다.
+`serve` 타겟은 웹사이트를 위한 로컬 개발 서버를 시작합니다. 이 타겟을 사용하려면 웹사이트가 상호 작용하는 지원 인프라를 배포하고 [로컬 런타임 구성을 로드](#local-runtime-config)해야 합니다.
 
 다음 명령으로 이 타겟을 실행할 수 있습니다:
 
@@ -542,7 +627,7 @@ Terraform 프로젝트의 경우 `load-runtime-config` 타겟은 가장 최근�
 
 ### Dev 타겟
 
-`dev` 타겟은 웹사이트를 위한 로컬 개발 서버([Vite `MODE`](https://vite.dev/guide/env-and-mode)가 `local-dev`로 설정됨)를 시작하고, <Link path="/guides/connection">Connection 생성기</Link>를 통해 웹사이트에 연결한 API의 로컬 서버도 시작합니다.
+`dev` 타겟은 웹사이트를 위한 로컬 개발 서버([Vite `MODE`](https://vite.dev/guide/env-and-mode)가 `local-dev`로 설정됨)를 시작하고, <Link path="/guides/connection">연결 생성기</Link>를 통해 웹사이트에 연결한 API의 로컬 서버도 시작합니다.
 
 이 타겟을 통해 로컬 웹사이트 서버가 실행되면 `runtime-config.json`이 자동으로 재정의되어 로컬에서 실행 중인 API URL을 가리킵니다.
 
@@ -550,7 +635,7 @@ Terraform 프로젝트의 경우 `load-runtime-config` 타겟은 가장 최근�
 
 <NxCommands commands={['dev <my-website>']} />
 
-이 타겟은 웹사이트와 API를 함께 작업하고 인프라를 배포하지 않고 빠르게 반복하려는 경우에 유용합니다.
+이 타겟은 웹사이트와 API 전반에 걸쳐 작업하고 인프라를 배포하지 않고 빠르게 반복하려는 경우 유용합니다.
 
 :::note[워크스페이스 `dev` 스크립트]
 워크스페이스의 루트 `package.json`에는 `dev` 타겟이 있는 모든 프로젝트에 대해 `dev` 타겟을 실행하는 `dev` 스크립트가 포함되어 있습니다:
@@ -561,7 +646,7 @@ Terraform 프로젝트의 경우 `load-runtime-config` 타겟은 가장 최근�
 :::
 
 :::warning[모의 인증]
-이 모드에서 실행되고 `runtime-config.json`이 없는 경우, (<Link path="/guides/react-website-auth">`ts#website#auth` 생성기</Link>를 통해) Cognito 인증을 구성했다면 로그인이 건너뛰어지고 로컬 서버에 대한 요청에 인증 헤더가 포함되지 않습니다.
+이 모드에서 실행되고 `runtime-config.json`이 없는 경우, Cognito 인증을 구성했다면(<Link path="/guides/react-website-auth">`ts#website#auth` 생성기</Link>를 통해) 로그인이 건너뛰어지고 로컬 서버에 대한 요청에 인증 헤더가 포함되지 않습니다.
 
 `dev`에 대한 로그인 및 인증을 활성화하려면 인프라를 배포하고 런타임 구성을 로드하세요.
 :::
@@ -576,7 +661,7 @@ Terraform 프로젝트의 경우 `load-runtime-config` 타겟은 가장 최근�
 
 ## 빌드
 
-`build` 타겟을 사용하여 웹사이트를 빌드할 수 있습니다. 이는 `bundle`, `compile`, `test` 및 `lint` 타겟을 실행하여 웹사이트를 타입 검사, 번들링, 테스트 및 린트합니다.
+`build` 타겟을 사용하여 웹사이트를 빌드할 수 있습니다. 이는 `bundle`, `compile`, `test` 및 `lint` 타겟을 실행하여 웹사이트를 타입 검사, 번들링, 테스트 및 린팅합니다.
 
 <NxCommands commands={['build <my-website>']} />
 
@@ -596,7 +681,7 @@ React 특정 테스트의 경우 React Testing Library가 이미 설치되어 �
 
 ## 연결
 
-<Link path="guides/connection">`connection`</Link> 생성기를 사용하여 이 프로젝트를 워크스페이스의 다른 프로젝트와 통합하세요. 다음 연결은 이 프로젝트와 관련됩니다:
+<Link path="guides/connection">`connection`</Link> 생성기를 사용하여 이 프로젝트를 워크스페이스의 다른 프로젝트와 통합하세요. 다음 연결에는 이 프로젝트가 포함됩니다:
 
 <CardGrid>
   <ConnectionCard
@@ -651,3 +736,4 @@ React 특정 테스트의 경우 React Testing Library가 이미 설치되어 �
     target="agentcore"
   />
 </CardGrid>
+

--- a/docs/src/content/docs/ko/guides/react-website.mdx
+++ b/docs/src/content/docs/ko/guides/react-website.mdx
@@ -1,6 +1,6 @@
 ---
-title: React Website
-description: React Website에 대한 참조 문서
+title: React 웹사이트
+description: React 웹사이트에 대한 참조 문서
 generator: ts#website
 when:
   framework:
@@ -18,7 +18,7 @@ import Infrastructure from '@components/infrastructure.astro';
 import Snippet from '@components/snippet.astro';
 import OptionFilter from '@components/option-filter.astro';
 
-이 생성기는 기본적으로 [shadcn/ui](https://ui.shadcn.com/)가 구성된 새로운 [React](https://react.dev/) 웹사이트를 생성하며, [S3](https://aws.amazon.com/s3/)에서 호스팅되고 [CloudFront](https://aws.amazon.com/cloudfront/)로 제공되며 [WAF](https://aws.amazon.com/waf/)로 보호되는 정적 웹사이트로 클라우드에 배포하기 위한 AWS CDK 또는 Terraform 인프라를 함께 생성합니다.
+이 생성기는 기본적으로 [shadcn/ui](https://ui.shadcn.com/)가 구성된 새로운 [React](https://react.dev/) 웹사이트를 생성하며, [S3](https://aws.amazon.com/s3/)에 호스팅되고 [CloudFront](https://aws.amazon.com/cloudfront/)로 제공되며 [WAF](https://aws.amazon.com/waf/)로 보호되는 정적 웹사이트로 클라우드에 배포하기 위한 AWS CDK 또는 Terraform 인프라를 함께 생성합니다.
 
 생성된 애플리케이션은 빌드 도구 및 번들러로 [Vite](https://vite.dev/)를 사용합니다. 타입 안전 라우팅을 위해 [TanStack Router](https://tanstack.com/router/v1)를 사용합니다.
 
@@ -28,9 +28,9 @@ import OptionFilter from '@components/option-filter.astro';
 
 ## 사용법
 
-### React Website 생성
+### React 웹사이트 생성
 
-두 가지 방법으로 새로운 React Website를 생성할 수 있습니다:
+두 가지 방법으로 새로운 React 웹사이트를 생성할 수 있습니다:
 
 <RunGenerator generator="ts#website" requiredParameters={{ framework: 'react' }} />
 
@@ -51,7 +51,7 @@ import OptionFilter from '@components/option-filter.astro';
     - components
       - AppLayout 전체 레이아웃 및 네비게이션 바를 위한 컴포넌트
     - hooks
-      - useAppLayout.tsx 중첩된 컴포넌트에서 AppLayout을 조정하기 위한 훅 (Cloudscape 전용)
+      - useAppLayout.tsx 중첩된 컴포넌트에서 AppLayout을 조정하기 위한 훅 (Cloudscape만 해당)
     - routes
       - index.tsx TanStack Router를 위한 예제 라우트 (또는 페이지)
     - styles.css 전역 스타일
@@ -78,7 +78,7 @@ import OptionFilter from '@components/option-filter.astro';
   - packages/common/constructs/src
     - app
       - static-websites
-        - \<name>.ts 웹사이트에 특정한 인프라
+        - \<name>.ts 웹사이트에 특화된 인프라
     - core
       - static-website.ts 일반 StaticWebsite 구성
 </FileTree>
@@ -89,7 +89,7 @@ import OptionFilter from '@components/option-filter.astro';
     - app
       - static-websites
         - \<name>
-          - \<name>.tf 웹사이트에 특정한 모듈
+          - \<name>.tf 웹사이트에 특화된 모듈
     - core
       - static-website
         - static-website.tf 일반 정적 웹사이트 모듈
@@ -129,60 +129,9 @@ waf -> cloudfront
 cloudfront -> s3
 ```
 
-#### 보안 헤더
+## 웹사이트 구현
 
-CloudFront 배포는 모든 응답에 `Strict-Transport-Security`, `X-Content-Type-Options`, `X-Frame-Options: DENY`, `Referrer-Policy` 및 `Content-Security-Policy`를 설정하는 응답 헤더 정책을 적용합니다.
-
-기본 `Content-Security-Policy`가 적용됩니다. 이는 XSS 및 클릭재킹을 완화하기 위해 스크립트와 프레이밍을 제한하면서, 배포 시점에만 알 수 있는 URL을 가진 AWS 서비스 엔드포인트(예: API Gateway, Cognito 및 Bedrock AgentCore)를 웹사이트가 호출할 수 있도록 HTTPS 및 WSS 연결을 허용합니다. 정책을 조정하려면(예: `connect-src`를 특정 출처로 강화) 생성된 `static-website.ts`(CDK) 또는 `static-website.tf`(Terraform)에서 `content_security_policy` 값을 편집하세요.
-
-`runtime-config.json`은 `Cache-Control: no-cache`로 제공되어 브라우저가 재배포 후 캐시된 오래된 복사본을 사용하는 대신 항상 최신 구성을 가져오도록 합니다.
-
-#### 사용자 정의 도메인 및 TLS
-
-기본적으로 배포는 기본 CloudFront 도메인 이름(`*.cloudfront.net`)과 기본 인증서를 사용하며, 이는 최소 TLS 버전 1.2 적용을 지원하지 않습니다. 자체 도메인에서 웹사이트를 제공하려면 [ACM 인증서](https://docs.aws.amazon.com/acm/latest/userguide/acm-overview.html)(CloudFront와 함께 사용하려면 `us-east-1`에 있어야 함)와 도메인 이름을 제공하세요 — 그러면 뷰어에 대해 최소 TLS 버전 1.2가 적용됩니다:
-
-<Infrastructure>
-<Fragment slot="cdk">
-`packages/common/constructs/src/app/static-websites`에 있는 생성된 웹사이트 구성에서 `certificate` 및 `domainNames` props를 전달하세요:
-
-```ts {6-8}
-export class MyWebsite extends StaticWebsite {
-  constructor(scope: Construct, id: string) {
-    super(scope, id, {
-      websiteName: 'MyWebsite',
-      websiteFilePath: ...,
-      domainNames: ['www.example.com'],
-      certificate: Certificate.fromCertificateArn(scope, 'Cert',
-        'arn:aws:acm:us-east-1:123456789012:certificate/...'),
-    });
-  }
-}
-```
-</Fragment>
-<Fragment slot="terraform">
-`packages/common/terraform/src/app/static-websites`에 있는 생성된 웹사이트 모듈에서 `custom_domain_names` 및 `acm_certificate_arn` 변수를 설정하세요:
-
-```hcl {5-6}
-module "static_website" {
-  source            = "../../../core/static-website"
-  website_name      = "my-website"
-  website_file_path = ...
-  custom_domain_names = ["www.example.com"]
-  acm_certificate_arn = "arn:aws:acm:us-east-1:123456789012:certificate/..."
-
-  providers = {
-    aws.us_east_1 = aws.us_east_1
-  }
-}
-```
-</Fragment>
-</Infrastructure>
-
-또한 CloudFront 배포를 가리키는 DNS 레코드(예: Route 53에서)를 생성해야 합니다.
-
-## React Website 구현
-
-[React 문서](https://react.dev/learn)는 React로 빌드하는 기본 사항을 배우기 위한 좋은 시작점입니다.
+[React 문서](https://react.dev/learn)는 React로 빌드하는 기본 사항을 배우기 좋은 시작점입니다.
 
 <OptionFilter when={{ ux: 'cloudscape' }} description="Cloudscape component docs pointer">
 사용 가능한 컴포넌트와 사용 방법에 대한 자세한 내용은 [Cloudscape 문서](https://cloudscape.design/components/)를 참조하세요.
@@ -201,12 +150,12 @@ module "static_website" {
 <Steps>
   1. [로컬 개발 서버 실행](#local-development-server)
   2. `src/routes`에 새로운 `<page-name>.tsx` 파일을 생성하며, 파일 트리에서의 위치가 경로를 나타냅니다
-  3. `Route` 및 `RouteComponent`가 자동으로 생성되는 것을 확인하세요. 여기서 페이지 빌드를 시작할 수 있습니다!
+  3. `Route`와 `RouteComponent`가 자동으로 생성되는 것을 확인하세요. 여기서 페이지 빌드를 시작할 수 있습니다!
 </Steps>
 
 #### 페이지 간 탐색
 
-페이지 간 탐색을 위해 `Link` 컴포넌트 또는 `useNavigate` 훅을 사용할 수 있습니다:
+`Link` 컴포넌트 또는 `useNavigate` 훅을 사용하여 페이지 간 탐색할 수 있습니다:
 
 ```tsx {1, 4, 8-9, 14}
 import { Link, useNavigate } from '@tanstack/react-router';
@@ -231,6 +180,236 @@ export const MyComponent = () => {
 
 자세한 내용은 [TanStack Router](https://tanstack.com/router/latest/docs/framework/react/overview) 문서를 확인하세요.
 
+## 웹사이트 배포
+
+React 웹사이트 생성기는 선택한 `iac`에 따라 CDK 또는 Terraform 코드형 인프라를 생성합니다. 이를 사용하여 웹사이트를 배포할 수 있습니다.
+
+<Infrastructure>
+<Fragment slot="cdk">
+웹사이트를 배포하려면 <Link path="guides/typescript-infrastructure">`ts#infra` 생성기</Link>를 사용하여 CDK 애플리케이션을 생성하는 것을 권장합니다.
+
+`packages/common/constructs`에 생성된 CDK 구성을 사용하여 웹사이트를 배포할 수 있습니다.
+
+```ts title="packages/infra/src/stacks/application-stack.ts" {3, 9}
+import { Stack } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { MyWebsite } from '@my-scope/common-constructs';
+
+export class ApplicationStack extends Stack {
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+
+    new MyWebsite(this, 'MyWebsite');
+  }
+}
+```
+
+이는 다음을 설정합니다:
+
+1. 정적 웹사이트 파일을 호스팅하기 위한 S3 버킷
+2. 글로벌 콘텐츠 전송을 위한 CloudFront 배포
+3. 보안 보호를 위한 WAF Web ACL
+4. 안전한 S3 액세스를 위한 Origin Access Control
+5. 웹사이트 파일 및 런타임 구성의 자동 배포
+</Fragment>
+<Fragment slot="terraform">
+웹사이트를 배포하려면 <Link path="/guides/terraform-project">`terraform#project` 생성기</Link>를 사용하여 Terraform 프로젝트를 생성하는 것을 권장합니다.
+
+`packages/common/terraform`에 생성된 Terraform 모듈을 사용하여 웹사이트를 배포할 수 있습니다.
+
+```hcl title="packages/infra/src/main.tf" {3}
+# Deploy website
+module "my_website" {
+  source = "../../common/terraform/src/app/static-websites/my-website"
+
+  providers = {
+    aws.us_east_1 = aws.us_east_1
+  }
+}
+```
+
+이는 다음을 설정합니다:
+
+1. 정적 웹사이트 파일을 호스팅하기 위한 S3 버킷
+2. 글로벌 콘텐츠 전송을 위한 CloudFront 배포
+3. 보안 보호를 위한 WAF Web ACL (us-east-1에 배포)
+4. 안전한 S3 액세스를 위한 Origin Access Control
+5. 웹사이트 파일 및 런타임 구성의 자동 배포
+
+:::note[WAF Provider 리전]
+`aws.us_east_1` 프로바이더는 CloudFront 및 WAF 리소스에 필요하며, 이들은 us-east-1 리전에 배포되어야 합니다. Terraform 구성에 이 프로바이더가 포함되어 있는지 확인하세요:
+
+```hcl title="packages/infra/src/providers.tf"
+provider "aws" {
+  alias  = "us_east_1"
+  region = "us-east-1"
+}
+```
+:::
+</Fragment>
+</Infrastructure>
+
+### 보안 헤더
+
+CloudFront 배포는 모든 응답에 `Strict-Transport-Security`, `X-Content-Type-Options`, `X-Frame-Options: DENY`, `Referrer-Policy` 및 `Content-Security-Policy`를 설정하는 응답 헤더 정책을 적용합니다.
+
+기본 `Content-Security-Policy`가 적용됩니다. 이는 XSS 및 클릭재킹을 완화하기 위해 스크립트와 프레이밍을 제한하면서, 배포 시점에만 알 수 있는 URL을 가진 AWS 서비스 엔드포인트(예: API Gateway, Cognito 및 Bedrock AgentCore)를 웹사이트가 호출할 수 있도록 HTTPS 및 WSS 연결을 허용합니다. 정책을 조정하려면(예: `connect-src`를 특정 출처로 강화) 생성된 `static-website.ts`(CDK) 또는 `static-website.tf`(Terraform)에서 `content_security_policy` 값을 편집하세요.
+
+`runtime-config.json`은 `Cache-Control: no-cache`로 제공되어 브라우저가 재배포 후 캐시된 오래된 복사본을 사용하는 대신 항상 최신 구성을 가져오도록 합니다.
+
+### WAF
+
+CloudFront 배포는 기본적으로 [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACL로 보호됩니다. Web ACL은 AWS 관리형 기본 규칙 세트([`AWSManagedRulesCommonRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs) 및 [`AWSManagedRulesKnownBadInputsRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs))를 사용하여 OWASP Top 10을 포함한 일반적인 웹 취약점에 대한 보호를 제공합니다.
+
+<Infrastructure>
+<Fragment slot="cdk">
+비활성화하려면 웹사이트를 생성할 때 `enableWaf`를 `false`로 설정하세요:
+
+```ts title="packages/infra/src/stacks/application-stack.ts" {10,15-18}
+import { Stack } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { MyWebsite, suppressRules } from '@my-scope/common-constructs';
+
+export class ApplicationStack extends Stack {
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+
+    const website = new MyWebsite(this, 'MyWebsite', {
+      enableWaf: false,
+    });
+
+    // Disabling WAF fails the checkov CKV_AWS_68 check ("CloudFront
+    // Distribution should have WAF enabled"). Suppress it explicitly.
+    suppressRules(
+      website.cloudFrontDistribution,
+      ['CKV_AWS_68'],
+      'WAF is intentionally disabled for this distribution',
+    );
+  }
+}
+```
+
+:::caution[WAF 비활성화 시 CKV_AWS_68 억제]
+WAF를 비활성화하면 합성된 CloudFront 배포에 Web ACL이 연결되지 않아 위에 표시된 대로 억제하지 않는 한 `checkov` 보안 스캔이 `CKV_AWS_68: "CloudFront Distribution should have WAF enabled"`로 실패합니다.
+:::
+</Fragment>
+<Fragment slot="terraform">
+비활성화하려면 `enable_waf`를 `false`로 설정하세요:
+
+```hcl title="packages/infra/src/main.tf" {7}
+module "my_website" {
+  source = "../../common/terraform/src/app/static-websites/my-website"
+
+  providers = {
+    aws.us_east_1 = aws.us_east_1
+  }
+  enable_waf = false
+}
+```
+</Fragment>
+</Infrastructure>
+
+### 버킷 암호화
+
+웹사이트 버킷, CloudFront 배포 로그 버킷, 그리고 서버 액세스 로그를 수신하는 CloudWatch Logs 그룹은 기본적으로 고객 관리형 [AWS KMS](https://aws.amazon.com/kms/) 키로 암호화됩니다. 이 키는 키 교체가 활성화된 상태로 자동으로 생성됩니다.
+
+<Infrastructure>
+<Fragment slot="cdk">
+다른 암호화 구성을 사용하려면 웹사이트를 생성할 때 `encryption`, `encryptionKey` 및 `enableKeyRotation` 속성을 전달하세요:
+
+```ts title="packages/infra/src/stacks/application-stack.ts" {11}
+import { Stack } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { BucketEncryption } from 'aws-cdk-lib/aws-s3';
+import { MyWebsite } from '@my-scope/common-constructs';
+
+export class ApplicationStack extends Stack {
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+
+    new MyWebsite(this, 'MyWebsite', {
+      encryption: BucketEncryption.S3_MANAGED,
+    });
+  }
+}
+```
+
+자동으로 생성되는 대신 자체 KMS 키를 사용하려면 `encryptionKey`를 전달하세요:
+
+```ts {2}
+new MyWebsite(this, 'MyWebsite', {
+  encryptionKey: myKey,
+});
+```
+
+`enableKeyRotation`(기본값 `true`)은 자동으로 생성된 키에만 적용됩니다. 즉, `encryption`이 `BucketEncryption.KMS`(기본값)이고 `encryptionKey`가 제공되지 않은 경우입니다.
+</Fragment>
+<Fragment slot="terraform">
+다른 암호화 구성을 사용하려면 `encryption`, `kms_key_arn` 및 `enable_key_rotation` 변수를 설정하세요:
+
+```hcl title="packages/infra/src/main.tf" {7}
+module "my_website" {
+  source = "../../common/terraform/src/app/static-websites/my-website"
+
+  providers = {
+    aws.us_east_1 = aws.us_east_1
+  }
+  encryption = "S3_MANAGED"
+}
+```
+
+자동으로 생성되는 대신 자체 KMS 키를 사용하려면 `kms_key_arn`을 전달하세요. 고객이 제공한 키는 자체 키 정책에서 CloudWatch Logs, S3 및 CloudFront 서비스 주체에게 필요한 권한을 이미 부여해야 합니다.
+
+`enable_key_rotation`(기본값 `true`)은 자동으로 생성된 키에만 적용됩니다. 즉, `encryption`이 `"KMS"`(기본값)이고 `kms_key_arn`이 제공되지 않은 경우입니다.
+</Fragment>
+</Infrastructure>
+
+### 사용자 지정 도메인 및 TLS
+
+기본적으로 배포는 기본 CloudFront 도메인 이름(`*.cloudfront.net`)과 기본 인증서를 사용하며, 이는 최소 TLS 버전 1.2 적용을 지원하지 않습니다. 자체 도메인에서 웹사이트를 제공하려면 [ACM 인증서](https://docs.aws.amazon.com/acm/latest/userguide/acm-overview.html)(CloudFront와 함께 사용하려면 `us-east-1`에 있어야 함)와 도메인 이름을 제공하세요. 그러면 뷰어에 대해 최소 TLS 버전 1.2가 적용됩니다:
+
+<Infrastructure>
+<Fragment slot="cdk">
+웹사이트를 생성할 때 `certificate` 및 `domainNames` 속성을 전달하세요:
+
+```ts title="packages/infra/src/stacks/application-stack.ts" {11-13}
+import { Stack } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { Certificate } from 'aws-cdk-lib/aws-certificatemanager';
+import { MyWebsite } from '@my-scope/common-constructs';
+
+export class ApplicationStack extends Stack {
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+
+    new MyWebsite(this, 'MyWebsite', {
+      domainNames: ['www.example.com'],
+      certificate: Certificate.fromCertificateArn(this, 'Cert',
+        'arn:aws:acm:us-east-1:123456789012:certificate/...'),
+    });
+  }
+}
+```
+</Fragment>
+<Fragment slot="terraform">
+`custom_domain_names` 및 `acm_certificate_arn` 변수를 설정하세요:
+
+```hcl title="packages/infra/src/main.tf" {7-8}
+module "my_website" {
+  source = "../../common/terraform/src/app/static-websites/my-website"
+
+  providers = {
+    aws.us_east_1 = aws.us_east_1
+  }
+  custom_domain_names = ["www.example.com"]
+  acm_certificate_arn = "arn:aws:acm:us-east-1:123456789012:certificate/..."
+}
+```
+</Fragment>
+</Infrastructure>
+
+또한 CloudFront 배포를 가리키는 DNS 레코드(예: Route 53에서)를 생성해야 합니다.
+
 ## 런타임 구성
 
 인프라의 구성은 <Link href="guides/runtime-config">런타임 구성</Link>을 통해 웹사이트에 제공됩니다. 이를 통해 웹사이트는 애플리케이션이 배포될 때까지 알 수 없는 API URL과 같은 세부 정보에 액세스할 수 있습니다.
@@ -239,7 +418,7 @@ export const MyComponent = () => {
 
 <Infrastructure>
 <Fragment slot="cdk">
-`RuntimeConfig` CDK 구성을 사용하여 CDK 인프라에서 구성을 추가하고 검색할 수 있습니다. `@aws/nx-plugin` 생성기(<Link path="guides/trpc">`ts#api`</Link> 및 <Link path="guides/fastapi">`py#api`</Link>와 같은)에서 생성된 CDK 구성은 자동으로 `RuntimeConfig`에 적절한 값을 추가합니다.
+`RuntimeConfig` CDK 구성을 사용하여 CDK 인프라에서 구성을 추가하고 검색할 수 있습니다. `@aws/nx-plugin` 생성기(<Link path="guides/trpc">`ts#api`</Link> 및 <Link path="guides/fastapi">`py#api`</Link>와 같은)가 생성한 CDK 구성은 자동으로 `RuntimeConfig`에 적절한 값을 추가합니다.
 
 웹사이트 CDK 구성은 런타임 구성의 `connection` 네임스페이스를 S3 버킷의 루트에 `runtime-config.json` 파일로 배포합니다.
 
@@ -252,7 +431,7 @@ export class ApplicationStack extends Stack {
   constructor(scope: Construct, id: string) {
     super(scope, id);
 
-    // Website can be declared at any point — runtime config is resolved lazily
+    // Website can be declared at any point, since runtime config is resolved lazily
     new MyWebsite(this, 'MyWebsite');
 
     // Automatically adds values to the RuntimeConfig
@@ -263,12 +442,12 @@ export class ApplicationStack extends Stack {
 }
 ```
 
-:::note[CDK Website Construct]
-CDK를 사용하면 웹사이트 구성을 스택의 어느 시점에서나 선언할 수 있습니다. 런타임 구성은 synth 시점에 지연 해결되므로 선언 순서에 관계없이 모든 값이 포함됩니다.
+:::note[CDK 웹사이트 구성]
+CDK를 사용하면 웹사이트 구성을 스택의 어느 지점에서든 선언할 수 있습니다. 런타임 구성은 합성 시점에 지연 해결되므로 선언 순서에 관계없이 모든 값이 포함됩니다.
 :::
 </Fragment>
 <Fragment slot="terraform">
-Terraform을 사용하면 런타임 구성은 runtime-config 모듈을 통해 관리됩니다. `@aws/nx-plugin` 생성기(<Link path="guides/trpc">`ts#api`</Link> 및 <Link path="guides/fastapi">`py#api`</Link>와 같은)에서 생성된 Terraform 모듈은 자동으로 런타임 구성에 적절한 값을 추가합니다.
+Terraform을 사용하면 런타임 구성은 runtime-config 모듈을 통해 관리됩니다. `@aws/nx-plugin` 생성기(<Link path="guides/trpc">`ts#api`</Link> 및 <Link path="guides/fastapi">`py#api`</Link>와 같은)가 생성한 Terraform 모듈은 자동으로 런타임 구성에 적절한 값을 추가합니다.
 
 웹사이트 Terraform 모듈은 런타임 구성의 `connection` 네임스페이스를 S3 버킷의 루트에 `runtime-config.json` 파일로 배포합니다.
 
@@ -330,30 +509,30 @@ const MyComponent = () => {
 
 <NxCommands commands={['load-runtime-config <my-website>']} />
 
-:::note[사용자 정의 스테이지 이름]
+:::note[사용자 지정 스테이지 이름]
 <Infrastructure>
 <Fragment slot="cdk">
-인프라 프로젝트의 `src/main.ts`에서 스테이지 이름의 접두사를 변경하는 경우, 웹사이트의 `project.json` 파일에서 `load-runtime-config` 타겟을 그에 따라 업데이트해야 합니다.
+인프라 프로젝트의 `src/main.ts`에서 스테이지 이름의 접두사를 변경하는 경우, 웹사이트의 `project.json` 파일에서 `load-runtime-config` 타겟을 그에 맞게 업데이트해야 합니다.
 
-또한 `load-runtime-config` 타겟은 AWS 자격 증명이 있는 환경에 애플리케이션의 단일 스테이지가 배포되어 있다고 가정한다는 점에 유의할 필요가 있습니다. 동일한 계정 및 리전에 여러 스테이지를 배포하는 경우 명령을 조정해야 합니다.
+또한 `load-runtime-config` 타겟은 AWS 자격 증명이 있는 환경에 애플리케이션의 단일 스테이지가 배포되어 있다고 가정한다는 점에 유의할 가치가 있습니다. 동일한 계정과 리전에 여러 스테이지를 배포하는 경우 명령을 조정해야 합니다.
 </Fragment>
 <Fragment slot="terraform">
-Terraform 프로젝트의 경우 `load-runtime-config` 타겟은 가장 최근의 로컬 `terraform apply` 후에 생성된 `runtime-config.json` 파일을 복사합니다.
+Terraform 프로젝트의 경우 `load-runtime-config` 타겟은 가장 최근의 로컬 `terraform apply` 이후에 생성된 `runtime-config.json` 파일을 복사합니다.
 </Fragment>
 </Infrastructure>
 :::
 
 ## 로컬 개발 서버
 
-로컬 개발을 위한 표준 명령은 `dev`로, 하나의 명령으로 웹사이트(및 연결한 API의 로컬 서버)를 시작합니다:
+로컬 개발을 위한 표준 명령은 `dev`이며, 이는 하나의 명령으로 웹사이트(및 연결한 API의 로컬 서버)를 시작합니다:
 
 <NxCommands commands={['dev <my-website>']} />
 
-`serve` 타겟은 배포된 AWS 인프라를 가리키는 것과 로컬에서 실행되는 애플리케이션의 범위를 제어해야 할 때 사용할 수 있습니다. 여러 컴포넌트가 있는 프로젝트에서 `dev`가 어떻게 동작하는지를 포함하여 연결된 프로젝트 전체의 로컬 개발에 대한 광범위한 개요는 <Link path="guides/local-development">로컬 개발</Link> 가이드를 참조하세요.
+`serve` 타겟은 로컬에서 실행되는 애플리케이션의 양과 배포된 AWS 인프라를 가리키는 양을 제어해야 할 때 사용할 수 있습니다. 여러 컴포넌트가 있는 프로젝트에서 `dev`가 어떻게 동작하는지를 포함하여 연결된 프로젝트 전체의 로컬 개발에 대한 광범위한 개요는 <Link path="guides/local-development">로컬 개발</Link> 가이드를 참조하세요.
 
 ### Serve 타겟
 
-`serve` 타겟은 웹사이트를 위한 로컬 개발 서버를 시작합니다. 이 타겟을 사용하려면 웹사이트가 상호 작용하는 지원 인프라를 배포하고 [로컬 런타임 구성을 로드](#local-runtime-config)해야 합니다.
+`serve` 타겟은 웹사이트를 위한 로컬 개발 서버를 시작합니다. 이 타겟은 웹사이트가 상호 작용하는 지원 인프라를 배포하고 [로컬 런타임 구성을 로드](#local-runtime-config)해야 합니다.
 
 다음 명령으로 이 타겟을 실행할 수 있습니다:
 
@@ -382,7 +561,7 @@ Terraform 프로젝트의 경우 `load-runtime-config` 타겟은 가장 최근�
 :::
 
 :::warning[모의 인증]
-이 모드에서 실행되고 `runtime-config.json`이 없는 경우, Cognito 인증을 구성했다면(<Link path="/guides/react-website-auth">`ts#website#auth` 생성기</Link>를 통해) 로그인이 건너뛰어지고 로컬 서버에 대한 요청에 인증 헤더가 포함되지 않습니다.
+이 모드에서 실행되고 `runtime-config.json`이 없는 경우, (<Link path="/guides/react-website-auth">`ts#website#auth` 생성기</Link>를 통해) Cognito 인증을 구성했다면 로그인이 건너뛰어지고 로컬 서버에 대한 요청에 인증 헤더가 포함되지 않습니다.
 
 `dev`에 대한 로그인 및 인증을 활성화하려면 인프라를 배포하고 런타임 구성을 로드하세요.
 :::
@@ -401,7 +580,7 @@ Terraform 프로젝트의 경우 `load-runtime-config` 타겟은 가장 최근�
 
 <NxCommands commands={['build <my-website>']} />
 
-`bundle` 타겟은 Vite를 사용하여 루트 `dist/packages/<my-website>/bundle` 디렉토리에 프로덕션 번들을 생성합니다. 이것은 웹사이트 인프라에서 사용하는 배포 가능한 아티팩트입니다. 단독으로 실행할 수 있습니다:
+`bundle` 타겟은 Vite를 사용하여 루트 `dist/packages/<my-website>/bundle` 디렉토리에 프로덕션 번들을 생성합니다. 이것이 웹사이트 인프라에서 사용하는 배포 가능한 아티팩트입니다. 단독으로 실행할 수 있습니다:
 
 <NxCommands commands={['bundle <my-website>']} />
 
@@ -415,105 +594,36 @@ React 특정 테스트의 경우 React Testing Library가 이미 설치되어 �
 
 <NxCommands commands={['test <my-website>']} />
 
-## 웹사이트 배포
-
-React 웹사이트 생성기는 선택한 `iac`에 따라 CDK 또는 Terraform 코드형 인프라를 생성합니다. 이를 사용하여 웹사이트를 배포할 수 있습니다.
-
-<Infrastructure>
-<Fragment slot="cdk">
-웹사이트를 배포하려면 <Link path="guides/typescript-infrastructure">`ts#infra` 생성기</Link>를 사용하여 CDK 애플리케이션을 생성하는 것이 좋습니다.
-
-`packages/common/constructs`에서 생성된 CDK 구성을 사용하여 웹사이트를 배포할 수 있습니다.
-
-```ts title="packages/infra/src/stacks/application-stack.ts" {3, 9}
-import { Stack } from 'aws-cdk-lib';
-import { Construct } from 'constructs';
-import { MyWebsite } from '@my-scope/common-constructs';
-
-export class ApplicationStack extends Stack {
-  constructor(scope: Construct, id: string) {
-    super(scope, id);
-
-    new MyWebsite(this, 'MyWebsite');
-  }
-}
-```
-
-이는 다음을 설정합니다:
-
-1. 정적 웹사이트 파일을 호스팅하기 위한 S3 버킷
-2. 글로벌 콘텐츠 전송을 위한 CloudFront 배포
-3. 보안 보호를 위한 WAF Web ACL
-4. 안전한 S3 액세스를 위한 Origin Access Control
-5. 웹사이트 파일 및 런타임 구성의 자동 배포
-</Fragment>
-<Fragment slot="terraform">
-웹사이트를 배포하려면 <Link path="/guides/terraform-project">`terraform#project` 생성기</Link>를 사용하여 Terraform 프로젝트를 생성하는 것이 좋습니다.
-
-`packages/common/terraform`에서 생성된 Terraform 모듈을 사용하여 웹사이트를 배포할 수 있습니다.
-
-```hcl title="packages/infra/src/main.tf" {3}
-# Deploy website
-module "my_website" {
-  source = "../../common/terraform/src/app/static-websites/my-website"
-
-  providers = {
-    aws.us_east_1 = aws.us_east_1
-  }
-}
-```
-
-이는 다음을 설정합니다:
-
-1. 정적 웹사이트 파일을 호스팅하기 위한 S3 버킷
-2. 글로벌 콘텐츠 전송을 위한 CloudFront 배포
-3. 보안 보호를 위한 WAF Web ACL (us-east-1에 배포됨)
-4. 안전한 S3 액세스를 위한 Origin Access Control
-5. 웹사이트 파일 및 런타임 구성의 자동 배포
-
-:::note[WAF Provider 리전]
-`aws.us_east_1` 프로바이더는 us-east-1 리전에 배포되어야 하는 CloudFront 및 WAF 리소스에 필요합니다. Terraform 구성에 이 프로바이더가 포함되어 있는지 확인하세요:
-
-```hcl title="packages/infra/src/providers.tf"
-provider "aws" {
-  alias  = "us_east_1"
-  region = "us-east-1"
-}
-```
-:::
-</Fragment>
-</Infrastructure>
-
 ## 연결
 
-<Link path="guides/connection">`connection`</Link> 생성기를 사용하여 이 프로젝트를 워크스페이스의 다른 프로젝트와 통합하세요. 다음 연결에는 이 프로젝트가 포함됩니다:
+<Link path="guides/connection">`connection`</Link> 생성기를 사용하여 이 프로젝트를 워크스페이스의 다른 프로젝트와 통합하세요. 다음 연결은 이 프로젝트와 관련됩니다:
 
 <CardGrid>
   <ConnectionCard
     title="React to tRPC"
     description="React 웹사이트에서 tRPC API 호출"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'ko'}/guides/connection/react-trpc`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/react-trpc`}
     source="react"
     target="trpc"
   />
   <ConnectionCard
     title="React to FastAPI"
     description="React 웹사이트에서 Python FastAPI 호출"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'ko'}/guides/connection/react-fastapi`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/react-fastapi`}
     source="react"
     target="fastapi"
   />
   <ConnectionCard
     title="React to Smithy API"
     description="React 웹사이트에서 Smithy API 호출"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'ko'}/guides/connection/react-smithy`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/react-smithy`}
     source="react"
     target="smithy"
   />
   <ConnectionCard
     title="React to Python Agent"
     description="React 웹사이트에서 Python Agent 호출"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'ko'}/guides/connection/react-py-agent`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/react-py-agent`}
     source="react"
     target="strands"
     targetBadge="python"
@@ -521,7 +631,7 @@ provider "aws" {
   <ConnectionCard
     title="React to TypeScript Agent"
     description="React 웹사이트에서 TypeScript Agent 호출"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'ko'}/guides/connection/react-ts-agent`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/react-ts-agent`}
     source="react"
     target="strands"
     targetBadge="typescript"
@@ -529,14 +639,14 @@ provider "aws" {
   <ConnectionCard
     title="React to AG-UI Agent"
     description="CopilotKit을 통해 React 웹사이트에서 AG-UI 프로토콜을 노출하는 Agent 호출"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'ko'}/guides/connection/react-agui`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/react-agui`}
     source="react"
     target="copilotkit"
   />
   <ConnectionCard
     title="React Website to AgentCore Gateway"
     description="AgentCore Gateway를 통해 React 웹사이트를 에이전트에 연결"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'ko'}/guides/connection/react-agentcore-gateway`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/react-agentcore-gateway`}
     source="react"
     target="agentcore"
   />

--- a/docs/src/content/docs/pt/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/pt/get_started/tutorials/dungeon-game/1.mdx
@@ -1,6 +1,6 @@
 ---
 title: Configurar um monorepo
-description: "Um guia passo a passo de como construir um jogo de aventura em dungeon com IA agêntica usando o @aws/nx-plugin."
+description: "Um passo a passo de como construir um jogo de aventura em masmorra com IA agêntica usando o @aws/nx-plugin."
 ---
 
 import { Aside, Code, FileTree, Steps, Tabs, TabItem } from '@astrojs/starlight/components';
@@ -32,7 +32,7 @@ Para criar um novo monorepo, dentro do diretório desejado, execute o seguinte c
 Usamos `--iac=cdk` pois utilizaremos CDK para infraestrutura como código neste tutorial. O Nx Plugin for AWS também suporta `terraform`.
 :::
 
-Isso irá configurar um monorepo NX dentro do diretório `dungeon-adventure`. Ao abrir o diretório no VSCode, você verá esta estrutura de arquivos:
+Isso configurará um monorepo NX dentro do diretório `dungeon-adventure`. Quando você abrir o diretório no VSCode, verá esta estrutura de arquivos:
 
 <FileTree>
 - .nx/
@@ -51,26 +51,26 @@ Isso irá configurar um monorepo NX dentro do diretório `dungeon-adventure`. Ao
 - aws-nx-plugin.config.mts configuração para o Nx Plugin for AWS
 </FileTree>
 
-<Aside type="tip" title="Faça commits com frequência">É uma boa prática garantir que todos os seus arquivos não preparados estejam commitados no Git antes de executar qualquer gerador. Isso permite que você veja o que mudou após executar seu gerador via `git diff`.</Aside>
+<Aside type="tip" title="Faça Commits Frequentes">É uma boa prática garantir que todos os seus arquivos não preparados estejam commitados no Git antes de executar qualquer gerador. Isso permite que você veja o que mudou após executar seu gerador via `git diff`.</Aside>
 
-## Tarefa 2: Estruturar o Dungeon Adventure Game
+## Tarefa 2: Estruturar o Jogo de Aventura em Masmorra
 
-Com o workspace configurado, estruturamos os sub-projetos do jogo — a Game API, o Story Agent, o servidor MCP de Inventário, o banco de dados do jogo e o website — juntamente com as conexões que os interligam. Há duas maneiras de fazer isso:
+Com o workspace configurado, estruturamos os sub-projetos do jogo — a API do Jogo, Agente de História, servidor MCP de Inventário, banco de dados do jogo e website — juntamente com as conexões que os conectam. Existem duas maneiras de fazer isso:
 
 - **Rápido** — copie os comandos diretamente do diagrama abaixo e execute-os. A maneira mais rápida de chegar ao mesmo ponto de partida.
 - **Passo a Passo** — expanda a seção abaixo para executar cada gerador você mesmo e examinar exatamente o que cada um produz.
 
-O diagrama abaixo _é_ o workspace do Dungeon Adventure: cada projeto, componente e conexão que você construirá neste módulo. Clique em **Copy commands** para obter toda a série e execute-os dentro do diretório `dungeon-adventure` criado na Tarefa 1.
+O diagrama abaixo _é_ o workspace Dungeon Adventure: cada projeto, componente e conexão que você construirá neste módulo. Clique em **Copy commands** para pegar toda a série, depois execute-os de dentro do diretório `dungeon-adventure` que você criou na Tarefa 1.
 
 <EmbeddedGraph preset="dungeon-adventure" workspace="dungeon-adventure" iac="cdk" skipWorkspace />
 
 <Drawer title="Passo a Passo" trigger="Passo a Passo: execute cada gerador você mesmo e veja o que ele produz">
 
-Em vez de copiar todos os comandos de uma vez, você pode executar cada gerador individualmente. Esta é a melhor maneira de entender o que cada gerador adiciona ao seu workspace. Execute cada gerador em sequência, dentro do diretório `dungeon-adventure` criado na Tarefa 1.
+Em vez de copiar os comandos de uma vez, você pode executar cada gerador individualmente. Esta é a melhor maneira de entender o que cada gerador adiciona ao seu workspace. Execute cada gerador por vez, de dentro do diretório `dungeon-adventure` que você criou na Tarefa 1.
 
-##### Criar uma Game API
+##### Criar uma API do Jogo
 
-Primeiro, vamos criar nossa Game API. Para isso, crie uma API tRPC chamada `GameApi` usando estas etapas:
+Primeiro, vamos criar nossa API do Jogo. Para fazer isso, crie uma API tRPC chamada `GameApi` usando estas etapas:
 
 <RunGenerator generator="ts#api" requiredParameters={{ name: "GameApi", framework: "trpc" }} noInteractive />
 
@@ -84,7 +84,7 @@ Para mais detalhes sobre como trabalhar com projetos TypeScript, consulte o <Lin
 </Aside>
 
 <details>
-<summary>Examine os arquivos gerados por `ts#api` em detalhes</summary>
+<summary>Examine os arquivos gerados pelo `ts#api` em detalhes</summary>
 
 Abaixo está uma lista de todos os arquivos que foram gerados pelo gerador `ts#api`. Vamos examinar alguns dos arquivos principais destacados na árvore de arquivos:
 <FileTree>
@@ -390,15 +390,15 @@ export class GameApi<
 }
 ```
 
-Este é o construct CDK que define nossa `GameApi`. Ele fornece um método `defaultIntegrations` que cria automaticamente uma função Lambda para cada procedimento em nossa API tRPC, apontando para a implementação da API empacotada. Isso significa que no momento do `cdk synth`, o empacotamento não ocorre (ao contrário de usar [NodeJsFunction](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_lambda_nodejs.NodejsFunction.html)) pois já o empacotamos como parte do target de build do projeto backend.
+Este é o construct CDK que define nossa `GameApi`. Ele fornece um método `defaultIntegrations` que cria automaticamente uma função Lambda para cada procedimento em nossa API tRPC, apontando para a implementação da API empacotada. Isso significa que no tempo de `cdk synth`, o empacotamento não ocorre (ao contrário de usar [NodeJsFunction](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_lambda_nodejs.NodejsFunction.html)) pois já empacotamos como parte do target de build do projeto backend.
 
 </details>
 
-##### Criar o Story Agent
+##### Criar o Agente de História
 
-Agora vamos criar nosso Story Agent.
+Agora vamos criar nosso Agente de História.
 
-###### Story agent: Projeto Python
+###### Agente de história: Projeto Python
 
 Para criar um projeto Python:
 
@@ -406,7 +406,7 @@ Para criar um projeto Python:
 
 Você verá alguns novos arquivos aparecerem na sua árvore de arquivos.
 <details>
-<summary>Examine os arquivos gerados por `py#project` em detalhes</summary>
+<summary>Examine os arquivos gerados pelo `py#project` em detalhes</summary>
 
 O `py#project` gera estes arquivos:
 
@@ -419,7 +419,7 @@ O `py#project` gera estes arquivos:
     - .python-version
     - pyproject.toml
     - project.json
-- .python-version versão python fixada pelo uv
+- .python-version versão python do uv fixada
 - pyproject.toml
 - uv.lock
 </FileTree>
@@ -435,12 +435,12 @@ Para adicionar um agente Strands ao projeto com o gerador `py#agent`:
 <RunGenerator generator="py#agent" requiredParameters={{project:"story", auth:"cognito", protocol:"ag-ui"}} noInteractive />
 
 :::note[Protocolo AG-UI]
-Escolhemos `--protocol=ag-ui` para que o agente fale o [protocolo Agent-User Interaction](https://docs.copilotkit.ai/aws-strands/protocol) — isso permite que nosso website React se comunique diretamente com ele via [CopilotKit](https://docs.copilotkit.ai/), com streaming, chamadas de ferramentas e histórico de conversas gerenciados pelo protocolo em vez de um cliente HTTP manual.
+Escolhemos `--protocol=ag-ui` para que o agente fale o [protocolo Agent-User Interaction](https://docs.copilotkit.ai/aws-strands/protocol) — isso permite que nosso website React converse com ele diretamente via [CopilotKit](https://docs.copilotkit.ai/), com streaming, chamadas de ferramentas e histórico de conversação tratados pelo protocolo em vez de um cliente HTTP feito à mão.
 :::
 
 Você verá alguns novos arquivos aparecerem na sua árvore de arquivos.
 <details>
-<summary>Examine os arquivos gerados por `py#agent` em detalhes</summary>
+<summary>Examine os arquivos gerados pelo `py#agent` em detalhes</summary>
 
 O `py#agent` gera estes arquivos:
 
@@ -515,7 +515,7 @@ class SessionIdMiddleware(BaseHTTPMiddleware):
             return await call_next(request)
 ```
 
-O `SessionIdMiddleware` vincula o ID de sessão do runtime AgentCore de entrada a um `ContextVar` durante a requisição.
+O `SessionIdMiddleware` vincula o ID de sessão do runtime AgentCore de entrada em um `ContextVar` pela duração da requisição.
 
 ```python
 # agent/main.py
@@ -603,7 +603,7 @@ async def ping():
     return {"status": "healthy"}
 ```
 
-Este é o ponto de entrada para o agente. Como selecionamos `--protocol=ag-ui`, o gerador envolve nosso `Agent` Strands com `StrandsAgent` de [`ag_ui_strands`](https://docs.copilotkit.ai/aws-strands/integration) e o monta em um app FastAPI que fala o [protocolo AG-UI](https://docs.copilotkit.ai/aws-strands/protocol) — é com isso que o CopilotKit se comunicará a partir do website React. O agente é construído dentro de um handler `lifespan` — não no momento da importação — para que a inicialização do container, e não a importação do módulo, controle a construção, e cada sessão AgentCore obtenha seu próprio container. O `SessionIdMiddleware` que vimos acima encaminha o ID de sessão do runtime AgentCore de entrada para que qualquer cliente MCP/A2A downstream que conectarmos posteriormente (por exemplo, o servidor MCP de Inventário no <Link path="get_started/tutorials/dungeon-game/2">Módulo 2</Link>) o encaminhe automaticamente em suas chamadas de saída. Como o AG-UI armazena em cache um agente Strands por `thread_id`, conectamos um `session_manager_provider` em vez do gerenciador de sessão do agente template — isso dá a cada thread seu próprio `SessionManager` para que o histórico de conversas persista entre turnos. Essa função `get_session_manager()` vem de um `session.py` gerado como irmão: implantado, retorna um `strands.session.S3SessionManager` apoiado por um bucket S3 que o gerador provisiona automaticamente; sob `agent-dev` (`LOCAL_DEV=true`) sempre retorna um `FileSessionManager` gravando em um diretório temporário local, independentemente da configuração implantada.
+Este é o ponto de entrada para o agente. Como selecionamos `--protocol=ag-ui`, o gerador envolve nosso `Agent` Strands com `StrandsAgent` de [`ag_ui_strands`](https://docs.copilotkit.ai/aws-strands/integration) e o monta em um aplicativo FastAPI que fala o [protocolo AG-UI](https://docs.copilotkit.ai/aws-strands/protocol) — é com isso que o CopilotKit conversará a partir do website React. O agente é construído dentro de um handler `lifespan` — não no momento da importação — então a inicialização do contêiner, não a importação do módulo, possui a construção, e cada sessão AgentCore obtém seu próprio contêiner. O `SessionIdMiddleware` que vimos acima encaminha o ID de sessão do runtime AgentCore de entrada para que qualquer cliente MCP/A2A downstream que conectarmos mais tarde (por exemplo, o servidor MCP de Inventário no <Link path="get_started/tutorials/dungeon-game/2">Módulo 2</Link>) o encaminhe automaticamente em suas chamadas de saída. Como AG-UI armazena em cache um agente Strands por `thread_id`, conectamos um `session_manager_provider` em vez do gerenciador de sessão do próprio agente de template — isso dá a cada thread seu próprio `SessionManager` para que o histórico de conversação persista entre turnos. Essa função `get_session_manager()` vem de um `session.py` irmão gerado: implantado, ele retorna um `strands.session.S3SessionManager` apoiado por um bucket S3 que o gerador provisiona automaticamente; sob `agent-dev` (`LOCAL_DEV=true`) ele sempre retorna um `FileSessionManager` escrevendo em um diretório temporário local, independentemente da configuração implantada.
 
 ```ts
 // common/constructs/src/app/agents/story-agent/story-agent.ts
@@ -891,7 +891,7 @@ export class StoryAgent extends Construct implements IGrantable, IConnectable {
 }
 ```
 
-Isso configura um `AgentRuntimeArtifact` CDK que faz upload da imagem Docker do seu agente para o ECR e a hospeda usando o AgentCore Runtime. Como escolhemos `--auth=cognito`, o construct requer a identidade do user pool/client e autoriza as invocações do AgentCore Runtime através do Cognito, encaminhando o cabeçalho `Authorization` do chamador. Ele também provisiona o bucket de sessão que o `session.py` do Story Agent lê em tempo de execução — um bucket S3 criptografado com KMS com logs de acesso ao servidor entregues ao CloudWatch Logs — concede ao agente acesso de leitura/gravação a ele, concede acesso para invocar modelos Bedrock e registra seu ARN e nome do bucket no `RuntimeConfig` para que tanto o agente (em tempo de execução, via AppConfig) quanto a Game API (em tempo de síntese, via `invocationUrl`) possam encontrá-lo.
+Isso configura um `AgentRuntimeArtifact` CDK que faz upload da imagem Docker do seu agente para o ECR e a hospeda usando AgentCore Runtime. Como escolhemos `--auth=cognito`, o construct requer a identidade do user pool/client e autoriza invocações do AgentCore Runtime através do Cognito, encaminhando o cabeçalho `Authorization` do chamador. Ele também provisiona o bucket de sessão que o `session.py` do Story Agent lê de volta em tempo de execução — um bucket S3 criptografado com KMS com logs de acesso do servidor entregues ao CloudWatch Logs — concede ao agente acesso de leitura/gravação a ele, concede acesso para invocar modelos Bedrock e registra seu ARN e nome do bucket no `RuntimeConfig` para que tanto o agente (em tempo de execução, via AppConfig) quanto a Game API (em tempo de synth, via `invocationUrl`) possam encontrá-lo.
 
 Você pode notar um `Dockerfile` extra que referencia a imagem Docker do projeto `story`, permitindo co-localizar o Dockerfile e o código-fonte do agente.
 
@@ -901,7 +901,7 @@ Você pode notar um `Dockerfile` extra que referencia a imagem Docker do projeto
 
 ###### Inventário: Projeto TypeScript
 
-Vamos criar um servidor MCP para fornecer ferramentas ao nosso Story Agent para gerenciar o inventário de um jogador.
+Vamos criar um servidor MCP para fornecer ferramentas para nosso Story Agent gerenciar o inventário de um jogador.
 
 Primeiro, criamos um projeto TypeScript:
 
@@ -910,7 +910,7 @@ Primeiro, criamos um projeto TypeScript:
 Isso criará um projeto TypeScript vazio.
 
 <details>
-<summary>Examine os arquivos gerados por `ts#project` em detalhes</summary>
+<summary>Examine os arquivos gerados pelo `ts#project` em detalhes</summary>
 
 O gerador `ts#project` gera estes arquivos.
 
@@ -937,7 +937,7 @@ Em seguida, adicionaremos um servidor MCP ao nosso projeto TypeScript:
 
 Isso adicionará um servidor MCP.
 <details>
-<summary>Examine os arquivos gerados por `ts#mcp-server` em detalhes</summary>
+<summary>Examine os arquivos gerados pelo `ts#mcp-server` em detalhes</summary>
 
 O gerador `ts#mcp-server` gera estes arquivos.
 
@@ -965,17 +965,17 @@ O gerador `ts#mcp-server` gera estes arquivos.
 
 ##### Criar o banco de dados do jogo
 
-O estado do nosso jogo — partidas salvas e o inventário de cada jogador — reside no [Amazon DynamoDB](https://aws.amazon.com/dynamodb/). Crie um projeto DynamoDB chamado `DungeonDb` com o gerador `ts#dynamodb`:
+O estado do nosso jogo — jogos salvos e o inventário de cada jogador — vive no [Amazon DynamoDB](https://aws.amazon.com/dynamodb/). Crie um projeto DynamoDB chamado `DungeonDb` com o gerador `ts#dynamodb`:
 
 <RunGenerator generator="ts#dynamodb" requiredParameters={{name:"DungeonDb"}} noInteractive />
 
-:::tip[Desenvolvimento local primeiro]
-O gerador `ts#dynamodb` fornece um target `dev` que executa o [DynamoDB Local](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html) em um container. Combinado com o gerador `connection` (que executamos abaixo), isso significa que **o jogo inteiro roda na sua máquina sem uma implantação** até o final do tutorial.
+:::tip[Desenvolvimento local-first]
+O gerador `ts#dynamodb` fornece um target `dev` que executa [DynamoDB Local](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html) em um contêiner. Combinado com o gerador `connection` (que executamos abaixo), isso significa que **o jogo inteiro roda na sua máquina sem uma implantação** até o final do tutorial.
 :::
 
 Você verá alguns novos arquivos aparecerem na sua árvore de arquivos.
 <details>
-<summary>Examine os arquivos gerados por `ts#dynamodb` em detalhes</summary>
+<summary>Examine os arquivos gerados pelo `ts#dynamodb` em detalhes</summary>
 
 O gerador `ts#dynamodb` gera estes arquivos.
 
@@ -1005,7 +1005,7 @@ O gerador `ts#dynamodb` gera estes arquivos.
           - dynamodb.ts construct de tabela DynamoDB genérico
 </FileTree>
 
-O `src/client.ts` gerado exporta `getDynamoDBClient()` e `resolveTableName()`. Quando `LOCAL_DEV=true` (definido automaticamente pelos targets `dev`) eles se conectam ao DynamoDB Local; caso contrário, conectam-se à AWS e resolvem o nome da tabela implantada a partir da <Link path="guides/runtime-config">Configuração de Runtime</Link>. Modelaremos nossas entidades `Game` e `Inventory` neste projeto no <Link path="get_started/tutorials/dungeon-game/2">Módulo 2</Link>.
+O `src/client.ts` gerado exporta `getDynamoDBClient()` e `resolveTableName()`. Quando `LOCAL_DEV=true` (definido automaticamente pelos targets `dev`) estes se conectam ao DynamoDB Local; caso contrário, eles se conectam à AWS e resolvem o nome da tabela implantada a partir da <Link path="guides/runtime-config">Configuração de Runtime</Link>. Vamos modelar nossas entidades `Game` e `Inventory` neste projeto no <Link path="get_started/tutorials/dungeon-game/2">Módulo 2</Link>.
 
 Para mais detalhes, consulte o <Link path="guides/ts-dynamodb">guia do gerador ts#dynamodb</Link>.
 
@@ -1028,7 +1028,7 @@ Selecionamos `--ux=shadcn` para que o website gerado use componentes [shadcn/ui]
 Você verá alguns novos arquivos aparecerem na sua árvore de arquivos.
 
 <details>
-<summary>Examine os arquivos gerados por `ts#website` em detalhes</summary>
+<summary>Examine os arquivos gerados pelo `ts#website` em detalhes</summary>
 
 O `ts#website` gera estes arquivos. Vamos examinar alguns dos arquivos principais destacados na árvore de arquivos:
 
@@ -1072,11 +1072,17 @@ O `ts#website` gera estes arquivos. Vamos examinar alguns dos arquivos principai
 // packages/common/constructs/src/app/static-websites/game-ui.ts
 import * as url from 'url';
 import { Construct } from 'constructs';
-import { StaticWebsite } from '../../core/index.js';
+import { StaticWebsite, StaticWebsiteProps } from '../../core/index.js';
+
+export type GameUIProps = Omit<
+  StaticWebsiteProps,
+  'websiteName' | 'websiteFilePath'
+>;
 
 export class GameUI extends StaticWebsite {
-  constructor(scope: Construct, id: string) {
+  constructor(scope: Construct, id: string, props?: GameUIProps) {
     super(scope, id, {
+      ...props,
       websiteName: 'GameUI',
       websiteFilePath: url.fileURLToPath(
         new URL(
@@ -1089,7 +1095,7 @@ export class GameUI extends StaticWebsite {
 }
 ```
 
-Este é o construct CDK que define nossa GameUI. Ele já configurou o caminho do arquivo para o bundle gerado para nossa UI baseada em Vite. Isso significa que no momento do `build`, o empacotamento ocorre dentro do target de build do projeto game-ui e a saída é usada aqui.
+Este é o construct CDK que define nossa GameUI. Ele já configurou o caminho do arquivo para o bundle gerado para nossa UI baseada em Vite. Isso significa que no tempo de `build`, o empacotamento ocorre dentro do target de build do projeto game-ui e a saída é usada aqui.
 
 ```tsx
 // packages/game-ui/src/main.tsx
@@ -1155,7 +1161,7 @@ Vamos configurar nossa Game UI para exigir acesso autenticado via Amazon Cognito
 Você verá alguns novos arquivos aparecerem/mudarem na sua árvore de arquivos.
 
 <details>
-<summary>Examine os arquivos gerados por `ts#website#auth` em detalhes</summary>
+<summary>Examine os arquivos gerados pelo `ts#website#auth` em detalhes</summary>
 
 O gerador `ts#website#auth` atualiza/gera estes arquivos. Vamos examinar alguns dos arquivos principais destacados na árvore de arquivos:
 
@@ -1282,8 +1288,8 @@ export const useGameApiClient = () => {
 
 Este hook fornece acesso ao cliente tRPC para chamar a GameApi. Para exemplos de como chamar APIs tRPC, consulte o <Link path="guides/connection/react-trpc#using-the-generated-code">guia de uso do hook tRPC</Link>.
 
-<Aside title="Hooks com Segurança de Tipos">
-Graças à [inferência de Typescript](https://trpc.io/docs/concepts) do tRPC, o `useGameApi` não precisa de uma etapa de build para que as mudanças no backend cheguem ao frontend — edições no roteador ou em qualquer procedimento são detectadas pelo verificador de tipos instantaneamente.
+<Aside title="Hooks Type-Safe">
+Graças à [inferência TypeScript](https://trpc.io/docs/concepts) do tRPC, `useGameApi` não precisa de uma etapa de build para que mudanças no backend cheguem ao frontend — edições no roteador ou em qualquer procedimento são detectadas pelo verificador de tipos instantaneamente.
 </Aside>
 
 ```diff lang="tsx"
@@ -1403,7 +1409,7 @@ Tanto a Game API quanto o servidor MCP de Inventário leem e escrevem em nossa t
 
 <RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/inventory", targetProject:"@dungeon-adventure/dungeon-db"}} noInteractive />
 
-<Aside type="tip" title="Um comando inicializa toda a stack localmente">
+<Aside type="tip" title="Um comando inicializa toda a pilha localmente">
 Como o `agent-dev` do Story Agent já depende do `mcp-server-dev` do servidor MCP de Inventário (via a conexão `story → inventory` acima), e tanto a Game API quanto o servidor MCP agora dependem de `dungeon-db:dev`, executar o target `dev` de qualquer projeto inicia todas as dependências necessárias na ordem correta.
 </Aside>
 
@@ -1416,7 +1422,7 @@ Vamos criar o sub-projeto final para a infraestrutura CDK.
 Você verá alguns novos arquivos aparecerem/mudarem na sua árvore de arquivos.
 
 <details>
-<summary>Examine os arquivos gerados por `ts#infra` em detalhes</summary>
+<summary>Examine os arquivos gerados pelo `ts#infra` em detalhes</summary>
 
 O gerador `ts#infra` gera/atualiza estes. Vamos examinar alguns dos arquivos principais destacados na árvore de arquivos:
 
@@ -1481,7 +1487,7 @@ export class ApplicationStack extends Stack {
 }
 ```
 
-Vamos instanciar nossos constructs CDK para construir nosso jogo de aventura em dungeon.
+Vamos instanciar nossos constructs CDK para construir nosso jogo de aventura em masmorra.
 
 </details>
 
@@ -1497,15 +1503,15 @@ Vamos atualizar `packages/infra/src/stacks/application-stack.ts` para instanciar
 Fornecemos integrações padrão para nossa Game API. Por padrão, cada operação em nossa API é mapeada para uma função Lambda individual para lidar com essa operação.
 :::
 
-## Tarefa 4: Compilar o código
+## Tarefa 4: Construir o código
 
-<Drawer title="Comandos Nx" trigger="Agora é hora de compilar nosso código pela primeira vez">
+<Drawer title="Comandos Nx" trigger="Agora é hora de construirmos nosso código pela primeira vez">
 
 ###### Targets únicos vs múltiplos
 
-O comando `run-many` executará um target em múltiplos sub-projetos listados (`--all` irá direcionar todos eles). Isso garante que as dependências sejam executadas na ordem correta.
+O comando `run-many` executará um target em múltiplos sub-projetos listados (`--all` irá direcioná-los todos). Isso garante que as dependências sejam executadas na ordem correta.
 
-Você também pode acionar um build (ou qualquer outra tarefa) para um único target de projeto executando o target diretamente no projeto. Por exemplo, para compilar o projeto `@dungeon-adventure/infra`, execute o seguinte comando:
+Você também pode acionar um build (ou qualquer outra tarefa) para um target de projeto único executando o target diretamente no projeto. Por exemplo, para construir o projeto `@dungeon-adventure/infra`, execute o seguinte comando:
 
 <NxCommands commands={['build infra']} />
 
@@ -1557,8 +1563,8 @@ No, run the tasks without syncing the changes
 
 Esta mensagem indica que o NX detectou alguns arquivos que podem ser atualizados automaticamente para você. Neste caso, está se referindo aos arquivos `tsconfig.json` que não têm referências Typescript configuradas em projetos referenciados.
 
-Selecione a opção **Yes, sync the changes and run the tasks** para prosseguir. Você deverá notar que todos os erros de importação relacionados ao IDE são resolvidos automaticamente, pois o gerador de sincronização adicionará as referências typescript ausentes automaticamente!
+Selecione a opção **Yes, sync the changes and run the tasks** para prosseguir. Você deve notar que todos os seus erros de importação relacionados ao IDE são resolvidos automaticamente, pois o gerador de sincronização adicionará as referências typescript ausentes automaticamente!
 
-Todos os artefatos compilados agora estão disponíveis dentro da `pasta dist/` localizada na raiz do monorepo. Esta é uma prática padrão ao usar projetos gerados pelo `@aws/nx-plugin`, pois não polui sua árvore de arquivos com arquivos gerados. Caso queira limpar seus arquivos, exclua a pasta `dist/` sem se preocupar com artefatos de build espalhados pela árvore de arquivos.
+Todos os artefatos construídos agora estão disponíveis dentro da pasta `dist/` localizada na raiz do monorepo. Esta é uma prática padrão ao usar projetos gerados pelo `@aws/nx-plugin`, pois não polui sua árvore de arquivos com arquivos gerados. No caso de você querer limpar seus arquivos, exclua a pasta `dist/` sem se preocupar com artefatos de build espalhados por toda a árvore de arquivos.
 
-Parabéns! Você criou todos os sub-projetos necessários para começar a implementar o núcleo do nosso jogo AI Dungeon Adventure. 🎉🎉🎉
+Parabéns! Você criou todos os sub-projetos necessários para começar a implementar o núcleo do nosso jogo de Aventura em Masmorra com IA.  🎉🎉🎉

--- a/docs/src/content/docs/pt/guides/react-website.mdx
+++ b/docs/src/content/docs/pt/guides/react-website.mdx
@@ -259,7 +259,7 @@ Uma `Content-Security-Policy` padrão é aplicada. Ela restringe scripts e frami
 
 ### WAF
 
-A distribuição CloudFront é protegida por um Web ACL [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) por padrão. O Web ACL usa o conjunto de regras padrão gerenciado pela AWS ([`AWSManagedRulesCommonRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs) e [`AWSManagedRulesKnownBadInputsRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs)), fornecendo proteção contra explorações web comuns, incluindo o OWASP Top 10.
+A distribuição CloudFront é protegida por um [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACL por padrão. O Web ACL usa o conjunto de regras padrão gerenciado pela AWS ([`AWSManagedRulesCommonRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs) e [`AWSManagedRulesKnownBadInputsRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs)), fornecendo proteção contra explorações web comuns, incluindo o OWASP Top 10.
 
 <Infrastructure>
 <Fragment slot="cdk">
@@ -334,6 +334,22 @@ export class ApplicationStack extends Stack {
 }
 ```
 
+:::caution[Suprimir CKV_AWS_158 ao usar S3_MANAGED]
+Escolher `BucketEncryption.S3_MANAGED` significa que o grupo de log de acesso não está mais criptografado com KMS, o que falha na verificação de segurança `checkov` com `CKV_AWS_158`. Suprima-o:
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { LogGroup } from 'aws-cdk-lib/aws-logs';
+import { suppressRules } from '@my-scope/common-constructs';
+
+suppressRules(
+  website,
+  ['CKV_AWS_158'],
+  'Access log group is not KMS encrypted when encryption is S3_MANAGED',
+  (c) => c instanceof LogGroup,
+);
+```
+:::
+
 Para usar sua própria chave KMS em vez de uma criada automaticamente, passe `encryptionKey`:
 
 ```ts {2}
@@ -342,10 +358,36 @@ new MyWebsite(this, 'MyWebsite', {
 });
 ```
 
-`enableKeyRotation` (padrão `true`) aplica-se apenas à chave criada automaticamente, ou seja, quando `encryption` é `BucketEncryption.KMS` (o padrão) e nenhum `encryptionKey` é fornecido.
+:::caution[Chaves importadas precisam de suas próprias permissões]
+Uma chave importada via `Key.fromKeyArn` já deve conceder aos principais de serviço CloudWatch Logs, S3 e CloudFront as permissões necessárias em sua própria política de chave. `addToResourcePolicy` é um no-op em uma chave importada, então este construct não pode concedê-las para você, e `cdk synth` não irá avisá-lo - a falha só aparece no momento da implantação. Uma chave criada no mesmo app (`new Key(this, 'WebsiteKey')`) não tem esse problema, já que o CDK pode atualizar sua política diretamente.
+:::
+
+`enableKeyRotation` (padrão `true`) só se aplica à chave criada automaticamente, ou seja, quando `encryption` é `BucketEncryption.KMS` (o padrão) e nenhum `encryptionKey` é fornecido:
+
+```ts {2}
+new MyWebsite(this, 'MyWebsite', {
+  enableKeyRotation: false,
+});
+```
+
+:::caution[Suprimir CKV_AWS_7 ao desativar rotação de chave]
+Desativar a rotação de chave na chave criada automaticamente falha na verificação de segurança `checkov` com `CKV_AWS_7`. Suprima-o:
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { Key } from 'aws-cdk-lib/aws-kms';
+import { suppressRules } from '@my-scope/common-constructs';
+
+suppressRules(
+  website,
+  ['CKV_AWS_7'],
+  'Key rotation is managed externally',
+  (c) => c instanceof Key,
+);
+```
+:::
 </Fragment>
 <Fragment slot="terraform">
-Se você quiser usar uma configuração de criptografia diferente, defina as variáveis `encryption`, `kms_key_arn` e `enable_key_rotation`:
+Se você quiser usar uma configuração de criptografia diferente, defina as variáveis `encryption`, `kms_key_arn`, `create_kms_key` e `enable_key_rotation`:
 
 ```hcl title="packages/infra/src/main.tf" {7}
 module "my_website" {
@@ -358,15 +400,58 @@ module "my_website" {
 }
 ```
 
-Para usar sua própria chave KMS em vez de uma criada automaticamente, passe `kms_key_arn`. Uma chave fornecida pelo cliente já deve conceder aos principais de serviço CloudWatch Logs, S3 e CloudFront as permissões necessárias em sua própria política de chave.
+:::caution[Checkov: S3_MANAGED]
+Escolher `S3_MANAGED` falha na verificação de segurança `checkov` com `CKV_AWS_145` nos buckets de site e log de distribuição. O target `test` fornecido não aceita um `--config-file`, mas `checkov` descobre automaticamente um `.checkov.yaml` em seu diretório de trabalho, então coloque um em `packages/infra/src`:
 
-`enable_key_rotation` (padrão `true`) aplica-se apenas à chave criada automaticamente, ou seja, quando `encryption` é `"KMS"` (o padrão) e nenhum `kms_key_arn` é fornecido.
+```yaml title="packages/infra/src/.checkov.yaml"
+skip-check:
+  - CKV_AWS_145
+```
+:::
+
+Para usar sua própria chave KMS em vez de uma criada automaticamente, passe `kms_key_arn` e defina `create_kms_key` como `false`:
+
+```hcl title="packages/infra/src/main.tf" {7-8}
+module "my_website" {
+  source = "../../common/terraform/src/app/static-websites/my-website"
+
+  providers = {
+    aws.us_east_1 = aws.us_east_1
+  }
+  kms_key_arn    = aws_kms_key.website.arn
+  create_kms_key = false
+}
+```
+
+Uma chave fornecida pelo cliente já deve conceder aos principais de serviço CloudWatch Logs, S3 e CloudFront as permissões necessárias em sua própria política de chave.
+
+`enable_key_rotation` (padrão `true`) só se aplica à chave criada automaticamente, ou seja, quando `encryption` é `"KMS"` (o padrão) e `create_kms_key` é `true`:
+
+```hcl title="packages/infra/src/main.tf" {7}
+module "my_website" {
+  source = "../../common/terraform/src/app/static-websites/my-website"
+
+  providers = {
+    aws.us_east_1 = aws.us_east_1
+  }
+  enable_key_rotation = false
+}
+```
+
+:::caution[Checkov: rotação de chave desativada]
+Desativar a rotação de chave na chave criada automaticamente falha na verificação de segurança `checkov` com `CKV_AWS_7`. Adicione-o ao mesmo `.checkov.yaml`:
+
+```yaml title="packages/infra/src/.checkov.yaml"
+skip-check:
+  - CKV_AWS_7
+```
+:::
 </Fragment>
 </Infrastructure>
 
 ### Domínio Personalizado e TLS
 
-Por padrão, a distribuição usa o nome de domínio CloudFront padrão (`*.cloudfront.net`) e seu certificado padrão, que não suporta a aplicação de uma versão TLS mínima de 1.2. Para servir seu site a partir do seu próprio domínio, forneça um [certificado ACM](https://docs.aws.amazon.com/acm/latest/userguide/acm-overview.html) (que deve residir em `us-east-1` para uso com CloudFront) e seus nomes de domínio. Uma versão TLS mínima de 1.2 é então aplicada para os visualizadores:
+Por padrão, a distribuição usa o nome de domínio padrão do CloudFront (`*.cloudfront.net`) e seu certificado padrão, que não suporta a aplicação de uma versão TLS mínima de 1.2. Para servir seu site a partir do seu próprio domínio, forneça um [certificado ACM](https://docs.aws.amazon.com/acm/latest/userguide/acm-overview.html) (que deve residir em `us-east-1` para uso com CloudFront) e seus nomes de domínio. Uma versão TLS mínima de 1.2 é então aplicada para os visualizadores:
 
 <Infrastructure>
 <Fragment slot="cdk">
@@ -418,7 +503,7 @@ A configuração da sua infraestrutura é fornecida ao seu site via <Link href="
 
 <Infrastructure>
 <Fragment slot="cdk">
-O construct CDK `RuntimeConfig` pode ser usado para adicionar e recuperar configuração na sua infraestrutura CDK. Os constructs CDK gerados pelos geradores `@aws/nx-plugin` (como <Link path="guides/trpc">`ts#api`</Link> e <Link path="guides/fastapi">`py#api`</Link>) adicionarão automaticamente valores apropriados ao `RuntimeConfig`.
+O construct CDK `RuntimeConfig` pode ser usado para adicionar e recuperar configuração em sua infraestrutura CDK. Os constructs CDK gerados pelos geradores `@aws/nx-plugin` (como <Link path="guides/trpc">`ts#api`</Link> e <Link path="guides/fastapi">`py#api`</Link>) adicionarão automaticamente valores apropriados ao `RuntimeConfig`.
 
 Seu construct CDK de site implantará o namespace `connection` da configuração de runtime como um arquivo `runtime-config.json` na raiz do seu bucket S3.
 
@@ -477,7 +562,7 @@ module "my_website" {
 ```
 
 :::caution[Ordenação de Módulos]
-Você deve garantir que declare seu módulo de site _após_ quaisquer módulos que adicionem à configuração de runtime e configure o `depends_on` apropriado para garantir a ordenação, caso contrário eles estarão faltando no seu arquivo `runtime-config.json`.
+Você deve garantir que declare seu módulo de site _depois_ de quaisquer módulos que adicionem à configuração de runtime e configure o `depends_on` apropriado para garantir a ordenação, caso contrário eles estarão faltando no seu arquivo `runtime-config.json`.
 :::
 </Fragment>
 </Infrastructure>
@@ -503,7 +588,7 @@ Para detalhes sobre como a configuração de runtime é armazenada no AWS AppCon
 
 ### Configuração de Runtime Local
 
-Ao executar o [servidor de desenvolvimento local](#servidor-de-desenvolvimento-local), você precisará de um arquivo `runtime-config.json` no seu diretório `public` para que seu site local conheça as URLs do backend, configuração de identidade, etc.
+Ao executar o [servidor de desenvolvimento local](#servidor-de-desenvolvimento-local), você precisará de um arquivo `runtime-config.json` no seu diretório `public` para que seu site local conheça as URLs de backend, configuração de identidade, etc.
 
 Seu projeto de site está configurado com um target `load-runtime-config` que você pode usar para baixar o arquivo `runtime-config.json` de uma aplicação implantada:
 
@@ -514,7 +599,7 @@ Seu projeto de site está configurado com um target `load-runtime-config` que vo
 <Fragment slot="cdk">
 Se você alterar o prefixo para seus nomes de stage no `src/main.ts` do seu projeto de infraestrutura, você precisará atualizar o target `load-runtime-config` no arquivo `project.json` do seu site de acordo.
 
-Além disso, vale notar que o target `load-runtime-config` assume que um único stage da sua aplicação está implantado no ambiente para o qual você tem credenciais AWS. Você precisará ajustar o comando se implantar vários stages na mesma conta e região.
+Além disso, vale notar que o target `load-runtime-config` assume que um único stage da sua aplicação está implantado no ambiente para o qual você tem credenciais AWS. Você precisará ajustar o comando se implantar múltiplos stages na mesma conta e região.
 </Fragment>
 <Fragment slot="terraform">
 Para projetos Terraform, o target `load-runtime-config` copia o arquivo `runtime-config.json` que foi criado após seu `terraform apply` local mais recente.
@@ -524,11 +609,11 @@ Para projetos Terraform, o target `load-runtime-config` copia o arquivo `runtime
 
 ## Servidor de Desenvolvimento Local
 
-O comando canônico para desenvolvimento local é `dev`, que inicia seu site (e quaisquer servidores locais para APIs às quais você o conectou) com um comando:
+O comando canônico para desenvolvimento local é `dev`, que inicia seu site (e quaisquer servidores locais para APIs que você conectou a ele) com um único comando:
 
 <NxCommands commands={['dev <my-website>']} />
 
-O target `serve` também está disponível para quando você precisar controlar quanto da sua aplicação é executado localmente versus apontando para a infraestrutura AWS implantada. Para uma visão geral mais ampla do desenvolvimento local em projetos conectados, incluindo como `dev` se comporta para projetos com vários componentes, consulte o guia <Link path="guides/local-development">Desenvolvimento Local</Link>.
+O target `serve` também está disponível para quando você precisa controlar quanto da sua aplicação é executado localmente versus apontando para infraestrutura AWS implantada. Para uma visão geral mais ampla do desenvolvimento local em projetos conectados, incluindo como `dev` se comporta para projetos com múltiplos componentes, consulte o guia <Link path="guides/local-development">Desenvolvimento Local</Link>.
 
 ### Target Serve
 
@@ -542,7 +627,7 @@ Este target é útil para trabalhar em alterações do site enquanto aponta para
 
 ### Target Dev
 
-O target `dev` inicia um servidor de desenvolvimento local para seu site (com [Vite `MODE`](https://vite.dev/guide/env-and-mode) definido como `local-dev`), bem como inicia quaisquer servidores locais para APIs às quais você conectou seu site via o <Link path="/guides/connection">gerador Connection</Link>.
+O target `dev` inicia um servidor de desenvolvimento local para seu site (com [Vite `MODE`](https://vite.dev/guide/env-and-mode) definido como `local-dev`), bem como inicia quaisquer servidores locais para APIs que você conectou ao seu site via o <Link path="/guides/connection">gerador Connection</Link>.
 
 Quando seu servidor de site local é executado via este target, `runtime-config.json` é automaticamente substituído para apontar para suas URLs de API em execução local.
 
@@ -557,7 +642,7 @@ O `package.json` raiz do seu workspace inclui um script `dev` que executa o targ
 
 <PackageManagerShortCommand commands={["dev"]} />
 
-Isso inicia o servidor de desenvolvimento local para seu site (e quaisquer outros projetos com um target `dev`) em um comando. Para executar apenas este site, use seu próprio target `dev` (por exemplo, `nx dev <my-website>`).
+Isso inicia o servidor de desenvolvimento local para seu site (e quaisquer outros projetos com um target `dev`) em um único comando. Para executar apenas este site, use seu próprio target `dev` (por exemplo, `nx dev <my-website>`).
 :::
 
 :::warning[Autenticação Simulada]
@@ -574,9 +659,9 @@ Ao executar com `dev`, você pode especificar quaisquer variáveis de ambiente n
 Observe que seus servidores de API locais serão executados com as credenciais AWS que você configurou localmente.
 :::
 
-## Building
+## Build
 
-Você pode fazer o build do seu site usando o target `build`. Isso executa os targets `bundle`, `compile`, `test` e `lint`, verificando tipos, empacotando, testando e fazendo lint do seu site.
+Você pode fazer o build do seu site usando o target `build`. Isso executa os targets `bundle`, `compile`, `test` e `lint`, fazendo verificação de tipos, bundling, testes e linting do seu site.
 
 <NxCommands commands={['build <my-website>']} />
 
@@ -651,3 +736,4 @@ Use o gerador <Link path="guides/connection">`connection`</Link> para integrar e
     target="agentcore"
   />
 </CardGrid>
+

--- a/docs/src/content/docs/pt/guides/react-website.mdx
+++ b/docs/src/content/docs/pt/guides/react-website.mdx
@@ -18,9 +18,9 @@ import Infrastructure from '@components/infrastructure.astro';
 import Snippet from '@components/snippet.astro';
 import OptionFilter from '@components/option-filter.astro';
 
-Este gerador cria um novo website [React](https://react.dev/) com [shadcn/ui](https://ui.shadcn.com/) configurado por padrão, juntamente com a infraestrutura AWS CDK ou Terraform para implantar seu website na nuvem como um site estático hospedado no [S3](https://aws.amazon.com/s3/), servido pelo [CloudFront](https://aws.amazon.com/cloudfront/) e protegido pelo [WAF](https://aws.amazon.com/waf/).
+Este gerador cria um novo site [React](https://react.dev/) com [shadcn/ui](https://ui.shadcn.com/) configurado por padrão, juntamente com a infraestrutura AWS CDK ou Terraform para implantar seu site na nuvem como um site estático hospedado no [S3](https://aws.amazon.com/s3/), servido pelo [CloudFront](https://aws.amazon.com/cloudfront/) e protegido pelo [WAF](https://aws.amazon.com/waf/).
 
-A aplicação gerada usa [Vite](https://vite.dev/) como ferramenta de build e bundler. Ela usa [TanStack Router](https://tanstack.com/router/v1) para roteamento com segurança de tipos.
+A aplicação gerada usa [Vite](https://vite.dev/) como ferramenta de build e bundler. Ela usa [TanStack Router](https://tanstack.com/router/v1) para roteamento type-safe.
 
 :::note[Provedor de UX]
 O `ux` padrão é [shadcn/ui](https://ui.shadcn.com/). Você também pode selecionar [Cloudscape](http://cloudscape.design/) ou `none` (traga sua própria biblioteca de componentes).
@@ -70,7 +70,7 @@ Se você optou por não usar [TanStack Router](https://tanstack.com/router/v1), 
 
 <Snippet name="shared-constructs" />
 
-O gerador cria infraestrutura como código para implantar seu website com base no `iac` selecionado:
+O gerador cria infraestrutura como código para implantar seu site com base no `iac` selecionado:
 
 <Infrastructure>
 <Fragment slot="cdk">
@@ -99,7 +99,7 @@ O gerador cria infraestrutura como código para implantar seu website com base n
 
 #### Arquitetura
 
-O website implantado possui a seguinte arquitetura:
+O site implantado tem a seguinte arquitetura:
 
 ```d2 inline=true
 direction: right
@@ -129,60 +129,9 @@ waf -> cloudfront
 cloudfront -> s3
 ```
 
-#### Cabeçalhos de Segurança
+## Implementando seu Site
 
-A distribuição CloudFront aplica uma política de cabeçalhos de resposta que define `Strict-Transport-Security`, `X-Content-Type-Options`, `X-Frame-Options: DENY`, `Referrer-Policy` e uma `Content-Security-Policy` em todas as respostas.
-
-Uma `Content-Security-Policy` padrão é aplicada. Ela restringe scripts e framing para mitigar XSS e clickjacking, enquanto permite conexões HTTPS e WSS para que o website possa chamar endpoints de serviços AWS (como API Gateway, Cognito e Bedrock AgentCore) cujas URLs são conhecidas apenas no momento da implantação. Para ajustar a política (por exemplo, para restringir `connect-src` às suas origens específicas), edite o valor `content_security_policy` no seu `static-website.ts` (CDK) ou `static-website.tf` (Terraform) gerado.
-
-`runtime-config.json` é servido com `Cache-Control: no-cache` para que os navegadores sempre busquem a configuração mais recente após uma reimplantação, em vez de usar uma cópia em cache desatualizada.
-
-#### Domínio Personalizado e TLS
-
-Por padrão, a distribuição usa o nome de domínio padrão do CloudFront (`*.cloudfront.net`) e seu certificado padrão, que não suporta a aplicação de uma versão mínima de TLS de 1.2. Para servir seu website a partir do seu próprio domínio, forneça um [certificado ACM](https://docs.aws.amazon.com/acm/latest/userguide/acm-overview.html) (que deve residir em `us-east-1` para uso com CloudFront) e seus nomes de domínio — uma versão mínima de TLS de 1.2 é então aplicada para os visualizadores:
-
-<Infrastructure>
-<Fragment slot="cdk">
-Passe as props `certificate` e `domainNames` no seu construto de website gerado em `packages/common/constructs/src/app/static-websites`:
-
-```ts {6-8}
-export class MyWebsite extends StaticWebsite {
-  constructor(scope: Construct, id: string) {
-    super(scope, id, {
-      websiteName: 'MyWebsite',
-      websiteFilePath: ...,
-      domainNames: ['www.example.com'],
-      certificate: Certificate.fromCertificateArn(scope, 'Cert',
-        'arn:aws:acm:us-east-1:123456789012:certificate/...'),
-    });
-  }
-}
-```
-</Fragment>
-<Fragment slot="terraform">
-Defina as variáveis `custom_domain_names` e `acm_certificate_arn` no seu módulo de website gerado em `packages/common/terraform/src/app/static-websites`:
-
-```hcl {5-6}
-module "static_website" {
-  source            = "../../../core/static-website"
-  website_name      = "my-website"
-  website_file_path = ...
-  custom_domain_names = ["www.example.com"]
-  acm_certificate_arn = "arn:aws:acm:us-east-1:123456789012:certificate/..."
-
-  providers = {
-    aws.us_east_1 = aws.us_east_1
-  }
-}
-```
-</Fragment>
-</Infrastructure>
-
-Você também precisará criar registros DNS (por exemplo, no Route 53) apontando seu domínio para a distribuição CloudFront.
-
-## Implementando seu React Website
-
-A [documentação do React](https://react.dev/learn) é um bom lugar para começar a aprender os fundamentos de construção com React.
+A [documentação do React](https://react.dev/learn) é um bom lugar para começar a aprender os conceitos básicos de construção com React.
 
 <OptionFilter when={{ ux: 'cloudscape' }} description="Cloudscape component docs pointer">
 Você pode consultar a [documentação do Cloudscape](https://cloudscape.design/components/) para detalhes sobre os componentes disponíveis e como usá-los.
@@ -196,7 +145,7 @@ Você pode consultar a [documentação do shadcn/ui](https://ui.shadcn.com/docs)
 
 #### Criando uma Rota/Página
 
-Seu website vem com [TanStack Router](https://tanstack.com/router/v1) configurado por padrão. Isso facilita a adição de novas rotas:
+Seu site vem com [TanStack Router](https://tanstack.com/router/v1) configurado por padrão. Isso facilita a adição de novas rotas:
 
 <Steps>
   1. [Execute o Servidor de Desenvolvimento Local](#servidor-de-desenvolvimento-local)
@@ -231,17 +180,247 @@ export const MyComponent = () => {
 
 Para mais detalhes, confira a documentação do [TanStack Router](https://tanstack.com/router/latest/docs/framework/react/overview).
 
+## Implantando seu Site
+
+O gerador de site React cria infraestrutura como código CDK ou Terraform com base no `iac` selecionado. Você pode usar isso para implantar seu site.
+
+<Infrastructure>
+<Fragment slot="cdk">
+Para implantar seu site, recomendamos usar o <Link path="guides/typescript-infrastructure">gerador `ts#infra`</Link> para criar uma aplicação CDK.
+
+Você pode usar o construct CDK gerado para você em `packages/common/constructs` para implantar seu site.
+
+```ts title="packages/infra/src/stacks/application-stack.ts" {3, 9}
+import { Stack } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { MyWebsite } from '@my-scope/common-constructs';
+
+export class ApplicationStack extends Stack {
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+
+    new MyWebsite(this, 'MyWebsite');
+  }
+}
+```
+
+Isso configura:
+
+1. Um bucket S3 para hospedar seus arquivos de site estático
+2. Distribuição CloudFront para entrega global de conteúdo
+3. WAF Web ACL para proteção de segurança
+4. Origin Access Control para acesso seguro ao S3
+5. Implantação automática de arquivos do site e configuração de runtime
+</Fragment>
+<Fragment slot="terraform">
+Para implantar seu site, recomendamos usar o <Link path="/guides/terraform-project">gerador `terraform#project`</Link> para criar um projeto Terraform.
+
+Você pode usar o módulo Terraform gerado para você em `packages/common/terraform` para implantar seu site.
+
+```hcl title="packages/infra/src/main.tf" {3}
+# Deploy website
+module "my_website" {
+  source = "../../common/terraform/src/app/static-websites/my-website"
+
+  providers = {
+    aws.us_east_1 = aws.us_east_1
+  }
+}
+```
+
+Isso configura:
+
+1. Um bucket S3 para hospedar seus arquivos de site estático
+2. Distribuição CloudFront para entrega global de conteúdo
+3. WAF Web ACL para proteção de segurança (implantado em us-east-1)
+4. Origin Access Control para acesso seguro ao S3
+5. Implantação automática de arquivos do site e configuração de runtime
+
+:::note[Região do Provedor WAF]
+O provedor `aws.us_east_1` é necessário para recursos CloudFront e WAF, que devem ser implantados na região us-east-1. Certifique-se de que sua configuração Terraform inclui este provedor:
+
+```hcl title="packages/infra/src/providers.tf"
+provider "aws" {
+  alias  = "us_east_1"
+  region = "us-east-1"
+}
+```
+:::
+</Fragment>
+</Infrastructure>
+
+### Cabeçalhos de Segurança
+
+A distribuição CloudFront aplica uma política de cabeçalhos de resposta que define `Strict-Transport-Security`, `X-Content-Type-Options`, `X-Frame-Options: DENY`, `Referrer-Policy` e uma `Content-Security-Policy` em todas as respostas.
+
+Uma `Content-Security-Policy` padrão é aplicada. Ela restringe scripts e framing para mitigar XSS e clickjacking, enquanto permite conexões HTTPS e WSS para que o site possa chamar endpoints de serviços AWS (como API Gateway, Cognito e Bedrock AgentCore) cujas URLs são conhecidas apenas no momento da implantação. Para ajustar a política (por exemplo, para restringir `connect-src` às suas origens específicas), edite o valor `content_security_policy` no seu `static-website.ts` (CDK) ou `static-website.tf` (Terraform) gerado.
+
+`runtime-config.json` é servido com `Cache-Control: no-cache` para que os navegadores sempre busquem a configuração mais recente após uma reimplantação, em vez de usar uma cópia em cache desatualizada.
+
+### WAF
+
+A distribuição CloudFront é protegida por um Web ACL [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) por padrão. O Web ACL usa o conjunto de regras padrão gerenciado pela AWS ([`AWSManagedRulesCommonRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs) e [`AWSManagedRulesKnownBadInputsRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs)), fornecendo proteção contra explorações web comuns, incluindo o OWASP Top 10.
+
+<Infrastructure>
+<Fragment slot="cdk">
+Para desativar, defina `enableWaf` como `false` ao criar seu site:
+
+```ts title="packages/infra/src/stacks/application-stack.ts" {10,15-18}
+import { Stack } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { MyWebsite, suppressRules } from '@my-scope/common-constructs';
+
+export class ApplicationStack extends Stack {
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+
+    const website = new MyWebsite(this, 'MyWebsite', {
+      enableWaf: false,
+    });
+
+    // Disabling WAF fails the checkov CKV_AWS_68 check ("CloudFront
+    // Distribution should have WAF enabled"). Suppress it explicitly.
+    suppressRules(
+      website.cloudFrontDistribution,
+      ['CKV_AWS_68'],
+      'WAF is intentionally disabled for this distribution',
+    );
+  }
+}
+```
+
+:::caution[Suprimir CKV_AWS_68 ao desativar WAF]
+Desativar o WAF significa que a distribuição CloudFront sintetizada não tem Web ACL associado, o que falha na verificação de segurança `checkov` com `CKV_AWS_68: "CloudFront Distribution should have WAF enabled"` a menos que seja suprimido conforme mostrado acima.
+:::
+</Fragment>
+<Fragment slot="terraform">
+Para desativar, defina `enable_waf` como `false`:
+
+```hcl title="packages/infra/src/main.tf" {7}
+module "my_website" {
+  source = "../../common/terraform/src/app/static-websites/my-website"
+
+  providers = {
+    aws.us_east_1 = aws.us_east_1
+  }
+  enable_waf = false
+}
+```
+</Fragment>
+</Infrastructure>
+
+### Criptografia de Bucket
+
+O bucket do site, o bucket de log da distribuição CloudFront e o grupo CloudWatch Logs que recebe seus logs de acesso ao servidor são criptografados com uma chave [AWS KMS](https://aws.amazon.com/kms/) gerenciada pelo cliente por padrão. Esta chave é criada automaticamente para você, com rotação de chave habilitada.
+
+<Infrastructure>
+<Fragment slot="cdk">
+Se você quiser usar uma configuração de criptografia diferente, passe as props `encryption`, `encryptionKey` e `enableKeyRotation` ao criar seu site:
+
+```ts title="packages/infra/src/stacks/application-stack.ts" {11}
+import { Stack } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { BucketEncryption } from 'aws-cdk-lib/aws-s3';
+import { MyWebsite } from '@my-scope/common-constructs';
+
+export class ApplicationStack extends Stack {
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+
+    new MyWebsite(this, 'MyWebsite', {
+      encryption: BucketEncryption.S3_MANAGED,
+    });
+  }
+}
+```
+
+Para usar sua própria chave KMS em vez de uma criada automaticamente, passe `encryptionKey`:
+
+```ts {2}
+new MyWebsite(this, 'MyWebsite', {
+  encryptionKey: myKey,
+});
+```
+
+`enableKeyRotation` (padrão `true`) aplica-se apenas à chave criada automaticamente, ou seja, quando `encryption` é `BucketEncryption.KMS` (o padrão) e nenhum `encryptionKey` é fornecido.
+</Fragment>
+<Fragment slot="terraform">
+Se você quiser usar uma configuração de criptografia diferente, defina as variáveis `encryption`, `kms_key_arn` e `enable_key_rotation`:
+
+```hcl title="packages/infra/src/main.tf" {7}
+module "my_website" {
+  source = "../../common/terraform/src/app/static-websites/my-website"
+
+  providers = {
+    aws.us_east_1 = aws.us_east_1
+  }
+  encryption = "S3_MANAGED"
+}
+```
+
+Para usar sua própria chave KMS em vez de uma criada automaticamente, passe `kms_key_arn`. Uma chave fornecida pelo cliente já deve conceder aos principais de serviço CloudWatch Logs, S3 e CloudFront as permissões necessárias em sua própria política de chave.
+
+`enable_key_rotation` (padrão `true`) aplica-se apenas à chave criada automaticamente, ou seja, quando `encryption` é `"KMS"` (o padrão) e nenhum `kms_key_arn` é fornecido.
+</Fragment>
+</Infrastructure>
+
+### Domínio Personalizado e TLS
+
+Por padrão, a distribuição usa o nome de domínio CloudFront padrão (`*.cloudfront.net`) e seu certificado padrão, que não suporta a aplicação de uma versão TLS mínima de 1.2. Para servir seu site a partir do seu próprio domínio, forneça um [certificado ACM](https://docs.aws.amazon.com/acm/latest/userguide/acm-overview.html) (que deve residir em `us-east-1` para uso com CloudFront) e seus nomes de domínio. Uma versão TLS mínima de 1.2 é então aplicada para os visualizadores:
+
+<Infrastructure>
+<Fragment slot="cdk">
+Passe as props `certificate` e `domainNames` ao criar seu site:
+
+```ts title="packages/infra/src/stacks/application-stack.ts" {11-13}
+import { Stack } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { Certificate } from 'aws-cdk-lib/aws-certificatemanager';
+import { MyWebsite } from '@my-scope/common-constructs';
+
+export class ApplicationStack extends Stack {
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+
+    new MyWebsite(this, 'MyWebsite', {
+      domainNames: ['www.example.com'],
+      certificate: Certificate.fromCertificateArn(this, 'Cert',
+        'arn:aws:acm:us-east-1:123456789012:certificate/...'),
+    });
+  }
+}
+```
+</Fragment>
+<Fragment slot="terraform">
+Defina as variáveis `custom_domain_names` e `acm_certificate_arn`:
+
+```hcl title="packages/infra/src/main.tf" {7-8}
+module "my_website" {
+  source = "../../common/terraform/src/app/static-websites/my-website"
+
+  providers = {
+    aws.us_east_1 = aws.us_east_1
+  }
+  custom_domain_names = ["www.example.com"]
+  acm_certificate_arn = "arn:aws:acm:us-east-1:123456789012:certificate/..."
+}
+```
+</Fragment>
+</Infrastructure>
+
+Você também precisará criar registros DNS (por exemplo, no Route 53) apontando seu domínio para a distribuição CloudFront.
+
 ## Configuração de Runtime
 
-A configuração da sua infraestrutura é fornecida ao seu website via <Link href="guides/runtime-config">Configuração de Runtime</Link>. Isso permite que seu website acesse detalhes como URLs de API que não são conhecidas até que sua aplicação seja implantada.
+A configuração da sua infraestrutura é fornecida ao seu site via <Link href="guides/runtime-config">Configuração de Runtime</Link>. Isso permite que seu site acesse detalhes como URLs de API que não são conhecidas até que sua aplicação seja implantada.
 
 ### Infraestrutura
 
 <Infrastructure>
 <Fragment slot="cdk">
-O construto CDK `RuntimeConfig` pode ser usado para adicionar e recuperar configuração na sua infraestrutura CDK. Os construtos CDK gerados pelos geradores `@aws/nx-plugin` (como <Link path="guides/trpc">`ts#api`</Link> e <Link path="guides/fastapi">`py#api`</Link>) adicionarão automaticamente valores apropriados ao `RuntimeConfig`.
+O construct CDK `RuntimeConfig` pode ser usado para adicionar e recuperar configuração na sua infraestrutura CDK. Os constructs CDK gerados pelos geradores `@aws/nx-plugin` (como <Link path="guides/trpc">`ts#api`</Link> e <Link path="guides/fastapi">`py#api`</Link>) adicionarão automaticamente valores apropriados ao `RuntimeConfig`.
 
-Seu construto CDK de website implantará o namespace `connection` da configuração de runtime como um arquivo `runtime-config.json` na raiz do seu bucket S3.
+Seu construct CDK de site implantará o namespace `connection` da configuração de runtime como um arquivo `runtime-config.json` na raiz do seu bucket S3.
 
 ```ts title="packages/infra/src/stacks/application-stack.ts"
 import { Stack } from 'aws-cdk-lib';
@@ -252,7 +431,7 @@ export class ApplicationStack extends Stack {
   constructor(scope: Construct, id: string) {
     super(scope, id);
 
-    // Website can be declared at any point — runtime config is resolved lazily
+    // Website can be declared at any point, since runtime config is resolved lazily
     new MyWebsite(this, 'MyWebsite');
 
     // Automatically adds values to the RuntimeConfig
@@ -263,14 +442,14 @@ export class ApplicationStack extends Stack {
 }
 ```
 
-:::note[Construto CDK de Website]
-Com CDK, o construto de website pode ser declarado em qualquer ponto da sua stack. A configuração de runtime é resolvida preguiçosamente no momento da síntese, então todos os valores serão incluídos independentemente da ordem de declaração.
+:::note[Construct CDK de Site]
+Com CDK, o construct de site pode ser declarado em qualquer ponto da sua stack. A configuração de runtime é resolvida preguiçosamente no momento da síntese, então todos os valores serão incluídos independentemente da ordem de declaração.
 :::
 </Fragment>
 <Fragment slot="terraform">
 Com Terraform, a configuração de runtime é gerenciada através dos módulos runtime-config. Os módulos Terraform gerados pelos geradores `@aws/nx-plugin` (como <Link path="guides/trpc">`ts#api`</Link> e <Link path="guides/fastapi">`py#api`</Link>) adicionarão automaticamente valores apropriados à configuração de runtime.
 
-Seu módulo Terraform de website implantará o namespace `connection` da configuração de runtime como um arquivo `runtime-config.json` na raiz do seu bucket S3.
+Seu módulo Terraform de site implantará o namespace `connection` da configuração de runtime como um arquivo `runtime-config.json` na raiz do seu bucket S3.
 
 ```hcl title="packages/infra/src/main.tf" {20-21}
 module "asset_bucket" {
@@ -298,14 +477,14 @@ module "my_website" {
 ```
 
 :::caution[Ordenação de Módulos]
-Você deve garantir que declare seu módulo de website _depois_ de quaisquer módulos que adicionem à configuração de runtime e configure o `depends_on` apropriado para garantir a ordenação, caso contrário eles estarão faltando no seu arquivo `runtime-config.json`.
+Você deve garantir que declare seu módulo de site _após_ quaisquer módulos que adicionem à configuração de runtime e configure o `depends_on` apropriado para garantir a ordenação, caso contrário eles estarão faltando no seu arquivo `runtime-config.json`.
 :::
 </Fragment>
 </Infrastructure>
 
-### Código do Website
+### Código do Site
 
-No seu website, você pode usar o hook `useRuntimeConfig` para recuperar valores da configuração de runtime:
+No seu site, você pode usar o hook `useRuntimeConfig` para recuperar valores da configuração de runtime:
 
 ```tsx {1,4}
 import { useRuntimeConfig } from '../hooks/useRuntimeConfig';
@@ -324,18 +503,18 @@ Para detalhes sobre como a configuração de runtime é armazenada no AWS AppCon
 
 ### Configuração de Runtime Local
 
-Ao executar o [servidor de desenvolvimento local](#servidor-de-desenvolvimento-local), você precisará de um arquivo `runtime-config.json` no seu diretório `public` para que seu website local saiba as URLs do backend, configuração de identidade, etc.
+Ao executar o [servidor de desenvolvimento local](#servidor-de-desenvolvimento-local), você precisará de um arquivo `runtime-config.json` no seu diretório `public` para que seu site local conheça as URLs do backend, configuração de identidade, etc.
 
-Seu projeto de website está configurado com um target `load-runtime-config` que você pode usar para baixar o arquivo `runtime-config.json` de uma aplicação implantada:
+Seu projeto de site está configurado com um target `load-runtime-config` que você pode usar para baixar o arquivo `runtime-config.json` de uma aplicação implantada:
 
 <NxCommands commands={['load-runtime-config <my-website>']} />
 
 :::note[Nomes de Stage Personalizados]
 <Infrastructure>
 <Fragment slot="cdk">
-Se você alterar o prefixo para os nomes de stage no `src/main.ts` do seu projeto de infraestrutura, você precisará atualizar o target `load-runtime-config` no arquivo `project.json` do seu website de acordo.
+Se você alterar o prefixo para seus nomes de stage no `src/main.ts` do seu projeto de infraestrutura, você precisará atualizar o target `load-runtime-config` no arquivo `project.json` do seu site de acordo.
 
-Além disso, vale notar que o target `load-runtime-config` assume que um único stage da sua aplicação está implantado no ambiente para o qual você tem credenciais AWS. Você precisará ajustar o comando se implantar múltiplos stages na mesma conta e região.
+Além disso, vale notar que o target `load-runtime-config` assume que um único stage da sua aplicação está implantado no ambiente para o qual você tem credenciais AWS. Você precisará ajustar o comando se implantar vários stages na mesma conta e região.
 </Fragment>
 <Fragment slot="terraform">
 Para projetos Terraform, o target `load-runtime-config` copia o arquivo `runtime-config.json` que foi criado após seu `terraform apply` local mais recente.
@@ -345,144 +524,75 @@ Para projetos Terraform, o target `load-runtime-config` copia o arquivo `runtime
 
 ## Servidor de Desenvolvimento Local
 
-O comando canônico para desenvolvimento local é `dev`, que inicia seu website (e quaisquer servidores locais para APIs que você conectou a ele) com um único comando:
+O comando canônico para desenvolvimento local é `dev`, que inicia seu site (e quaisquer servidores locais para APIs às quais você o conectou) com um comando:
 
 <NxCommands commands={['dev <my-website>']} />
 
-O target `serve` também está disponível para quando você precisar controlar quanto da sua aplicação é executado localmente versus apontando para infraestrutura AWS implantada. Para uma visão geral mais ampla do desenvolvimento local em projetos conectados, incluindo como `dev` se comporta para projetos com múltiplos componentes, consulte o guia <Link path="guides/local-development">Desenvolvimento Local</Link>.
+O target `serve` também está disponível para quando você precisar controlar quanto da sua aplicação é executado localmente versus apontando para a infraestrutura AWS implantada. Para uma visão geral mais ampla do desenvolvimento local em projetos conectados, incluindo como `dev` se comporta para projetos com vários componentes, consulte o guia <Link path="guides/local-development">Desenvolvimento Local</Link>.
 
 ### Target Serve
 
-O target `serve` inicia um servidor de desenvolvimento local para seu website. Este target requer que você tenha implantado qualquer infraestrutura de suporte com a qual o website interage e tenha [carregado a configuração de runtime local](#configuração-de-runtime-local).
+O target `serve` inicia um servidor de desenvolvimento local para seu site. Este target requer que você tenha implantado qualquer infraestrutura de suporte com a qual o site interage e tenha [carregado a configuração de runtime local](#configuração-de-runtime-local).
 
 Você pode executar este target com o seguinte comando:
 
 <NxCommands commands={['serve <my-website>']} />
 
-Este target é útil para trabalhar em alterações do website enquanto aponta para APIs "reais" implantadas e outra infraestrutura.
+Este target é útil para trabalhar em alterações do site enquanto aponta para APIs "reais" implantadas e outra infraestrutura.
 
 ### Target Dev
 
-O target `dev` inicia um servidor de desenvolvimento local para seu website (com [Vite `MODE`](https://vite.dev/guide/env-and-mode) definido como `local-dev`), além de iniciar quaisquer servidores locais para APIs que você conectou ao seu website via o <Link path="/guides/connection">gerador Connection</Link>.
+O target `dev` inicia um servidor de desenvolvimento local para seu site (com [Vite `MODE`](https://vite.dev/guide/env-and-mode) definido como `local-dev`), bem como inicia quaisquer servidores locais para APIs às quais você conectou seu site via o <Link path="/guides/connection">gerador Connection</Link>.
 
-Quando seu servidor de website local é executado via este target, `runtime-config.json` é automaticamente substituído para apontar para suas URLs de API em execução local.
+Quando seu servidor de site local é executado via este target, `runtime-config.json` é automaticamente substituído para apontar para suas URLs de API em execução local.
 
 Você pode executar este target com o seguinte comando:
 
 <NxCommands commands={['dev <my-website>']} />
 
-Este target é útil quando você está trabalhando em seu website e API e deseja iterar rapidamente sem implantar sua infraestrutura.
+Este target é útil quando você está trabalhando em seu site e API e deseja iterar rapidamente sem implantar sua infraestrutura.
 
 :::note[Script `dev` do Workspace]
 O `package.json` raiz do seu workspace inclui um script `dev` que executa o target `dev` para cada projeto que o possui:
 
 <PackageManagerShortCommand commands={["dev"]} />
 
-Isso inicia o servidor de desenvolvimento local para seu website (e quaisquer outros projetos com um target `dev`) em um único comando. Para executar apenas este website, use seu próprio target `dev` (por exemplo, `nx dev <my-website>`).
+Isso inicia o servidor de desenvolvimento local para seu site (e quaisquer outros projetos com um target `dev`) em um comando. Para executar apenas este site, use seu próprio target `dev` (por exemplo, `nx dev <my-website>`).
 :::
 
 :::warning[Autenticação Simulada]
-Quando executado neste modo e nenhum `runtime-config.json` está presente, se você configurou Autenticação Cognito (via o <Link path="/guides/react-website-auth">gerador `ts#website#auth`</Link>), o login será ignorado e as requisições para seus servidores locais não incluirão cabeçalhos de autenticação.
+Quando executado neste modo e nenhum `runtime-config.json` está presente, se você configurou Autenticação Cognito (via o <Link path="/guides/react-website-auth">gerador `ts#website#auth`</Link>), o login será ignorado e as solicitações aos seus servidores locais não incluirão cabeçalhos de autenticação.
 
 Para habilitar login e autenticação para `dev`, implante sua infraestrutura e carregue a configuração de runtime.
 :::
 
 :::tip[Comportamento do Dev]
-Ao executar com `dev`, você pode especificar quaisquer variáveis de ambiente requeridas por suas APIs para apontar para outros recursos AWS implantados, por exemplo:
+Ao executar com `dev`, você pode especificar quaisquer variáveis de ambiente necessárias pelas suas APIs para apontar para outros recursos AWS implantados, por exemplo:
 
 <NxCommands env={{DYNAMODB_TABLE_NAME: 'xxxxx'}} commands={['dev <my-website>']} />
 
 Observe que seus servidores de API locais serão executados com as credenciais AWS que você configurou localmente.
 :::
 
-## Build
+## Building
 
-Você pode fazer o build do seu website usando o target `build`. Isso executa os targets `bundle`, `compile`, `test` e `lint`, verificando tipos, empacotando, testando e fazendo lint do seu website.
+Você pode fazer o build do seu site usando o target `build`. Isso executa os targets `bundle`, `compile`, `test` e `lint`, verificando tipos, empacotando, testando e fazendo lint do seu site.
 
 <NxCommands commands={['build <my-website>']} />
 
-O target `bundle` usa Vite para criar um bundle de produção no diretório raiz `dist/packages/<my-website>/bundle`. Este é o artefato implantável consumido pela sua infraestrutura de website. Você pode executá-lo sozinho:
+O target `bundle` usa Vite para criar um bundle de produção no diretório raiz `dist/packages/<my-website>/bundle`. Este é o artefato implantável consumido pela sua infraestrutura de site. Você pode executá-lo sozinho:
 
 <NxCommands commands={['bundle <my-website>']} />
 
 ## Testes
 
-Testar seu website é muito parecido com escrever testes em um projeto TypeScript padrão, então consulte o <Link path="guides/typescript-project#testing">guia de projeto TypeScript</Link> para mais detalhes.
+Testar seu site é muito parecido com escrever testes em um projeto TypeScript padrão, então consulte o <Link path="guides/typescript-project#testing">guia de projeto TypeScript</Link> para mais detalhes.
 
 Para testes específicos do React, React Testing Library já está instalado e disponível para você usar para escrever testes. Para mais detalhes sobre seu uso, consulte a [documentação do React Testing Library](https://testing-library.com/docs/react-testing-library/example-intro).
 
 Você pode executar seus testes usando o target `test`:
 
 <NxCommands commands={['test <my-website>']} />
-
-## Implantando Seu Website
-
-O gerador de website React cria infraestrutura como código CDK ou Terraform com base no seu `iac` selecionado. Você pode usar isso para implantar seu website.
-
-<Infrastructure>
-<Fragment slot="cdk">
-Para implantar seu website, recomendamos usar o <Link path="guides/typescript-infrastructure">gerador `ts#infra`</Link> para criar uma aplicação CDK.
-
-Você pode usar o construto CDK gerado para você em `packages/common/constructs` para implantar seu website.
-
-```ts title="packages/infra/src/stacks/application-stack.ts" {3, 9}
-import { Stack } from 'aws-cdk-lib';
-import { Construct } from 'constructs';
-import { MyWebsite } from '@my-scope/common-constructs';
-
-export class ApplicationStack extends Stack {
-  constructor(scope: Construct, id: string) {
-    super(scope, id);
-
-    new MyWebsite(this, 'MyWebsite');
-  }
-}
-```
-
-Isso configura:
-
-1. Um bucket S3 para hospedar seus arquivos de website estático
-2. Distribuição CloudFront para entrega global de conteúdo
-3. WAF Web ACL para proteção de segurança
-4. Origin Access Control para acesso seguro ao S3
-5. Implantação automática de arquivos do website e configuração de runtime
-</Fragment>
-<Fragment slot="terraform">
-Para implantar seu website, recomendamos usar o <Link path="/guides/terraform-project">gerador `terraform#project`</Link> para criar um projeto Terraform.
-
-Você pode usar o módulo Terraform gerado para você em `packages/common/terraform` para implantar seu website.
-
-```hcl title="packages/infra/src/main.tf" {3}
-# Deploy website
-module "my_website" {
-  source = "../../common/terraform/src/app/static-websites/my-website"
-
-  providers = {
-    aws.us_east_1 = aws.us_east_1
-  }
-}
-```
-
-Isso configura:
-
-1. Um bucket S3 para hospedar seus arquivos de website estático
-2. Distribuição CloudFront para entrega global de conteúdo
-3. WAF Web ACL para proteção de segurança (implantado em us-east-1)
-4. Origin Access Control para acesso seguro ao S3
-5. Implantação automática de arquivos do website e configuração de runtime
-
-:::note[Região do Provedor WAF]
-O provedor `aws.us_east_1` é necessário para recursos CloudFront e WAF, que devem ser implantados na região us-east-1. Certifique-se de que sua configuração Terraform inclui este provedor:
-
-```hcl title="packages/infra/src/providers.tf"
-provider "aws" {
-  alias  = "us_east_1"
-  region = "us-east-1"
-}
-```
-:::
-</Fragment>
-</Infrastructure>
 
 ## Conexões
 
@@ -492,28 +602,28 @@ Use o gerador <Link path="guides/connection">`connection`</Link> para integrar e
   <ConnectionCard
     title="React to tRPC"
     description="Call a tRPC API from a React website"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/react-trpc`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'pt'}/guides/connection/react-trpc`}
     source="react"
     target="trpc"
   />
   <ConnectionCard
     title="React to FastAPI"
     description="Call a Python FastAPI from a React website"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/react-fastapi`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'pt'}/guides/connection/react-fastapi`}
     source="react"
     target="fastapi"
   />
   <ConnectionCard
     title="React to Smithy API"
     description="Call a Smithy API from a React website"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/react-smithy`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'pt'}/guides/connection/react-smithy`}
     source="react"
     target="smithy"
   />
   <ConnectionCard
     title="React to Python Agent"
     description="Call a Python Agent from a React website"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/react-py-agent`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'pt'}/guides/connection/react-py-agent`}
     source="react"
     target="strands"
     targetBadge="python"
@@ -521,7 +631,7 @@ Use o gerador <Link path="guides/connection">`connection`</Link> para integrar e
   <ConnectionCard
     title="React to TypeScript Agent"
     description="Call a TypeScript Agent from a React website"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/react-ts-agent`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'pt'}/guides/connection/react-ts-agent`}
     source="react"
     target="strands"
     targetBadge="typescript"
@@ -529,14 +639,14 @@ Use o gerador <Link path="guides/connection">`connection`</Link> para integrar e
   <ConnectionCard
     title="React to AG-UI Agent"
     description="Call an Agent exposing the AG-UI protocol from a React website via CopilotKit"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/react-agui`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'pt'}/guides/connection/react-agui`}
     source="react"
     target="copilotkit"
   />
   <ConnectionCard
     title="React Website to AgentCore Gateway"
     description="Connect a React website to agents through an AgentCore Gateway"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/react-agentcore-gateway`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'pt'}/guides/connection/react-agentcore-gateway`}
     source="react"
     target="agentcore"
   />

--- a/docs/src/content/docs/vi/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/vi/get_started/tutorials/dungeon-game/1.mdx
@@ -1,6 +1,6 @@
 ---
 title: Thiết lập monorepo
-description: "Hướng dẫn từng bước xây dựng trò chơi phiêu lưu ngục tối được hỗ trợ bởi AI tác nhân sử dụng @aws/nx-plugin."
+description: "Hướng dẫn chi tiết cách xây dựng trò chơi phiêu lưu hầm ngục được hỗ trợ bởi AI agentic sử dụng @aws/nx-plugin."
 ---
 
 import { Aside, Code, FileTree, Steps, Tabs, TabItem } from '@astrojs/starlight/components';
@@ -24,34 +24,34 @@ import gameConversationPng from '@assets/game-conversation.png'
 
 ## Nhiệm vụ 1: Tạo monorepo
 
-Để tạo một monorepo mới, từ thư mục bạn muốn, chạy lệnh sau:
+Để tạo monorepo mới, từ thư mục mong muốn của bạn, chạy lệnh sau:
 
 <CreateNxWorkspaceCommand workspace="dungeon-adventure" iac="cdk" />
 
-:::note[CDK là IaC Provider]
-Chúng ta sử dụng `--iac=cdk` vì sẽ dùng CDK cho cơ sở hạ tầng dưới dạng mã trong hướng dẫn này. Nx Plugin for AWS cũng hỗ trợ `terraform`.
+:::note[CDK làm IaC Provider]
+Chúng ta sử dụng `--iac=cdk` vì chúng ta sẽ sử dụng CDK cho infrastructure as code trong hướng dẫn này. Nx Plugin for AWS cũng hỗ trợ `terraform`.
 :::
 
-Lệnh này sẽ thiết lập một monorepo NX trong thư mục `dungeon-adventure`. Khi bạn mở thư mục trong VSCode, bạn sẽ thấy cấu trúc tệp như sau:
+Lệnh này sẽ thiết lập một NX monorepo trong thư mục `dungeon-adventure`. Khi bạn mở thư mục trong VSCode, bạn sẽ thấy cấu trúc tệp này:
 
 <FileTree>
 - .nx/
 - .vscode/
 - node_modules/
-- packages/ đây là nơi các dự án con của bạn sẽ nằm
+- packages/ this is where your sub-projects will reside
 - .gitignore
-- biome.json cấu hình Biome cho linting và định dạng
-- nx.json cấu hình Nx CLI và các mặc định monorepo
-- package.json tất cả các phụ thuộc node được định nghĩa ở đây
-- pnpm-lock.yaml hoặc bun.lock, yarn.lock, package-lock.json tùy thuộc vào trình quản lý gói
-- pnpm-workspace.yaml nếu sử dụng pnpm
+- biome.json configures Biome for linting and formatting
+- nx.json configures the Nx CLI and monorepo defaults
+- package.json all node dependencies are defined here
+- pnpm-lock.yaml or bun.lock, yarn.lock, package-lock.json depending on package manager
+- pnpm-workspace.yaml if using pnpm
 - README.md
-- tsconfig.base.json tất cả các dự án con dựa trên node đều kế thừa từ đây
+- tsconfig.base.json all node based sub-projects extend this
 - tsconfig.json
-- aws-nx-plugin.config.mts cấu hình cho Nx Plugin for AWS
+- aws-nx-plugin.config.mts configuraton for the Nx Plugin for AWS
 </FileTree>
 
-<Aside type="tip" title="Commit thường xuyên">Thực hành tốt nhất là đảm bảo tất cả các tệp chưa được stage đều được commit trong Git trước khi chạy bất kỳ generator nào. Điều này cho phép bạn xem những gì đã thay đổi sau khi chạy generator thông qua `git diff`.</Aside>
+<Aside type="tip" title="Commit Often">Thực hành tốt nhất là đảm bảo tất cả các tệp chưa được staged của bạn được commit trong Git trước khi chạy bất kỳ generator nào. Điều này cho phép bạn xem những gì đã thay đổi sau khi chạy generator của bạn thông qua `git diff`.</Aside>
 
 ## Nhiệm vụ 2: Khởi tạo Dungeon Adventure Game
 
@@ -1072,11 +1072,17 @@ Bạn sẽ thấy một số tệp mới xuất hiện trong cây tệp của m�
 // packages/common/constructs/src/app/static-websites/game-ui.ts
 import * as url from 'url';
 import { Construct } from 'constructs';
-import { StaticWebsite } from '../../core/index.js';
+import { StaticWebsite, StaticWebsiteProps } from '../../core/index.js';
+
+export type GameUIProps = Omit<
+  StaticWebsiteProps,
+  'websiteName' | 'websiteFilePath'
+>;
 
 export class GameUI extends StaticWebsite {
-  constructor(scope: Construct, id: string) {
+  constructor(scope: Construct, id: string, props?: GameUIProps) {
     super(scope, id, {
+      ...props,
       websiteName: 'GameUI',
       websiteFilePath: url.fileURLToPath(
         new URL(

--- a/docs/src/content/docs/vi/guides/react-website.mdx
+++ b/docs/src/content/docs/vi/guides/react-website.mdx
@@ -18,7 +18,7 @@ import Infrastructure from '@components/infrastructure.astro';
 import Snippet from '@components/snippet.astro';
 import OptionFilter from '@components/option-filter.astro';
 
-Generator này tạo một website [React](https://react.dev/) mới với [shadcn/ui](https://ui.shadcn.com/) được cấu hình mặc định, cùng với cơ sở hạ tầng AWS CDK hoặc Terraform để triển khai website của bạn lên cloud dưới dạng website tĩnh được lưu trữ trong [S3](https://aws.amazon.com/s3/), phân phối bởi [CloudFront](https://aws.amazon.com/cloudfront/) và được bảo vệ bởi [WAF](https://aws.amazon.com/waf/).
+Generator này tạo một website [React](https://react.dev/) mới với [shadcn/ui](https://ui.shadcn.com/) được cấu hình mặc định, cùng với cơ sở hạ tầng AWS CDK hoặc Terraform để triển khai website của bạn lên cloud dưới dạng website tĩnh được lưu trữ trong [S3](https://aws.amazon.com/s3/), phục vụ bởi [CloudFront](https://aws.amazon.com/cloudfront/) và được bảo vệ bởi [WAF](https://aws.amazon.com/waf/).
 
 Ứng dụng được tạo ra sử dụng [Vite](https://vite.dev/) làm công cụ build và bundler. Nó sử dụng [TanStack Router](https://tanstack.com/router/v1) cho routing an toàn kiểu.
 
@@ -38,7 +38,7 @@ Bạn có thể tạo React Website mới theo hai cách:
 
 <GeneratorParameters generator="ts#website" />
 
-## Kết quả từ Generator
+## Kết quả của Generator
 
 Generator sẽ tạo cấu trúc dự án sau trong thư mục `<directory>/<name>`:
 
@@ -63,7 +63,7 @@ Generator sẽ tạo cấu trúc dự án sau trong thư mục `<directory>/<nam
 </FileTree>
 
 :::note[Không có TanStack Router]
-Nếu bạn chọn không sử dụng [TanStack Router](https://tanstack.com/router/v1), bạn sẽ nhận được một file `src/app.tsx` đơn giản làm điểm khởi đầu ứng dụng thay vì thư mục `routes`.
+Nếu bạn chọn không sử dụng [TanStack Router](https://tanstack.com/router/v1), bạn sẽ nhận được một file `src/app.tsx` đơn giản làm điểm vào ứng dụng thay vì thư mục `routes`.
 :::
 
 ### Cơ sở hạ tầng
@@ -129,58 +129,7 @@ waf -> cloudfront
 cloudfront -> s3
 ```
 
-#### Security Headers
-
-CloudFront distribution áp dụng response headers policy thiết lập `Strict-Transport-Security`, `X-Content-Type-Options`, `X-Frame-Options: DENY`, `Referrer-Policy` và `Content-Security-Policy` trên tất cả các response.
-
-Một `Content-Security-Policy` mặc định được áp dụng. Nó hạn chế scripts và framing để giảm thiểu XSS và clickjacking, đồng thời cho phép kết nối HTTPS và WSS để website có thể gọi các endpoint dịch vụ AWS (như API Gateway, Cognito và Bedrock AgentCore) mà URL chỉ được biết tại thời điểm triển khai. Để điều chỉnh policy (ví dụ để thắt chặt `connect-src` cho các origin cụ thể của bạn), chỉnh sửa giá trị `content_security_policy` trong `static-website.ts` (CDK) hoặc `static-website.tf` (Terraform) đã được tạo.
-
-`runtime-config.json` được phân phối với `Cache-Control: no-cache` để trình duyệt luôn lấy cấu hình mới nhất sau khi triển khai lại, thay vì sử dụng bản sao được cache cũ.
-
-#### Custom Domain & TLS
-
-Mặc định, distribution sử dụng tên miền CloudFront mặc định (`*.cloudfront.net`) và certificate mặc định của nó, không hỗ trợ áp dụng phiên bản TLS tối thiểu là 1.2. Để phân phối website của bạn từ tên miền riêng, cung cấp [ACM certificate](https://docs.aws.amazon.com/acm/latest/userguide/acm-overview.html) (phải nằm trong `us-east-1` để sử dụng với CloudFront) và tên miền của bạn — phiên bản TLS tối thiểu là 1.2 sau đó sẽ được áp dụng cho viewers:
-
-<Infrastructure>
-<Fragment slot="cdk">
-Truyền props `certificate` và `domainNames` trong website construct đã được tạo trong `packages/common/constructs/src/app/static-websites`:
-
-```ts {6-8}
-export class MyWebsite extends StaticWebsite {
-  constructor(scope: Construct, id: string) {
-    super(scope, id, {
-      websiteName: 'MyWebsite',
-      websiteFilePath: ...,
-      domainNames: ['www.example.com'],
-      certificate: Certificate.fromCertificateArn(scope, 'Cert',
-        'arn:aws:acm:us-east-1:123456789012:certificate/...'),
-    });
-  }
-}
-```
-</Fragment>
-<Fragment slot="terraform">
-Đặt các biến `custom_domain_names` và `acm_certificate_arn` trong website module đã được tạo trong `packages/common/terraform/src/app/static-websites`:
-
-```hcl {5-6}
-module "static_website" {
-  source            = "../../../core/static-website"
-  website_name      = "my-website"
-  website_file_path = ...
-  custom_domain_names = ["www.example.com"]
-  acm_certificate_arn = "arn:aws:acm:us-east-1:123456789012:certificate/..."
-
-  providers = {
-    aws.us_east_1 = aws.us_east_1
-  }
-}
-```
-</Fragment>
-</Infrastructure>
-
-Bạn cũng sẽ cần tạo các bản ghi DNS (ví dụ trong Route 53) trỏ tên miền của bạn đến CloudFront distribution.
-
-## Triển khai React Website của bạn
+## Triển khai Website của bạn
 
 [Tài liệu React](https://react.dev/learn) là nơi tốt để bắt đầu học các kiến thức cơ bản về xây dựng với React.
 
@@ -229,11 +178,241 @@ export const MyComponent = () => {
 };
 ```
 
-Để biết thêm chi tiết, hãy xem [tài liệu TanStack Router](https://tanstack.com/router/latest/docs/framework/react/overview).
+Để biết thêm chi tiết, hãy xem tài liệu [TanStack Router](https://tanstack.com/router/latest/docs/framework/react/overview).
+
+## Triển khai Website của bạn
+
+Generator React website tạo infrastructure as code CDK hoặc Terraform dựa trên `iac` bạn đã chọn. Bạn có thể sử dụng nó để triển khai website của mình.
+
+<Infrastructure>
+<Fragment slot="cdk">
+Để triển khai website của bạn, chúng tôi khuyên dùng <Link path="guides/typescript-infrastructure">generator `ts#infra`</Link> để tạo ứng dụng CDK.
+
+Bạn có thể sử dụng CDK construct được tạo cho bạn trong `packages/common/constructs` để triển khai website của mình.
+
+```ts title="packages/infra/src/stacks/application-stack.ts" {3, 9}
+import { Stack } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { MyWebsite } from '@my-scope/common-constructs';
+
+export class ApplicationStack extends Stack {
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+
+    new MyWebsite(this, 'MyWebsite');
+  }
+}
+```
+
+Điều này thiết lập:
+
+1. Một S3 bucket để lưu trữ các file website tĩnh của bạn
+2. CloudFront distribution để phân phối nội dung toàn cầu
+3. WAF Web ACL để bảo vệ bảo mật
+4. Origin Access Control để truy cập S3 an toàn
+5. Tự động triển khai các file website và cấu hình runtime
+</Fragment>
+<Fragment slot="terraform">
+Để triển khai website của bạn, chúng tôi khuyên dùng <Link path="/guides/terraform-project">generator `terraform#project`</Link> để tạo dự án Terraform.
+
+Bạn có thể sử dụng module Terraform được tạo cho bạn trong `packages/common/terraform` để triển khai website của mình.
+
+```hcl title="packages/infra/src/main.tf" {3}
+# Deploy website
+module "my_website" {
+  source = "../../common/terraform/src/app/static-websites/my-website"
+
+  providers = {
+    aws.us_east_1 = aws.us_east_1
+  }
+}
+```
+
+Điều này thiết lập:
+
+1. Một S3 bucket để lưu trữ các file website tĩnh của bạn
+2. CloudFront distribution để phân phối nội dung toàn cầu
+3. WAF Web ACL để bảo vệ bảo mật (được triển khai trong us-east-1)
+4. Origin Access Control để truy cập S3 an toàn
+5. Tự động triển khai các file website và cấu hình runtime
+
+:::note[WAF Provider Region]
+Provider `aws.us_east_1` là bắt buộc cho các tài nguyên CloudFront và WAF, phải được triển khai trong vùng us-east-1. Đảm bảo cấu hình Terraform của bạn bao gồm provider này:
+
+```hcl title="packages/infra/src/providers.tf"
+provider "aws" {
+  alias  = "us_east_1"
+  region = "us-east-1"
+}
+```
+:::
+</Fragment>
+</Infrastructure>
+
+### Security Headers
+
+CloudFront distribution áp dụng chính sách response headers thiết lập `Strict-Transport-Security`, `X-Content-Type-Options`, `X-Frame-Options: DENY`, `Referrer-Policy` và `Content-Security-Policy` trên tất cả các response.
+
+Một `Content-Security-Policy` mặc định được áp dụng. Nó hạn chế script và framing để giảm thiểu XSS và clickjacking, đồng thời cho phép kết nối HTTPS và WSS để website có thể gọi các endpoint dịch vụ AWS (như API Gateway, Cognito và Bedrock AgentCore) có URL chỉ được biết tại thời điểm triển khai. Để điều chỉnh chính sách (ví dụ: thắt chặt `connect-src` cho các origin cụ thể của bạn), hãy chỉnh sửa giá trị `content_security_policy` trong `static-website.ts` (CDK) hoặc `static-website.tf` (Terraform) được tạo của bạn.
+
+`runtime-config.json` được phục vụ với `Cache-Control: no-cache` để trình duyệt luôn lấy cấu hình mới nhất sau khi triển khai lại, thay vì sử dụng bản sao được lưu trong cache cũ.
+
+### WAF
+
+CloudFront distribution được bảo vệ bởi [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACL theo mặc định. Web ACL sử dụng bộ quy tắc mặc định do AWS quản lý ([`AWSManagedRulesCommonRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs) và [`AWSManagedRulesKnownBadInputsRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs)), cung cấp bảo vệ chống lại các khai thác web phổ biến bao gồm OWASP Top 10.
+
+<Infrastructure>
+<Fragment slot="cdk">
+Để tắt, đặt `enableWaf` thành `false` khi bạn tạo website của mình:
+
+```ts title="packages/infra/src/stacks/application-stack.ts" {10,15-18}
+import { Stack } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { MyWebsite, suppressRules } from '@my-scope/common-constructs';
+
+export class ApplicationStack extends Stack {
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+
+    const website = new MyWebsite(this, 'MyWebsite', {
+      enableWaf: false,
+    });
+
+    // Disabling WAF fails the checkov CKV_AWS_68 check ("CloudFront
+    // Distribution should have WAF enabled"). Suppress it explicitly.
+    suppressRules(
+      website.cloudFrontDistribution,
+      ['CKV_AWS_68'],
+      'WAF is intentionally disabled for this distribution',
+    );
+  }
+}
+```
+
+:::caution[Suppress CKV_AWS_68 khi tắt WAF]
+Tắt WAF có nghĩa là CloudFront distribution được tổng hợp không có Web ACL liên kết, điều này làm thất bại quét bảo mật `checkov` với `CKV_AWS_68: "CloudFront Distribution should have WAF enabled"` trừ khi được suppress như hiển thị ở trên.
+:::
+</Fragment>
+<Fragment slot="terraform">
+Để tắt, đặt `enable_waf` thành `false`:
+
+```hcl title="packages/infra/src/main.tf" {7}
+module "my_website" {
+  source = "../../common/terraform/src/app/static-websites/my-website"
+
+  providers = {
+    aws.us_east_1 = aws.us_east_1
+  }
+  enable_waf = false
+}
+```
+</Fragment>
+</Infrastructure>
+
+### Bucket Encryption
+
+Website bucket, CloudFront distribution log bucket, và CloudWatch Logs group nhận server access logs của chúng được mã hóa bằng khóa [AWS KMS](https://aws.amazon.com/kms/) do khách hàng quản lý theo mặc định. Khóa này được tạo tự động cho bạn, với tính năng xoay khóa được bật.
+
+<Infrastructure>
+<Fragment slot="cdk">
+Nếu bạn muốn sử dụng cấu hình mã hóa khác, hãy truyền các prop `encryption`, `encryptionKey` và `enableKeyRotation` khi bạn tạo website của mình:
+
+```ts title="packages/infra/src/stacks/application-stack.ts" {11}
+import { Stack } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { BucketEncryption } from 'aws-cdk-lib/aws-s3';
+import { MyWebsite } from '@my-scope/common-constructs';
+
+export class ApplicationStack extends Stack {
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+
+    new MyWebsite(this, 'MyWebsite', {
+      encryption: BucketEncryption.S3_MANAGED,
+    });
+  }
+}
+```
+
+Để sử dụng khóa KMS của riêng bạn thay vì khóa được tạo tự động, hãy truyền `encryptionKey`:
+
+```ts {2}
+new MyWebsite(this, 'MyWebsite', {
+  encryptionKey: myKey,
+});
+```
+
+`enableKeyRotation` (mặc định `true`) chỉ áp dụng cho khóa được tạo tự động, tức là khi `encryption` là `BucketEncryption.KMS` (mặc định) và không có `encryptionKey` được cung cấp.
+</Fragment>
+<Fragment slot="terraform">
+Nếu bạn muốn sử dụng cấu hình mã hóa khác, hãy đặt các biến `encryption`, `kms_key_arn` và `enable_key_rotation`:
+
+```hcl title="packages/infra/src/main.tf" {7}
+module "my_website" {
+  source = "../../common/terraform/src/app/static-websites/my-website"
+
+  providers = {
+    aws.us_east_1 = aws.us_east_1
+  }
+  encryption = "S3_MANAGED"
+}
+```
+
+Để sử dụng khóa KMS của riêng bạn thay vì khóa được tạo tự động, hãy truyền `kms_key_arn`. Khóa do khách hàng cung cấp phải đã cấp cho các service principal CloudWatch Logs, S3 và CloudFront các quyền mà chúng cần trong chính sách khóa của nó.
+
+`enable_key_rotation` (mặc định `true`) chỉ áp dụng cho khóa được tạo tự động, tức là khi `encryption` là `"KMS"` (mặc định) và không có `kms_key_arn` được cung cấp.
+</Fragment>
+</Infrastructure>
+
+### Custom Domain & TLS
+
+Theo mặc định, distribution sử dụng tên miền CloudFront mặc định (`*.cloudfront.net`) và chứng chỉ mặc định của nó, không hỗ trợ áp dụng phiên bản TLS tối thiểu là 1.2. Để phục vụ website của bạn từ domain của riêng bạn, hãy cung cấp [chứng chỉ ACM](https://docs.aws.amazon.com/acm/latest/userguide/acm-overview.html) (phải nằm trong `us-east-1` để sử dụng với CloudFront) và tên miền của bạn. Phiên bản TLS tối thiểu là 1.2 sau đó được áp dụng cho người xem:
+
+<Infrastructure>
+<Fragment slot="cdk">
+Truyền các prop `certificate` và `domainNames` khi bạn tạo website của mình:
+
+```ts title="packages/infra/src/stacks/application-stack.ts" {11-13}
+import { Stack } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { Certificate } from 'aws-cdk-lib/aws-certificatemanager';
+import { MyWebsite } from '@my-scope/common-constructs';
+
+export class ApplicationStack extends Stack {
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+
+    new MyWebsite(this, 'MyWebsite', {
+      domainNames: ['www.example.com'],
+      certificate: Certificate.fromCertificateArn(this, 'Cert',
+        'arn:aws:acm:us-east-1:123456789012:certificate/...'),
+    });
+  }
+}
+```
+</Fragment>
+<Fragment slot="terraform">
+Đặt các biến `custom_domain_names` và `acm_certificate_arn`:
+
+```hcl title="packages/infra/src/main.tf" {7-8}
+module "my_website" {
+  source = "../../common/terraform/src/app/static-websites/my-website"
+
+  providers = {
+    aws.us_east_1 = aws.us_east_1
+  }
+  custom_domain_names = ["www.example.com"]
+  acm_certificate_arn = "arn:aws:acm:us-east-1:123456789012:certificate/..."
+}
+```
+</Fragment>
+</Infrastructure>
+
+Bạn cũng sẽ cần tạo các bản ghi DNS (ví dụ trong Route 53) trỏ domain của bạn đến CloudFront distribution.
 
 ## Runtime Configuration
 
-Cấu hình từ cơ sở hạ tầng của bạn được cung cấp cho website thông qua <Link href="guides/runtime-config">Runtime Configuration</Link>. Điều này cho phép website của bạn truy cập các chi tiết như API URLs mà không được biết cho đến khi ứng dụng của bạn được triển khai.
+Cấu hình từ cơ sở hạ tầng của bạn được cung cấp cho website của bạn thông qua <Link href="guides/runtime-config">Runtime Configuration</Link>. Điều này cho phép website của bạn truy cập các chi tiết như API URLs không được biết cho đến khi ứng dụng của bạn được triển khai.
 
 ### Cơ sở hạ tầng
 
@@ -241,7 +420,7 @@ Cấu hình từ cơ sở hạ tầng của bạn được cung cấp cho websit
 <Fragment slot="cdk">
 CDK construct `RuntimeConfig` có thể được sử dụng để thêm và truy xuất cấu hình trong cơ sở hạ tầng CDK của bạn. Các CDK construct được tạo bởi các generator `@aws/nx-plugin` (như <Link path="guides/trpc">`ts#api`</Link> và <Link path="guides/fastapi">`py#api`</Link>) sẽ tự động thêm các giá trị phù hợp vào `RuntimeConfig`.
 
-Website CDK construct của bạn sẽ triển khai namespace `connection` của runtime configuration dưới dạng file `runtime-config.json` vào thư mục gốc của S3 bucket.
+CDK construct website của bạn sẽ triển khai namespace `connection` của runtime configuration dưới dạng file `runtime-config.json` vào thư mục gốc của S3 bucket của bạn.
 
 ```ts title="packages/infra/src/stacks/application-stack.ts"
 import { Stack } from 'aws-cdk-lib';
@@ -252,7 +431,7 @@ export class ApplicationStack extends Stack {
   constructor(scope: Construct, id: string) {
     super(scope, id);
 
-    // Website can be declared at any point — runtime config is resolved lazily
+    // Website can be declared at any point, since runtime config is resolved lazily
     new MyWebsite(this, 'MyWebsite');
 
     // Automatically adds values to the RuntimeConfig
@@ -264,13 +443,13 @@ export class ApplicationStack extends Stack {
 ```
 
 :::note[CDK Website Construct]
-Với CDK, website construct có thể được khai báo tại bất kỳ điểm nào trong stack của bạn. Runtime configuration được giải quyết một cách lazy tại thời điểm synth, vì vậy tất cả các giá trị sẽ được bao gồm bất kể thứ tự khai báo.
+Với CDK, website construct có thể được khai báo tại bất kỳ điểm nào trong stack của bạn. Runtime configuration được giải quyết một cách lười biếng tại thời điểm synth, vì vậy tất cả các giá trị sẽ được bao gồm bất kể thứ tự khai báo.
 :::
 </Fragment>
 <Fragment slot="terraform">
-Với Terraform, runtime configuration được quản lý thông qua các runtime-config module. Các Terraform module được tạo bởi các generator `@aws/nx-plugin` (như <Link path="guides/trpc">`ts#api`</Link> và <Link path="guides/fastapi">`py#api`</Link>) sẽ tự động thêm các giá trị phù hợp vào runtime configuration.
+Với Terraform, runtime configuration được quản lý thông qua các module runtime-config. Các module Terraform được tạo bởi các generator `@aws/nx-plugin` (như <Link path="guides/trpc">`ts#api`</Link> và <Link path="guides/fastapi">`py#api`</Link>) sẽ tự động thêm các giá trị phù hợp vào runtime configuration.
 
-Website Terraform module của bạn sẽ triển khai namespace `connection` của runtime configuration dưới dạng file `runtime-config.json` vào thư mục gốc của S3 bucket.
+Module Terraform website của bạn sẽ triển khai namespace `connection` của runtime configuration dưới dạng file `runtime-config.json` vào thư mục gốc của S3 bucket của bạn.
 
 ```hcl title="packages/infra/src/main.tf" {20-21}
 module "asset_bucket" {
@@ -297,8 +476,8 @@ module "my_website" {
 }
 ```
 
-:::caution[Thứ tự Module]
-Bạn phải đảm bảo rằng bạn khai báo website module _sau_ bất kỳ module nào thêm vào runtime configuration và cấu hình `depends_on` phù hợp để đảm bảo thứ tự, nếu không chúng sẽ bị thiếu trong file `runtime-config.json` của bạn.
+:::caution[Module Ordering]
+Bạn phải đảm bảo rằng bạn khai báo module website của mình _sau_ bất kỳ module nào thêm vào runtime configuration và cấu hình `depends_on` phù hợp để đảm bảo thứ tự, nếu không chúng sẽ bị thiếu trong file `runtime-config.json` của bạn.
 :::
 </Fragment>
 </Infrastructure>
@@ -319,72 +498,72 @@ const MyComponent = () => {
 ```
 
 :::note[Runtime Configuration]
-Để biết chi tiết về cách runtime configuration được lưu trữ trong AWS AppConfig và cách các consumer phía server (Lambda functions, agents) có thể truy xuất nó, xem hướng dẫn <Link path="guides/runtime-config">Runtime Configuration</Link>.
+Để biết chi tiết về cách runtime configuration được lưu trữ trong AWS AppConfig và cách các consumer phía server (Lambda function, agent) có thể truy xuất nó, hãy xem hướng dẫn <Link path="guides/runtime-config">Runtime Configuration</Link>.
 :::
 
 ### Local Runtime Config
 
-Khi chạy [local development server](#local-development-server), bạn sẽ cần file `runtime-config.json` trong thư mục `public` để website local của bạn biết các backend URLs, cấu hình identity, v.v.
+Khi chạy [local development server](#local-development-server), bạn sẽ cần file `runtime-config.json` trong thư mục `public` của mình để website cục bộ của bạn biết URL backend, cấu hình identity, v.v.
 
 Dự án website của bạn được cấu hình với target `load-runtime-config` mà bạn có thể sử dụng để tải xuống file `runtime-config.json` từ ứng dụng đã triển khai:
 
 <NxCommands commands={['load-runtime-config <my-website>']} />
 
-:::note[Tên Stage tùy chỉnh]
+:::note[Custom Stage Names]
 <Infrastructure>
 <Fragment slot="cdk">
-Nếu bạn thay đổi prefix cho tên stage trong `src/main.ts` của dự án infrastructure, bạn sẽ cần cập nhật target `load-runtime-config` trong file `project.json` của website tương ứng.
+Nếu bạn thay đổi tiền tố cho tên stage trong `src/main.ts` của dự án cơ sở hạ tầng, bạn sẽ cần cập nhật target `load-runtime-config` trong file `project.json` của website của bạn cho phù hợp.
 
-Ngoài ra, đáng chú ý là target `load-runtime-config` giả định một stage duy nhất của ứng dụng được triển khai vào môi trường mà bạn có AWS credentials. Bạn sẽ cần điều chỉnh lệnh nếu bạn triển khai nhiều stage vào cùng một account và region.
+Ngoài ra, đáng chú ý là target `load-runtime-config` giả định một stage duy nhất của ứng dụng của bạn được triển khai vào môi trường mà bạn có AWS credentials. Bạn sẽ cần điều chỉnh lệnh nếu bạn triển khai nhiều stage vào cùng một tài khoản và vùng.
 </Fragment>
 <Fragment slot="terraform">
-Đối với các dự án Terraform, target `load-runtime-config` sao chép file `runtime-config.json` được tạo sau lần `terraform apply` local gần nhất của bạn.
+Đối với các dự án Terraform, target `load-runtime-config` sao chép file `runtime-config.json` được tạo sau lần `terraform apply` cục bộ gần nhất của bạn.
 </Fragment>
 </Infrastructure>
 :::
 
 ## Local Development Server
 
-Lệnh chính thức cho phát triển local là `dev`, khởi động website của bạn (và bất kỳ local server nào cho các API mà bạn đã kết nối với nó) bằng một lệnh:
+Lệnh chính thức cho phát triển cục bộ là `dev`, khởi động website của bạn (và bất kỳ server cục bộ nào cho các API bạn đã kết nối với nó) bằng một lệnh:
 
 <NxCommands commands={['dev <my-website>']} />
 
-Target `serve` cũng có sẵn khi bạn cần kiểm soát bao nhiêu phần của ứng dụng chạy locally so với việc trỏ đến cơ sở hạ tầng AWS đã triển khai. Để có cái nhìn tổng quan rộng hơn về phát triển local trên các dự án được kết nối, bao gồm cách `dev` hoạt động cho các dự án với nhiều component, xem hướng dẫn <Link path="guides/local-development">Local Development</Link>.
+Target `serve` cũng có sẵn cho khi bạn cần kiểm soát mức độ ứng dụng của bạn chạy cục bộ so với trỏ đến cơ sở hạ tầng AWS đã triển khai. Để có cái nhìn tổng quan rộng hơn về phát triển cục bộ trên các dự án được kết nối, bao gồm cách `dev` hoạt động cho các dự án có nhiều component, hãy xem hướng dẫn <Link path="guides/local-development">Local Development</Link>.
 
 ### Serve Target
 
-Target `serve` khởi động local development server cho website của bạn. Target này yêu cầu bạn đã triển khai bất kỳ cơ sở hạ tầng hỗ trợ nào mà website tương tác, và đã [tải local runtime configuration](#local-runtime-config).
+Target `serve` khởi động local development server cho website của bạn. Target này yêu cầu bạn đã triển khai bất kỳ cơ sở hạ tầng hỗ trợ nào mà website tương tác với, và đã [tải local runtime configuration](#local-runtime-config).
 
-Bạn có thể chạy target này với lệnh sau:
+Bạn có thể chạy target này bằng lệnh sau:
 
 <NxCommands commands={['serve <my-website>']} />
 
-Target này hữu ích để làm việc với các thay đổi website trong khi trỏ đến các API "thực" đã triển khai và cơ sở hạ tầng khác.
+Target này hữu ích để làm việc trên các thay đổi website trong khi trỏ đến các API "thực" đã triển khai và cơ sở hạ tầng khác.
 
 ### Dev Target
 
-Target `dev` khởi động local development server cho website của bạn (với [Vite `MODE`](https://vite.dev/guide/env-and-mode) được đặt thành `local-dev`), cũng như khởi động bất kỳ local server nào cho các API mà bạn đã kết nối website với thông qua <Link path="/guides/connection">Connection generator</Link>.
+Target `dev` khởi động local development server cho website của bạn (với [Vite `MODE`](https://vite.dev/guide/env-and-mode) được đặt thành `local-dev`), cũng như khởi động bất kỳ server cục bộ nào cho các API bạn đã kết nối website của mình thông qua <Link path="/guides/connection">Connection generator</Link>.
 
-Khi local website server của bạn được chạy qua target này, `runtime-config.json` tự động được ghi đè để trỏ đến các url API đang chạy locally của bạn.
+Khi local website server của bạn được chạy thông qua target này, `runtime-config.json` được tự động ghi đè để trỏ đến các url API đang chạy cục bộ của bạn.
 
-Bạn có thể chạy target này với lệnh sau:
+Bạn có thể chạy target này bằng lệnh sau:
 
 <NxCommands commands={['dev <my-website>']} />
 
-Target này hữu ích khi bạn đang làm việc trên cả website và API của mình và muốn lặp lại nhanh chóng mà không cần triển khai cơ sở hạ tầng.
+Target này hữu ích khi bạn đang làm việc trên cả website và API của mình và muốn lặp lại nhanh chóng mà không cần triển khai cơ sở hạ tầng của bạn.
 
 :::note[Workspace `dev` script]
-`package.json` gốc của workspace bao gồm script `dev` chạy target `dev` cho mọi dự án có nó:
+`package.json` gốc của workspace của bạn bao gồm script `dev` chạy target `dev` cho mọi dự án có nó:
 
 <PackageManagerShortCommand commands={["dev"]} />
 
-Điều này khởi động local development server cho website của bạn (và bất kỳ dự án nào khác có target `dev`) trong một lệnh. Để chỉ chạy website này, sử dụng target `dev` riêng của nó (ví dụ: `nx dev <my-website>`).
+Điều này khởi động local development server cho website của bạn (và bất kỳ dự án nào khác có target `dev`) trong một lệnh. Để chỉ chạy website này, hãy sử dụng target `dev` của riêng nó (ví dụ: `nx dev <my-website>`).
 :::
 
 :::warning[Mock Authentication]
-Khi chạy ở chế độ này và không có `runtime-config.json`, nếu bạn đã cấu hình Cognito Authentication (thông qua <Link path="/guides/react-website-auth">`ts#website#auth` generator</Link>), đăng nhập sẽ được bỏ qua và các request đến local server của bạn sẽ không bao gồm authentication headers.
+Khi chạy ở chế độ này và không có `runtime-config.json`, nếu bạn đã cấu hình Cognito Authentication (thông qua <Link path="/guides/react-website-auth">generator `ts#website#auth`</Link>), đăng nhập sẽ được bỏ qua và các yêu cầu đến server cục bộ của bạn sẽ không bao gồm header xác thực.
 
-Để bật đăng nhập và xác thực cho `dev`, triển khai cơ sở hạ tầng của bạn và tải runtime config.
+Để bật đăng nhập và xác thực cho `dev`, hãy triển khai cơ sở hạ tầng của bạn và tải runtime config.
 :::
 
 :::tip[Dev Behavior]
@@ -392,97 +571,28 @@ Khi chạy với `dev`, bạn có thể chỉ định bất kỳ biến môi tr�
 
 <NxCommands env={{DYNAMODB_TABLE_NAME: 'xxxxx'}} commands={['dev <my-website>']} />
 
-Lưu ý rằng các local API server của bạn sẽ chạy với AWS credentials mà bạn đã cấu hình locally.
+Lưu ý rằng các server API cục bộ của bạn sẽ chạy với AWS credentials bạn đã cấu hình cục bộ.
 :::
 
 ## Building
 
-Bạn có thể build website của mình bằng target `build`. Điều này chạy các target `bundle`, `compile`, `test` và `lint`, type-checking, bundling, testing và linting website của bạn.
+Bạn có thể build website của mình bằng target `build`. Điều này chạy các target `bundle`, `compile`, `test` và `lint`, kiểm tra kiểu, đóng gói, kiểm thử và lint website của bạn.
 
 <NxCommands commands={['build <my-website>']} />
 
-Target `bundle` sử dụng Vite để tạo production bundle trong thư mục gốc `dist/packages/<my-website>/bundle`. Đây là artifact có thể triển khai được sử dụng bởi cơ sở hạ tầng website của bạn. Bạn có thể chạy nó riêng lẻ:
+Target `bundle` sử dụng Vite để tạo production bundle trong thư mục gốc `dist/packages/<my-website>/bundle`. Đây là artifact có thể triển khai được sử dụng bởi cơ sở hạ tầng website của bạn. Bạn có thể chạy nó riêng:
 
 <NxCommands commands={['bundle <my-website>']} />
 
 ## Testing
 
-Testing website của bạn giống như viết test trong một dự án TypeScript tiêu chuẩn, vì vậy vui lòng tham khảo <Link path="guides/typescript-project#testing">hướng dẫn dự án TypeScript</Link> để biết thêm chi tiết.
+Kiểm thử website của bạn giống như viết test trong một dự án TypeScript tiêu chuẩn, vì vậy vui lòng tham khảo <Link path="guides/typescript-project#testing">hướng dẫn dự án TypeScript</Link> để biết thêm chi tiết.
 
-Đối với testing cụ thể cho React, React Testing Library đã được cài đặt và có sẵn để bạn sử dụng để viết test. Để biết thêm chi tiết về cách sử dụng, vui lòng tham khảo [tài liệu React Testing Library](https://testing-library.com/docs/react-testing-library/example-intro).
+Đối với kiểm thử cụ thể cho React, React Testing Library đã được cài đặt và có sẵn để bạn sử dụng để viết test. Để biết thêm chi tiết về cách sử dụng, vui lòng tham khảo [tài liệu React Testing Library](https://testing-library.com/docs/react-testing-library/example-intro).
 
 Bạn có thể chạy các test của mình bằng target `test`:
 
 <NxCommands commands={['test <my-website>']} />
-
-## Triển khai Website của bạn
-
-React website generator tạo CDK hoặc Terraform infrastructure as code dựa trên `iac` bạn đã chọn. Bạn có thể sử dụng điều này để triển khai website của mình.
-
-<Infrastructure>
-<Fragment slot="cdk">
-Để triển khai website của bạn, chúng tôi khuyên bạn nên sử dụng <Link path="guides/typescript-infrastructure">`ts#infra` generator</Link> để tạo ứng dụng CDK.
-
-Bạn có thể sử dụng CDK construct được tạo cho bạn trong `packages/common/constructs` để triển khai website của bạn.
-
-```ts title="packages/infra/src/stacks/application-stack.ts" {3, 9}
-import { Stack } from 'aws-cdk-lib';
-import { Construct } from 'constructs';
-import { MyWebsite } from '@my-scope/common-constructs';
-
-export class ApplicationStack extends Stack {
-  constructor(scope: Construct, id: string) {
-    super(scope, id);
-
-    new MyWebsite(this, 'MyWebsite');
-  }
-}
-```
-
-Điều này thiết lập:
-
-1. S3 bucket để lưu trữ các file website tĩnh của bạn
-2. CloudFront distribution cho phân phối nội dung toàn cầu
-3. WAF Web ACL để bảo vệ bảo mật
-4. Origin Access Control cho truy cập S3 an toàn
-5. Tự động triển khai các file website và runtime configuration
-</Fragment>
-<Fragment slot="terraform">
-Để triển khai website của bạn, chúng tôi khuyên bạn nên sử dụng <Link path="/guides/terraform-project">`terraform#project` generator</Link> để tạo dự án Terraform.
-
-Bạn có thể sử dụng Terraform module được tạo cho bạn trong `packages/common/terraform` để triển khai website của bạn.
-
-```hcl title="packages/infra/src/main.tf" {3}
-# Deploy website
-module "my_website" {
-  source = "../../common/terraform/src/app/static-websites/my-website"
-
-  providers = {
-    aws.us_east_1 = aws.us_east_1
-  }
-}
-```
-
-Điều này thiết lập:
-
-1. S3 bucket để lưu trữ các file website tĩnh của bạn
-2. CloudFront distribution cho phân phối nội dung toàn cầu
-3. WAF Web ACL để bảo vệ bảo mật (được triển khai trong us-east-1)
-4. Origin Access Control cho truy cập S3 an toàn
-5. Tự động triển khai các file website và runtime configuration
-
-:::note[WAF Provider Region]
-Provider `aws.us_east_1` là bắt buộc cho các tài nguyên CloudFront và WAF, phải được triển khai trong region us-east-1. Đảm bảo cấu hình Terraform của bạn bao gồm provider này:
-
-```hcl title="packages/infra/src/providers.tf"
-provider "aws" {
-  alias  = "us_east_1"
-  region = "us-east-1"
-}
-```
-:::
-</Fragment>
-</Infrastructure>
 
 ## Connections
 
@@ -492,28 +602,28 @@ Sử dụng generator <Link path="guides/connection">`connection`</Link> để t
   <ConnectionCard
     title="React to tRPC"
     description="Call a tRPC API from a React website"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'vi'}/guides/connection/react-trpc`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/react-trpc`}
     source="react"
     target="trpc"
   />
   <ConnectionCard
     title="React to FastAPI"
     description="Call a Python FastAPI from a React website"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'vi'}/guides/connection/react-fastapi`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/react-fastapi`}
     source="react"
     target="fastapi"
   />
   <ConnectionCard
     title="React to Smithy API"
     description="Call a Smithy API from a React website"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'vi'}/guides/connection/react-smithy`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/react-smithy`}
     source="react"
     target="smithy"
   />
   <ConnectionCard
     title="React to Python Agent"
     description="Call a Python Agent from a React website"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'vi'}/guides/connection/react-py-agent`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/react-py-agent`}
     source="react"
     target="strands"
     targetBadge="python"
@@ -521,7 +631,7 @@ Sử dụng generator <Link path="guides/connection">`connection`</Link> để t
   <ConnectionCard
     title="React to TypeScript Agent"
     description="Call a TypeScript Agent from a React website"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'vi'}/guides/connection/react-ts-agent`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/react-ts-agent`}
     source="react"
     target="strands"
     targetBadge="typescript"
@@ -529,14 +639,14 @@ Sử dụng generator <Link path="guides/connection">`connection`</Link> để t
   <ConnectionCard
     title="React to AG-UI Agent"
     description="Call an Agent exposing the AG-UI protocol from a React website via CopilotKit"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'vi'}/guides/connection/react-agui`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/react-agui`}
     source="react"
     target="copilotkit"
   />
   <ConnectionCard
     title="React Website to AgentCore Gateway"
     description="Connect a React website to agents through an AgentCore Gateway"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'vi'}/guides/connection/react-agentcore-gateway`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/react-agentcore-gateway`}
     source="react"
     target="agentcore"
   />

--- a/docs/src/content/docs/vi/guides/react-website.mdx
+++ b/docs/src/content/docs/vi/guides/react-website.mdx
@@ -23,14 +23,14 @@ Generator này tạo một website [React](https://react.dev/) mới với [shad
 Ứng dụng được tạo ra sử dụng [Vite](https://vite.dev/) làm công cụ build và bundler. Nó sử dụng [TanStack Router](https://tanstack.com/router/v1) cho routing an toàn kiểu.
 
 :::note[UX Provider]
-`ux` mặc định là [shadcn/ui](https://ui.shadcn.com/). Bạn cũng có thể chọn [Cloudscape](http://cloudscape.design/) hoặc `none` (mang thư viện component của riêng bạn).
+`ux` mặc định là [shadcn/ui](https://ui.shadcn.com/). Bạn cũng có thể chọn [Cloudscape](http://cloudscape.design/) hoặc `none` (tự mang thư viện component của riêng bạn).
 :::
 
 ## Cách sử dụng
 
-### Tạo React Website
+### Tạo một React Website
 
-Bạn có thể tạo React Website mới theo hai cách:
+Bạn có thể tạo một React Website mới theo hai cách:
 
 <RunGenerator generator="ts#website" requiredParameters={{ framework: 'react' }} />
 
@@ -38,7 +38,7 @@ Bạn có thể tạo React Website mới theo hai cách:
 
 <GeneratorParameters generator="ts#website" />
 
-## Kết quả của Generator
+## Kết quả từ Generator
 
 Generator sẽ tạo cấu trúc dự án sau trong thư mục `<directory>/<name>`:
 
@@ -63,7 +63,7 @@ Generator sẽ tạo cấu trúc dự án sau trong thư mục `<directory>/<nam
 </FileTree>
 
 :::note[Không có TanStack Router]
-Nếu bạn chọn không sử dụng [TanStack Router](https://tanstack.com/router/v1), bạn sẽ nhận được một file `src/app.tsx` đơn giản làm điểm vào ứng dụng thay vì thư mục `routes`.
+Nếu bạn chọn không sử dụng [TanStack Router](https://tanstack.com/router/v1), bạn sẽ nhận được một file `src/app.tsx` đơn giản làm điểm khởi đầu ứng dụng thay vì thư mục `routes`.
 :::
 
 ### Cơ sở hạ tầng
@@ -143,17 +143,17 @@ Bạn có thể tham khảo [tài liệu shadcn/ui](https://ui.shadcn.com/docs) 
 
 ### Routes
 
-#### Tạo Route/Page
+#### Tạo một Route/Page
 
 Website của bạn đi kèm với [TanStack Router](https://tanstack.com/router/v1) được cấu hình mặc định. Điều này giúp dễ dàng thêm các route mới:
 
 <Steps>
   1. [Chạy Local Development Server](#local-development-server)
-  2. Tạo file `<page-name>.tsx` mới trong `src/routes`, với vị trí của nó trong cây file đại diện cho đường dẫn
-  3. Lưu ý rằng `Route` và `RouteComponent` được tự động tạo cho bạn. Bạn có thể bắt đầu xây dựng trang của mình tại đây!
+  2. Tạo một file `<page-name>.tsx` mới trong `src/routes`, với vị trí của nó trong cây file đại diện cho đường dẫn
+  3. Lưu ý rằng một `Route` và `RouteComponent` được tự động tạo cho bạn. Bạn có thể bắt đầu xây dựng trang của mình tại đây!
 </Steps>
 
-#### Điều hướng giữa các Page
+#### Điều hướng giữa các Trang
 
 Bạn có thể sử dụng component `Link` hoặc hook `useNavigate` để điều hướng giữa các trang:
 
@@ -186,7 +186,7 @@ Generator React website tạo infrastructure as code CDK hoặc Terraform dựa 
 
 <Infrastructure>
 <Fragment slot="cdk">
-Để triển khai website của bạn, chúng tôi khuyên dùng <Link path="guides/typescript-infrastructure">generator `ts#infra`</Link> để tạo ứng dụng CDK.
+Để triển khai website của bạn, chúng tôi khuyến nghị sử dụng <Link path="guides/typescript-infrastructure">generator `ts#infra`</Link> để tạo một ứng dụng CDK.
 
 Bạn có thể sử dụng CDK construct được tạo cho bạn trong `packages/common/constructs` để triển khai website của mình.
 
@@ -213,7 +213,7 @@ export class ApplicationStack extends Stack {
 5. Tự động triển khai các file website và cấu hình runtime
 </Fragment>
 <Fragment slot="terraform">
-Để triển khai website của bạn, chúng tôi khuyên dùng <Link path="/guides/terraform-project">generator `terraform#project`</Link> để tạo dự án Terraform.
+Để triển khai website của bạn, chúng tôi khuyến nghị sử dụng <Link path="/guides/terraform-project">generator `terraform#project`</Link> để tạo một dự án Terraform.
 
 Bạn có thể sử dụng module Terraform được tạo cho bạn trong `packages/common/terraform` để triển khai website của mình.
 
@@ -251,19 +251,19 @@ provider "aws" {
 
 ### Security Headers
 
-CloudFront distribution áp dụng chính sách response headers thiết lập `Strict-Transport-Security`, `X-Content-Type-Options`, `X-Frame-Options: DENY`, `Referrer-Policy` và `Content-Security-Policy` trên tất cả các response.
+CloudFront distribution áp dụng chính sách response headers thiết lập `Strict-Transport-Security`, `X-Content-Type-Options`, `X-Frame-Options: DENY`, `Referrer-Policy` và một `Content-Security-Policy` trên tất cả các response.
 
-Một `Content-Security-Policy` mặc định được áp dụng. Nó hạn chế script và framing để giảm thiểu XSS và clickjacking, đồng thời cho phép kết nối HTTPS và WSS để website có thể gọi các endpoint dịch vụ AWS (như API Gateway, Cognito và Bedrock AgentCore) có URL chỉ được biết tại thời điểm triển khai. Để điều chỉnh chính sách (ví dụ: thắt chặt `connect-src` cho các origin cụ thể của bạn), hãy chỉnh sửa giá trị `content_security_policy` trong `static-website.ts` (CDK) hoặc `static-website.tf` (Terraform) được tạo của bạn.
+Một `Content-Security-Policy` mặc định được thực thi. Nó hạn chế scripts và framing để giảm thiểu XSS và clickjacking, trong khi cho phép kết nối HTTPS và WSS để website có thể gọi các endpoint dịch vụ AWS (như API Gateway, Cognito và Bedrock AgentCore) mà URL chỉ được biết tại thời điểm triển khai. Để điều chỉnh chính sách (ví dụ: để thắt chặt `connect-src` cho các origin cụ thể của bạn), hãy chỉnh sửa giá trị `content_security_policy` trong `static-website.ts` (CDK) hoặc `static-website.tf` (Terraform) được tạo của bạn.
 
-`runtime-config.json` được phục vụ với `Cache-Control: no-cache` để trình duyệt luôn lấy cấu hình mới nhất sau khi triển khai lại, thay vì sử dụng bản sao được lưu trong cache cũ.
+`runtime-config.json` được phục vụ với `Cache-Control: no-cache` để trình duyệt luôn lấy cấu hình mới nhất sau khi triển khai lại, thay vì sử dụng bản sao được cache cũ.
 
 ### WAF
 
-CloudFront distribution được bảo vệ bởi [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACL theo mặc định. Web ACL sử dụng bộ quy tắc mặc định do AWS quản lý ([`AWSManagedRulesCommonRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs) và [`AWSManagedRulesKnownBadInputsRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs)), cung cấp bảo vệ chống lại các khai thác web phổ biến bao gồm OWASP Top 10.
+CloudFront distribution được bảo vệ bởi một [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACL theo mặc định. Web ACL sử dụng bộ quy tắc mặc định được quản lý bởi AWS ([`AWSManagedRulesCommonRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs) và [`AWSManagedRulesKnownBadInputsRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs)), cung cấp bảo vệ chống lại các khai thác web phổ biến bao gồm OWASP Top 10.
 
 <Infrastructure>
 <Fragment slot="cdk">
-Để tắt, đặt `enableWaf` thành `false` khi bạn tạo website của mình:
+Để từ chối, đặt `enableWaf` thành `false` khi bạn tạo website của mình:
 
 ```ts title="packages/infra/src/stacks/application-stack.ts" {10,15-18}
 import { Stack } from 'aws-cdk-lib';
@@ -289,12 +289,12 @@ export class ApplicationStack extends Stack {
 }
 ```
 
-:::caution[Suppress CKV_AWS_68 khi tắt WAF]
-Tắt WAF có nghĩa là CloudFront distribution được tổng hợp không có Web ACL liên kết, điều này làm thất bại quét bảo mật `checkov` với `CKV_AWS_68: "CloudFront Distribution should have WAF enabled"` trừ khi được suppress như hiển thị ở trên.
+:::caution[Suppress CKV_AWS_68 khi vô hiệu hóa WAF]
+Vô hiệu hóa WAF có nghĩa là CloudFront distribution được tổng hợp không có Web ACL liên kết, điều này làm thất bại quét bảo mật `checkov` với `CKV_AWS_68: "CloudFront Distribution should have WAF enabled"` trừ khi được suppress như hiển thị ở trên.
 :::
 </Fragment>
 <Fragment slot="terraform">
-Để tắt, đặt `enable_waf` thành `false`:
+Để từ chối, đặt `enable_waf` thành `false`:
 
 ```hcl title="packages/infra/src/main.tf" {7}
 module "my_website" {
@@ -315,7 +315,7 @@ Website bucket, CloudFront distribution log bucket, và CloudWatch Logs group nh
 
 <Infrastructure>
 <Fragment slot="cdk">
-Nếu bạn muốn sử dụng cấu hình mã hóa khác, hãy truyền các prop `encryption`, `encryptionKey` và `enableKeyRotation` khi bạn tạo website của mình:
+Nếu bạn muốn sử dụng cấu hình mã hóa khác, hãy truyền các props `encryption`, `encryptionKey` và `enableKeyRotation` khi bạn tạo website của mình:
 
 ```ts title="packages/infra/src/stacks/application-stack.ts" {11}
 import { Stack } from 'aws-cdk-lib';
@@ -334,6 +334,22 @@ export class ApplicationStack extends Stack {
 }
 ```
 
+:::caution[Suppress CKV_AWS_158 khi sử dụng S3_MANAGED]
+Chọn `BucketEncryption.S3_MANAGED` có nghĩa là access log group không còn được mã hóa KMS, điều này làm thất bại quét bảo mật `checkov` với `CKV_AWS_158`. Suppress nó:
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { LogGroup } from 'aws-cdk-lib/aws-logs';
+import { suppressRules } from '@my-scope/common-constructs';
+
+suppressRules(
+  website,
+  ['CKV_AWS_158'],
+  'Access log group is not KMS encrypted when encryption is S3_MANAGED',
+  (c) => c instanceof LogGroup,
+);
+```
+:::
+
 Để sử dụng khóa KMS của riêng bạn thay vì khóa được tạo tự động, hãy truyền `encryptionKey`:
 
 ```ts {2}
@@ -342,10 +358,36 @@ new MyWebsite(this, 'MyWebsite', {
 });
 ```
 
-`enableKeyRotation` (mặc định `true`) chỉ áp dụng cho khóa được tạo tự động, tức là khi `encryption` là `BucketEncryption.KMS` (mặc định) và không có `encryptionKey` được cung cấp.
+:::caution[Khóa được import cần quyền riêng của chúng]
+Một khóa được import qua `Key.fromKeyArn` phải đã cấp cho các service principals CloudWatch Logs, S3 và CloudFront các quyền mà chúng cần trong chính sách khóa của chính nó. `addToResourcePolicy` là một no-op trên khóa được import, vì vậy construct này không thể cấp chúng cho bạn, và `cdk synth` sẽ không cảnh báo bạn - lỗi chỉ xuất hiện tại thời điểm triển khai. Một khóa được tạo trong cùng một app (`new Key(this, 'WebsiteKey')`) không có vấn đề này, vì CDK có thể cập nhật chính sách của nó trực tiếp.
+:::
+
+`enableKeyRotation` (mặc định `true`) chỉ áp dụng cho khóa được tạo tự động, tức là khi `encryption` là `BucketEncryption.KMS` (mặc định) và không có `encryptionKey` được cung cấp:
+
+```ts {2}
+new MyWebsite(this, 'MyWebsite', {
+  enableKeyRotation: false,
+});
+```
+
+:::caution[Suppress CKV_AWS_7 khi vô hiệu hóa xoay khóa]
+Vô hiệu hóa xoay khóa trên khóa được tạo tự động làm thất bại quét bảo mật `checkov` với `CKV_AWS_7`. Suppress nó:
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { Key } from 'aws-cdk-lib/aws-kms';
+import { suppressRules } from '@my-scope/common-constructs';
+
+suppressRules(
+  website,
+  ['CKV_AWS_7'],
+  'Key rotation is managed externally',
+  (c) => c instanceof Key,
+);
+```
+:::
 </Fragment>
 <Fragment slot="terraform">
-Nếu bạn muốn sử dụng cấu hình mã hóa khác, hãy đặt các biến `encryption`, `kms_key_arn` và `enable_key_rotation`:
+Nếu bạn muốn sử dụng cấu hình mã hóa khác, hãy đặt các biến `encryption`, `kms_key_arn`, `create_kms_key` và `enable_key_rotation`:
 
 ```hcl title="packages/infra/src/main.tf" {7}
 module "my_website" {
@@ -358,19 +400,62 @@ module "my_website" {
 }
 ```
 
-Để sử dụng khóa KMS của riêng bạn thay vì khóa được tạo tự động, hãy truyền `kms_key_arn`. Khóa do khách hàng cung cấp phải đã cấp cho các service principal CloudWatch Logs, S3 và CloudFront các quyền mà chúng cần trong chính sách khóa của nó.
+:::caution[Checkov: S3_MANAGED]
+Chọn `S3_MANAGED` làm thất bại quét bảo mật `checkov` với `CKV_AWS_145` trên website và distribution log buckets. Target `test` được cung cấp không chấp nhận `--config-file`, nhưng `checkov` tự động phát hiện một `.checkov.yaml` trong thư mục làm việc của nó, vì vậy hãy đặt một cái trong `packages/infra/src`:
 
-`enable_key_rotation` (mặc định `true`) chỉ áp dụng cho khóa được tạo tự động, tức là khi `encryption` là `"KMS"` (mặc định) và không có `kms_key_arn` được cung cấp.
+```yaml title="packages/infra/src/.checkov.yaml"
+skip-check:
+  - CKV_AWS_145
+```
+:::
+
+Để sử dụng khóa KMS của riêng bạn thay vì khóa được tạo tự động, hãy truyền `kms_key_arn` và đặt `create_kms_key` thành `false`:
+
+```hcl title="packages/infra/src/main.tf" {7-8}
+module "my_website" {
+  source = "../../common/terraform/src/app/static-websites/my-website"
+
+  providers = {
+    aws.us_east_1 = aws.us_east_1
+  }
+  kms_key_arn    = aws_kms_key.website.arn
+  create_kms_key = false
+}
+```
+
+Một khóa do khách hàng cung cấp phải đã cấp cho các service principals CloudWatch Logs, S3 và CloudFront các quyền mà chúng cần trong chính sách khóa của chính nó.
+
+`enable_key_rotation` (mặc định `true`) chỉ áp dụng cho khóa được tạo tự động, tức là khi `encryption` là `"KMS"` (mặc định) và `create_kms_key` là `true`:
+
+```hcl title="packages/infra/src/main.tf" {7}
+module "my_website" {
+  source = "../../common/terraform/src/app/static-websites/my-website"
+
+  providers = {
+    aws.us_east_1 = aws.us_east_1
+  }
+  enable_key_rotation = false
+}
+```
+
+:::caution[Checkov: xoay khóa bị vô hiệu hóa]
+Vô hiệu hóa xoay khóa trên khóa được tạo tự động làm thất bại quét bảo mật `checkov` với `CKV_AWS_7`. Thêm nó vào cùng một `.checkov.yaml`:
+
+```yaml title="packages/infra/src/.checkov.yaml"
+skip-check:
+  - CKV_AWS_7
+```
+:::
 </Fragment>
 </Infrastructure>
 
 ### Custom Domain & TLS
 
-Theo mặc định, distribution sử dụng tên miền CloudFront mặc định (`*.cloudfront.net`) và chứng chỉ mặc định của nó, không hỗ trợ áp dụng phiên bản TLS tối thiểu là 1.2. Để phục vụ website của bạn từ domain của riêng bạn, hãy cung cấp [chứng chỉ ACM](https://docs.aws.amazon.com/acm/latest/userguide/acm-overview.html) (phải nằm trong `us-east-1` để sử dụng với CloudFront) và tên miền của bạn. Phiên bản TLS tối thiểu là 1.2 sau đó được áp dụng cho người xem:
+Theo mặc định, distribution sử dụng tên miền CloudFront mặc định (`*.cloudfront.net`) và chứng chỉ mặc định của nó, không hỗ trợ thực thi phiên bản TLS tối thiểu là 1.2. Để phục vụ website của bạn từ tên miền của riêng bạn, hãy cung cấp một [chứng chỉ ACM](https://docs.aws.amazon.com/acm/latest/userguide/acm-overview.html) (phải nằm trong `us-east-1` để sử dụng với CloudFront) và tên miền của bạn. Phiên bản TLS tối thiểu là 1.2 sau đó được thực thi cho người xem:
 
 <Infrastructure>
 <Fragment slot="cdk">
-Truyền các prop `certificate` và `domainNames` khi bạn tạo website của mình:
+Truyền các props `certificate` và `domainNames` khi bạn tạo website của mình:
 
 ```ts title="packages/infra/src/stacks/application-stack.ts" {11-13}
 import { Stack } from 'aws-cdk-lib';
@@ -408,17 +493,17 @@ module "my_website" {
 </Fragment>
 </Infrastructure>
 
-Bạn cũng sẽ cần tạo các bản ghi DNS (ví dụ trong Route 53) trỏ domain của bạn đến CloudFront distribution.
+Bạn cũng sẽ cần tạo các bản ghi DNS (ví dụ trong Route 53) trỏ tên miền của bạn đến CloudFront distribution.
 
 ## Runtime Configuration
 
-Cấu hình từ cơ sở hạ tầng của bạn được cung cấp cho website của bạn thông qua <Link href="guides/runtime-config">Runtime Configuration</Link>. Điều này cho phép website của bạn truy cập các chi tiết như API URLs không được biết cho đến khi ứng dụng của bạn được triển khai.
+Cấu hình từ cơ sở hạ tầng của bạn được cung cấp cho website của bạn qua <Link href="guides/runtime-config">Runtime Configuration</Link>. Điều này cho phép website của bạn truy cập các chi tiết như API URLs mà không được biết cho đến khi ứng dụng của bạn được triển khai.
 
 ### Cơ sở hạ tầng
 
 <Infrastructure>
 <Fragment slot="cdk">
-CDK construct `RuntimeConfig` có thể được sử dụng để thêm và truy xuất cấu hình trong cơ sở hạ tầng CDK của bạn. Các CDK construct được tạo bởi các generator `@aws/nx-plugin` (như <Link path="guides/trpc">`ts#api`</Link> và <Link path="guides/fastapi">`py#api`</Link>) sẽ tự động thêm các giá trị phù hợp vào `RuntimeConfig`.
+CDK construct `RuntimeConfig` có thể được sử dụng để thêm và truy xuất cấu hình trong cơ sở hạ tầng CDK của bạn. Các CDK constructs được tạo bởi các generators `@aws/nx-plugin` (như <Link path="guides/trpc">`ts#api`</Link> và <Link path="guides/fastapi">`py#api`</Link>) sẽ tự động thêm các giá trị thích hợp vào `RuntimeConfig`.
 
 CDK construct website của bạn sẽ triển khai namespace `connection` của runtime configuration dưới dạng file `runtime-config.json` vào thư mục gốc của S3 bucket của bạn.
 
@@ -447,9 +532,9 @@ Với CDK, website construct có thể được khai báo tại bất kỳ đi�
 :::
 </Fragment>
 <Fragment slot="terraform">
-Với Terraform, runtime configuration được quản lý thông qua các module runtime-config. Các module Terraform được tạo bởi các generator `@aws/nx-plugin` (như <Link path="guides/trpc">`ts#api`</Link> và <Link path="guides/fastapi">`py#api`</Link>) sẽ tự động thêm các giá trị phù hợp vào runtime configuration.
+Với Terraform, runtime configuration được quản lý thông qua các runtime-config modules. Các Terraform modules được tạo bởi các generators `@aws/nx-plugin` (như <Link path="guides/trpc">`ts#api`</Link> và <Link path="guides/fastapi">`py#api`</Link>) sẽ tự động thêm các giá trị thích hợp vào runtime configuration.
 
-Module Terraform website của bạn sẽ triển khai namespace `connection` của runtime configuration dưới dạng file `runtime-config.json` vào thư mục gốc của S3 bucket của bạn.
+Terraform module website của bạn sẽ triển khai namespace `connection` của runtime configuration dưới dạng file `runtime-config.json` vào thư mục gốc của S3 bucket của bạn.
 
 ```hcl title="packages/infra/src/main.tf" {20-21}
 module "asset_bucket" {
@@ -477,7 +562,7 @@ module "my_website" {
 ```
 
 :::caution[Module Ordering]
-Bạn phải đảm bảo rằng bạn khai báo module website của mình _sau_ bất kỳ module nào thêm vào runtime configuration và cấu hình `depends_on` phù hợp để đảm bảo thứ tự, nếu không chúng sẽ bị thiếu trong file `runtime-config.json` của bạn.
+Bạn phải đảm bảo rằng bạn khai báo website module của mình _sau_ bất kỳ modules nào thêm vào runtime configuration và cấu hình `depends_on` thích hợp để đảm bảo thứ tự, nếu không chúng sẽ bị thiếu trong file `runtime-config.json` của bạn.
 :::
 </Fragment>
 </Infrastructure>
@@ -498,105 +583,105 @@ const MyComponent = () => {
 ```
 
 :::note[Runtime Configuration]
-Để biết chi tiết về cách runtime configuration được lưu trữ trong AWS AppConfig và cách các consumer phía server (Lambda function, agent) có thể truy xuất nó, hãy xem hướng dẫn <Link path="guides/runtime-config">Runtime Configuration</Link>.
+Để biết chi tiết về cách runtime configuration được lưu trữ trong AWS AppConfig và cách các consumers phía server (Lambda functions, agents) có thể truy xuất nó, hãy xem hướng dẫn <Link path="guides/runtime-config">Runtime Configuration</Link>.
 :::
 
 ### Local Runtime Config
 
-Khi chạy [local development server](#local-development-server), bạn sẽ cần file `runtime-config.json` trong thư mục `public` của mình để website cục bộ của bạn biết URL backend, cấu hình identity, v.v.
+Khi chạy [local development server](#local-development-server), bạn sẽ cần một file `runtime-config.json` trong thư mục `public` của bạn để website local của bạn biết các backend URLs, cấu hình identity, v.v.
 
-Dự án website của bạn được cấu hình với target `load-runtime-config` mà bạn có thể sử dụng để tải xuống file `runtime-config.json` từ ứng dụng đã triển khai:
+Dự án website của bạn được cấu hình với target `load-runtime-config` mà bạn có thể sử dụng để tải xuống file `runtime-config.json` từ một ứng dụng đã triển khai:
 
 <NxCommands commands={['load-runtime-config <my-website>']} />
 
 :::note[Custom Stage Names]
 <Infrastructure>
 <Fragment slot="cdk">
-Nếu bạn thay đổi tiền tố cho tên stage trong `src/main.ts` của dự án cơ sở hạ tầng, bạn sẽ cần cập nhật target `load-runtime-config` trong file `project.json` của website của bạn cho phù hợp.
+Nếu bạn thay đổi tiền tố cho tên stage của bạn trong `src/main.ts` của dự án cơ sở hạ tầng, bạn sẽ cần cập nhật target `load-runtime-config` trong file `project.json` của website của bạn cho phù hợp.
 
-Ngoài ra, đáng chú ý là target `load-runtime-config` giả định một stage duy nhất của ứng dụng của bạn được triển khai vào môi trường mà bạn có AWS credentials. Bạn sẽ cần điều chỉnh lệnh nếu bạn triển khai nhiều stage vào cùng một tài khoản và vùng.
+Ngoài ra, đáng chú ý là target `load-runtime-config` giả định một stage duy nhất của ứng dụng của bạn được triển khai vào môi trường mà bạn có AWS credentials. Bạn sẽ cần điều chỉnh lệnh nếu bạn triển khai nhiều stages vào cùng một account và region.
 </Fragment>
 <Fragment slot="terraform">
-Đối với các dự án Terraform, target `load-runtime-config` sao chép file `runtime-config.json` được tạo sau lần `terraform apply` cục bộ gần nhất của bạn.
+Đối với các dự án Terraform, target `load-runtime-config` sao chép file `runtime-config.json` được tạo sau lần `terraform apply` local gần nhất của bạn.
 </Fragment>
 </Infrastructure>
 :::
 
 ## Local Development Server
 
-Lệnh chính thức cho phát triển cục bộ là `dev`, khởi động website của bạn (và bất kỳ server cục bộ nào cho các API bạn đã kết nối với nó) bằng một lệnh:
+Lệnh chính thức cho phát triển local là `dev`, khởi động website của bạn (và bất kỳ local servers nào cho các APIs bạn đã kết nối nó) bằng một lệnh:
 
 <NxCommands commands={['dev <my-website>']} />
 
-Target `serve` cũng có sẵn cho khi bạn cần kiểm soát mức độ ứng dụng của bạn chạy cục bộ so với trỏ đến cơ sở hạ tầng AWS đã triển khai. Để có cái nhìn tổng quan rộng hơn về phát triển cục bộ trên các dự án được kết nối, bao gồm cách `dev` hoạt động cho các dự án có nhiều component, hãy xem hướng dẫn <Link path="guides/local-development">Local Development</Link>.
+Target `serve` cũng có sẵn cho khi bạn cần kiểm soát bao nhiêu ứng dụng của bạn chạy locally so với trỏ đến cơ sở hạ tầng AWS đã triển khai. Để có cái nhìn tổng quan rộng hơn về phát triển local trên các dự án được kết nối, bao gồm cách `dev` hoạt động cho các dự án với nhiều components, hãy xem hướng dẫn <Link path="guides/local-development">Local Development</Link>.
 
 ### Serve Target
 
-Target `serve` khởi động local development server cho website của bạn. Target này yêu cầu bạn đã triển khai bất kỳ cơ sở hạ tầng hỗ trợ nào mà website tương tác với, và đã [tải local runtime configuration](#local-runtime-config).
+Target `serve` khởi động một local development server cho website của bạn. Target này yêu cầu bạn đã triển khai bất kỳ cơ sở hạ tầng hỗ trợ nào mà website tương tác với, và đã [tải local runtime configuration](#local-runtime-config).
 
-Bạn có thể chạy target này bằng lệnh sau:
+Bạn có thể chạy target này với lệnh sau:
 
 <NxCommands commands={['serve <my-website>']} />
 
-Target này hữu ích để làm việc trên các thay đổi website trong khi trỏ đến các API "thực" đã triển khai và cơ sở hạ tầng khác.
+Target này hữu ích cho việc làm việc trên các thay đổi website trong khi trỏ đến các APIs "thực" đã triển khai và cơ sở hạ tầng khác.
 
 ### Dev Target
 
-Target `dev` khởi động local development server cho website của bạn (với [Vite `MODE`](https://vite.dev/guide/env-and-mode) được đặt thành `local-dev`), cũng như khởi động bất kỳ server cục bộ nào cho các API bạn đã kết nối website của mình thông qua <Link path="/guides/connection">Connection generator</Link>.
+Target `dev` khởi động một local development server cho website của bạn (với [Vite `MODE`](https://vite.dev/guide/env-and-mode) được đặt thành `local-dev`), cũng như khởi động bất kỳ local servers nào cho các APIs bạn đã kết nối website của mình qua <Link path="/guides/connection">Connection generator</Link>.
 
-Khi local website server của bạn được chạy thông qua target này, `runtime-config.json` được tự động ghi đè để trỏ đến các url API đang chạy cục bộ của bạn.
+Khi local website server của bạn được chạy qua target này, `runtime-config.json` được tự động ghi đè để trỏ đến các locally running API urls của bạn.
 
-Bạn có thể chạy target này bằng lệnh sau:
+Bạn có thể chạy target này với lệnh sau:
 
 <NxCommands commands={['dev <my-website>']} />
 
-Target này hữu ích khi bạn đang làm việc trên cả website và API của mình và muốn lặp lại nhanh chóng mà không cần triển khai cơ sở hạ tầng của bạn.
+Target này hữu ích khi bạn đang làm việc trên website và API của mình và muốn lặp lại nhanh chóng mà không cần triển khai cơ sở hạ tầng của bạn.
 
 :::note[Workspace `dev` script]
-`package.json` gốc của workspace của bạn bao gồm script `dev` chạy target `dev` cho mọi dự án có nó:
+`package.json` gốc của workspace của bạn bao gồm một script `dev` chạy target `dev` cho mọi dự án có nó:
 
 <PackageManagerShortCommand commands={["dev"]} />
 
-Điều này khởi động local development server cho website của bạn (và bất kỳ dự án nào khác có target `dev`) trong một lệnh. Để chỉ chạy website này, hãy sử dụng target `dev` của riêng nó (ví dụ: `nx dev <my-website>`).
+Điều này khởi động local development server cho website của bạn (và bất kỳ dự án nào khác có target `dev`) trong một lệnh. Để chỉ chạy website này, hãy sử dụng target `dev` riêng của nó (ví dụ: `nx dev <my-website>`).
 :::
 
 :::warning[Mock Authentication]
-Khi chạy ở chế độ này và không có `runtime-config.json`, nếu bạn đã cấu hình Cognito Authentication (thông qua <Link path="/guides/react-website-auth">generator `ts#website#auth`</Link>), đăng nhập sẽ được bỏ qua và các yêu cầu đến server cục bộ của bạn sẽ không bao gồm header xác thực.
+Khi chạy ở chế độ này và không có `runtime-config.json`, nếu bạn đã cấu hình Cognito Authentication (qua <Link path="/guides/react-website-auth">generator `ts#website#auth`</Link>), đăng nhập sẽ được bỏ qua và các yêu cầu đến local servers của bạn sẽ không bao gồm authentication headers.
 
 Để bật đăng nhập và xác thực cho `dev`, hãy triển khai cơ sở hạ tầng của bạn và tải runtime config.
 :::
 
 :::tip[Dev Behavior]
-Khi chạy với `dev`, bạn có thể chỉ định bất kỳ biến môi trường nào được yêu cầu bởi các API của bạn để trỏ đến các tài nguyên AWS đã triển khai khác, ví dụ:
+Khi chạy với `dev`, bạn có thể chỉ định bất kỳ biến môi trường nào được yêu cầu bởi các APIs của bạn để trỏ đến các tài nguyên AWS đã triển khai khác, ví dụ:
 
 <NxCommands env={{DYNAMODB_TABLE_NAME: 'xxxxx'}} commands={['dev <my-website>']} />
 
-Lưu ý rằng các server API cục bộ của bạn sẽ chạy với AWS credentials bạn đã cấu hình cục bộ.
+Lưu ý rằng các local API servers của bạn sẽ chạy với AWS credentials bạn đã cấu hình locally.
 :::
 
 ## Building
 
-Bạn có thể build website của mình bằng target `build`. Điều này chạy các target `bundle`, `compile`, `test` và `lint`, kiểm tra kiểu, đóng gói, kiểm thử và lint website của bạn.
+Bạn có thể build website của mình bằng target `build`. Điều này chạy các targets `bundle`, `compile`, `test` và `lint`, type-checking, bundling, testing và linting website của bạn.
 
 <NxCommands commands={['build <my-website>']} />
 
-Target `bundle` sử dụng Vite để tạo production bundle trong thư mục gốc `dist/packages/<my-website>/bundle`. Đây là artifact có thể triển khai được sử dụng bởi cơ sở hạ tầng website của bạn. Bạn có thể chạy nó riêng:
+Target `bundle` sử dụng Vite để tạo một production bundle trong thư mục gốc `dist/packages/<my-website>/bundle`. Đây là artifact có thể triển khai được sử dụng bởi cơ sở hạ tầng website của bạn. Bạn có thể chạy nó một mình:
 
 <NxCommands commands={['bundle <my-website>']} />
 
 ## Testing
 
-Kiểm thử website của bạn giống như viết test trong một dự án TypeScript tiêu chuẩn, vì vậy vui lòng tham khảo <Link path="guides/typescript-project#testing">hướng dẫn dự án TypeScript</Link> để biết thêm chi tiết.
+Kiểm thử website của bạn giống như viết tests trong một dự án TypeScript tiêu chuẩn, vì vậy vui lòng tham khảo <Link path="guides/typescript-project#testing">hướng dẫn dự án TypeScript</Link> để biết thêm chi tiết.
 
-Đối với kiểm thử cụ thể cho React, React Testing Library đã được cài đặt và có sẵn để bạn sử dụng để viết test. Để biết thêm chi tiết về cách sử dụng, vui lòng tham khảo [tài liệu React Testing Library](https://testing-library.com/docs/react-testing-library/example-intro).
+Đối với kiểm thử cụ thể của React, React Testing Library đã được cài đặt và có sẵn để bạn sử dụng để viết tests. Để biết thêm chi tiết về cách sử dụng, vui lòng tham khảo [tài liệu React Testing Library](https://testing-library.com/docs/react-testing-library/example-intro).
 
-Bạn có thể chạy các test của mình bằng target `test`:
+Bạn có thể chạy tests của mình bằng target `test`:
 
 <NxCommands commands={['test <my-website>']} />
 
 ## Connections
 
-Sử dụng generator <Link path="guides/connection">`connection`</Link> để tích hợp dự án này với các dự án khác trong workspace của bạn. Các kết nối sau liên quan đến dự án này:
+Sử dụng generator <Link path="guides/connection">`connection`</Link> để tích hợp dự án này với các dự án khác trong workspace của bạn. Các connections sau liên quan đến dự án này:
 
 <CardGrid>
   <ConnectionCard

--- a/docs/src/content/docs/zh/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/zh/get_started/tutorials/dungeon-game/1.mdx
@@ -1072,11 +1072,17 @@ export class StoryAgent extends Construct implements IGrantable, IConnectable {
 // packages/common/constructs/src/app/static-websites/game-ui.ts
 import * as url from 'url';
 import { Construct } from 'constructs';
-import { StaticWebsite } from '../../core/index.js';
+import { StaticWebsite, StaticWebsiteProps } from '../../core/index.js';
+
+export type GameUIProps = Omit<
+  StaticWebsiteProps,
+  'websiteName' | 'websiteFilePath'
+>;
 
 export class GameUI extends StaticWebsite {
-  constructor(scope: Construct, id: string) {
+  constructor(scope: Construct, id: string, props?: GameUIProps) {
     super(scope, id, {
+      ...props,
       websiteName: 'GameUI',
       websiteFilePath: url.fileURLToPath(
         new URL(

--- a/docs/src/content/docs/zh/guides/react-website.mdx
+++ b/docs/src/content/docs/zh/guides/react-website.mdx
@@ -18,12 +18,12 @@ import Infrastructure from '@components/infrastructure.astro';
 import Snippet from '@components/snippet.astro';
 import OptionFilter from '@components/option-filter.astro';
 
-此生成器创建一个新的 [React](https://react.dev/) 网站，默认配置了 [shadcn/ui](https://ui.shadcn.com/)，以及用于将您的网站部署到云端的 AWS CDK 或 Terraform 基础设施，作为托管在 [S3](https://aws.amazon.com/s3/) 中的静态网站，由 [CloudFront](https://aws.amazon.com/cloudfront/) 提供服务，并受 [WAF](https://aws.amazon.com/waf/) 保护。
+此生成器创建一个新的 [React](https://react.dev/) 网站，默认配置了 [shadcn/ui](https://ui.shadcn.com/)，以及用于将网站部署到云端的 AWS CDK 或 Terraform 基础设施，作为托管在 [S3](https://aws.amazon.com/s3/) 中的静态网站，由 [CloudFront](https://aws.amazon.com/cloudfront/) 提供服务，并受 [WAF](https://aws.amazon.com/waf/) 保护。
 
 生成的应用程序使用 [Vite](https://vite.dev/) 作为构建工具和打包器。它使用 [TanStack Router](https://tanstack.com/router/v1) 进行类型安全的路由。
 
 :::note[UX 提供者]
-默认的 `ux` 是 [shadcn/ui](https://ui.shadcn.com/)。您也可以选择 [Cloudscape](http://cloudscape.design/) 或 `none`（自带组件库）。
+默认的 `ux` 是 [shadcn/ui](https://ui.shadcn.com/)。您也可以选择 [Cloudscape](http://cloudscape.design/) 或 `none`（使用您自己的组件库）。
 :::
 
 ## 用法
@@ -43,23 +43,23 @@ import OptionFilter from '@components/option-filter.astro';
 生成器将在 `<directory>/<name>` 目录中创建以下项目结构：
 
 <FileTree>
-  - index.html HTML 入口点
-  - public 静态资源
+  - index.html HTML entry point
+  - public Static assets
   - src
-    - main.tsx 应用程序入口点，包含 React 设置
-    - config.ts 应用程序配置（例如 logo）
+    - main.tsx Application entry point with React setup
+    - config.ts Application configuration (eg. logo)
     - components
-      - AppLayout 整体布局和导航栏的组件
+      - AppLayout Components for the overall layout and navigation bar
     - hooks
-      - useAppLayout.tsx 用于从嵌套组件调整 AppLayout 的 Hook（仅限 Cloudscape）
+      - useAppLayout.tsx Hook for adjusting the AppLayout from nested components (Cloudscape only)
     - routes
-      - index.tsx TanStack Router 的示例路由（或页面）
-    - styles.css 全局样式
-  - vite.config.mts Vite 和 Vitest 配置
-  - tsconfig.json 源代码和测试的基础 TypeScript 配置
-  - tsconfig.app.json 源代码的 TypeScript 配置
-  - tsconfig.spec.json 测试的 TypeScript 配置
-  - package.json 定义项目包名称和依赖项的项目清单
+      - index.tsx Example route (or page) for TanStack Router
+    - styles.css Global styles
+  - vite.config.mts Vite and Vitest configuration
+  - tsconfig.json Base TypeScript configuration for source and tests
+  - tsconfig.app.json TypeScript configuration for source code
+  - tsconfig.spec.json TypeScript configuration for tests
+  - package.json Project manifest defining the project's package name and dependencies
 </FileTree>
 
 :::note[不使用 TanStack Router]
@@ -78,9 +78,9 @@ import OptionFilter from '@components/option-filter.astro';
   - packages/common/constructs/src
     - app
       - static-websites
-        - \<name>.ts 特定于您的网站的基础设施
+        - \<name>.ts Infrastructure specific to your website
     - core
-      - static-website.ts 通用 StaticWebsite 构造
+      - static-website.ts Generic StaticWebsite construct
 </FileTree>
 </Fragment>
 <Fragment slot="terraform">
@@ -89,10 +89,10 @@ import OptionFilter from '@components/option-filter.astro';
     - app
       - static-websites
         - \<name>
-          - \<name>.tf 特定于您的网站的模块
+          - \<name>.tf Module specific to your website
     - core
       - static-website
-        - static-website.tf 通用静态网站模块
+        - static-website.tf Generic static website module
 </FileTree>
 </Fragment>
 </Infrastructure>
@@ -129,67 +129,16 @@ waf -> cloudfront
 cloudfront -> s3
 ```
 
-#### 安全标头
+## 实现您的网站
 
-CloudFront 分发应用响应标头策略，在所有响应上设置 `Strict-Transport-Security`、`X-Content-Type-Options`、`X-Frame-Options: DENY`、`Referrer-Policy` 和 `Content-Security-Policy`。
-
-强制执行默认的 `Content-Security-Policy`。它限制脚本和框架以缓解 XSS 和点击劫持，同时允许 HTTPS 和 WSS 连接，以便网站可以调用 AWS 服务端点（如 API Gateway、Cognito 和 Bedrock AgentCore），这些 URL 仅在部署时才知道。要调整策略（例如将 `connect-src` 收紧到您的特定来源），请编辑生成的 `static-website.ts`（CDK）或 `static-website.tf`（Terraform）中的 `content_security_policy` 值。
-
-`runtime-config.json` 使用 `Cache-Control: no-cache` 提供服务，以便浏览器在重新部署后始终获取最新配置，而不是使用过时的缓存副本。
-
-#### 自定义域名和 TLS
-
-默认情况下，分发使用默认的 CloudFront 域名（`*.cloudfront.net`）及其默认证书，该证书不支持强制执行最低 TLS 版本 1.2。要从您自己的域名提供网站服务，请提供 [ACM 证书](https://docs.aws.amazon.com/acm/latest/userguide/acm-overview.html)（必须位于 `us-east-1` 才能与 CloudFront 一起使用）和您的域名 — 然后为查看者强制执行最低 TLS 版本 1.2：
-
-<Infrastructure>
-<Fragment slot="cdk">
-在 `packages/common/constructs/src/app/static-websites` 中生成的网站构造中传递 `certificate` 和 `domainNames` 属性：
-
-```ts {6-8}
-export class MyWebsite extends StaticWebsite {
-  constructor(scope: Construct, id: string) {
-    super(scope, id, {
-      websiteName: 'MyWebsite',
-      websiteFilePath: ...,
-      domainNames: ['www.example.com'],
-      certificate: Certificate.fromCertificateArn(scope, 'Cert',
-        'arn:aws:acm:us-east-1:123456789012:certificate/...'),
-    });
-  }
-}
-```
-</Fragment>
-<Fragment slot="terraform">
-在 `packages/common/terraform/src/app/static-websites` 中生成的网站模块中设置 `custom_domain_names` 和 `acm_certificate_arn` 变量：
-
-```hcl {5-6}
-module "static_website" {
-  source            = "../../../core/static-website"
-  website_name      = "my-website"
-  website_file_path = ...
-  custom_domain_names = ["www.example.com"]
-  acm_certificate_arn = "arn:aws:acm:us-east-1:123456789012:certificate/..."
-
-  providers = {
-    aws.us_east_1 = aws.us_east_1
-  }
-}
-```
-</Fragment>
-</Infrastructure>
-
-您还需要创建 DNS 记录（例如在 Route 53 中），将您的域名指向 CloudFront 分发。
-
-## 实现您的 React 网站
-
-[React 文档](https://react.dev/learn)是学习使用 React 构建基础知识的好地方。
+[React 文档](https://react.dev/learn) 是学习使用 React 构建的基础知识的好地方。
 
 <OptionFilter when={{ ux: 'cloudscape' }} description="Cloudscape component docs pointer">
-您可以参考 [Cloudscape 文档](https://cloudscape.design/components/)了解可用组件的详细信息以及如何使用它们。
+您可以参考 [Cloudscape 文档](https://cloudscape.design/components/) 了解可用组件的详细信息以及如何使用它们。
 </OptionFilter>
 
 <OptionFilter when={{ ux: 'shadcn' }} description="Shadcn component docs pointer">
-您可以参考 [shadcn/ui 文档](https://ui.shadcn.com/docs)了解可用组件的详细信息以及如何使用它们。
+您可以参考 [shadcn/ui 文档](https://ui.shadcn.com/docs) 了解可用组件的详细信息以及如何使用它们。
 </OptionFilter>
 
 ### 路由
@@ -206,7 +155,7 @@ module "static_website" {
 
 #### 在页面之间导航
 
-您可以使用 `Link` 组件或 `useNavigate` hook 在页面之间导航：
+您可以使用 `Link` 组件或 `useNavigate` 钩子在页面之间导航：
 
 ```tsx {1, 4, 8-9, 14}
 import { Link, useNavigate } from '@tanstack/react-router';
@@ -231,15 +180,245 @@ export const MyComponent = () => {
 
 有关更多详细信息，请查看 [TanStack Router](https://tanstack.com/router/latest/docs/framework/react/overview) 文档。
 
+## 部署您的网站
+
+React 网站生成器根据您选择的 `iac` 创建 CDK 或 Terraform 基础设施即代码。您可以使用它来部署您的网站。
+
+<Infrastructure>
+<Fragment slot="cdk">
+要部署您的网站，我们建议使用 <Link path="guides/typescript-infrastructure">`ts#infra` 生成器</Link> 创建 CDK 应用程序。
+
+您可以使用在 `packages/common/constructs` 中为您生成的 CDK 构造来部署您的网站。
+
+```ts title="packages/infra/src/stacks/application-stack.ts" {3, 9}
+import { Stack } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { MyWebsite } from '@my-scope/common-constructs';
+
+export class ApplicationStack extends Stack {
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+
+    new MyWebsite(this, 'MyWebsite');
+  }
+}
+```
+
+这将设置：
+
+1. 用于托管静态网站文件的 S3 存储桶
+2. 用于全球内容分发的 CloudFront 分配
+3. 用于安全保护的 WAF Web ACL
+4. 用于安全 S3 访问的源访问控制
+5. 自动部署网站文件和运行时配置
+</Fragment>
+<Fragment slot="terraform">
+要部署您的网站，我们建议使用 <Link path="/guides/terraform-project">`terraform#project` 生成器</Link> 创建 Terraform 项目。
+
+您可以使用在 `packages/common/terraform` 中为您生成的 Terraform 模块来部署您的网站。
+
+```hcl title="packages/infra/src/main.tf" {3}
+# Deploy website
+module "my_website" {
+  source = "../../common/terraform/src/app/static-websites/my-website"
+
+  providers = {
+    aws.us_east_1 = aws.us_east_1
+  }
+}
+```
+
+这将设置：
+
+1. 用于托管静态网站文件的 S3 存储桶
+2. 用于全球内容分发的 CloudFront 分配
+3. 用于安全保护的 WAF Web ACL（部署在 us-east-1）
+4. 用于安全 S3 访问的源访问控制
+5. 自动部署网站文件和运行时配置
+
+:::note[WAF 提供者区域]
+CloudFront 和 WAF 资源需要 `aws.us_east_1` 提供者，它们必须部署在 us-east-1 区域。确保您的 Terraform 配置包含此提供者：
+
+```hcl title="packages/infra/src/providers.tf"
+provider "aws" {
+  alias  = "us_east_1"
+  region = "us-east-1"
+}
+```
+:::
+</Fragment>
+</Infrastructure>
+
+### 安全标头
+
+CloudFront 分配应用响应标头策略，在所有响应上设置 `Strict-Transport-Security`、`X-Content-Type-Options`、`X-Frame-Options: DENY`、`Referrer-Policy` 和 `Content-Security-Policy`。
+
+强制执行默认的 `Content-Security-Policy`。它限制脚本和框架以缓解 XSS 和点击劫持，同时允许 HTTPS 和 WSS 连接，以便网站可以调用 AWS 服务端点（如 API Gateway、Cognito 和 Bedrock AgentCore），这些 URL 仅在部署时才知道。要调整策略（例如将 `connect-src` 收紧到您的特定源），请编辑生成的 `static-website.ts`（CDK）或 `static-website.tf`（Terraform）中的 `content_security_policy` 值。
+
+`runtime-config.json` 使用 `Cache-Control: no-cache` 提供服务，以便浏览器在重新部署后始终获取最新配置，而不是使用陈旧的缓存副本。
+
+### WAF
+
+默认情况下，CloudFront 分配受 [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACL 保护。Web ACL 使用 AWS 托管的默认规则集（[`AWSManagedRulesCommonRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs) 和 [`AWSManagedRulesKnownBadInputsRuleSet`](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs)），提供针对常见 Web 漏洞（包括 OWASP Top 10）的保护。
+
+<Infrastructure>
+<Fragment slot="cdk">
+要选择退出，在创建网站时将 `enableWaf` 设置为 `false`：
+
+```ts title="packages/infra/src/stacks/application-stack.ts" {10,15-18}
+import { Stack } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { MyWebsite, suppressRules } from '@my-scope/common-constructs';
+
+export class ApplicationStack extends Stack {
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+
+    const website = new MyWebsite(this, 'MyWebsite', {
+      enableWaf: false,
+    });
+
+    // Disabling WAF fails the checkov CKV_AWS_68 check ("CloudFront
+    // Distribution should have WAF enabled"). Suppress it explicitly.
+    suppressRules(
+      website.cloudFrontDistribution,
+      ['CKV_AWS_68'],
+      'WAF is intentionally disabled for this distribution',
+    );
+  }
+}
+```
+
+:::caution[禁用 WAF 时抑制 CKV_AWS_68]
+禁用 WAF 意味着合成的 CloudFront 分配没有关联的 Web ACL，这会导致 `checkov` 安全扫描失败，出现 `CKV_AWS_68: "CloudFront Distribution should have WAF enabled"`，除非如上所示进行抑制。
+:::
+</Fragment>
+<Fragment slot="terraform">
+要选择退出，将 `enable_waf` 设置为 `false`：
+
+```hcl title="packages/infra/src/main.tf" {7}
+module "my_website" {
+  source = "../../common/terraform/src/app/static-websites/my-website"
+
+  providers = {
+    aws.us_east_1 = aws.us_east_1
+  }
+  enable_waf = false
+}
+```
+</Fragment>
+</Infrastructure>
+
+### 存储桶加密
+
+默认情况下，网站存储桶、CloudFront 分配日志存储桶以及接收其服务器访问日志的 CloudWatch Logs 组都使用客户管理的 [AWS KMS](https://aws.amazon.com/kms/) 密钥进行加密。此密钥会自动为您创建，并启用密钥轮换。
+
+<Infrastructure>
+<Fragment slot="cdk">
+如果您想使用不同的加密配置，请在创建网站时传递 `encryption`、`encryptionKey` 和 `enableKeyRotation` 属性：
+
+```ts title="packages/infra/src/stacks/application-stack.ts" {11}
+import { Stack } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { BucketEncryption } from 'aws-cdk-lib/aws-s3';
+import { MyWebsite } from '@my-scope/common-constructs';
+
+export class ApplicationStack extends Stack {
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+
+    new MyWebsite(this, 'MyWebsite', {
+      encryption: BucketEncryption.S3_MANAGED,
+    });
+  }
+}
+```
+
+要使用您自己的 KMS 密钥而不是自动创建的密钥，请传递 `encryptionKey`：
+
+```ts {2}
+new MyWebsite(this, 'MyWebsite', {
+  encryptionKey: myKey,
+});
+```
+
+`enableKeyRotation`（默认为 `true`）仅适用于自动创建的密钥，即当 `encryption` 为 `BucketEncryption.KMS`（默认值）且未提供 `encryptionKey` 时。
+</Fragment>
+<Fragment slot="terraform">
+如果您想使用不同的加密配置，请设置 `encryption`、`kms_key_arn` 和 `enable_key_rotation` 变量：
+
+```hcl title="packages/infra/src/main.tf" {7}
+module "my_website" {
+  source = "../../common/terraform/src/app/static-websites/my-website"
+
+  providers = {
+    aws.us_east_1 = aws.us_east_1
+  }
+  encryption = "S3_MANAGED"
+}
+```
+
+要使用您自己的 KMS 密钥而不是自动创建的密钥，请传递 `kms_key_arn`。客户提供的密钥必须在其自己的密钥策略中已经授予 CloudWatch Logs、S3 和 CloudFront 服务主体所需的权限。
+
+`enable_key_rotation`（默认为 `true`）仅适用于自动创建的密钥，即当 `encryption` 为 `"KMS"`（默认值）且未提供 `kms_key_arn` 时。
+</Fragment>
+</Infrastructure>
+
+### 自定义域名和 TLS
+
+默认情况下，分配使用默认的 CloudFront 域名（`*.cloudfront.net`）及其默认证书，该证书不支持强制执行最低 TLS 版本 1.2。要从您自己的域名提供网站服务，请提供 [ACM 证书](https://docs.aws.amazon.com/acm/latest/userguide/acm-overview.html)（必须位于 `us-east-1` 才能与 CloudFront 一起使用）和您的域名。然后将为查看者强制执行最低 TLS 版本 1.2：
+
+<Infrastructure>
+<Fragment slot="cdk">
+在创建网站时传递 `certificate` 和 `domainNames` 属性：
+
+```ts title="packages/infra/src/stacks/application-stack.ts" {11-13}
+import { Stack } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { Certificate } from 'aws-cdk-lib/aws-certificatemanager';
+import { MyWebsite } from '@my-scope/common-constructs';
+
+export class ApplicationStack extends Stack {
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+
+    new MyWebsite(this, 'MyWebsite', {
+      domainNames: ['www.example.com'],
+      certificate: Certificate.fromCertificateArn(this, 'Cert',
+        'arn:aws:acm:us-east-1:123456789012:certificate/...'),
+    });
+  }
+}
+```
+</Fragment>
+<Fragment slot="terraform">
+设置 `custom_domain_names` 和 `acm_certificate_arn` 变量：
+
+```hcl title="packages/infra/src/main.tf" {7-8}
+module "my_website" {
+  source = "../../common/terraform/src/app/static-websites/my-website"
+
+  providers = {
+    aws.us_east_1 = aws.us_east_1
+  }
+  custom_domain_names = ["www.example.com"]
+  acm_certificate_arn = "arn:aws:acm:us-east-1:123456789012:certificate/..."
+}
+```
+</Fragment>
+</Infrastructure>
+
+您还需要创建 DNS 记录（例如在 Route 53 中），将您的域名指向 CloudFront 分配。
+
 ## 运行时配置
 
-来自您的基础设施的配置通过<Link href="guides/runtime-config">运行时配置</Link>提供给您的网站。这允许您的网站访问诸如 API URL 之类的详细信息，这些信息在应用程序部署之前是未知的。
+来自基础设施的配置通过 <Link href="guides/runtime-config">运行时配置</Link> 提供给您的网站。这允许您的网站访问诸如 API URL 之类的详细信息，这些信息在应用程序部署之前是未知的。
 
 ### 基础设施
 
 <Infrastructure>
 <Fragment slot="cdk">
-`RuntimeConfig` CDK 构造可用于在您的 CDK 基础设施中添加和检索配置。由 `@aws/nx-plugin` 生成器生成的 CDK 构造（如 <Link path="guides/trpc">`ts#api`</Link> 和 <Link path="guides/fastapi">`py#api`</Link>）将自动向 `RuntimeConfig` 添加适当的值。
+`RuntimeConfig` CDK 构造可用于在 CDK 基础设施中添加和检索配置。由 `@aws/nx-plugin` 生成器生成的 CDK 构造（如 <Link path="guides/trpc">`ts#api`</Link> 和 <Link path="guides/fastapi">`py#api`</Link>）将自动向 `RuntimeConfig` 添加适当的值。
 
 您的网站 CDK 构造将把运行时配置的 `connection` 命名空间作为 `runtime-config.json` 文件部署到 S3 存储桶的根目录。
 
@@ -252,7 +431,7 @@ export class ApplicationStack extends Stack {
   constructor(scope: Construct, id: string) {
     super(scope, id);
 
-    // Website can be declared at any point — runtime config is resolved lazily
+    // Website can be declared at any point, since runtime config is resolved lazily
     new MyWebsite(this, 'MyWebsite');
 
     // Automatically adds values to the RuntimeConfig
@@ -268,7 +447,7 @@ export class ApplicationStack extends Stack {
 :::
 </Fragment>
 <Fragment slot="terraform">
-使用 Terraform 时，运行时配置通过 runtime-config 模块进行管理。由 `@aws/nx-plugin` 生成器生成的 Terraform 模块（如 <Link path="guides/trpc">`ts#api`</Link> 和 <Link path="guides/fastapi">`py#api`</Link>）将自动向运行时配置添加适当的值。
+使用 Terraform 时，运行时配置通过 runtime-config 模块管理。由 `@aws/nx-plugin` 生成器生成的 Terraform 模块（如 <Link path="guides/trpc">`ts#api`</Link> 和 <Link path="guides/fastapi">`py#api`</Link>）将自动向运行时配置添加适当的值。
 
 您的网站 Terraform 模块将把运行时配置的 `connection` 命名空间作为 `runtime-config.json` 文件部署到 S3 存储桶的根目录。
 
@@ -305,7 +484,7 @@ module "my_website" {
 
 ### 网站代码
 
-在您的网站中，您可以使用 `useRuntimeConfig` hook 从运行时配置中检索值：
+在您的网站中，您可以使用 `useRuntimeConfig` 钩子从运行时配置中检索值：
 
 ```tsx {1,4}
 import { useRuntimeConfig } from '../hooks/useRuntimeConfig';
@@ -319,12 +498,12 @@ const MyComponent = () => {
 ```
 
 :::note[运行时配置]
-有关运行时配置如何存储在 AWS AppConfig 中以及服务器端消费者（Lambda 函数、代理）如何检索它的详细信息，请参阅<Link path="guides/runtime-config">运行时配置</Link>指南。
+有关运行时配置如何存储在 AWS AppConfig 中以及服务器端消费者（Lambda 函数、代理）如何检索它的详细信息，请参阅 <Link path="guides/runtime-config">运行时配置</Link> 指南。
 :::
 
 ### 本地运行时配置
 
-运行[本地开发服务器](#local-development-server)时，您需要在 `public` 目录中有一个 `runtime-config.json` 文件，以便本地网站知道后端 URL、身份配置等。
+运行 [本地开发服务器](#local-development-server) 时，您需要在 `public` 目录中有一个 `runtime-config.json` 文件，以便本地网站知道后端 URL、身份配置等。
 
 您的网站项目配置了一个 `load-runtime-config` 目标，您可以使用它从已部署的应用程序中拉取 `runtime-config.json` 文件：
 
@@ -345,15 +524,15 @@ const MyComponent = () => {
 
 ## 本地开发服务器
 
-本地开发的规范命令是 `dev`，它使用一个命令启动您的网站（以及您已连接到它的任何 API 的本地服务器）：
+本地开发的规范命令是 `dev`，它使用一个命令启动您的网站（以及您已连接到它的 API 的任何本地服务器）：
 
 <NxCommands commands={['dev <my-website>']} />
 
-当您需要控制应用程序在本地运行的部分与指向已部署的 AWS 基础设施的部分时，`serve` 目标也可用。有关跨连接项目的本地开发的更广泛概述，包括 `dev` 对具有多个组件的项目的行为方式，请参阅<Link path="guides/local-development">本地开发</Link>指南。
+当您需要控制应用程序在本地运行的程度与指向已部署的 AWS 基础设施时，`serve` 目标也可用。有关跨连接项目的本地开发的更广泛概述，包括 `dev` 对具有多个组件的项目的行为方式，请参阅 <Link path="guides/local-development">本地开发</Link> 指南。
 
 ### Serve 目标
 
-`serve` 目标为您的网站启动本地开发服务器。此目标要求您已部署网站交互的任何支持基础设施，并已[加载本地运行时配置](#local-runtime-config)。
+`serve` 目标为您的网站启动本地开发服务器。此目标要求您已部署网站与之交互的任何支持基础设施，并已 [加载本地运行时配置](#local-runtime-config)。
 
 您可以使用以下命令运行此目标：
 
@@ -363,9 +542,9 @@ const MyComponent = () => {
 
 ### Dev 目标
 
-`dev` 目标为您的网站启动本地开发服务器（将 [Vite `MODE`](https://vite.dev/guide/env-and-mode) 设置为 `local-dev`），并为您通过<Link path="/guides/connection">连接生成器</Link>连接到网站的任何 API 启动本地服务器。
+`dev` 目标为您的网站启动本地开发服务器（将 [Vite `MODE`](https://vite.dev/guide/env-and-mode) 设置为 `local-dev`），并启动您通过 <Link path="/guides/connection">连接生成器</Link> 连接到网站的 API 的任何本地服务器。
 
-当您的本地网站服务器通过此目标运行时，`runtime-config.json` 会自动覆盖以指向您本地运行的 API URL。
+当通过此目标运行本地网站服务器时，`runtime-config.json` 会自动覆盖以指向您本地运行的 API URL。
 
 您可以使用以下命令运行此目标：
 
@@ -374,11 +553,11 @@ const MyComponent = () => {
 当您跨网站和 API 工作并希望快速迭代而无需部署基础设施时，此目标非常有用。
 
 :::note[工作区 `dev` 脚本]
-您的工作区的根 `package.json` 包含一个 `dev` 脚本，该脚本为每个拥有该目标的项目运行 `dev` 目标：
+您的工作区的根 `package.json` 包含一个 `dev` 脚本，该脚本为每个具有 `dev` 目标的项目运行 `dev` 目标：
 
 <PackageManagerShortCommand commands={["dev"]} />
 
-这会在一个命令中启动您的网站（以及任何其他具有 `dev` 目标的项目）的本地开发服务器。要仅运行此网站，请使用其自己的 `dev` 目标（例如 `nx dev <my-website>`）。
+这将使用一个命令启动网站（以及任何其他具有 `dev` 目标的项目）的本地开发服务器。要仅运行此网站，请使用其自己的 `dev` 目标（例如 `nx dev <my-website>`）。
 :::
 
 :::warning[模拟身份验证]
@@ -397,7 +576,7 @@ const MyComponent = () => {
 
 ## 构建
 
-您可以使用 `build` 目标构建您的网站。这会运行 `bundle`、`compile`、`test` 和 `lint` 目标，对您的网站进行类型检查、打包、测试和 lint。
+您可以使用 `build` 目标构建您的网站。这将运行 `bundle`、`compile`、`test` 和 `lint` 目标，对您的网站进行类型检查、打包、测试和 lint。
 
 <NxCommands commands={['build <my-website>']} />
 
@@ -407,82 +586,13 @@ const MyComponent = () => {
 
 ## 测试
 
-测试您的网站与在标准 TypeScript 项目中编写测试非常相似，因此请参阅 <Link path="guides/typescript-project#testing">TypeScript 项目指南</Link>了解更多详细信息。
+测试您的网站与在标准 TypeScript 项目中编写测试非常相似，因此请参阅 <Link path="guides/typescript-project#testing">TypeScript 项目指南</Link> 了解更多详细信息。
 
-对于 React 特定的测试，React Testing Library 已经安装并可供您用于编写测试。有关其用法的更多详细信息，请参阅 [React Testing Library 文档](https://testing-library.com/docs/react-testing-library/example-intro)。
+对于 React 特定的测试，React Testing Library 已经安装并可供您用于编写测试。有关其使用的更多详细信息，请参阅 [React Testing Library 文档](https://testing-library.com/docs/react-testing-library/example-intro)。
 
 您可以使用 `test` 目标运行测试：
 
 <NxCommands commands={['test <my-website>']} />
-
-## 部署您的网站
-
-React 网站生成器根据您选择的 `iac` 创建 CDK 或 Terraform 基础设施即代码。您可以使用它来部署您的网站。
-
-<Infrastructure>
-<Fragment slot="cdk">
-要部署您的网站，我们建议使用 <Link path="guides/typescript-infrastructure">`ts#infra` 生成器</Link>创建 CDK 应用程序。
-
-您可以使用在 `packages/common/constructs` 中为您生成的 CDK 构造来部署您的网站。
-
-```ts title="packages/infra/src/stacks/application-stack.ts" {3, 9}
-import { Stack } from 'aws-cdk-lib';
-import { Construct } from 'constructs';
-import { MyWebsite } from '@my-scope/common-constructs';
-
-export class ApplicationStack extends Stack {
-  constructor(scope: Construct, id: string) {
-    super(scope, id);
-
-    new MyWebsite(this, 'MyWebsite');
-  }
-}
-```
-
-这会设置：
-
-1. 用于托管静态网站文件的 S3 存储桶
-2. 用于全球内容交付的 CloudFront 分发
-3. 用于安全保护的 WAF Web ACL
-4. 用于安全 S3 访问的源访问控制
-5. 自动部署网站文件和运行时配置
-</Fragment>
-<Fragment slot="terraform">
-要部署您的网站，我们建议使用 <Link path="/guides/terraform-project">`terraform#project` 生成器</Link>创建 Terraform 项目。
-
-您可以使用在 `packages/common/terraform` 中为您生成的 Terraform 模块来部署您的网站。
-
-```hcl title="packages/infra/src/main.tf" {3}
-# Deploy website
-module "my_website" {
-  source = "../../common/terraform/src/app/static-websites/my-website"
-
-  providers = {
-    aws.us_east_1 = aws.us_east_1
-  }
-}
-```
-
-这会设置：
-
-1. 用于托管静态网站文件的 S3 存储桶
-2. 用于全球内容交付的 CloudFront 分发
-3. 用于安全保护的 WAF Web ACL（部署在 us-east-1）
-4. 用于安全 S3 访问的源访问控制
-5. 自动部署网站文件和运行时配置
-
-:::note[WAF 提供者区域]
-CloudFront 和 WAF 资源需要 `aws.us_east_1` 提供者，这些资源必须部署在 us-east-1 区域。确保您的 Terraform 配置包含此提供者：
-
-```hcl title="packages/infra/src/providers.tf"
-provider "aws" {
-  alias  = "us_east_1"
-  region = "us-east-1"
-}
-```
-:::
-</Fragment>
-</Infrastructure>
 
 ## 连接
 
@@ -491,52 +601,52 @@ provider "aws" {
 <CardGrid>
   <ConnectionCard
     title="React to tRPC"
-    description="从 React 网站调用 tRPC API"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/react-trpc`}
+    description="Call a tRPC API from a React website"
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'zh'}/guides/connection/react-trpc`}
     source="react"
     target="trpc"
   />
   <ConnectionCard
     title="React to FastAPI"
-    description="从 React 网站调用 Python FastAPI"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/react-fastapi`}
+    description="Call a Python FastAPI from a React website"
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'zh'}/guides/connection/react-fastapi`}
     source="react"
     target="fastapi"
   />
   <ConnectionCard
     title="React to Smithy API"
-    description="从 React 网站调用 Smithy API"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/react-smithy`}
+    description="Call a Smithy API from a React website"
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'zh'}/guides/connection/react-smithy`}
     source="react"
     target="smithy"
   />
   <ConnectionCard
     title="React to Python Agent"
-    description="从 React 网站调用 Python Agent"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/react-py-agent`}
+    description="Call a Python Agent from a React website"
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'zh'}/guides/connection/react-py-agent`}
     source="react"
     target="strands"
     targetBadge="python"
   />
   <ConnectionCard
     title="React to TypeScript Agent"
-    description="从 React 网站调用 TypeScript Agent"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/react-ts-agent`}
+    description="Call a TypeScript Agent from a React website"
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'zh'}/guides/connection/react-ts-agent`}
     source="react"
     target="strands"
     targetBadge="typescript"
   />
   <ConnectionCard
     title="React to AG-UI Agent"
-    description="通过 CopilotKit 从 React 网站调用公开 AG-UI 协议的 Agent"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/react-agui`}
+    description="Call an Agent exposing the AG-UI protocol from a React website via CopilotKit"
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'zh'}/guides/connection/react-agui`}
     source="react"
     target="copilotkit"
   />
   <ConnectionCard
     title="React Website to AgentCore Gateway"
-    description="通过 AgentCore Gateway 将 React 网站连接到代理"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/react-agentcore-gateway`}
+    description="Connect a React website to agents through an AgentCore Gateway"
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'zh'}/guides/connection/react-agentcore-gateway`}
     source="react"
     target="agentcore"
   />

--- a/docs/src/content/docs/zh/guides/react-website.mdx
+++ b/docs/src/content/docs/zh/guides/react-website.mdx
@@ -23,7 +23,7 @@ import OptionFilter from '@components/option-filter.astro';
 生成的应用程序使用 [Vite](https://vite.dev/) 作为构建工具和打包器。它使用 [TanStack Router](https://tanstack.com/router/v1) 进行类型安全的路由。
 
 :::note[UX 提供者]
-默认的 `ux` 是 [shadcn/ui](https://ui.shadcn.com/)。您也可以选择 [Cloudscape](http://cloudscape.design/) 或 `none`（使用您自己的组件库）。
+默认的 `ux` 是 [shadcn/ui](https://ui.shadcn.com/)。您也可以选择 [Cloudscape](http://cloudscape.design/) 或 `none`（自带组件库）。
 :::
 
 ## 用法
@@ -43,23 +43,23 @@ import OptionFilter from '@components/option-filter.astro';
 生成器将在 `<directory>/<name>` 目录中创建以下项目结构：
 
 <FileTree>
-  - index.html HTML entry point
-  - public Static assets
+  - index.html HTML 入口点
+  - public 静态资源
   - src
-    - main.tsx Application entry point with React setup
-    - config.ts Application configuration (eg. logo)
+    - main.tsx 应用程序入口点，包含 React 设置
+    - config.ts 应用程序配置（例如 logo）
     - components
-      - AppLayout Components for the overall layout and navigation bar
+      - AppLayout 整体布局和导航栏的组件
     - hooks
-      - useAppLayout.tsx Hook for adjusting the AppLayout from nested components (Cloudscape only)
+      - useAppLayout.tsx 用于从嵌套组件调整 AppLayout 的钩子（仅限 Cloudscape）
     - routes
-      - index.tsx Example route (or page) for TanStack Router
-    - styles.css Global styles
-  - vite.config.mts Vite and Vitest configuration
-  - tsconfig.json Base TypeScript configuration for source and tests
-  - tsconfig.app.json TypeScript configuration for source code
-  - tsconfig.spec.json TypeScript configuration for tests
-  - package.json Project manifest defining the project's package name and dependencies
+      - index.tsx TanStack Router 的示例路由（或页面）
+    - styles.css 全局样式
+  - vite.config.mts Vite 和 Vitest 配置
+  - tsconfig.json 源代码和测试的基础 TypeScript 配置
+  - tsconfig.app.json 源代码的 TypeScript 配置
+  - tsconfig.spec.json 测试的 TypeScript 配置
+  - package.json 定义项目包名称和依赖项的项目清单
 </FileTree>
 
 :::note[不使用 TanStack Router]
@@ -78,9 +78,9 @@ import OptionFilter from '@components/option-filter.astro';
   - packages/common/constructs/src
     - app
       - static-websites
-        - \<name>.ts Infrastructure specific to your website
+        - \<name>.ts 特定于您网站的基础设施
     - core
-      - static-website.ts Generic StaticWebsite construct
+      - static-website.ts 通用 StaticWebsite 构造
 </FileTree>
 </Fragment>
 <Fragment slot="terraform">
@@ -89,10 +89,10 @@ import OptionFilter from '@components/option-filter.astro';
     - app
       - static-websites
         - \<name>
-          - \<name>.tf Module specific to your website
+          - \<name>.tf 特定于您网站的模块
     - core
       - static-website
-        - static-website.tf Generic static website module
+        - static-website.tf 通用静态网站模块
 </FileTree>
 </Fragment>
 </Infrastructure>
@@ -131,14 +131,14 @@ cloudfront -> s3
 
 ## 实现您的网站
 
-[React 文档](https://react.dev/learn) 是学习使用 React 构建的基础知识的好地方。
+[React 文档](https://react.dev/learn)是学习使用 React 构建的基础知识的好地方。
 
 <OptionFilter when={{ ux: 'cloudscape' }} description="Cloudscape component docs pointer">
-您可以参考 [Cloudscape 文档](https://cloudscape.design/components/) 了解可用组件的详细信息以及如何使用它们。
+您可以参考 [Cloudscape 文档](https://cloudscape.design/components/)了解可用组件的详细信息以及如何使用它们。
 </OptionFilter>
 
 <OptionFilter when={{ ux: 'shadcn' }} description="Shadcn component docs pointer">
-您可以参考 [shadcn/ui 文档](https://ui.shadcn.com/docs) 了解可用组件的详细信息以及如何使用它们。
+您可以参考 [shadcn/ui 文档](https://ui.shadcn.com/docs)了解可用组件的详细信息以及如何使用它们。
 </OptionFilter>
 
 ### 路由
@@ -150,7 +150,7 @@ cloudfront -> s3
 <Steps>
   1. [运行本地开发服务器](#local-development-server)
   2. 在 `src/routes` 中创建一个新的 `<page-name>.tsx` 文件，其在文件树中的位置代表路径
-  3. 注意会自动为您生成 `Route` 和 `RouteComponent`。您可以在这里开始构建您的页面！
+  3. 注意 `Route` 和 `RouteComponent` 会自动为您生成。您可以在这里开始构建您的页面！
 </Steps>
 
 #### 在页面之间导航
@@ -186,7 +186,7 @@ React 网站生成器根据您选择的 `iac` 创建 CDK 或 Terraform 基础设
 
 <Infrastructure>
 <Fragment slot="cdk">
-要部署您的网站，我们建议使用 <Link path="guides/typescript-infrastructure">`ts#infra` 生成器</Link> 创建 CDK 应用程序。
+要部署您的网站，我们建议使用 <Link path="guides/typescript-infrastructure">`ts#infra` 生成器</Link>创建 CDK 应用程序。
 
 您可以使用在 `packages/common/constructs` 中为您生成的 CDK 构造来部署您的网站。
 
@@ -213,7 +213,7 @@ export class ApplicationStack extends Stack {
 5. 自动部署网站文件和运行时配置
 </Fragment>
 <Fragment slot="terraform">
-要部署您的网站，我们建议使用 <Link path="/guides/terraform-project">`terraform#project` 生成器</Link> 创建 Terraform 项目。
+要部署您的网站，我们建议使用 <Link path="/guides/terraform-project">`terraform#project` 生成器</Link>创建 Terraform 项目。
 
 您可以使用在 `packages/common/terraform` 中为您生成的 Terraform 模块来部署您的网站。
 
@@ -253,9 +253,9 @@ provider "aws" {
 
 CloudFront 分配应用响应标头策略，在所有响应上设置 `Strict-Transport-Security`、`X-Content-Type-Options`、`X-Frame-Options: DENY`、`Referrer-Policy` 和 `Content-Security-Policy`。
 
-强制执行默认的 `Content-Security-Policy`。它限制脚本和框架以缓解 XSS 和点击劫持，同时允许 HTTPS 和 WSS 连接，以便网站可以调用 AWS 服务端点（如 API Gateway、Cognito 和 Bedrock AgentCore），这些 URL 仅在部署时才知道。要调整策略（例如将 `connect-src` 收紧到您的特定源），请编辑生成的 `static-website.ts`（CDK）或 `static-website.tf`（Terraform）中的 `content_security_policy` 值。
+强制执行默认的 `Content-Security-Policy`。它限制脚本和框架以减轻 XSS 和点击劫持，同时允许 HTTPS 和 WSS 连接，以便网站可以调用 AWS 服务端点（如 API Gateway、Cognito 和 Bedrock AgentCore），这些 URL 仅在部署时才知道。要调整策略（例如将 `connect-src` 收紧到您的特定源），请编辑生成的 `static-website.ts`（CDK）或 `static-website.tf`（Terraform）中的 `content_security_policy` 值。
 
-`runtime-config.json` 使用 `Cache-Control: no-cache` 提供服务，以便浏览器在重新部署后始终获取最新配置，而不是使用陈旧的缓存副本。
+`runtime-config.json` 使用 `Cache-Control: no-cache` 提供服务，以便浏览器在重新部署后始终获取最新配置，而不是使用过时的缓存副本。
 
 ### WAF
 
@@ -290,7 +290,7 @@ export class ApplicationStack extends Stack {
 ```
 
 :::caution[禁用 WAF 时抑制 CKV_AWS_68]
-禁用 WAF 意味着合成的 CloudFront 分配没有关联的 Web ACL，这会导致 `checkov` 安全扫描失败，出现 `CKV_AWS_68: "CloudFront Distribution should have WAF enabled"`，除非如上所示进行抑制。
+禁用 WAF 意味着合成的 CloudFront 分配没有关联的 Web ACL，这会导致 `checkov` 安全扫描失败，错误为 `CKV_AWS_68: "CloudFront Distribution should have WAF enabled"`，除非如上所示进行抑制。
 :::
 </Fragment>
 <Fragment slot="terraform">
@@ -311,7 +311,7 @@ module "my_website" {
 
 ### 存储桶加密
 
-默认情况下，网站存储桶、CloudFront 分配日志存储桶以及接收其服务器访问日志的 CloudWatch Logs 组都使用客户管理的 [AWS KMS](https://aws.amazon.com/kms/) 密钥进行加密。此密钥会自动为您创建，并启用密钥轮换。
+网站存储桶、CloudFront 分配日志存储桶以及接收其服务器访问日志的 CloudWatch Logs 组默认使用客户管理的 [AWS KMS](https://aws.amazon.com/kms/) 密钥进行加密。此密钥会自动为您创建，并启用密钥轮换。
 
 <Infrastructure>
 <Fragment slot="cdk">
@@ -334,6 +334,22 @@ export class ApplicationStack extends Stack {
 }
 ```
 
+:::caution[使用 S3_MANAGED 时抑制 CKV_AWS_158]
+选择 `BucketEncryption.S3_MANAGED` 意味着访问日志组不再使用 KMS 加密，这会导致 `checkov` 安全扫描失败，错误为 `CKV_AWS_158`。抑制它：
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { LogGroup } from 'aws-cdk-lib/aws-logs';
+import { suppressRules } from '@my-scope/common-constructs';
+
+suppressRules(
+  website,
+  ['CKV_AWS_158'],
+  'Access log group is not KMS encrypted when encryption is S3_MANAGED',
+  (c) => c instanceof LogGroup,
+);
+```
+:::
+
 要使用您自己的 KMS 密钥而不是自动创建的密钥，请传递 `encryptionKey`：
 
 ```ts {2}
@@ -342,10 +358,36 @@ new MyWebsite(this, 'MyWebsite', {
 });
 ```
 
-`enableKeyRotation`（默认为 `true`）仅适用于自动创建的密钥，即当 `encryption` 为 `BucketEncryption.KMS`（默认值）且未提供 `encryptionKey` 时。
+:::caution[导入的密钥需要自己的权限]
+通过 `Key.fromKeyArn` 导入的密钥必须在其自己的密钥策略中已经授予 CloudWatch Logs、S3 和 CloudFront 服务主体所需的权限。`addToResourcePolicy` 在导入的密钥上是无操作的，因此此构造无法为您授予它们，并且 `cdk synth` 不会警告您 - 失败仅在部署时显示。在同一应用程序中创建的密钥（`new Key(this, 'WebsiteKey')`）没有此问题，因为 CDK 可以直接更新其策略。
+:::
+
+`enableKeyRotation`（默认为 `true`）仅适用于自动创建的密钥，即当 `encryption` 为 `BucketEncryption.KMS`（默认值）且未提供 `encryptionKey` 时：
+
+```ts {2}
+new MyWebsite(this, 'MyWebsite', {
+  enableKeyRotation: false,
+});
+```
+
+:::caution[禁用密钥轮换时抑制 CKV_AWS_7]
+在自动创建的密钥上禁用密钥轮换会导致 `checkov` 安全扫描失败，错误为 `CKV_AWS_7`。抑制它：
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { Key } from 'aws-cdk-lib/aws-kms';
+import { suppressRules } from '@my-scope/common-constructs';
+
+suppressRules(
+  website,
+  ['CKV_AWS_7'],
+  'Key rotation is managed externally',
+  (c) => c instanceof Key,
+);
+```
+:::
 </Fragment>
 <Fragment slot="terraform">
-如果您想使用不同的加密配置，请设置 `encryption`、`kms_key_arn` 和 `enable_key_rotation` 变量：
+如果您想使用不同的加密配置，请设置 `encryption`、`kms_key_arn`、`create_kms_key` 和 `enable_key_rotation` 变量：
 
 ```hcl title="packages/infra/src/main.tf" {7}
 module "my_website" {
@@ -358,15 +400,58 @@ module "my_website" {
 }
 ```
 
-要使用您自己的 KMS 密钥而不是自动创建的密钥，请传递 `kms_key_arn`。客户提供的密钥必须在其自己的密钥策略中已经授予 CloudWatch Logs、S3 和 CloudFront 服务主体所需的权限。
+:::caution[Checkov: S3_MANAGED]
+选择 `S3_MANAGED` 会导致 `checkov` 安全扫描在网站和分配日志存储桶上失败，错误为 `CKV_AWS_145`。提供的 `test` 目标不接受 `--config-file`，但 `checkov` 会自动发现其工作目录中的 `.checkov.yaml`，因此在 `packages/infra/src` 中放置一个：
 
-`enable_key_rotation`（默认为 `true`）仅适用于自动创建的密钥，即当 `encryption` 为 `"KMS"`（默认值）且未提供 `kms_key_arn` 时。
+```yaml title="packages/infra/src/.checkov.yaml"
+skip-check:
+  - CKV_AWS_145
+```
+:::
+
+要使用您自己的 KMS 密钥而不是自动创建的密钥，请传递 `kms_key_arn` 并将 `create_kms_key` 设置为 `false`：
+
+```hcl title="packages/infra/src/main.tf" {7-8}
+module "my_website" {
+  source = "../../common/terraform/src/app/static-websites/my-website"
+
+  providers = {
+    aws.us_east_1 = aws.us_east_1
+  }
+  kms_key_arn    = aws_kms_key.website.arn
+  create_kms_key = false
+}
+```
+
+客户提供的密钥必须在其自己的密钥策略中已经授予 CloudWatch Logs、S3 和 CloudFront 服务主体所需的权限。
+
+`enable_key_rotation`（默认为 `true`）仅适用于自动创建的密钥，即当 `encryption` 为 `"KMS"`（默认值）且 `create_kms_key` 为 `true` 时：
+
+```hcl title="packages/infra/src/main.tf" {7}
+module "my_website" {
+  source = "../../common/terraform/src/app/static-websites/my-website"
+
+  providers = {
+    aws.us_east_1 = aws.us_east_1
+  }
+  enable_key_rotation = false
+}
+```
+
+:::caution[Checkov: 禁用密钥轮换]
+在自动创建的密钥上禁用密钥轮换会导致 `checkov` 安全扫描失败，错误为 `CKV_AWS_7`。将其添加到同一个 `.checkov.yaml`：
+
+```yaml title="packages/infra/src/.checkov.yaml"
+skip-check:
+  - CKV_AWS_7
+```
+:::
 </Fragment>
 </Infrastructure>
 
 ### 自定义域名和 TLS
 
-默认情况下，分配使用默认的 CloudFront 域名（`*.cloudfront.net`）及其默认证书，该证书不支持强制执行最低 TLS 版本 1.2。要从您自己的域名提供网站服务，请提供 [ACM 证书](https://docs.aws.amazon.com/acm/latest/userguide/acm-overview.html)（必须位于 `us-east-1` 才能与 CloudFront 一起使用）和您的域名。然后将为查看者强制执行最低 TLS 版本 1.2：
+默认情况下，分配使用默认的 CloudFront 域名（`*.cloudfront.net`）及其默认证书，不支持强制执行最低 TLS 版本 1.2。要从您自己的域名提供网站服务，请提供 [ACM 证书](https://docs.aws.amazon.com/acm/latest/userguide/acm-overview.html)（必须位于 `us-east-1` 才能与 CloudFront 一起使用）和您的域名。然后为查看者强制执行最低 TLS 版本 1.2：
 
 <Infrastructure>
 <Fragment slot="cdk">
@@ -408,11 +493,11 @@ module "my_website" {
 </Fragment>
 </Infrastructure>
 
-您还需要创建 DNS 记录（例如在 Route 53 中），将您的域名指向 CloudFront 分配。
+您还需要创建 DNS 记录（例如在 Route 53 中）将您的域名指向 CloudFront 分配。
 
 ## 运行时配置
 
-来自基础设施的配置通过 <Link href="guides/runtime-config">运行时配置</Link> 提供给您的网站。这允许您的网站访问诸如 API URL 之类的详细信息，这些信息在应用程序部署之前是未知的。
+来自基础设施的配置通过<Link href="guides/runtime-config">运行时配置</Link>提供给您的网站。这允许您的网站访问诸如 API URL 之类的详细信息，这些信息在应用程序部署之前是未知的。
 
 ### 基础设施
 
@@ -443,11 +528,11 @@ export class ApplicationStack extends Stack {
 ```
 
 :::note[CDK 网站构造]
-使用 CDK 时，网站构造可以在堆栈中的任何位置声明。运行时配置在合成时延迟解析，因此无论声明顺序如何，都将包含所有值。
+使用 CDK，网站构造可以在堆栈中的任何位置声明。运行时配置在合成时延迟解析，因此无论声明顺序如何，所有值都将包含在内。
 :::
 </Fragment>
 <Fragment slot="terraform">
-使用 Terraform 时，运行时配置通过 runtime-config 模块管理。由 `@aws/nx-plugin` 生成器生成的 Terraform 模块（如 <Link path="guides/trpc">`ts#api`</Link> 和 <Link path="guides/fastapi">`py#api`</Link>）将自动向运行时配置添加适当的值。
+使用 Terraform，运行时配置通过 runtime-config 模块管理。由 `@aws/nx-plugin` 生成器生成的 Terraform 模块（如 <Link path="guides/trpc">`ts#api`</Link> 和 <Link path="guides/fastapi">`py#api`</Link>）将自动向运行时配置添加适当的值。
 
 您的网站 Terraform 模块将把运行时配置的 `connection` 命名空间作为 `runtime-config.json` 文件部署到 S3 存储桶的根目录。
 
@@ -477,7 +562,7 @@ module "my_website" {
 ```
 
 :::caution[模块顺序]
-您必须确保在添加到运行时配置的任何模块_之后_声明您的网站模块，并配置适当的 `depends_on` 以确保顺序，否则它们将在您的 `runtime-config.json` 文件中丢失。
+您必须确保在添加到运行时配置的任何模块_之后_声明您的网站模块，并配置适当的 `depends_on` 以确保顺序，否则它们将在您的 `runtime-config.json` 文件中缺失。
 :::
 </Fragment>
 </Infrastructure>
@@ -498,12 +583,12 @@ const MyComponent = () => {
 ```
 
 :::note[运行时配置]
-有关运行时配置如何存储在 AWS AppConfig 中以及服务器端消费者（Lambda 函数、代理）如何检索它的详细信息，请参阅 <Link path="guides/runtime-config">运行时配置</Link> 指南。
+有关运行时配置如何存储在 AWS AppConfig 中以及服务器端消费者（Lambda 函数、代理）如何检索它的详细信息，请参阅<Link path="guides/runtime-config">运行时配置</Link>指南。
 :::
 
 ### 本地运行时配置
 
-运行 [本地开发服务器](#local-development-server) 时，您需要在 `public` 目录中有一个 `runtime-config.json` 文件，以便本地网站知道后端 URL、身份配置等。
+运行[本地开发服务器](#local-development-server)时，您需要在 `public` 目录中有一个 `runtime-config.json` 文件，以便本地网站知道后端 URL、身份配置等。
 
 您的网站项目配置了一个 `load-runtime-config` 目标，您可以使用它从已部署的应用程序中拉取 `runtime-config.json` 文件：
 
@@ -524,44 +609,44 @@ const MyComponent = () => {
 
 ## 本地开发服务器
 
-本地开发的规范命令是 `dev`，它使用一个命令启动您的网站（以及您已连接到它的 API 的任何本地服务器）：
+本地开发的规范命令是 `dev`，它使用一个命令启动您的网站（以及您连接到它的任何 API 的本地服务器）：
 
 <NxCommands commands={['dev <my-website>']} />
 
-当您需要控制应用程序在本地运行的程度与指向已部署的 AWS 基础设施时，`serve` 目标也可用。有关跨连接项目的本地开发的更广泛概述，包括 `dev` 对具有多个组件的项目的行为方式，请参阅 <Link path="guides/local-development">本地开发</Link> 指南。
+当您需要控制应用程序的多少部分在本地运行与指向已部署的 AWS 基础设施时，`serve` 目标也可用。有关跨连接项目的本地开发的更广泛概述，包括 `dev` 如何为具有多个组件的项目运行，请参阅<Link path="guides/local-development">本地开发</Link>指南。
 
 ### Serve 目标
 
-`serve` 目标为您的网站启动本地开发服务器。此目标要求您已部署网站与之交互的任何支持基础设施，并已 [加载本地运行时配置](#local-runtime-config)。
+`serve` 目标为您的网站启动本地开发服务器。此目标要求您已部署网站交互的任何支持基础设施，并已[加载本地运行时配置](#local-runtime-config)。
 
 您可以使用以下命令运行此目标：
 
 <NxCommands commands={['serve <my-website>']} />
 
-此目标对于在指向"真实"已部署的 API 和其他基础设施时处理网站更改非常有用。
+此目标对于在指向"真实"已部署的 API 和其他基础设施时处理网站更改很有用。
 
 ### Dev 目标
 
-`dev` 目标为您的网站启动本地开发服务器（将 [Vite `MODE`](https://vite.dev/guide/env-and-mode) 设置为 `local-dev`），并启动您通过 <Link path="/guides/connection">连接生成器</Link> 连接到网站的 API 的任何本地服务器。
+`dev` 目标为您的网站启动本地开发服务器（[Vite `MODE`](https://vite.dev/guide/env-and-mode) 设置为 `local-dev`），并为您通过<Link path="/guides/connection">连接生成器</Link>连接到网站的任何 API 启动本地服务器。
 
-当通过此目标运行本地网站服务器时，`runtime-config.json` 会自动覆盖以指向您本地运行的 API URL。
+当您的本地网站服务器通过此目标运行时，`runtime-config.json` 会自动覆盖以指向您本地运行的 API URL。
 
 您可以使用以下命令运行此目标：
 
 <NxCommands commands={['dev <my-website>']} />
 
-当您跨网站和 API 工作并希望快速迭代而无需部署基础设施时，此目标非常有用。
+当您跨网站和 API 工作并希望快速迭代而无需部署基础设施时，此目标很有用。
 
 :::note[工作区 `dev` 脚本]
-您的工作区的根 `package.json` 包含一个 `dev` 脚本，该脚本为每个具有 `dev` 目标的项目运行 `dev` 目标：
+您的工作区的根 `package.json` 包含一个 `dev` 脚本，该脚本为每个具有 `dev` 目标的项目运行该目标：
 
 <PackageManagerShortCommand commands={["dev"]} />
 
-这将使用一个命令启动网站（以及任何其他具有 `dev` 目标的项目）的本地开发服务器。要仅运行此网站，请使用其自己的 `dev` 目标（例如 `nx dev <my-website>`）。
+这将在一个命令中启动您的网站（以及任何其他具有 `dev` 目标的项目）的本地开发服务器。要仅运行此网站，请使用其自己的 `dev` 目标（例如 `nx dev <my-website>`）。
 :::
 
 :::warning[模拟身份验证]
-在此模式下运行且不存在 `runtime-config.json` 时，如果您已配置 Cognito 身份验证（通过 <Link path="/guides/react-website-auth">`ts#website#auth` 生成器</Link>），将跳过登录，对本地服务器的请求将不包含身份验证标头。
+在此模式下运行且不存在 `runtime-config.json` 时，如果您已配置 Cognito 身份验证（通过 <Link path="/guides/react-website-auth">`ts#website#auth` 生成器</Link>），将跳过登录，并且对本地服务器的请求将不包含身份验证标头。
 
 要为 `dev` 启用登录和身份验证，请部署您的基础设施并加载运行时配置。
 :::
@@ -576,7 +661,7 @@ const MyComponent = () => {
 
 ## 构建
 
-您可以使用 `build` 目标构建您的网站。这将运行 `bundle`、`compile`、`test` 和 `lint` 目标，对您的网站进行类型检查、打包、测试和 lint。
+您可以使用 `build` 目标构建您的网站。这会运行 `bundle`、`compile`、`test` 和 `lint` 目标，对您的网站进行类型检查、打包、测试和 lint。
 
 <NxCommands commands={['build <my-website>']} />
 
@@ -586,9 +671,9 @@ const MyComponent = () => {
 
 ## 测试
 
-测试您的网站与在标准 TypeScript 项目中编写测试非常相似，因此请参阅 <Link path="guides/typescript-project#testing">TypeScript 项目指南</Link> 了解更多详细信息。
+测试您的网站与在标准 TypeScript 项目中编写测试非常相似，因此请参阅 <Link path="guides/typescript-project#testing">TypeScript 项目指南</Link>了解更多详细信息。
 
-对于 React 特定的测试，React Testing Library 已经安装并可供您用于编写测试。有关其使用的更多详细信息，请参阅 [React Testing Library 文档](https://testing-library.com/docs/react-testing-library/example-intro)。
+对于 React 特定的测试，React Testing Library 已经安装并可供您使用来编写测试。有关其用法的更多详细信息，请参阅 [React Testing Library 文档](https://testing-library.com/docs/react-testing-library/example-intro)。
 
 您可以使用 `test` 目标运行测试：
 
@@ -600,54 +685,55 @@ const MyComponent = () => {
 
 <CardGrid>
   <ConnectionCard
-    title="React to tRPC"
-    description="Call a tRPC API from a React website"
+    title="React 到 tRPC"
+    description="从 React 网站调用 tRPC API"
     href={`/nx-plugin-for-aws/${Astro.currentLocale || 'zh'}/guides/connection/react-trpc`}
     source="react"
     target="trpc"
   />
   <ConnectionCard
-    title="React to FastAPI"
-    description="Call a Python FastAPI from a React website"
+    title="React 到 FastAPI"
+    description="从 React 网站调用 Python FastAPI"
     href={`/nx-plugin-for-aws/${Astro.currentLocale || 'zh'}/guides/connection/react-fastapi`}
     source="react"
     target="fastapi"
   />
   <ConnectionCard
-    title="React to Smithy API"
-    description="Call a Smithy API from a React website"
+    title="React 到 Smithy API"
+    description="从 React 网站调用 Smithy API"
     href={`/nx-plugin-for-aws/${Astro.currentLocale || 'zh'}/guides/connection/react-smithy`}
     source="react"
     target="smithy"
   />
   <ConnectionCard
-    title="React to Python Agent"
-    description="Call a Python Agent from a React website"
+    title="React 到 Python Agent"
+    description="从 React 网站调用 Python Agent"
     href={`/nx-plugin-for-aws/${Astro.currentLocale || 'zh'}/guides/connection/react-py-agent`}
     source="react"
     target="strands"
     targetBadge="python"
   />
   <ConnectionCard
-    title="React to TypeScript Agent"
-    description="Call a TypeScript Agent from a React website"
+    title="React 到 TypeScript Agent"
+    description="从 React 网站调用 TypeScript Agent"
     href={`/nx-plugin-for-aws/${Astro.currentLocale || 'zh'}/guides/connection/react-ts-agent`}
     source="react"
     target="strands"
     targetBadge="typescript"
   />
   <ConnectionCard
-    title="React to AG-UI Agent"
-    description="Call an Agent exposing the AG-UI protocol from a React website via CopilotKit"
+    title="React 到 AG-UI Agent"
+    description="通过 CopilotKit 从 React 网站调用公开 AG-UI 协议的 Agent"
     href={`/nx-plugin-for-aws/${Astro.currentLocale || 'zh'}/guides/connection/react-agui`}
     source="react"
     target="copilotkit"
   />
   <ConnectionCard
-    title="React Website to AgentCore Gateway"
-    description="Connect a React website to agents through an AgentCore Gateway"
+    title="React 网站到 AgentCore Gateway"
+    description="通过 AgentCore Gateway 将 React 网站连接到代理"
     href={`/nx-plugin-for-aws/${Astro.currentLocale || 'zh'}/guides/connection/react-agentcore-gateway`}
     source="react"
     target="agentcore"
   />
 </CardGrid>
+

--- a/packages/nx-plugin/src/migrations/latest/static-website-configurable-waf-encryption/metadata.json
+++ b/packages/nx-plugin/src/migrations/latest/static-website-configurable-waf-encryption/metadata.json
@@ -1,0 +1,3 @@
+{
+  "description": "Surface enableWaf, encryption, encryptionKey and enableKeyRotation on the vended StaticWebsite construct/module"
+}

--- a/packages/nx-plugin/src/migrations/latest/static-website-configurable-waf-encryption/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/latest/static-website-configurable-waf-encryption/migration.spec.ts
@@ -1,0 +1,920 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import type { Tree } from '@nx/devkit';
+import { joinPathFragments } from '@nx/devkit';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test';
+import migration from './migration';
+
+const CDK_FILE = 'packages/common/constructs/src/core/static-website.ts';
+const APP_DIR = 'packages/common/constructs/src/app/static-websites';
+const TF_FILE =
+  'packages/common/terraform/src/core/static-website/static-website.tf';
+const TF_APP_DIR = 'packages/common/terraform/src/app/static-websites';
+
+const OLD_CDK_CONSTRUCT = `import {
+  CfnOutput,
+  CfnResource,
+  Duration,
+  Lazy,
+  Names,
+  RemovalPolicy,
+  Stack,
+} from 'aws-cdk-lib';
+import {
+  Distribution,
+  HeadersFrameOption,
+  HeadersReferrerPolicy,
+  ResponseHeadersPolicy,
+  SecurityPolicyProtocol,
+  ViewerProtocolPolicy,
+} from 'aws-cdk-lib/aws-cloudfront';
+import { ICertificate } from 'aws-cdk-lib/aws-certificatemanager';
+import { S3BucketOrigin } from 'aws-cdk-lib/aws-cloudfront-origins';
+import {
+  BlockPublicAccess,
+  Bucket,
+  BucketEncryption,
+  IBucket,
+  ObjectOwnership,
+} from 'aws-cdk-lib/aws-s3';
+import {
+  BucketDeployment,
+  CacheControl,
+  Source,
+} from 'aws-cdk-lib/aws-s3-deployment';
+import { Construct } from 'constructs';
+import { RuntimeConfig } from './runtime-config.js';
+import { Key } from 'aws-cdk-lib/aws-kms';
+import {
+  CfnDelivery,
+  CfnDeliveryDestination,
+  CfnDeliverySource,
+  LogGroup,
+  RetentionDays,
+} from 'aws-cdk-lib/aws-logs';
+import { Effect, PolicyStatement, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
+import { CfnWebACL } from 'aws-cdk-lib/aws-wafv2';
+import { suppressRules } from './checkov.js';
+
+const DEFAULT_RUNTIME_CONFIG_FILENAME = 'runtime-config.json';
+
+const CONTENT_SECURITY_POLICY = [
+  "default-src 'self'",
+  "script-src 'self'",
+].join('; ');
+
+export interface StaticWebsiteProps {
+  readonly websiteName: string;
+  readonly websiteFilePath: string;
+  /**
+   * Custom domain names for the CloudFront distribution. Requires \`certificate\`.
+   */
+  readonly domainNames?: string[];
+  /**
+   * ACM certificate for the custom domain names. Must be in us-east-1.
+   * When provided, viewers are required to use TLS 1.2 or later.
+   */
+  readonly certificate?: ICertificate;
+}
+
+export class StaticWebsite extends Construct {
+  public readonly websiteBucket: IBucket;
+  public readonly cloudFrontDistribution: Distribution;
+  public readonly bucketDeployment: BucketDeployment;
+
+  constructor(
+    scope: Construct,
+    id: string,
+    { websiteFilePath, websiteName, domainNames, certificate }: StaticWebsiteProps
+  ) {
+    super(scope, id);
+
+    const websiteKey = new Key(this, 'WebsiteKey', {
+      enableKeyRotation: true,
+    });
+
+    // Allow CloudWatch Logs to use the website key for server access log delivery.
+    const stack = Stack.of(this);
+    websiteKey.addToResourcePolicy(
+      new PolicyStatement({
+        effect: Effect.ALLOW,
+        principals: [
+          new ServicePrincipal(\`logs.\${stack.region}.amazonaws.com\`),
+        ],
+        actions: [
+          'kms:Encrypt',
+          'kms:Decrypt',
+          'kms:ReEncrypt*',
+          'kms:GenerateDataKey*',
+          'kms:DescribeKey',
+        ],
+        resources: ['*'],
+        conditions: {
+          ArnLike: {
+            'kms:EncryptionContext:aws:logs:arn': \`arn:aws:logs:\${stack.region}:\${stack.account}:log-group:*\`,
+          },
+        },
+      }),
+    );
+
+    const accessLogs = new LogGroup(this, 'AccessLogs', {
+      retention: RetentionDays.ONE_YEAR,
+      encryptionKey: websiteKey,
+      removalPolicy: RemovalPolicy.DESTROY,
+    });
+
+    // S3 Bucket to hold website files
+    this.websiteBucket = new Bucket(this, 'WebsiteBucket', {
+      versioned: true,
+      enforceSSL: true,
+      autoDeleteObjects: true,
+      removalPolicy: RemovalPolicy.DESTROY,
+      encryption: BucketEncryption.KMS,
+      encryptionKey: websiteKey,
+      objectOwnership: ObjectOwnership.BUCKET_OWNER_ENFORCED,
+      publicReadAccess: false,
+      blockPublicAccess: BlockPublicAccess.BLOCK_ALL,
+    });
+    suppressRules(
+      this.websiteBucket,
+      ['CKV_AWS_18'],
+      'Server access logs are delivered to CloudWatch Logs',
+    );
+    this.deliverAccessLogsToCloudWatch(
+      'Website',
+      this.websiteBucket,
+      accessLogs,
+    );
+    // Web ACL
+    const wafStack = new CloudfrontWebAcl(this, 'waf');
+
+    // Bucket holding CloudFront standard access logs. CloudFront delivers its
+    // own logs to S3 only, so this bucket is retained; its S3 server access
+    // logs are delivered to CloudWatch Logs.
+    const logBucket = new Bucket(this, 'DistributionLogBucket', {
+      enforceSSL: true,
+      autoDeleteObjects: true,
+      removalPolicy: RemovalPolicy.DESTROY,
+      encryption: BucketEncryption.KMS,
+      encryptionKey: websiteKey,
+      objectOwnership: ObjectOwnership.BUCKET_OWNER_PREFERRED,
+      publicReadAccess: false,
+      blockPublicAccess: BlockPublicAccess.BLOCK_ALL,
+    });
+    suppressRules(
+      logBucket,
+      ['CKV_AWS_21'],
+      'Distribution log bucket does not need versioning enabled',
+    );
+    suppressRules(
+      logBucket,
+      ['CKV_AWS_18'],
+      'Server access logs are delivered to CloudWatch Logs',
+    );
+    this.deliverAccessLogsToCloudWatch('Distribution', logBucket, accessLogs);
+
+    const defaultRootObject = 'index.html';
+    this.cloudFrontDistribution = new Distribution(
+      this,
+      'CloudfrontDistribution',
+      {
+        webAclId: wafStack.wafArn,
+        enableLogging: true,
+        logBucket: logBucket,
+        ...(certificate
+          ? {
+              certificate,
+              domainNames,
+              minimumProtocolVersion: SecurityPolicyProtocol.TLS_V1_2_2021,
+            }
+          : {}),
+        defaultBehavior: {
+          origin: S3BucketOrigin.withOriginAccessControl(this.websiteBucket),
+          viewerProtocolPolicy: ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+          responseHeadersPolicy: undefined as unknown as ResponseHeadersPolicy,
+        },
+        defaultRootObject,
+      },
+    );
+    if (!certificate) {
+      suppressRules(
+        this.cloudFrontDistribution,
+        ['CKV_AWS_174'],
+        'Cloudfront default certificate does not use TLS 1.2',
+      );
+    }
+
+    this.bucketDeployment = new BucketDeployment(this, 'WebsiteDeployment', {
+      sources: [Source.asset(websiteFilePath)],
+      destinationBucket: this.websiteBucket,
+      distribution: this.cloudFrontDistribution,
+      exclude: [DEFAULT_RUNTIME_CONFIG_FILENAME],
+      memoryLimit: 1024,
+    });
+
+    new CfnOutput(this, 'DistributionDomainName', {
+      value: this.cloudFrontDistribution.domainName,
+    });
+    new CfnOutput(this, \`\${websiteName}WebsiteBucketName\`, {
+      value: this.websiteBucket.bucketName,
+    });
+  }
+
+  private deliverAccessLogsToCloudWatch(
+    id: string,
+    bucket: IBucket,
+    logGroup: LogGroup,
+  ) {
+    const source: CfnDeliverySource = new CfnDeliverySource(
+      this,
+      \`\${id}AccessLogsSource\`,
+      {
+        name: Lazy.string({
+          produce: () => Names.uniqueResourceName(source, { maxLength: 60 }),
+        }),
+        logType: 'S3_SERVER_ACCESS_LOGS',
+        resourceArn: bucket.bucketArn,
+      },
+    );
+    const bucketPolicy = (bucket as Bucket).policy;
+    if (bucketPolicy) {
+      source.node.addDependency(bucketPolicy);
+    }
+    const destination: CfnDeliveryDestination = new CfnDeliveryDestination(
+      this,
+      \`\${id}AccessLogsDestination\`,
+      {
+        name: Lazy.string({
+          produce: () => Names.uniqueResourceName(destination, { maxLength: 60 }),
+        }),
+        destinationResourceArn: logGroup.logGroupArn,
+      },
+    );
+    const delivery = new CfnDelivery(this, \`\${id}AccessLogsDelivery\`, {
+      deliverySourceName: source.name,
+      deliveryDestinationArn: destination.attrArn,
+    });
+    delivery.addDependency(source);
+  }
+}
+
+export class CloudfrontWebAcl extends Stack {
+  public readonly wafArn;
+  constructor(scope: Construct, id: string) {
+    super(scope, id, {
+      env: {
+        region: 'us-east-1',
+        account: Stack.of(scope).account,
+      },
+      crossRegionReferences: true,
+    });
+
+    this.wafArn = new CfnWebACL(this, 'WebAcl', {
+      defaultAction: { allow: {} },
+      scope: 'CLOUDFRONT',
+      visibilityConfig: {
+        cloudWatchMetricsEnabled: true,
+        metricName: id,
+        sampledRequestsEnabled: true,
+      },
+      rules: [],
+    }).attrArn;
+  }
+}
+`;
+
+const oldAppConstruct = (name: string) => `import * as url from 'url';
+import { Construct } from 'constructs';
+import { StaticWebsite } from '../../core/index.js';
+
+export class ${name} extends StaticWebsite {
+  constructor(scope: Construct, id: string) {
+    super(scope, id, {
+      websiteName: '${name}',
+      websiteFilePath: url.fileURLToPath(
+        new URL('../../../../../../apps/${name.toLowerCase()}/bundle', import.meta.url)
+      ),
+    });
+  }
+}
+`;
+
+// The pre-existing documented customization point (before this migration
+// added props pass-through): hand-editing the super() call to add
+// domainNames/certificate directly in the generated construct.
+const oldAppConstructWithCustomDomain = (
+  name: string,
+) => `import * as url from 'url';
+import { Construct } from 'constructs';
+import { Certificate } from 'aws-cdk-lib/aws-certificatemanager';
+import { StaticWebsite } from '../../core/index.js';
+
+export class ${name} extends StaticWebsite {
+  constructor(scope: Construct, id: string) {
+    super(scope, id, {
+      websiteName: '${name}',
+      websiteFilePath: url.fileURLToPath(
+        new URL('../../../../../../apps/${name.toLowerCase()}/bundle', import.meta.url)
+      ),
+      domainNames: ['www.example.com'],
+      certificate: Certificate.fromCertificateArn(this, 'Cert',
+        'arn:aws:acm:us-east-1:123456789012:certificate/...'),
+    });
+  }
+}
+`;
+
+const OLD_TERRAFORM_MODULE = `terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+      configuration_aliases = [aws.us_east_1]
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+  }
+}
+
+# Variables
+variable "website_name" {
+  description = "Name of the website"
+  type        = string
+}
+
+variable "website_file_path" {
+  description = "Path to the website files"
+  type        = string
+}
+
+variable "custom_domain_names" {
+  description = "Custom domain names (aliases) for the CloudFront distribution. Requires acm_certificate_arn."
+  type        = list(string)
+  default     = []
+}
+
+variable "acm_certificate_arn" {
+  description = "ARN of an ACM certificate (in us-east-1) for the custom domain names. When set, viewers are required to use TLS 1.2 or later."
+  type        = string
+  default     = null
+}
+
+locals {
+  content_security_policy = "default-src 'self'"
+
+  # Delivery source/destination names have a 60 character maximum. Truncate the
+  # website name so the longest delivery name stays within the limit.
+  access_logs_name_prefix = substr(lower(var.website_name), 0, 16)
+}
+
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
+
+resource "aws_kms_key" "website_key" {
+  description             = "KMS key for \${var.website_name} website encryption"
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "Enable IAM User Permissions"
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:aws:iam::\${data.aws_caller_identity.current.account_id}:root"
+        }
+        Action   = "kms:*"
+        Resource = "*"
+      }
+    ]
+  })
+
+  tags = {
+    Name = "\${lower(var.website_name)}-website-key-\${random_id.unique_suffix.hex}"
+  }
+}
+
+resource "aws_kms_alias" "website_key_alias" {
+  name          = "alias/\${lower(var.website_name)}-website-key-\${random_id.unique_suffix.hex}"
+  target_key_id = aws_kms_key.website_key.key_id
+}
+
+resource "aws_cloudwatch_log_group" "access_logs" {
+  name              = "/aws/s3/\${lower(var.website_name)}-access-logs-\${random_id.bucket_suffix.hex}"
+  retention_in_days = 365
+  kms_key_id        = aws_kms_key.website_key.arn
+}
+
+resource "random_id" "unique_suffix" {
+  byte_length = 4
+}
+
+resource "random_id" "bucket_suffix" {
+  byte_length = 8
+}
+
+resource "aws_s3_bucket" "website" {
+  bucket        = "\${lower(var.website_name)}-website-\${random_id.bucket_suffix.hex}"
+  force_destroy = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "website_encryption" {
+  bucket = aws_s3_bucket.website.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      kms_master_key_id = aws_kms_key.website_key.arn
+      sse_algorithm     = "aws:kms"
+    }
+  }
+}
+
+resource "aws_s3_bucket" "distribution_logs" {
+  bucket        = "\${lower(var.website_name)}-distribution-logs-\${random_id.bucket_suffix.hex}"
+  force_destroy = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "distribution_logs_encryption" {
+  bucket = aws_s3_bucket.distribution_logs.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      kms_master_key_id = aws_kms_key.website_key.arn
+      sse_algorithm     = "aws:kms"
+    }
+  }
+}
+
+resource "aws_wafv2_web_acl" "cloudfront_waf" {
+  provider = aws.us_east_1
+  name     = "\${lower(var.website_name)}-cloudfront-waf-\${random_id.unique_suffix.hex}"
+  scope    = "CLOUDFRONT"
+
+  default_action {
+    allow {}
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = true
+    metric_name                 = "\${lower(var.website_name)}-waf"
+    sampled_requests_enabled    = true
+  }
+}
+
+resource "aws_cloudfront_distribution" "website" {
+  origin {
+    domain_name              = aws_s3_bucket.website.bucket_regional_domain_name
+    origin_id                = "S3-\${aws_s3_bucket.website.bucket}"
+  }
+
+  enabled             = true
+  default_root_object = "index.html"
+  web_acl_id          = aws_wafv2_web_acl.cloudfront_waf.arn
+  aliases             = var.custom_domain_names
+
+  lifecycle {
+    replace_triggered_by = [
+      aws_wafv2_web_acl.cloudfront_waf
+    ]
+  }
+}
+
+output "cloudfront_domain_name" {
+  description = "Domain name of the CloudFront distribution"
+  value       = aws_cloudfront_distribution.website.domain_name
+}
+
+output "waf_web_acl_arn" {
+  description = "ARN of the WAF Web ACL"
+  value       = aws_wafv2_web_acl.cloudfront_waf.arn
+}
+`;
+
+const oldTerraformAppModule = (name: string) => `terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+      configuration_aliases = [aws.us_east_1]
+    }
+  }
+}
+
+# Static website module configured for the web package
+module "static_website" {
+  source = "../../../core/static-website"
+
+  website_name      = "${name}"
+  website_file_path = "\${path.module}/../../../../../../../apps/${name}/bundle"
+
+  providers = {
+    aws.us_east_1 = aws.us_east_1
+  }
+}
+
+# Outputs
+output "website_url" {
+  description = "URL of the deployed website"
+  value       = "https://\${module.static_website.cloudfront_domain_name}"
+}
+
+output "website_bucket_name" {
+  description = "Name of the S3 bucket hosting the website"
+  value       = module.static_website.website_bucket_name
+}
+
+output "cloudfront_distribution_id" {
+  description = "ID of the CloudFront distribution"
+  value       = module.static_website.cloudfront_distribution_id
+}
+
+output "cloudfront_domain_name" {
+  description = "Domain name of the CloudFront distribution"
+  value       = module.static_website.cloudfront_domain_name
+}
+`;
+
+// custom_domain_names/acm_certificate_arn predate this migration as a
+// documented customization point (hand-editing the module block directly).
+const oldTerraformAppModuleWithCustomDomain = (name: string) => `terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+      configuration_aliases = [aws.us_east_1]
+    }
+  }
+}
+
+# Static website module configured for the web package
+module "static_website" {
+  source = "../../../core/static-website"
+
+  website_name      = "${name}"
+  website_file_path = "\${path.module}/../../../../../../../apps/${name}/bundle"
+  custom_domain_names = ["www.example.com"]
+  acm_certificate_arn = "arn:aws:acm:us-east-1:123456789012:certificate/..."
+
+  providers = {
+    aws.us_east_1 = aws.us_east_1
+  }
+}
+`;
+
+describe('static-website-configurable-waf-encryption migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeUsingTsSolutionSetup();
+  });
+
+  describe('CDK construct', () => {
+    it('does nothing when the file does not exist', async () => {
+      const result = await migration(tree);
+      expect(result.nextSteps).toEqual([]);
+    });
+
+    it('surfaces enableWaf/encryption/encryptionKey/enableKeyRotation on the vended shape', async () => {
+      tree.write(CDK_FILE, OLD_CDK_CONSTRUCT);
+
+      const result = await migration(tree);
+
+      const migrated = tree.read(CDK_FILE, 'utf-8')!;
+      expect(migrated).toMatch(
+        /import \{ (IKey, Key|Key, IKey) \} from 'aws-cdk-lib\/aws-kms'/,
+      );
+      expect(migrated).not.toContain(
+        "import { Key } from 'aws-cdk-lib/aws-kms'",
+      );
+      expect(migrated).toContain('readonly enableWaf?: boolean');
+      expect(migrated).toContain('readonly encryption?: BucketEncryption');
+      expect(migrated).toContain('readonly encryptionKey?: IKey');
+      expect(migrated).toContain('readonly enableKeyRotation?: boolean');
+      expect(migrated).toContain('enableWaf = true');
+      expect(migrated).toContain('encryption = BucketEncryption.KMS');
+      expect(migrated).toContain('enableKeyRotation = true');
+      expect(migrated).toContain('encryption === BucketEncryption.KMS');
+      expect(migrated).toContain(
+        "encryptionKey ?? new Key(this, 'WebsiteKey', { enableKeyRotation })",
+      );
+      expect(migrated).toContain('websiteKey?.addToResourcePolicy(');
+      expect(migrated).not.toContain('websiteKey.addToResourcePolicy(');
+      expect(migrated).not.toContain('encryption: BucketEncryption.KMS');
+      expect(migrated).toContain(
+        "const wafStack = enableWaf ? new CloudfrontWebAcl(this, 'waf') : undefined",
+      );
+      expect(migrated).toContain('webAclId: wafStack?.wafArn');
+      expect(result.nextSteps).toEqual([]);
+    });
+
+    it('is idempotent', async () => {
+      tree.write(CDK_FILE, OLD_CDK_CONSTRUCT);
+      await migration(tree);
+      const migratedOnce = tree.read(CDK_FILE, 'utf-8');
+
+      const result = await migration(tree);
+
+      expect(tree.read(CDK_FILE, 'utf-8')).toEqual(migratedOnce);
+      expect(result.nextSteps).toEqual([]);
+    });
+
+    it('skips and reports a diverged construct', async () => {
+      tree.write(
+        CDK_FILE,
+        OLD_CDK_CONSTRUCT.replace(
+          "const wafStack = new CloudfrontWebAcl(this, 'waf');",
+          "const wafStack = new CloudfrontWebAcl(this, 'my-custom-waf');",
+        ),
+      );
+
+      const result = await migration(tree);
+
+      expect(tree.read(CDK_FILE, 'utf-8')).toContain(
+        "new CloudfrontWebAcl(this, 'my-custom-waf')",
+      );
+      expect(result.nextSteps.some((step) => step.includes(CDK_FILE))).toBe(
+        true,
+      );
+    });
+  });
+
+  describe('CDK app constructs', () => {
+    it('adds an optional props parameter to each vended website construct', async () => {
+      tree.write(CDK_FILE, OLD_CDK_CONSTRUCT);
+      tree.write(
+        joinPathFragments(APP_DIR, 'my-website.ts'),
+        oldAppConstruct('MyWebsite'),
+      );
+      tree.write(
+        joinPathFragments(APP_DIR, 'index.ts'),
+        `export * from './my-website.js';\n`,
+      );
+
+      const result = await migration(tree);
+
+      const migrated = tree.read(
+        joinPathFragments(APP_DIR, 'my-website.ts'),
+        'utf-8',
+      )!;
+      expect(migrated).toContain(
+        "import { StaticWebsite, StaticWebsiteProps } from '../../core/index.js'",
+      );
+      expect(migrated).toContain(
+        "export type MyWebsiteProps = Omit<\n  StaticWebsiteProps,\n  'websiteName' | 'websiteFilePath'\n>;",
+      );
+      expect(migrated).toContain(
+        'constructor(scope: Construct, id: string, props?: MyWebsiteProps)',
+      );
+      expect(migrated).toContain("...props,\n      websiteName: 'MyWebsite',");
+      expect(result.nextSteps).toEqual([]);
+    });
+
+    it('preserves a pre-existing domainNames/certificate customization', async () => {
+      const appFile = joinPathFragments(APP_DIR, 'my-website.ts');
+      tree.write(appFile, oldAppConstructWithCustomDomain('MyWebsite'));
+
+      const result = await migration(tree);
+
+      const migrated = tree.read(appFile, 'utf-8')!;
+      expect(migrated).toContain("domainNames: ['www.example.com']");
+      expect(migrated).toContain('Certificate.fromCertificateArn');
+      expect(migrated).toContain(
+        'constructor(scope: Construct, id: string, props?: MyWebsiteProps)',
+      );
+      expect(migrated).toContain('...props,');
+      expect(result.nextSteps).toEqual([]);
+    });
+
+    it('is idempotent', async () => {
+      tree.write(CDK_FILE, OLD_CDK_CONSTRUCT);
+      const appFile = joinPathFragments(APP_DIR, 'my-website.ts');
+      tree.write(appFile, oldAppConstruct('MyWebsite'));
+
+      await migration(tree);
+      const migratedOnce = tree.read(appFile, 'utf-8');
+
+      const result = await migration(tree);
+
+      expect(tree.read(appFile, 'utf-8')).toEqual(migratedOnce);
+      expect(result.nextSteps).toEqual([]);
+    });
+
+    it('skips and reports a diverged app construct', async () => {
+      const appFile = joinPathFragments(APP_DIR, 'my-website.ts');
+      tree.write(
+        appFile,
+        oldAppConstruct('MyWebsite').replace(
+          'constructor(scope: Construct, id: string) {',
+          'constructor(scope: Construct, id: string, extra: string) {',
+        ),
+      );
+
+      const result = await migration(tree);
+
+      expect(tree.read(appFile, 'utf-8')).toContain('extra: string');
+      expect(result.nextSteps.some((step) => step.includes(appFile))).toBe(
+        true,
+      );
+    });
+
+    it('leaves non-StaticWebsite files in the directory untouched', async () => {
+      const helperFile = joinPathFragments(APP_DIR, 'helpers.ts');
+      tree.write(helperFile, `export const helper = () => 1;\n`);
+
+      const result = await migration(tree);
+
+      expect(tree.read(helperFile, 'utf-8')).toEqual(
+        `export const helper = () => 1;\n`,
+      );
+      expect(result.nextSteps).toEqual([]);
+    });
+  });
+
+  describe('Terraform module', () => {
+    it('surfaces enable_waf/encryption/kms_key_arn/enable_key_rotation on the vended shape', async () => {
+      tree.write(TF_FILE, OLD_TERRAFORM_MODULE);
+
+      const result = await migration(tree);
+
+      const migrated = tree.read(TF_FILE, 'utf-8')!;
+      expect(migrated).toContain('variable "enable_waf"');
+      expect(migrated).toContain('variable "encryption"');
+      expect(migrated).toContain('variable "kms_key_arn"');
+      expect(migrated).toContain('variable "enable_key_rotation"');
+      expect(migrated).toContain('create_website_key');
+      expect(migrated).toContain('website_kms_key_arn');
+      expect(migrated).toContain('count = local.create_website_key ? 1 : 0');
+      expect(migrated).toContain(
+        'enable_key_rotation = var.enable_key_rotation',
+      );
+      expect(migrated).toContain(
+        'target_key_id = aws_kms_key.website_key[0].key_id',
+      );
+      expect(migrated).toContain('kms_key_id = local.website_kms_key_arn');
+      expect(migrated).toContain(
+        'kms_master_key_id = var.encryption == "KMS" ? local.website_kms_key_arn : null',
+      );
+      expect(migrated).toContain(
+        'sse_algorithm = var.encryption == "KMS" ? "aws:kms" : "AES256"',
+      );
+      expect(migrated).toContain('count = var.enable_waf ? 1 : 0');
+      expect(migrated).toContain(
+        'web_acl_id = var.enable_waf ? aws_wafv2_web_acl.cloudfront_waf[0].arn : null',
+      );
+      expect(migrated).toContain(
+        'value = var.enable_waf ? aws_wafv2_web_acl.cloudfront_waf[0].arn : null',
+      );
+      expect(migrated).not.toContain('aws_kms_key.website_key.arn');
+      expect(migrated).not.toContain('aws_kms_key.website_key.key_id');
+      expect(migrated).not.toContain('aws_wafv2_web_acl.cloudfront_waf.arn');
+      expect(result.nextSteps).toEqual([]);
+    });
+
+    it('is idempotent', async () => {
+      tree.write(TF_FILE, OLD_TERRAFORM_MODULE);
+      await migration(tree);
+      const migratedOnce = tree.read(TF_FILE, 'utf-8');
+
+      const result = await migration(tree);
+
+      expect(tree.read(TF_FILE, 'utf-8')).toEqual(migratedOnce);
+      expect(result.nextSteps).toEqual([]);
+    });
+
+    it('skips and reports a diverged module', async () => {
+      tree.write(
+        TF_FILE,
+        OLD_TERRAFORM_MODULE.replace(
+          'resource "aws_kms_alias" "website_key_alias"',
+          'resource "aws_kms_alias" "my_custom_alias"',
+        ),
+      );
+
+      const result = await migration(tree);
+
+      expect(tree.read(TF_FILE, 'utf-8')).toContain(
+        'resource "aws_kms_alias" "my_custom_alias"',
+      );
+      expect(result.nextSteps.some((step) => step.includes(TF_FILE))).toBe(
+        true,
+      );
+    });
+  });
+
+  describe('Terraform app module', () => {
+    it('adds pass-through variables to each vended website app module', async () => {
+      const appFile = joinPathFragments(
+        TF_APP_DIR,
+        'my-website',
+        'my-website.tf',
+      );
+      tree.write(appFile, oldTerraformAppModule('my-website'));
+
+      const result = await migration(tree);
+
+      const migrated = tree.read(appFile, 'utf-8')!;
+      expect(migrated).toContain('variable "custom_domain_names"');
+      expect(migrated).toContain('variable "acm_certificate_arn"');
+      expect(migrated).toContain('variable "enable_waf"');
+      expect(migrated).toContain('variable "encryption"');
+      expect(migrated).toContain('variable "kms_key_arn"');
+      expect(migrated).toContain('variable "enable_key_rotation"');
+      expect(migrated).toContain(
+        'custom_domain_names = var.custom_domain_names',
+      );
+      expect(migrated).toContain(
+        'acm_certificate_arn = var.acm_certificate_arn',
+      );
+      expect(migrated).toContain('enable_waf          = var.enable_waf');
+      expect(migrated).toContain('encryption          = var.encryption');
+      expect(migrated).toContain('kms_key_arn         = var.kms_key_arn');
+      expect(migrated).toContain(
+        'enable_key_rotation = var.enable_key_rotation',
+      );
+      expect(result.nextSteps).toEqual([]);
+    });
+
+    it('skips and reports rather than duplicating a pre-existing custom_domain_names argument', async () => {
+      const appFile = joinPathFragments(
+        TF_APP_DIR,
+        'my-website',
+        'my-website.tf',
+      );
+      tree.write(appFile, oldTerraformAppModuleWithCustomDomain('my-website'));
+
+      const result = await migration(tree);
+
+      const migrated = tree.read(appFile, 'utf-8')!;
+      const customDomainCount = (
+        migrated.match(/custom_domain_names\s*=/g) ?? []
+      ).length;
+      const certArnCount = (migrated.match(/acm_certificate_arn\s*=/g) ?? [])
+        .length;
+      expect(customDomainCount).toBe(1);
+      expect(certArnCount).toBe(1);
+      expect(migrated).toContain('custom_domain_names = ["www.example.com"]');
+      expect(result.nextSteps.some((step) => step.includes(appFile))).toBe(
+        true,
+      );
+    });
+
+    it('is idempotent', async () => {
+      const appFile = joinPathFragments(
+        TF_APP_DIR,
+        'my-website',
+        'my-website.tf',
+      );
+      tree.write(appFile, oldTerraformAppModule('my-website'));
+
+      await migration(tree);
+      const migratedOnce = tree.read(appFile, 'utf-8');
+
+      const result = await migration(tree);
+
+      expect(tree.read(appFile, 'utf-8')).toEqual(migratedOnce);
+      expect(result.nextSteps).toEqual([]);
+    });
+
+    it('skips and reports a diverged app module', async () => {
+      const appFile = joinPathFragments(
+        TF_APP_DIR,
+        'my-website',
+        'my-website.tf',
+      );
+      tree.write(
+        appFile,
+        oldTerraformAppModule('my-website').replace(
+          'module "static_website" {',
+          'module "my_custom_website" {',
+        ),
+      );
+
+      const result = await migration(tree);
+
+      expect(tree.read(appFile, 'utf-8')).toContain(
+        'module "my_custom_website" {',
+      );
+      expect(result.nextSteps.some((step) => step.includes(appFile))).toBe(
+        true,
+      );
+    });
+
+    it('handles multiple website app modules independently', async () => {
+      const fooFile = joinPathFragments(TF_APP_DIR, 'foo', 'foo.tf');
+      const barFile = joinPathFragments(TF_APP_DIR, 'bar', 'bar.tf');
+      tree.write(fooFile, oldTerraformAppModule('foo'));
+      tree.write(barFile, oldTerraformAppModule('bar'));
+
+      const result = await migration(tree);
+
+      expect(tree.read(fooFile, 'utf-8')).toContain('variable "enable_waf"');
+      expect(tree.read(barFile, 'utf-8')).toContain('variable "enable_waf"');
+      expect(result.nextSteps).toEqual([]);
+    });
+  });
+});

--- a/packages/nx-plugin/src/migrations/latest/static-website-configurable-waf-encryption/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/latest/static-website-configurable-waf-encryption/migration.spec.ts
@@ -745,8 +745,11 @@ describe('static-website-configurable-waf-encryption migration', () => {
       expect(migrated).toContain('variable "enable_waf"');
       expect(migrated).toContain('variable "encryption"');
       expect(migrated).toContain('variable "kms_key_arn"');
+      expect(migrated).toContain('variable "create_kms_key"');
       expect(migrated).toContain('variable "enable_key_rotation"');
-      expect(migrated).toContain('create_website_key');
+      expect(migrated).toContain(
+        'create_website_key = var.encryption == "KMS" && var.create_kms_key',
+      );
       expect(migrated).toContain('website_kms_key_arn');
       expect(migrated).toContain('count = local.create_website_key ? 1 : 0');
       expect(migrated).toContain(
@@ -772,6 +775,7 @@ describe('static-website-configurable-waf-encryption migration', () => {
       expect(migrated).not.toContain('aws_kms_key.website_key.arn');
       expect(migrated).not.toContain('aws_kms_key.website_key.key_id');
       expect(migrated).not.toContain('aws_wafv2_web_acl.cloudfront_waf.arn');
+      expect(migrated).not.toContain('replace_triggered_by');
       expect(result.nextSteps).toEqual([]);
     });
 
@@ -823,6 +827,7 @@ describe('static-website-configurable-waf-encryption migration', () => {
       expect(migrated).toContain('variable "enable_waf"');
       expect(migrated).toContain('variable "encryption"');
       expect(migrated).toContain('variable "kms_key_arn"');
+      expect(migrated).toContain('variable "create_kms_key"');
       expect(migrated).toContain('variable "enable_key_rotation"');
       expect(migrated).toContain(
         'custom_domain_names = var.custom_domain_names',
@@ -833,6 +838,7 @@ describe('static-website-configurable-waf-encryption migration', () => {
       expect(migrated).toContain('enable_waf          = var.enable_waf');
       expect(migrated).toContain('encryption          = var.encryption');
       expect(migrated).toContain('kms_key_arn         = var.kms_key_arn');
+      expect(migrated).toContain('create_kms_key      = var.create_kms_key');
       expect(migrated).toContain(
         'enable_key_rotation = var.enable_key_rotation',
       );

--- a/packages/nx-plugin/src/migrations/latest/static-website-configurable-waf-encryption/migration.ts
+++ b/packages/nx-plugin/src/migrations/latest/static-website-configurable-waf-encryption/migration.ts
@@ -35,14 +35,19 @@ import {
  *   an optional `props` constructor parameter so these can be configured per
  *   app, rather than only by hand-editing the vended construct.
  * - The vended Terraform static-website core module gains the equivalent
- *   `enable_waf`, `encryption`, `kms_key_arn` and `enable_key_rotation`
- *   variables.
+ *   `enable_waf`, `encryption`, `kms_key_arn`, `create_kms_key` and
+ *   `enable_key_rotation` variables. The CloudFront distribution's
+ *   `lifecycle.replace_triggered_by` on the WAF ACL is also dropped - it
+ *   can't resolve once the ACL has a count of 0 and no prior state to
+ *   reference, which broke `terraform plan` on any greenfield deployment
+ *   with `enable_waf = false`.
  * - Each vended per-website Terraform app module (`app/static-websites/<name>/<name>.tf`)
  *   gains pass-through `custom_domain_names`, `acm_certificate_arn`,
- *   `enable_waf`, `encryption`, `kms_key_arn` and `enable_key_rotation`
- *   variables forwarded to the core module call, matching the pass-through
- *   convention every other app-wraps-core Terraform module in this plugin
- *   already follows (`rdb`, `agent-core`, `dcr-proxies`, the REST/HTTP API).
+ *   `enable_waf`, `encryption`, `kms_key_arn`, `create_kms_key` and
+ *   `enable_key_rotation` variables forwarded to the core module call,
+ *   matching the pass-through convention every other app-wraps-core
+ *   Terraform module in this plugin already follows (`rdb`, `agent-core`,
+ *   `dcr-proxies`, the REST/HTTP API).
  *
  * These files are generated with `KeepExisting`, so without this an upgraded
  * workspace has generators that support this configuration but vended files
@@ -56,10 +61,10 @@ const TERRAFORM_STATIC_WEBSITES_APP_DIR = `${PACKAGES_DIR}/${SHARED_TERRAFORM_DI
 
 const CDK_DIVERGED_MESSAGE = `${CDK_STATIC_WEBSITE_FILE}: has diverged from the generated shape - left untouched. To pick up the enableWaf, encryption, encryptionKey and enableKeyRotation props, manually port them from the vended core/static-website.ts template (see the ts#react-website generator's static-website construct).`;
 
-const TERRAFORM_DIVERGED_MESSAGE = `${TERRAFORM_STATIC_WEBSITE_FILE}: has diverged from the generated shape - left untouched. To pick up the enable_waf, encryption, kms_key_arn and enable_key_rotation variables, manually port them from the vended static-website.tf template (see the ts#react-website generator's static-website module).`;
+const TERRAFORM_DIVERGED_MESSAGE = `${TERRAFORM_STATIC_WEBSITE_FILE}: has diverged from the generated shape - left untouched. To pick up the enable_waf, encryption, kms_key_arn, create_kms_key and enable_key_rotation variables, manually port them from the vended static-website.tf template (see the ts#react-website generator's static-website module).`;
 
 const terraformAppDivergedMessage = (filePath: string) =>
-  `${filePath}: has diverged from the generated shape - left untouched. To make custom_domain_names, acm_certificate_arn, enable_waf, encryption, kms_key_arn and enable_key_rotation configurable from your root Terraform configuration, add pass-through variables here and forward them to the static_website module call (see the ts#react-website generator's static-websites app template).`;
+  `${filePath}: has diverged from the generated shape - left untouched. To make custom_domain_names, acm_certificate_arn, enable_waf, encryption, kms_key_arn, create_kms_key and enable_key_rotation configurable from your root Terraform configuration, add pass-through variables here and forward them to the static_website module call (see the ts#react-website generator's static-websites app template).`;
 
 // The doc comments below carry backticked markdown, which must stay out of
 // the GritQL pattern that inserts this text (see insertViaGritQL). It's routed
@@ -78,7 +83,10 @@ const STATIC_WEBSITE_PROPS_TEXT = `/**
   readonly encryption?: BucketEncryption;
   /**
    * KMS key used to encrypt the website and distribution log buckets. Only used when \`encryption\` is
-   * \`BucketEncryption.KMS\`. When not provided, a new key is created.
+   * \`BucketEncryption.KMS\`. When not provided, a new key is created. Note that a key imported via
+   * \`Key.fromKeyArn\` must already grant the CloudWatch Logs, S3 and CloudFront service principals the
+   * necessary permissions in its own key policy - \`addToResourcePolicy\` is a no-op on an imported key,
+   * so this construct cannot grant them on your behalf.
    */
   readonly encryptionKey?: IKey;
   /**
@@ -347,13 +355,19 @@ const NEW_VARIABLES_TEXT = [
   '}',
   '',
   'variable "kms_key_arn" {',
-  '  description = "ARN of an existing KMS key used to encrypt the website and distribution log buckets when encryption is KMS. When not provided, a new key is created. Note that a customer-supplied key must already grant the CloudWatch Logs, S3 and CloudFront service principals the necessary permissions in its own key policy."',
+  '  description = "ARN of an existing KMS key used to encrypt the website and distribution log buckets when encryption is KMS. When not provided and create_kms_key is true, a new key is created. Note that a customer-supplied key must already grant the CloudWatch Logs, S3 and CloudFront service principals the necessary permissions in its own key policy."',
   '  type        = string',
   '  default     = null',
   '}',
   '',
+  'variable "create_kms_key" {',
+  '  description = "Whether to create a KMS key for the website. Only applies when encryption is KMS. Set to false when supplying kms_key_arn."',
+  '  type        = bool',
+  '  default     = true',
+  '}',
+  '',
   'variable "enable_key_rotation" {',
-  '  description = "Whether the automatically created KMS key has rotation enabled. Only applies when encryption is KMS and kms_key_arn is not provided."',
+  '  description = "Whether the automatically created KMS key has rotation enabled. Only applies when encryption is KMS and create_kms_key is true."',
   '  type        = bool',
   '  default     = true',
   '}',
@@ -361,7 +375,7 @@ const NEW_VARIABLES_TEXT = [
 
 const NEW_LOCALS_TEXT = [
   '',
-  '  create_website_key = var.encryption == "KMS" && var.kms_key_arn == null',
+  '  create_website_key = var.encryption == "KMS" && var.create_kms_key',
   '  website_kms_key_arn = (',
   '    var.encryption != "KMS" ? null :',
   '    local.create_website_key ? aws_kms_key.website_key[0].arn :',
@@ -439,6 +453,15 @@ const migrateTerraformModule = async (
       '  $line <: within `output "waf_web_acl_arn" { $_ }`\n' +
       '}',
   );
+  // Forces distribution replacement whenever the WAF ACL changes. Once the
+  // ACL gains `count`, this can't be resolved on a greenfield apply where
+  // count is 0 and there's no prior state to reference - see
+  // https://github.com/awslabs/nx-plugin-for-aws/pull/1107. It's also
+  // redundant: web_acl_id already references the ACL ARN directly, so a
+  // replaced ACL still drives a plain distribution update.
+  const LIFECYCLE_REPLACE_TRIGGERED_BY_BLOCK = hcl(
+    '`lifecycle {\n    replace_triggered_by = [\n      aws_wafv2_web_acl.cloudfront_waf\n    ]\n  }`',
+  );
 
   const anchors = [
     ACM_CERT_VARIABLE,
@@ -455,6 +478,7 @@ const migrateTerraformModule = async (
     WAF_BLOCK,
     WEB_ACL_ID_LINE,
     WAF_OUTPUT_VALUE_LINE,
+    LIFECYCLE_REPLACE_TRIGGERED_BY_BLOCK,
   ];
 
   const allPresent = (
@@ -584,6 +608,14 @@ const migrateTerraformModule = async (
     WAF_OUTPUT_VALUE_LINE +
       ' => `value = var.enable_waf ? aws_wafv2_web_acl.cloudfront_waf[0].arn : null`',
   );
+
+  // 6. Drop the lifecycle block that can no longer resolve once the WAF ACL
+  //    has a count of 0 and no prior state to reference.
+  await applyGritQL(
+    tree,
+    TERRAFORM_STATIC_WEBSITE_FILE,
+    LIFECYCLE_REPLACE_TRIGGERED_BY_BLOCK + ' => ``',
+  );
 };
 
 const NEW_APP_MODULE_VARIABLES_TEXT = [
@@ -617,13 +649,19 @@ const NEW_APP_MODULE_VARIABLES_TEXT = [
   '}',
   '',
   'variable "kms_key_arn" {',
-  '  description = "ARN of an existing KMS key used to encrypt the website and distribution log buckets when encryption is KMS. When not provided, a new key is created. Note that a customer-supplied key must already grant the CloudWatch Logs, S3 and CloudFront service principals the necessary permissions in its own key policy."',
+  '  description = "ARN of an existing KMS key used to encrypt the website and distribution log buckets when encryption is KMS. When not provided and create_kms_key is true, a new key is created. Note that a customer-supplied key must already grant the CloudWatch Logs, S3 and CloudFront service principals the necessary permissions in its own key policy."',
   '  type        = string',
   '  default     = null',
   '}',
   '',
+  'variable "create_kms_key" {',
+  '  description = "Whether to create a KMS key for the website. Only applies when encryption is KMS. Set to false when supplying kms_key_arn."',
+  '  type        = bool',
+  '  default     = true',
+  '}',
+  '',
   'variable "enable_key_rotation" {',
-  '  description = "Whether the automatically created KMS key has rotation enabled. Only applies when encryption is KMS and kms_key_arn is not provided."',
+  '  description = "Whether the automatically created KMS key has rotation enabled. Only applies when encryption is KMS and create_kms_key is true."',
   '  type        = bool',
   '  default     = true',
   '}',
@@ -635,6 +673,7 @@ const NEW_APP_MODULE_FORWARD_TEXT = [
   'enable_waf          = var.enable_waf',
   'encryption          = var.encryption',
   'kms_key_arn         = var.kms_key_arn',
+  'create_kms_key      = var.create_kms_key',
   'enable_key_rotation = var.enable_key_rotation',
 ].join('\n  ');
 

--- a/packages/nx-plugin/src/migrations/latest/static-website-configurable-waf-encryption/migration.ts
+++ b/packages/nx-plugin/src/migrations/latest/static-website-configurable-waf-encryption/migration.ts
@@ -1,0 +1,742 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import {
+  joinPathFragments,
+  type MigrationReturnObject,
+  type Tree,
+} from '@nx/devkit';
+import {
+  addDestructuredImport,
+  applyGritQL,
+  captureGritQLVariable,
+  GRIT_INSERT_PLACEHOLDER,
+  insertViaGritQL,
+  matchGritQL,
+} from '../../../utils/ast';
+import { formatFilesInSubtree } from '../../../utils/format';
+import {
+  PACKAGES_DIR,
+  SHARED_CONSTRUCTS_DIR,
+  SHARED_TERRAFORM_DIR,
+} from '../../../utils/shared-constructs-constants';
+
+/**
+ * Bring existing workspaces up to the generators' current StaticWebsite
+ * configurability:
+ *
+ * - The vended `StaticWebsite` CDK construct gains `enableWaf`, `encryption`,
+ *   `encryptionKey` and `enableKeyRotation` props. The WAF Web ACL is now
+ *   optional, the KMS key used to encrypt the website and distribution log
+ *   buckets is now overridable (or skippable in favour of another
+ *   `BucketEncryption`), and the auto-created key's rotation is configurable.
+ * - Each vended per-website app construct (`app/static-websites/*.ts`) gains
+ *   an optional `props` constructor parameter so these can be configured per
+ *   app, rather than only by hand-editing the vended construct.
+ * - The vended Terraform static-website core module gains the equivalent
+ *   `enable_waf`, `encryption`, `kms_key_arn` and `enable_key_rotation`
+ *   variables.
+ * - Each vended per-website Terraform app module (`app/static-websites/<name>/<name>.tf`)
+ *   gains pass-through `custom_domain_names`, `acm_certificate_arn`,
+ *   `enable_waf`, `encryption`, `kms_key_arn` and `enable_key_rotation`
+ *   variables forwarded to the core module call, matching the pass-through
+ *   convention every other app-wraps-core Terraform module in this plugin
+ *   already follows (`rdb`, `agent-core`, `dcr-proxies`, the REST/HTTP API).
+ *
+ * These files are generated with `KeepExisting`, so without this an upgraded
+ * workspace has generators that support this configuration but vended files
+ * that don't. Diverged files are left untouched and reported via `nextSteps`.
+ */
+
+const CDK_STATIC_WEBSITE_FILE = `${PACKAGES_DIR}/${SHARED_CONSTRUCTS_DIR}/src/core/static-website.ts`;
+const CDK_STATIC_WEBSITES_APP_DIR = `${PACKAGES_DIR}/${SHARED_CONSTRUCTS_DIR}/src/app/static-websites`;
+const TERRAFORM_STATIC_WEBSITE_FILE = `${PACKAGES_DIR}/${SHARED_TERRAFORM_DIR}/src/core/static-website/static-website.tf`;
+const TERRAFORM_STATIC_WEBSITES_APP_DIR = `${PACKAGES_DIR}/${SHARED_TERRAFORM_DIR}/src/app/static-websites`;
+
+const CDK_DIVERGED_MESSAGE = `${CDK_STATIC_WEBSITE_FILE}: has diverged from the generated shape - left untouched. To pick up the enableWaf, encryption, encryptionKey and enableKeyRotation props, manually port them from the vended core/static-website.ts template (see the ts#react-website generator's static-website construct).`;
+
+const TERRAFORM_DIVERGED_MESSAGE = `${TERRAFORM_STATIC_WEBSITE_FILE}: has diverged from the generated shape - left untouched. To pick up the enable_waf, encryption, kms_key_arn and enable_key_rotation variables, manually port them from the vended static-website.tf template (see the ts#react-website generator's static-website module).`;
+
+const terraformAppDivergedMessage = (filePath: string) =>
+  `${filePath}: has diverged from the generated shape - left untouched. To make custom_domain_names, acm_certificate_arn, enable_waf, encryption, kms_key_arn and enable_key_rotation configurable from your root Terraform configuration, add pass-through variables here and forward them to the static_website module call (see the ts#react-website generator's static-websites app template).`;
+
+// The doc comments below carry backticked markdown, which must stay out of
+// the GritQL pattern that inserts this text (see insertViaGritQL). It's routed
+// in as plain text via the placeholder instead.
+const STATIC_WEBSITE_PROPS_TEXT = `/**
+   * Whether to protect the CloudFront distribution with an AWS WAF Web ACL.
+   *
+   * @default true
+   */
+  readonly enableWaf?: boolean;
+  /**
+   * Server-side encryption for the website and distribution log buckets.
+   *
+   * @default BucketEncryption.KMS
+   */
+  readonly encryption?: BucketEncryption;
+  /**
+   * KMS key used to encrypt the website and distribution log buckets. Only used when \`encryption\` is
+   * \`BucketEncryption.KMS\`. When not provided, a new key is created.
+   */
+  readonly encryptionKey?: IKey;
+  /**
+   * Whether the automatically created KMS key has rotation enabled. Only applies when \`encryption\` is
+   * \`BucketEncryption.KMS\` and no \`encryptionKey\` is supplied.
+   *
+   * @default true
+   */
+  readonly enableKeyRotation?: boolean`;
+
+/**
+ * Surface enableWaf/encryption/encryptionKey/enableKeyRotation on the vended
+ * StaticWebsite CDK construct.
+ */
+const migrateCdkConstruct = async (
+  tree: Tree,
+  nextSteps: string[],
+): Promise<void> => {
+  if (!tree.exists(CDK_STATIC_WEBSITE_FILE)) {
+    return; // This workspace has no CDK static website construct.
+  }
+
+  if (
+    await matchGritQL(
+      tree,
+      CDK_STATIC_WEBSITE_FILE,
+      '`readonly enableWaf?: boolean`',
+    )
+  ) {
+    return; // Already migrated.
+  }
+
+  const CERTIFICATE_FIELD = '`readonly certificate?: ICertificate`';
+  const DESTRUCTURE_OLD =
+    '`{ websiteFilePath, websiteName, domainNames, certificate }: StaticWebsiteProps`';
+  const KEY_CREATION_OLD =
+    "`const websiteKey = new Key(this, 'WebsiteKey', { enableKeyRotation: true })`";
+  const ADD_TO_RESOURCE_POLICY_OLD = '`websiteKey.addToResourcePolicy($args)`';
+  const WEBSITE_BUCKET_ENCRYPTION_OLD =
+    "`encryption: BucketEncryption.KMS` as $prop where { $prop <: within `new Bucket($_, 'WebsiteBucket', $_)` }";
+  const DISTRIBUTION_LOGS_BUCKET_ENCRYPTION_OLD =
+    "`encryption: BucketEncryption.KMS` as $prop where { $prop <: within `new Bucket($_, 'DistributionLogBucket', $_)` }";
+  const WAF_STACK_OLD = "`const wafStack = new CloudfrontWebAcl(this, 'waf')`";
+  const WEB_ACL_ID_OLD = '`webAclId: wafStack.wafArn`';
+
+  const anchors = [
+    CERTIFICATE_FIELD,
+    DESTRUCTURE_OLD,
+    KEY_CREATION_OLD,
+    ADD_TO_RESOURCE_POLICY_OLD,
+    WEBSITE_BUCKET_ENCRYPTION_OLD,
+    DISTRIBUTION_LOGS_BUCKET_ENCRYPTION_OLD,
+    WAF_STACK_OLD,
+    WEB_ACL_ID_OLD,
+  ];
+
+  const allPresent = (
+    await Promise.all(
+      anchors.map((pattern) =>
+        matchGritQL(tree, CDK_STATIC_WEBSITE_FILE, pattern),
+      ),
+    )
+  ).every(Boolean);
+
+  if (!allPresent) {
+    nextSteps.push(CDK_DIVERGED_MESSAGE);
+    return;
+  }
+
+  await addDestructuredImport(
+    tree,
+    CDK_STATIC_WEBSITE_FILE,
+    ['IKey'],
+    'aws-cdk-lib/aws-kms',
+  );
+
+  await insertViaGritQL(
+    tree,
+    CDK_STATIC_WEBSITE_FILE,
+    `${CERTIFICATE_FIELD} as $field => \`$field;
+  ${GRIT_INSERT_PLACEHOLDER}\``,
+    STATIC_WEBSITE_PROPS_TEXT,
+  );
+
+  await applyGritQL(
+    tree,
+    CDK_STATIC_WEBSITE_FILE,
+    `${DESTRUCTURE_OLD} => \`{
+      websiteFilePath,
+      websiteName,
+      domainNames,
+      certificate,
+      enableWaf = true,
+      encryption = BucketEncryption.KMS,
+      encryptionKey,
+      enableKeyRotation = true,
+    }: StaticWebsiteProps\``,
+  );
+
+  await applyGritQL(
+    tree,
+    CDK_STATIC_WEBSITE_FILE,
+    `${KEY_CREATION_OLD} => \`const websiteKey: IKey | undefined =
+      encryption === BucketEncryption.KMS
+        ? (encryptionKey ?? new Key(this, 'WebsiteKey', { enableKeyRotation }))
+        : undefined;\``,
+  );
+
+  await applyGritQL(
+    tree,
+    CDK_STATIC_WEBSITE_FILE,
+    `${ADD_TO_RESOURCE_POLICY_OLD} => \`websiteKey?.addToResourcePolicy($args)\``,
+  );
+
+  await applyGritQL(
+    tree,
+    CDK_STATIC_WEBSITE_FILE,
+    `${WEBSITE_BUCKET_ENCRYPTION_OLD} => \`encryption\``,
+  );
+
+  await applyGritQL(
+    tree,
+    CDK_STATIC_WEBSITE_FILE,
+    `${DISTRIBUTION_LOGS_BUCKET_ENCRYPTION_OLD} => \`encryption\``,
+  );
+
+  await applyGritQL(
+    tree,
+    CDK_STATIC_WEBSITE_FILE,
+    `${WAF_STACK_OLD} => \`const wafStack = enableWaf ? new CloudfrontWebAcl(this, 'waf') : undefined;\``,
+  );
+
+  await applyGritQL(
+    tree,
+    CDK_STATIC_WEBSITE_FILE,
+    `${WEB_ACL_ID_OLD} => \`webAclId: wafStack?.wafArn\``,
+  );
+};
+
+/**
+ * Surface the same props on each vended per-website app construct, so they
+ * can be configured per app rather than only by editing the shared construct.
+ */
+const migrateCdkAppConstructs = async (
+  tree: Tree,
+  nextSteps: string[],
+): Promise<void> => {
+  if (!tree.exists(CDK_STATIC_WEBSITES_APP_DIR)) {
+    return;
+  }
+
+  for (const fileName of tree.children(CDK_STATIC_WEBSITES_APP_DIR)) {
+    if (fileName === 'index.ts' || !fileName.endsWith('.ts')) {
+      continue;
+    }
+    const filePath = joinPathFragments(CDK_STATIC_WEBSITES_APP_DIR, fileName);
+
+    const contents = tree.read(filePath, 'utf-8') ?? '';
+    if (contents.includes('StaticWebsiteProps')) {
+      continue; // Already migrated.
+    }
+
+    const name = await captureGritQLVariable(
+      tree,
+      filePath,
+      '`export class $name extends StaticWebsite { $_ }`',
+      'name',
+    );
+    if (!name) {
+      continue; // Not a StaticWebsite subclass, not ours to touch.
+    }
+
+    const importPattern = '`import { StaticWebsite } from $path`';
+    const ctorPattern = '`constructor(scope: Construct, id: string) { $body }`';
+    // Captures the whole property list rather than anchoring on websiteName
+    // being followed by exactly one more property ($rest binds a single
+    // trailing node, not a variadic list). This must still match when a
+    // workspace already customised the super() call with e.g. domainNames
+    // and certificate (the pre-existing documented customization point).
+    const superPattern = `\`super(scope, id, { $props })\` as $call where {
+  $props <: contains \`websiteName: '${name}'\`
+}`;
+
+    const ready = (
+      await Promise.all(
+        [importPattern, ctorPattern, superPattern].map((pattern) =>
+          matchGritQL(tree, filePath, pattern),
+        ),
+      )
+    ).every(Boolean);
+
+    if (!ready) {
+      nextSteps.push(
+        `${filePath}: has diverged from the generated shape - left untouched. To make enableWaf, encryption, encryptionKey and enableKeyRotation configurable here, add an optional \`props?: ${name}Props\` constructor parameter (\`Omit<StaticWebsiteProps, 'websiteName' | 'websiteFilePath'>\`) and spread it into the super() call (see the ts#react-website generator's static-websites app template).`,
+      );
+      continue;
+    }
+
+    await applyGritQL(
+      tree,
+      filePath,
+      `${importPattern} => \`import { StaticWebsite, StaticWebsiteProps } from $path\``,
+    );
+
+    await insertViaGritQL(
+      tree,
+      filePath,
+      `\`export class ${name} extends StaticWebsite { $body }\` as $cls => \`${GRIT_INSERT_PLACEHOLDER}
+
+$cls\``,
+      `export type ${name}Props = Omit<\n  StaticWebsiteProps,\n  'websiteName' | 'websiteFilePath'\n>;`,
+    );
+
+    await applyGritQL(
+      tree,
+      filePath,
+      `${ctorPattern} => \`constructor(scope: Construct, id: string, props?: ${name}Props) { $body }\``,
+    );
+
+    await applyGritQL(
+      tree,
+      filePath,
+      `${superPattern} => \`super(scope, id, { ...props, $props })\``,
+    );
+  }
+};
+
+// Terraform (HCL) patterns are built from plain strings rather than JS
+// template literals, since the HCL text itself is full of `${...}`
+// interpolations that would otherwise be parsed as JS interpolation.
+const hcl = (pattern: string) => 'language hcl\n' + pattern;
+
+const withinResource = (
+  linePattern: string,
+  resourceType: string,
+  resourceLabel: string,
+) =>
+  hcl(
+    '`' +
+      linePattern +
+      '` as $line where {\n' +
+      '  $line <: within `resource "' +
+      resourceType +
+      '" "' +
+      resourceLabel +
+      '" { $_ }`\n' +
+      '}',
+  );
+
+const NEW_VARIABLES_TEXT = [
+  'variable "enable_waf" {',
+  '  description = "Whether to protect the CloudFront distribution with an AWS WAF Web ACL."',
+  '  type        = bool',
+  '  default     = true',
+  '}',
+  '',
+  'variable "encryption" {',
+  '  description = "Server-side encryption for the website and distribution log buckets. One of KMS or S3_MANAGED."',
+  '  type        = string',
+  '  default     = "KMS"',
+  '',
+  '  validation {',
+  '    condition     = contains(["KMS", "S3_MANAGED"], var.encryption)',
+  '    error_message = "encryption must be one of KMS or S3_MANAGED."',
+  '  }',
+  '}',
+  '',
+  'variable "kms_key_arn" {',
+  '  description = "ARN of an existing KMS key used to encrypt the website and distribution log buckets when encryption is KMS. When not provided, a new key is created. Note that a customer-supplied key must already grant the CloudWatch Logs, S3 and CloudFront service principals the necessary permissions in its own key policy."',
+  '  type        = string',
+  '  default     = null',
+  '}',
+  '',
+  'variable "enable_key_rotation" {',
+  '  description = "Whether the automatically created KMS key has rotation enabled. Only applies when encryption is KMS and kms_key_arn is not provided."',
+  '  type        = bool',
+  '  default     = true',
+  '}',
+].join('\n');
+
+const NEW_LOCALS_TEXT = [
+  '',
+  '  create_website_key = var.encryption == "KMS" && var.kms_key_arn == null',
+  '  website_kms_key_arn = (',
+  '    var.encryption != "KMS" ? null :',
+  '    local.create_website_key ? aws_kms_key.website_key[0].arn :',
+  '    var.kms_key_arn',
+  '  )',
+].join('\n');
+
+/**
+ * Surface the same configuration on the vended Terraform static-website
+ * module.
+ */
+const migrateTerraformModule = async (
+  tree: Tree,
+  nextSteps: string[],
+): Promise<void> => {
+  if (!tree.exists(TERRAFORM_STATIC_WEBSITE_FILE)) {
+    return; // This workspace has no Terraform static website module.
+  }
+
+  if (
+    await matchGritQL(
+      tree,
+      TERRAFORM_STATIC_WEBSITE_FILE,
+      hcl('`variable "enable_waf" { $_ }`'),
+    )
+  ) {
+    return; // Already migrated.
+  }
+
+  const ACM_CERT_VARIABLE = hcl('`variable "acm_certificate_arn" { $_ }`');
+  const ACCESS_LOGS_LOCAL = hcl(
+    '`access_logs_name_prefix = substr(lower(var.website_name), 0, 16)`',
+  );
+  const KMS_KEY_BLOCK = hcl('`resource "aws_kms_key" "website_key" { $_ }`');
+  const KMS_KEY_ROTATION_LINE = withinResource(
+    'enable_key_rotation = true',
+    'aws_kms_key',
+    'website_key',
+  );
+  const KMS_ALIAS_BLOCK = hcl(
+    '`resource "aws_kms_alias" "website_key_alias" { $_ }`',
+  );
+  const KMS_ALIAS_TARGET_LINE = hcl(
+    '`target_key_id = aws_kms_key.website_key.key_id`',
+  );
+  const LOG_GROUP_KMS_LINE = hcl('`kms_key_id = aws_kms_key.website_key.arn`');
+  const WEBSITE_ENCRYPTION_KEY_LINE = withinResource(
+    'kms_master_key_id = aws_kms_key.website_key.arn',
+    'aws_s3_bucket_server_side_encryption_configuration',
+    'website_encryption',
+  );
+  const WEBSITE_ENCRYPTION_ALGO_LINE = withinResource(
+    'sse_algorithm = "aws:kms"',
+    'aws_s3_bucket_server_side_encryption_configuration',
+    'website_encryption',
+  );
+  const DISTRIBUTION_LOGS_ENCRYPTION_KEY_LINE = withinResource(
+    'kms_master_key_id = aws_kms_key.website_key.arn',
+    'aws_s3_bucket_server_side_encryption_configuration',
+    'distribution_logs_encryption',
+  );
+  const DISTRIBUTION_LOGS_ENCRYPTION_ALGO_LINE = withinResource(
+    'sse_algorithm = "aws:kms"',
+    'aws_s3_bucket_server_side_encryption_configuration',
+    'distribution_logs_encryption',
+  );
+  const WAF_BLOCK = hcl(
+    '`resource "aws_wafv2_web_acl" "cloudfront_waf" { $_ }`',
+  );
+  const WEB_ACL_ID_LINE = hcl(
+    '`web_acl_id = aws_wafv2_web_acl.cloudfront_waf.arn`',
+  );
+  const WAF_OUTPUT_VALUE_LINE = hcl(
+    '`value = aws_wafv2_web_acl.cloudfront_waf.arn` as $line where {\n' +
+      '  $line <: within `output "waf_web_acl_arn" { $_ }`\n' +
+      '}',
+  );
+
+  const anchors = [
+    ACM_CERT_VARIABLE,
+    ACCESS_LOGS_LOCAL,
+    KMS_KEY_BLOCK,
+    KMS_KEY_ROTATION_LINE,
+    KMS_ALIAS_BLOCK,
+    KMS_ALIAS_TARGET_LINE,
+    LOG_GROUP_KMS_LINE,
+    WEBSITE_ENCRYPTION_KEY_LINE,
+    WEBSITE_ENCRYPTION_ALGO_LINE,
+    DISTRIBUTION_LOGS_ENCRYPTION_KEY_LINE,
+    DISTRIBUTION_LOGS_ENCRYPTION_ALGO_LINE,
+    WAF_BLOCK,
+    WEB_ACL_ID_LINE,
+    WAF_OUTPUT_VALUE_LINE,
+  ];
+
+  const allPresent = (
+    await Promise.all(
+      anchors.map((pattern) =>
+        matchGritQL(tree, TERRAFORM_STATIC_WEBSITE_FILE, pattern),
+      ),
+    )
+  ).every(Boolean);
+
+  if (!allPresent) {
+    nextSteps.push(TERRAFORM_DIVERGED_MESSAGE);
+    return;
+  }
+
+  // 1. New variables, after acm_certificate_arn. Routed through the
+  //    placeholder since the variable descriptions contain double-quoted
+  //    HCL string values.
+  await insertViaGritQL(
+    tree,
+    TERRAFORM_STATIC_WEBSITE_FILE,
+    hcl(
+      '`variable "acm_certificate_arn" { $body }` as $var => `$var\n\n' +
+        GRIT_INSERT_PLACEHOLDER +
+        '`',
+    ),
+    NEW_VARIABLES_TEXT,
+  );
+
+  // 2. New locals, after access_logs_name_prefix.
+  await insertViaGritQL(
+    tree,
+    TERRAFORM_STATIC_WEBSITE_FILE,
+    hcl(
+      '`access_logs_name_prefix = substr(lower(var.website_name), 0, 16)` as $line => `$line\n' +
+        GRIT_INSERT_PLACEHOLDER +
+        '`',
+    ),
+    NEW_LOCALS_TEXT,
+  );
+
+  // 3. Make the KMS key and alias conditional on encryption/kms_key_arn.
+  await applyGritQL(
+    tree,
+    TERRAFORM_STATIC_WEBSITE_FILE,
+    hcl(
+      '`resource "aws_kms_key" "website_key" { $body }` => `resource "aws_kms_key" "website_key" {\n' +
+        '  count = local.create_website_key ? 1 : 0\n\n' +
+        '  $body\n' +
+        '}`',
+    ),
+  );
+  await applyGritQL(
+    tree,
+    TERRAFORM_STATIC_WEBSITE_FILE,
+    KMS_KEY_ROTATION_LINE +
+      ' => `enable_key_rotation = var.enable_key_rotation`',
+  );
+  await applyGritQL(
+    tree,
+    TERRAFORM_STATIC_WEBSITE_FILE,
+    hcl(
+      '`resource "aws_kms_alias" "website_key_alias" { $body }` => `resource "aws_kms_alias" "website_key_alias" {\n' +
+        '  count = local.create_website_key ? 1 : 0\n\n' +
+        '  $body\n' +
+        '}`',
+    ),
+  );
+  await applyGritQL(
+    tree,
+    TERRAFORM_STATIC_WEBSITE_FILE,
+    KMS_ALIAS_TARGET_LINE +
+      ' => `target_key_id = aws_kms_key.website_key[0].key_id`',
+  );
+
+  // 4. Resolve the key ARN through the new local everywhere it's consumed.
+  await applyGritQL(
+    tree,
+    TERRAFORM_STATIC_WEBSITE_FILE,
+    LOG_GROUP_KMS_LINE + ' => `kms_key_id = local.website_kms_key_arn`',
+  );
+  await applyGritQL(
+    tree,
+    TERRAFORM_STATIC_WEBSITE_FILE,
+    WEBSITE_ENCRYPTION_KEY_LINE +
+      ' => `kms_master_key_id = var.encryption == "KMS" ? local.website_kms_key_arn : null`',
+  );
+  await applyGritQL(
+    tree,
+    TERRAFORM_STATIC_WEBSITE_FILE,
+    WEBSITE_ENCRYPTION_ALGO_LINE +
+      ' => `sse_algorithm = var.encryption == "KMS" ? "aws:kms" : "AES256"`',
+  );
+  await applyGritQL(
+    tree,
+    TERRAFORM_STATIC_WEBSITE_FILE,
+    DISTRIBUTION_LOGS_ENCRYPTION_KEY_LINE +
+      ' => `kms_master_key_id = var.encryption == "KMS" ? local.website_kms_key_arn : null`',
+  );
+  await applyGritQL(
+    tree,
+    TERRAFORM_STATIC_WEBSITE_FILE,
+    DISTRIBUTION_LOGS_ENCRYPTION_ALGO_LINE +
+      ' => `sse_algorithm = var.encryption == "KMS" ? "aws:kms" : "AES256"`',
+  );
+
+  // 5. Make the WAF Web ACL conditional on enable_waf.
+  await applyGritQL(
+    tree,
+    TERRAFORM_STATIC_WEBSITE_FILE,
+    hcl(
+      '`resource "aws_wafv2_web_acl" "cloudfront_waf" { $body }` => `resource "aws_wafv2_web_acl" "cloudfront_waf" {\n' +
+        '  count = var.enable_waf ? 1 : 0\n\n' +
+        '  $body\n' +
+        '}`',
+    ),
+  );
+  await applyGritQL(
+    tree,
+    TERRAFORM_STATIC_WEBSITE_FILE,
+    WEB_ACL_ID_LINE +
+      ' => `web_acl_id = var.enable_waf ? aws_wafv2_web_acl.cloudfront_waf[0].arn : null`',
+  );
+  await applyGritQL(
+    tree,
+    TERRAFORM_STATIC_WEBSITE_FILE,
+    WAF_OUTPUT_VALUE_LINE +
+      ' => `value = var.enable_waf ? aws_wafv2_web_acl.cloudfront_waf[0].arn : null`',
+  );
+};
+
+const NEW_APP_MODULE_VARIABLES_TEXT = [
+  'variable "custom_domain_names" {',
+  '  description = "Custom domain names (aliases) for the CloudFront distribution. Requires acm_certificate_arn."',
+  '  type        = list(string)',
+  '  default     = []',
+  '}',
+  '',
+  'variable "acm_certificate_arn" {',
+  '  description = "ARN of an ACM certificate (in us-east-1) for the custom domain names. When set, viewers are required to use TLS 1.2 or later."',
+  '  type        = string',
+  '  default     = null',
+  '}',
+  '',
+  'variable "enable_waf" {',
+  '  description = "Whether to protect the CloudFront distribution with an AWS WAF Web ACL."',
+  '  type        = bool',
+  '  default     = true',
+  '}',
+  '',
+  'variable "encryption" {',
+  '  description = "Server-side encryption for the website and distribution log buckets. One of KMS or S3_MANAGED."',
+  '  type        = string',
+  '  default     = "KMS"',
+  '',
+  '  validation {',
+  '    condition     = contains(["KMS", "S3_MANAGED"], var.encryption)',
+  '    error_message = "encryption must be one of KMS or S3_MANAGED."',
+  '  }',
+  '}',
+  '',
+  'variable "kms_key_arn" {',
+  '  description = "ARN of an existing KMS key used to encrypt the website and distribution log buckets when encryption is KMS. When not provided, a new key is created. Note that a customer-supplied key must already grant the CloudWatch Logs, S3 and CloudFront service principals the necessary permissions in its own key policy."',
+  '  type        = string',
+  '  default     = null',
+  '}',
+  '',
+  'variable "enable_key_rotation" {',
+  '  description = "Whether the automatically created KMS key has rotation enabled. Only applies when encryption is KMS and kms_key_arn is not provided."',
+  '  type        = bool',
+  '  default     = true',
+  '}',
+].join('\n');
+
+const NEW_APP_MODULE_FORWARD_TEXT = [
+  'custom_domain_names = var.custom_domain_names',
+  'acm_certificate_arn = var.acm_certificate_arn',
+  'enable_waf          = var.enable_waf',
+  'encryption          = var.encryption',
+  'kms_key_arn         = var.kms_key_arn',
+  'enable_key_rotation = var.enable_key_rotation',
+].join('\n  ');
+
+/**
+ * Surface the same configuration as pass-through variables on each vended
+ * per-website Terraform app module, matching the pass-through convention
+ * every other app-wraps-core Terraform module already follows.
+ */
+const migrateTerraformAppModules = async (
+  tree: Tree,
+  nextSteps: string[],
+): Promise<void> => {
+  if (!tree.exists(TERRAFORM_STATIC_WEBSITES_APP_DIR)) {
+    return;
+  }
+
+  for (const dirName of tree.children(TERRAFORM_STATIC_WEBSITES_APP_DIR)) {
+    const filePath = joinPathFragments(
+      TERRAFORM_STATIC_WEBSITES_APP_DIR,
+      dirName,
+      `${dirName}.tf`,
+    );
+    if (!tree.exists(filePath)) {
+      continue; // Not a website app module directory.
+    }
+
+    if (
+      await matchGritQL(tree, filePath, hcl('`variable "enable_waf" { $_ }`'))
+    ) {
+      continue; // Already migrated.
+    }
+
+    const TERRAFORM_BLOCK = hcl('`terraform { $_ }`');
+    const MODULE_BLOCK = hcl('`module "static_website" { $_ }`');
+    const FILE_PATH_LINE = hcl(
+      '`website_file_path = $val` as $line where {\n' +
+        '  $line <: within `module "static_website" { $_ }`\n' +
+        '}',
+    );
+    // custom_domain_names/acm_certificate_arn predate this migration as a
+    // documented customization point (hand-editing the module block). If
+    // either is already present as a literal argument, blindly forwarding
+    // our own `= var.x` line would produce a duplicate argument, which is
+    // invalid HCL. Treat that as diverged instead of silently corrupting the file.
+    const hasExistingCustomDomainArg = async (name: string) =>
+      matchGritQL(
+        tree,
+        filePath,
+        hcl(
+          `\`${name} = $_\` as $line where {\n` +
+            '  $line <: within `module "static_website" { $_ }`\n' +
+            '}',
+        ),
+      );
+
+    const ready =
+      (
+        await Promise.all(
+          [TERRAFORM_BLOCK, MODULE_BLOCK, FILE_PATH_LINE].map((pattern) =>
+            matchGritQL(tree, filePath, pattern),
+          ),
+        )
+      ).every(Boolean) &&
+      !(await hasExistingCustomDomainArg('custom_domain_names')) &&
+      !(await hasExistingCustomDomainArg('acm_certificate_arn'));
+
+    if (!ready) {
+      nextSteps.push(terraformAppDivergedMessage(filePath));
+      continue;
+    }
+
+    // Inserted right after the terraform/required_providers block (and
+    // before the "Static website module" comment), matching where the
+    // vended template puts these variables.
+    await insertViaGritQL(
+      tree,
+      filePath,
+      hcl('`terraform { $body }` as $tf') +
+        ` => \`$tf\n\n${GRIT_INSERT_PLACEHOLDER}\``,
+      NEW_APP_MODULE_VARIABLES_TEXT,
+    );
+
+    await insertViaGritQL(
+      tree,
+      filePath,
+      FILE_PATH_LINE + ` => \`$line\n\n  ${GRIT_INSERT_PLACEHOLDER}\``,
+      NEW_APP_MODULE_FORWARD_TEXT,
+    );
+  }
+};
+
+export default async function migration(
+  tree: Tree,
+): Promise<MigrationReturnObject> {
+  const nextSteps: string[] = [];
+
+  await migrateCdkConstruct(tree, nextSteps);
+  await migrateCdkAppConstructs(tree, nextSteps);
+  await migrateTerraformModule(tree, nextSteps);
+  await migrateTerraformAppModules(tree, nextSteps);
+
+  await formatFilesInSubtree(tree);
+
+  return { nextSteps };
+}

--- a/packages/nx-plugin/src/ts/react-website/app/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/react-website/app/__snapshots__/generator.spec.ts.snap
@@ -164,6 +164,35 @@ variable "acm_certificate_arn" {
   default     = null
 }
 
+variable "enable_waf" {
+  description = "Whether to protect the CloudFront distribution with an AWS WAF Web ACL."
+  type        = bool
+  default     = true
+}
+
+variable "encryption" {
+  description = "Server-side encryption for the website and distribution log buckets. One of KMS or S3_MANAGED."
+  type        = string
+  default     = "KMS"
+
+  validation {
+    condition     = contains(["KMS", "S3_MANAGED"], var.encryption)
+    error_message = "encryption must be one of KMS or S3_MANAGED."
+  }
+}
+
+variable "kms_key_arn" {
+  description = "ARN of an existing KMS key used to encrypt the website and distribution log buckets when encryption is KMS. When not provided, a new key is created. Note that a customer-supplied key must already grant the CloudWatch Logs, S3 and CloudFront service principals the necessary permissions in its own key policy."
+  type        = string
+  default     = null
+}
+
+variable "enable_key_rotation" {
+  description = "Whether the automatically created KMS key has rotation enabled. Only applies when encryption is KMS and kms_key_arn is not provided."
+  type        = bool
+  default     = true
+}
+
 # Content-Security-Policy enforced on all responses. Restricts scripts and
 # framing to mitigate XSS and clickjacking, while permitting HTTPS/WSS calls
 # (connect-src) to AWS service endpoints such as API Gateway, Cognito and
@@ -175,6 +204,13 @@ locals {
   # Delivery source/destination names have a 60 character maximum. Truncate the
   # website name so the longest delivery name stays within the limit.
   access_logs_name_prefix = substr(lower(var.website_name), 0, 16)
+
+  create_website_key = var.encryption == "KMS" && var.kms_key_arn == null
+  website_kms_key_arn = (
+    var.encryption != "KMS" ? null :
+    local.create_website_key ? aws_kms_key.website_key[0].arn :
+    var.kms_key_arn
+  )
 }
 
 
@@ -185,9 +221,11 @@ data "aws_region" "current" {}
 
 # KMS Key for encryption
 resource "aws_kms_key" "website_key" {
+  count = local.create_website_key ? 1 : 0
+
   description             = "KMS key for \${var.website_name} website encryption"
   deletion_window_in_days = 7
-  enable_key_rotation     = true
+  enable_key_rotation     = var.enable_key_rotation
 
   policy = jsonencode({
     Version = "2012-10-17"
@@ -260,8 +298,10 @@ resource "aws_kms_key" "website_key" {
 }
 
 resource "aws_kms_alias" "website_key_alias" {
+  count = local.create_website_key ? 1 : 0
+
   name          = "alias/\${lower(var.website_name)}-website-key-\${random_id.unique_suffix.hex}"
-  target_key_id = aws_kms_key.website_key.key_id
+  target_key_id = aws_kms_key.website_key[0].key_id
 }
 
 # CloudWatch log group receiving S3 server access logs for the website and
@@ -269,7 +309,7 @@ resource "aws_kms_alias" "website_key_alias" {
 resource "aws_cloudwatch_log_group" "access_logs" {
   name              = "/aws/s3/\${lower(var.website_name)}-access-logs-\${random_id.bucket_suffix.hex}"
   retention_in_days = 365
-  kms_key_id        = aws_kms_key.website_key.arn
+  kms_key_id        = local.website_kms_key_arn
 }
 
 resource "random_id" "unique_suffix" {
@@ -306,8 +346,8 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "website_encryptio
 
   rule {
     apply_server_side_encryption_by_default {
-      kms_master_key_id = aws_kms_key.website_key.arn
-      sse_algorithm     = "aws:kms"
+      kms_master_key_id = var.encryption == "KMS" ? local.website_kms_key_arn : null
+      sse_algorithm     = var.encryption == "KMS" ? "aws:kms" : "AES256"
     }
   }
 }
@@ -371,8 +411,8 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "distribution_logs
 
   rule {
     apply_server_side_encryption_by_default {
-      kms_master_key_id = aws_kms_key.website_key.arn
-      sse_algorithm     = "aws:kms"
+      kms_master_key_id = var.encryption == "KMS" ? local.website_kms_key_arn : null
+      sse_algorithm     = var.encryption == "KMS" ? "aws:kms" : "AES256"
     }
   }
 }
@@ -442,6 +482,8 @@ resource "aws_s3_bucket_policy" "distribution_logs_ssl_policy" {
 
 # WAF Web ACL (must be in us-east-1 for CloudFront)
 resource "aws_wafv2_web_acl" "cloudfront_waf" {
+  count = var.enable_waf ? 1 : 0
+
   #checkov:skip=CKV2_AWS_31:WAF logging disabled
   provider = aws.us_east_1
   name     = "\${lower(var.website_name)}-cloudfront-waf-\${random_id.unique_suffix.hex}"
@@ -566,7 +608,7 @@ resource "aws_cloudfront_distribution" "website" {
   enabled             = true
   is_ipv6_enabled     = true
   default_root_object = "index.html"
-  web_acl_id          = aws_wafv2_web_acl.cloudfront_waf.arn
+  web_acl_id          = var.enable_waf ? aws_wafv2_web_acl.cloudfront_waf[0].arn : null
   aliases             = var.custom_domain_names
 
   logging_config {
@@ -902,7 +944,7 @@ output "cloudfront_domain_name" {
 
 output "waf_web_acl_arn" {
   description = "ARN of the WAF Web ACL"
-  value       = aws_wafv2_web_acl.cloudfront_waf.arn
+  value       = var.enable_waf ? aws_wafv2_web_acl.cloudfront_waf[0].arn : null
 }",
   "test-app.tf": "terraform {
   required_providers {
@@ -914,12 +956,60 @@ output "waf_web_acl_arn" {
   }
 }
 
+variable "custom_domain_names" {
+  description = "Custom domain names (aliases) for the CloudFront distribution. Requires acm_certificate_arn."
+  type        = list(string)
+  default     = []
+}
+
+variable "acm_certificate_arn" {
+  description = "ARN of an ACM certificate (in us-east-1) for the custom domain names. When set, viewers are required to use TLS 1.2 or later."
+  type        = string
+  default     = null
+}
+
+variable "enable_waf" {
+  description = "Whether to protect the CloudFront distribution with an AWS WAF Web ACL."
+  type        = bool
+  default     = true
+}
+
+variable "encryption" {
+  description = "Server-side encryption for the website and distribution log buckets. One of KMS or S3_MANAGED."
+  type        = string
+  default     = "KMS"
+
+  validation {
+    condition     = contains(["KMS", "S3_MANAGED"], var.encryption)
+    error_message = "encryption must be one of KMS or S3_MANAGED."
+  }
+}
+
+variable "kms_key_arn" {
+  description = "ARN of an existing KMS key used to encrypt the website and distribution log buckets when encryption is KMS. When not provided, a new key is created. Note that a customer-supplied key must already grant the CloudWatch Logs, S3 and CloudFront service principals the necessary permissions in its own key policy."
+  type        = string
+  default     = null
+}
+
+variable "enable_key_rotation" {
+  description = "Whether the automatically created KMS key has rotation enabled. Only applies when encryption is KMS and kms_key_arn is not provided."
+  type        = bool
+  default     = true
+}
+
 # Static website module configured for the web package
 module "static_website" {
   source = "../../../core/static-website"
 
   website_name      = "test-app"
   website_file_path = "\${path.module}/../../../../../../../dist/test-app/bundle"
+
+  custom_domain_names = var.custom_domain_names
+  acm_certificate_arn = var.acm_certificate_arn
+  enable_waf          = var.enable_waf
+  encryption          = var.encryption
+  kms_key_arn         = var.kms_key_arn
+  enable_key_rotation = var.enable_key_rotation
 
   providers = {
     aws.us_east_1 = aws.us_east_1
@@ -1299,11 +1389,17 @@ exports[`react-website generator > Tanstack router integration > should generate
 exports[`react-website generator > Tanstack router integration > should generate website with no router correctly > packages/common/constructs/src/app/static-websites/test-app.ts 1`] = `
 "import * as url from 'url';
 import { Construct } from 'constructs';
-import { StaticWebsite } from '../../core/index.js';
+import { StaticWebsite, StaticWebsiteProps } from '../../core/index.js';
+
+export type TestAppProps = Omit<
+  StaticWebsiteProps,
+  'websiteName' | 'websiteFilePath'
+>;
 
 export class TestApp extends StaticWebsite {
-  constructor(scope: Construct, id: string) {
+  constructor(scope: Construct, id: string, props?: TestAppProps) {
     super(scope, id, {
+      ...props,
       websiteName: 'TestApp',
       websiteFilePath: url.fileURLToPath(
         new URL('../../../../../../dist/test-app/bundle', import.meta.url),
@@ -1641,7 +1737,7 @@ import {
 } from 'aws-cdk-lib/aws-s3-deployment';
 import { Construct } from 'constructs';
 import { RuntimeConfig } from './runtime-config.js';
-import { Key } from 'aws-cdk-lib/aws-kms';
+import { IKey, Key } from 'aws-cdk-lib/aws-kms';
 import {
   CfnDelivery,
   CfnDeliveryDestination,
@@ -1684,6 +1780,30 @@ export interface StaticWebsiteProps {
    * When provided, viewers are required to use TLS 1.2 or later.
    */
   readonly certificate?: ICertificate;
+  /**
+   * Whether to protect the CloudFront distribution with an AWS WAF Web ACL.
+   *
+   * @default true
+   */
+  readonly enableWaf?: boolean;
+  /**
+   * Server-side encryption for the website and distribution log buckets.
+   *
+   * @default BucketEncryption.KMS
+   */
+  readonly encryption?: BucketEncryption;
+  /**
+   * KMS key used to encrypt the website and distribution log buckets. Only used when \`encryption\` is
+   * \`BucketEncryption.KMS\`. When not provided, a new key is created.
+   */
+  readonly encryptionKey?: IKey;
+  /**
+   * Whether the automatically created KMS key has rotation enabled. Only applies when \`encryption\` is
+   * \`BucketEncryption.KMS\` and no \`encryptionKey\` is supplied.
+   *
+   * @default true
+   */
+  readonly enableKeyRotation?: boolean;
 }
 
 /**
@@ -1707,17 +1827,22 @@ export class StaticWebsite extends Construct {
       websiteName,
       domainNames,
       certificate,
+      enableWaf = true,
+      encryption = BucketEncryption.KMS,
+      encryptionKey,
+      enableKeyRotation = true,
     }: StaticWebsiteProps,
   ) {
     super(scope, id);
 
-    const websiteKey = new Key(this, 'WebsiteKey', {
-      enableKeyRotation: true,
-    });
+    const websiteKey: IKey | undefined =
+      encryption === BucketEncryption.KMS
+        ? (encryptionKey ?? new Key(this, 'WebsiteKey', { enableKeyRotation }))
+        : undefined;
 
     // Allow CloudWatch Logs to use the website key for server access log delivery.
     const stack = Stack.of(this);
-    websiteKey.addToResourcePolicy(
+    websiteKey?.addToResourcePolicy(
       new PolicyStatement({
         effect: Effect.ALLOW,
         principals: [
@@ -1751,7 +1876,7 @@ export class StaticWebsite extends Construct {
       enforceSSL: true,
       autoDeleteObjects: true,
       removalPolicy: RemovalPolicy.DESTROY,
-      encryption: BucketEncryption.KMS,
+      encryption,
       encryptionKey: websiteKey,
       objectOwnership: ObjectOwnership.BUCKET_OWNER_ENFORCED,
       publicReadAccess: false,
@@ -1768,7 +1893,7 @@ export class StaticWebsite extends Construct {
       accessLogs,
     );
     // Web ACL
-    const wafStack = new CloudfrontWebAcl(this, 'waf');
+    const wafStack = enableWaf ? new CloudfrontWebAcl(this, 'waf') : undefined;
 
     // Bucket holding CloudFront standard access logs. CloudFront delivers its
     // own logs to S3 only, so this bucket is retained; its S3 server access
@@ -1777,7 +1902,7 @@ export class StaticWebsite extends Construct {
       enforceSSL: true,
       autoDeleteObjects: true,
       removalPolicy: RemovalPolicy.DESTROY,
-      encryption: BucketEncryption.KMS,
+      encryption,
       encryptionKey: websiteKey,
       objectOwnership: ObjectOwnership.BUCKET_OWNER_PREFERRED,
       publicReadAccess: false,
@@ -1830,7 +1955,7 @@ export class StaticWebsite extends Construct {
       this,
       'CloudfrontDistribution',
       {
-        webAclId: wafStack.wafArn,
+        webAclId: wafStack?.wafArn,
         enableLogging: true,
         logBucket: logBucket,
         ...(certificate
@@ -3124,11 +3249,17 @@ exports[`react-website generator > Tanstack router integration > should generate
 exports[`react-website generator > Tanstack router integration > should generate website with router correctly > packages/common/constructs/src/app/static-websites/test-app.ts 1`] = `
 "import * as url from 'url';
 import { Construct } from 'constructs';
-import { StaticWebsite } from '../../core/index.js';
+import { StaticWebsite, StaticWebsiteProps } from '../../core/index.js';
+
+export type TestAppProps = Omit<
+  StaticWebsiteProps,
+  'websiteName' | 'websiteFilePath'
+>;
 
 export class TestApp extends StaticWebsite {
-  constructor(scope: Construct, id: string) {
+  constructor(scope: Construct, id: string, props?: TestAppProps) {
     super(scope, id, {
+      ...props,
       websiteName: 'TestApp',
       websiteFilePath: url.fileURLToPath(
         new URL('../../../../../../dist/test-app/bundle', import.meta.url),
@@ -3466,7 +3597,7 @@ import {
 } from 'aws-cdk-lib/aws-s3-deployment';
 import { Construct } from 'constructs';
 import { RuntimeConfig } from './runtime-config.js';
-import { Key } from 'aws-cdk-lib/aws-kms';
+import { IKey, Key } from 'aws-cdk-lib/aws-kms';
 import {
   CfnDelivery,
   CfnDeliveryDestination,
@@ -3509,6 +3640,30 @@ export interface StaticWebsiteProps {
    * When provided, viewers are required to use TLS 1.2 or later.
    */
   readonly certificate?: ICertificate;
+  /**
+   * Whether to protect the CloudFront distribution with an AWS WAF Web ACL.
+   *
+   * @default true
+   */
+  readonly enableWaf?: boolean;
+  /**
+   * Server-side encryption for the website and distribution log buckets.
+   *
+   * @default BucketEncryption.KMS
+   */
+  readonly encryption?: BucketEncryption;
+  /**
+   * KMS key used to encrypt the website and distribution log buckets. Only used when \`encryption\` is
+   * \`BucketEncryption.KMS\`. When not provided, a new key is created.
+   */
+  readonly encryptionKey?: IKey;
+  /**
+   * Whether the automatically created KMS key has rotation enabled. Only applies when \`encryption\` is
+   * \`BucketEncryption.KMS\` and no \`encryptionKey\` is supplied.
+   *
+   * @default true
+   */
+  readonly enableKeyRotation?: boolean;
 }
 
 /**
@@ -3532,17 +3687,22 @@ export class StaticWebsite extends Construct {
       websiteName,
       domainNames,
       certificate,
+      enableWaf = true,
+      encryption = BucketEncryption.KMS,
+      encryptionKey,
+      enableKeyRotation = true,
     }: StaticWebsiteProps,
   ) {
     super(scope, id);
 
-    const websiteKey = new Key(this, 'WebsiteKey', {
-      enableKeyRotation: true,
-    });
+    const websiteKey: IKey | undefined =
+      encryption === BucketEncryption.KMS
+        ? (encryptionKey ?? new Key(this, 'WebsiteKey', { enableKeyRotation }))
+        : undefined;
 
     // Allow CloudWatch Logs to use the website key for server access log delivery.
     const stack = Stack.of(this);
-    websiteKey.addToResourcePolicy(
+    websiteKey?.addToResourcePolicy(
       new PolicyStatement({
         effect: Effect.ALLOW,
         principals: [
@@ -3576,7 +3736,7 @@ export class StaticWebsite extends Construct {
       enforceSSL: true,
       autoDeleteObjects: true,
       removalPolicy: RemovalPolicy.DESTROY,
-      encryption: BucketEncryption.KMS,
+      encryption,
       encryptionKey: websiteKey,
       objectOwnership: ObjectOwnership.BUCKET_OWNER_ENFORCED,
       publicReadAccess: false,
@@ -3593,7 +3753,7 @@ export class StaticWebsite extends Construct {
       accessLogs,
     );
     // Web ACL
-    const wafStack = new CloudfrontWebAcl(this, 'waf');
+    const wafStack = enableWaf ? new CloudfrontWebAcl(this, 'waf') : undefined;
 
     // Bucket holding CloudFront standard access logs. CloudFront delivers its
     // own logs to S3 only, so this bucket is retained; its S3 server access
@@ -3602,7 +3762,7 @@ export class StaticWebsite extends Construct {
       enforceSSL: true,
       autoDeleteObjects: true,
       removalPolicy: RemovalPolicy.DESTROY,
-      encryption: BucketEncryption.KMS,
+      encryption,
       encryptionKey: websiteKey,
       objectOwnership: ObjectOwnership.BUCKET_OWNER_PREFERRED,
       publicReadAccess: false,
@@ -3655,7 +3815,7 @@ export class StaticWebsite extends Construct {
       this,
       'CloudfrontDistribution',
       {
-        webAclId: wafStack.wafArn,
+        webAclId: wafStack?.wafArn,
         enableLogging: true,
         logBucket: logBucket,
         ...(certificate
@@ -5151,7 +5311,7 @@ import {
 } from 'aws-cdk-lib/aws-s3-deployment';
 import { Construct } from 'constructs';
 import { RuntimeConfig } from './runtime-config.js';
-import { Key } from 'aws-cdk-lib/aws-kms';
+import { IKey, Key } from 'aws-cdk-lib/aws-kms';
 import {
   CfnDelivery,
   CfnDeliveryDestination,
@@ -5194,6 +5354,30 @@ export interface StaticWebsiteProps {
    * When provided, viewers are required to use TLS 1.2 or later.
    */
   readonly certificate?: ICertificate;
+  /**
+   * Whether to protect the CloudFront distribution with an AWS WAF Web ACL.
+   *
+   * @default true
+   */
+  readonly enableWaf?: boolean;
+  /**
+   * Server-side encryption for the website and distribution log buckets.
+   *
+   * @default BucketEncryption.KMS
+   */
+  readonly encryption?: BucketEncryption;
+  /**
+   * KMS key used to encrypt the website and distribution log buckets. Only used when \`encryption\` is
+   * \`BucketEncryption.KMS\`. When not provided, a new key is created.
+   */
+  readonly encryptionKey?: IKey;
+  /**
+   * Whether the automatically created KMS key has rotation enabled. Only applies when \`encryption\` is
+   * \`BucketEncryption.KMS\` and no \`encryptionKey\` is supplied.
+   *
+   * @default true
+   */
+  readonly enableKeyRotation?: boolean;
 }
 
 /**
@@ -5217,17 +5401,22 @@ export class StaticWebsite extends Construct {
       websiteName,
       domainNames,
       certificate,
+      enableWaf = true,
+      encryption = BucketEncryption.KMS,
+      encryptionKey,
+      enableKeyRotation = true,
     }: StaticWebsiteProps,
   ) {
     super(scope, id);
 
-    const websiteKey = new Key(this, 'WebsiteKey', {
-      enableKeyRotation: true,
-    });
+    const websiteKey: IKey | undefined =
+      encryption === BucketEncryption.KMS
+        ? (encryptionKey ?? new Key(this, 'WebsiteKey', { enableKeyRotation }))
+        : undefined;
 
     // Allow CloudWatch Logs to use the website key for server access log delivery.
     const stack = Stack.of(this);
-    websiteKey.addToResourcePolicy(
+    websiteKey?.addToResourcePolicy(
       new PolicyStatement({
         effect: Effect.ALLOW,
         principals: [
@@ -5261,7 +5450,7 @@ export class StaticWebsite extends Construct {
       enforceSSL: true,
       autoDeleteObjects: true,
       removalPolicy: RemovalPolicy.DESTROY,
-      encryption: BucketEncryption.KMS,
+      encryption,
       encryptionKey: websiteKey,
       objectOwnership: ObjectOwnership.BUCKET_OWNER_ENFORCED,
       publicReadAccess: false,
@@ -5278,7 +5467,7 @@ export class StaticWebsite extends Construct {
       accessLogs,
     );
     // Web ACL
-    const wafStack = new CloudfrontWebAcl(this, 'waf');
+    const wafStack = enableWaf ? new CloudfrontWebAcl(this, 'waf') : undefined;
 
     // Bucket holding CloudFront standard access logs. CloudFront delivers its
     // own logs to S3 only, so this bucket is retained; its S3 server access
@@ -5287,7 +5476,7 @@ export class StaticWebsite extends Construct {
       enforceSSL: true,
       autoDeleteObjects: true,
       removalPolicy: RemovalPolicy.DESTROY,
-      encryption: BucketEncryption.KMS,
+      encryption,
       encryptionKey: websiteKey,
       objectOwnership: ObjectOwnership.BUCKET_OWNER_PREFERRED,
       publicReadAccess: false,
@@ -5340,7 +5529,7 @@ export class StaticWebsite extends Construct {
       this,
       'CloudfrontDistribution',
       {
-        webAclId: wafStack.wafArn,
+        webAclId: wafStack?.wafArn,
         enableLogging: true,
         logBucket: logBucket,
         ...(certificate
@@ -5539,11 +5728,17 @@ export class CloudfrontWebAcl extends Stack {
 exports[`react-website generator > should generate shared constructs > test-app.ts 1`] = `
 "import * as url from 'url';
 import { Construct } from 'constructs';
-import { StaticWebsite } from '../../core/index.js';
+import { StaticWebsite, StaticWebsiteProps } from '../../core/index.js';
+
+export type TestAppProps = Omit<
+  StaticWebsiteProps,
+  'websiteName' | 'websiteFilePath'
+>;
 
 export class TestApp extends StaticWebsite {
-  constructor(scope: Construct, id: string) {
+  constructor(scope: Construct, id: string, props?: TestAppProps) {
     super(scope, id, {
+      ...props,
       websiteName: 'TestApp',
       websiteFilePath: url.fileURLToPath(
         new URL('../../../../../../dist/test-app/bundle', import.meta.url),

--- a/packages/nx-plugin/src/ts/react-website/app/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/react-website/app/__snapshots__/generator.spec.ts.snap
@@ -182,13 +182,19 @@ variable "encryption" {
 }
 
 variable "kms_key_arn" {
-  description = "ARN of an existing KMS key used to encrypt the website and distribution log buckets when encryption is KMS. When not provided, a new key is created. Note that a customer-supplied key must already grant the CloudWatch Logs, S3 and CloudFront service principals the necessary permissions in its own key policy."
+  description = "ARN of an existing KMS key used to encrypt the website and distribution log buckets when encryption is KMS. When not provided and create_kms_key is true, a new key is created. Note that a customer-supplied key must already grant the CloudWatch Logs, S3 and CloudFront service principals the necessary permissions in its own key policy."
   type        = string
   default     = null
 }
 
+variable "create_kms_key" {
+  description = "Whether to create a KMS key for the website. Only applies when encryption is KMS. Set to false when supplying kms_key_arn."
+  type        = bool
+  default     = true
+}
+
 variable "enable_key_rotation" {
-  description = "Whether the automatically created KMS key has rotation enabled. Only applies when encryption is KMS and kms_key_arn is not provided."
+  description = "Whether the automatically created KMS key has rotation enabled. Only applies when encryption is KMS and create_kms_key is true."
   type        = bool
   default     = true
 }
@@ -205,7 +211,7 @@ locals {
   # website name so the longest delivery name stays within the limit.
   access_logs_name_prefix = substr(lower(var.website_name), 0, 16)
 
-  create_website_key = var.encryption == "KMS" && var.kms_key_arn == null
+  create_website_key = var.encryption == "KMS" && var.create_kms_key
   website_kms_key_arn = (
     var.encryption != "KMS" ? null :
     local.create_website_key ? aws_kms_key.website_key[0].arn :
@@ -666,12 +672,6 @@ resource "aws_cloudfront_distribution" "website" {
     Name = "\${lower(var.website_name)}-distribution-\${random_id.unique_suffix.hex}"
   }
 
-  lifecycle {
-    replace_triggered_by = [
-      aws_wafv2_web_acl.cloudfront_waf
-    ]
-  }
-
   # CloudFront validates access to the distribution logs bucket when it
   # creates the distribution.
   depends_on = [
@@ -986,13 +986,19 @@ variable "encryption" {
 }
 
 variable "kms_key_arn" {
-  description = "ARN of an existing KMS key used to encrypt the website and distribution log buckets when encryption is KMS. When not provided, a new key is created. Note that a customer-supplied key must already grant the CloudWatch Logs, S3 and CloudFront service principals the necessary permissions in its own key policy."
+  description = "ARN of an existing KMS key used to encrypt the website and distribution log buckets when encryption is KMS. When not provided and create_kms_key is true, a new key is created. Note that a customer-supplied key must already grant the CloudWatch Logs, S3 and CloudFront service principals the necessary permissions in its own key policy."
   type        = string
   default     = null
 }
 
+variable "create_kms_key" {
+  description = "Whether to create a KMS key for the website. Only applies when encryption is KMS. Set to false when supplying kms_key_arn."
+  type        = bool
+  default     = true
+}
+
 variable "enable_key_rotation" {
-  description = "Whether the automatically created KMS key has rotation enabled. Only applies when encryption is KMS and kms_key_arn is not provided."
+  description = "Whether the automatically created KMS key has rotation enabled. Only applies when encryption is KMS and create_kms_key is true."
   type        = bool
   default     = true
 }
@@ -1009,6 +1015,7 @@ module "static_website" {
   enable_waf          = var.enable_waf
   encryption          = var.encryption
   kms_key_arn         = var.kms_key_arn
+  create_kms_key      = var.create_kms_key
   enable_key_rotation = var.enable_key_rotation
 
   providers = {
@@ -1794,7 +1801,10 @@ export interface StaticWebsiteProps {
   readonly encryption?: BucketEncryption;
   /**
    * KMS key used to encrypt the website and distribution log buckets. Only used when \`encryption\` is
-   * \`BucketEncryption.KMS\`. When not provided, a new key is created.
+   * \`BucketEncryption.KMS\`. When not provided, a new key is created. Note that a key imported via
+   * \`Key.fromKeyArn\` must already grant the CloudWatch Logs, S3 and CloudFront service principals the
+   * necessary permissions in its own key policy - \`addToResourcePolicy\` is a no-op on an imported key,
+   * so this construct cannot grant them on your behalf.
    */
   readonly encryptionKey?: IKey;
   /**
@@ -3654,7 +3664,10 @@ export interface StaticWebsiteProps {
   readonly encryption?: BucketEncryption;
   /**
    * KMS key used to encrypt the website and distribution log buckets. Only used when \`encryption\` is
-   * \`BucketEncryption.KMS\`. When not provided, a new key is created.
+   * \`BucketEncryption.KMS\`. When not provided, a new key is created. Note that a key imported via
+   * \`Key.fromKeyArn\` must already grant the CloudWatch Logs, S3 and CloudFront service principals the
+   * necessary permissions in its own key policy - \`addToResourcePolicy\` is a no-op on an imported key,
+   * so this construct cannot grant them on your behalf.
    */
   readonly encryptionKey?: IKey;
   /**
@@ -5368,7 +5381,10 @@ export interface StaticWebsiteProps {
   readonly encryption?: BucketEncryption;
   /**
    * KMS key used to encrypt the website and distribution log buckets. Only used when \`encryption\` is
-   * \`BucketEncryption.KMS\`. When not provided, a new key is created.
+   * \`BucketEncryption.KMS\`. When not provided, a new key is created. Note that a key imported via
+   * \`Key.fromKeyArn\` must already grant the CloudWatch Logs, S3 and CloudFront service principals the
+   * necessary permissions in its own key policy - \`addToResourcePolicy\` is a no-op on an imported key,
+   * so this construct cannot grant them on your behalf.
    */
   readonly encryptionKey?: IKey;
   /**

--- a/packages/nx-plugin/src/utils/website-constructs/files/cdk/app/static-websites/__websiteNameKebabCase__.ts.template
+++ b/packages/nx-plugin/src/utils/website-constructs/files/cdk/app/static-websites/__websiteNameKebabCase__.ts.template
@@ -1,10 +1,19 @@
 import * as url from 'url';
 import { Construct } from 'constructs';
-import { StaticWebsite } from '../../core/index<% if (esm) { %>.js<% } %>';
+import {
+  StaticWebsite,
+  StaticWebsiteProps,
+} from '../../core/index<% if (esm) { %>.js<% } %>';
+
+export type <%= websiteNameClassName %>Props = Omit<
+  StaticWebsiteProps,
+  'websiteName' | 'websiteFilePath'
+>;
 
 export class <%= websiteNameClassName %> extends StaticWebsite {
-  constructor(scope: Construct, id: string) {
+  constructor(scope: Construct, id: string, props?: <%= websiteNameClassName %>Props) {
     super(scope, id, {
+      ...props,
       websiteName: '<%= websiteNameClassName %>',
       websiteFilePath: url.fileURLToPath(
         new URL('../../../../../../<%= websiteContentPath %>/bundle', <% if (esm) { %>import.meta.url<% } else { %>require('url').pathToFileURL(__filename).href<% } %>)

--- a/packages/nx-plugin/src/utils/website-constructs/files/cdk/core/static-website.ts.template
+++ b/packages/nx-plugin/src/utils/website-constructs/files/cdk/core/static-website.ts.template
@@ -31,7 +31,7 @@ import {
 } from 'aws-cdk-lib/aws-s3-deployment';
 import { Construct } from 'constructs';
 import { RuntimeConfig } from './runtime-config<% if (esm) { %>.js<% } %>';
-import { Key } from 'aws-cdk-lib/aws-kms';
+import { IKey, Key } from 'aws-cdk-lib/aws-kms';
 import {
   CfnDelivery,
   CfnDeliveryDestination,
@@ -74,6 +74,30 @@ export interface StaticWebsiteProps {
    * When provided, viewers are required to use TLS 1.2 or later.
    */
   readonly certificate?: ICertificate;
+  /**
+   * Whether to protect the CloudFront distribution with an AWS WAF Web ACL.
+   *
+   * @default true
+   */
+  readonly enableWaf?: boolean;
+  /**
+   * Server-side encryption for the website and distribution log buckets.
+   *
+   * @default BucketEncryption.KMS
+   */
+  readonly encryption?: BucketEncryption;
+  /**
+   * KMS key used to encrypt the website and distribution log buckets. Only used when `encryption` is
+   * `BucketEncryption.KMS`. When not provided, a new key is created.
+   */
+  readonly encryptionKey?: IKey;
+  /**
+   * Whether the automatically created KMS key has rotation enabled. Only applies when `encryption` is
+   * `BucketEncryption.KMS` and no `encryptionKey` is supplied.
+   *
+   * @default true
+   */
+  readonly enableKeyRotation?: boolean;
 }
 
 /**
@@ -92,17 +116,27 @@ export class StaticWebsite extends Construct {
   constructor(
     scope: Construct,
     id: string,
-    { websiteFilePath, websiteName, domainNames, certificate }: StaticWebsiteProps
+    {
+      websiteFilePath,
+      websiteName,
+      domainNames,
+      certificate,
+      enableWaf = true,
+      encryption = BucketEncryption.KMS,
+      encryptionKey,
+      enableKeyRotation = true,
+    }: StaticWebsiteProps
   ) {
     super(scope, id);
 
-    const websiteKey = new Key(this, 'WebsiteKey', {
-      enableKeyRotation: true,
-    });
+    const websiteKey: IKey | undefined =
+      encryption === BucketEncryption.KMS
+        ? (encryptionKey ?? new Key(this, 'WebsiteKey', { enableKeyRotation }))
+        : undefined;
 
     // Allow CloudWatch Logs to use the website key for server access log delivery.
     const stack = Stack.of(this);
-    websiteKey.addToResourcePolicy(
+    websiteKey?.addToResourcePolicy(
       new PolicyStatement({
         effect: Effect.ALLOW,
         principals: [
@@ -136,7 +170,7 @@ export class StaticWebsite extends Construct {
       enforceSSL: true,
       autoDeleteObjects: true,
       removalPolicy: RemovalPolicy.DESTROY,
-      encryption: BucketEncryption.KMS,
+      encryption,
       encryptionKey: websiteKey,
       objectOwnership: ObjectOwnership.BUCKET_OWNER_ENFORCED,
       publicReadAccess: false,
@@ -153,7 +187,7 @@ export class StaticWebsite extends Construct {
       accessLogs,
     );
     // Web ACL
-    const wafStack = new CloudfrontWebAcl(this, 'waf');
+    const wafStack = enableWaf ? new CloudfrontWebAcl(this, 'waf') : undefined;
 
     // Bucket holding CloudFront standard access logs. CloudFront delivers its
     // own logs to S3 only, so this bucket is retained; its S3 server access
@@ -162,7 +196,7 @@ export class StaticWebsite extends Construct {
       enforceSSL: true,
       autoDeleteObjects: true,
       removalPolicy: RemovalPolicy.DESTROY,
-      encryption: BucketEncryption.KMS,
+      encryption,
       encryptionKey: websiteKey,
       objectOwnership: ObjectOwnership.BUCKET_OWNER_PREFERRED,
       publicReadAccess: false,
@@ -214,7 +248,7 @@ export class StaticWebsite extends Construct {
       this,
       'CloudfrontDistribution',
       {
-        webAclId: wafStack.wafArn,
+        webAclId: wafStack?.wafArn,
         enableLogging: true,
         logBucket: logBucket,
         ...(certificate

--- a/packages/nx-plugin/src/utils/website-constructs/files/cdk/core/static-website.ts.template
+++ b/packages/nx-plugin/src/utils/website-constructs/files/cdk/core/static-website.ts.template
@@ -88,7 +88,10 @@ export interface StaticWebsiteProps {
   readonly encryption?: BucketEncryption;
   /**
    * KMS key used to encrypt the website and distribution log buckets. Only used when `encryption` is
-   * `BucketEncryption.KMS`. When not provided, a new key is created.
+   * `BucketEncryption.KMS`. When not provided, a new key is created. Note that a key imported via
+   * `Key.fromKeyArn` must already grant the CloudWatch Logs, S3 and CloudFront service principals the
+   * necessary permissions in its own key policy - `addToResourcePolicy` is a no-op on an imported key,
+   * so this construct cannot grant them on your behalf.
    */
   readonly encryptionKey?: IKey;
   /**

--- a/packages/nx-plugin/src/utils/website-constructs/files/terraform/app/static-websites/__websiteNameKebabCase__/__websiteNameKebabCase__.tf.template
+++ b/packages/nx-plugin/src/utils/website-constructs/files/terraform/app/static-websites/__websiteNameKebabCase__/__websiteNameKebabCase__.tf.template
@@ -38,13 +38,19 @@ variable "encryption" {
 }
 
 variable "kms_key_arn" {
-  description = "ARN of an existing KMS key used to encrypt the website and distribution log buckets when encryption is KMS. When not provided, a new key is created. Note that a customer-supplied key must already grant the CloudWatch Logs, S3 and CloudFront service principals the necessary permissions in its own key policy."
+  description = "ARN of an existing KMS key used to encrypt the website and distribution log buckets when encryption is KMS. When not provided and create_kms_key is true, a new key is created. Note that a customer-supplied key must already grant the CloudWatch Logs, S3 and CloudFront service principals the necessary permissions in its own key policy."
   type        = string
   default     = null
 }
 
+variable "create_kms_key" {
+  description = "Whether to create a KMS key for the website. Only applies when encryption is KMS. Set to false when supplying kms_key_arn."
+  type        = bool
+  default     = true
+}
+
 variable "enable_key_rotation" {
-  description = "Whether the automatically created KMS key has rotation enabled. Only applies when encryption is KMS and kms_key_arn is not provided."
+  description = "Whether the automatically created KMS key has rotation enabled. Only applies when encryption is KMS and create_kms_key is true."
   type        = bool
   default     = true
 }
@@ -61,6 +67,7 @@ module "static_website" {
   enable_waf          = var.enable_waf
   encryption          = var.encryption
   kms_key_arn         = var.kms_key_arn
+  create_kms_key      = var.create_kms_key
   enable_key_rotation = var.enable_key_rotation
 
   providers = {

--- a/packages/nx-plugin/src/utils/website-constructs/files/terraform/app/static-websites/__websiteNameKebabCase__/__websiteNameKebabCase__.tf.template
+++ b/packages/nx-plugin/src/utils/website-constructs/files/terraform/app/static-websites/__websiteNameKebabCase__/__websiteNameKebabCase__.tf.template
@@ -8,12 +8,60 @@ terraform {
   }
 }
 
+variable "custom_domain_names" {
+  description = "Custom domain names (aliases) for the CloudFront distribution. Requires acm_certificate_arn."
+  type        = list(string)
+  default     = []
+}
+
+variable "acm_certificate_arn" {
+  description = "ARN of an ACM certificate (in us-east-1) for the custom domain names. When set, viewers are required to use TLS 1.2 or later."
+  type        = string
+  default     = null
+}
+
+variable "enable_waf" {
+  description = "Whether to protect the CloudFront distribution with an AWS WAF Web ACL."
+  type        = bool
+  default     = true
+}
+
+variable "encryption" {
+  description = "Server-side encryption for the website and distribution log buckets. One of KMS or S3_MANAGED."
+  type        = string
+  default     = "KMS"
+
+  validation {
+    condition     = contains(["KMS", "S3_MANAGED"], var.encryption)
+    error_message = "encryption must be one of KMS or S3_MANAGED."
+  }
+}
+
+variable "kms_key_arn" {
+  description = "ARN of an existing KMS key used to encrypt the website and distribution log buckets when encryption is KMS. When not provided, a new key is created. Note that a customer-supplied key must already grant the CloudWatch Logs, S3 and CloudFront service principals the necessary permissions in its own key policy."
+  type        = string
+  default     = null
+}
+
+variable "enable_key_rotation" {
+  description = "Whether the automatically created KMS key has rotation enabled. Only applies when encryption is KMS and kms_key_arn is not provided."
+  type        = bool
+  default     = true
+}
+
 # Static website module configured for the web package
 module "static_website" {
   source = "../../../core/static-website"
 
   website_name      = "<%= websiteNameKebabCase %>"
   website_file_path = "${path.module}/../../../../../../../<%= websiteContentPath %>/bundle"
+
+  custom_domain_names = var.custom_domain_names
+  acm_certificate_arn = var.acm_certificate_arn
+  enable_waf          = var.enable_waf
+  encryption          = var.encryption
+  kms_key_arn         = var.kms_key_arn
+  enable_key_rotation = var.enable_key_rotation
 
   providers = {
     aws.us_east_1 = aws.us_east_1

--- a/packages/nx-plugin/src/utils/website-constructs/files/terraform/core/static-website/static-website.tf.template
+++ b/packages/nx-plugin/src/utils/website-constructs/files/terraform/core/static-website/static-website.tf.template
@@ -53,13 +53,19 @@ variable "encryption" {
 }
 
 variable "kms_key_arn" {
-  description = "ARN of an existing KMS key used to encrypt the website and distribution log buckets when encryption is KMS. When not provided, a new key is created. Note that a customer-supplied key must already grant the CloudWatch Logs, S3 and CloudFront service principals the necessary permissions in its own key policy."
+  description = "ARN of an existing KMS key used to encrypt the website and distribution log buckets when encryption is KMS. When not provided and create_kms_key is true, a new key is created. Note that a customer-supplied key must already grant the CloudWatch Logs, S3 and CloudFront service principals the necessary permissions in its own key policy."
   type        = string
   default     = null
 }
 
+variable "create_kms_key" {
+  description = "Whether to create a KMS key for the website. Only applies when encryption is KMS. Set to false when supplying kms_key_arn."
+  type        = bool
+  default     = true
+}
+
 variable "enable_key_rotation" {
-  description = "Whether the automatically created KMS key has rotation enabled. Only applies when encryption is KMS and kms_key_arn is not provided."
+  description = "Whether the automatically created KMS key has rotation enabled. Only applies when encryption is KMS and create_kms_key is true."
   type        = bool
   default     = true
 }
@@ -76,7 +82,7 @@ locals {
   # website name so the longest delivery name stays within the limit.
   access_logs_name_prefix = substr(lower(var.website_name), 0, 16)
 
-  create_website_key = var.encryption == "KMS" && var.kms_key_arn == null
+  create_website_key = var.encryption == "KMS" && var.create_kms_key
   website_kms_key_arn = (
     var.encryption != "KMS" ? null :
     local.create_website_key ? aws_kms_key.website_key[0].arn :
@@ -535,12 +541,6 @@ resource "aws_cloudfront_distribution" "website" {
 
   tags = {
     Name = "${lower(var.website_name)}-distribution-${random_id.unique_suffix.hex}"
-  }
-
-  lifecycle {
-    replace_triggered_by = [
-      aws_wafv2_web_acl.cloudfront_waf
-    ]
   }
 
   # CloudFront validates access to the distribution logs bucket when it

--- a/packages/nx-plugin/src/utils/website-constructs/files/terraform/core/static-website/static-website.tf.template
+++ b/packages/nx-plugin/src/utils/website-constructs/files/terraform/core/static-website/static-website.tf.template
@@ -35,6 +35,35 @@ variable "acm_certificate_arn" {
   default     = null
 }
 
+variable "enable_waf" {
+  description = "Whether to protect the CloudFront distribution with an AWS WAF Web ACL."
+  type        = bool
+  default     = true
+}
+
+variable "encryption" {
+  description = "Server-side encryption for the website and distribution log buckets. One of KMS or S3_MANAGED."
+  type        = string
+  default     = "KMS"
+
+  validation {
+    condition     = contains(["KMS", "S3_MANAGED"], var.encryption)
+    error_message = "encryption must be one of KMS or S3_MANAGED."
+  }
+}
+
+variable "kms_key_arn" {
+  description = "ARN of an existing KMS key used to encrypt the website and distribution log buckets when encryption is KMS. When not provided, a new key is created. Note that a customer-supplied key must already grant the CloudWatch Logs, S3 and CloudFront service principals the necessary permissions in its own key policy."
+  type        = string
+  default     = null
+}
+
+variable "enable_key_rotation" {
+  description = "Whether the automatically created KMS key has rotation enabled. Only applies when encryption is KMS and kms_key_arn is not provided."
+  type        = bool
+  default     = true
+}
+
 # Content-Security-Policy enforced on all responses. Restricts scripts and
 # framing to mitigate XSS and clickjacking, while permitting HTTPS/WSS calls
 # (connect-src) to AWS service endpoints such as API Gateway, Cognito and
@@ -46,6 +75,13 @@ locals {
   # Delivery source/destination names have a 60 character maximum. Truncate the
   # website name so the longest delivery name stays within the limit.
   access_logs_name_prefix = substr(lower(var.website_name), 0, 16)
+
+  create_website_key = var.encryption == "KMS" && var.kms_key_arn == null
+  website_kms_key_arn = (
+    var.encryption != "KMS" ? null :
+    local.create_website_key ? aws_kms_key.website_key[0].arn :
+    var.kms_key_arn
+  )
 }
 
 
@@ -56,9 +92,11 @@ data "aws_region" "current" {}
 
 # KMS Key for encryption
 resource "aws_kms_key" "website_key" {
+  count = local.create_website_key ? 1 : 0
+
   description             = "KMS key for ${var.website_name} website encryption"
   deletion_window_in_days = 7
-  enable_key_rotation     = true
+  enable_key_rotation     = var.enable_key_rotation
 
   policy = jsonencode({
     Version = "2012-10-17"
@@ -131,8 +169,10 @@ resource "aws_kms_key" "website_key" {
 }
 
 resource "aws_kms_alias" "website_key_alias" {
+  count = local.create_website_key ? 1 : 0
+
   name          = "alias/${lower(var.website_name)}-website-key-${random_id.unique_suffix.hex}"
-  target_key_id = aws_kms_key.website_key.key_id
+  target_key_id = aws_kms_key.website_key[0].key_id
 }
 
 # CloudWatch log group receiving S3 server access logs for the website and
@@ -140,7 +180,7 @@ resource "aws_kms_alias" "website_key_alias" {
 resource "aws_cloudwatch_log_group" "access_logs" {
   name              = "/aws/s3/${lower(var.website_name)}-access-logs-${random_id.bucket_suffix.hex}"
   retention_in_days = 365
-  kms_key_id        = aws_kms_key.website_key.arn
+  kms_key_id        = local.website_kms_key_arn
 }
 
 resource "random_id" "unique_suffix" {
@@ -177,8 +217,8 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "website_encryptio
 
   rule {
     apply_server_side_encryption_by_default {
-      kms_master_key_id = aws_kms_key.website_key.arn
-      sse_algorithm     = "aws:kms"
+      kms_master_key_id = var.encryption == "KMS" ? local.website_kms_key_arn : null
+      sse_algorithm     = var.encryption == "KMS" ? "aws:kms" : "AES256"
     }
   }
 }
@@ -242,8 +282,8 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "distribution_logs
 
   rule {
     apply_server_side_encryption_by_default {
-      kms_master_key_id = aws_kms_key.website_key.arn
-      sse_algorithm     = "aws:kms"
+      kms_master_key_id = var.encryption == "KMS" ? local.website_kms_key_arn : null
+      sse_algorithm     = var.encryption == "KMS" ? "aws:kms" : "AES256"
     }
   }
 }
@@ -313,6 +353,8 @@ resource "aws_s3_bucket_policy" "distribution_logs_ssl_policy" {
 
 # WAF Web ACL (must be in us-east-1 for CloudFront)
 resource "aws_wafv2_web_acl" "cloudfront_waf" {
+  count = var.enable_waf ? 1 : 0
+
   #checkov:skip=CKV2_AWS_31:WAF logging disabled
   provider = aws.us_east_1
   name     = "${lower(var.website_name)}-cloudfront-waf-${random_id.unique_suffix.hex}"
@@ -437,7 +479,7 @@ resource "aws_cloudfront_distribution" "website" {
   enabled             = true
   is_ipv6_enabled     = true
   default_root_object = "index.html"
-  web_acl_id          = aws_wafv2_web_acl.cloudfront_waf.arn
+  web_acl_id          = var.enable_waf ? aws_wafv2_web_acl.cloudfront_waf[0].arn : null
   aliases             = var.custom_domain_names
 
   logging_config {
@@ -773,5 +815,5 @@ output "cloudfront_domain_name" {
 
 output "waf_web_acl_arn" {
   description = "ARN of the WAF Web ACL"
-  value       = aws_wafv2_web_acl.cloudfront_waf.arn
+  value       = var.enable_waf ? aws_wafv2_web_acl.cloudfront_waf[0].arn : null
 }


### PR DESCRIPTION
### Reason for this change

The `StaticWebsite` CDK construct and its Terraform equivalent always attached a WAF Web ACL and always created a new customer-managed KMS key, with no way to opt out or bring your own. Every consumer paid for and managed a KMS key and Web ACL even when their use case didn't need one, and there was no way to point at an existing key or a different encryption mode.

This configuration was also baked into the shared base class/module instead of exposed on the per-website construct. A workspace with more than one website had no way to configure them differently; every website was forced into the same WAF and encryption behavior.

### Description of changes

- CDK `StaticWebsite` gains `enableWaf`, `encryption`, `encryptionKey` and `enableKeyRotation` props. The WAF Web ACL is now optional. The KMS key is only created when `encryption` is `BucketEncryption.KMS` and no `encryptionKey` is supplied. `enableKeyRotation` (default `true`) only applies to that auto-created key.
- The generated per-website CDK app construct (`MyWebsite`) now takes an optional `props` parameter that forwards through to `StaticWebsite`, so these props (and `domainNames`/`certificate`) can be set per website where the construct is instantiated in the application stack, instead of editing the generated file.
- Terraform `core/static-website` gains the equivalent `enable_waf`, `encryption`, `kms_key_arn`, `enable_key_rotation` variables, with the KMS key/alias and WAF ACL made conditional via `count`.
- Extended this to the Terraform app-level module too (`app/static-websites/<name>/<name>.tf`), which previously hardcoded everything except `website_name`/`website_file_path`. It now forwards all of the above plus the pre-existing `custom_domain_names`/`acm_certificate_arn`, matching the pass-through convention every other app-wraps-core Terraform module in this plugin already follows (`rdb`, `agent-core`, `dcr-proxies`, the REST/HTTP API). Each website's module can now be configured independently.
- Added an Nx migration (`static-website-configurable-waf-encryption`) to bring existing workspaces up to this shape across all three surfaces: the CDK core construct, CDK app constructs, and Terraform core plus app modules. It pattern-matches the vended shape before rewriting anything and reports diverged files via `nextSteps` instead of touching what it can't confirm.
- Updated the `react-website` guide with new WAF and Bucket Encryption sections, and rewrote the Custom Domain & TLS example. All three, plus the existing Security Headers section, moved from under Generator Output → Infrastructure to their own sections under Deploying Your Website, matching how `trpc.mdx`/`fastapi.mdx` place WAF and Access logging under their own "Deploying your X" heading rather than under Generator Output. The CDK examples now show configuring `domainNames`/`certificate`/`enableWaf`/`encryption` at the application-stack level (`new MyWebsite(this, 'MyWebsite', { ... })`), matching the equivalent `enableWaf` example already documented for the tRPC API generator.
- Added a note with working code showing that disabling WAF on CDK requires suppressing the checkov `CKV_AWS_68` check. Terraform doesn't need the same suppression, since checkov doesn't statically evaluate its runtime conditional the same way.
- Fixed a stale code example in the dungeon-game tutorial: the literal `GameUI` construct snippet no longer matched what `ts#website` generates, since it predated this change. Updated it to show the new `Props` type and `props` constructor parameter.

### Description of how you validated changes

Unit tests for the migration cover 17 cases: applying to the vended shape, idempotency on re-run, and workspaces that already customized the pre-existing `domainNames`/`certificate` (CDK) or `custom_domain_names`/`acm_certificate_arn` (Terraform) properties. That last case caught two real bugs while writing the migration:

- A GritQL pattern that anchored on `websiteName` being followed by exactly one more property, which only matches a single trailing node, not an arbitrary list. A workspace with more than one existing customization (say `domainNames` and `certificate` both) failed the match and was safely skipped, though not migrated.
- A missing divergence check on the Terraform side that would have silently produced a duplicate `custom_domain_names` argument, which is invalid HCL, with no warning to the user.

Both are fixed and now have regression tests.

Also validated end to end against real generated workspaces, not just unit tests:

- Built the plugin locally, generated fresh CDK and Terraform workspaces on the published version, and ran the actual `nx migrate` cycle against the local build.
- `terraform validate` passes on the migrated module, including with `enable_waf = false` and `encryption = "S3_MANAGED"` set at the root module call.
- The Terraform `checkov` target reports 0 failed checks for the default configuration. Setting `encryption = "S3_MANAGED"` or `enable_key_rotation = false` does fail checkov (`CKV_AWS_145`/`CKV_AWS_7`); this needs a `.checkov.yaml` skip, now documented in the Bucket Encryption section.
- The CDK `checkov` target genuinely fails with `CKV_AWS_68` when `enableWaf: false`, confirming the new doc note is necessary, and passes again once suppressed per the documented example.
- Re-running the migration reports "No changes were made" against the real project.
- Checked the one change that looked riskiest for anyone with an already-deployed Terraform stack: introducing `count` on the KMS key, KMS alias, and WAF ACL changes their resource addresses. Reproduced the exact same pattern locally (a `local` expression combining two variables, same as the real template) with `random_id` resources so I could actually apply and plan without AWS credentials. Terraform's plan showed 0 to add, 0 to change, 0 to destroy, just a "has moved to" note. This has been automatic since Terraform 1.1, so it's not a break for anyone on a reasonably current CLI.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
