### PR TITLE
fix(py#agent): forward Strands hooks to the AG-UI adapter

### DIFF
--- a/docs/src/content/docs/en/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/en/get_started/tutorials/dungeon-game/1.mdx
@@ -468,6 +468,7 @@ Let's take a look at some of the files in detail:
 from contextlib import contextmanager
 
 from strands import Agent, tool
+from strands.hooks import HookCallback, HookProvider
 from strands_tools import current_time
 from dungeon_adventure_agent_connection import log_model_errors, log_tool_errors
 
@@ -475,6 +476,9 @@ from dungeon_adventure_agent_connection import log_model_errors, log_tool_errors
 @tool
 def subtract(a: int, b: int) -> int:
     return a - b
+
+
+AGENT_HOOKS: list[HookProvider | HookCallback] = [log_model_errors, log_tool_errors]
 
 
 @contextmanager
@@ -488,7 +492,7 @@ Use your tools for mathematical tasks.
 Refer to tools as your 'spellbook'.
 """,
         tools=[subtract, current_time],
-        hooks=[log_model_errors, log_tool_errors],
+        hooks=AGENT_HOOKS,
     )
 ```
 
@@ -531,7 +535,7 @@ from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import StreamingResponse
 
-from .agent import get_agent
+from .agent import AGENT_HOOKS, get_agent
 from .middleware.session_id_middleware import SESSION_ID_HEADER, SessionIdMiddleware
 from .session import get_session_manager
 
@@ -548,6 +552,10 @@ async def lifespan(app: FastAPI):
             # A per-thread session manager, not the template Agent's own, since
             # AG-UI caches one Strands agent per thread_id.
             config=StrandsAgentConfig(session_manager_provider=lambda _input_data: get_session_manager()),
+            # Required as well as on the template Agent: AG-UI keeps only the
+            # built HookRegistry, so hooks it can't read back are never
+            # registered and model/tool failures go unreported.
+            hooks=AGENT_HOOKS,
         )
         yield
 

--- a/docs/src/content/docs/es/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/es/get_started/tutorials/dungeon-game/1.mdx
@@ -468,6 +468,7 @@ Veamos algunos de los archivos en detalle:
 from contextlib import contextmanager
 
 from strands import Agent, tool
+from strands.hooks import HookCallback, HookProvider
 from strands_tools import current_time
 from dungeon_adventure_agent_connection import log_model_errors, log_tool_errors
 
@@ -475,6 +476,9 @@ from dungeon_adventure_agent_connection import log_model_errors, log_tool_errors
 @tool
 def subtract(a: int, b: int) -> int:
     return a - b
+
+
+AGENT_HOOKS: list[HookProvider | HookCallback] = [log_model_errors, log_tool_errors]
 
 
 @contextmanager
@@ -488,7 +492,7 @@ Use your tools for mathematical tasks.
 Refer to tools as your 'spellbook'.
 """,
         tools=[subtract, current_time],
-        hooks=[log_model_errors, log_tool_errors],
+        hooks=AGENT_HOOKS,
     )
 ```
 
@@ -531,7 +535,7 @@ from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import StreamingResponse
 
-from .agent import get_agent
+from .agent import AGENT_HOOKS, get_agent
 from .middleware.session_id_middleware import SESSION_ID_HEADER, SessionIdMiddleware
 from .session import get_session_manager
 
@@ -548,6 +552,10 @@ async def lifespan(app: FastAPI):
             # A per-thread session manager, not the template Agent's own, since
             # AG-UI caches one Strands agent per thread_id.
             config=StrandsAgentConfig(session_manager_provider=lambda _input_data: get_session_manager()),
+            # Required as well as on the template Agent: AG-UI keeps only the
+            # built HookRegistry, so hooks it can't read back are never
+            # registered and model/tool failures go unreported.
+            hooks=AGENT_HOOKS,
         )
         yield
 

--- a/docs/src/content/docs/fr/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/fr/get_started/tutorials/dungeon-game/1.mdx
@@ -468,6 +468,7 @@ Examinons certains fichiers en détail :
 from contextlib import contextmanager
 
 from strands import Agent, tool
+from strands.hooks import HookCallback, HookProvider
 from strands_tools import current_time
 from dungeon_adventure_agent_connection import log_model_errors, log_tool_errors
 
@@ -475,6 +476,9 @@ from dungeon_adventure_agent_connection import log_model_errors, log_tool_errors
 @tool
 def subtract(a: int, b: int) -> int:
     return a - b
+
+
+AGENT_HOOKS: list[HookProvider | HookCallback] = [log_model_errors, log_tool_errors]
 
 
 @contextmanager
@@ -488,7 +492,7 @@ Use your tools for mathematical tasks.
 Refer to tools as your 'spellbook'.
 """,
         tools=[subtract, current_time],
-        hooks=[log_model_errors, log_tool_errors],
+        hooks=AGENT_HOOKS,
     )
 ```
 
@@ -531,7 +535,7 @@ from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import StreamingResponse
 
-from .agent import get_agent
+from .agent import AGENT_HOOKS, get_agent
 from .middleware.session_id_middleware import SESSION_ID_HEADER, SessionIdMiddleware
 from .session import get_session_manager
 
@@ -548,6 +552,10 @@ async def lifespan(app: FastAPI):
             # A per-thread session manager, not the template Agent's own, since
             # AG-UI caches one Strands agent per thread_id.
             config=StrandsAgentConfig(session_manager_provider=lambda _input_data: get_session_manager()),
+            # Required as well as on the template Agent: AG-UI keeps only the
+            # built HookRegistry, so hooks it can't read back are never
+            # registered and model/tool failures go unreported.
+            hooks=AGENT_HOOKS,
         )
         yield
 

--- a/docs/src/content/docs/it/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/it/get_started/tutorials/dungeon-game/1.mdx
@@ -468,6 +468,7 @@ Diamo un'occhiata ad alcuni dei file in dettaglio:
 from contextlib import contextmanager
 
 from strands import Agent, tool
+from strands.hooks import HookCallback, HookProvider
 from strands_tools import current_time
 from dungeon_adventure_agent_connection import log_model_errors, log_tool_errors
 
@@ -475,6 +476,9 @@ from dungeon_adventure_agent_connection import log_model_errors, log_tool_errors
 @tool
 def subtract(a: int, b: int) -> int:
     return a - b
+
+
+AGENT_HOOKS: list[HookProvider | HookCallback] = [log_model_errors, log_tool_errors]
 
 
 @contextmanager
@@ -488,7 +492,7 @@ Use your tools for mathematical tasks.
 Refer to tools as your 'spellbook'.
 """,
         tools=[subtract, current_time],
-        hooks=[log_model_errors, log_tool_errors],
+        hooks=AGENT_HOOKS,
     )
 ```
 
@@ -531,7 +535,7 @@ from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import StreamingResponse
 
-from .agent import get_agent
+from .agent import AGENT_HOOKS, get_agent
 from .middleware.session_id_middleware import SESSION_ID_HEADER, SessionIdMiddleware
 from .session import get_session_manager
 
@@ -548,6 +552,10 @@ async def lifespan(app: FastAPI):
             # A per-thread session manager, not the template Agent's own, since
             # AG-UI caches one Strands agent per thread_id.
             config=StrandsAgentConfig(session_manager_provider=lambda _input_data: get_session_manager()),
+            # Required as well as on the template Agent: AG-UI keeps only the
+            # built HookRegistry, so hooks it can't read back are never
+            # registered and model/tool failures go unreported.
+            hooks=AGENT_HOOKS,
         )
         yield
 

--- a/docs/src/content/docs/jp/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/jp/get_started/tutorials/dungeon-game/1.mdx
@@ -468,6 +468,7 @@ Python プロジェクトを作成するには:
 from contextlib import contextmanager
 
 from strands import Agent, tool
+from strands.hooks import HookCallback, HookProvider
 from strands_tools import current_time
 from dungeon_adventure_agent_connection import log_model_errors, log_tool_errors
 
@@ -475,6 +476,9 @@ from dungeon_adventure_agent_connection import log_model_errors, log_tool_errors
 @tool
 def subtract(a: int, b: int) -> int:
     return a - b
+
+
+AGENT_HOOKS: list[HookProvider | HookCallback] = [log_model_errors, log_tool_errors]
 
 
 @contextmanager
@@ -488,7 +492,7 @@ Use your tools for mathematical tasks.
 Refer to tools as your 'spellbook'.
 """,
         tools=[subtract, current_time],
-        hooks=[log_model_errors, log_tool_errors],
+        hooks=AGENT_HOOKS,
     )
 ```
 
@@ -531,7 +535,7 @@ from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import StreamingResponse
 
-from .agent import get_agent
+from .agent import AGENT_HOOKS, get_agent
 from .middleware.session_id_middleware import SESSION_ID_HEADER, SessionIdMiddleware
 from .session import get_session_manager
 
@@ -548,6 +552,10 @@ async def lifespan(app: FastAPI):
             # A per-thread session manager, not the template Agent's own, since
             # AG-UI caches one Strands agent per thread_id.
             config=StrandsAgentConfig(session_manager_provider=lambda _input_data: get_session_manager()),
+            # Required as well as on the template Agent: AG-UI keeps only the
+            # built HookRegistry, so hooks it can't read back are never
+            # registered and model/tool failures go unreported.
+            hooks=AGENT_HOOKS,
         )
         yield
 

--- a/docs/src/content/docs/ko/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/ko/get_started/tutorials/dungeon-game/1.mdx
@@ -468,6 +468,7 @@ Python 프로젝트를 생성하려면:
 from contextlib import contextmanager
 
 from strands import Agent, tool
+from strands.hooks import HookCallback, HookProvider
 from strands_tools import current_time
 from dungeon_adventure_agent_connection import log_model_errors, log_tool_errors
 
@@ -475,6 +476,9 @@ from dungeon_adventure_agent_connection import log_model_errors, log_tool_errors
 @tool
 def subtract(a: int, b: int) -> int:
     return a - b
+
+
+AGENT_HOOKS: list[HookProvider | HookCallback] = [log_model_errors, log_tool_errors]
 
 
 @contextmanager
@@ -488,7 +492,7 @@ Use your tools for mathematical tasks.
 Refer to tools as your 'spellbook'.
 """,
         tools=[subtract, current_time],
-        hooks=[log_model_errors, log_tool_errors],
+        hooks=AGENT_HOOKS,
     )
 ```
 
@@ -531,7 +535,7 @@ from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import StreamingResponse
 
-from .agent import get_agent
+from .agent import AGENT_HOOKS, get_agent
 from .middleware.session_id_middleware import SESSION_ID_HEADER, SessionIdMiddleware
 from .session import get_session_manager
 
@@ -548,6 +552,10 @@ async def lifespan(app: FastAPI):
             # A per-thread session manager, not the template Agent's own, since
             # AG-UI caches one Strands agent per thread_id.
             config=StrandsAgentConfig(session_manager_provider=lambda _input_data: get_session_manager()),
+            # Required as well as on the template Agent: AG-UI keeps only the
+            # built HookRegistry, so hooks it can't read back are never
+            # registered and model/tool failures go unreported.
+            hooks=AGENT_HOOKS,
         )
         yield
 

--- a/docs/src/content/docs/pt/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/pt/get_started/tutorials/dungeon-game/1.mdx
@@ -468,6 +468,7 @@ Vamos examinar alguns dos arquivos em detalhes:
 from contextlib import contextmanager
 
 from strands import Agent, tool
+from strands.hooks import HookCallback, HookProvider
 from strands_tools import current_time
 from dungeon_adventure_agent_connection import log_model_errors, log_tool_errors
 
@@ -475,6 +476,9 @@ from dungeon_adventure_agent_connection import log_model_errors, log_tool_errors
 @tool
 def subtract(a: int, b: int) -> int:
     return a - b
+
+
+AGENT_HOOKS: list[HookProvider | HookCallback] = [log_model_errors, log_tool_errors]
 
 
 @contextmanager
@@ -488,7 +492,7 @@ Use your tools for mathematical tasks.
 Refer to tools as your 'spellbook'.
 """,
         tools=[subtract, current_time],
-        hooks=[log_model_errors, log_tool_errors],
+        hooks=AGENT_HOOKS,
     )
 ```
 
@@ -531,7 +535,7 @@ from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import StreamingResponse
 
-from .agent import get_agent
+from .agent import AGENT_HOOKS, get_agent
 from .middleware.session_id_middleware import SESSION_ID_HEADER, SessionIdMiddleware
 from .session import get_session_manager
 
@@ -548,6 +552,10 @@ async def lifespan(app: FastAPI):
             # A per-thread session manager, not the template Agent's own, since
             # AG-UI caches one Strands agent per thread_id.
             config=StrandsAgentConfig(session_manager_provider=lambda _input_data: get_session_manager()),
+            # Required as well as on the template Agent: AG-UI keeps only the
+            # built HookRegistry, so hooks it can't read back are never
+            # registered and model/tool failures go unreported.
+            hooks=AGENT_HOOKS,
         )
         yield
 

--- a/docs/src/content/docs/vi/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/vi/get_started/tutorials/dungeon-game/1.mdx
@@ -468,6 +468,7 @@ Hãy xem xét một số tệp chi tiết:
 from contextlib import contextmanager
 
 from strands import Agent, tool
+from strands.hooks import HookCallback, HookProvider
 from strands_tools import current_time
 from dungeon_adventure_agent_connection import log_model_errors, log_tool_errors
 
@@ -475,6 +476,9 @@ from dungeon_adventure_agent_connection import log_model_errors, log_tool_errors
 @tool
 def subtract(a: int, b: int) -> int:
     return a - b
+
+
+AGENT_HOOKS: list[HookProvider | HookCallback] = [log_model_errors, log_tool_errors]
 
 
 @contextmanager
@@ -488,7 +492,7 @@ Use your tools for mathematical tasks.
 Refer to tools as your 'spellbook'.
 """,
         tools=[subtract, current_time],
-        hooks=[log_model_errors, log_tool_errors],
+        hooks=AGENT_HOOKS,
     )
 ```
 
@@ -531,7 +535,7 @@ from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import StreamingResponse
 
-from .agent import get_agent
+from .agent import AGENT_HOOKS, get_agent
 from .middleware.session_id_middleware import SESSION_ID_HEADER, SessionIdMiddleware
 from .session import get_session_manager
 
@@ -548,6 +552,10 @@ async def lifespan(app: FastAPI):
             # A per-thread session manager, not the template Agent's own, since
             # AG-UI caches one Strands agent per thread_id.
             config=StrandsAgentConfig(session_manager_provider=lambda _input_data: get_session_manager()),
+            # Required as well as on the template Agent: AG-UI keeps only the
+            # built HookRegistry, so hooks it can't read back are never
+            # registered and model/tool failures go unreported.
+            hooks=AGENT_HOOKS,
         )
         yield
 

--- a/docs/src/content/docs/zh/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/zh/get_started/tutorials/dungeon-game/1.mdx
@@ -468,6 +468,7 @@ export class GameApi<
 from contextlib import contextmanager
 
 from strands import Agent, tool
+from strands.hooks import HookCallback, HookProvider
 from strands_tools import current_time
 from dungeon_adventure_agent_connection import log_model_errors, log_tool_errors
 
@@ -475,6 +476,9 @@ from dungeon_adventure_agent_connection import log_model_errors, log_tool_errors
 @tool
 def subtract(a: int, b: int) -> int:
     return a - b
+
+
+AGENT_HOOKS: list[HookProvider | HookCallback] = [log_model_errors, log_tool_errors]
 
 
 @contextmanager
@@ -488,7 +492,7 @@ Use your tools for mathematical tasks.
 Refer to tools as your 'spellbook'.
 """,
         tools=[subtract, current_time],
-        hooks=[log_model_errors, log_tool_errors],
+        hooks=AGENT_HOOKS,
     )
 ```
 
@@ -531,7 +535,7 @@ from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import StreamingResponse
 
-from .agent import get_agent
+from .agent import AGENT_HOOKS, get_agent
 from .middleware.session_id_middleware import SESSION_ID_HEADER, SessionIdMiddleware
 from .session import get_session_manager
 
@@ -548,6 +552,10 @@ async def lifespan(app: FastAPI):
             # A per-thread session manager, not the template Agent's own, since
             # AG-UI caches one Strands agent per thread_id.
             config=StrandsAgentConfig(session_manager_provider=lambda _input_data: get_session_manager()),
+            # Required as well as on the template Agent: AG-UI keeps only the
+            # built HookRegistry, so hooks it can't read back are never
+            # registered and model/tool failures go unreported.
+            hooks=AGENT_HOOKS,
         )
         yield
 

--- a/e2e/src/files/dungeon-adventure/3/agent.py.old.template
+++ b/e2e/src/files/dungeon-adventure/3/agent.py.old.template
@@ -2,12 +2,16 @@ from contextlib import contextmanager
 
 from dungeon_adventure_agent_connection import InventoryMcpServerClientStrands, log_model_errors, log_tool_errors
 from strands import Agent, tool
+from strands.hooks import HookCallback, HookProvider
 from strands_tools import current_time
 
 
 @tool
 def subtract(a: int, b: int) -> int:
     return a - b
+
+
+AGENT_HOOKS: list[HookProvider | HookCallback] = [log_model_errors, log_tool_errors]
 
 
 @contextmanager
@@ -25,5 +29,5 @@ Use your tools for mathematical tasks.
 Refer to tools as your 'spellbook'.
 """,
             tools=[subtract, current_time, *inventory_mcp_server.list_tools_sync()],
-            hooks=[log_model_errors, log_tool_errors],
+            hooks=AGENT_HOOKS,
         )

--- a/e2e/src/files/dungeon-adventure/3/agent.py.template
+++ b/e2e/src/files/dungeon-adventure/3/agent.py.template
@@ -2,6 +2,10 @@ from contextlib import contextmanager
 
 from dungeon_adventure_agent_connection import InventoryMcpServerClientStrands, log_model_errors, log_tool_errors
 from strands import Agent
+from strands.hooks import HookCallback, HookProvider
+
+
+AGENT_HOOKS: list[HookProvider | HookCallback] = [log_model_errors, log_tool_errors]
 
 
 @contextmanager
@@ -27,5 +31,5 @@ Items should be a key part of the narrative.
 Keep responses under 100 words.
 """,
             tools=[*inventory_mcp_server.list_tools_sync()],
-            hooks=[log_model_errors, log_tool_errors],
+            hooks=AGENT_HOOKS,
         )

--- a/packages/nx-plugin/src/migrations/latest/py-agent-ag-ui-hooks/metadata.json
+++ b/packages/nx-plugin/src/migrations/latest/py-agent-ag-ui-hooks/metadata.json
@@ -1,0 +1,3 @@
+{
+  "description": "Forward the py#agent Strands hooks to the AG-UI adapter so model and tool errors are reported"
+}

--- a/packages/nx-plugin/src/migrations/latest/py-agent-ag-ui-hooks/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/latest/py-agent-ag-ui-hooks/migration.spec.ts
@@ -1,0 +1,431 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { addProjectConfiguration, type Tree } from '@nx/devkit';
+import { PY_AGENT_GENERATOR_INFO } from '../../../py/agent/generator';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test';
+import migration from './migration';
+
+const PROJECT_ROOT = 'apps/test-project';
+const AGENT_DIR = `${PROJECT_ROOT}/proj_test_project/agent`;
+const AGENT_PY = `${AGENT_DIR}/agent.py`;
+const MAIN_PY = `${AGENT_DIR}/main.py`;
+
+const setUpProject = (
+  tree: Tree,
+  options: {
+    path?: string;
+    protocol?: 'http' | 'a2a' | 'ag-ui';
+    framework?: 'strands' | 'langchain';
+  } = {},
+) => {
+  addProjectConfiguration(tree, 'test-project', {
+    root: PROJECT_ROOT,
+    sourceRoot: `${PROJECT_ROOT}/proj_test_project`,
+    targets: {},
+    metadata: {
+      components: [
+        {
+          generator: PY_AGENT_GENERATOR_INFO.id,
+          path: options.path ?? 'proj_test_project/agent',
+          protocol: options.protocol ?? 'ag-ui',
+          framework: options.framework ?? 'strands',
+          name: 'agent',
+          rc: 'SnapshotAgent',
+        },
+      ],
+    } as any,
+  });
+};
+
+const OLD_AGUI_AGENT_PY = `from contextlib import contextmanager
+
+from strands import Agent, tool
+from strands_tools import current_time
+from proj_agent_connection import log_model_errors, log_tool_errors
+
+
+@tool
+def subtract(a: int, b: int) -> int:
+    return a - b
+
+
+@contextmanager
+def get_agent():
+    yield Agent(
+        name="SnapshotAgent",
+        description="SnapshotAgent Strands Agent",
+        system_prompt="""
+You are a mathematical wizard.
+""",
+        tools=[subtract, current_time],
+        hooks=[log_model_errors, log_tool_errors],
+    )
+`;
+
+const OLD_HTTP_AGENT_PY = `from contextlib import contextmanager
+
+from strands import Agent, tool
+from strands_tools import current_time
+from proj_agent_connection import log_model_errors, log_tool_errors
+
+from .session import get_session_manager
+
+
+@tool
+def subtract(a: int, b: int) -> int:
+    return a - b
+
+
+@contextmanager
+def get_agent():
+    yield Agent(
+        name="SnapshotAgent",
+        description="SnapshotAgent Strands Agent",
+        system_prompt="""
+You are a mathematical wizard.
+""",
+        tools=[subtract, current_time],
+        hooks=[log_model_errors, log_tool_errors],
+        session_manager=get_session_manager(),
+    )
+`;
+
+const OLD_AGUI_MAIN_PY = `import logging
+from contextlib import asynccontextmanager
+
+from ag_ui_strands import StrandsAgent, StrandsAgentConfig
+from fastapi import FastAPI
+
+from .agent import get_agent
+from .middleware.session_id_middleware import SessionIdMiddleware
+from .session import get_session_manager
+
+logging.basicConfig(level=logging.INFO)
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    with get_agent() as agent:
+        app.state.agui_agent = StrandsAgent(
+            agent=agent,
+            name="SnapshotAgent",
+            description="A Strands Agent exposed via the AG-UI protocol.",
+            # A per-thread session manager, not the template Agent's own, since
+            # AG-UI caches one Strands agent per thread_id.
+            config=StrandsAgentConfig(
+                session_manager_provider=lambda _input_data: get_session_manager()
+            ),
+        )
+        yield
+
+
+app = FastAPI(title="AWS Strands - SnapshotAgent", lifespan=lifespan)
+app.add_middleware(SessionIdMiddleware)
+
+
+@app.get("/ping")
+async def ping():
+    return {"status": "healthy"}
+`;
+
+// A connection generator has wrapped the get_agent body in a `with` block and
+// given it a parameter, so the hoist can't assume the vended body or signature.
+const OLD_CONNECTED_AGUI_AGENT_PY = `from contextlib import contextmanager
+
+from proj_agent_connection import (
+    InventoryMcpClientStrands,
+    log_model_errors,
+    log_tool_errors,
+)
+from strands import Agent, tool
+from strands_tools import current_time
+
+
+@tool
+def subtract(a: int, b: int) -> int:
+    return a - b
+
+
+@contextmanager
+def get_agent(session_id: str):
+    inventory_mcp = InventoryMcpClientStrands.create()
+    with (
+        inventory_mcp,
+    ):
+        yield Agent(
+            name="SnapshotAgent",
+            tools=[subtract, current_time, *inventory_mcp.list_tools_sync()],
+            hooks=[log_model_errors, log_tool_errors],
+        )
+`;
+
+const OLD_LANGCHAIN_AGENT_PY = `from langchain.agents import create_agent
+from langchain_aws import ChatBedrockConverse
+from langchain_core.tools import tool
+
+from .session import get_checkpointer
+
+
+@tool
+def subtract(a: int, b: int) -> int:
+    """Subtract b from a."""
+    return a - b
+
+
+def get_agent():
+    return create_agent(
+        model=ChatBedrockConverse(model="model-id", region_name="us-east-1"),
+        tools=[subtract],
+        checkpointer=get_checkpointer(),
+    )
+`;
+
+describe('py-agent-ag-ui-hooks migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeUsingTsSolutionSetup();
+  });
+
+  it('should do nothing when no projects contain Python agents', async () => {
+    await expect(migration(tree)).resolves.toEqual({ nextSteps: [] });
+  });
+
+  describe('Strands AG-UI', () => {
+    beforeEach(() => {
+      tree.write(AGENT_PY, OLD_AGUI_AGENT_PY);
+      tree.write(MAIN_PY, OLD_AGUI_MAIN_PY);
+    });
+
+    it('should hoist the hooks and forward them to the AG-UI adapter', async () => {
+      setUpProject(tree);
+
+      const result = await migration(tree);
+      const agent = tree.read(AGENT_PY, 'utf-8') ?? '';
+      const main = tree.read(MAIN_PY, 'utf-8') ?? '';
+
+      expect(result.nextSteps).toEqual([]);
+      expect(agent).toContain(
+        'AGENT_HOOKS: list[HookProvider | HookCallback] = [log_model_errors, log_tool_errors]',
+      );
+      expect(agent).toContain('hooks=AGENT_HOOKS,');
+      expect(agent).not.toContain('hooks=[log_model_errors, log_tool_errors]');
+
+      expect(main).toContain('from .agent import AGENT_HOOKS, get_agent');
+      expect(main).toContain('hooks=AGENT_HOOKS,');
+      // The existing arguments, and the comment above them, are untouched.
+      expect(main).toContain(
+        'session_manager_provider=lambda _input_data: get_session_manager()',
+      );
+      expect(main).toContain('# AG-UI caches one Strands agent per thread_id.');
+    });
+
+    it('should carry a customised hooks list along', async () => {
+      setUpProject(tree);
+      tree.write(
+        AGENT_PY,
+        OLD_AGUI_AGENT_PY.replace(
+          'hooks=[log_model_errors, log_tool_errors]',
+          'hooks=[log_model_errors, log_tool_errors, MyHook()]',
+        ),
+      );
+
+      const result = await migration(tree);
+
+      expect(result.nextSteps).toEqual([]);
+      expect(tree.read(AGENT_PY, 'utf-8')).toContain(
+        'log_model_errors,\n    log_tool_errors,\n    MyHook(),\n]',
+      );
+      expect(tree.read(MAIN_PY, 'utf-8')).toContain('hooks=AGENT_HOOKS,');
+    });
+
+    it('should hoist an agent.py a connection generator has transformed', async () => {
+      setUpProject(tree);
+      tree.write(AGENT_PY, OLD_CONNECTED_AGUI_AGENT_PY);
+
+      const result = await migration(tree);
+      const agent = tree.read(AGENT_PY, 'utf-8') ?? '';
+
+      expect(result.nextSteps).toEqual([]);
+      expect(agent).toContain(
+        'AGENT_HOOKS: list[HookProvider | HookCallback] = [log_model_errors, log_tool_errors]',
+      );
+      expect(agent).toContain('hooks=AGENT_HOOKS,');
+      expect(agent).toContain('def get_agent(session_id: str):');
+      expect(agent).toContain(
+        'inventory_mcp = InventoryMcpClientStrands.create()',
+      );
+      expect(tree.read(MAIN_PY, 'utf-8')).toContain('hooks=AGENT_HOOKS,');
+    });
+
+    it('should support legacy component paths ending in agent.py', async () => {
+      setUpProject(tree, { path: 'proj_test_project/agent/agent.py' });
+
+      await migration(tree);
+
+      expect(tree.read(AGENT_PY, 'utf-8')).toContain(
+        'AGENT_HOOKS: list[HookProvider | HookCallback] = [',
+      );
+      expect(tree.read(MAIN_PY, 'utf-8')).toContain('hooks=AGENT_HOOKS,');
+    });
+
+    it('should complete the main.py half when agent.py is already hoisted', async () => {
+      setUpProject(tree);
+      tree.write(
+        AGENT_PY,
+        OLD_AGUI_AGENT_PY.replace(
+          'hooks=[log_model_errors, log_tool_errors]',
+          'hooks=AGENT_HOOKS',
+        ).replace(
+          '@contextmanager',
+          'AGENT_HOOKS: list[HookProvider | HookCallback] = [log_model_errors, log_tool_errors]\n\n\n@contextmanager',
+        ),
+      );
+
+      const result = await migration(tree);
+
+      expect(result.nextSteps).toEqual([]);
+      expect(tree.read(MAIN_PY, 'utf-8')).toContain(
+        'from .agent import AGENT_HOOKS, get_agent',
+      );
+      expect(tree.read(MAIN_PY, 'utf-8')).toContain('hooks=AGENT_HOOKS,');
+    });
+
+    it('should report a diverged agent.py without partially rewriting it', async () => {
+      setUpProject(tree);
+      tree.write(
+        AGENT_PY,
+        OLD_AGUI_AGENT_PY.replace(
+          'hooks=[log_model_errors, log_tool_errors],',
+          'hooks=my_hooks(),',
+        ),
+      );
+
+      const result = await migration(tree);
+
+      expect(result.nextSteps).toHaveLength(1);
+      expect(result.nextSteps[0]).toContain(AGENT_PY);
+      expect(result.nextSteps[0]).toContain(MAIN_PY);
+      expect(tree.read(AGENT_PY, 'utf-8')).toContain('hooks=my_hooks(),');
+      expect(tree.read(AGENT_PY, 'utf-8')).not.toContain('AGENT_HOOKS');
+      expect(tree.read(MAIN_PY, 'utf-8')).not.toContain('hooks=');
+    });
+
+    it('should report a diverged main.py without partially rewriting it', async () => {
+      setUpProject(tree);
+      tree.write(
+        MAIN_PY,
+        OLD_AGUI_MAIN_PY.replace(
+          'StrandsAgent(\n            agent=agent,',
+          'StrandsAgent(\n            **agui_kwargs,',
+        ),
+      );
+
+      const result = await migration(tree);
+      const main = tree.read(MAIN_PY, 'utf-8') ?? '';
+
+      expect(result.nextSteps).toHaveLength(1);
+      expect(result.nextSteps[0]).toContain(MAIN_PY);
+      expect(main).toContain('**agui_kwargs,');
+      expect(main).not.toContain('AGENT_HOOKS');
+      // agent.py is still hoisted - it matches what the generator vends now.
+      expect(tree.read(AGENT_PY, 'utf-8')).toContain(
+        'AGENT_HOOKS: list[HookProvider | HookCallback] = [',
+      );
+    });
+
+    it('should leave a main.py that already passes its own hooks alone', async () => {
+      setUpProject(tree);
+      tree.write(
+        MAIN_PY,
+        OLD_AGUI_MAIN_PY.replace(
+          '            config=StrandsAgentConfig(',
+          '            hooks=[MyHook()],\n            config=StrandsAgentConfig(',
+        ),
+      );
+
+      const result = await migration(tree);
+      const main = tree.read(MAIN_PY, 'utf-8') ?? '';
+
+      expect(result.nextSteps).toEqual([]);
+      expect(main).toContain('hooks=[MyHook()],');
+      expect(main).not.toContain('AGENT_HOOKS');
+    });
+
+    it('should be idempotent', async () => {
+      setUpProject(tree);
+
+      await migration(tree);
+      const once = {
+        agent: tree.read(AGENT_PY, 'utf-8'),
+        main: tree.read(MAIN_PY, 'utf-8'),
+      };
+
+      const result = await migration(tree);
+
+      expect(result.nextSteps).toEqual([]);
+      expect(tree.read(AGENT_PY, 'utf-8')).toEqual(once.agent);
+      expect(tree.read(MAIN_PY, 'utf-8')).toEqual(once.main);
+    });
+  });
+
+  describe('Strands HTTP', () => {
+    beforeEach(() => {
+      tree.write(AGENT_PY, OLD_HTTP_AGENT_PY);
+    });
+
+    it('should hoist the hooks to match what the generator vends', async () => {
+      setUpProject(tree, { protocol: 'http' });
+
+      const result = await migration(tree);
+      const agent = tree.read(AGENT_PY, 'utf-8') ?? '';
+
+      expect(result.nextSteps).toEqual([]);
+      expect(agent).toContain(
+        'AGENT_HOOKS: list[HookProvider | HookCallback] = [log_model_errors, log_tool_errors]',
+      );
+      expect(agent).toContain('hooks=AGENT_HOOKS,');
+      expect(agent).toContain('session_manager=get_session_manager(),');
+    });
+
+    it('should not report a diverged agent.py, having nothing to forward', async () => {
+      setUpProject(tree, { protocol: 'http' });
+      tree.write(
+        AGENT_PY,
+        OLD_HTTP_AGENT_PY.replace(
+          'hooks=[log_model_errors, log_tool_errors],',
+          'hooks=my_hooks(),',
+        ),
+      );
+
+      await expect(migration(tree)).resolves.toEqual({ nextSteps: [] });
+      expect(tree.read(AGENT_PY, 'utf-8')).not.toContain('AGENT_HOOKS');
+    });
+
+    it('should be idempotent', async () => {
+      setUpProject(tree, { protocol: 'http' });
+
+      await migration(tree);
+      const once = tree.read(AGENT_PY, 'utf-8');
+
+      const result = await migration(tree);
+
+      expect(result.nextSteps).toEqual([]);
+      expect(tree.read(AGENT_PY, 'utf-8')).toEqual(once);
+    });
+  });
+
+  describe('LangChain', () => {
+    it('should leave LangChain agents untouched', async () => {
+      setUpProject(tree, { framework: 'langchain', protocol: 'ag-ui' });
+      tree.write(AGENT_PY, OLD_LANGCHAIN_AGENT_PY);
+
+      const result = await migration(tree);
+
+      expect(result.nextSteps).toEqual([]);
+      expect(tree.read(AGENT_PY, 'utf-8')).toEqual(OLD_LANGCHAIN_AGENT_PY);
+    });
+  });
+});

--- a/packages/nx-plugin/src/migrations/latest/py-agent-ag-ui-hooks/migration.ts
+++ b/packages/nx-plugin/src/migrations/latest/py-agent-ag-ui-hooks/migration.ts
@@ -1,0 +1,189 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import {
+  getProjects,
+  joinPathFragments,
+  type MigrationReturnObject,
+  type Tree,
+} from '@nx/devkit';
+import { PY_AGENT_GENERATOR_INFO } from '../../../py/agent/generator';
+import {
+  addPythonDestructuredImport,
+  applyGritQL,
+  captureGritQLVariable,
+  GRIT_INSERT_PLACEHOLDER,
+  insertViaGritQL,
+  matchGritQL,
+} from '../../../utils/ast';
+import { formatFilesInSubtree } from '../../../utils/format';
+import type { ComponentMetadata } from '../../../utils/nx';
+
+/**
+ * Forward a Strands py#agent's hooks to the AG-UI adapter.
+ *
+ * `StrandsAgent` builds a fresh `Agent` per `thread_id` by copying the template
+ * Agent's kwargs, but deliberately skips `hooks` - Strands keeps only the built
+ * `HookRegistry`, so the providers can't be read back off it. An AG-UI agent's
+ * `log_model_errors` / `log_tool_errors` therefore never fired for served
+ * requests, and model/tool failures were reported as successful runs.
+ *
+ * The fix hoists the hooks list out of the `Agent(...)` call into an
+ * `AGENT_HOOKS` module constant in `agent.py` - whatever the user has put in it,
+ * so custom hooks come along - and passes that to `StrandsAgent(...)` in
+ * `main.py` as well. `agent.py` is hoisted for every protocol so the constant
+ * matches what the generator vends today; only AG-UI needs the `main.py` half.
+ */
+
+// `Agent`'s `hooks` list is invariant, so the hoisted constant has to declare
+// the parameter's own type - an inline literal was inferred from it instead.
+const HOOKS_TYPE = 'list[HookProvider | HookCallback]';
+const HOOKS_MODULE = 'strands.hooks';
+
+// Anchored on the `get_agent` context manager - the one shape shared by every
+// generated protocol and connection combination - so the constant lands
+// directly above its only use, where the generator vends it.
+const HOIST_HOOKS_PATTERN = `language python
+\`@contextmanager
+def get_agent($params):
+    $body\` => raw\`AGENT_HOOKS: ${HOOKS_TYPE} = ${GRIT_INSERT_PLACEHOLDER}
+
+
+@contextmanager
+def get_agent($params):
+    $body\` where { $program <: not contains \`AGENT_HOOKS\` }`;
+
+// Scoped to the Agent constructor so a hooks list the user passes elsewhere in
+// agent.py is left alone.
+const HOOKS_LIST_CAPTURE_PATTERN =
+  'language python\n`hooks=[$hooks]` where { $hooks <: within `Agent($_)` }';
+const HOOKS_LIST_REWRITE_PATTERN =
+  'language python\n`hooks=[$_]` as $kwarg where { $kwarg <: within `Agent($_)`, $kwarg => `hooks=AGENT_HOOKS` }';
+
+const AGUI_CONSTRUCTOR_MATCH_PATTERN =
+  'language python\n`StrandsAgent($args)` where { $args <: contains `agent=$_` }';
+const AGUI_HOOKS_WIRED_PATTERN =
+  'language python\n`StrandsAgent($args)` where { $args <: contains `agent=$_`, $args <: contains `hooks=$_` }';
+// Appends after the last argument rather than re-emitting the argument list,
+// both to land `hooks=` where the template puts it and to leave the other
+// arguments' formatting and comments untouched.
+const AGUI_HOOKS_APPEND_PATTERN =
+  'language python\n`StrandsAgent($args)` where { $args <: contains `agent=$_`, $args <: not contains `hooks=$_`, $args <: [$..., $last], $last += `, hooks=AGENT_HOOKS` }';
+
+const findAgentComponents = (
+  components: ComponentMetadata[] | undefined,
+): ComponentMetadata[] =>
+  (components ?? []).filter(
+    (component) => component.generator === PY_AGENT_GENERATOR_INFO.id,
+  );
+
+/**
+ * Hoists `agent.py`'s `hooks=[...]` list into an `AGENT_HOOKS` module constant,
+ * returning whether the file ends up exporting one.
+ */
+const hoistAgentHooks = async (
+  tree: Tree,
+  agentPath: string,
+): Promise<boolean> => {
+  if ((tree.read(agentPath, 'utf-8') ?? '').includes('AGENT_HOOKS')) {
+    return true;
+  }
+
+  // Nothing to hoist unless the Agent is constructed with an inline hooks list.
+  const hooks = await captureGritQLVariable(
+    tree,
+    agentPath,
+    HOOKS_LIST_CAPTURE_PATTERN,
+    'hooks',
+  );
+  if (!hooks) return false;
+
+  if (
+    !(await insertViaGritQL(tree, agentPath, HOIST_HOOKS_PATTERN, `[${hooks}]`))
+  ) {
+    return false;
+  }
+  await applyGritQL(tree, agentPath, HOOKS_LIST_REWRITE_PATTERN);
+  await addPythonDestructuredImport(
+    tree,
+    agentPath,
+    ['HookCallback', 'HookProvider'],
+    HOOKS_MODULE,
+  );
+  return true;
+};
+
+const migrateAgent = async (
+  tree: Tree,
+  agentDir: string,
+  component: ComponentMetadata,
+  nextSteps: string[],
+): Promise<void> => {
+  // LangChain agents pass no hooks - their AG-UI adapter is handed the graph
+  // itself rather than rebuilding one, so nothing is dropped.
+  if (component.framework === 'langchain') return;
+
+  const agentPath = joinPathFragments(agentDir, 'agent.py');
+  const mainPath = joinPathFragments(agentDir, 'main.py');
+  const isAgUi = component.protocol === 'ag-ui';
+
+  if (!tree.exists(agentPath)) return;
+
+  if (!(await hoistAgentHooks(tree, agentPath))) {
+    if (isAgUi) {
+      nextSteps.push(
+        `${agentPath}: the hooks passed to \`Agent(...)\` have diverged from the generated shape - left untouched. Hoist them into an \`AGENT_HOOKS\` module constant and pass it to \`StrandsAgent(...)\` in ${mainPath} too, or AG-UI will not register them (see the py#agent generator's template).`,
+      );
+    }
+    return;
+  }
+
+  // Only AG-UI rebuilds the Agent, so only its main.py needs the hooks.
+  if (!isAgUi || !tree.exists(mainPath)) return;
+
+  // Already passing hooks, whether from a previous run or the user's own wiring.
+  if (await matchGritQL(tree, mainPath, AGUI_HOOKS_WIRED_PATTERN)) return;
+
+  if (!(await matchGritQL(tree, mainPath, AGUI_CONSTRUCTOR_MATCH_PATTERN))) {
+    nextSteps.push(
+      `${mainPath}: the \`StrandsAgent(...)\` constructor has diverged from the generated shape - left untouched. Pass \`hooks=AGENT_HOOKS\` to it, importing \`AGENT_HOOKS\` from \`.agent\`, or AG-UI will not register the agent's hooks (see the py#agent generator's template).`,
+    );
+    return;
+  }
+
+  await applyGritQL(tree, mainPath, AGUI_HOOKS_APPEND_PATTERN);
+  await addPythonDestructuredImport(tree, mainPath, ['AGENT_HOOKS'], '.agent');
+};
+
+export default async function migration(
+  tree: Tree,
+): Promise<MigrationReturnObject> {
+  const nextSteps: string[] = [];
+
+  for (const project of getProjects(tree).values()) {
+    const components = findAgentComponents(
+      (project.metadata as { components?: ComponentMetadata[] })?.components,
+    );
+
+    for (const component of components) {
+      if (!component.path) continue;
+
+      // Legacy component paths point at agent.py rather than its directory.
+      const componentDir = component.path.endsWith('/agent.py')
+        ? component.path.slice(0, -'/agent.py'.length)
+        : component.path;
+
+      await migrateAgent(
+        tree,
+        joinPathFragments(project.root, componentDir),
+        component,
+        nextSteps,
+      );
+    }
+  }
+
+  await formatFilesInSubtree(tree);
+
+  return { nextSteps };
+}

--- a/packages/nx-plugin/src/py/agent/__snapshots__/generator.constructs.spec.ts.snap
+++ b/packages/nx-plugin/src/py/agent/__snapshots__/generator.constructs.spec.ts.snap
@@ -665,6 +665,7 @@ exports[`py#agent generator > should match snapshot for generated files > agent-
 
 from proj_agent_connection import log_model_errors, log_tool_errors
 from strands import Agent, tool
+from strands.hooks import HookCallback, HookProvider
 from strands_tools import current_time
 
 from .session import get_session_manager
@@ -673,6 +674,9 @@ from .session import get_session_manager
 @tool
 def subtract(a: int, b: int) -> int:
     return a - b
+
+
+AGENT_HOOKS: list[HookProvider | HookCallback] = [log_model_errors, log_tool_errors]
 
 
 @contextmanager
@@ -686,7 +690,7 @@ Use your tools for mathematical tasks.
 Refer to tools as your 'spellbook'.
 """,
         tools=[subtract, current_time],
-        hooks=[log_model_errors, log_tool_errors],
+        hooks=AGENT_HOOKS,
         session_manager=get_session_manager(),
     )
 "

--- a/packages/nx-plugin/src/py/agent/files/strands/ag-ui/main.py.template
+++ b/packages/nx-plugin/src/py/agent/files/strands/ag-ui/main.py.template
@@ -10,7 +10,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import StreamingResponse
 from <%- agentConnectionModuleName %> import get_current_session_id, session_id_context
 
-from .agent import get_agent
+from .agent import AGENT_HOOKS, get_agent
 from .middleware.session_id_middleware import SESSION_ID_HEADER, SessionIdMiddleware
 from .session import get_session_manager
 
@@ -27,6 +27,10 @@ async def lifespan(app: FastAPI):
             # A per-thread session manager, not the template Agent's own, since
             # AG-UI caches one Strands agent per thread_id.
             config=StrandsAgentConfig(session_manager_provider=lambda _input_data: get_session_manager()),
+            # Required as well as on the template Agent: AG-UI keeps only the
+            # built HookRegistry, so hooks it can't read back are never
+            # registered and model/tool failures go unreported.
+            hooks=AGENT_HOOKS,
         )
         yield
 

--- a/packages/nx-plugin/src/py/agent/files/strands/common/agent.py.template
+++ b/packages/nx-plugin/src/py/agent/files/strands/common/agent.py.template
@@ -1,6 +1,7 @@
 from contextlib import contextmanager
 
 from strands import Agent, tool
+from strands.hooks import HookCallback, HookProvider
 from strands_tools import current_time
 from <%- agentConnectionModuleName %> import log_model_errors, log_tool_errors
 <%_ if (protocol !== 'ag-ui') { _%>
@@ -14,6 +15,9 @@ def subtract(a: int, b: int) -> int:
     return a - b
 
 
+AGENT_HOOKS: list[HookProvider | HookCallback] = [log_model_errors, log_tool_errors]
+
+
 @contextmanager
 def get_agent():
     yield Agent(
@@ -25,7 +29,7 @@ Use your tools for mathematical tasks.
 Refer to tools as your 'spellbook'.
 """,
         tools=[subtract, current_time],
-        hooks=[log_model_errors, log_tool_errors],
+        hooks=AGENT_HOOKS,
 <%_ if (protocol !== 'ag-ui') { _%>
         session_manager=get_session_manager(),
 <%_ } _%>

--- a/packages/nx-plugin/src/py/agent/generator.frameworks.spec.ts
+++ b/packages/nx-plugin/src/py/agent/generator.frameworks.spec.ts
@@ -66,6 +66,21 @@ dev-dependencies = []
     expect(mainContent).toContain('async def lifespan(app: FastAPI)');
     expect(mainContent).toContain('app.state.agui_agent');
 
+    // AG-UI builds a fresh Agent per thread_id and copies the template Agent's
+    // kwargs, but skips `hooks` (Strands only keeps the built HookRegistry), so
+    // the hooks must be handed to the adapter as well or model/tool failures go
+    // unreported for every served request.
+    const aguiAgentContent = tree.read(
+      'apps/test-project/proj_test_project/agent/agent.py',
+      'utf-8',
+    );
+    expect(aguiAgentContent).toContain(
+      'AGENT_HOOKS: list[HookProvider | HookCallback] = [log_model_errors, log_tool_errors]',
+    );
+    expect(aguiAgentContent).toContain('hooks=AGENT_HOOKS,');
+    expect(mainContent).toContain('from .agent import AGENT_HOOKS, get_agent');
+    expect(mainContent).toContain('hooks=AGENT_HOOKS,');
+
     // AG-UI must bind the inbound AgentCore session ID into the ContextVar
     // so downstream MCP / A2A connection clients forward it on outbound
     // calls. (AG-UI handles its own per-thread conversation isolation, so


### PR DESCRIPTION
`StrandsAgent` builds a fresh `Agent` per `thread_id` by copying the template Agent's kwargs, but deliberately skips `hooks` since Strands keeps only the built `HookRegistry` and the providers can't be read back off it. An AG-UI agent's `log_model_errors` / `log_tool_errors` therefore never fired for served requests: a model failure (an invalid-credentials error, say) went unlogged and the run still reported success.

Hoist the hooks list into an `AGENT_HOOKS` module constant in `agent.py` and pass it to `StrandsAgent(...)` in `main.py` as well. The constant is annotated because `Agent`'s `hooks` list is invariant, where an inline literal was inferred from the parameter.

LangChain is unaffected — it passes no hooks, and its AG-UI adapter is handed the graph itself rather than rebuilding an agent.

Includes a migration that hoists whatever hooks list a workspace has, so custom hooks come along, and reports a diverged constructor via `nextSteps` rather than rewriting it.

### Reason for this change

<!--What is the bug or use case behind this change?-->

### Description of changes

<!--What code changes did you make? Have you made any important design decisions?-->

### Description of how you validated changes

<!--Have you added any unit tests and/or integration tests?-->

### Issue # (if applicable)

Closes #<issue number here>.

### Checklist
- [ ] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*