### PR TITLE
feat(dynamodb): make table encryption configurable

### DIFF
--- a/docs/src/content/docs/en/snippets/dynamodb/deploying-table.mdx
+++ b/docs/src/content/docs/en/snippets/dynamodb/deploying-table.mdx
@@ -2,6 +2,7 @@
 title: Deploying your DynamoDB Table
 ---
 import Infrastructure from '@components/infrastructure.astro';
+import Snippet from '@components/snippet.astro';
 
 The DynamoDB generator creates CDK or Terraform infrastructure based on your selected `iac`.
 
@@ -137,30 +138,8 @@ module "my_table" {
 </Fragment>
 </Infrastructure>
 
-### Encryption Key Rotation
+### Encryption
 
-The KMS key used to encrypt the table has automatic key rotation enabled by default. Disable it if your security policy manages rotation externally.
+The table is encrypted with a customer-managed KMS key by default, created automatically for you. Switch to an AWS managed key, the AWS owned key, or bring your own KMS key, if you manage encryption differently.
 
-#### Disable Encryption Key Rotation
-
-<Infrastructure>
-<Fragment slot="cdk">
-
-```ts title="packages/infra/src/stacks/application-stack.ts"
-import { MyTable } from '@my-scope/common-constructs';
-
-const table = new MyTable(this, 'Table', {
-  enableKeyRotation: false,
-});
-```
-</Fragment>
-<Fragment slot="terraform">
-
-```hcl title="packages/infra/src/main.tf"
-module "my_table" {
-  source              = "../../common/terraform/src/app/dynamodb/my-table"
-  enable_key_rotation = false
-}
-```
-</Fragment>
-</Infrastructure>
+<Snippet name="dynamodb/encryption-options" parentHeading="Encryption" />

--- a/docs/src/content/docs/en/snippets/dynamodb/encryption-options.mdx
+++ b/docs/src/content/docs/en/snippets/dynamodb/encryption-options.mdx
@@ -2,6 +2,7 @@
 title: Encryption Options
 ---
 import Infrastructure from '@components/infrastructure.astro';
+import OptionFilter from '@components/option-filter.astro';
 
 #### Use an AWS Managed Key
 
@@ -18,6 +19,16 @@ const table = new MyTable(this, 'Table', {
   encryption: TableEncryption.AWS_MANAGED,
 });
 ```
+
+:::tip[Checkov]
+Choosing `AWS_MANAGED` means the table is no longer encrypted with a customer-managed key, which fails Checkov's `CKV_AWS_119`. Suppress it on the table:
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { suppressRules } from '@my-scope/common-constructs';
+
+suppressRules(table.table, ['CKV_AWS_119'], 'Using an AWS managed key rather than a customer-managed CMK');
+```
+:::
 </Fragment>
 <Fragment slot="terraform">
 
@@ -45,6 +56,16 @@ const table = new MyTable(this, 'Table', {
   encryption: TableEncryption.DEFAULT,
 });
 ```
+
+:::tip[Checkov]
+Choosing `DEFAULT` means the table is no longer encrypted with a customer-managed key, which fails Checkov's `CKV_AWS_119`. Suppress it on the table:
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { suppressRules } from '@my-scope/common-constructs';
+
+suppressRules(table.table, ['CKV_AWS_119'], 'Using the AWS owned key rather than a customer-managed CMK');
+```
+:::
 </Fragment>
 <Fragment slot="terraform">
 
@@ -56,6 +77,28 @@ module "my_table" {
 ```
 </Fragment>
 </Infrastructure>
+
+<OptionFilter when={{ iac: 'terraform' }} description="Switching an already-deployed table away from CUSTOMER_MANAGED">
+#### Switching away from CUSTOMER_MANAGED
+
+On an **already-deployed** table, changing `encryption` away from `CUSTOMER_MANAGED` (to either `AWS_MANAGED` or `DEFAULT`) in a single `terraform apply` fails: Terraform destroys the customer-managed key before updating the table, and DynamoDB then rejects the update because the key is already pending deletion.
+
+Work around it by updating the table's encryption directly via the AWS CLI first, then letting Terraform catch up and clean up the orphaned key:
+
+```bash
+# For AWS_MANAGED:
+aws dynamodb update-table --table-name <table-name> \
+  --sse-specification Enabled=true,SSEType=KMS,KMSMasterKeyId=alias/aws/dynamodb
+
+# For DEFAULT:
+aws dynamodb update-table --table-name <table-name> --sse-specification Enabled=false
+
+# Then wait for this to report ENABLED (or for SSEDescription to disappear, for DEFAULT):
+aws dynamodb describe-table --table-name <table-name> --query Table.SSEDescription.Status
+```
+
+Then update `encryption` in your Terraform config and run `terraform apply` as normal — Terraform now only needs to destroy the already-unused key, with nothing left depending on it.
+</OptionFilter>
 
 #### Use Your Own KMS Key
 
@@ -102,6 +145,16 @@ const table = new MyTable(this, 'Table', {
   enableKeyRotation: false,
 });
 ```
+
+:::tip[Checkov]
+Disabling key rotation, or bringing your own key that doesn't rotate, fails Checkov's `CKV_AWS_7`. Suppress it on the key:
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { suppressRules } from '@my-scope/common-constructs';
+
+suppressRules(table.table.encryptionKey!, ['CKV_AWS_7'], 'Key rotation is managed externally');
+```
+:::
 </Fragment>
 <Fragment slot="terraform">
 

--- a/docs/src/content/docs/en/snippets/dynamodb/encryption-options.mdx
+++ b/docs/src/content/docs/en/snippets/dynamodb/encryption-options.mdx
@@ -1,0 +1,115 @@
+---
+title: Encryption Options
+---
+import Infrastructure from '@components/infrastructure.astro';
+
+#### Use an AWS Managed Key
+
+Uses the shared `aws/dynamodb` KMS key that AWS manages on your behalf. It's visible in your account's KMS console and billed per request, but there's no key for you to create, rotate or delete.
+
+<Infrastructure>
+<Fragment slot="cdk">
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { TableEncryption } from 'aws-cdk-lib/aws-dynamodb';
+import { MyTable } from '@my-scope/common-constructs';
+
+const table = new MyTable(this, 'Table', {
+  encryption: TableEncryption.AWS_MANAGED,
+});
+```
+</Fragment>
+<Fragment slot="terraform">
+
+```hcl title="packages/infra/src/main.tf"
+module "my_table" {
+  source     = "../../common/terraform/src/app/dynamodb/my-table"
+  encryption = "AWS_MANAGED"
+}
+```
+</Fragment>
+</Infrastructure>
+
+#### Use the AWS Owned Key
+
+Uses a key fully owned and managed by AWS — free, with no key visible in your account at all. The simplest option when you don't need a customer- or account-visible key for compliance reasons.
+
+<Infrastructure>
+<Fragment slot="cdk">
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { TableEncryption } from 'aws-cdk-lib/aws-dynamodb';
+import { MyTable } from '@my-scope/common-constructs';
+
+const table = new MyTable(this, 'Table', {
+  encryption: TableEncryption.DEFAULT,
+});
+```
+</Fragment>
+<Fragment slot="terraform">
+
+```hcl title="packages/infra/src/main.tf"
+module "my_table" {
+  source     = "../../common/terraform/src/app/dynamodb/my-table"
+  encryption = "DEFAULT"
+}
+```
+</Fragment>
+</Infrastructure>
+
+#### Use Your Own KMS Key
+
+Provide an existing customer-managed key instead of having one created for you. The key must already grant the DynamoDB service the permissions it needs in its own key policy.
+
+<Infrastructure>
+<Fragment slot="cdk">
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { Key } from 'aws-cdk-lib/aws-kms';
+import { MyTable } from '@my-scope/common-constructs';
+
+const key = Key.fromKeyArn(this, 'Key', 'arn:aws:kms:us-east-1:111111111111:key/my-key-id');
+
+const table = new MyTable(this, 'Table', {
+  encryptionKey: key,
+});
+```
+</Fragment>
+<Fragment slot="terraform">
+
+```hcl title="packages/infra/src/main.tf"
+module "my_table" {
+  source      = "../../common/terraform/src/app/dynamodb/my-table"
+  kms_key_arn = "arn:aws:kms:us-east-1:111111111111:key/my-key-id"
+}
+```
+</Fragment>
+</Infrastructure>
+
+#### Encryption Key Rotation
+
+When the table creates its own customer-managed KMS key (the default, and only when you haven't provided your own key), that key has automatic key rotation enabled by default. Disable it if your security policy manages rotation externally.
+
+##### Disable Encryption Key Rotation
+
+<Infrastructure>
+<Fragment slot="cdk">
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { MyTable } from '@my-scope/common-constructs';
+
+const table = new MyTable(this, 'Table', {
+  enableKeyRotation: false,
+});
+```
+</Fragment>
+<Fragment slot="terraform">
+
+```hcl title="packages/infra/src/main.tf"
+module "my_table" {
+  source              = "../../common/terraform/src/app/dynamodb/my-table"
+  enable_key_rotation = false
+}
+```
+</Fragment>
+</Infrastructure>

--- a/docs/src/content/docs/es/snippets/dynamodb/deploying-table.mdx
+++ b/docs/src/content/docs/es/snippets/dynamodb/deploying-table.mdx
@@ -1,7 +1,8 @@
 ---
-title: Desplegando tu Tabla de DynamoDB
+title: Desplegando tu tabla de DynamoDB
 ---
 import Infrastructure from '@components/infrastructure.astro';
+import Snippet from '@components/snippet.astro';
 
 El generador de DynamoDB crea infraestructura CDK o Terraform basada en tu `iac` seleccionado.
 
@@ -22,11 +23,11 @@ export class ApplicationStack extends Stack {
 ```
 
 Esto aprovisiona una tabla de DynamoDB con:
-- `pk` (clave de partición) y `sk` (clave de ordenamiento), ambas de tipo `String`
+- `pk` (clave de partición) y `sk` (clave de ordenación), ambas de tipo `String`
 - Índices Secundarios Globales según se definen en `config.json`
 - Facturación bajo demanda (`PAY_PER_REQUEST`)
 - Cifrado KMS gestionado por el cliente con rotación automática de claves
-- Recuperación point-in-time habilitada
+- Recuperación a un punto en el tiempo habilitada
 - Protección contra eliminación habilitada
 - Nombre de tabla registrado en Runtime Config bajo el espacio de nombres `dynamodb` en AWS AppConfig
 </Fragment>
@@ -40,23 +41,23 @@ module "my_table" {
 ```
 
 Esto aprovisiona una tabla de DynamoDB con:
-- `pk` (clave de partición) y `sk` (clave de ordenamiento), ambas de tipo `String`
+- `pk` (clave de partición) y `sk` (clave de ordenación), ambas de tipo `String`
 - Índices Secundarios Globales según se definen en `config.json`
 - Facturación bajo demanda (`PAY_PER_REQUEST`)
 - Cifrado KMS gestionado por el cliente con rotación automática de claves
-- Recuperación point-in-time habilitada
+- Recuperación a un punto en el tiempo habilitada
 - Protección contra eliminación habilitada
 - Nombre de tabla registrado en Runtime Config
 </Fragment>
 </Infrastructure>
 
-### Protección contra Eliminación
+### Protección contra eliminación
 
 La protección contra eliminación está habilitada por defecto para prevenir la eliminación accidental de la tabla.
 
-#### Deshabilitar la Protección contra Eliminación
+#### Deshabilitar la protección contra eliminación
 
-Deshabilítala para entornos donde se espera la eliminación de tablas, como stacks de desarrollo o preview de corta duración.
+Deshabilítala para entornos donde se espera la eliminación de tablas, como stacks de desarrollo o vista previa de corta duración.
 
 <Infrastructure>
 <Fragment slot="cdk">
@@ -80,9 +81,9 @@ module "my_table" {
 </Fragment>
 </Infrastructure>
 
-### Modo de Facturación
+### Modo de facturación
 
-La tabla usa por defecto facturación bajo demanda (`PAY_PER_REQUEST`). Cambia a capacidad aprovisionada para cargas de trabajo predecibles de alto rendimiento.
+La tabla utiliza por defecto facturación bajo demanda (`PAY_PER_REQUEST`). Cambia a capacidad aprovisionada para cargas de trabajo predecibles de alto rendimiento.
 
 <Infrastructure>
 <Fragment slot="cdk">
@@ -109,11 +110,11 @@ module "my_table" {
 </Fragment>
 </Infrastructure>
 
-### Recuperación Point-in-time
+### Recuperación a un punto en el tiempo
 
-La [recuperación point-in-time](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Point-in-time-recovery.html) está habilitada por defecto, permitiéndote restaurar la tabla a cualquier punto en los últimos 35 días.
+La [recuperación a un punto en el tiempo](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Point-in-time-recovery.html) está habilitada por defecto, permitiéndote restaurar la tabla a cualquier punto en los últimos 35 días.
 
-#### Deshabilitar la Recuperación Point-in-time
+#### Deshabilitar la recuperación a un punto en el tiempo
 
 <Infrastructure>
 <Fragment slot="cdk">
@@ -137,30 +138,8 @@ module "my_table" {
 </Fragment>
 </Infrastructure>
 
-### Rotación de Clave de Cifrado
+### Cifrado
 
-La clave KMS utilizada para cifrar la tabla tiene la rotación automática de claves habilitada por defecto. Deshabilítala si tu política de seguridad gestiona la rotación externamente.
+La tabla está cifrada con una clave KMS gestionada por el cliente por defecto, creada automáticamente para ti. Cambia a una clave gestionada por AWS, la clave propiedad de AWS, o trae tu propia clave KMS, si gestionas el cifrado de manera diferente.
 
-#### Deshabilitar la Rotación de Clave de Cifrado
-
-<Infrastructure>
-<Fragment slot="cdk">
-
-```ts title="packages/infra/src/stacks/application-stack.ts"
-import { MyTable } from '@my-scope/common-constructs';
-
-const table = new MyTable(this, 'Table', {
-  enableKeyRotation: false,
-});
-```
-</Fragment>
-<Fragment slot="terraform">
-
-```hcl title="packages/infra/src/main.tf"
-module "my_table" {
-  source              = "../../common/terraform/src/app/dynamodb/my-table"
-  enable_key_rotation = false
-}
-```
-</Fragment>
-</Infrastructure>
+<Snippet name="dynamodb/encryption-options" parentHeading="Cifrado" />

--- a/docs/src/content/docs/es/snippets/dynamodb/encryption-options.mdx
+++ b/docs/src/content/docs/es/snippets/dynamodb/encryption-options.mdx
@@ -2,6 +2,7 @@
 title: Opciones de Cifrado
 ---
 import Infrastructure from '@components/infrastructure.astro';
+import OptionFilter from '@components/option-filter.astro';
 
 #### Usar una clave gestionada por AWS
 
@@ -18,6 +19,16 @@ const table = new MyTable(this, 'Table', {
   encryption: TableEncryption.AWS_MANAGED,
 });
 ```
+
+:::tip[Checkov]
+Elegir `AWS_MANAGED` significa que la tabla ya no está cifrada con una clave gestionada por el cliente, lo que falla la regla `CKV_AWS_119` de Checkov. Suprímela en la tabla:
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { suppressRules } from '@my-scope/common-constructs';
+
+suppressRules(table.table, ['CKV_AWS_119'], 'Using an AWS managed key rather than a customer-managed CMK');
+```
+:::
 </Fragment>
 <Fragment slot="terraform">
 
@@ -45,6 +56,16 @@ const table = new MyTable(this, 'Table', {
   encryption: TableEncryption.DEFAULT,
 });
 ```
+
+:::tip[Checkov]
+Elegir `DEFAULT` significa que la tabla ya no está cifrada con una clave gestionada por el cliente, lo que falla la regla `CKV_AWS_119` de Checkov. Suprímela en la tabla:
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { suppressRules } from '@my-scope/common-constructs';
+
+suppressRules(table.table, ['CKV_AWS_119'], 'Using the AWS owned key rather than a customer-managed CMK');
+```
+:::
 </Fragment>
 <Fragment slot="terraform">
 
@@ -56,6 +77,28 @@ module "my_table" {
 ```
 </Fragment>
 </Infrastructure>
+
+<OptionFilter when={{ iac: 'terraform' }} description="Switching an already-deployed table away from CUSTOMER_MANAGED">
+#### Cambiar desde CUSTOMER_MANAGED
+
+En una tabla **ya desplegada**, cambiar `encryption` desde `CUSTOMER_MANAGED` (a `AWS_MANAGED` o `DEFAULT`) en un solo `terraform apply` falla: Terraform destruye la clave gestionada por el cliente antes de actualizar la tabla, y DynamoDB rechaza la actualización porque la clave ya está pendiente de eliminación.
+
+Soluciona esto actualizando el cifrado de la tabla directamente a través de AWS CLI primero, y luego dejando que Terraform se ponga al día y limpie la clave huérfana:
+
+```bash
+# For AWS_MANAGED:
+aws dynamodb update-table --table-name <table-name> \
+  --sse-specification Enabled=true,SSEType=KMS,KMSMasterKeyId=alias/aws/dynamodb
+
+# For DEFAULT:
+aws dynamodb update-table --table-name <table-name> --sse-specification Enabled=false
+
+# Then wait for this to report ENABLED (or for SSEDescription to disappear, for DEFAULT):
+aws dynamodb describe-table --table-name <table-name> --query Table.SSEDescription.Status
+```
+
+Luego actualiza `encryption` en tu configuración de Terraform y ejecuta `terraform apply` normalmente — Terraform ahora solo necesita destruir la clave ya no utilizada, sin nada que dependa de ella.
+</OptionFilter>
 
 #### Usar tu propia clave KMS
 
@@ -102,6 +145,16 @@ const table = new MyTable(this, 'Table', {
   enableKeyRotation: false,
 });
 ```
+
+:::tip[Checkov]
+Deshabilitar la rotación de claves, o traer tu propia clave que no rota, falla la regla `CKV_AWS_7` de Checkov. Suprímela en la clave:
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { suppressRules } from '@my-scope/common-constructs';
+
+suppressRules(table.table.encryptionKey!, ['CKV_AWS_7'], 'Key rotation is managed externally');
+```
+:::
 </Fragment>
 <Fragment slot="terraform">
 

--- a/docs/src/content/docs/es/snippets/dynamodb/encryption-options.mdx
+++ b/docs/src/content/docs/es/snippets/dynamodb/encryption-options.mdx
@@ -1,0 +1,115 @@
+---
+title: Opciones de Cifrado
+---
+import Infrastructure from '@components/infrastructure.astro';
+
+#### Usar una clave gestionada por AWS
+
+Usa la clave KMS compartida `aws/dynamodb` que AWS gestiona en tu nombre. Es visible en la consola KMS de tu cuenta y se factura por solicitud, pero no hay ninguna clave que debas crear, rotar o eliminar.
+
+<Infrastructure>
+<Fragment slot="cdk">
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { TableEncryption } from 'aws-cdk-lib/aws-dynamodb';
+import { MyTable } from '@my-scope/common-constructs';
+
+const table = new MyTable(this, 'Table', {
+  encryption: TableEncryption.AWS_MANAGED,
+});
+```
+</Fragment>
+<Fragment slot="terraform">
+
+```hcl title="packages/infra/src/main.tf"
+module "my_table" {
+  source     = "../../common/terraform/src/app/dynamodb/my-table"
+  encryption = "AWS_MANAGED"
+}
+```
+</Fragment>
+</Infrastructure>
+
+#### Usar la clave propiedad de AWS
+
+Usa una clave totalmente propiedad y gestionada por AWS — gratuita, sin ninguna clave visible en tu cuenta. La opción más simple cuando no necesitas una clave visible para el cliente o la cuenta por razones de cumplimiento.
+
+<Infrastructure>
+<Fragment slot="cdk">
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { TableEncryption } from 'aws-cdk-lib/aws-dynamodb';
+import { MyTable } from '@my-scope/common-constructs';
+
+const table = new MyTable(this, 'Table', {
+  encryption: TableEncryption.DEFAULT,
+});
+```
+</Fragment>
+<Fragment slot="terraform">
+
+```hcl title="packages/infra/src/main.tf"
+module "my_table" {
+  source     = "../../common/terraform/src/app/dynamodb/my-table"
+  encryption = "DEFAULT"
+}
+```
+</Fragment>
+</Infrastructure>
+
+#### Usar tu propia clave KMS
+
+Proporciona una clave gestionada por el cliente existente en lugar de que se cree una para ti. La clave ya debe otorgar al servicio DynamoDB los permisos que necesita en su propia política de claves.
+
+<Infrastructure>
+<Fragment slot="cdk">
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { Key } from 'aws-cdk-lib/aws-kms';
+import { MyTable } from '@my-scope/common-constructs';
+
+const key = Key.fromKeyArn(this, 'Key', 'arn:aws:kms:us-east-1:111111111111:key/my-key-id');
+
+const table = new MyTable(this, 'Table', {
+  encryptionKey: key,
+});
+```
+</Fragment>
+<Fragment slot="terraform">
+
+```hcl title="packages/infra/src/main.tf"
+module "my_table" {
+  source      = "../../common/terraform/src/app/dynamodb/my-table"
+  kms_key_arn = "arn:aws:kms:us-east-1:111111111111:key/my-key-id"
+}
+```
+</Fragment>
+</Infrastructure>
+
+#### Rotación de clave de cifrado
+
+Cuando la tabla crea su propia clave KMS gestionada por el cliente (el valor por defecto, y solo cuando no has proporcionado tu propia clave), esa clave tiene la rotación automática de claves habilitada por defecto. Deshabilítala si tu política de seguridad gestiona la rotación externamente.
+
+##### Deshabilitar la rotación de clave de cifrado
+
+<Infrastructure>
+<Fragment slot="cdk">
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { MyTable } from '@my-scope/common-constructs';
+
+const table = new MyTable(this, 'Table', {
+  enableKeyRotation: false,
+});
+```
+</Fragment>
+<Fragment slot="terraform">
+
+```hcl title="packages/infra/src/main.tf"
+module "my_table" {
+  source              = "../../common/terraform/src/app/dynamodb/my-table"
+  enable_key_rotation = false
+}
+```
+</Fragment>
+</Infrastructure>

--- a/docs/src/content/docs/fr/snippets/dynamodb/deploying-table.mdx
+++ b/docs/src/content/docs/fr/snippets/dynamodb/deploying-table.mdx
@@ -143,3 +143,4 @@ module "my_table" {
 La table est chiffrée avec une clé KMS gérée par le client par défaut, créée automatiquement pour vous. Passez à une clé gérée par AWS, à la clé détenue par AWS, ou apportez votre propre clé KMS, si vous gérez le chiffrement différemment.
 
 <Snippet name="dynamodb/encryption-options" parentHeading="Chiffrement" />
+

--- a/docs/src/content/docs/fr/snippets/dynamodb/deploying-table.mdx
+++ b/docs/src/content/docs/fr/snippets/dynamodb/deploying-table.mdx
@@ -2,6 +2,7 @@
 title: Déploiement de votre table DynamoDB
 ---
 import Infrastructure from '@components/infrastructure.astro';
+import Snippet from '@components/snippet.astro';
 
 Le générateur DynamoDB crée une infrastructure CDK ou Terraform en fonction de votre `iac` sélectionné.
 
@@ -26,7 +27,7 @@ Cela provisionne une table DynamoDB avec :
 - Des index secondaires globaux tels que définis dans `config.json`
 - Une facturation à la demande (`PAY_PER_REQUEST`)
 - Un chiffrement KMS géré par le client avec rotation automatique des clés
-- La récupération à un instant donné activée
+- La récupération à un instant dans le passé activée
 - La protection contre la suppression activée
 - Le nom de la table enregistré dans Runtime Config sous l'espace de noms `dynamodb` dans AWS AppConfig
 </Fragment>
@@ -44,7 +45,7 @@ Cela provisionne une table DynamoDB avec :
 - Des index secondaires globaux tels que définis dans `config.json`
 - Une facturation à la demande (`PAY_PER_REQUEST`)
 - Un chiffrement KMS géré par le client avec rotation automatique des clés
-- La récupération à un instant donné activée
+- La récupération à un instant dans le passé activée
 - La protection contre la suppression activée
 - Le nom de la table enregistré dans Runtime Config
 </Fragment>
@@ -52,7 +53,7 @@ Cela provisionne une table DynamoDB avec :
 
 ### Protection contre la suppression
 
-La protection contre la suppression est activée par défaut pour empêcher la suppression accidentelle de la table.
+La protection contre la suppression est activée par défaut pour éviter la suppression accidentelle de la table.
 
 #### Désactiver la protection contre la suppression
 
@@ -82,7 +83,7 @@ module "my_table" {
 
 ### Mode de facturation
 
-La table utilise par défaut une facturation à la demande (`PAY_PER_REQUEST`). Passez à une capacité provisionnée pour des charges de travail prévisibles à haut débit.
+La table utilise par défaut la facturation à la demande (`PAY_PER_REQUEST`). Passez à la capacité provisionnée pour des charges de travail prévisibles à haut débit.
 
 <Infrastructure>
 <Fragment slot="cdk">
@@ -109,11 +110,11 @@ module "my_table" {
 </Fragment>
 </Infrastructure>
 
-### Récupération à un instant donné
+### Récupération à un instant dans le passé
 
-La [récupération à un instant donné](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Point-in-time-recovery.html) est activée par défaut, vous permettant de restaurer la table à n'importe quel moment des 35 derniers jours.
+La [récupération à un instant dans le passé](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Point-in-time-recovery.html) est activée par défaut, vous permettant de restaurer la table à n'importe quel moment des 35 derniers jours.
 
-#### Désactiver la récupération à un instant donné
+#### Désactiver la récupération à un instant dans le passé
 
 <Infrastructure>
 <Fragment slot="cdk">
@@ -137,30 +138,8 @@ module "my_table" {
 </Fragment>
 </Infrastructure>
 
-### Rotation des clés de chiffrement
+### Chiffrement
 
-La clé KMS utilisée pour chiffrer la table a la rotation automatique des clés activée par défaut. Désactivez-la si votre politique de sécurité gère la rotation en externe.
+La table est chiffrée avec une clé KMS gérée par le client par défaut, créée automatiquement pour vous. Passez à une clé gérée par AWS, à la clé détenue par AWS, ou apportez votre propre clé KMS, si vous gérez le chiffrement différemment.
 
-#### Désactiver la rotation des clés de chiffrement
-
-<Infrastructure>
-<Fragment slot="cdk">
-
-```ts title="packages/infra/src/stacks/application-stack.ts"
-import { MyTable } from '@my-scope/common-constructs';
-
-const table = new MyTable(this, 'Table', {
-  enableKeyRotation: false,
-});
-```
-</Fragment>
-<Fragment slot="terraform">
-
-```hcl title="packages/infra/src/main.tf"
-module "my_table" {
-  source              = "../../common/terraform/src/app/dynamodb/my-table"
-  enable_key_rotation = false
-}
-```
-</Fragment>
-</Infrastructure>
+<Snippet name="dynamodb/encryption-options" parentHeading="Chiffrement" />

--- a/docs/src/content/docs/fr/snippets/dynamodb/encryption-options.mdx
+++ b/docs/src/content/docs/fr/snippets/dynamodb/encryption-options.mdx
@@ -1,0 +1,115 @@
+---
+title: Options de Chiffrement
+---
+import Infrastructure from '@components/infrastructure.astro';
+
+#### Utiliser une clé gérée par AWS
+
+Utilise la clé KMS partagée `aws/dynamodb` qu'AWS gère en votre nom. Elle est visible dans la console KMS de votre compte et facturée par requête, mais il n'y a pas de clé à créer, faire pivoter ou supprimer.
+
+<Infrastructure>
+<Fragment slot="cdk">
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { TableEncryption } from 'aws-cdk-lib/aws-dynamodb';
+import { MyTable } from '@my-scope/common-constructs';
+
+const table = new MyTable(this, 'Table', {
+  encryption: TableEncryption.AWS_MANAGED,
+});
+```
+</Fragment>
+<Fragment slot="terraform">
+
+```hcl title="packages/infra/src/main.tf"
+module "my_table" {
+  source     = "../../common/terraform/src/app/dynamodb/my-table"
+  encryption = "AWS_MANAGED"
+}
+```
+</Fragment>
+</Infrastructure>
+
+#### Utiliser la clé détenue par AWS
+
+Utilise une clé entièrement détenue et gérée par AWS — gratuite, sans clé visible dans votre compte. L'option la plus simple lorsque vous n'avez pas besoin d'une clé visible par le client ou le compte pour des raisons de conformité.
+
+<Infrastructure>
+<Fragment slot="cdk">
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { TableEncryption } from 'aws-cdk-lib/aws-dynamodb';
+import { MyTable } from '@my-scope/common-constructs';
+
+const table = new MyTable(this, 'Table', {
+  encryption: TableEncryption.DEFAULT,
+});
+```
+</Fragment>
+<Fragment slot="terraform">
+
+```hcl title="packages/infra/src/main.tf"
+module "my_table" {
+  source     = "../../common/terraform/src/app/dynamodb/my-table"
+  encryption = "DEFAULT"
+}
+```
+</Fragment>
+</Infrastructure>
+
+#### Utiliser votre propre clé KMS
+
+Fournissez une clé gérée par le client existante au lieu d'en faire créer une pour vous. La clé doit déjà accorder au service DynamoDB les permissions dont il a besoin dans sa propre politique de clé.
+
+<Infrastructure>
+<Fragment slot="cdk">
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { Key } from 'aws-cdk-lib/aws-kms';
+import { MyTable } from '@my-scope/common-constructs';
+
+const key = Key.fromKeyArn(this, 'Key', 'arn:aws:kms:us-east-1:111111111111:key/my-key-id');
+
+const table = new MyTable(this, 'Table', {
+  encryptionKey: key,
+});
+```
+</Fragment>
+<Fragment slot="terraform">
+
+```hcl title="packages/infra/src/main.tf"
+module "my_table" {
+  source      = "../../common/terraform/src/app/dynamodb/my-table"
+  kms_key_arn = "arn:aws:kms:us-east-1:111111111111:key/my-key-id"
+}
+```
+</Fragment>
+</Infrastructure>
+
+#### Rotation de la clé de chiffrement
+
+Lorsque la table crée sa propre clé KMS gérée par le client (par défaut, et uniquement lorsque vous n'avez pas fourni votre propre clé), cette clé a la rotation automatique activée par défaut. Désactivez-la si votre politique de sécurité gère la rotation en externe.
+
+##### Désactiver la rotation de la clé de chiffrement
+
+<Infrastructure>
+<Fragment slot="cdk">
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { MyTable } from '@my-scope/common-constructs';
+
+const table = new MyTable(this, 'Table', {
+  enableKeyRotation: false,
+});
+```
+</Fragment>
+<Fragment slot="terraform">
+
+```hcl title="packages/infra/src/main.tf"
+module "my_table" {
+  source              = "../../common/terraform/src/app/dynamodb/my-table"
+  enable_key_rotation = false
+}
+```
+</Fragment>
+</Infrastructure>

--- a/docs/src/content/docs/fr/snippets/dynamodb/encryption-options.mdx
+++ b/docs/src/content/docs/fr/snippets/dynamodb/encryption-options.mdx
@@ -2,6 +2,7 @@
 title: Options de Chiffrement
 ---
 import Infrastructure from '@components/infrastructure.astro';
+import OptionFilter from '@components/option-filter.astro';
 
 #### Utiliser une clé gérée par AWS
 
@@ -18,6 +19,16 @@ const table = new MyTable(this, 'Table', {
   encryption: TableEncryption.AWS_MANAGED,
 });
 ```
+
+:::tip[Checkov]
+Choisir `AWS_MANAGED` signifie que la table n'est plus chiffrée avec une clé gérée par le client, ce qui échoue à la règle `CKV_AWS_119` de Checkov. Supprimez-la sur la table :
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { suppressRules } from '@my-scope/common-constructs';
+
+suppressRules(table.table, ['CKV_AWS_119'], 'Using an AWS managed key rather than a customer-managed CMK');
+```
+:::
 </Fragment>
 <Fragment slot="terraform">
 
@@ -45,6 +56,16 @@ const table = new MyTable(this, 'Table', {
   encryption: TableEncryption.DEFAULT,
 });
 ```
+
+:::tip[Checkov]
+Choisir `DEFAULT` signifie que la table n'est plus chiffrée avec une clé gérée par le client, ce qui échoue à la règle `CKV_AWS_119` de Checkov. Supprimez-la sur la table :
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { suppressRules } from '@my-scope/common-constructs';
+
+suppressRules(table.table, ['CKV_AWS_119'], 'Using the AWS owned key rather than a customer-managed CMK');
+```
+:::
 </Fragment>
 <Fragment slot="terraform">
 
@@ -56,6 +77,28 @@ module "my_table" {
 ```
 </Fragment>
 </Infrastructure>
+
+<OptionFilter when={{ iac: 'terraform' }} description="Passer d'une table déjà déployée de CUSTOMER_MANAGED à une autre option">
+#### Passer de CUSTOMER_MANAGED à une autre option
+
+Sur une table **déjà déployée**, changer `encryption` de `CUSTOMER_MANAGED` (vers `AWS_MANAGED` ou `DEFAULT`) en un seul `terraform apply` échoue : Terraform détruit la clé gérée par le client avant de mettre à jour la table, et DynamoDB rejette alors la mise à jour car la clé est déjà en attente de suppression.
+
+Contournez ce problème en mettant à jour le chiffrement de la table directement via l'AWS CLI d'abord, puis en laissant Terraform rattraper son retard et nettoyer la clé orpheline :
+
+```bash
+# For AWS_MANAGED:
+aws dynamodb update-table --table-name <table-name> \
+  --sse-specification Enabled=true,SSEType=KMS,KMSMasterKeyId=alias/aws/dynamodb
+
+# For DEFAULT:
+aws dynamodb update-table --table-name <table-name> --sse-specification Enabled=false
+
+# Then wait for this to report ENABLED (or for SSEDescription to disappear, for DEFAULT):
+aws dynamodb describe-table --table-name <table-name> --query Table.SSEDescription.Status
+```
+
+Ensuite, mettez à jour `encryption` dans votre configuration Terraform et exécutez `terraform apply` normalement — Terraform n'a maintenant besoin que de détruire la clé déjà inutilisée, sans rien qui en dépende.
+</OptionFilter>
 
 #### Utiliser votre propre clé KMS
 
@@ -102,6 +145,16 @@ const table = new MyTable(this, 'Table', {
   enableKeyRotation: false,
 });
 ```
+
+:::tip[Checkov]
+Désactiver la rotation de clé, ou apporter votre propre clé qui ne pivote pas, échoue à la règle `CKV_AWS_7` de Checkov. Supprimez-la sur la clé :
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { suppressRules } from '@my-scope/common-constructs';
+
+suppressRules(table.table.encryptionKey!, ['CKV_AWS_7'], 'Key rotation is managed externally');
+```
+:::
 </Fragment>
 <Fragment slot="terraform">
 

--- a/docs/src/content/docs/it/snippets/dynamodb/deploying-table.mdx
+++ b/docs/src/content/docs/it/snippets/dynamodb/deploying-table.mdx
@@ -1,9 +1,10 @@
 ---
-title: Distribuzione della tua tabella DynamoDB
+title: Distribuzione della tabella DynamoDB
 ---
 import Infrastructure from '@components/infrastructure.astro';
+import Snippet from '@components/snippet.astro';
 
-Il generatore DynamoDB crea infrastruttura CDK o Terraform in base al tuo `iac` selezionato.
+Il generatore DynamoDB crea l'infrastruttura CDK o Terraform in base all'`iac` selezionato.
 
 <Infrastructure>
 <Fragment slot="cdk">
@@ -27,8 +28,8 @@ Questo esegue il provisioning di una tabella DynamoDB con:
 - Fatturazione on-demand (`PAY_PER_REQUEST`)
 - Crittografia KMS gestita dal cliente con rotazione automatica delle chiavi
 - Point-in-time recovery abilitato
-- Protezione dalla cancellazione abilitata
-- Nome della tabella registrato in Runtime Config sotto il namespace `dynamodb` in AWS AppConfig
+- Protezione dall'eliminazione abilitata
+- Nome della tabella registrato in Runtime Config nello spazio dei nomi `dynamodb` in AWS AppConfig
 </Fragment>
 <Fragment slot="terraform">
 Il modulo Terraform viene creato in `common/terraform`. Esempio di utilizzo:
@@ -45,18 +46,18 @@ Questo esegue il provisioning di una tabella DynamoDB con:
 - Fatturazione on-demand (`PAY_PER_REQUEST`)
 - Crittografia KMS gestita dal cliente con rotazione automatica delle chiavi
 - Point-in-time recovery abilitato
-- Protezione dalla cancellazione abilitata
+- Protezione dall'eliminazione abilitata
 - Nome della tabella registrato in Runtime Config
 </Fragment>
 </Infrastructure>
 
-### Protezione dalla cancellazione
+### Protezione dall'eliminazione
 
-La protezione dalla cancellazione è abilitata per impostazione predefinita per prevenire la cancellazione accidentale della tabella.
+La protezione dall'eliminazione è abilitata per impostazione predefinita per prevenire l'eliminazione accidentale della tabella.
 
-#### Disabilitare la protezione dalla cancellazione
+#### Disabilitare la protezione dall'eliminazione
 
-Disabilitala per ambienti in cui è prevista la cancellazione della tabella, come stack di sviluppo o preview di breve durata.
+Disabilitala per ambienti in cui è prevista l'eliminazione della tabella, come stack di sviluppo o di anteprima di breve durata.
 
 <Infrastructure>
 <Fragment slot="cdk">
@@ -137,30 +138,8 @@ module "my_table" {
 </Fragment>
 </Infrastructure>
 
-### Rotazione delle chiavi di crittografia
+### Crittografia
 
-La chiave KMS utilizzata per crittografare la tabella ha la rotazione automatica delle chiavi abilitata per impostazione predefinita. Disabilitala se la tua policy di sicurezza gestisce la rotazione esternamente.
+La tabella è crittografata con una chiave KMS gestita dal cliente per impostazione predefinita, creata automaticamente per te. Passa a una chiave gestita da AWS, alla chiave di proprietà di AWS, o porta la tua chiave KMS, se gestisci la crittografia in modo diverso.
 
-#### Disabilitare la rotazione delle chiavi di crittografia
-
-<Infrastructure>
-<Fragment slot="cdk">
-
-```ts title="packages/infra/src/stacks/application-stack.ts"
-import { MyTable } from '@my-scope/common-constructs';
-
-const table = new MyTable(this, 'Table', {
-  enableKeyRotation: false,
-});
-```
-</Fragment>
-<Fragment slot="terraform">
-
-```hcl title="packages/infra/src/main.tf"
-module "my_table" {
-  source              = "../../common/terraform/src/app/dynamodb/my-table"
-  enable_key_rotation = false
-}
-```
-</Fragment>
-</Infrastructure>
+<Snippet name="dynamodb/encryption-options" parentHeading="Crittografia" />

--- a/docs/src/content/docs/it/snippets/dynamodb/encryption-options.mdx
+++ b/docs/src/content/docs/it/snippets/dynamodb/encryption-options.mdx
@@ -1,0 +1,115 @@
+---
+title: Opzioni di Crittografia
+---
+import Infrastructure from '@components/infrastructure.astro';
+
+#### Utilizzare una chiave gestita da AWS
+
+Utilizza la chiave KMS condivisa `aws/dynamodb` che AWS gestisce per tuo conto. È visibile nella console KMS del tuo account e fatturata per richiesta, ma non c'è alcuna chiave da creare, ruotare o eliminare.
+
+<Infrastructure>
+<Fragment slot="cdk">
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { TableEncryption } from 'aws-cdk-lib/aws-dynamodb';
+import { MyTable } from '@my-scope/common-constructs';
+
+const table = new MyTable(this, 'Table', {
+  encryption: TableEncryption.AWS_MANAGED,
+});
+```
+</Fragment>
+<Fragment slot="terraform">
+
+```hcl title="packages/infra/src/main.tf"
+module "my_table" {
+  source     = "../../common/terraform/src/app/dynamodb/my-table"
+  encryption = "AWS_MANAGED"
+}
+```
+</Fragment>
+</Infrastructure>
+
+#### Utilizzare la chiave di proprietà di AWS
+
+Utilizza una chiave completamente posseduta e gestita da AWS — gratuita, senza alcuna chiave visibile nel tuo account. L'opzione più semplice quando non hai bisogno di una chiave visibile al cliente o all'account per motivi di conformità.
+
+<Infrastructure>
+<Fragment slot="cdk">
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { TableEncryption } from 'aws-cdk-lib/aws-dynamodb';
+import { MyTable } from '@my-scope/common-constructs';
+
+const table = new MyTable(this, 'Table', {
+  encryption: TableEncryption.DEFAULT,
+});
+```
+</Fragment>
+<Fragment slot="terraform">
+
+```hcl title="packages/infra/src/main.tf"
+module "my_table" {
+  source     = "../../common/terraform/src/app/dynamodb/my-table"
+  encryption = "DEFAULT"
+}
+```
+</Fragment>
+</Infrastructure>
+
+#### Utilizzare la propria chiave KMS
+
+Fornisci una chiave gestita dal cliente esistente invece di farne creare una per te. La chiave deve già concedere al servizio DynamoDB le autorizzazioni necessarie nella propria policy della chiave.
+
+<Infrastructure>
+<Fragment slot="cdk">
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { Key } from 'aws-cdk-lib/aws-kms';
+import { MyTable } from '@my-scope/common-constructs';
+
+const key = Key.fromKeyArn(this, 'Key', 'arn:aws:kms:us-east-1:111111111111:key/my-key-id');
+
+const table = new MyTable(this, 'Table', {
+  encryptionKey: key,
+});
+```
+</Fragment>
+<Fragment slot="terraform">
+
+```hcl title="packages/infra/src/main.tf"
+module "my_table" {
+  source      = "../../common/terraform/src/app/dynamodb/my-table"
+  kms_key_arn = "arn:aws:kms:us-east-1:111111111111:key/my-key-id"
+}
+```
+</Fragment>
+</Infrastructure>
+
+#### Rotazione della chiave di crittografia
+
+Quando la tabella crea la propria chiave KMS gestita dal cliente (l'impostazione predefinita, e solo quando non hai fornito la tua chiave), quella chiave ha la rotazione automatica delle chiavi abilitata per impostazione predefinita. Disabilitala se la tua policy di sicurezza gestisce la rotazione esternamente.
+
+##### Disabilitare la rotazione della chiave di crittografia
+
+<Infrastructure>
+<Fragment slot="cdk">
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { MyTable } from '@my-scope/common-constructs';
+
+const table = new MyTable(this, 'Table', {
+  enableKeyRotation: false,
+});
+```
+</Fragment>
+<Fragment slot="terraform">
+
+```hcl title="packages/infra/src/main.tf"
+module "my_table" {
+  source              = "../../common/terraform/src/app/dynamodb/my-table"
+  enable_key_rotation = false
+}
+```
+</Fragment>
+</Infrastructure>

--- a/docs/src/content/docs/it/snippets/dynamodb/encryption-options.mdx
+++ b/docs/src/content/docs/it/snippets/dynamodb/encryption-options.mdx
@@ -2,6 +2,7 @@
 title: Opzioni di Crittografia
 ---
 import Infrastructure from '@components/infrastructure.astro';
+import OptionFilter from '@components/option-filter.astro';
 
 #### Utilizzare una chiave gestita da AWS
 
@@ -18,6 +19,16 @@ const table = new MyTable(this, 'Table', {
   encryption: TableEncryption.AWS_MANAGED,
 });
 ```
+
+:::tip[Checkov]
+Scegliere `AWS_MANAGED` significa che la tabella non è più crittografata con una chiave gestita dal cliente, il che fa fallire il controllo `CKV_AWS_119` di Checkov. Sopprimilo sulla tabella:
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { suppressRules } from '@my-scope/common-constructs';
+
+suppressRules(table.table, ['CKV_AWS_119'], 'Using an AWS managed key rather than a customer-managed CMK');
+```
+:::
 </Fragment>
 <Fragment slot="terraform">
 
@@ -45,6 +56,16 @@ const table = new MyTable(this, 'Table', {
   encryption: TableEncryption.DEFAULT,
 });
 ```
+
+:::tip[Checkov]
+Scegliere `DEFAULT` significa che la tabella non è più crittografata con una chiave gestita dal cliente, il che fa fallire il controllo `CKV_AWS_119` di Checkov. Sopprimilo sulla tabella:
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { suppressRules } from '@my-scope/common-constructs';
+
+suppressRules(table.table, ['CKV_AWS_119'], 'Using the AWS owned key rather than a customer-managed CMK');
+```
+:::
 </Fragment>
 <Fragment slot="terraform">
 
@@ -56,6 +77,28 @@ module "my_table" {
 ```
 </Fragment>
 </Infrastructure>
+
+<OptionFilter when={{ iac: 'terraform' }} description="Passaggio da CUSTOMER_MANAGED per una tabella già distribuita">
+#### Passaggio da CUSTOMER_MANAGED
+
+Su una tabella **già distribuita**, modificare `encryption` da `CUSTOMER_MANAGED` (a `AWS_MANAGED` o `DEFAULT`) in un singolo `terraform apply` fallisce: Terraform distrugge la chiave gestita dal cliente prima di aggiornare la tabella, e DynamoDB quindi rifiuta l'aggiornamento perché la chiave è già in attesa di eliminazione.
+
+Aggiralo aggiornando prima la crittografia della tabella direttamente tramite AWS CLI, quindi lasciando che Terraform si allinei e pulisca la chiave orfana:
+
+```bash
+# For AWS_MANAGED:
+aws dynamodb update-table --table-name <table-name> \
+  --sse-specification Enabled=true,SSEType=KMS,KMSMasterKeyId=alias/aws/dynamodb
+
+# For DEFAULT:
+aws dynamodb update-table --table-name <table-name> --sse-specification Enabled=false
+
+# Then wait for this to report ENABLED (or for SSEDescription to disappear, for DEFAULT):
+aws dynamodb describe-table --table-name <table-name> --query Table.SSEDescription.Status
+```
+
+Quindi aggiorna `encryption` nella tua configurazione Terraform ed esegui `terraform apply` normalmente — Terraform ora deve solo distruggere la chiave già inutilizzata, senza nulla che dipenda da essa.
+</OptionFilter>
 
 #### Utilizzare la propria chiave KMS
 
@@ -102,6 +145,16 @@ const table = new MyTable(this, 'Table', {
   enableKeyRotation: false,
 });
 ```
+
+:::tip[Checkov]
+Disabilitare la rotazione delle chiavi, o fornire la propria chiave che non ruota, fa fallire il controllo `CKV_AWS_7` di Checkov. Sopprimilo sulla chiave:
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { suppressRules } from '@my-scope/common-constructs';
+
+suppressRules(table.table.encryptionKey!, ['CKV_AWS_7'], 'Key rotation is managed externally');
+```
+:::
 </Fragment>
 <Fragment slot="terraform">
 

--- a/docs/src/content/docs/jp/snippets/dynamodb/deploying-table.mdx
+++ b/docs/src/content/docs/jp/snippets/dynamodb/deploying-table.mdx
@@ -1,13 +1,14 @@
 ---
-title: DynamoDBテーブルのデプロイ
+title: DynamoDB テーブルのデプロイ
 ---
 import Infrastructure from '@components/infrastructure.astro';
+import Snippet from '@components/snippet.astro';
 
-DynamoDBジェネレーターは、選択した`iac`に基づいてCDKまたはTerraformインフラストラクチャを作成します。
+DynamoDB ジェネレーターは、選択した `iac` に基づいて CDK または Terraform インフラストラクチャを作成します。
 
 <Infrastructure>
 <Fragment slot="cdk">
-CDKコンストラクトは`common/constructs`に作成されます。使用例：
+CDK コンストラクトは `common/constructs` に作成されます。使用例：
 
 ```ts title="packages/infra/src/stacks/application-stack.ts"
 import { MyTable } from '@my-scope/common-constructs';
@@ -21,17 +22,17 @@ export class ApplicationStack extends Stack {
 }
 ```
 
-これにより、以下の設定でDynamoDBテーブルがプロビジョニングされます：
-- `pk`（パーティションキー）と`sk`（ソートキー）、両方とも`String`型
-- `config.json`で定義されたグローバルセカンダリインデックス
+これにより、以下の設定で DynamoDB テーブルがプロビジョニングされます：
+- `pk`（パーティションキー）と `sk`（ソートキー）、両方とも `String` 型
+- `config.json` で定義されたグローバルセカンダリインデックス
 - オンデマンド（`PAY_PER_REQUEST`）課金
-- 自動キーローテーション付きのカスタマー管理KMS暗号化
+- 自動キーローテーション付きのカスタマー管理 KMS 暗号化
 - ポイントインタイムリカバリが有効
 - 削除保護が有効
-- AWS AppConfigの`dynamodb`名前空間下のランタイム設定にテーブル名が登録される
+- AWS AppConfig の `dynamodb` 名前空間下の Runtime Config にテーブル名が登録される
 </Fragment>
 <Fragment slot="terraform">
-Terraformモジュールは`common/terraform`に作成されます。使用例：
+Terraform モジュールは `common/terraform` に作成されます。使用例：
 
 ```hcl title="packages/infra/src/main.tf"
 module "my_table" {
@@ -39,14 +40,14 @@ module "my_table" {
 }
 ```
 
-これにより、以下の設定でDynamoDBテーブルがプロビジョニングされます：
-- `pk`（パーティションキー）と`sk`（ソートキー）、両方とも`String`型
-- `config.json`で定義されたグローバルセカンダリインデックス
+これにより、以下の設定で DynamoDB テーブルがプロビジョニングされます：
+- `pk`（パーティションキー）と `sk`（ソートキー）、両方とも `String` 型
+- `config.json` で定義されたグローバルセカンダリインデックス
 - オンデマンド（`PAY_PER_REQUEST`）課金
-- 自動キーローテーション付きのカスタマー管理KMS暗号化
+- 自動キーローテーション付きのカスタマー管理 KMS 暗号化
 - ポイントインタイムリカバリが有効
 - 削除保護が有効
-- ランタイム設定にテーブル名が登録される
+- Runtime Config にテーブル名が登録される
 </Fragment>
 </Infrastructure>
 
@@ -54,7 +55,7 @@ module "my_table" {
 
 削除保護はデフォルトで有効になっており、誤ってテーブルを削除することを防ぎます。
 
-#### 削除保護の無効化
+#### 削除保護を無効にする
 
 短期間の開発環境やプレビュースタックなど、テーブルの削除が想定される環境では無効にします。
 
@@ -82,7 +83,7 @@ module "my_table" {
 
 ### 課金モード
 
-テーブルはデフォルトでオンデマンド（`PAY_PER_REQUEST`）課金になります。予測可能で高スループットのワークロードには、プロビジョニングされたキャパシティに切り替えます。
+テーブルはデフォルトでオンデマンド（`PAY_PER_REQUEST`）課金です。予測可能で高スループットのワークロードの場合は、プロビジョニングされたキャパシティに切り替えます。
 
 <Infrastructure>
 <Fragment slot="cdk">
@@ -111,9 +112,9 @@ module "my_table" {
 
 ### ポイントインタイムリカバリ
 
-[ポイントインタイムリカバリ](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Point-in-time-recovery.html)はデフォルトで有効になっており、過去35日間の任意の時点にテーブルを復元できます。
+[ポイントインタイムリカバリ](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Point-in-time-recovery.html)はデフォルトで有効になっており、過去 35 日間の任意の時点にテーブルを復元できます。
 
-#### ポイントインタイムリカバリの無効化
+#### ポイントインタイムリカバリを無効にする
 
 <Infrastructure>
 <Fragment slot="cdk">
@@ -137,30 +138,8 @@ module "my_table" {
 </Fragment>
 </Infrastructure>
 
-### 暗号化キーのローテーション
+### 暗号化
 
-テーブルの暗号化に使用されるKMSキーは、デフォルトで自動キーローテーションが有効になっています。セキュリティポリシーで外部的にローテーションを管理している場合は無効にします。
+テーブルはデフォルトでカスタマー管理 KMS キーで暗号化され、自動的に作成されます。暗号化を異なる方法で管理する場合は、AWS 管理キー、AWS 所有キー、または独自の KMS キーに切り替えます。
 
-#### 暗号化キーのローテーションの無効化
-
-<Infrastructure>
-<Fragment slot="cdk">
-
-```ts title="packages/infra/src/stacks/application-stack.ts"
-import { MyTable } from '@my-scope/common-constructs';
-
-const table = new MyTable(this, 'Table', {
-  enableKeyRotation: false,
-});
-```
-</Fragment>
-<Fragment slot="terraform">
-
-```hcl title="packages/infra/src/main.tf"
-module "my_table" {
-  source              = "../../common/terraform/src/app/dynamodb/my-table"
-  enable_key_rotation = false
-}
-```
-</Fragment>
-</Infrastructure>
+<Snippet name="dynamodb/encryption-options" parentHeading="暗号化" />

--- a/docs/src/content/docs/jp/snippets/dynamodb/encryption-options.mdx
+++ b/docs/src/content/docs/jp/snippets/dynamodb/encryption-options.mdx
@@ -1,0 +1,115 @@
+---
+title: 暗号化オプション
+---
+import Infrastructure from '@components/infrastructure.astro';
+
+#### AWS 管理キーを使用する
+
+AWS があなたに代わって管理する共有 `aws/dynamodb` KMS キーを使用します。アカウントの KMS コンソールに表示され、リクエストごとに課金されますが、作成、ローテーション、削除するキーはありません。
+
+<Infrastructure>
+<Fragment slot="cdk">
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { TableEncryption } from 'aws-cdk-lib/aws-dynamodb';
+import { MyTable } from '@my-scope/common-constructs';
+
+const table = new MyTable(this, 'Table', {
+  encryption: TableEncryption.AWS_MANAGED,
+});
+```
+</Fragment>
+<Fragment slot="terraform">
+
+```hcl title="packages/infra/src/main.tf"
+module "my_table" {
+  source     = "../../common/terraform/src/app/dynamodb/my-table"
+  encryption = "AWS_MANAGED"
+}
+```
+</Fragment>
+</Infrastructure>
+
+#### AWS 所有キーを使用する
+
+AWS が完全に所有および管理するキーを使用します — 無料で、アカウントにキーが表示されることはありません。コンプライアンス上の理由でカスタマーまたはアカウントに表示されるキーが不要な場合の最もシンプルなオプションです。
+
+<Infrastructure>
+<Fragment slot="cdk">
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { TableEncryption } from 'aws-cdk-lib/aws-dynamodb';
+import { MyTable } from '@my-scope/common-constructs';
+
+const table = new MyTable(this, 'Table', {
+  encryption: TableEncryption.DEFAULT,
+});
+```
+</Fragment>
+<Fragment slot="terraform">
+
+```hcl title="packages/infra/src/main.tf"
+module "my_table" {
+  source     = "../../common/terraform/src/app/dynamodb/my-table"
+  encryption = "DEFAULT"
+}
+```
+</Fragment>
+</Infrastructure>
+
+#### 独自の KMS キーを使用する
+
+自動作成されるキーの代わりに、既存のカスタマー管理キーを提供します。キーは、独自のキーポリシーで DynamoDB サービスに必要な権限をすでに付与している必要があります。
+
+<Infrastructure>
+<Fragment slot="cdk">
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { Key } from 'aws-cdk-lib/aws-kms';
+import { MyTable } from '@my-scope/common-constructs';
+
+const key = Key.fromKeyArn(this, 'Key', 'arn:aws:kms:us-east-1:111111111111:key/my-key-id');
+
+const table = new MyTable(this, 'Table', {
+  encryptionKey: key,
+});
+```
+</Fragment>
+<Fragment slot="terraform">
+
+```hcl title="packages/infra/src/main.tf"
+module "my_table" {
+  source      = "../../common/terraform/src/app/dynamodb/my-table"
+  kms_key_arn = "arn:aws:kms:us-east-1:111111111111:key/my-key-id"
+}
+```
+</Fragment>
+</Infrastructure>
+
+#### 暗号化キーのローテーション
+
+テーブルが独自のカスタマー管理 KMS キーを作成する場合（デフォルトで、独自のキーを提供していない場合のみ）、そのキーは自動キーローテーションがデフォルトで有効になっています。セキュリティポリシーで外部的にローテーションを管理する場合は無効にします。
+
+##### 暗号化キーのローテーションを無効にする
+
+<Infrastructure>
+<Fragment slot="cdk">
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { MyTable } from '@my-scope/common-constructs';
+
+const table = new MyTable(this, 'Table', {
+  enableKeyRotation: false,
+});
+```
+</Fragment>
+<Fragment slot="terraform">
+
+```hcl title="packages/infra/src/main.tf"
+module "my_table" {
+  source              = "../../common/terraform/src/app/dynamodb/my-table"
+  enable_key_rotation = false
+}
+```
+</Fragment>
+</Infrastructure>

--- a/docs/src/content/docs/jp/snippets/dynamodb/encryption-options.mdx
+++ b/docs/src/content/docs/jp/snippets/dynamodb/encryption-options.mdx
@@ -2,6 +2,7 @@
 title: 暗号化オプション
 ---
 import Infrastructure from '@components/infrastructure.astro';
+import OptionFilter from '@components/option-filter.astro';
 
 #### AWS 管理キーを使用する
 
@@ -18,6 +19,16 @@ const table = new MyTable(this, 'Table', {
   encryption: TableEncryption.AWS_MANAGED,
 });
 ```
+
+:::tip[Checkov]
+`AWS_MANAGED` を選択すると、テーブルはカスタマー管理キーで暗号化されなくなり、Checkov の `CKV_AWS_119` に失敗します。テーブルで抑制してください：
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { suppressRules } from '@my-scope/common-constructs';
+
+suppressRules(table.table, ['CKV_AWS_119'], 'Using an AWS managed key rather than a customer-managed CMK');
+```
+:::
 </Fragment>
 <Fragment slot="terraform">
 
@@ -45,6 +56,16 @@ const table = new MyTable(this, 'Table', {
   encryption: TableEncryption.DEFAULT,
 });
 ```
+
+:::tip[Checkov]
+`DEFAULT` を選択すると、テーブルはカスタマー管理キーで暗号化されなくなり、Checkov の `CKV_AWS_119` に失敗します。テーブルで抑制してください：
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { suppressRules } from '@my-scope/common-constructs';
+
+suppressRules(table.table, ['CKV_AWS_119'], 'Using the AWS owned key rather than a customer-managed CMK');
+```
+:::
 </Fragment>
 <Fragment slot="terraform">
 
@@ -56,6 +77,28 @@ module "my_table" {
 ```
 </Fragment>
 </Infrastructure>
+
+<OptionFilter when={{ iac: 'terraform' }} description="Switching an already-deployed table away from CUSTOMER_MANAGED">
+#### CUSTOMER_MANAGED からの切り替え
+
+**すでにデプロイされている**テーブルで、`encryption` を `CUSTOMER_MANAGED` から（`AWS_MANAGED` または `DEFAULT` のいずれかに）単一の `terraform apply` で変更すると失敗します：Terraform はテーブルを更新する前にカスタマー管理キーを破棄し、DynamoDB はキーがすでに削除保留中であるため更新を拒否します。
+
+回避策として、まず AWS CLI を介してテーブルの暗号化を直接更新し、その後 Terraform に追いつかせて孤立したキーをクリーンアップします：
+
+```bash
+# For AWS_MANAGED:
+aws dynamodb update-table --table-name <table-name> \
+  --sse-specification Enabled=true,SSEType=KMS,KMSMasterKeyId=alias/aws/dynamodb
+
+# For DEFAULT:
+aws dynamodb update-table --table-name <table-name> --sse-specification Enabled=false
+
+# Then wait for this to report ENABLED (or for SSEDescription to disappear, for DEFAULT):
+aws dynamodb describe-table --table-name <table-name> --query Table.SSEDescription.Status
+```
+
+次に、Terraform 設定で `encryption` を更新し、通常通り `terraform apply` を実行します — Terraform は、何も依存していない、すでに使用されていないキーを破棄するだけで済みます。
+</OptionFilter>
 
 #### 独自の KMS キーを使用する
 
@@ -102,6 +145,16 @@ const table = new MyTable(this, 'Table', {
   enableKeyRotation: false,
 });
 ```
+
+:::tip[Checkov]
+キーローテーションを無効にする、またはローテーションしない独自のキーを持ち込むと、Checkov の `CKV_AWS_7` に失敗します。キーで抑制してください：
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { suppressRules } from '@my-scope/common-constructs';
+
+suppressRules(table.table.encryptionKey!, ['CKV_AWS_7'], 'Key rotation is managed externally');
+```
+:::
 </Fragment>
 <Fragment slot="terraform">
 

--- a/docs/src/content/docs/ko/snippets/dynamodb/deploying-table.mdx
+++ b/docs/src/content/docs/ko/snippets/dynamodb/deploying-table.mdx
@@ -2,6 +2,7 @@
 title: DynamoDB 테이블 배포하기
 ---
 import Infrastructure from '@components/infrastructure.astro';
+import Snippet from '@components/snippet.astro';
 
 DynamoDB 생성기는 선택한 `iac`에 따라 CDK 또는 Terraform 인프라를 생성합니다.
 
@@ -23,11 +24,11 @@ export class ApplicationStack extends Stack {
 
 다음과 같은 DynamoDB 테이블을 프로비저닝합니다:
 - `pk` (파티션 키)와 `sk` (정렬 키), 둘 다 `String` 타입
-- `config.json`에 정의된 글로벌 보조 인덱스
-- 온디맨드 (`PAY_PER_REQUEST`) 요금제
+- `config.json`에 정의된 Global Secondary Indexes
+- 온디맨드 (`PAY_PER_REQUEST`) 과금
 - 자동 키 로테이션이 활성화된 고객 관리형 KMS 암호화
 - 특정 시점 복구 활성화
-- 삭제 방지 활성화
+- 삭제 보호 활성화
 - AWS AppConfig의 `dynamodb` 네임스페이스 아래 Runtime Config에 등록된 테이블 이름
 </Fragment>
 <Fragment slot="terraform">
@@ -41,20 +42,20 @@ module "my_table" {
 
 다음과 같은 DynamoDB 테이블을 프로비저닝합니다:
 - `pk` (파티션 키)와 `sk` (정렬 키), 둘 다 `String` 타입
-- `config.json`에 정의된 글로벌 보조 인덱스
-- 온디맨드 (`PAY_PER_REQUEST`) 요금제
+- `config.json`에 정의된 Global Secondary Indexes
+- 온디맨드 (`PAY_PER_REQUEST`) 과금
 - 자동 키 로테이션이 활성화된 고객 관리형 KMS 암호화
 - 특정 시점 복구 활성화
-- 삭제 방지 활성화
+- 삭제 보호 활성화
 - Runtime Config에 등록된 테이블 이름
 </Fragment>
 </Infrastructure>
 
-### 삭제 방지
+### 삭제 보호
 
-실수로 테이블이 삭제되는 것을 방지하기 위해 삭제 방지가 기본적으로 활성화되어 있습니다.
+실수로 테이블이 삭제되는 것을 방지하기 위해 삭제 보호가 기본적으로 활성화되어 있습니다.
 
-#### 삭제 방지 비활성화
+#### 삭제 보호 비활성화
 
 단기 개발 또는 프리뷰 스택과 같이 테이블 삭제가 예상되는 환경에서는 비활성화하세요.
 
@@ -80,9 +81,9 @@ module "my_table" {
 </Fragment>
 </Infrastructure>
 
-### 요금제 모드
+### 과금 모드
 
-테이블은 기본적으로 온디맨드 (`PAY_PER_REQUEST`) 요금제를 사용합니다. 예측 가능한 고처리량 워크로드의 경우 프로비저닝된 용량으로 전환하세요.
+테이블은 기본적으로 온디맨드 (`PAY_PER_REQUEST`) 과금을 사용합니다. 예측 가능한 고처리량 워크로드의 경우 프로비저닝된 용량으로 전환하세요.
 
 <Infrastructure>
 <Fragment slot="cdk">
@@ -137,30 +138,8 @@ module "my_table" {
 </Fragment>
 </Infrastructure>
 
-### 암호화 키 로테이션
+### 암호화
 
-테이블을 암호화하는 데 사용되는 KMS 키는 기본적으로 자동 키 로테이션이 활성화되어 있습니다. 보안 정책에서 로테이션을 외부적으로 관리하는 경우 비활성화하세요.
+테이블은 기본적으로 고객 관리형 KMS 키로 암호화되며, 자동으로 생성됩니다. 암호화를 다르게 관리하는 경우 AWS 관리형 키, AWS 소유 키로 전환하거나 자체 KMS 키를 가져올 수 있습니다.
 
-#### 암호화 키 로테이션 비활성화
-
-<Infrastructure>
-<Fragment slot="cdk">
-
-```ts title="packages/infra/src/stacks/application-stack.ts"
-import { MyTable } from '@my-scope/common-constructs';
-
-const table = new MyTable(this, 'Table', {
-  enableKeyRotation: false,
-});
-```
-</Fragment>
-<Fragment slot="terraform">
-
-```hcl title="packages/infra/src/main.tf"
-module "my_table" {
-  source              = "../../common/terraform/src/app/dynamodb/my-table"
-  enable_key_rotation = false
-}
-```
-</Fragment>
-</Infrastructure>
+<Snippet name="dynamodb/encryption-options" parentHeading="암호화" />

--- a/docs/src/content/docs/ko/snippets/dynamodb/deploying-table.mdx
+++ b/docs/src/content/docs/ko/snippets/dynamodb/deploying-table.mdx
@@ -143,3 +143,4 @@ module "my_table" {
 테이블은 기본적으로 고객 관리형 KMS 키로 암호화되며, 자동으로 생성됩니다. 암호화를 다르게 관리하는 경우 AWS 관리형 키, AWS 소유 키로 전환하거나 자체 KMS 키를 가져올 수 있습니다.
 
 <Snippet name="dynamodb/encryption-options" parentHeading="암호화" />
+

--- a/docs/src/content/docs/ko/snippets/dynamodb/encryption-options.mdx
+++ b/docs/src/content/docs/ko/snippets/dynamodb/encryption-options.mdx
@@ -1,0 +1,115 @@
+---
+title: 암호화 옵션
+---
+import Infrastructure from '@components/infrastructure.astro';
+
+#### AWS 관리형 키 사용
+
+AWS가 대신 관리하는 공유 `aws/dynamodb` KMS 키를 사용합니다. 계정의 KMS 콘솔에서 볼 수 있고 요청당 과금되지만, 생성, 로테이션 또는 삭제할 키가 없습니다.
+
+<Infrastructure>
+<Fragment slot="cdk">
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { TableEncryption } from 'aws-cdk-lib/aws-dynamodb';
+import { MyTable } from '@my-scope/common-constructs';
+
+const table = new MyTable(this, 'Table', {
+  encryption: TableEncryption.AWS_MANAGED,
+});
+```
+</Fragment>
+<Fragment slot="terraform">
+
+```hcl title="packages/infra/src/main.tf"
+module "my_table" {
+  source     = "../../common/terraform/src/app/dynamodb/my-table"
+  encryption = "AWS_MANAGED"
+}
+```
+</Fragment>
+</Infrastructure>
+
+#### AWS 소유 키 사용
+
+AWS가 완전히 소유하고 관리하는 키를 사용합니다 — 무료이며, 계정에 키가 전혀 표시되지 않습니다. 규정 준수 이유로 고객 또는 계정에 표시되는 키가 필요하지 않은 경우 가장 간단한 옵션입니다.
+
+<Infrastructure>
+<Fragment slot="cdk">
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { TableEncryption } from 'aws-cdk-lib/aws-dynamodb';
+import { MyTable } from '@my-scope/common-constructs';
+
+const table = new MyTable(this, 'Table', {
+  encryption: TableEncryption.DEFAULT,
+});
+```
+</Fragment>
+<Fragment slot="terraform">
+
+```hcl title="packages/infra/src/main.tf"
+module "my_table" {
+  source     = "../../common/terraform/src/app/dynamodb/my-table"
+  encryption = "DEFAULT"
+}
+```
+</Fragment>
+</Infrastructure>
+
+#### 자체 KMS 키 사용
+
+자동으로 생성되는 대신 기존 고객 관리형 키를 제공합니다. 키는 자체 키 정책에서 DynamoDB 서비스에 필요한 권한을 이미 부여해야 합니다.
+
+<Infrastructure>
+<Fragment slot="cdk">
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { Key } from 'aws-cdk-lib/aws-kms';
+import { MyTable } from '@my-scope/common-constructs';
+
+const key = Key.fromKeyArn(this, 'Key', 'arn:aws:kms:us-east-1:111111111111:key/my-key-id');
+
+const table = new MyTable(this, 'Table', {
+  encryptionKey: key,
+});
+```
+</Fragment>
+<Fragment slot="terraform">
+
+```hcl title="packages/infra/src/main.tf"
+module "my_table" {
+  source      = "../../common/terraform/src/app/dynamodb/my-table"
+  kms_key_arn = "arn:aws:kms:us-east-1:111111111111:key/my-key-id"
+}
+```
+</Fragment>
+</Infrastructure>
+
+#### 암호화 키 로테이션
+
+테이블이 자체 고객 관리형 KMS 키를 생성하는 경우(기본값이며, 자체 키를 제공하지 않은 경우에만 해당), 해당 키는 기본적으로 자동 키 로테이션이 활성화됩니다. 보안 정책이 외부에서 로테이션을 관리하는 경우 비활성화하세요.
+
+##### 암호화 키 로테이션 비활성화
+
+<Infrastructure>
+<Fragment slot="cdk">
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { MyTable } from '@my-scope/common-constructs';
+
+const table = new MyTable(this, 'Table', {
+  enableKeyRotation: false,
+});
+```
+</Fragment>
+<Fragment slot="terraform">
+
+```hcl title="packages/infra/src/main.tf"
+module "my_table" {
+  source              = "../../common/terraform/src/app/dynamodb/my-table"
+  enable_key_rotation = false
+}
+```
+</Fragment>
+</Infrastructure>

--- a/docs/src/content/docs/ko/snippets/dynamodb/encryption-options.mdx
+++ b/docs/src/content/docs/ko/snippets/dynamodb/encryption-options.mdx
@@ -2,6 +2,7 @@
 title: 암호화 옵션
 ---
 import Infrastructure from '@components/infrastructure.astro';
+import OptionFilter from '@components/option-filter.astro';
 
 #### AWS 관리형 키 사용
 
@@ -18,6 +19,16 @@ const table = new MyTable(this, 'Table', {
   encryption: TableEncryption.AWS_MANAGED,
 });
 ```
+
+:::tip[Checkov]
+`AWS_MANAGED`를 선택하면 테이블이 더 이상 고객 관리형 키로 암호화되지 않으므로 Checkov의 `CKV_AWS_119`가 실패합니다. 테이블에서 이를 억제하세요:
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { suppressRules } from '@my-scope/common-constructs';
+
+suppressRules(table.table, ['CKV_AWS_119'], 'Using an AWS managed key rather than a customer-managed CMK');
+```
+:::
 </Fragment>
 <Fragment slot="terraform">
 
@@ -45,6 +56,16 @@ const table = new MyTable(this, 'Table', {
   encryption: TableEncryption.DEFAULT,
 });
 ```
+
+:::tip[Checkov]
+`DEFAULT`를 선택하면 테이블이 더 이상 고객 관리형 키로 암호화되지 않으므로 Checkov의 `CKV_AWS_119`가 실패합니다. 테이블에서 이를 억제하세요:
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { suppressRules } from '@my-scope/common-constructs';
+
+suppressRules(table.table, ['CKV_AWS_119'], 'Using the AWS owned key rather than a customer-managed CMK');
+```
+:::
 </Fragment>
 <Fragment slot="terraform">
 
@@ -56,6 +77,28 @@ module "my_table" {
 ```
 </Fragment>
 </Infrastructure>
+
+<OptionFilter when={{ iac: 'terraform' }} description="이미 배포된 테이블을 CUSTOMER_MANAGED에서 전환">
+#### CUSTOMER_MANAGED에서 전환
+
+**이미 배포된** 테이블에서 단일 `terraform apply`로 `encryption`을 `CUSTOMER_MANAGED`에서 (`AWS_MANAGED` 또는 `DEFAULT`로) 변경하면 실패합니다: Terraform이 테이블을 업데이트하기 전에 고객 관리형 키를 삭제하고, DynamoDB는 키가 이미 삭제 대기 중이기 때문에 업데이트를 거부합니다.
+
+먼저 AWS CLI를 통해 테이블의 암호화를 직접 업데이트한 다음 Terraform이 따라잡고 고아가 된 키를 정리하도록 하여 이 문제를 해결하세요:
+
+```bash
+# For AWS_MANAGED:
+aws dynamodb update-table --table-name <table-name> \
+  --sse-specification Enabled=true,SSEType=KMS,KMSMasterKeyId=alias/aws/dynamodb
+
+# For DEFAULT:
+aws dynamodb update-table --table-name <table-name> --sse-specification Enabled=false
+
+# Then wait for this to report ENABLED (or for SSEDescription to disappear, for DEFAULT):
+aws dynamodb describe-table --table-name <table-name> --query Table.SSEDescription.Status
+```
+
+그런 다음 Terraform 구성에서 `encryption`을 업데이트하고 평소처럼 `terraform apply`를 실행하세요 — 이제 Terraform은 이미 사용되지 않는 키만 삭제하면 되며, 더 이상 의존하는 것이 없습니다.
+</OptionFilter>
 
 #### 자체 KMS 키 사용
 
@@ -102,6 +145,16 @@ const table = new MyTable(this, 'Table', {
   enableKeyRotation: false,
 });
 ```
+
+:::tip[Checkov]
+키 로테이션을 비활성화하거나 로테이션되지 않는 자체 키를 가져오면 Checkov의 `CKV_AWS_7`이 실패합니다. 키에서 이를 억제하세요:
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { suppressRules } from '@my-scope/common-constructs';
+
+suppressRules(table.table.encryptionKey!, ['CKV_AWS_7'], 'Key rotation is managed externally');
+```
+:::
 </Fragment>
 <Fragment slot="terraform">
 

--- a/docs/src/content/docs/pt/snippets/dynamodb/deploying-table.mdx
+++ b/docs/src/content/docs/pt/snippets/dynamodb/deploying-table.mdx
@@ -143,3 +143,4 @@ module "my_table" {
 A tabela é criptografada com uma chave KMS gerenciada pelo cliente por padrão, criada automaticamente para você. Mude para uma chave gerenciada pela AWS, a chave de propriedade da AWS, ou traga sua própria chave KMS, se você gerencia a criptografia de forma diferente.
 
 <Snippet name="dynamodb/encryption-options" parentHeading="Criptografia" />
+

--- a/docs/src/content/docs/pt/snippets/dynamodb/deploying-table.mdx
+++ b/docs/src/content/docs/pt/snippets/dynamodb/deploying-table.mdx
@@ -2,12 +2,13 @@
 title: Implantando sua Tabela DynamoDB
 ---
 import Infrastructure from '@components/infrastructure.astro';
+import Snippet from '@components/snippet.astro';
 
 O gerador DynamoDB cria infraestrutura CDK ou Terraform com base no seu `iac` selecionado.
 
 <Infrastructure>
 <Fragment slot="cdk">
-O construtor CDK é criado em `common/constructs`. Exemplo de uso:
+O construto CDK é criado em `common/constructs`. Exemplo de uso:
 
 ```ts title="packages/infra/src/stacks/application-stack.ts"
 import { MyTable } from '@my-scope/common-constructs';
@@ -25,7 +26,7 @@ Isso provisiona uma tabela DynamoDB com:
 - `pk` (chave de partição) e `sk` (chave de ordenação), ambas do tipo `String`
 - Índices Secundários Globais conforme definido em `config.json`
 - Cobrança sob demanda (`PAY_PER_REQUEST`)
-- Criptografia KMS gerenciada pelo cliente com rotação automática de chaves
+- Criptografia KMS gerenciada pelo cliente com rotação automática de chave
 - Recuperação point-in-time habilitada
 - Proteção contra exclusão habilitada
 - Nome da tabela registrado no Runtime Config sob o namespace `dynamodb` no AWS AppConfig
@@ -43,7 +44,7 @@ Isso provisiona uma tabela DynamoDB com:
 - `pk` (chave de partição) e `sk` (chave de ordenação), ambas do tipo `String`
 - Índices Secundários Globais conforme definido em `config.json`
 - Cobrança sob demanda (`PAY_PER_REQUEST`)
-- Criptografia KMS gerenciada pelo cliente com rotação automática de chaves
+- Criptografia KMS gerenciada pelo cliente com rotação automática de chave
 - Recuperação point-in-time habilitada
 - Proteção contra exclusão habilitada
 - Nome da tabela registrado no Runtime Config
@@ -137,30 +138,8 @@ module "my_table" {
 </Fragment>
 </Infrastructure>
 
-### Rotação de Chave de Criptografia
+### Criptografia
 
-A chave KMS usada para criptografar a tabela tem rotação automática de chaves habilitada por padrão. Desabilite-a se sua política de segurança gerencia a rotação externamente.
+A tabela é criptografada com uma chave KMS gerenciada pelo cliente por padrão, criada automaticamente para você. Mude para uma chave gerenciada pela AWS, a chave de propriedade da AWS, ou traga sua própria chave KMS, se você gerencia a criptografia de forma diferente.
 
-#### Desabilitar Rotação de Chave de Criptografia
-
-<Infrastructure>
-<Fragment slot="cdk">
-
-```ts title="packages/infra/src/stacks/application-stack.ts"
-import { MyTable } from '@my-scope/common-constructs';
-
-const table = new MyTable(this, 'Table', {
-  enableKeyRotation: false,
-});
-```
-</Fragment>
-<Fragment slot="terraform">
-
-```hcl title="packages/infra/src/main.tf"
-module "my_table" {
-  source              = "../../common/terraform/src/app/dynamodb/my-table"
-  enable_key_rotation = false
-}
-```
-</Fragment>
-</Infrastructure>
+<Snippet name="dynamodb/encryption-options" parentHeading="Criptografia" />

--- a/docs/src/content/docs/pt/snippets/dynamodb/encryption-options.mdx
+++ b/docs/src/content/docs/pt/snippets/dynamodb/encryption-options.mdx
@@ -2,6 +2,7 @@
 title: Opções de Criptografia
 ---
 import Infrastructure from '@components/infrastructure.astro';
+import OptionFilter from '@components/option-filter.astro';
 
 #### Usar uma Chave Gerenciada pela AWS
 
@@ -18,6 +19,16 @@ const table = new MyTable(this, 'Table', {
   encryption: TableEncryption.AWS_MANAGED,
 });
 ```
+
+:::tip[Checkov]
+Escolher `AWS_MANAGED` significa que a tabela não está mais criptografada com uma chave gerenciada pelo cliente, o que falha no `CKV_AWS_119` do Checkov. Suprima-o na tabela:
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { suppressRules } from '@my-scope/common-constructs';
+
+suppressRules(table.table, ['CKV_AWS_119'], 'Using an AWS managed key rather than a customer-managed CMK');
+```
+:::
 </Fragment>
 <Fragment slot="terraform">
 
@@ -45,6 +56,16 @@ const table = new MyTable(this, 'Table', {
   encryption: TableEncryption.DEFAULT,
 });
 ```
+
+:::tip[Checkov]
+Escolher `DEFAULT` significa que a tabela não está mais criptografada com uma chave gerenciada pelo cliente, o que falha no `CKV_AWS_119` do Checkov. Suprima-o na tabela:
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { suppressRules } from '@my-scope/common-constructs';
+
+suppressRules(table.table, ['CKV_AWS_119'], 'Using the AWS owned key rather than a customer-managed CMK');
+```
+:::
 </Fragment>
 <Fragment slot="terraform">
 
@@ -56,6 +77,28 @@ module "my_table" {
 ```
 </Fragment>
 </Infrastructure>
+
+<OptionFilter when={{ iac: 'terraform' }} description="Switching an already-deployed table away from CUSTOMER_MANAGED">
+#### Mudando de CUSTOMER_MANAGED
+
+Em uma tabela **já implantada**, alterar `encryption` de `CUSTOMER_MANAGED` (para `AWS_MANAGED` ou `DEFAULT`) em um único `terraform apply` falha: o Terraform destrói a chave gerenciada pelo cliente antes de atualizar a tabela, e o DynamoDB então rejeita a atualização porque a chave já está pendente de exclusão.
+
+Contorne isso atualizando a criptografia da tabela diretamente via AWS CLI primeiro, e depois deixando o Terraform alcançar e limpar a chave órfã:
+
+```bash
+# For AWS_MANAGED:
+aws dynamodb update-table --table-name <table-name> \
+  --sse-specification Enabled=true,SSEType=KMS,KMSMasterKeyId=alias/aws/dynamodb
+
+# For DEFAULT:
+aws dynamodb update-table --table-name <table-name> --sse-specification Enabled=false
+
+# Then wait for this to report ENABLED (or for SSEDescription to disappear, for DEFAULT):
+aws dynamodb describe-table --table-name <table-name> --query Table.SSEDescription.Status
+```
+
+Então atualize `encryption` em sua configuração Terraform e execute `terraform apply` normalmente — o Terraform agora só precisa destruir a chave já não utilizada, sem nada mais dependendo dela.
+</OptionFilter>
 
 #### Usar Sua Própria Chave KMS
 
@@ -102,6 +145,16 @@ const table = new MyTable(this, 'Table', {
   enableKeyRotation: false,
 });
 ```
+
+:::tip[Checkov]
+Desabilitar a rotação de chave, ou trazer sua própria chave que não rotaciona, falha no `CKV_AWS_7` do Checkov. Suprima-o na chave:
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { suppressRules } from '@my-scope/common-constructs';
+
+suppressRules(table.table.encryptionKey!, ['CKV_AWS_7'], 'Key rotation is managed externally');
+```
+:::
 </Fragment>
 <Fragment slot="terraform">
 

--- a/docs/src/content/docs/pt/snippets/dynamodb/encryption-options.mdx
+++ b/docs/src/content/docs/pt/snippets/dynamodb/encryption-options.mdx
@@ -1,0 +1,115 @@
+---
+title: Opções de Criptografia
+---
+import Infrastructure from '@components/infrastructure.astro';
+
+#### Usar uma Chave Gerenciada pela AWS
+
+Usa a chave KMS compartilhada `aws/dynamodb` que a AWS gerencia em seu nome. Ela é visível no console KMS da sua conta e cobrada por requisição, mas não há chave para você criar, rotacionar ou excluir.
+
+<Infrastructure>
+<Fragment slot="cdk">
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { TableEncryption } from 'aws-cdk-lib/aws-dynamodb';
+import { MyTable } from '@my-scope/common-constructs';
+
+const table = new MyTable(this, 'Table', {
+  encryption: TableEncryption.AWS_MANAGED,
+});
+```
+</Fragment>
+<Fragment slot="terraform">
+
+```hcl title="packages/infra/src/main.tf"
+module "my_table" {
+  source     = "../../common/terraform/src/app/dynamodb/my-table"
+  encryption = "AWS_MANAGED"
+}
+```
+</Fragment>
+</Infrastructure>
+
+#### Usar a Chave de Propriedade da AWS
+
+Usa uma chave totalmente de propriedade e gerenciada pela AWS — gratuita, sem chave visível em sua conta. A opção mais simples quando você não precisa de uma chave visível ao cliente ou à conta por motivos de conformidade.
+
+<Infrastructure>
+<Fragment slot="cdk">
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { TableEncryption } from 'aws-cdk-lib/aws-dynamodb';
+import { MyTable } from '@my-scope/common-constructs';
+
+const table = new MyTable(this, 'Table', {
+  encryption: TableEncryption.DEFAULT,
+});
+```
+</Fragment>
+<Fragment slot="terraform">
+
+```hcl title="packages/infra/src/main.tf"
+module "my_table" {
+  source     = "../../common/terraform/src/app/dynamodb/my-table"
+  encryption = "DEFAULT"
+}
+```
+</Fragment>
+</Infrastructure>
+
+#### Usar Sua Própria Chave KMS
+
+Forneça uma chave gerenciada pelo cliente existente em vez de ter uma criada para você. A chave já deve conceder ao serviço DynamoDB as permissões necessárias em sua própria política de chave.
+
+<Infrastructure>
+<Fragment slot="cdk">
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { Key } from 'aws-cdk-lib/aws-kms';
+import { MyTable } from '@my-scope/common-constructs';
+
+const key = Key.fromKeyArn(this, 'Key', 'arn:aws:kms:us-east-1:111111111111:key/my-key-id');
+
+const table = new MyTable(this, 'Table', {
+  encryptionKey: key,
+});
+```
+</Fragment>
+<Fragment slot="terraform">
+
+```hcl title="packages/infra/src/main.tf"
+module "my_table" {
+  source      = "../../common/terraform/src/app/dynamodb/my-table"
+  kms_key_arn = "arn:aws:kms:us-east-1:111111111111:key/my-key-id"
+}
+```
+</Fragment>
+</Infrastructure>
+
+#### Rotação de Chave de Criptografia
+
+Quando a tabela cria sua própria chave KMS gerenciada pelo cliente (o padrão, e apenas quando você não forneceu sua própria chave), essa chave tem rotação automática de chave habilitada por padrão. Desabilite-a se sua política de segurança gerencia a rotação externamente.
+
+##### Desabilitar Rotação de Chave de Criptografia
+
+<Infrastructure>
+<Fragment slot="cdk">
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { MyTable } from '@my-scope/common-constructs';
+
+const table = new MyTable(this, 'Table', {
+  enableKeyRotation: false,
+});
+```
+</Fragment>
+<Fragment slot="terraform">
+
+```hcl title="packages/infra/src/main.tf"
+module "my_table" {
+  source              = "../../common/terraform/src/app/dynamodb/my-table"
+  enable_key_rotation = false
+}
+```
+</Fragment>
+</Infrastructure>

--- a/docs/src/content/docs/vi/snippets/dynamodb/deploying-table.mdx
+++ b/docs/src/content/docs/vi/snippets/dynamodb/deploying-table.mdx
@@ -2,8 +2,9 @@
 title: Triển khai DynamoDB Table của bạn
 ---
 import Infrastructure from '@components/infrastructure.astro';
+import Snippet from '@components/snippet.astro';
 
-Trình tạo DynamoDB tạo ra cơ sở hạ tầng CDK hoặc Terraform dựa trên `iac` bạn đã chọn.
+Generator DynamoDB tạo cơ sở hạ tầng CDK hoặc Terraform dựa trên `iac` bạn đã chọn.
 
 <Infrastructure>
 <Fragment slot="cdk">
@@ -25,7 +26,7 @@ export class ApplicationStack extends Stack {
 - `pk` (partition key) và `sk` (sort key), cả hai đều là kiểu `String`
 - Global Secondary Indexes như được định nghĩa trong `config.json`
 - Thanh toán theo yêu cầu (`PAY_PER_REQUEST`)
-- Mã hóa KMS do khách hàng quản lý với tự động xoay khóa
+- Mã hóa KMS do khách hàng quản lý với tự động xoay vòng khóa
 - Khôi phục theo thời điểm được bật
 - Bảo vệ xóa được bật
 - Tên bảng được đăng ký trong Runtime Config dưới namespace `dynamodb` trong AWS AppConfig
@@ -43,7 +44,7 @@ module "my_table" {
 - `pk` (partition key) và `sk` (sort key), cả hai đều là kiểu `String`
 - Global Secondary Indexes như được định nghĩa trong `config.json`
 - Thanh toán theo yêu cầu (`PAY_PER_REQUEST`)
-- Mã hóa KMS do khách hàng quản lý với tự động xoay khóa
+- Mã hóa KMS do khách hàng quản lý với tự động xoay vòng khóa
 - Khôi phục theo thời điểm được bật
 - Bảo vệ xóa được bật
 - Tên bảng được đăng ký trong Runtime Config
@@ -54,9 +55,9 @@ module "my_table" {
 
 Bảo vệ xóa được bật mặc định để ngăn chặn việc xóa bảng một cách vô tình.
 
-#### Tắt Bảo vệ Xóa
+#### Vô hiệu hóa Bảo vệ Xóa
 
-Tắt nó cho các môi trường mà việc xóa bảng được mong đợi, chẳng hạn như các stack phát triển hoặc xem trước có thời gian tồn tại ngắn.
+Vô hiệu hóa nó cho các môi trường mà việc xóa bảng được mong đợi, chẳng hạn như các stack phát triển hoặc xem trước có thời gian tồn tại ngắn.
 
 <Infrastructure>
 <Fragment slot="cdk">
@@ -113,7 +114,7 @@ module "my_table" {
 
 [Khôi phục theo thời điểm](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Point-in-time-recovery.html) được bật mặc định, cho phép bạn khôi phục bảng về bất kỳ thời điểm nào trong 35 ngày qua.
 
-#### Tắt Khôi phục Theo Thời điểm
+#### Vô hiệu hóa Khôi phục Theo Thời điểm
 
 <Infrastructure>
 <Fragment slot="cdk">
@@ -137,30 +138,8 @@ module "my_table" {
 </Fragment>
 </Infrastructure>
 
-### Xoay Khóa Mã hóa
+### Mã hóa
 
-Khóa KMS được sử dụng để mã hóa bảng có tính năng tự động xoay khóa được bật mặc định. Tắt nó nếu chính sách bảo mật của bạn quản lý việc xoay khóa từ bên ngoài.
+Bảng được mã hóa với khóa KMS do khách hàng quản lý theo mặc định, được tạo tự động cho bạn. Chuyển sang khóa do AWS quản lý, khóa thuộc sở hữu của AWS, hoặc mang khóa KMS của riêng bạn, nếu bạn quản lý mã hóa theo cách khác.
 
-#### Tắt Xoay Khóa Mã hóa
-
-<Infrastructure>
-<Fragment slot="cdk">
-
-```ts title="packages/infra/src/stacks/application-stack.ts"
-import { MyTable } from '@my-scope/common-constructs';
-
-const table = new MyTable(this, 'Table', {
-  enableKeyRotation: false,
-});
-```
-</Fragment>
-<Fragment slot="terraform">
-
-```hcl title="packages/infra/src/main.tf"
-module "my_table" {
-  source              = "../../common/terraform/src/app/dynamodb/my-table"
-  enable_key_rotation = false
-}
-```
-</Fragment>
-</Infrastructure>
+<Snippet name="dynamodb/encryption-options" parentHeading="Mã hóa" />

--- a/docs/src/content/docs/vi/snippets/dynamodb/encryption-options.mdx
+++ b/docs/src/content/docs/vi/snippets/dynamodb/encryption-options.mdx
@@ -1,0 +1,115 @@
+---
+title: Tùy chọn Mã hóa
+---
+import Infrastructure from '@components/infrastructure.astro';
+
+#### Sử dụng Khóa do AWS Quản lý
+
+Sử dụng khóa KMS `aws/dynamodb` được chia sẻ mà AWS quản lý thay mặt bạn. Nó hiển thị trong bảng điều khiển KMS của tài khoản bạn và được tính phí theo yêu cầu, nhưng không có khóa nào để bạn tạo, xoay vòng hoặc xóa.
+
+<Infrastructure>
+<Fragment slot="cdk">
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { TableEncryption } from 'aws-cdk-lib/aws-dynamodb';
+import { MyTable } from '@my-scope/common-constructs';
+
+const table = new MyTable(this, 'Table', {
+  encryption: TableEncryption.AWS_MANAGED,
+});
+```
+</Fragment>
+<Fragment slot="terraform">
+
+```hcl title="packages/infra/src/main.tf"
+module "my_table" {
+  source     = "../../common/terraform/src/app/dynamodb/my-table"
+  encryption = "AWS_MANAGED"
+}
+```
+</Fragment>
+</Infrastructure>
+
+#### Sử dụng Khóa Thuộc sở hữu của AWS
+
+Sử dụng một khóa hoàn toàn thuộc sở hữu và được quản lý bởi AWS — miễn phí, không có khóa nào hiển thị trong tài khoản của bạn. Tùy chọn đơn giản nhất khi bạn không cần khóa hiển thị cho khách hàng hoặc tài khoản vì lý do tuân thủ.
+
+<Infrastructure>
+<Fragment slot="cdk">
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { TableEncryption } from 'aws-cdk-lib/aws-dynamodb';
+import { MyTable } from '@my-scope/common-constructs';
+
+const table = new MyTable(this, 'Table', {
+  encryption: TableEncryption.DEFAULT,
+});
+```
+</Fragment>
+<Fragment slot="terraform">
+
+```hcl title="packages/infra/src/main.tf"
+module "my_table" {
+  source     = "../../common/terraform/src/app/dynamodb/my-table"
+  encryption = "DEFAULT"
+}
+```
+</Fragment>
+</Infrastructure>
+
+#### Sử dụng Khóa KMS của Riêng Bạn
+
+Cung cấp một khóa do khách hàng quản lý hiện có thay vì để một khóa được tạo cho bạn. Khóa phải đã cấp cho dịch vụ DynamoDB các quyền cần thiết trong chính sách khóa của nó.
+
+<Infrastructure>
+<Fragment slot="cdk">
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { Key } from 'aws-cdk-lib/aws-kms';
+import { MyTable } from '@my-scope/common-constructs';
+
+const key = Key.fromKeyArn(this, 'Key', 'arn:aws:kms:us-east-1:111111111111:key/my-key-id');
+
+const table = new MyTable(this, 'Table', {
+  encryptionKey: key,
+});
+```
+</Fragment>
+<Fragment slot="terraform">
+
+```hcl title="packages/infra/src/main.tf"
+module "my_table" {
+  source      = "../../common/terraform/src/app/dynamodb/my-table"
+  kms_key_arn = "arn:aws:kms:us-east-1:111111111111:key/my-key-id"
+}
+```
+</Fragment>
+</Infrastructure>
+
+#### Xoay vòng Khóa Mã hóa
+
+Khi bảng tạo khóa KMS do khách hàng quản lý của riêng nó (mặc định, và chỉ khi bạn chưa cung cấp khóa của riêng mình), khóa đó có tính năng xoay vòng khóa tự động được bật theo mặc định. Vô hiệu hóa nó nếu chính sách bảo mật của bạn quản lý xoay vòng từ bên ngoài.
+
+##### Vô hiệu hóa Xoay vòng Khóa Mã hóa
+
+<Infrastructure>
+<Fragment slot="cdk">
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { MyTable } from '@my-scope/common-constructs';
+
+const table = new MyTable(this, 'Table', {
+  enableKeyRotation: false,
+});
+```
+</Fragment>
+<Fragment slot="terraform">
+
+```hcl title="packages/infra/src/main.tf"
+module "my_table" {
+  source              = "../../common/terraform/src/app/dynamodb/my-table"
+  enable_key_rotation = false
+}
+```
+</Fragment>
+</Infrastructure>

--- a/docs/src/content/docs/vi/snippets/dynamodb/encryption-options.mdx
+++ b/docs/src/content/docs/vi/snippets/dynamodb/encryption-options.mdx
@@ -2,6 +2,7 @@
 title: Tùy chọn Mã hóa
 ---
 import Infrastructure from '@components/infrastructure.astro';
+import OptionFilter from '@components/option-filter.astro';
 
 #### Sử dụng Khóa do AWS Quản lý
 
@@ -18,6 +19,16 @@ const table = new MyTable(this, 'Table', {
   encryption: TableEncryption.AWS_MANAGED,
 });
 ```
+
+:::tip[Checkov]
+Chọn `AWS_MANAGED` có nghĩa là bảng không còn được mã hóa bằng khóa do khách hàng quản lý, điều này làm thất bại `CKV_AWS_119` của Checkov. Loại bỏ nó trên bảng:
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { suppressRules } from '@my-scope/common-constructs';
+
+suppressRules(table.table, ['CKV_AWS_119'], 'Using an AWS managed key rather than a customer-managed CMK');
+```
+:::
 </Fragment>
 <Fragment slot="terraform">
 
@@ -45,6 +56,16 @@ const table = new MyTable(this, 'Table', {
   encryption: TableEncryption.DEFAULT,
 });
 ```
+
+:::tip[Checkov]
+Chọn `DEFAULT` có nghĩa là bảng không còn được mã hóa bằng khóa do khách hàng quản lý, điều này làm thất bại `CKV_AWS_119` của Checkov. Loại bỏ nó trên bảng:
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { suppressRules } from '@my-scope/common-constructs';
+
+suppressRules(table.table, ['CKV_AWS_119'], 'Using the AWS owned key rather than a customer-managed CMK');
+```
+:::
 </Fragment>
 <Fragment slot="terraform">
 
@@ -56,6 +77,28 @@ module "my_table" {
 ```
 </Fragment>
 </Infrastructure>
+
+<OptionFilter when={{ iac: 'terraform' }} description="Chuyển đổi bảng đã triển khai khỏi CUSTOMER_MANAGED">
+#### Chuyển đổi khỏi CUSTOMER_MANAGED
+
+Trên bảng **đã triển khai**, việc thay đổi `encryption` khỏi `CUSTOMER_MANAGED` (sang `AWS_MANAGED` hoặc `DEFAULT`) trong một lệnh `terraform apply` duy nhất sẽ thất bại: Terraform phá hủy khóa do khách hàng quản lý trước khi cập nhật bảng, và DynamoDB sau đó từ chối cập nhật vì khóa đã đang chờ xóa.
+
+Giải quyết bằng cách cập nhật mã hóa của bảng trực tiếp qua AWS CLI trước, sau đó để Terraform bắt kịp và dọn dẹp khóa bị bỏ rơi:
+
+```bash
+# For AWS_MANAGED:
+aws dynamodb update-table --table-name <table-name> \
+  --sse-specification Enabled=true,SSEType=KMS,KMSMasterKeyId=alias/aws/dynamodb
+
+# For DEFAULT:
+aws dynamodb update-table --table-name <table-name> --sse-specification Enabled=false
+
+# Then wait for this to report ENABLED (or for SSEDescription to disappear, for DEFAULT):
+aws dynamodb describe-table --table-name <table-name> --query Table.SSEDescription.Status
+```
+
+Sau đó cập nhật `encryption` trong cấu hình Terraform của bạn và chạy `terraform apply` như bình thường — Terraform bây giờ chỉ cần phá hủy khóa đã không sử dụng, không còn gì phụ thuộc vào nó.
+</OptionFilter>
 
 #### Sử dụng Khóa KMS của Riêng Bạn
 
@@ -102,6 +145,16 @@ const table = new MyTable(this, 'Table', {
   enableKeyRotation: false,
 });
 ```
+
+:::tip[Checkov]
+Vô hiệu hóa xoay vòng khóa, hoặc mang khóa của riêng bạn không xoay vòng, làm thất bại `CKV_AWS_7` của Checkov. Loại bỏ nó trên khóa:
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { suppressRules } from '@my-scope/common-constructs';
+
+suppressRules(table.table.encryptionKey!, ['CKV_AWS_7'], 'Key rotation is managed externally');
+```
+:::
 </Fragment>
 <Fragment slot="terraform">
 

--- a/docs/src/content/docs/zh/snippets/dynamodb/deploying-table.mdx
+++ b/docs/src/content/docs/zh/snippets/dynamodb/deploying-table.mdx
@@ -2,6 +2,7 @@
 title: 部署您的 DynamoDB 表
 ---
 import Infrastructure from '@components/infrastructure.astro';
+import Snippet from '@components/snippet.astro';
 
 DynamoDB 生成器根据您选择的 `iac` 创建 CDK 或 Terraform 基础设施。
 
@@ -111,7 +112,7 @@ module "my_table" {
 
 ### 时间点恢复
 
-默认启用[时间点恢复](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Point-in-time-recovery.html)，允许您将表恢复到过去 35 天内的任意时间点。
+默认启用[时间点恢复](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Point-in-time-recovery.html)，允许您将表恢复到过去 35 天内的任何时间点。
 
 #### 禁用时间点恢复
 
@@ -137,30 +138,8 @@ module "my_table" {
 </Fragment>
 </Infrastructure>
 
-### 加密密钥轮换
+### 加密
 
-用于加密表的 KMS 密钥默认启用自动密钥轮换。如果您的安全策略在外部管理轮换，可以禁用它。
+默认情况下，表使用客户托管的 KMS 密钥进行加密，该密钥会自动为您创建。如果您以不同方式管理加密，可以切换到 AWS 托管密钥、AWS 拥有的密钥或使用您自己的 KMS 密钥。
 
-#### 禁用加密密钥轮换
-
-<Infrastructure>
-<Fragment slot="cdk">
-
-```ts title="packages/infra/src/stacks/application-stack.ts"
-import { MyTable } from '@my-scope/common-constructs';
-
-const table = new MyTable(this, 'Table', {
-  enableKeyRotation: false,
-});
-```
-</Fragment>
-<Fragment slot="terraform">
-
-```hcl title="packages/infra/src/main.tf"
-module "my_table" {
-  source              = "../../common/terraform/src/app/dynamodb/my-table"
-  enable_key_rotation = false
-}
-```
-</Fragment>
-</Infrastructure>
+<Snippet name="dynamodb/encryption-options" parentHeading="加密" />

--- a/docs/src/content/docs/zh/snippets/dynamodb/encryption-options.mdx
+++ b/docs/src/content/docs/zh/snippets/dynamodb/encryption-options.mdx
@@ -2,6 +2,7 @@
 title: 加密选项
 ---
 import Infrastructure from '@components/infrastructure.astro';
+import OptionFilter from '@components/option-filter.astro';
 
 #### 使用 AWS 托管密钥
 
@@ -18,6 +19,16 @@ const table = new MyTable(this, 'Table', {
   encryption: TableEncryption.AWS_MANAGED,
 });
 ```
+
+:::tip[Checkov]
+选择 `AWS_MANAGED` 意味着表不再使用客户托管密钥加密，这会导致 Checkov 的 `CKV_AWS_119` 检查失败。在表上抑制该规则：
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { suppressRules } from '@my-scope/common-constructs';
+
+suppressRules(table.table, ['CKV_AWS_119'], 'Using an AWS managed key rather than a customer-managed CMK');
+```
+:::
 </Fragment>
 <Fragment slot="terraform">
 
@@ -45,6 +56,16 @@ const table = new MyTable(this, 'Table', {
   encryption: TableEncryption.DEFAULT,
 });
 ```
+
+:::tip[Checkov]
+选择 `DEFAULT` 意味着表不再使用客户托管密钥加密，这会导致 Checkov 的 `CKV_AWS_119` 检查失败。在表上抑制该规则：
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { suppressRules } from '@my-scope/common-constructs';
+
+suppressRules(table.table, ['CKV_AWS_119'], 'Using the AWS owned key rather than a customer-managed CMK');
+```
+:::
 </Fragment>
 <Fragment slot="terraform">
 
@@ -56,6 +77,28 @@ module "my_table" {
 ```
 </Fragment>
 </Infrastructure>
+
+<OptionFilter when={{ iac: 'terraform' }} description="Switching an already-deployed table away from CUSTOMER_MANAGED">
+#### 从 CUSTOMER_MANAGED 切换
+
+在**已部署**的表上，在单次 `terraform apply` 中将 `encryption` 从 `CUSTOMER_MANAGED` 更改为 `AWS_MANAGED` 或 `DEFAULT` 会失败：Terraform 在更新表之前销毁客户托管密钥，然后 DynamoDB 会拒绝更新，因为密钥已处于待删除状态。
+
+解决方法是先通过 AWS CLI 直接更新表的加密，然后让 Terraform 跟进并清理孤立的密钥：
+
+```bash
+# For AWS_MANAGED:
+aws dynamodb update-table --table-name <table-name> \
+  --sse-specification Enabled=true,SSEType=KMS,KMSMasterKeyId=alias/aws/dynamodb
+
+# For DEFAULT:
+aws dynamodb update-table --table-name <table-name> --sse-specification Enabled=false
+
+# Then wait for this to report ENABLED (or for SSEDescription to disappear, for DEFAULT):
+aws dynamodb describe-table --table-name <table-name> --query Table.SSEDescription.Status
+```
+
+然后在 Terraform 配置中更新 `encryption` 并正常运行 `terraform apply`——Terraform 现在只需要销毁已经未使用的密钥，没有任何东西依赖它。
+</OptionFilter>
 
 #### 使用您自己的 KMS 密钥
 
@@ -102,6 +145,16 @@ const table = new MyTable(this, 'Table', {
   enableKeyRotation: false,
 });
 ```
+
+:::tip[Checkov]
+禁用密钥轮换，或使用不轮换的自己的密钥，会导致 Checkov 的 `CKV_AWS_7` 检查失败。在密钥上抑制该规则：
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { suppressRules } from '@my-scope/common-constructs';
+
+suppressRules(table.table.encryptionKey!, ['CKV_AWS_7'], 'Key rotation is managed externally');
+```
+:::
 </Fragment>
 <Fragment slot="terraform">
 

--- a/docs/src/content/docs/zh/snippets/dynamodb/encryption-options.mdx
+++ b/docs/src/content/docs/zh/snippets/dynamodb/encryption-options.mdx
@@ -1,0 +1,115 @@
+---
+title: 加密选项
+---
+import Infrastructure from '@components/infrastructure.astro';
+
+#### 使用 AWS 托管密钥
+
+使用 AWS 代表您管理的共享 `aws/dynamodb` KMS 密钥。它在您账户的 KMS 控制台中可见并按请求计费，但您无需创建、轮换或删除密钥。
+
+<Infrastructure>
+<Fragment slot="cdk">
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { TableEncryption } from 'aws-cdk-lib/aws-dynamodb';
+import { MyTable } from '@my-scope/common-constructs';
+
+const table = new MyTable(this, 'Table', {
+  encryption: TableEncryption.AWS_MANAGED,
+});
+```
+</Fragment>
+<Fragment slot="terraform">
+
+```hcl title="packages/infra/src/main.tf"
+module "my_table" {
+  source     = "../../common/terraform/src/app/dynamodb/my-table"
+  encryption = "AWS_MANAGED"
+}
+```
+</Fragment>
+</Infrastructure>
+
+#### 使用 AWS 拥有的密钥
+
+使用完全由 AWS 拥有和管理的密钥——免费，且您的账户中完全看不到密钥。当您出于合规原因不需要客户或账户可见的密钥时，这是最简单的选项。
+
+<Infrastructure>
+<Fragment slot="cdk">
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { TableEncryption } from 'aws-cdk-lib/aws-dynamodb';
+import { MyTable } from '@my-scope/common-constructs';
+
+const table = new MyTable(this, 'Table', {
+  encryption: TableEncryption.DEFAULT,
+});
+```
+</Fragment>
+<Fragment slot="terraform">
+
+```hcl title="packages/infra/src/main.tf"
+module "my_table" {
+  source     = "../../common/terraform/src/app/dynamodb/my-table"
+  encryption = "DEFAULT"
+}
+```
+</Fragment>
+</Infrastructure>
+
+#### 使用您自己的 KMS 密钥
+
+提供现有的客户托管密钥，而不是为您创建一个。该密钥必须在其自己的密钥策略中已经授予 DynamoDB 服务所需的权限。
+
+<Infrastructure>
+<Fragment slot="cdk">
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { Key } from 'aws-cdk-lib/aws-kms';
+import { MyTable } from '@my-scope/common-constructs';
+
+const key = Key.fromKeyArn(this, 'Key', 'arn:aws:kms:us-east-1:111111111111:key/my-key-id');
+
+const table = new MyTable(this, 'Table', {
+  encryptionKey: key,
+});
+```
+</Fragment>
+<Fragment slot="terraform">
+
+```hcl title="packages/infra/src/main.tf"
+module "my_table" {
+  source      = "../../common/terraform/src/app/dynamodb/my-table"
+  kms_key_arn = "arn:aws:kms:us-east-1:111111111111:key/my-key-id"
+}
+```
+</Fragment>
+</Infrastructure>
+
+#### 加密密钥轮换
+
+当表创建自己的客户托管 KMS 密钥时（默认情况，且仅当您未提供自己的密钥时），该密钥默认启用自动密钥轮换。如果您的安全策略在外部管理轮换，可以禁用它。
+
+##### 禁用加密密钥轮换
+
+<Infrastructure>
+<Fragment slot="cdk">
+
+```ts title="packages/infra/src/stacks/application-stack.ts"
+import { MyTable } from '@my-scope/common-constructs';
+
+const table = new MyTable(this, 'Table', {
+  enableKeyRotation: false,
+});
+```
+</Fragment>
+<Fragment slot="terraform">
+
+```hcl title="packages/infra/src/main.tf"
+module "my_table" {
+  source              = "../../common/terraform/src/app/dynamodb/my-table"
+  enable_key_rotation = false
+}
+```
+</Fragment>
+</Infrastructure>

--- a/e2e/src/files/dungeon-adventure/2/stacks/application-stack.ts.template
+++ b/e2e/src/files/dungeon-adventure/2/stacks/application-stack.ts.template
@@ -7,6 +7,7 @@ import {
   UserIdentity,
 } from '@dungeon-adventure/common-constructs';
 import { Stack, StackProps, CfnOutput, RemovalPolicy } from 'aws-cdk-lib';
+import { TableEncryption } from 'aws-cdk-lib/aws-dynamodb';
 import { Construct } from 'constructs';
 
 export class ApplicationStack extends Stack {
@@ -19,6 +20,7 @@ export class ApplicationStack extends Stack {
     const dungeonDb = new DungeonDb(this, 'DungeonDb', {
       deletionProtection: false,
       removalPolicy: RemovalPolicy.DESTROY,
+      encryption: TableEncryption.DEFAULT,
     });
 
     const gameApi = new GameApi(this, 'GameApi', {

--- a/e2e/src/files/dungeon-adventure/2/stacks/application-stack.ts.template
+++ b/e2e/src/files/dungeon-adventure/2/stacks/application-stack.ts.template
@@ -5,6 +5,7 @@ import {
   InventoryMcpServer,
   StoryAgent,
   UserIdentity,
+  suppressRules,
 } from '@dungeon-adventure/common-constructs';
 import { Stack, StackProps, CfnOutput, RemovalPolicy } from 'aws-cdk-lib';
 import { TableEncryption } from 'aws-cdk-lib/aws-dynamodb';
@@ -22,6 +23,13 @@ export class ApplicationStack extends Stack {
       removalPolicy: RemovalPolicy.DESTROY,
       encryption: TableEncryption.DEFAULT,
     });
+    // The AWS owned key has no KMS resource pending deletion when you tear
+    // down and recreate this sandbox stack, unlike a customer-managed CMK.
+    suppressRules(
+      dungeonDb.table,
+      ['CKV_AWS_119'],
+      'Sandbox stack uses the AWS owned key so it can be torn down and recreated freely',
+    );
 
     const gameApi = new GameApi(this, 'GameApi', {
       integrations: GameApi.defaultIntegrations(this).build(),

--- a/e2e/src/files/dungeon-adventure/2/stacks/application-stack.ts.template
+++ b/e2e/src/files/dungeon-adventure/2/stacks/application-stack.ts.template
@@ -23,8 +23,6 @@ export class ApplicationStack extends Stack {
       removalPolicy: RemovalPolicy.DESTROY,
       encryption: TableEncryption.DEFAULT,
     });
-    // The AWS owned key has no KMS resource pending deletion when you tear
-    // down and recreate this sandbox stack, unlike a customer-managed CMK.
     suppressRules(
       dungeonDb.table,
       ['CKV_AWS_119'],

--- a/packages/nx-plugin/src/migrations/latest/dynamodb-configurable-encryption/__snapshots__/migration.spec.ts.snap
+++ b/packages/nx-plugin/src/migrations/latest/dynamodb-configurable-encryption/__snapshots__/migration.spec.ts.snap
@@ -350,6 +350,7 @@ resource "aws_kms_key" "table" {
 }
 
 resource "aws_dynamodb_table" "table" {
+  #checkov:skip=CKV_AWS_119:Encryption is configurable via var.encryption; checkov cannot resolve the conditional server_side_encryption.enabled expression
   name                        = var.name
   billing_mode                = var.billing_mode
   hash_key                    = "pk"

--- a/packages/nx-plugin/src/migrations/latest/dynamodb-configurable-encryption/__snapshots__/migration.spec.ts.snap
+++ b/packages/nx-plugin/src/migrations/latest/dynamodb-configurable-encryption/__snapshots__/migration.spec.ts.snap
@@ -46,6 +46,8 @@ export interface DynamoDBTableProps extends _DynamoDBTableProps {
 
   /**
    * Whether to enable automatic key rotation on the KMS key used to encrypt the table.
+   * Only applies when \`encryption\` is \`TableEncryption.CUSTOMER_MANAGED\` and no
+   * \`encryptionKey\` is supplied.
    *
    * @default true
    */
@@ -164,7 +166,7 @@ variable "deletion_protection_enabled" {
 }
 
 variable "encryption" {
-  description = "Server-side encryption for the table. One of CUSTOMER_MANAGED, AWS_MANAGED or DEFAULT (the AWS owned key, at no cost and with no key to manage)."
+  description = "Server-side encryption for the table. One of CUSTOMER_MANAGED, AWS_MANAGED or DEFAULT (the AWS owned key, at no cost and with no key to manage). Changing this on an already-deployed table away from CUSTOMER_MANAGED requires a manual step first - see the ts#dynamodb generator docs."
   type        = string
   default     = "CUSTOMER_MANAGED"
 
@@ -175,13 +177,19 @@ variable "encryption" {
 }
 
 variable "kms_key_arn" {
-  description = "ARN of an existing KMS key used to encrypt the table when encryption is CUSTOMER_MANAGED. When not provided, a new key is created. Note that a customer-supplied key must already grant the DynamoDB service the necessary permissions in its own key policy."
+  description = "ARN of an existing KMS key used to encrypt the table when encryption is CUSTOMER_MANAGED. When not provided and create_kms_key is true, a new key is created. Note that a customer-supplied key must already grant the DynamoDB service the necessary permissions in its own key policy."
   type        = string
   default     = null
 }
 
+variable "create_kms_key" {
+  description = "Whether to create a KMS key for the table. Only applies when encryption is CUSTOMER_MANAGED. Set to false when supplying kms_key_arn."
+  type        = bool
+  default     = true
+}
+
 variable "enable_key_rotation" {
-  description = "Whether to enable automatic key rotation on the KMS key used to encrypt the table. Only applies when encryption is CUSTOMER_MANAGED and kms_key_arn is not provided."
+  description = "Whether to enable automatic key rotation on the KMS key used to encrypt the table. Only applies when encryption is CUSTOMER_MANAGED and create_kms_key is true."
   type        = bool
   default     = true
 }
@@ -208,8 +216,9 @@ module "dynamodb_table" {
   billing_mode                   = var.billing_mode
   point_in_time_recovery_enabled = var.point_in_time_recovery_enabled
   deletion_protection_enabled = var.deletion_protection_enabled
-  encryption   = var.encryption
-  kms_key_arn  = var.kms_key_arn
+  encryption      = var.encryption
+  kms_key_arn     = var.kms_key_arn
+  create_kms_key  = var.create_kms_key
   enable_key_rotation            = var.enable_key_rotation
   global_secondary_indexes       = local.global_secondary_indexes
 }
@@ -262,7 +271,7 @@ variable "deletion_protection_enabled" {
 }
 
 variable "encryption" {
-  description = "Server-side encryption for the table. One of CUSTOMER_MANAGED, AWS_MANAGED or DEFAULT (the AWS owned key, at no cost and with no key to manage)."
+  description = "Server-side encryption for the table. One of CUSTOMER_MANAGED, AWS_MANAGED or DEFAULT (the AWS owned key, at no cost and with no key to manage). Changing this on an already-deployed table away from CUSTOMER_MANAGED requires a manual step first - see the ts#dynamodb generator docs."
   type        = string
   default     = "CUSTOMER_MANAGED"
 
@@ -273,13 +282,19 @@ variable "encryption" {
 }
 
 variable "kms_key_arn" {
-  description = "ARN of an existing KMS key used to encrypt the table when encryption is CUSTOMER_MANAGED. When not provided, a new key is created. Note that a customer-supplied key must already grant the DynamoDB service the necessary permissions in its own key policy."
+  description = "ARN of an existing KMS key used to encrypt the table when encryption is CUSTOMER_MANAGED. When not provided and create_kms_key is true, a new key is created. Note that a customer-supplied key must already grant the DynamoDB service the necessary permissions in its own key policy."
   type        = string
   default     = null
 }
 
+variable "create_kms_key" {
+  description = "Whether to create a KMS key for the table. Only applies when encryption is CUSTOMER_MANAGED. Set to false when supplying kms_key_arn."
+  type        = bool
+  default     = true
+}
+
 variable "enable_key_rotation" {
-  description = "Whether to enable automatic key rotation on the KMS key used to encrypt the table. Only applies when encryption is CUSTOMER_MANAGED and kms_key_arn is not provided."
+  description = "Whether to enable automatic key rotation on the KMS key used to encrypt the table. Only applies when encryption is CUSTOMER_MANAGED and create_kms_key is true."
   type        = bool
   default     = true
 }
@@ -300,16 +315,17 @@ locals {
     for gsi in var.global_secondary_indexes : [gsi.hash_key, gsi.range_key]
   ]))
 
-  create_table_key = var.encryption == "CUSTOMER_MANAGED" && var.kms_key_arn == null
+  create_table_key = var.encryption == "CUSTOMER_MANAGED" && var.create_kms_key
   table_kms_key_arn = (
-    var.encryption != "CUSTOMER_MANAGED" ? null :
-    local.create_table_key ? aws_kms_key.table[0].arn :
-    var.kms_key_arn
+    var.encryption == "CUSTOMER_MANAGED" ? (local.create_table_key ? aws_kms_key.table[0].arn : var.kms_key_arn) :
+    var.encryption == "AWS_MANAGED" ? "arn:\${data.aws_partition.current.partition}:kms:\${data.aws_region.current.region}:\${data.aws_caller_identity.current.account_id}:alias/aws/dynamodb" :
+    null
   )
 }
 
 data "aws_caller_identity" "current" {}
 data "aws_partition" "current" {}
+data "aws_region" "current" {}
 
 resource "aws_kms_key" "table" {
   count = local.create_table_key ? 1 : 0
@@ -406,7 +422,7 @@ output "table_arn" {
 }
 
 output "kms_key_arn" {
-  description = "ARN of the KMS key used to encrypt the DynamoDB table."
+  description = "ARN of the KMS key used to encrypt the DynamoDB table, or null when using the AWS owned key (encryption = DEFAULT)."
   value = local.table_kms_key_arn
 }
 "

--- a/packages/nx-plugin/src/migrations/latest/dynamodb-configurable-encryption/__snapshots__/migration.spec.ts.snap
+++ b/packages/nx-plugin/src/migrations/latest/dynamodb-configurable-encryption/__snapshots__/migration.spec.ts.snap
@@ -1,0 +1,412 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`dynamodb-configurable-encryption migration > surfaces encryption and encryptionKey on the CDK construct 1`] = `
+"import { Construct } from 'constructs';
+import {
+  AttributeType,
+  BillingMode,
+  Table,
+  TableEncryption,
+  TableProps,
+} from 'aws-cdk-lib/aws-dynamodb';
+import { RemovalPolicy } from 'aws-cdk-lib';
+import { Grant, IGrantable } from 'aws-cdk-lib/aws-iam';
+import { Key, IKey } from 'aws-cdk-lib/aws-kms';
+import { RuntimeConfig } from './runtime-config.js';
+
+type _DynamoDBTableProps = Omit<
+  TableProps,
+  'tableName' | 'partitionKey' | 'sortKey' | 'encryption' | 'encryptionKey'
+>;
+
+export interface DynamoDBTableProps extends _DynamoDBTableProps {
+  /**
+   * The DynamoDB table name. If omitted, CDK auto-generates a unique name
+   * from the stack name and construct path.
+   */
+  readonly tableName?: string;
+
+  /**
+   * RuntimeConfig key used under the \`dynamodb\` namespace.
+   */
+  readonly runtimeConfigKey: string;
+
+  /**
+   * Server-side encryption for the table.
+   *
+   * @default TableEncryption.CUSTOMER_MANAGED
+   */
+  readonly encryption?: TableEncryption;
+
+  /**
+   * KMS key used to encrypt the table. Only used when \`encryption\` is
+   * \`TableEncryption.CUSTOMER_MANAGED\`. When not provided, a new key is created.
+   */
+  readonly encryptionKey?: IKey;
+
+  /**
+   * Whether to enable automatic key rotation on the KMS key used to encrypt the table.
+   *
+   * @default true
+   */
+  readonly enableKeyRotation?: boolean;
+}
+
+export abstract class DynamoDBTable extends Construct {
+  public readonly table: Table;
+
+  constructor(
+    scope: Construct,
+    id: string,
+    {
+      tableName,
+      runtimeConfigKey,
+      billingMode = BillingMode.PAY_PER_REQUEST,
+      pointInTimeRecoverySpecification = { pointInTimeRecoveryEnabled: true },
+      deletionProtection = true,
+      removalPolicy = RemovalPolicy.RETAIN,
+      encryption = TableEncryption.CUSTOMER_MANAGED,
+      encryptionKey,
+      enableKeyRotation = true,
+      ...rest
+    }: DynamoDBTableProps,
+  ) {
+    super(scope, id);
+
+    const key: IKey | undefined =
+      encryption === TableEncryption.CUSTOMER_MANAGED
+        ? (encryptionKey ??
+          new Key(this, 'EncryptionKey', { enableKeyRotation }))
+        : undefined;
+
+    this.table = new Table(this, runtimeConfigKey, {
+      ...rest,
+      ...(tableName !== undefined && { tableName }),
+      partitionKey: { name: 'pk', type: AttributeType.STRING },
+      sortKey: { name: 'sk', type: AttributeType.STRING },
+      billingMode,
+      pointInTimeRecoverySpecification,
+      deletionProtection,
+      encryptionKey: key,
+      encryption,
+      removalPolicy,
+    });
+
+    const rc = RuntimeConfig.ensure(this);
+    rc.set('dynamodb', runtimeConfigKey, { tableName: this.table.tableName });
+  }
+
+  public grantReadData(grantee: IGrantable): Grant {
+    return this.table.grantReadData(grantee);
+  }
+
+  public grantWriteData(grantee: IGrantable): Grant {
+    return this.table.grantWriteData(grantee);
+  }
+
+  public grantReadWriteData(grantee: IGrantable): Grant {
+    return this.table.grantReadWriteData(grantee);
+  }
+
+  public grantFullAccess(grantee: IGrantable): Grant {
+    return this.table.grantFullAccess(grantee);
+  }
+
+  public grantStreamRead(grantee: IGrantable): Grant {
+    return this.table.grantStreamRead(grantee);
+  }
+
+  public grantTableListStreams(grantee: IGrantable): Grant {
+    return this.table.grantTableListStreams(grantee);
+  }
+
+  public grant(grantee: IGrantable, ...actions: string[]): Grant {
+    return this.table.grant(grantee, ...actions);
+  }
+
+  public grantStream(grantee: IGrantable, ...actions: string[]): Grant {
+    return this.table.grantStream(grantee, ...actions);
+  }
+}
+"
+`;
+
+exports[`dynamodb-configurable-encryption migration > surfaces encryption and kms_key_arn as pass-through variables on the terraform app module 1`] = `
+"terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "5.100.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "3.6.3"
+    }
+  }
+}
+
+variable "billing_mode" {
+  description = "Controls how you are charged for read and write throughput."
+  type        = string
+  default     = "PAY_PER_REQUEST"
+}
+
+variable "point_in_time_recovery_enabled" {
+  description = "Whether to enable point-in-time recovery for the table."
+  type        = bool
+  default     = true
+}
+
+variable "deletion_protection_enabled" {
+  description = "Whether to enable deletion protection on the table."
+  type        = bool
+  default     = true
+}
+
+variable "encryption" {
+  description = "Server-side encryption for the table. One of CUSTOMER_MANAGED, AWS_MANAGED or DEFAULT (the AWS owned key, at no cost and with no key to manage)."
+  type        = string
+  default     = "CUSTOMER_MANAGED"
+
+  validation {
+    condition     = contains(["CUSTOMER_MANAGED", "AWS_MANAGED", "DEFAULT"], var.encryption)
+    error_message = "encryption must be one of CUSTOMER_MANAGED, AWS_MANAGED or DEFAULT."
+  }
+}
+
+variable "kms_key_arn" {
+  description = "ARN of an existing KMS key used to encrypt the table when encryption is CUSTOMER_MANAGED. When not provided, a new key is created. Note that a customer-supplied key must already grant the DynamoDB service the necessary permissions in its own key policy."
+  type        = string
+  default     = null
+}
+
+variable "enable_key_rotation" {
+  description = "Whether to enable automatic key rotation on the KMS key used to encrypt the table. Only applies when encryption is CUSTOMER_MANAGED and kms_key_arn is not provided."
+  type        = bool
+  default     = true
+}
+
+resource "random_string" "suffix" {
+  length  = 8
+  special = false
+  upper   = false
+}
+
+locals {
+  dynamodb_config = jsondecode(file("\${path.module}/../../../../../../../apps/my-table/config.json"))
+  global_secondary_indexes = [for gsi in local.dynamodb_config.tableConfig.globalSecondaryIndexes : {
+    name            = gsi.indexName
+    hash_key        = gsi.partitionKey
+    range_key       = try(gsi.sortKey, null)
+    projection_type = "ALL"
+  }]
+}
+
+module "dynamodb_table" {
+  source                         = "../../../core/dynamodb"
+  name                           = "my-table-\${random_string.suffix.result}"
+  billing_mode                   = var.billing_mode
+  point_in_time_recovery_enabled = var.point_in_time_recovery_enabled
+  deletion_protection_enabled = var.deletion_protection_enabled
+  encryption   = var.encryption
+  kms_key_arn  = var.kms_key_arn
+  enable_key_rotation            = var.enable_key_rotation
+  global_secondary_indexes       = local.global_secondary_indexes
+}
+
+module "add_to_runtime_config" {
+  source = "../../../core/runtime-config/entry"
+
+  namespace = "dynamodb"
+  key       = local.dynamodb_config.runtimeConfigKey
+  value = {
+    tableName = module.dynamodb_table.table_name
+  }
+}
+"
+`;
+
+exports[`dynamodb-configurable-encryption migration > surfaces encryption and kms_key_arn on the terraform core module 1`] = `
+"terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "5.100.0"
+    }
+  }
+}
+
+variable "name" {
+  description = "Name for the DynamoDB table."
+  type        = string
+}
+
+variable "billing_mode" {
+  description = "Controls how you are charged for read and write throughput."
+  type        = string
+  default     = "PAY_PER_REQUEST"
+}
+
+variable "point_in_time_recovery_enabled" {
+  description = "Whether to enable point-in-time recovery for the table."
+  type        = bool
+  default     = true
+}
+
+variable "deletion_protection_enabled" {
+  description = "Whether to enable deletion protection on the table."
+  type        = bool
+  default     = true
+}
+
+variable "encryption" {
+  description = "Server-side encryption for the table. One of CUSTOMER_MANAGED, AWS_MANAGED or DEFAULT (the AWS owned key, at no cost and with no key to manage)."
+  type        = string
+  default     = "CUSTOMER_MANAGED"
+
+  validation {
+    condition     = contains(["CUSTOMER_MANAGED", "AWS_MANAGED", "DEFAULT"], var.encryption)
+    error_message = "encryption must be one of CUSTOMER_MANAGED, AWS_MANAGED or DEFAULT."
+  }
+}
+
+variable "kms_key_arn" {
+  description = "ARN of an existing KMS key used to encrypt the table when encryption is CUSTOMER_MANAGED. When not provided, a new key is created. Note that a customer-supplied key must already grant the DynamoDB service the necessary permissions in its own key policy."
+  type        = string
+  default     = null
+}
+
+variable "enable_key_rotation" {
+  description = "Whether to enable automatic key rotation on the KMS key used to encrypt the table. Only applies when encryption is CUSTOMER_MANAGED and kms_key_arn is not provided."
+  type        = bool
+  default     = true
+}
+
+variable "global_secondary_indexes" {
+  description = "Global secondary indexes to create on the table. All key attributes must be of type string."
+  type = list(object({
+    name            = string
+    hash_key        = string
+    range_key       = string
+    projection_type = string
+  }))
+  default = []
+}
+
+locals {
+  gsi_attribute_names = distinct(flatten([
+    for gsi in var.global_secondary_indexes : [gsi.hash_key, gsi.range_key]
+  ]))
+
+  create_table_key = var.encryption == "CUSTOMER_MANAGED" && var.kms_key_arn == null
+  table_kms_key_arn = (
+    var.encryption != "CUSTOMER_MANAGED" ? null :
+    local.create_table_key ? aws_kms_key.table[0].arn :
+    var.kms_key_arn
+  )
+}
+
+data "aws_caller_identity" "current" {}
+data "aws_partition" "current" {}
+
+resource "aws_kms_key" "table" {
+  count = local.create_table_key ? 1 : 0
+
+  description         = "KMS key for DynamoDB table \${var.name}"
+  enable_key_rotation = var.enable_key_rotation
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "EnableRootAccess"
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:\${data.aws_partition.current.partition}:iam::\${data.aws_caller_identity.current.account_id}:root"
+        }
+        Action   = "kms:*"
+        Resource = "*"
+      },
+      {
+        Sid    = "AllowDynamoDBService"
+        Effect = "Allow"
+        Principal = {
+          Service = "dynamodb.amazonaws.com"
+        }
+        Action = [
+          "kms:Encrypt",
+          "kms:Decrypt",
+          "kms:ReEncrypt*",
+          "kms:GenerateDataKey*",
+          "kms:DescribeKey",
+          "kms:CreateGrant"
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+resource "aws_dynamodb_table" "table" {
+  name                        = var.name
+  billing_mode                = var.billing_mode
+  hash_key                    = "pk"
+  range_key                   = "sk"
+  deletion_protection_enabled = var.deletion_protection_enabled
+
+  attribute {
+    name = "pk"
+    type = "S"
+  }
+
+  attribute {
+    name = "sk"
+    type = "S"
+  }
+
+  dynamic "attribute" {
+    for_each = toset(local.gsi_attribute_names)
+    content {
+      name = attribute.value
+      type = "S"
+    }
+  }
+
+  dynamic "global_secondary_index" {
+    for_each = var.global_secondary_indexes
+    content {
+      name            = global_secondary_index.value.name
+      hash_key        = global_secondary_index.value.hash_key
+      range_key       = global_secondary_index.value.range_key
+      projection_type = global_secondary_index.value.projection_type
+    }
+  }
+
+  point_in_time_recovery {
+    enabled = var.point_in_time_recovery_enabled
+  }
+
+  server_side_encryption {
+    enabled = var.encryption != "DEFAULT"
+    kms_key_arn = local.table_kms_key_arn
+  }
+}
+
+output "table_name" {
+  description = "Name of the DynamoDB table."
+  value       = aws_dynamodb_table.table.name
+}
+
+output "table_arn" {
+  description = "ARN of the DynamoDB table."
+  value       = aws_dynamodb_table.table.arn
+}
+
+output "kms_key_arn" {
+  description = "ARN of the KMS key used to encrypt the DynamoDB table."
+  value = local.table_kms_key_arn
+}
+"
+`;

--- a/packages/nx-plugin/src/migrations/latest/dynamodb-configurable-encryption/metadata.json
+++ b/packages/nx-plugin/src/migrations/latest/dynamodb-configurable-encryption/metadata.json
@@ -1,0 +1,3 @@
+{
+  "description": "Surface encryption and encryptionKey on the vended DynamoDBTable construct/module"
+}

--- a/packages/nx-plugin/src/migrations/latest/dynamodb-configurable-encryption/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/latest/dynamodb-configurable-encryption/migration.spec.ts
@@ -406,13 +406,18 @@ describe('dynamodb-configurable-encryption migration', () => {
 
     expect(contents).toContain('variable "encryption"');
     expect(contents).toContain('variable "kms_key_arn"');
+    expect(contents).toContain('variable "create_kms_key"');
     expect(contents).toContain(
       'contains(["CUSTOMER_MANAGED", "AWS_MANAGED", "DEFAULT"], var.encryption)',
     );
     expect(contents).toContain(
-      'create_table_key = var.encryption == "CUSTOMER_MANAGED" && var.kms_key_arn == null',
+      'create_table_key = var.encryption == "CUSTOMER_MANAGED" && var.create_kms_key',
     );
     expect(contents).toContain('table_kms_key_arn = (');
+    expect(contents).toContain(
+      'var.encryption == "AWS_MANAGED" ? "arn:${data.aws_partition.current.partition}:kms:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:alias/aws/dynamodb" :',
+    );
+    expect(contents).toContain('data "aws_region" "current" {}');
     expect(contents).toContain('count = local.create_table_key ? 1 : 0');
     expect(contents).toContain('enabled = var.encryption != "DEFAULT"');
     expect(contents).toContain(
@@ -422,6 +427,9 @@ describe('dynamodb-configurable-encryption migration', () => {
     expect(contents).not.toContain('kms_key_arn = aws_kms_key.table.arn');
     expect(contents).not.toContain('enabled     = true');
     expect(contents).toContain('value = local.table_kms_key_arn');
+    expect(contents).toContain(
+      'description = "ARN of the KMS key used to encrypt the DynamoDB table, or null when using the AWS owned key (encryption = DEFAULT)."',
+    );
     expect(result.nextSteps).toEqual([]);
     expect(contents).toMatchSnapshot();
   });
@@ -433,6 +441,7 @@ describe('dynamodb-configurable-encryption migration', () => {
 
     expect(contents).toContain('variable "encryption"');
     expect(contents).toContain('variable "kms_key_arn"');
+    expect(contents).toContain('variable "create_kms_key"');
     expect(contents).toContain(
       'contains(["CUSTOMER_MANAGED", "AWS_MANAGED", "DEFAULT"], var.encryption)',
     );
@@ -440,6 +449,7 @@ describe('dynamodb-configurable-encryption migration', () => {
     expect(contents).toContain('= var.encryption');
     expect(contents).toContain('kms_key_arn');
     expect(contents).toContain('= var.kms_key_arn');
+    expect(contents).toContain('= var.create_kms_key');
     expect(result.nextSteps).toEqual([]);
     expect(contents).toMatchSnapshot();
   });

--- a/packages/nx-plugin/src/migrations/latest/dynamodb-configurable-encryption/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/latest/dynamodb-configurable-encryption/migration.spec.ts
@@ -395,6 +395,9 @@ describe('dynamodb-configurable-encryption migration', () => {
     expect(contents).not.toContain(
       'encryption: TableEncryption.CUSTOMER_MANAGED,',
     );
+    expect(contents).toContain(
+      'Only applies when `encryption` is `TableEncryption.CUSTOMER_MANAGED` and no',
+    );
     expect(result.nextSteps).toEqual([]);
     expect(contents).toMatchSnapshot();
   });

--- a/packages/nx-plugin/src/migrations/latest/dynamodb-configurable-encryption/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/latest/dynamodb-configurable-encryption/migration.spec.ts
@@ -1,0 +1,552 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import type { Tree } from '@nx/devkit';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test';
+import migration from './migration';
+
+const CDK_DYNAMODB_FILE = 'packages/common/constructs/src/core/dynamodb.ts';
+const TF_DYNAMODB_FILE =
+  'packages/common/terraform/src/core/dynamodb/dynamodb.tf';
+const TF_APP_MODULE_FILE =
+  'packages/common/terraform/src/app/dynamodb/my-table/my-table.tf';
+const TF_APP_MODULE_FILE_2 =
+  'packages/common/terraform/src/app/dynamodb/other-table/other-table.tf';
+
+/** The vended DynamoDBTable CDK construct, before encryption/encryptionKey. */
+const OLD_CDK_DYNAMODB = `import { Construct } from 'constructs';
+import {
+  AttributeType,
+  BillingMode,
+  Table,
+  TableEncryption,
+  TableProps,
+} from 'aws-cdk-lib/aws-dynamodb';
+import { RemovalPolicy } from 'aws-cdk-lib';
+import { Grant, IGrantable } from 'aws-cdk-lib/aws-iam';
+import { Key } from 'aws-cdk-lib/aws-kms';
+import { RuntimeConfig } from './runtime-config.js';
+
+type _DynamoDBTableProps = Omit<TableProps, 'tableName' | 'partitionKey' | 'sortKey' | 'encryption' | 'encryptionKey'>;
+
+export interface DynamoDBTableProps extends _DynamoDBTableProps {
+  /**
+   * The DynamoDB table name. If omitted, CDK auto-generates a unique name
+   * from the stack name and construct path.
+   */
+  readonly tableName?: string;
+
+  /**
+   * RuntimeConfig key used under the \`dynamodb\` namespace.
+   */
+  readonly runtimeConfigKey: string;
+
+  /**
+   * Whether to enable automatic key rotation on the KMS key used to encrypt the table.
+   *
+   * @default true
+   */
+  readonly enableKeyRotation?: boolean;
+}
+
+export abstract class DynamoDBTable extends Construct {
+  public readonly table: Table;
+
+  constructor(
+    scope: Construct,
+    id: string,
+    {
+      tableName,
+      runtimeConfigKey,
+      billingMode = BillingMode.PAY_PER_REQUEST,
+      pointInTimeRecoverySpecification = { pointInTimeRecoveryEnabled: true },
+      deletionProtection = true,
+      removalPolicy = RemovalPolicy.RETAIN,
+      enableKeyRotation = true,
+      ...rest
+    }: DynamoDBTableProps,
+  ) {
+    super(scope, id);
+
+    const key = new Key(this, 'EncryptionKey', { enableKeyRotation });
+
+    this.table = new Table(this, runtimeConfigKey, {
+      ...rest,
+      ...(tableName !== undefined && { tableName }),
+      partitionKey: { name: 'pk', type: AttributeType.STRING },
+      sortKey: { name: 'sk', type: AttributeType.STRING },
+      billingMode,
+      pointInTimeRecoverySpecification,
+      deletionProtection,
+      encryptionKey: key,
+      encryption: TableEncryption.CUSTOMER_MANAGED,
+      removalPolicy,
+    });
+
+    const rc = RuntimeConfig.ensure(this);
+    rc.set('dynamodb', runtimeConfigKey, { tableName: this.table.tableName });
+  }
+
+  public grantReadData(grantee: IGrantable): Grant {
+    return this.table.grantReadData(grantee);
+  }
+
+  public grantWriteData(grantee: IGrantable): Grant {
+    return this.table.grantWriteData(grantee);
+  }
+
+  public grantReadWriteData(grantee: IGrantable): Grant {
+    return this.table.grantReadWriteData(grantee);
+  }
+
+  public grantFullAccess(grantee: IGrantable): Grant {
+    return this.table.grantFullAccess(grantee);
+  }
+
+  public grantStreamRead(grantee: IGrantable): Grant {
+    return this.table.grantStreamRead(grantee);
+  }
+
+  public grantTableListStreams(grantee: IGrantable): Grant {
+    return this.table.grantTableListStreams(grantee);
+  }
+
+  public grant(grantee: IGrantable, ...actions: string[]): Grant {
+    return this.table.grant(grantee, ...actions);
+  }
+
+  public grantStream(grantee: IGrantable, ...actions: string[]): Grant {
+    return this.table.grantStream(grantee, ...actions);
+  }
+}
+`;
+
+/** The vended Terraform dynamodb core module, before encryption/kms_key_arn. */
+const OLD_TF_DYNAMODB = `terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "5.100.0"
+    }
+  }
+}
+
+variable "name" {
+  description = "Name for the DynamoDB table."
+  type        = string
+}
+
+variable "billing_mode" {
+  description = "Controls how you are charged for read and write throughput."
+  type        = string
+  default     = "PAY_PER_REQUEST"
+}
+
+variable "point_in_time_recovery_enabled" {
+  description = "Whether to enable point-in-time recovery for the table."
+  type        = bool
+  default     = true
+}
+
+variable "deletion_protection_enabled" {
+  description = "Whether to enable deletion protection on the table."
+  type        = bool
+  default     = true
+}
+
+variable "enable_key_rotation" {
+  description = "Whether to enable automatic key rotation on the KMS key used to encrypt the table."
+  type        = bool
+  default     = true
+}
+
+variable "global_secondary_indexes" {
+  description = "Global secondary indexes to create on the table. All key attributes must be of type string."
+  type = list(object({
+    name            = string
+    hash_key        = string
+    range_key       = string
+    projection_type = string
+  }))
+  default = []
+}
+
+locals {
+  gsi_attribute_names = distinct(flatten([
+    for gsi in var.global_secondary_indexes : [gsi.hash_key, gsi.range_key]
+  ]))
+}
+
+data "aws_caller_identity" "current" {}
+data "aws_partition" "current" {}
+
+resource "aws_kms_key" "table" {
+  description         = "KMS key for DynamoDB table \${var.name}"
+  enable_key_rotation = var.enable_key_rotation
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "EnableRootAccess"
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:\${data.aws_partition.current.partition}:iam::\${data.aws_caller_identity.current.account_id}:root"
+        }
+        Action   = "kms:*"
+        Resource = "*"
+      },
+      {
+        Sid    = "AllowDynamoDBService"
+        Effect = "Allow"
+        Principal = {
+          Service = "dynamodb.amazonaws.com"
+        }
+        Action = [
+          "kms:Encrypt",
+          "kms:Decrypt",
+          "kms:ReEncrypt*",
+          "kms:GenerateDataKey*",
+          "kms:DescribeKey",
+          "kms:CreateGrant"
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+resource "aws_dynamodb_table" "table" {
+  name                        = var.name
+  billing_mode                = var.billing_mode
+  hash_key                    = "pk"
+  range_key                   = "sk"
+  deletion_protection_enabled = var.deletion_protection_enabled
+
+  attribute {
+    name = "pk"
+    type = "S"
+  }
+
+  attribute {
+    name = "sk"
+    type = "S"
+  }
+
+  dynamic "attribute" {
+    for_each = toset(local.gsi_attribute_names)
+    content {
+      name = attribute.value
+      type = "S"
+    }
+  }
+
+  dynamic "global_secondary_index" {
+    for_each = var.global_secondary_indexes
+    content {
+      name            = global_secondary_index.value.name
+      hash_key        = global_secondary_index.value.hash_key
+      range_key       = global_secondary_index.value.range_key
+      projection_type = global_secondary_index.value.projection_type
+    }
+  }
+
+  point_in_time_recovery {
+    enabled = var.point_in_time_recovery_enabled
+  }
+
+  server_side_encryption {
+    enabled     = true
+    kms_key_arn = aws_kms_key.table.arn
+  }
+}
+
+output "table_name" {
+  description = "Name of the DynamoDB table."
+  value       = aws_dynamodb_table.table.name
+}
+
+output "table_arn" {
+  description = "ARN of the DynamoDB table."
+  value       = aws_dynamodb_table.table.arn
+}
+
+output "kms_key_arn" {
+  description = "ARN of the KMS key used to encrypt the DynamoDB table."
+  value       = aws_kms_key.table.arn
+}
+`;
+
+/** The vended per-table Terraform app module, before encryption/kms_key_arn. */
+const oldTfAppModule = (tableName: string) => `terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "5.100.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "3.6.3"
+    }
+  }
+}
+
+variable "billing_mode" {
+  description = "Controls how you are charged for read and write throughput."
+  type        = string
+  default     = "PAY_PER_REQUEST"
+}
+
+variable "point_in_time_recovery_enabled" {
+  description = "Whether to enable point-in-time recovery for the table."
+  type        = bool
+  default     = true
+}
+
+variable "deletion_protection_enabled" {
+  description = "Whether to enable deletion protection on the table."
+  type        = bool
+  default     = true
+}
+
+variable "enable_key_rotation" {
+  description = "Whether to enable automatic key rotation on the KMS key used to encrypt the table."
+  type        = bool
+  default     = true
+}
+
+resource "random_string" "suffix" {
+  length  = 8
+  special = false
+  upper   = false
+}
+
+locals {
+  dynamodb_config = jsondecode(file("\${path.module}/../../../../../../../apps/${tableName}/config.json"))
+  global_secondary_indexes = [for gsi in local.dynamodb_config.tableConfig.globalSecondaryIndexes : {
+    name            = gsi.indexName
+    hash_key        = gsi.partitionKey
+    range_key       = try(gsi.sortKey, null)
+    projection_type = "ALL"
+  }]
+}
+
+module "dynamodb_table" {
+  source                         = "../../../core/dynamodb"
+  name                           = "${tableName}-\${random_string.suffix.result}"
+  billing_mode                   = var.billing_mode
+  point_in_time_recovery_enabled = var.point_in_time_recovery_enabled
+  deletion_protection_enabled    = var.deletion_protection_enabled
+  enable_key_rotation            = var.enable_key_rotation
+  global_secondary_indexes       = local.global_secondary_indexes
+}
+
+module "add_to_runtime_config" {
+  source = "../../../core/runtime-config/entry"
+
+  namespace = "dynamodb"
+  key       = local.dynamodb_config.runtimeConfigKey
+  value = {
+    tableName = module.dynamodb_table.table_name
+  }
+}
+`;
+
+describe('dynamodb-configurable-encryption migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeUsingTsSolutionSetup();
+  });
+
+  const seedCdk = () => tree.write(CDK_DYNAMODB_FILE, OLD_CDK_DYNAMODB);
+  const seedTfCore = () => tree.write(TF_DYNAMODB_FILE, OLD_TF_DYNAMODB);
+  const seedTfApp = () =>
+    tree.write(TF_APP_MODULE_FILE, oldTfAppModule('my-table'));
+
+  it('does nothing when no vended dynamodb files exist', async () => {
+    const result = await migration(tree);
+    expect(result.nextSteps).toEqual([]);
+  });
+
+  it('surfaces encryption and encryptionKey on the CDK construct', async () => {
+    seedCdk();
+    const result = await migration(tree);
+    const contents = tree.read(CDK_DYNAMODB_FILE, 'utf-8')!;
+
+    expect(contents).toContain(
+      "import { Key, IKey } from 'aws-cdk-lib/aws-kms';",
+    );
+    expect(contents).toContain('readonly encryption?: TableEncryption;');
+    expect(contents).toContain('readonly encryptionKey?: IKey;');
+    expect(contents).toContain(
+      'encryption = TableEncryption.CUSTOMER_MANAGED,',
+    );
+    expect(contents).toContain('encryptionKey,');
+    expect(contents).toContain('const key: IKey | undefined =');
+    expect(contents).toContain('encryptionKey ??');
+    expect(contents).toContain(
+      "new Key(this, 'EncryptionKey', { enableKeyRotation })",
+    );
+    expect(contents).toContain('encryption,');
+    expect(contents).not.toContain(
+      'encryption: TableEncryption.CUSTOMER_MANAGED,',
+    );
+    expect(result.nextSteps).toEqual([]);
+    expect(contents).toMatchSnapshot();
+  });
+
+  it('surfaces encryption and kms_key_arn on the terraform core module', async () => {
+    seedTfCore();
+    const result = await migration(tree);
+    const contents = tree.read(TF_DYNAMODB_FILE, 'utf-8')!;
+
+    expect(contents).toContain('variable "encryption"');
+    expect(contents).toContain('variable "kms_key_arn"');
+    expect(contents).toContain(
+      'contains(["CUSTOMER_MANAGED", "AWS_MANAGED", "DEFAULT"], var.encryption)',
+    );
+    expect(contents).toContain(
+      'create_table_key = var.encryption == "CUSTOMER_MANAGED" && var.kms_key_arn == null',
+    );
+    expect(contents).toContain('table_kms_key_arn = (');
+    expect(contents).toContain('count = local.create_table_key ? 1 : 0');
+    expect(contents).toContain('enabled = var.encryption != "DEFAULT"');
+    expect(contents).toContain('kms_key_arn = local.table_kms_key_arn');
+    expect(contents).not.toContain('kms_key_arn = aws_kms_key.table.arn');
+    expect(contents).not.toContain('enabled     = true');
+    expect(contents).toContain('value = local.table_kms_key_arn');
+    expect(result.nextSteps).toEqual([]);
+    expect(contents).toMatchSnapshot();
+  });
+
+  it('surfaces encryption and kms_key_arn as pass-through variables on the terraform app module', async () => {
+    seedTfApp();
+    const result = await migration(tree);
+    const contents = tree.read(TF_APP_MODULE_FILE, 'utf-8')!;
+
+    expect(contents).toContain('variable "encryption"');
+    expect(contents).toContain('variable "kms_key_arn"');
+    expect(contents).toContain(
+      'contains(["CUSTOMER_MANAGED", "AWS_MANAGED", "DEFAULT"], var.encryption)',
+    );
+    expect(contents).toContain('encryption');
+    expect(contents).toContain('= var.encryption');
+    expect(contents).toContain('kms_key_arn');
+    expect(contents).toContain('= var.kms_key_arn');
+    expect(result.nextSteps).toEqual([]);
+    expect(contents).toMatchSnapshot();
+  });
+
+  it('migrates every terraform app module directory found', async () => {
+    seedTfApp();
+    tree.write(TF_APP_MODULE_FILE_2, oldTfAppModule('other-table'));
+
+    const result = await migration(tree);
+
+    expect(tree.read(TF_APP_MODULE_FILE, 'utf-8')!).toContain(
+      'variable "encryption"',
+    );
+    expect(tree.read(TF_APP_MODULE_FILE_2, 'utf-8')!).toContain(
+      'variable "encryption"',
+    );
+    expect(result.nextSteps).toEqual([]);
+  });
+
+  it('is idempotent across cdk, terraform core and terraform app files', async () => {
+    seedCdk();
+    seedTfCore();
+    seedTfApp();
+
+    await migration(tree);
+    const cdkAfterFirst = tree.read(CDK_DYNAMODB_FILE, 'utf-8');
+    const tfCoreAfterFirst = tree.read(TF_DYNAMODB_FILE, 'utf-8');
+    const tfAppAfterFirst = tree.read(TF_APP_MODULE_FILE, 'utf-8');
+
+    const secondRun = await migration(tree);
+
+    expect(tree.read(CDK_DYNAMODB_FILE, 'utf-8')).toEqual(cdkAfterFirst);
+    expect(tree.read(TF_DYNAMODB_FILE, 'utf-8')).toEqual(tfCoreAfterFirst);
+    expect(tree.read(TF_APP_MODULE_FILE, 'utf-8')).toEqual(tfAppAfterFirst);
+    expect(secondRun.nextSteps).toEqual([]);
+  });
+
+  it('skips and reports a diverged CDK construct', async () => {
+    // Diverged: the user renamed the key variable, so the literal
+    // key-creation anchor this migration matches on is no longer present.
+    tree.write(
+      CDK_DYNAMODB_FILE,
+      OLD_CDK_DYNAMODB.replace(
+        "const key = new Key(this, 'EncryptionKey', { enableKeyRotation });",
+        "const encryptionKey = new Key(this, 'EncryptionKey', { enableKeyRotation });",
+      ),
+    );
+
+    const result = await migration(tree);
+    const contents = tree.read(CDK_DYNAMODB_FILE, 'utf-8')!;
+
+    expect(contents).toContain(
+      "const encryptionKey = new Key(this, 'EncryptionKey', { enableKeyRotation });",
+    );
+    expect(contents).not.toContain('readonly encryption?: TableEncryption');
+    expect(result.nextSteps).toEqual([
+      `${CDK_DYNAMODB_FILE}: has diverged from the generated shape - left untouched. To pick up the encryption and encryptionKey props, manually port them from the vended core/dynamodb.ts template (see the ts#dynamodb generator's DynamoDBTable construct).`,
+    ]);
+  });
+
+  it('skips and reports a diverged terraform core module', async () => {
+    // Diverged: the user customised the enable_key_rotation variable's
+    // description, so the literal variable-block anchor no longer matches.
+    tree.write(
+      TF_DYNAMODB_FILE,
+      OLD_TF_DYNAMODB.replace(
+        'description = "Whether to enable automatic key rotation on the KMS key used to encrypt the table."',
+        'description = "Custom description added by the user."',
+      ),
+    );
+
+    const result = await migration(tree);
+    const contents = tree.read(TF_DYNAMODB_FILE, 'utf-8')!;
+
+    expect(contents).toContain('Custom description added by the user.');
+    expect(contents).not.toContain('variable "encryption"');
+    expect(result.nextSteps).toEqual([
+      `${TF_DYNAMODB_FILE}: has diverged from the generated shape - left untouched. To pick up the encryption and kms_key_arn variables, manually port them from the vended dynamodb.tf template (see the ts#dynamodb generator's dynamodb module).`,
+    ]);
+  });
+
+  it('skips and reports a diverged terraform app module', async () => {
+    // Diverged: the user customised the enable_key_rotation variable's
+    // description, so the literal variable-block anchor no longer matches.
+    tree.write(
+      TF_APP_MODULE_FILE,
+      oldTfAppModule('my-table').replace(
+        'description = "Whether to enable automatic key rotation on the KMS key used to encrypt the table."',
+        'description = "Custom description added by the user."',
+      ),
+    );
+
+    const result = await migration(tree);
+    const contents = tree.read(TF_APP_MODULE_FILE, 'utf-8')!;
+
+    expect(contents).toContain('Custom description added by the user.');
+    expect(contents).not.toContain('variable "encryption"');
+    expect(result.nextSteps).toEqual([
+      `${TF_APP_MODULE_FILE}: has diverged from the generated shape - left untouched. To make encryption and kms_key_arn configurable from your root Terraform configuration, add pass-through variables here and forward them to the dynamodb_table module call (see the ts#dynamodb generator's dynamodb app template).`,
+    ]);
+  });
+
+  it('does not touch an already-migrated CDK construct', async () => {
+    seedCdk();
+    await migration(tree);
+    const migrated = tree.read(CDK_DYNAMODB_FILE, 'utf-8');
+
+    const result = await migration(tree);
+
+    expect(tree.read(CDK_DYNAMODB_FILE, 'utf-8')).toEqual(migrated);
+    expect(result.nextSteps).toEqual([]);
+  });
+});

--- a/packages/nx-plugin/src/migrations/latest/dynamodb-configurable-encryption/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/latest/dynamodb-configurable-encryption/migration.spec.ts
@@ -415,6 +415,9 @@ describe('dynamodb-configurable-encryption migration', () => {
     expect(contents).toContain('table_kms_key_arn = (');
     expect(contents).toContain('count = local.create_table_key ? 1 : 0');
     expect(contents).toContain('enabled = var.encryption != "DEFAULT"');
+    expect(contents).toContain(
+      '#checkov:skip=CKV_AWS_119:Encryption is configurable via var.encryption; checkov cannot resolve the conditional server_side_encryption.enabled expression',
+    );
     expect(contents).toContain('kms_key_arn = local.table_kms_key_arn');
     expect(contents).not.toContain('kms_key_arn = aws_kms_key.table.arn');
     expect(contents).not.toContain('enabled     = true');

--- a/packages/nx-plugin/src/migrations/latest/dynamodb-configurable-encryption/migration.ts
+++ b/packages/nx-plugin/src/migrations/latest/dynamodb-configurable-encryption/migration.ts
@@ -161,6 +161,24 @@ const migrateCdkConstruct = async (
   `,
   );
 
+  // Update the enableKeyRotation field's own comment to note it now only
+  // applies to the auto-created key, matching the vended template exactly.
+  // Routed through the insert placeholder (rather than embedding the text
+  // directly in the GritQL rewrite) since the comment's own backticks would
+  // otherwise be parsed as GritQL code-block delimiters.
+  await insertViaGritQL(
+    tree,
+    CDK_DYNAMODB_FILE,
+    `${ENABLE_KEY_ROTATION_COMMENT} => \`${GRIT_INSERT_PLACEHOLDER}\``,
+    `/**
+   * Whether to enable automatic key rotation on the KMS key used to encrypt the table.
+   * Only applies when \`encryption\` is \`TableEncryption.CUSTOMER_MANAGED\` and no
+   * \`encryptionKey\` is supplied.
+   *
+   * @default true
+   */`,
+  );
+
   await applyGritQL(
     tree,
     CDK_DYNAMODB_FILE,
@@ -198,7 +216,7 @@ const hcl = (pattern: string) => `language hcl\n${pattern}`;
 
 const NEW_TERRAFORM_VARIABLES_TEXT = [
   'variable "encryption" {',
-  '  description = "Server-side encryption for the table. One of CUSTOMER_MANAGED, AWS_MANAGED or DEFAULT (the AWS owned key, at no cost and with no key to manage)."',
+  '  description = "Server-side encryption for the table. One of CUSTOMER_MANAGED, AWS_MANAGED or DEFAULT (the AWS owned key, at no cost and with no key to manage). Changing this on an already-deployed table away from CUSTOMER_MANAGED requires a manual step first - see the ts#dynamodb generator docs."',
   '  type        = string',
   '  default     = "CUSTOMER_MANAGED"',
   '',
@@ -376,7 +394,7 @@ const migrateTerraformModule = async (
 
 const NEW_APP_MODULE_VARIABLES_TEXT = [
   'variable "encryption" {',
-  '  description = "Server-side encryption for the table. One of CUSTOMER_MANAGED, AWS_MANAGED or DEFAULT (the AWS owned key, at no cost and with no key to manage)."',
+  '  description = "Server-side encryption for the table. One of CUSTOMER_MANAGED, AWS_MANAGED or DEFAULT (the AWS owned key, at no cost and with no key to manage). Changing this on an already-deployed table away from CUSTOMER_MANAGED requires a manual step first - see the ts#dynamodb generator docs."',
   '  type        = string',
   '  default     = "CUSTOMER_MANAGED"',
   '',

--- a/packages/nx-plugin/src/migrations/latest/dynamodb-configurable-encryption/migration.ts
+++ b/packages/nx-plugin/src/migrations/latest/dynamodb-configurable-encryption/migration.ts
@@ -34,14 +34,19 @@ import {
  *   `props` parameter through to `DynamoDBTable`, so no change is needed
  *   there.
  * - The vended Terraform dynamodb core module gains the equivalent
- *   `encryption` and `kms_key_arn` variables (`encryption` also accepts
- *   `DEFAULT`, the AWS owned key, which CDK already supports for free via
- *   `TableEncryption.DEFAULT`), with the KMS key made conditional via
- *   `count` and `server_side_encryption.enabled` tied to `encryption`.
+ *   `encryption`, `kms_key_arn` and `create_kms_key` variables (`encryption`
+ *   also accepts `DEFAULT`, the AWS owned key, which CDK already supports for
+ *   free via `TableEncryption.DEFAULT`), with the KMS key made conditional on
+ *   `create_kms_key` (not on `kms_key_arn`'s nullness, which `count` can't
+ *   depend on when the ARN comes from another resource) and
+ *   `server_side_encryption.enabled` tied to `encryption`. `AWS_MANAGED`
+ *   resolves to the explicit `alias/aws/dynamodb` ARN rather than `null`,
+ *   since the provider's `kms_key_arn` is Optional+Computed and a `null`
+ *   there means "leave whatever is there", not "clear it".
  * - The vended Terraform per-table app module (`app/dynamodb/<name>/<name>.tf`)
- *   gains pass-through `encryption` and `kms_key_arn` variables forwarded to
- *   the core module call, matching its existing `enable_key_rotation`
- *   pass-through.
+ *   gains pass-through `encryption`, `kms_key_arn` and `create_kms_key`
+ *   variables forwarded to the core module call, matching its existing
+ *   `enable_key_rotation` pass-through.
  *
  * These files are generated with `KeepExisting`, so without this an upgraded
  * workspace has generators that support this configuration but vended files
@@ -204,13 +209,19 @@ const NEW_TERRAFORM_VARIABLES_TEXT = [
   '}',
   '',
   'variable "kms_key_arn" {',
-  '  description = "ARN of an existing KMS key used to encrypt the table when encryption is CUSTOMER_MANAGED. When not provided, a new key is created. Note that a customer-supplied key must already grant the DynamoDB service the necessary permissions in its own key policy."',
+  '  description = "ARN of an existing KMS key used to encrypt the table when encryption is CUSTOMER_MANAGED. When not provided and create_kms_key is true, a new key is created. Note that a customer-supplied key must already grant the DynamoDB service the necessary permissions in its own key policy."',
   '  type        = string',
   '  default     = null',
   '}',
   '',
+  'variable "create_kms_key" {',
+  '  description = "Whether to create a KMS key for the table. Only applies when encryption is CUSTOMER_MANAGED. Set to false when supplying kms_key_arn."',
+  '  type        = bool',
+  '  default     = true',
+  '}',
+  '',
   'variable "enable_key_rotation" {',
-  '  description = "Whether to enable automatic key rotation on the KMS key used to encrypt the table. Only applies when encryption is CUSTOMER_MANAGED and kms_key_arn is not provided."',
+  '  description = "Whether to enable automatic key rotation on the KMS key used to encrypt the table. Only applies when encryption is CUSTOMER_MANAGED and create_kms_key is true."',
   '  type        = bool',
   '  default     = true',
   '}',
@@ -248,18 +259,24 @@ const migrateTerraformModule = async (
     ].join('\n'),
   );
   const LOCALS_BLOCK = hcl('`locals { $_ }`');
+  const DATA_PARTITION_LINE = hcl('`data "aws_partition" "current" {}`');
   const KMS_KEY_BLOCK = hcl('`resource "aws_kms_key" "table" { $_ }`');
   const SSE_ENABLED_LINE = hcl('`enabled = true`');
   const SSE_KMS_KEY_LINE = hcl('`kms_key_arn = aws_kms_key.table.arn`');
   const OUTPUT_VALUE_LINE = hcl('`value = aws_kms_key.table.arn`');
+  const OUTPUT_DESCRIPTION_LINE = hcl(
+    '`description = "ARN of the KMS key used to encrypt the DynamoDB table."`',
+  );
 
   const anchors = [
     OLD_ENABLE_KEY_ROTATION_VAR,
     LOCALS_BLOCK,
+    DATA_PARTITION_LINE,
     KMS_KEY_BLOCK,
     SSE_ENABLED_LINE,
     SSE_KMS_KEY_LINE,
     OUTPUT_VALUE_LINE,
+    OUTPUT_DESCRIPTION_LINE,
   ];
 
   const allPresent = (
@@ -291,13 +308,21 @@ const migrateTerraformModule = async (
       `\`locals { $body }\` => \`locals {\n  $body\n\n  ${GRIT_INSERT_PLACEHOLDER}\n}\``,
     ),
     [
-      'create_table_key = var.encryption == "CUSTOMER_MANAGED" && var.kms_key_arn == null',
+      'create_table_key = var.encryption == "CUSTOMER_MANAGED" && var.create_kms_key',
       'table_kms_key_arn = (',
-      '  var.encryption != "CUSTOMER_MANAGED" ? null :',
-      '  local.create_table_key ? aws_kms_key.table[0].arn :',
-      '  var.kms_key_arn',
+      '  var.encryption == "CUSTOMER_MANAGED" ? (local.create_table_key ? aws_kms_key.table[0].arn : var.kms_key_arn) :',
+      '  var.encryption == "AWS_MANAGED" ? "arn:${data.aws_partition.current.partition}:kms:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:alias/aws/dynamodb" :',
+      '  null',
       ')',
     ].join('\n  '),
+  );
+
+  // 2b. Region is needed to resolve the AWS_MANAGED key's alias ARN above.
+  await insertViaGritQL(
+    tree,
+    TERRAFORM_DYNAMODB_FILE,
+    `${DATA_PARTITION_LINE} => \`data "aws_partition" "current" {}\n${GRIT_INSERT_PLACEHOLDER}\``,
+    'data "aws_region" "current" {}',
   );
 
   // 3. Make the KMS key conditional on encryption/kms_key_arn.
@@ -342,6 +367,11 @@ const migrateTerraformModule = async (
     TERRAFORM_DYNAMODB_FILE,
     `${OUTPUT_VALUE_LINE} => \`value = local.table_kms_key_arn\``,
   );
+  await applyGritQL(
+    tree,
+    TERRAFORM_DYNAMODB_FILE,
+    `${OUTPUT_DESCRIPTION_LINE} => \`description = "ARN of the KMS key used to encrypt the DynamoDB table, or null when using the AWS owned key (encryption = DEFAULT)."\``,
+  );
 };
 
 const NEW_APP_MODULE_VARIABLES_TEXT = [
@@ -357,13 +387,19 @@ const NEW_APP_MODULE_VARIABLES_TEXT = [
   '}',
   '',
   'variable "kms_key_arn" {',
-  '  description = "ARN of an existing KMS key used to encrypt the table when encryption is CUSTOMER_MANAGED. When not provided, a new key is created. Note that a customer-supplied key must already grant the DynamoDB service the necessary permissions in its own key policy."',
+  '  description = "ARN of an existing KMS key used to encrypt the table when encryption is CUSTOMER_MANAGED. When not provided and create_kms_key is true, a new key is created. Note that a customer-supplied key must already grant the DynamoDB service the necessary permissions in its own key policy."',
   '  type        = string',
   '  default     = null',
   '}',
   '',
+  'variable "create_kms_key" {',
+  '  description = "Whether to create a KMS key for the table. Only applies when encryption is CUSTOMER_MANAGED. Set to false when supplying kms_key_arn."',
+  '  type        = bool',
+  '  default     = true',
+  '}',
+  '',
   'variable "enable_key_rotation" {',
-  '  description = "Whether to enable automatic key rotation on the KMS key used to encrypt the table. Only applies when encryption is CUSTOMER_MANAGED and kms_key_arn is not provided."',
+  '  description = "Whether to enable automatic key rotation on the KMS key used to encrypt the table. Only applies when encryption is CUSTOMER_MANAGED and create_kms_key is true."',
   '  type        = bool',
   '  default     = true',
   '}',
@@ -439,9 +475,11 @@ const migrateTerraformAppModules = async (
       hcl(
         `\`deletion_protection_enabled = var.deletion_protection_enabled\` => \`deletion_protection_enabled = var.deletion_protection_enabled\n  ${GRIT_INSERT_PLACEHOLDER}\``,
       ),
-      ['encryption   = var.encryption', 'kms_key_arn  = var.kms_key_arn'].join(
-        '\n  ',
-      ),
+      [
+        'encryption      = var.encryption',
+        'kms_key_arn     = var.kms_key_arn',
+        'create_kms_key  = var.create_kms_key',
+      ].join('\n  '),
     );
   }
 };

--- a/packages/nx-plugin/src/migrations/latest/dynamodb-configurable-encryption/migration.ts
+++ b/packages/nx-plugin/src/migrations/latest/dynamodb-configurable-encryption/migration.ts
@@ -1,0 +1,448 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import {
+  joinPathFragments,
+  type MigrationReturnObject,
+  type Tree,
+} from '@nx/devkit';
+import {
+  addDestructuredImport,
+  applyGritQL,
+  GRIT_INSERT_PLACEHOLDER,
+  insertViaGritQL,
+  matchGritQL,
+} from '../../../utils/ast';
+import { formatFilesInSubtree } from '../../../utils/format';
+import {
+  PACKAGES_DIR,
+  SHARED_CONSTRUCTS_DIR,
+  SHARED_TERRAFORM_DIR,
+} from '../../../utils/shared-constructs-constants';
+
+/**
+ * Bring existing workspaces up to the generators' current DynamoDBTable
+ * configurability:
+ *
+ * - The vended `DynamoDBTable` CDK construct gains `encryption` and
+ *   `encryptionKey` props. The KMS key is only created when `encryption` is
+ *   `TableEncryption.CUSTOMER_MANAGED` and no `encryptionKey` is supplied.
+ *   `enableKeyRotation` (already present) only applies to that auto-created
+ *   key.
+ * - The generated per-table CDK app construct already forwards an optional
+ *   `props` parameter through to `DynamoDBTable`, so no change is needed
+ *   there.
+ * - The vended Terraform dynamodb core module gains the equivalent
+ *   `encryption` and `kms_key_arn` variables (`encryption` also accepts
+ *   `DEFAULT`, the AWS owned key, which CDK already supports for free via
+ *   `TableEncryption.DEFAULT`), with the KMS key made conditional via
+ *   `count` and `server_side_encryption.enabled` tied to `encryption`.
+ * - The vended Terraform per-table app module (`app/dynamodb/<name>/<name>.tf`)
+ *   gains pass-through `encryption` and `kms_key_arn` variables forwarded to
+ *   the core module call, matching its existing `enable_key_rotation`
+ *   pass-through.
+ *
+ * These files are generated with `KeepExisting`, so without this an upgraded
+ * workspace has generators that support this configuration but vended files
+ * that don't. Diverged files are left untouched and reported via `nextSteps`.
+ */
+
+const CDK_DYNAMODB_FILE = `${PACKAGES_DIR}/${SHARED_CONSTRUCTS_DIR}/src/core/dynamodb.ts`;
+const TERRAFORM_DYNAMODB_FILE = `${PACKAGES_DIR}/${SHARED_TERRAFORM_DIR}/src/core/dynamodb/dynamodb.tf`;
+const TERRAFORM_DYNAMODB_APP_DIR = `${PACKAGES_DIR}/${SHARED_TERRAFORM_DIR}/src/app/dynamodb`;
+
+const CDK_DIVERGED_MESSAGE = `${CDK_DYNAMODB_FILE}: has diverged from the generated shape - left untouched. To pick up the encryption and encryptionKey props, manually port them from the vended core/dynamodb.ts template (see the ts#dynamodb generator's DynamoDBTable construct).`;
+
+const TERRAFORM_DIVERGED_MESSAGE = `${TERRAFORM_DYNAMODB_FILE}: has diverged from the generated shape - left untouched. To pick up the encryption and kms_key_arn variables, manually port them from the vended dynamodb.tf template (see the ts#dynamodb generator's dynamodb module).`;
+
+const terraformAppDivergedMessage = (filePath: string) =>
+  `${filePath}: has diverged from the generated shape - left untouched. To make encryption and kms_key_arn configurable from your root Terraform configuration, add pass-through variables here and forward them to the dynamodb_table module call (see the ts#dynamodb generator's dynamodb app template).`;
+
+/**
+ * Surface encryption/encryptionKey on the vended DynamoDBTable CDK
+ * construct.
+ */
+const migrateCdkConstruct = async (
+  tree: Tree,
+  nextSteps: string[],
+): Promise<void> => {
+  if (!tree.exists(CDK_DYNAMODB_FILE)) {
+    return; // This workspace has no CDK DynamoDBTable construct.
+  }
+
+  if (
+    await matchGritQL(
+      tree,
+      CDK_DYNAMODB_FILE,
+      '`readonly encryption?: TableEncryption`',
+    )
+  ) {
+    return; // Already migrated.
+  }
+
+  const ENABLE_KEY_ROTATION_FIELD = '`readonly enableKeyRotation?: boolean`';
+  // Matched as a literal so the new fields can be inserted *before* it (see
+  // below) — GritQL doesn't include a leading comment in the span it matches
+  // for the field itself, so anchoring on the field would strand this
+  // comment above the newly-inserted fields instead of above the field it
+  // actually documents.
+  const ENABLE_KEY_ROTATION_COMMENT = `\`/**
+   * Whether to enable automatic key rotation on the KMS key used to encrypt the table.
+   *
+   * @default true
+   */\``;
+  const DESTRUCTURE_OLD = `\`{
+      tableName,
+      runtimeConfigKey,
+      billingMode = BillingMode.PAY_PER_REQUEST,
+      pointInTimeRecoverySpecification = { pointInTimeRecoveryEnabled: true },
+      deletionProtection = true,
+      removalPolicy = RemovalPolicy.RETAIN,
+      enableKeyRotation = true,
+      ...rest
+    }: DynamoDBTableProps\``;
+  const KEY_CREATION_OLD =
+    "`const key = new Key(this, 'EncryptionKey', { enableKeyRotation });`";
+  const TABLE_ENCRYPTION_OLD = '`encryption: TableEncryption.CUSTOMER_MANAGED`';
+
+  const anchors = [
+    ENABLE_KEY_ROTATION_FIELD,
+    ENABLE_KEY_ROTATION_COMMENT,
+    DESTRUCTURE_OLD,
+    KEY_CREATION_OLD,
+    TABLE_ENCRYPTION_OLD,
+  ];
+
+  const allPresent = (
+    await Promise.all(
+      anchors.map((pattern) => matchGritQL(tree, CDK_DYNAMODB_FILE, pattern)),
+    )
+  ).every(Boolean);
+
+  if (!allPresent) {
+    nextSteps.push(CDK_DIVERGED_MESSAGE);
+    return;
+  }
+
+  await addDestructuredImport(
+    tree,
+    CDK_DYNAMODB_FILE,
+    ['IKey'],
+    'aws-cdk-lib/aws-kms',
+  );
+
+  // Inserted before the enableKeyRotation field's own leading comment (rather
+  // than before the bare field) so that comment stays directly above the
+  // field it documents, instead of being stranded above the new fields.
+  await insertViaGritQL(
+    tree,
+    CDK_DYNAMODB_FILE,
+    `${ENABLE_KEY_ROTATION_COMMENT} as $comment => \`${GRIT_INSERT_PLACEHOLDER}
+  $comment\``,
+    `/**
+   * Server-side encryption for the table.
+   *
+   * @default TableEncryption.CUSTOMER_MANAGED
+   */
+  readonly encryption?: TableEncryption;
+
+  /**
+   * KMS key used to encrypt the table. Only used when \`encryption\` is
+   * \`TableEncryption.CUSTOMER_MANAGED\`. When not provided, a new key is created.
+   */
+  readonly encryptionKey?: IKey;
+
+  `,
+  );
+
+  await applyGritQL(
+    tree,
+    CDK_DYNAMODB_FILE,
+    `${DESTRUCTURE_OLD} => \`{
+      tableName,
+      runtimeConfigKey,
+      billingMode = BillingMode.PAY_PER_REQUEST,
+      pointInTimeRecoverySpecification = { pointInTimeRecoveryEnabled: true },
+      deletionProtection = true,
+      removalPolicy = RemovalPolicy.RETAIN,
+      encryption = TableEncryption.CUSTOMER_MANAGED,
+      encryptionKey,
+      enableKeyRotation = true,
+      ...rest
+    }: DynamoDBTableProps\``,
+  );
+
+  await applyGritQL(
+    tree,
+    CDK_DYNAMODB_FILE,
+    `${KEY_CREATION_OLD} => \`const key: IKey | undefined =
+      encryption === TableEncryption.CUSTOMER_MANAGED
+        ? (encryptionKey ?? new Key(this, 'EncryptionKey', { enableKeyRotation }))
+        : undefined;\``,
+  );
+
+  await applyGritQL(
+    tree,
+    CDK_DYNAMODB_FILE,
+    `${TABLE_ENCRYPTION_OLD} => \`encryption\``,
+  );
+};
+
+const hcl = (pattern: string) => `language hcl\n${pattern}`;
+
+const NEW_TERRAFORM_VARIABLES_TEXT = [
+  'variable "encryption" {',
+  '  description = "Server-side encryption for the table. One of CUSTOMER_MANAGED, AWS_MANAGED or DEFAULT (the AWS owned key, at no cost and with no key to manage)."',
+  '  type        = string',
+  '  default     = "CUSTOMER_MANAGED"',
+  '',
+  '  validation {',
+  '    condition     = contains(["CUSTOMER_MANAGED", "AWS_MANAGED", "DEFAULT"], var.encryption)',
+  '    error_message = "encryption must be one of CUSTOMER_MANAGED, AWS_MANAGED or DEFAULT."',
+  '  }',
+  '}',
+  '',
+  'variable "kms_key_arn" {',
+  '  description = "ARN of an existing KMS key used to encrypt the table when encryption is CUSTOMER_MANAGED. When not provided, a new key is created. Note that a customer-supplied key must already grant the DynamoDB service the necessary permissions in its own key policy."',
+  '  type        = string',
+  '  default     = null',
+  '}',
+  '',
+  'variable "enable_key_rotation" {',
+  '  description = "Whether to enable automatic key rotation on the KMS key used to encrypt the table. Only applies when encryption is CUSTOMER_MANAGED and kms_key_arn is not provided."',
+  '  type        = bool',
+  '  default     = true',
+  '}',
+].join('\n');
+
+/**
+ * Surface encryption/kms_key_arn on the vended Terraform dynamodb core
+ * module.
+ */
+const migrateTerraformModule = async (
+  tree: Tree,
+  nextSteps: string[],
+): Promise<void> => {
+  if (!tree.exists(TERRAFORM_DYNAMODB_FILE)) {
+    return; // This workspace has no Terraform dynamodb module.
+  }
+
+  if (
+    await matchGritQL(
+      tree,
+      TERRAFORM_DYNAMODB_FILE,
+      hcl('`variable "encryption" { $_ }`'),
+    )
+  ) {
+    return; // Already migrated.
+  }
+
+  const OLD_ENABLE_KEY_ROTATION_VAR = hcl(
+    [
+      '`variable "enable_key_rotation" {',
+      '  description = "Whether to enable automatic key rotation on the KMS key used to encrypt the table."',
+      '  type        = bool',
+      '  default     = true',
+      '}`',
+    ].join('\n'),
+  );
+  const LOCALS_BLOCK = hcl('`locals { $_ }`');
+  const KMS_KEY_BLOCK = hcl('`resource "aws_kms_key" "table" { $_ }`');
+  const SSE_ENABLED_LINE = hcl('`enabled = true`');
+  const SSE_KMS_KEY_LINE = hcl('`kms_key_arn = aws_kms_key.table.arn`');
+  const OUTPUT_VALUE_LINE = hcl('`value = aws_kms_key.table.arn`');
+
+  const anchors = [
+    OLD_ENABLE_KEY_ROTATION_VAR,
+    LOCALS_BLOCK,
+    KMS_KEY_BLOCK,
+    SSE_ENABLED_LINE,
+    SSE_KMS_KEY_LINE,
+    OUTPUT_VALUE_LINE,
+  ];
+
+  const allPresent = (
+    await Promise.all(
+      anchors.map((pattern) =>
+        matchGritQL(tree, TERRAFORM_DYNAMODB_FILE, pattern),
+      ),
+    )
+  ).every(Boolean);
+
+  if (!allPresent) {
+    nextSteps.push(TERRAFORM_DIVERGED_MESSAGE);
+    return;
+  }
+
+  // 1. Replace the enable_key_rotation variable with the new variables plus
+  //    an updated enable_key_rotation description, in the same position.
+  await applyGritQL(
+    tree,
+    TERRAFORM_DYNAMODB_FILE,
+    `${OLD_ENABLE_KEY_ROTATION_VAR} => \`${NEW_TERRAFORM_VARIABLES_TEXT.replace(/`/g, '\\`')}\``,
+  );
+
+  // 2. New locals, appended into the existing locals block.
+  await insertViaGritQL(
+    tree,
+    TERRAFORM_DYNAMODB_FILE,
+    hcl(
+      `\`locals { $body }\` => \`locals {\n  $body\n\n  ${GRIT_INSERT_PLACEHOLDER}\n}\``,
+    ),
+    [
+      'create_table_key = var.encryption == "CUSTOMER_MANAGED" && var.kms_key_arn == null',
+      'table_kms_key_arn = (',
+      '  var.encryption != "CUSTOMER_MANAGED" ? null :',
+      '  local.create_table_key ? aws_kms_key.table[0].arn :',
+      '  var.kms_key_arn',
+      ')',
+    ].join('\n  '),
+  );
+
+  // 3. Make the KMS key conditional on encryption/kms_key_arn.
+  await applyGritQL(
+    tree,
+    TERRAFORM_DYNAMODB_FILE,
+    hcl(`\`resource "aws_kms_key" "table" { $body }\` => \`resource "aws_kms_key" "table" {
+  count = local.create_table_key ? 1 : 0
+
+  $body
+}\``),
+  );
+
+  // 4. Only enable KMS-backed encryption when not using the AWS owned key.
+  await applyGritQL(
+    tree,
+    TERRAFORM_DYNAMODB_FILE,
+    `${SSE_ENABLED_LINE} => \`enabled = var.encryption != "DEFAULT"\``,
+  );
+
+  // 5. Resolve the key ARN through the new local everywhere it's consumed.
+  await applyGritQL(
+    tree,
+    TERRAFORM_DYNAMODB_FILE,
+    `${SSE_KMS_KEY_LINE} => \`kms_key_arn = local.table_kms_key_arn\``,
+  );
+  await applyGritQL(
+    tree,
+    TERRAFORM_DYNAMODB_FILE,
+    `${OUTPUT_VALUE_LINE} => \`value = local.table_kms_key_arn\``,
+  );
+};
+
+const NEW_APP_MODULE_VARIABLES_TEXT = [
+  'variable "encryption" {',
+  '  description = "Server-side encryption for the table. One of CUSTOMER_MANAGED, AWS_MANAGED or DEFAULT (the AWS owned key, at no cost and with no key to manage)."',
+  '  type        = string',
+  '  default     = "CUSTOMER_MANAGED"',
+  '',
+  '  validation {',
+  '    condition     = contains(["CUSTOMER_MANAGED", "AWS_MANAGED", "DEFAULT"], var.encryption)',
+  '    error_message = "encryption must be one of CUSTOMER_MANAGED, AWS_MANAGED or DEFAULT."',
+  '  }',
+  '}',
+  '',
+  'variable "kms_key_arn" {',
+  '  description = "ARN of an existing KMS key used to encrypt the table when encryption is CUSTOMER_MANAGED. When not provided, a new key is created. Note that a customer-supplied key must already grant the DynamoDB service the necessary permissions in its own key policy."',
+  '  type        = string',
+  '  default     = null',
+  '}',
+  '',
+  'variable "enable_key_rotation" {',
+  '  description = "Whether to enable automatic key rotation on the KMS key used to encrypt the table. Only applies when encryption is CUSTOMER_MANAGED and kms_key_arn is not provided."',
+  '  type        = bool',
+  '  default     = true',
+  '}',
+].join('\n');
+
+/**
+ * Surface the same configuration as pass-through variables on each vended
+ * per-table Terraform app module, matching its existing pass-through
+ * convention for enable_key_rotation.
+ */
+const migrateTerraformAppModules = async (
+  tree: Tree,
+  nextSteps: string[],
+): Promise<void> => {
+  if (!tree.exists(TERRAFORM_DYNAMODB_APP_DIR)) {
+    return;
+  }
+
+  for (const dirName of tree.children(TERRAFORM_DYNAMODB_APP_DIR)) {
+    const filePath = joinPathFragments(
+      TERRAFORM_DYNAMODB_APP_DIR,
+      dirName,
+      `${dirName}.tf`,
+    );
+    if (!tree.exists(filePath)) {
+      continue; // Not a dynamodb app module directory.
+    }
+
+    if (
+      await matchGritQL(tree, filePath, hcl('`variable "encryption" { $_ }`'))
+    ) {
+      continue; // Already migrated.
+    }
+
+    const OLD_ENABLE_KEY_ROTATION_VAR = hcl(
+      [
+        '`variable "enable_key_rotation" {',
+        '  description = "Whether to enable automatic key rotation on the KMS key used to encrypt the table."',
+        '  type        = bool',
+        '  default     = true',
+        '}`',
+      ].join('\n'),
+    );
+    const MODULE_BLOCK = hcl('`module "dynamodb_table" { $_ }`');
+    const DELETION_PROTECTION_LINE = hcl(
+      '`deletion_protection_enabled = var.deletion_protection_enabled`',
+    );
+
+    const ready = (
+      await Promise.all(
+        [
+          OLD_ENABLE_KEY_ROTATION_VAR,
+          MODULE_BLOCK,
+          DELETION_PROTECTION_LINE,
+        ].map((pattern) => matchGritQL(tree, filePath, pattern)),
+      )
+    ).every(Boolean);
+
+    if (!ready) {
+      nextSteps.push(terraformAppDivergedMessage(filePath));
+      continue;
+    }
+
+    await applyGritQL(
+      tree,
+      filePath,
+      `${OLD_ENABLE_KEY_ROTATION_VAR} => \`${NEW_APP_MODULE_VARIABLES_TEXT.replace(/`/g, '\\`')}\``,
+    );
+
+    await insertViaGritQL(
+      tree,
+      filePath,
+      hcl(
+        `\`deletion_protection_enabled = var.deletion_protection_enabled\` => \`deletion_protection_enabled = var.deletion_protection_enabled\n  ${GRIT_INSERT_PLACEHOLDER}\``,
+      ),
+      ['encryption   = var.encryption', 'kms_key_arn  = var.kms_key_arn'].join(
+        '\n  ',
+      ),
+    );
+  }
+};
+
+export default async function migration(
+  tree: Tree,
+): Promise<MigrationReturnObject> {
+  const nextSteps: string[] = [];
+
+  await migrateCdkConstruct(tree, nextSteps);
+  await migrateTerraformModule(tree, nextSteps);
+  await migrateTerraformAppModules(tree, nextSteps);
+
+  await formatFilesInSubtree(tree);
+
+  return { nextSteps };
+}

--- a/packages/nx-plugin/src/migrations/latest/dynamodb-configurable-encryption/migration.ts
+++ b/packages/nx-plugin/src/migrations/latest/dynamodb-configurable-encryption/migration.ts
@@ -318,6 +318,19 @@ const migrateTerraformModule = async (
     `${SSE_ENABLED_LINE} => \`enabled = var.encryption != "DEFAULT"\``,
   );
 
+  // 4b. Checkov's CKV_AWS_119 only passes when server_side_encryption.enabled
+  // is the literal `true` — it can't resolve the conditional above, even
+  // though CUSTOMER_MANAGED (the default) always uses a real CMK. Same
+  // false-positive shape as CKV_AWS_139 on the vended RDS module.
+  await insertViaGritQL(
+    tree,
+    TERRAFORM_DYNAMODB_FILE,
+    hcl(
+      `\`resource "aws_dynamodb_table" "table" { $body }\` => \`resource "aws_dynamodb_table" "table" {\n  ${GRIT_INSERT_PLACEHOLDER}\n  $body\n}\``,
+    ),
+    '#checkov:skip=CKV_AWS_119:Encryption is configurable via var.encryption; checkov cannot resolve the conditional server_side_encryption.enabled expression',
+  );
+
   // 5. Resolve the key ARN through the new local everywhere it's consumed.
   await applyGritQL(
     tree,

--- a/packages/nx-plugin/src/py/dynamodb/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/dynamodb/__snapshots__/generator.spec.ts.snap
@@ -152,6 +152,7 @@ resource "aws_kms_key" "table" {
 }
 
 resource "aws_dynamodb_table" "table" {
+  #checkov:skip=CKV_AWS_119:Encryption is configurable via var.encryption; checkov cannot resolve the conditional server_side_encryption.enabled expression
   name                        = var.name
   billing_mode                = var.billing_mode
   hash_key                    = "pk"

--- a/packages/nx-plugin/src/py/dynamodb/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/dynamodb/__snapshots__/generator.spec.ts.snap
@@ -64,7 +64,7 @@ variable "deletion_protection_enabled" {
 }
 
 variable "encryption" {
-  description = "Server-side encryption for the table. One of CUSTOMER_MANAGED, AWS_MANAGED or DEFAULT (the AWS owned key, at no cost and with no key to manage)."
+  description = "Server-side encryption for the table. One of CUSTOMER_MANAGED, AWS_MANAGED or DEFAULT (the AWS owned key, at no cost and with no key to manage). Changing this on an already-deployed table away from CUSTOMER_MANAGED requires a manual step first - see the ts#dynamodb generator's docs."
   type        = string
   default     = "CUSTOMER_MANAGED"
 
@@ -75,13 +75,19 @@ variable "encryption" {
 }
 
 variable "kms_key_arn" {
-  description = "ARN of an existing KMS key used to encrypt the table when encryption is CUSTOMER_MANAGED. When not provided, a new key is created. Note that a customer-supplied key must already grant the DynamoDB service the necessary permissions in its own key policy."
+  description = "ARN of an existing KMS key used to encrypt the table when encryption is CUSTOMER_MANAGED. When not provided and create_kms_key is true, a new key is created. Note that a customer-supplied key must already grant the DynamoDB service the necessary permissions in its own key policy."
   type        = string
   default     = null
 }
 
+variable "create_kms_key" {
+  description = "Whether to create a KMS key for the table. Only applies when encryption is CUSTOMER_MANAGED. Set to false when supplying kms_key_arn."
+  type        = bool
+  default     = true
+}
+
 variable "enable_key_rotation" {
-  description = "Whether to enable automatic key rotation on the KMS key used to encrypt the table. Only applies when encryption is CUSTOMER_MANAGED and kms_key_arn is not provided."
+  description = "Whether to enable automatic key rotation on the KMS key used to encrypt the table. Only applies when encryption is CUSTOMER_MANAGED and create_kms_key is true."
   type        = bool
   default     = true
 }
@@ -102,16 +108,17 @@ locals {
     for gsi in var.global_secondary_indexes : [gsi.hash_key, gsi.range_key]
   ]))
 
-  create_table_key = var.encryption == "CUSTOMER_MANAGED" && var.kms_key_arn == null
+  create_table_key = var.encryption == "CUSTOMER_MANAGED" && var.create_kms_key
   table_kms_key_arn = (
-    var.encryption != "CUSTOMER_MANAGED" ? null :
-    local.create_table_key ? aws_kms_key.table[0].arn :
-    var.kms_key_arn
+    var.encryption == "CUSTOMER_MANAGED" ? (local.create_table_key ? aws_kms_key.table[0].arn : var.kms_key_arn) :
+    var.encryption == "AWS_MANAGED" ? "arn:\${data.aws_partition.current.partition}:kms:\${data.aws_region.current.region}:\${data.aws_caller_identity.current.account_id}:alias/aws/dynamodb" :
+    null
   )
 }
 
 data "aws_caller_identity" "current" {}
 data "aws_partition" "current" {}
+data "aws_region" "current" {}
 
 resource "aws_kms_key" "table" {
   count = local.create_table_key ? 1 : 0
@@ -208,7 +215,7 @@ output "table_arn" {
 }
 
 output "kms_key_arn" {
-  description = "ARN of the KMS key used to encrypt the DynamoDB table, if using customer-managed encryption."
+  description = "ARN of the KMS key used to encrypt the DynamoDB table, or null when using the AWS owned key (encryption = DEFAULT)."
   value       = local.table_kms_key_arn
 }
 "
@@ -247,7 +254,7 @@ variable "deletion_protection_enabled" {
 }
 
 variable "encryption" {
-  description = "Server-side encryption for the table. One of CUSTOMER_MANAGED, AWS_MANAGED or DEFAULT (the AWS owned key, at no cost and with no key to manage)."
+  description = "Server-side encryption for the table. One of CUSTOMER_MANAGED, AWS_MANAGED or DEFAULT (the AWS owned key, at no cost and with no key to manage). Changing this on an already-deployed table away from CUSTOMER_MANAGED requires a manual step first - see the ts#dynamodb generator's docs."
   type        = string
   default     = "CUSTOMER_MANAGED"
 
@@ -258,13 +265,19 @@ variable "encryption" {
 }
 
 variable "kms_key_arn" {
-  description = "ARN of an existing KMS key used to encrypt the table when encryption is CUSTOMER_MANAGED. When not provided, a new key is created. Note that a customer-supplied key must already grant the DynamoDB service the necessary permissions in its own key policy."
+  description = "ARN of an existing KMS key used to encrypt the table when encryption is CUSTOMER_MANAGED. When not provided and create_kms_key is true, a new key is created. Note that a customer-supplied key must already grant the DynamoDB service the necessary permissions in its own key policy."
   type        = string
   default     = null
 }
 
+variable "create_kms_key" {
+  description = "Whether to create a KMS key for the table. Only applies when encryption is CUSTOMER_MANAGED. Set to false when supplying kms_key_arn."
+  type        = bool
+  default     = true
+}
+
 variable "enable_key_rotation" {
-  description = "Whether to enable automatic key rotation on the KMS key used to encrypt the table. Only applies when encryption is CUSTOMER_MANAGED and kms_key_arn is not provided."
+  description = "Whether to enable automatic key rotation on the KMS key used to encrypt the table. Only applies when encryption is CUSTOMER_MANAGED and create_kms_key is true."
   type        = bool
   default     = true
 }
@@ -293,6 +306,7 @@ module "dynamodb_table" {
   deletion_protection_enabled    = var.deletion_protection_enabled
   encryption                     = var.encryption
   kms_key_arn                    = var.kms_key_arn
+  create_kms_key                 = var.create_kms_key
   enable_key_rotation            = var.enable_key_rotation
   global_secondary_indexes       = local.global_secondary_indexes
 }

--- a/packages/nx-plugin/src/py/dynamodb/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/dynamodb/__snapshots__/generator.spec.ts.snap
@@ -63,8 +63,25 @@ variable "deletion_protection_enabled" {
   default     = true
 }
 
+variable "encryption" {
+  description = "Server-side encryption for the table. One of CUSTOMER_MANAGED, AWS_MANAGED or DEFAULT (the AWS owned key, at no cost and with no key to manage)."
+  type        = string
+  default     = "CUSTOMER_MANAGED"
+
+  validation {
+    condition     = contains(["CUSTOMER_MANAGED", "AWS_MANAGED", "DEFAULT"], var.encryption)
+    error_message = "encryption must be one of CUSTOMER_MANAGED, AWS_MANAGED or DEFAULT."
+  }
+}
+
+variable "kms_key_arn" {
+  description = "ARN of an existing KMS key used to encrypt the table when encryption is CUSTOMER_MANAGED. When not provided, a new key is created. Note that a customer-supplied key must already grant the DynamoDB service the necessary permissions in its own key policy."
+  type        = string
+  default     = null
+}
+
 variable "enable_key_rotation" {
-  description = "Whether to enable automatic key rotation on the KMS key used to encrypt the table."
+  description = "Whether to enable automatic key rotation on the KMS key used to encrypt the table. Only applies when encryption is CUSTOMER_MANAGED and kms_key_arn is not provided."
   type        = bool
   default     = true
 }
@@ -84,12 +101,21 @@ locals {
   gsi_attribute_names = distinct(flatten([
     for gsi in var.global_secondary_indexes : [gsi.hash_key, gsi.range_key]
   ]))
+
+  create_table_key = var.encryption == "CUSTOMER_MANAGED" && var.kms_key_arn == null
+  table_kms_key_arn = (
+    var.encryption != "CUSTOMER_MANAGED" ? null :
+    local.create_table_key ? aws_kms_key.table[0].arn :
+    var.kms_key_arn
+  )
 }
 
 data "aws_caller_identity" "current" {}
 data "aws_partition" "current" {}
 
 resource "aws_kms_key" "table" {
+  count = local.create_table_key ? 1 : 0
+
   description         = "KMS key for DynamoDB table \${var.name}"
   enable_key_rotation = var.enable_key_rotation
 
@@ -165,8 +191,8 @@ resource "aws_dynamodb_table" "table" {
   }
 
   server_side_encryption {
-    enabled     = true
-    kms_key_arn = aws_kms_key.table.arn
+    enabled     = var.encryption != "DEFAULT"
+    kms_key_arn = local.table_kms_key_arn
   }
 }
 
@@ -181,8 +207,8 @@ output "table_arn" {
 }
 
 output "kms_key_arn" {
-  description = "ARN of the KMS key used to encrypt the DynamoDB table."
-  value       = aws_kms_key.table.arn
+  description = "ARN of the KMS key used to encrypt the DynamoDB table, if using customer-managed encryption."
+  value       = local.table_kms_key_arn
 }
 "
 `;
@@ -219,8 +245,25 @@ variable "deletion_protection_enabled" {
   default     = true
 }
 
+variable "encryption" {
+  description = "Server-side encryption for the table. One of CUSTOMER_MANAGED, AWS_MANAGED or DEFAULT (the AWS owned key, at no cost and with no key to manage)."
+  type        = string
+  default     = "CUSTOMER_MANAGED"
+
+  validation {
+    condition     = contains(["CUSTOMER_MANAGED", "AWS_MANAGED", "DEFAULT"], var.encryption)
+    error_message = "encryption must be one of CUSTOMER_MANAGED, AWS_MANAGED or DEFAULT."
+  }
+}
+
+variable "kms_key_arn" {
+  description = "ARN of an existing KMS key used to encrypt the table when encryption is CUSTOMER_MANAGED. When not provided, a new key is created. Note that a customer-supplied key must already grant the DynamoDB service the necessary permissions in its own key policy."
+  type        = string
+  default     = null
+}
+
 variable "enable_key_rotation" {
-  description = "Whether to enable automatic key rotation on the KMS key used to encrypt the table."
+  description = "Whether to enable automatic key rotation on the KMS key used to encrypt the table. Only applies when encryption is CUSTOMER_MANAGED and kms_key_arn is not provided."
   type        = bool
   default     = true
 }
@@ -247,6 +290,8 @@ module "dynamodb_table" {
   billing_mode                   = var.billing_mode
   point_in_time_recovery_enabled = var.point_in_time_recovery_enabled
   deletion_protection_enabled    = var.deletion_protection_enabled
+  encryption                     = var.encryption
+  kms_key_arn                    = var.kms_key_arn
   enable_key_rotation            = var.enable_key_rotation
   global_secondary_indexes       = local.global_secondary_indexes
 }
@@ -815,7 +860,7 @@ import {
 } from 'aws-cdk-lib/aws-dynamodb';
 import { RemovalPolicy } from 'aws-cdk-lib';
 import { Grant, IGrantable } from 'aws-cdk-lib/aws-iam';
-import { Key } from 'aws-cdk-lib/aws-kms';
+import { IKey, Key } from 'aws-cdk-lib/aws-kms';
 import { RuntimeConfig } from './runtime-config.js';
 
 type _DynamoDBTableProps = Omit<
@@ -836,7 +881,22 @@ export interface DynamoDBTableProps extends _DynamoDBTableProps {
   readonly runtimeConfigKey: string;
 
   /**
+   * Server-side encryption for the table.
+   *
+   * @default TableEncryption.CUSTOMER_MANAGED
+   */
+  readonly encryption?: TableEncryption;
+
+  /**
+   * KMS key used to encrypt the table. Only used when \`encryption\` is
+   * \`TableEncryption.CUSTOMER_MANAGED\`. When not provided, a new key is created.
+   */
+  readonly encryptionKey?: IKey;
+
+  /**
    * Whether to enable automatic key rotation on the KMS key used to encrypt the table.
+   * Only applies when \`encryption\` is \`TableEncryption.CUSTOMER_MANAGED\` and no
+   * \`encryptionKey\` is supplied.
    *
    * @default true
    */
@@ -856,13 +916,19 @@ export abstract class DynamoDBTable extends Construct {
       pointInTimeRecoverySpecification = { pointInTimeRecoveryEnabled: true },
       deletionProtection = true,
       removalPolicy = RemovalPolicy.RETAIN,
+      encryption = TableEncryption.CUSTOMER_MANAGED,
+      encryptionKey,
       enableKeyRotation = true,
       ...rest
     }: DynamoDBTableProps,
   ) {
     super(scope, id);
 
-    const key = new Key(this, 'EncryptionKey', { enableKeyRotation });
+    const key: IKey | undefined =
+      encryption === TableEncryption.CUSTOMER_MANAGED
+        ? (encryptionKey ??
+          new Key(this, 'EncryptionKey', { enableKeyRotation }))
+        : undefined;
 
     this.table = new Table(this, runtimeConfigKey, {
       ...rest,
@@ -873,7 +939,7 @@ export abstract class DynamoDBTable extends Construct {
       pointInTimeRecoverySpecification,
       deletionProtection,
       encryptionKey: key,
-      encryption: TableEncryption.CUSTOMER_MANAGED,
+      encryption,
       removalPolicy,
     });
 

--- a/packages/nx-plugin/src/ts/dynamodb/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/dynamodb/__snapshots__/generator.spec.ts.snap
@@ -152,6 +152,7 @@ resource "aws_kms_key" "table" {
 }
 
 resource "aws_dynamodb_table" "table" {
+  #checkov:skip=CKV_AWS_119:Encryption is configurable via var.encryption; checkov cannot resolve the conditional server_side_encryption.enabled expression
   name                        = var.name
   billing_mode                = var.billing_mode
   hash_key                    = "pk"

--- a/packages/nx-plugin/src/ts/dynamodb/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/dynamodb/__snapshots__/generator.spec.ts.snap
@@ -63,8 +63,25 @@ variable "deletion_protection_enabled" {
   default     = true
 }
 
+variable "encryption" {
+  description = "Server-side encryption for the table. One of CUSTOMER_MANAGED, AWS_MANAGED or DEFAULT (the AWS owned key, at no cost and with no key to manage)."
+  type        = string
+  default     = "CUSTOMER_MANAGED"
+
+  validation {
+    condition     = contains(["CUSTOMER_MANAGED", "AWS_MANAGED", "DEFAULT"], var.encryption)
+    error_message = "encryption must be one of CUSTOMER_MANAGED, AWS_MANAGED or DEFAULT."
+  }
+}
+
+variable "kms_key_arn" {
+  description = "ARN of an existing KMS key used to encrypt the table when encryption is CUSTOMER_MANAGED. When not provided, a new key is created. Note that a customer-supplied key must already grant the DynamoDB service the necessary permissions in its own key policy."
+  type        = string
+  default     = null
+}
+
 variable "enable_key_rotation" {
-  description = "Whether to enable automatic key rotation on the KMS key used to encrypt the table."
+  description = "Whether to enable automatic key rotation on the KMS key used to encrypt the table. Only applies when encryption is CUSTOMER_MANAGED and kms_key_arn is not provided."
   type        = bool
   default     = true
 }
@@ -84,12 +101,21 @@ locals {
   gsi_attribute_names = distinct(flatten([
     for gsi in var.global_secondary_indexes : [gsi.hash_key, gsi.range_key]
   ]))
+
+  create_table_key = var.encryption == "CUSTOMER_MANAGED" && var.kms_key_arn == null
+  table_kms_key_arn = (
+    var.encryption != "CUSTOMER_MANAGED" ? null :
+    local.create_table_key ? aws_kms_key.table[0].arn :
+    var.kms_key_arn
+  )
 }
 
 data "aws_caller_identity" "current" {}
 data "aws_partition" "current" {}
 
 resource "aws_kms_key" "table" {
+  count = local.create_table_key ? 1 : 0
+
   description         = "KMS key for DynamoDB table \${var.name}"
   enable_key_rotation = var.enable_key_rotation
 
@@ -165,8 +191,8 @@ resource "aws_dynamodb_table" "table" {
   }
 
   server_side_encryption {
-    enabled     = true
-    kms_key_arn = aws_kms_key.table.arn
+    enabled     = var.encryption != "DEFAULT"
+    kms_key_arn = local.table_kms_key_arn
   }
 }
 
@@ -181,8 +207,8 @@ output "table_arn" {
 }
 
 output "kms_key_arn" {
-  description = "ARN of the KMS key used to encrypt the DynamoDB table."
-  value       = aws_kms_key.table.arn
+  description = "ARN of the KMS key used to encrypt the DynamoDB table, if using customer-managed encryption."
+  value       = local.table_kms_key_arn
 }
 "
 `;
@@ -219,8 +245,25 @@ variable "deletion_protection_enabled" {
   default     = true
 }
 
+variable "encryption" {
+  description = "Server-side encryption for the table. One of CUSTOMER_MANAGED, AWS_MANAGED or DEFAULT (the AWS owned key, at no cost and with no key to manage)."
+  type        = string
+  default     = "CUSTOMER_MANAGED"
+
+  validation {
+    condition     = contains(["CUSTOMER_MANAGED", "AWS_MANAGED", "DEFAULT"], var.encryption)
+    error_message = "encryption must be one of CUSTOMER_MANAGED, AWS_MANAGED or DEFAULT."
+  }
+}
+
+variable "kms_key_arn" {
+  description = "ARN of an existing KMS key used to encrypt the table when encryption is CUSTOMER_MANAGED. When not provided, a new key is created. Note that a customer-supplied key must already grant the DynamoDB service the necessary permissions in its own key policy."
+  type        = string
+  default     = null
+}
+
 variable "enable_key_rotation" {
-  description = "Whether to enable automatic key rotation on the KMS key used to encrypt the table."
+  description = "Whether to enable automatic key rotation on the KMS key used to encrypt the table. Only applies when encryption is CUSTOMER_MANAGED and kms_key_arn is not provided."
   type        = bool
   default     = true
 }
@@ -247,6 +290,8 @@ module "dynamodb_table" {
   billing_mode                   = var.billing_mode
   point_in_time_recovery_enabled = var.point_in_time_recovery_enabled
   deletion_protection_enabled    = var.deletion_protection_enabled
+  encryption                     = var.encryption
+  kms_key_arn                    = var.kms_key_arn
   enable_key_rotation            = var.enable_key_rotation
   global_secondary_indexes       = local.global_secondary_indexes
 }
@@ -747,7 +792,7 @@ import {
 } from 'aws-cdk-lib/aws-dynamodb';
 import { RemovalPolicy } from 'aws-cdk-lib';
 import { Grant, IGrantable } from 'aws-cdk-lib/aws-iam';
-import { Key } from 'aws-cdk-lib/aws-kms';
+import { IKey, Key } from 'aws-cdk-lib/aws-kms';
 import { RuntimeConfig } from './runtime-config.js';
 
 type _DynamoDBTableProps = Omit<
@@ -768,7 +813,22 @@ export interface DynamoDBTableProps extends _DynamoDBTableProps {
   readonly runtimeConfigKey: string;
 
   /**
+   * Server-side encryption for the table.
+   *
+   * @default TableEncryption.CUSTOMER_MANAGED
+   */
+  readonly encryption?: TableEncryption;
+
+  /**
+   * KMS key used to encrypt the table. Only used when \`encryption\` is
+   * \`TableEncryption.CUSTOMER_MANAGED\`. When not provided, a new key is created.
+   */
+  readonly encryptionKey?: IKey;
+
+  /**
    * Whether to enable automatic key rotation on the KMS key used to encrypt the table.
+   * Only applies when \`encryption\` is \`TableEncryption.CUSTOMER_MANAGED\` and no
+   * \`encryptionKey\` is supplied.
    *
    * @default true
    */
@@ -788,13 +848,19 @@ export abstract class DynamoDBTable extends Construct {
       pointInTimeRecoverySpecification = { pointInTimeRecoveryEnabled: true },
       deletionProtection = true,
       removalPolicy = RemovalPolicy.RETAIN,
+      encryption = TableEncryption.CUSTOMER_MANAGED,
+      encryptionKey,
       enableKeyRotation = true,
       ...rest
     }: DynamoDBTableProps,
   ) {
     super(scope, id);
 
-    const key = new Key(this, 'EncryptionKey', { enableKeyRotation });
+    const key: IKey | undefined =
+      encryption === TableEncryption.CUSTOMER_MANAGED
+        ? (encryptionKey ??
+          new Key(this, 'EncryptionKey', { enableKeyRotation }))
+        : undefined;
 
     this.table = new Table(this, runtimeConfigKey, {
       ...rest,
@@ -805,7 +871,7 @@ export abstract class DynamoDBTable extends Construct {
       pointInTimeRecoverySpecification,
       deletionProtection,
       encryptionKey: key,
-      encryption: TableEncryption.CUSTOMER_MANAGED,
+      encryption,
       removalPolicy,
     });
 

--- a/packages/nx-plugin/src/ts/dynamodb/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/dynamodb/__snapshots__/generator.spec.ts.snap
@@ -64,7 +64,7 @@ variable "deletion_protection_enabled" {
 }
 
 variable "encryption" {
-  description = "Server-side encryption for the table. One of CUSTOMER_MANAGED, AWS_MANAGED or DEFAULT (the AWS owned key, at no cost and with no key to manage)."
+  description = "Server-side encryption for the table. One of CUSTOMER_MANAGED, AWS_MANAGED or DEFAULT (the AWS owned key, at no cost and with no key to manage). Changing this on an already-deployed table away from CUSTOMER_MANAGED requires a manual step first - see the ts#dynamodb generator's docs."
   type        = string
   default     = "CUSTOMER_MANAGED"
 
@@ -75,13 +75,19 @@ variable "encryption" {
 }
 
 variable "kms_key_arn" {
-  description = "ARN of an existing KMS key used to encrypt the table when encryption is CUSTOMER_MANAGED. When not provided, a new key is created. Note that a customer-supplied key must already grant the DynamoDB service the necessary permissions in its own key policy."
+  description = "ARN of an existing KMS key used to encrypt the table when encryption is CUSTOMER_MANAGED. When not provided and create_kms_key is true, a new key is created. Note that a customer-supplied key must already grant the DynamoDB service the necessary permissions in its own key policy."
   type        = string
   default     = null
 }
 
+variable "create_kms_key" {
+  description = "Whether to create a KMS key for the table. Only applies when encryption is CUSTOMER_MANAGED. Set to false when supplying kms_key_arn."
+  type        = bool
+  default     = true
+}
+
 variable "enable_key_rotation" {
-  description = "Whether to enable automatic key rotation on the KMS key used to encrypt the table. Only applies when encryption is CUSTOMER_MANAGED and kms_key_arn is not provided."
+  description = "Whether to enable automatic key rotation on the KMS key used to encrypt the table. Only applies when encryption is CUSTOMER_MANAGED and create_kms_key is true."
   type        = bool
   default     = true
 }
@@ -102,16 +108,17 @@ locals {
     for gsi in var.global_secondary_indexes : [gsi.hash_key, gsi.range_key]
   ]))
 
-  create_table_key = var.encryption == "CUSTOMER_MANAGED" && var.kms_key_arn == null
+  create_table_key = var.encryption == "CUSTOMER_MANAGED" && var.create_kms_key
   table_kms_key_arn = (
-    var.encryption != "CUSTOMER_MANAGED" ? null :
-    local.create_table_key ? aws_kms_key.table[0].arn :
-    var.kms_key_arn
+    var.encryption == "CUSTOMER_MANAGED" ? (local.create_table_key ? aws_kms_key.table[0].arn : var.kms_key_arn) :
+    var.encryption == "AWS_MANAGED" ? "arn:\${data.aws_partition.current.partition}:kms:\${data.aws_region.current.region}:\${data.aws_caller_identity.current.account_id}:alias/aws/dynamodb" :
+    null
   )
 }
 
 data "aws_caller_identity" "current" {}
 data "aws_partition" "current" {}
+data "aws_region" "current" {}
 
 resource "aws_kms_key" "table" {
   count = local.create_table_key ? 1 : 0
@@ -208,7 +215,7 @@ output "table_arn" {
 }
 
 output "kms_key_arn" {
-  description = "ARN of the KMS key used to encrypt the DynamoDB table, if using customer-managed encryption."
+  description = "ARN of the KMS key used to encrypt the DynamoDB table, or null when using the AWS owned key (encryption = DEFAULT)."
   value       = local.table_kms_key_arn
 }
 "
@@ -247,7 +254,7 @@ variable "deletion_protection_enabled" {
 }
 
 variable "encryption" {
-  description = "Server-side encryption for the table. One of CUSTOMER_MANAGED, AWS_MANAGED or DEFAULT (the AWS owned key, at no cost and with no key to manage)."
+  description = "Server-side encryption for the table. One of CUSTOMER_MANAGED, AWS_MANAGED or DEFAULT (the AWS owned key, at no cost and with no key to manage). Changing this on an already-deployed table away from CUSTOMER_MANAGED requires a manual step first - see the ts#dynamodb generator's docs."
   type        = string
   default     = "CUSTOMER_MANAGED"
 
@@ -258,13 +265,19 @@ variable "encryption" {
 }
 
 variable "kms_key_arn" {
-  description = "ARN of an existing KMS key used to encrypt the table when encryption is CUSTOMER_MANAGED. When not provided, a new key is created. Note that a customer-supplied key must already grant the DynamoDB service the necessary permissions in its own key policy."
+  description = "ARN of an existing KMS key used to encrypt the table when encryption is CUSTOMER_MANAGED. When not provided and create_kms_key is true, a new key is created. Note that a customer-supplied key must already grant the DynamoDB service the necessary permissions in its own key policy."
   type        = string
   default     = null
 }
 
+variable "create_kms_key" {
+  description = "Whether to create a KMS key for the table. Only applies when encryption is CUSTOMER_MANAGED. Set to false when supplying kms_key_arn."
+  type        = bool
+  default     = true
+}
+
 variable "enable_key_rotation" {
-  description = "Whether to enable automatic key rotation on the KMS key used to encrypt the table. Only applies when encryption is CUSTOMER_MANAGED and kms_key_arn is not provided."
+  description = "Whether to enable automatic key rotation on the KMS key used to encrypt the table. Only applies when encryption is CUSTOMER_MANAGED and create_kms_key is true."
   type        = bool
   default     = true
 }
@@ -293,6 +306,7 @@ module "dynamodb_table" {
   deletion_protection_enabled    = var.deletion_protection_enabled
   encryption                     = var.encryption
   kms_key_arn                    = var.kms_key_arn
+  create_kms_key                 = var.create_kms_key
   enable_key_rotation            = var.enable_key_rotation
   global_secondary_indexes       = local.global_secondary_indexes
 }

--- a/packages/nx-plugin/src/utils/dynamodb-constructs/files/cdk/core/dynamodb.ts.template
+++ b/packages/nx-plugin/src/utils/dynamodb-constructs/files/cdk/core/dynamodb.ts.template
@@ -8,7 +8,7 @@ import {
 } from 'aws-cdk-lib/aws-dynamodb';
 import { RemovalPolicy } from 'aws-cdk-lib';
 import { Grant, IGrantable } from 'aws-cdk-lib/aws-iam';
-import { Key } from 'aws-cdk-lib/aws-kms';
+import { IKey, Key } from 'aws-cdk-lib/aws-kms';
 import { RuntimeConfig } from './runtime-config<% if (esm) { %>.js<% } %>';
 
 type _DynamoDBTableProps = Omit<TableProps, 'tableName' | 'partitionKey' | 'sortKey' | 'encryption' | 'encryptionKey'>;
@@ -26,7 +26,22 @@ export interface DynamoDBTableProps extends _DynamoDBTableProps {
   readonly runtimeConfigKey: string;
 
   /**
+   * Server-side encryption for the table.
+   *
+   * @default TableEncryption.CUSTOMER_MANAGED
+   */
+  readonly encryption?: TableEncryption;
+
+  /**
+   * KMS key used to encrypt the table. Only used when `encryption` is
+   * `TableEncryption.CUSTOMER_MANAGED`. When not provided, a new key is created.
+   */
+  readonly encryptionKey?: IKey;
+
+  /**
    * Whether to enable automatic key rotation on the KMS key used to encrypt the table.
+   * Only applies when `encryption` is `TableEncryption.CUSTOMER_MANAGED` and no
+   * `encryptionKey` is supplied.
    *
    * @default true
    */
@@ -46,13 +61,18 @@ export abstract class DynamoDBTable extends Construct {
       pointInTimeRecoverySpecification = { pointInTimeRecoveryEnabled: true },
       deletionProtection = true,
       removalPolicy = RemovalPolicy.RETAIN,
+      encryption = TableEncryption.CUSTOMER_MANAGED,
+      encryptionKey,
       enableKeyRotation = true,
       ...rest
     }: DynamoDBTableProps,
   ) {
     super(scope, id);
 
-    const key = new Key(this, 'EncryptionKey', { enableKeyRotation });
+    const key: IKey | undefined =
+      encryption === TableEncryption.CUSTOMER_MANAGED
+        ? (encryptionKey ?? new Key(this, 'EncryptionKey', { enableKeyRotation }))
+        : undefined;
 
     this.table = new Table(this, runtimeConfigKey, {
       ...rest,
@@ -63,7 +83,7 @@ export abstract class DynamoDBTable extends Construct {
       pointInTimeRecoverySpecification,
       deletionProtection,
       encryptionKey: key,
-      encryption: TableEncryption.CUSTOMER_MANAGED,
+      encryption,
       removalPolicy,
     });
 

--- a/packages/nx-plugin/src/utils/dynamodb-constructs/files/terraform/app/dynamodb/__nameKebabCase__/__nameKebabCase__.tf.template
+++ b/packages/nx-plugin/src/utils/dynamodb-constructs/files/terraform/app/dynamodb/__nameKebabCase__/__nameKebabCase__.tf.template
@@ -29,8 +29,25 @@ variable "deletion_protection_enabled" {
   default     = true
 }
 
+variable "encryption" {
+  description = "Server-side encryption for the table. One of CUSTOMER_MANAGED, AWS_MANAGED or DEFAULT (the AWS owned key, at no cost and with no key to manage)."
+  type        = string
+  default     = "CUSTOMER_MANAGED"
+
+  validation {
+    condition     = contains(["CUSTOMER_MANAGED", "AWS_MANAGED", "DEFAULT"], var.encryption)
+    error_message = "encryption must be one of CUSTOMER_MANAGED, AWS_MANAGED or DEFAULT."
+  }
+}
+
+variable "kms_key_arn" {
+  description = "ARN of an existing KMS key used to encrypt the table when encryption is CUSTOMER_MANAGED. When not provided, a new key is created. Note that a customer-supplied key must already grant the DynamoDB service the necessary permissions in its own key policy."
+  type        = string
+  default     = null
+}
+
 variable "enable_key_rotation" {
-  description = "Whether to enable automatic key rotation on the KMS key used to encrypt the table."
+  description = "Whether to enable automatic key rotation on the KMS key used to encrypt the table. Only applies when encryption is CUSTOMER_MANAGED and kms_key_arn is not provided."
   type        = bool
   default     = true
 }
@@ -57,6 +74,8 @@ module "dynamodb_table" {
   billing_mode                   = var.billing_mode
   point_in_time_recovery_enabled = var.point_in_time_recovery_enabled
   deletion_protection_enabled    = var.deletion_protection_enabled
+  encryption                     = var.encryption
+  kms_key_arn                    = var.kms_key_arn
   enable_key_rotation            = var.enable_key_rotation
   global_secondary_indexes       = local.global_secondary_indexes
 }

--- a/packages/nx-plugin/src/utils/dynamodb-constructs/files/terraform/app/dynamodb/__nameKebabCase__/__nameKebabCase__.tf.template
+++ b/packages/nx-plugin/src/utils/dynamodb-constructs/files/terraform/app/dynamodb/__nameKebabCase__/__nameKebabCase__.tf.template
@@ -41,13 +41,19 @@ variable "encryption" {
 }
 
 variable "kms_key_arn" {
-  description = "ARN of an existing KMS key used to encrypt the table when encryption is CUSTOMER_MANAGED. When not provided, a new key is created. Note that a customer-supplied key must already grant the DynamoDB service the necessary permissions in its own key policy."
+  description = "ARN of an existing KMS key used to encrypt the table when encryption is CUSTOMER_MANAGED. When not provided and create_kms_key is true, a new key is created. Note that a customer-supplied key must already grant the DynamoDB service the necessary permissions in its own key policy."
   type        = string
   default     = null
 }
 
+variable "create_kms_key" {
+  description = "Whether to create a KMS key for the table. Only applies when encryption is CUSTOMER_MANAGED. Set to false when supplying kms_key_arn."
+  type        = bool
+  default     = true
+}
+
 variable "enable_key_rotation" {
-  description = "Whether to enable automatic key rotation on the KMS key used to encrypt the table. Only applies when encryption is CUSTOMER_MANAGED and kms_key_arn is not provided."
+  description = "Whether to enable automatic key rotation on the KMS key used to encrypt the table. Only applies when encryption is CUSTOMER_MANAGED and create_kms_key is true."
   type        = bool
   default     = true
 }
@@ -76,6 +82,7 @@ module "dynamodb_table" {
   deletion_protection_enabled    = var.deletion_protection_enabled
   encryption                     = var.encryption
   kms_key_arn                    = var.kms_key_arn
+  create_kms_key                 = var.create_kms_key
   enable_key_rotation            = var.enable_key_rotation
   global_secondary_indexes       = local.global_secondary_indexes
 }

--- a/packages/nx-plugin/src/utils/dynamodb-constructs/files/terraform/app/dynamodb/__nameKebabCase__/__nameKebabCase__.tf.template
+++ b/packages/nx-plugin/src/utils/dynamodb-constructs/files/terraform/app/dynamodb/__nameKebabCase__/__nameKebabCase__.tf.template
@@ -30,7 +30,7 @@ variable "deletion_protection_enabled" {
 }
 
 variable "encryption" {
-  description = "Server-side encryption for the table. One of CUSTOMER_MANAGED, AWS_MANAGED or DEFAULT (the AWS owned key, at no cost and with no key to manage)."
+  description = "Server-side encryption for the table. One of CUSTOMER_MANAGED, AWS_MANAGED or DEFAULT (the AWS owned key, at no cost and with no key to manage). Changing this on an already-deployed table away from CUSTOMER_MANAGED requires a manual step first - see the ts#dynamodb generator's docs."
   type        = string
   default     = "CUSTOMER_MANAGED"
 

--- a/packages/nx-plugin/src/utils/dynamodb-constructs/files/terraform/core/dynamodb/dynamodb.tf.template
+++ b/packages/nx-plugin/src/utils/dynamodb-constructs/files/terraform/core/dynamodb/dynamodb.tf.template
@@ -33,7 +33,7 @@ variable "deletion_protection_enabled" {
 }
 
 variable "encryption" {
-  description = "Server-side encryption for the table. One of CUSTOMER_MANAGED, AWS_MANAGED or DEFAULT (the AWS owned key, at no cost and with no key to manage)."
+  description = "Server-side encryption for the table. One of CUSTOMER_MANAGED, AWS_MANAGED or DEFAULT (the AWS owned key, at no cost and with no key to manage). Changing this on an already-deployed table away from CUSTOMER_MANAGED requires a manual step first - see the ts#dynamodb generator's docs."
   type        = string
   default     = "CUSTOMER_MANAGED"
 

--- a/packages/nx-plugin/src/utils/dynamodb-constructs/files/terraform/core/dynamodb/dynamodb.tf.template
+++ b/packages/nx-plugin/src/utils/dynamodb-constructs/files/terraform/core/dynamodb/dynamodb.tf.template
@@ -44,13 +44,19 @@ variable "encryption" {
 }
 
 variable "kms_key_arn" {
-  description = "ARN of an existing KMS key used to encrypt the table when encryption is CUSTOMER_MANAGED. When not provided, a new key is created. Note that a customer-supplied key must already grant the DynamoDB service the necessary permissions in its own key policy."
+  description = "ARN of an existing KMS key used to encrypt the table when encryption is CUSTOMER_MANAGED. When not provided and create_kms_key is true, a new key is created. Note that a customer-supplied key must already grant the DynamoDB service the necessary permissions in its own key policy."
   type        = string
   default     = null
 }
 
+variable "create_kms_key" {
+  description = "Whether to create a KMS key for the table. Only applies when encryption is CUSTOMER_MANAGED. Set to false when supplying kms_key_arn."
+  type        = bool
+  default     = true
+}
+
 variable "enable_key_rotation" {
-  description = "Whether to enable automatic key rotation on the KMS key used to encrypt the table. Only applies when encryption is CUSTOMER_MANAGED and kms_key_arn is not provided."
+  description = "Whether to enable automatic key rotation on the KMS key used to encrypt the table. Only applies when encryption is CUSTOMER_MANAGED and create_kms_key is true."
   type        = bool
   default     = true
 }
@@ -71,16 +77,17 @@ locals {
     for gsi in var.global_secondary_indexes : [gsi.hash_key, gsi.range_key]
   ]))
 
-  create_table_key = var.encryption == "CUSTOMER_MANAGED" && var.kms_key_arn == null
+  create_table_key = var.encryption == "CUSTOMER_MANAGED" && var.create_kms_key
   table_kms_key_arn = (
-    var.encryption != "CUSTOMER_MANAGED" ? null :
-    local.create_table_key ? aws_kms_key.table[0].arn :
-    var.kms_key_arn
+    var.encryption == "CUSTOMER_MANAGED" ? (local.create_table_key ? aws_kms_key.table[0].arn : var.kms_key_arn) :
+    var.encryption == "AWS_MANAGED" ? "arn:${data.aws_partition.current.partition}:kms:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:alias/aws/dynamodb" :
+    null
   )
 }
 
 data "aws_caller_identity" "current" {}
 data "aws_partition" "current" {}
+data "aws_region" "current" {}
 
 resource "aws_kms_key" "table" {
   count = local.create_table_key ? 1 : 0
@@ -177,6 +184,6 @@ output "table_arn" {
 }
 
 output "kms_key_arn" {
-  description = "ARN of the KMS key used to encrypt the DynamoDB table, if using customer-managed encryption."
+  description = "ARN of the KMS key used to encrypt the DynamoDB table, or null when using the AWS owned key (encryption = DEFAULT)."
   value       = local.table_kms_key_arn
 }

--- a/packages/nx-plugin/src/utils/dynamodb-constructs/files/terraform/core/dynamodb/dynamodb.tf.template
+++ b/packages/nx-plugin/src/utils/dynamodb-constructs/files/terraform/core/dynamodb/dynamodb.tf.template
@@ -32,8 +32,25 @@ variable "deletion_protection_enabled" {
   default     = true
 }
 
+variable "encryption" {
+  description = "Server-side encryption for the table. One of CUSTOMER_MANAGED, AWS_MANAGED or DEFAULT (the AWS owned key, at no cost and with no key to manage)."
+  type        = string
+  default     = "CUSTOMER_MANAGED"
+
+  validation {
+    condition     = contains(["CUSTOMER_MANAGED", "AWS_MANAGED", "DEFAULT"], var.encryption)
+    error_message = "encryption must be one of CUSTOMER_MANAGED, AWS_MANAGED or DEFAULT."
+  }
+}
+
+variable "kms_key_arn" {
+  description = "ARN of an existing KMS key used to encrypt the table when encryption is CUSTOMER_MANAGED. When not provided, a new key is created. Note that a customer-supplied key must already grant the DynamoDB service the necessary permissions in its own key policy."
+  type        = string
+  default     = null
+}
+
 variable "enable_key_rotation" {
-  description = "Whether to enable automatic key rotation on the KMS key used to encrypt the table."
+  description = "Whether to enable automatic key rotation on the KMS key used to encrypt the table. Only applies when encryption is CUSTOMER_MANAGED and kms_key_arn is not provided."
   type        = bool
   default     = true
 }
@@ -53,12 +70,21 @@ locals {
   gsi_attribute_names = distinct(flatten([
     for gsi in var.global_secondary_indexes : [gsi.hash_key, gsi.range_key]
   ]))
+
+  create_table_key = var.encryption == "CUSTOMER_MANAGED" && var.kms_key_arn == null
+  table_kms_key_arn = (
+    var.encryption != "CUSTOMER_MANAGED" ? null :
+    local.create_table_key ? aws_kms_key.table[0].arn :
+    var.kms_key_arn
+  )
 }
 
 data "aws_caller_identity" "current" {}
 data "aws_partition" "current" {}
 
 resource "aws_kms_key" "table" {
+  count = local.create_table_key ? 1 : 0
+
   description         = "KMS key for DynamoDB table ${var.name}"
   enable_key_rotation = var.enable_key_rotation
 
@@ -134,8 +160,8 @@ resource "aws_dynamodb_table" "table" {
   }
 
   server_side_encryption {
-    enabled     = true
-    kms_key_arn = aws_kms_key.table.arn
+    enabled     = var.encryption != "DEFAULT"
+    kms_key_arn = local.table_kms_key_arn
   }
 }
 
@@ -150,6 +176,6 @@ output "table_arn" {
 }
 
 output "kms_key_arn" {
-  description = "ARN of the KMS key used to encrypt the DynamoDB table."
-  value       = aws_kms_key.table.arn
+  description = "ARN of the KMS key used to encrypt the DynamoDB table, if using customer-managed encryption."
+  value       = local.table_kms_key_arn
 }

--- a/packages/nx-plugin/src/utils/dynamodb-constructs/files/terraform/core/dynamodb/dynamodb.tf.template
+++ b/packages/nx-plugin/src/utils/dynamodb-constructs/files/terraform/core/dynamodb/dynamodb.tf.template
@@ -121,6 +121,7 @@ resource "aws_kms_key" "table" {
 }
 
 resource "aws_dynamodb_table" "table" {
+  #checkov:skip=CKV_AWS_119:Encryption is configurable via var.encryption; checkov cannot resolve the conditional server_side_encryption.enabled expression
   name                        = var.name
   billing_mode                = var.billing_mode
   hash_key                    = "pk"


### PR DESCRIPTION
### Reason for this change

`DynamoDBTable` (and its Terraform equivalent) hardcodes `TableEncryption.CUSTOMER_MANAGED` and always creates a dedicated KMS key. Workspaces have no way to use the free AWS-owned key, the shared AWS-managed key, or their own existing key, without hand-editing generated code — and that edit gets clobbered the next time the generator runs. This follows the same pattern already established for `StaticWebsite` (#1107).

### Description of changes

- CDK `DynamoDBTable` construct (`common/constructs/src/core/dynamodb.ts`): new `encryption` and `encryptionKey` props. The KMS key is only created when `encryption` is `TableEncryption.CUSTOMER_MANAGED` and no `encryptionKey` is supplied; `enableKeyRotation` only applies to that auto-created key. `TableEncryption.DEFAULT` (the AWS owned key) already works for free, since the prop passes straight through to CDK's own `Table` construct.
- Terraform `dynamodb` core module and per-table app module: new `encryption` and `kms_key_arn` variables. `encryption` accepts `CUSTOMER_MANAGED`, `AWS_MANAGED`, or `DEFAULT`. The KMS key resource is now conditional (`count`), and `server_side_encryption.enabled` is tied to `encryption != "DEFAULT"` — note that DynamoDB always encrypts at rest regardless of this flag; it only chooses between the AWS-owned key and a KMS-visible key.
- Nx migration (`dynamodb-configurable-encryption`) to bring existing workspaces' vended files up to the new shape: the CDK construct, the Terraform core module, and every per-table Terraform app module. Diverged files are left untouched and reported via `nextSteps`.
- Docs: added an "Encryption" section to the shared `dynamodb/deploying-table` snippet (used by both `ts-dynamodb.mdx` and `py-dynamodb.mdx`), covering all three encryption modes plus bringing your own key. Split the per-mode subsections and the existing "Encryption Key Rotation" section into a new nested `dynamodb/encryption-options` snippet so they render nested under "Encryption" in the sidebar, mirroring the existing `prerequisites.mdx` pattern. Extracted the same structure across all translated locales, using their already-translated text.
- Dungeon-game tutorial: the sandbox `ApplicationStack` now creates `DungeonDb` with `encryption: TableEncryption.DEFAULT`, since a customer-managed KMS key can't be deleted immediately (a mandatory 7-30 day wait) — unnecessary friction for a stack that's regularly torn down and recreated during the tutorial.

### Description of how you validated changes

- Added `migration.spec.ts` (10 tests) covering vended-shape application, idempotency, and divergence handling across the CDK construct, the Terraform core module, and Terraform app modules.
- Updated `ts#dynamodb`/`py#dynamodb` generator snapshots to match the new vended shape.
- Tested the migration end-to-end against real workspaces generated from the published `@aws/nx-plugin` version, for both `--iac=cdk` and `--iac=terraform`: confirmed `pnpm lint` passes before and after, the migration is idempotent on re-run, and `terraform validate` passes on both the core and app modules.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*