### PR TITLE
chore(nx-plugin): add explicit .js extensions to relative imports

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,4 @@
+# Nx defers to Node native TypeScript stripping by default, which does not map
+# NodeNext `.js` specifiers back to their `.ts` sources. Opt into the swc path so
+# generators run from source in this repo.
+NX_PREFER_NODE_STRIP_TYPES=false

--- a/packages/nx-plugin/src/agentcore-gateway/agent-connection/generator.spec.ts
+++ b/packages/nx-plugin/src/agentcore-gateway/agent-connection/generator.spec.ts
@@ -7,8 +7,8 @@ import {
   readProjectConfiguration,
   type Tree,
 } from '@nx/devkit';
-import { createTreeUsingTsSolutionSetup } from '../../utils/test';
-import { agentcoreGatewayAgentConnectionGenerator } from './generator';
+import { createTreeUsingTsSolutionSetup } from '../../utils/test.js';
+import { agentcoreGatewayAgentConnectionGenerator } from './generator.js';
 
 describe('agentcore-gateway#agent-connection generator', () => {
   let tree: Tree;

--- a/packages/nx-plugin/src/agentcore-gateway/agent-connection/generator.ts
+++ b/packages/nx-plugin/src/agentcore-gateway/agent-connection/generator.ts
@@ -3,18 +3,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { GeneratorCallback, Tree } from '@nx/devkit';
-import { formatFilesInSubtree } from '../../utils/format';
-import { installDependencies } from '../../utils/install';
-import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
-import { kebabCase, toClassName } from '../../utils/names';
+import { formatFilesInSubtree } from '../../utils/format.js';
+import { installDependencies } from '../../utils/install.js';
+import { addGeneratorMetricsIfApplicable } from '../../utils/metrics.js';
+import { kebabCase, toClassName } from '../../utils/names.js';
 import {
   addComponentGeneratorMetadata,
   getGeneratorInfo,
   type NxGeneratorInfo,
   readProjectConfigurationUnqualified,
-} from '../../utils/nx';
-import { attachAgentToLocalGateway } from '../attach-upstream';
-import { readAgentCoreGatewayMetadata } from '../generator';
+} from '../../utils/nx.js';
+import { attachAgentToLocalGateway } from '../attach-upstream.js';
+import { readAgentCoreGatewayMetadata } from '../generator.js';
 import type { AgentcoreGatewayAgentConnectionGeneratorSchema } from './schema';
 
 export const AGENTCORE_GATEWAY_AGENT_CONNECTION_GENERATOR_INFO: NxGeneratorInfo =

--- a/packages/nx-plugin/src/agentcore-gateway/agent-connection/schema.d.ts
+++ b/packages/nx-plugin/src/agentcore-gateway/agent-connection/schema.d.ts
@@ -2,7 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import type { ComponentMetadata } from '../../utils/nx';
+import type { ComponentMetadata } from '../../utils/nx.js';
 
 export interface AgentcoreGatewayAgentConnectionGeneratorSchema {
   sourceProject: string;

--- a/packages/nx-plugin/src/agentcore-gateway/attach-upstream.ts
+++ b/packages/nx-plugin/src/agentcore-gateway/attach-upstream.ts
@@ -8,8 +8,8 @@ import {
   type Tree,
   updateProjectConfiguration,
 } from '@nx/devkit';
-import { applyGritQL } from '../utils/ast';
-import { addDependencyToTargetIfNotPresent } from '../utils/nx';
+import { applyGritQL } from '../utils/ast.js';
+import { addDependencyToTargetIfNotPresent } from '../utils/nx.js';
 
 export interface LocalGatewayUpstream {
   /**

--- a/packages/nx-plugin/src/agentcore-gateway/gateway-connection/generator.spec.ts
+++ b/packages/nx-plugin/src/agentcore-gateway/gateway-connection/generator.spec.ts
@@ -8,13 +8,13 @@ import {
   type Tree,
   updateProjectConfiguration,
 } from '@nx/devkit';
-import { declareDependencies } from '../../utils/declared-dependencies';
-import { expectHasMetricTags } from '../../utils/metrics.spec';
-import { createTreeUsingTsSolutionSetup } from '../../utils/test';
+import { declareDependencies } from '../../utils/declared-dependencies.js';
+import { expectHasMetricTags } from '../../utils/metrics.spec.js';
+import { createTreeUsingTsSolutionSetup } from '../../utils/test.js';
 import {
   AGENTCORE_GATEWAY_GATEWAY_CONNECTION_GENERATOR_INFO,
   agentcoreGatewayGatewayConnectionGenerator,
-} from './generator';
+} from './generator.js';
 
 describe('agentcore-gateway#gateway-connection generator', () => {
   let tree: Tree;
@@ -303,7 +303,7 @@ describe('agentcore-gateway#gateway-connection generator', () => {
     const outer = addGateway('outer-gateway', 'OuterGateway', 8100);
     const inner = addGateway('inner-gateway', 'InnerGateway', 8101);
     const { SHARED_CONSTRUCTS_DEPENDENCIES, sharedConstructsGenerator } =
-      await import('../../utils/shared-constructs');
+      await import('../../utils/shared-constructs.js');
     await sharedConstructsGenerator(
       tree,
       { iac: 'cdk' },

--- a/packages/nx-plugin/src/agentcore-gateway/gateway-connection/generator.ts
+++ b/packages/nx-plugin/src/agentcore-gateway/gateway-connection/generator.ts
@@ -3,21 +3,21 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { GeneratorCallback, Tree } from '@nx/devkit';
-import { formatFilesInSubtree } from '../../utils/format';
-import { installDependencies } from '../../utils/install';
-import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
-import { kebabCase } from '../../utils/names';
+import { formatFilesInSubtree } from '../../utils/format.js';
+import { installDependencies } from '../../utils/install.js';
+import { addGeneratorMetricsIfApplicable } from '../../utils/metrics.js';
+import { kebabCase } from '../../utils/names.js';
 import {
   addComponentGeneratorMetadata,
   getGeneratorInfo,
   type NxGeneratorInfo,
   readProjectConfigurationUnqualified,
-} from '../../utils/nx';
-import { attachUpstreamToLocalGateway } from '../attach-upstream';
+} from '../../utils/nx.js';
+import { attachUpstreamToLocalGateway } from '../attach-upstream.js';
 import {
   AGENTCORE_GATEWAY_GENERATOR_INFO,
   readAgentCoreGatewayMetadata,
-} from '../generator';
+} from '../generator.js';
 import type { AgentcoreGatewayGatewayConnectionGeneratorSchema } from './schema';
 
 export const AGENTCORE_GATEWAY_GATEWAY_CONNECTION_GENERATOR_INFO: NxGeneratorInfo =

--- a/packages/nx-plugin/src/agentcore-gateway/gateway-connection/schema.d.ts
+++ b/packages/nx-plugin/src/agentcore-gateway/gateway-connection/schema.d.ts
@@ -2,7 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import type { ComponentMetadata } from '../../utils/nx';
+import type { ComponentMetadata } from '../../utils/nx.js';
 
 export interface AgentcoreGatewayGatewayConnectionGeneratorSchema {
   sourceProject: string;

--- a/packages/nx-plugin/src/agentcore-gateway/generator.spec.ts
+++ b/packages/nx-plugin/src/agentcore-gateway/generator.spec.ts
@@ -3,12 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { readProjectConfiguration, type Tree } from '@nx/devkit';
-import { expectHasMetricTags } from '../utils/metrics.spec';
-import { createTreeUsingTsSolutionSetup } from '../utils/test';
+import { expectHasMetricTags } from '../utils/metrics.spec.js';
+import { createTreeUsingTsSolutionSetup } from '../utils/test.js';
 import {
   AGENTCORE_GATEWAY_GENERATOR_INFO,
   agentcoreGatewayGenerator,
-} from './generator';
+} from './generator.js';
 
 describe('agentcore-gateway generator', () => {
   let tree: Tree;

--- a/packages/nx-plugin/src/agentcore-gateway/generator.ts
+++ b/packages/nx-plugin/src/agentcore-gateway/generator.ts
@@ -13,36 +13,36 @@ import {
   type Tree,
   updateProjectConfiguration,
 } from '@nx/devkit';
-import { addTsDependencies } from '../utils/add-dependencies';
+import { addTsDependencies } from '../utils/add-dependencies.js';
 import {
   AGENT_CORE_CONSTRUCTS_DEPENDENCIES,
   AGENT_CORE_CONSTRUCTS_PY_DEPENDENCIES,
   addAgentCoreGatewayInfra,
-} from '../utils/agent-core-constructs/agent-core-constructs';
+} from '../utils/agent-core-constructs/agent-core-constructs.js';
 import {
   declareDependencies,
   ownedElsewhere,
-} from '../utils/declared-dependencies';
-import { formatFilesInSubtree } from '../utils/format';
-import { resolveIac } from '../utils/iac';
-import { installDependencies } from '../utils/install';
-import { addGeneratorMetricsIfApplicable } from '../utils/metrics';
-import { kebabCase, toClassName } from '../utils/names';
-import { getNpmScopePrefix } from '../utils/npm-scope';
+} from '../utils/declared-dependencies.js';
+import { formatFilesInSubtree } from '../utils/format.js';
+import { resolveIac } from '../utils/iac.js';
+import { installDependencies } from '../utils/install.js';
+import { addGeneratorMetricsIfApplicable } from '../utils/metrics.js';
+import { kebabCase, toClassName } from '../utils/names.js';
+import { getNpmScopePrefix } from '../utils/npm-scope.js';
 import {
   addGeneratorMetadata,
   getGeneratorInfo,
   type NxGeneratorInfo,
   projectExists,
   readProjectConfigurationUnqualified,
-} from '../utils/nx';
-import { assignPort } from '../utils/port';
-import { ensureProjectPackageJson } from '../utils/project-package-json';
+} from '../utils/nx.js';
+import { assignPort } from '../utils/port.js';
+import { ensureProjectPackageJson } from '../utils/project-package-json.js';
 import {
   SHARED_CONSTRUCTS_DEPENDENCIES,
   sharedConstructsGenerator,
-} from '../utils/shared-constructs';
-import type { IacMetadata } from '../utils/shared-constructs-constants';
+} from '../utils/shared-constructs.js';
+import type { IacMetadata } from '../utils/shared-constructs-constants.js';
 import type { AgentcoreGatewayGeneratorSchema } from './schema';
 
 // The gateway's local-dev server and Cedar policy rendering need these

--- a/packages/nx-plugin/src/agentcore-gateway/mcp-connection/generator.spec.ts
+++ b/packages/nx-plugin/src/agentcore-gateway/mcp-connection/generator.spec.ts
@@ -3,13 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { addProjectConfiguration, type Tree } from '@nx/devkit';
-import { declareDependencies } from '../../utils/declared-dependencies';
-import { expectHasMetricTags } from '../../utils/metrics.spec';
-import { createTreeUsingTsSolutionSetup } from '../../utils/test';
+import { declareDependencies } from '../../utils/declared-dependencies.js';
+import { expectHasMetricTags } from '../../utils/metrics.spec.js';
+import { createTreeUsingTsSolutionSetup } from '../../utils/test.js';
 import {
   AGENTCORE_GATEWAY_MCP_CONNECTION_GENERATOR_INFO,
   agentcoreGatewayMcpConnectionGenerator,
-} from './generator';
+} from './generator.js';
 
 describe('agentcore-gateway#mcp-connection generator', () => {
   let tree: Tree;
@@ -249,7 +249,7 @@ describe('agentcore-gateway#mcp-connection generator', () => {
     const gw = addGateway();
     const mcp = addMcp();
     const { SHARED_CONSTRUCTS_DEPENDENCIES, sharedConstructsGenerator } =
-      await import('../../utils/shared-constructs');
+      await import('../../utils/shared-constructs.js');
     await sharedConstructsGenerator(
       tree,
       { iac: 'cdk' },

--- a/packages/nx-plugin/src/agentcore-gateway/mcp-connection/generator.ts
+++ b/packages/nx-plugin/src/agentcore-gateway/mcp-connection/generator.ts
@@ -3,18 +3,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { GeneratorCallback, Tree } from '@nx/devkit';
-import { formatFilesInSubtree } from '../../utils/format';
-import { installDependencies } from '../../utils/install';
-import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
-import { kebabCase } from '../../utils/names';
+import { formatFilesInSubtree } from '../../utils/format.js';
+import { installDependencies } from '../../utils/install.js';
+import { addGeneratorMetricsIfApplicable } from '../../utils/metrics.js';
+import { kebabCase } from '../../utils/names.js';
 import {
   addComponentGeneratorMetadata,
   getGeneratorInfo,
   type NxGeneratorInfo,
   readProjectConfigurationUnqualified,
-} from '../../utils/nx';
-import { attachUpstreamToLocalGateway } from '../attach-upstream';
-import { readAgentCoreGatewayMetadata } from '../generator';
+} from '../../utils/nx.js';
+import { attachUpstreamToLocalGateway } from '../attach-upstream.js';
+import { readAgentCoreGatewayMetadata } from '../generator.js';
 import type { AgentcoreGatewayMcpConnectionGeneratorSchema } from './schema';
 
 export const AGENTCORE_GATEWAY_MCP_CONNECTION_GENERATOR_INFO: NxGeneratorInfo =

--- a/packages/nx-plugin/src/agentcore-gateway/mcp-connection/schema.d.ts
+++ b/packages/nx-plugin/src/agentcore-gateway/mcp-connection/schema.d.ts
@@ -2,7 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import type { ComponentMetadata } from '../../utils/nx';
+import type { ComponentMetadata } from '../../utils/nx.js';
 
 export interface AgentcoreGatewayMcpConnectionGeneratorSchema {
   sourceProject: string;

--- a/packages/nx-plugin/src/agentcore-gateway/react-connection/generator.spec.ts
+++ b/packages/nx-plugin/src/agentcore-gateway/react-connection/generator.spec.ts
@@ -7,8 +7,8 @@ import {
   readProjectConfiguration,
   type Tree,
 } from '@nx/devkit';
-import { createTreeUsingTsSolutionSetup } from '../../utils/test';
-import { agentcoreGatewayReactConnectionGenerator } from './generator';
+import { createTreeUsingTsSolutionSetup } from '../../utils/test.js';
+import { agentcoreGatewayReactConnectionGenerator } from './generator.js';
 
 describe('agentcore-gateway#react-connection generator', () => {
   let tree: Tree;

--- a/packages/nx-plugin/src/agentcore-gateway/react-connection/generator.ts
+++ b/packages/nx-plugin/src/agentcore-gateway/react-connection/generator.ts
@@ -3,25 +3,25 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { getProjects, logger, type Tree } from '@nx/devkit';
-import { addGatewayTargetToLocalDev } from '../../connection/agent-local-dev';
-import { addGatewayUrlToConnectionNamespace } from '../../connection/gateway-runtime-config';
-import { PY_AGENT_GENERATOR_INFO } from '../../py/agent/generator';
-import { pyAgentReactConnectionGenerator } from '../../py/agent/react-connection/generator';
-import { TS_AGENT_GENERATOR_INFO } from '../../ts/agent/generator';
-import { tsAgentReactConnectionGenerator } from '../../ts/agent/react-connection/generator';
-import { formatFilesInSubtree } from '../../utils/format';
-import { installDependencies } from '../../utils/install';
-import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
-import { kebabCase } from '../../utils/names';
+import { addGatewayTargetToLocalDev } from '../../connection/agent-local-dev.js';
+import { addGatewayUrlToConnectionNamespace } from '../../connection/gateway-runtime-config.js';
+import { PY_AGENT_GENERATOR_INFO } from '../../py/agent/generator.js';
+import { pyAgentReactConnectionGenerator } from '../../py/agent/react-connection/generator.js';
+import { TS_AGENT_GENERATOR_INFO } from '../../ts/agent/generator.js';
+import { tsAgentReactConnectionGenerator } from '../../ts/agent/react-connection/generator.js';
+import { formatFilesInSubtree } from '../../utils/format.js';
+import { installDependencies } from '../../utils/install.js';
+import { addGeneratorMetricsIfApplicable } from '../../utils/metrics.js';
+import { kebabCase } from '../../utils/names.js';
 import {
   addComponentGeneratorMetadata,
   type ComponentMetadata,
   getGeneratorInfo,
   type NxGeneratorInfo,
   readProjectConfigurationUnqualified,
-} from '../../utils/nx';
-import { AGENTCORE_GATEWAY_AGENT_CONNECTION_GENERATOR_INFO } from '../agent-connection/generator';
-import { readAgentCoreGatewayMetadata } from '../generator';
+} from '../../utils/nx.js';
+import { AGENTCORE_GATEWAY_AGENT_CONNECTION_GENERATOR_INFO } from '../agent-connection/generator.js';
+import { readAgentCoreGatewayMetadata } from '../generator.js';
 import type { AgentcoreGatewayReactConnectionGeneratorSchema } from './schema';
 
 export const AGENTCORE_GATEWAY_REACT_CONNECTION_GENERATOR_INFO: NxGeneratorInfo =

--- a/packages/nx-plugin/src/agentcore-gateway/react-connection/schema.d.ts
+++ b/packages/nx-plugin/src/agentcore-gateway/react-connection/schema.d.ts
@@ -2,7 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import type { ComponentMetadata } from '../../utils/nx';
+import type { ComponentMetadata } from '../../utils/nx.js';
 
 export interface AgentcoreGatewayReactConnectionGeneratorSchema {
   sourceProject: string;

--- a/packages/nx-plugin/src/agentcore-gateway/schema.d.ts
+++ b/packages/nx-plugin/src/agentcore-gateway/schema.d.ts
@@ -2,7 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import type { IacOption } from '../utils/iac';
+import type { IacOption } from '../utils/iac.js';
 
 export interface AgentcoreGatewayGeneratorSchema {
   name: string;

--- a/packages/nx-plugin/src/agentcore-harness/generator.spec.ts
+++ b/packages/nx-plugin/src/agentcore-harness/generator.spec.ts
@@ -7,15 +7,18 @@ import yaml from 'js-yaml';
 import {
   ensureAwsNxPluginConfig,
   updateAwsNxPluginConfig,
-} from '../utils/config/utils';
-import { expectHasMetricTags } from '../utils/metrics.spec';
-import { createTreeUsingTsSolutionSetup, snapshotTreeDir } from '../utils/test';
-import { TS_VERSIONS } from '../utils/versions';
+} from '../utils/config/utils.js';
+import { expectHasMetricTags } from '../utils/metrics.spec.js';
+import {
+  createTreeUsingTsSolutionSetup,
+  snapshotTreeDir,
+} from '../utils/test.js';
+import { TS_VERSIONS } from '../utils/versions.js';
 import {
   AGENTCORE_HARNESS_GENERATOR_INFO,
   agentcoreHarnessGenerator,
   readAgentCoreHarnessMetadata,
-} from './generator';
+} from './generator.js';
 import type { AgentcoreHarnessGeneratorSchema } from './schema';
 import harnessSchema from './schema.json' with { type: 'json' };
 

--- a/packages/nx-plugin/src/agentcore-harness/generator.ts
+++ b/packages/nx-plugin/src/agentcore-harness/generator.ts
@@ -12,30 +12,30 @@ import {
   type Tree,
   updateProjectConfiguration,
 } from '@nx/devkit';
-import { addTsDependencies } from '../utils/add-dependencies';
-import { addAgentCoreHarnessInfra } from '../utils/agent-core-constructs/agent-core-constructs';
+import { addTsDependencies } from '../utils/add-dependencies.js';
+import { addAgentCoreHarnessInfra } from '../utils/agent-core-constructs/agent-core-constructs.js';
 import {
   declareDependencies,
   ownedElsewhere,
-} from '../utils/declared-dependencies';
-import { formatFilesInSubtree } from '../utils/format';
-import { resolveIac } from '../utils/iac';
-import { installDependencies } from '../utils/install';
-import { addGeneratorMetricsIfApplicable } from '../utils/metrics';
-import { kebabCase, toClassName } from '../utils/names';
-import { getNpmScopePrefix } from '../utils/npm-scope';
+} from '../utils/declared-dependencies.js';
+import { formatFilesInSubtree } from '../utils/format.js';
+import { resolveIac } from '../utils/iac.js';
+import { installDependencies } from '../utils/install.js';
+import { addGeneratorMetricsIfApplicable } from '../utils/metrics.js';
+import { kebabCase, toClassName } from '../utils/names.js';
+import { getNpmScopePrefix } from '../utils/npm-scope.js';
 import {
   addGeneratorMetadata,
   getGeneratorInfo,
   type NxGeneratorInfo,
   projectExists,
   readProjectConfigurationUnqualified,
-} from '../utils/nx';
+} from '../utils/nx.js';
 import {
   SHARED_CONSTRUCTS_DEPENDENCIES,
   sharedConstructsGenerator,
-} from '../utils/shared-constructs';
-import type { IacMetadata } from '../utils/shared-constructs-constants';
+} from '../utils/shared-constructs.js';
+import type { IacMetadata } from '../utils/shared-constructs-constants.js';
 import type { AgentcoreHarnessGeneratorSchema } from './schema';
 
 // scripts/chat.ts needs all of these whatever the infrastructure choice, so no

--- a/packages/nx-plugin/src/agentcore-harness/schema.d.ts
+++ b/packages/nx-plugin/src/agentcore-harness/schema.d.ts
@@ -2,7 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import type { IacOption } from '../utils/iac';
+import type { IacOption } from '../utils/iac.js';
 
 /**
  * Options for the agentcore-harness generator, mirroring schema.json.

--- a/packages/nx-plugin/src/connection/agent-local-dev.ts
+++ b/packages/nx-plugin/src/connection/agent-local-dev.ts
@@ -7,12 +7,12 @@ import {
   type Tree,
   updateProjectConfiguration,
 } from '@nx/devkit';
-import { applyGritQL } from '../utils/ast';
+import { applyGritQL } from '../utils/ast.js';
 import {
   addDependencyToTargetIfNotPresent,
   type ComponentMetadata,
   readProjectConfigurationUnqualified,
-} from '../utils/nx';
+} from '../utils/nx.js';
 
 export interface AgentLocalDevOptions {
   agentNameClassName: string;

--- a/packages/nx-plugin/src/connection/agent-runtime-config.ts
+++ b/packages/nx-plugin/src/connection/agent-runtime-config.ts
@@ -3,12 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { joinPathFragments, type Tree } from '@nx/devkit';
-import { applyGritQL, matchGritQL } from '../utils/ast';
+import { applyGritQL, matchGritQL } from '../utils/ast.js';
 import {
   PACKAGES_DIR,
   SHARED_CONSTRUCTS_DIR,
   SHARED_TERRAFORM_DIR,
-} from '../utils/shared-constructs-constants';
+} from '../utils/shared-constructs-constants.js';
 
 const CONNECTION_TF_MODULE_NAME =
   'add_agent_runtime_to_connection_runtime_config';

--- a/packages/nx-plugin/src/connection/gateway-runtime-config.ts
+++ b/packages/nx-plugin/src/connection/gateway-runtime-config.ts
@@ -3,12 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { joinPathFragments, type Tree } from '@nx/devkit';
-import { applyGritQL, matchGritQL } from '../utils/ast';
+import { applyGritQL, matchGritQL } from '../utils/ast.js';
 import {
   PACKAGES_DIR,
   SHARED_CONSTRUCTS_DIR,
   SHARED_TERRAFORM_DIR,
-} from '../utils/shared-constructs-constants';
+} from '../utils/shared-constructs-constants.js';
 
 const CONNECTION_TF_MODULE_NAME =
   'add_gateway_url_to_connection_runtime_config';

--- a/packages/nx-plugin/src/connection/generator.spec.ts
+++ b/packages/nx-plugin/src/connection/generator.spec.ts
@@ -4,13 +4,13 @@
  */
 import { type Tree, updateJson } from '@nx/devkit';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import fastApiReactGenerator from '../py/fast-api/react/generator';
-import smithyReactConnectionGenerator from '../smithy/react-connection/generator';
-import trpcReactGenerator from '../trpc/react/generator';
-import tsRdbAgentConnectionGenerator from '../ts/rdb/agent-connection/generator';
-import tsRdbSmithyConnectionGenerator from '../ts/rdb/smithy-connection/generator';
-import tsRdbTrpcConnectionGenerator from '../ts/rdb/trpc-connection/generator';
-import { createTreeUsingTsSolutionSetup } from '../utils/test';
+import fastApiReactGenerator from '../py/fast-api/react/generator.js';
+import smithyReactConnectionGenerator from '../smithy/react-connection/generator.js';
+import trpcReactGenerator from '../trpc/react/generator.js';
+import tsRdbAgentConnectionGenerator from '../ts/rdb/agent-connection/generator.js';
+import tsRdbSmithyConnectionGenerator from '../ts/rdb/smithy-connection/generator.js';
+import tsRdbTrpcConnectionGenerator from '../ts/rdb/trpc-connection/generator.js';
+import { createTreeUsingTsSolutionSetup } from '../utils/test.js';
 import {
   type Connection,
   connectionGenerator,
@@ -18,7 +18,7 @@ import {
   findComponentInMetadata,
   PROJECT_COMPONENT_SENTINEL,
   resolveConnection,
-} from './generator';
+} from './generator.js';
 
 // Mock the generators
 vi.mock('../trpc/react/generator', () => ({

--- a/packages/nx-plugin/src/connection/generator.ts
+++ b/packages/nx-plugin/src/connection/generator.ts
@@ -7,55 +7,55 @@ import {
   type ProjectConfiguration,
   type Tree,
 } from '@nx/devkit';
-import agentcoreGatewayAgentConnectionGenerator from '../agentcore-gateway/agent-connection/generator';
-import agentcoreGatewayGatewayConnectionGenerator from '../agentcore-gateway/gateway-connection/generator';
-import { AGENTCORE_GATEWAY_GENERATOR_INFO } from '../agentcore-gateway/generator';
-import agentcoreGatewayMcpConnectionGenerator from '../agentcore-gateway/mcp-connection/generator';
-import agentcoreGatewayReactConnectionGenerator from '../agentcore-gateway/react-connection/generator';
-import pyAgentA2aConnectionGenerator from '../py/agent/a2a-connection/generator';
-import pyAgentGatewayConnectionGenerator from '../py/agent/gateway-connection/generator';
-import pyAgentMcpConnectionGenerator from '../py/agent/mcp-connection/generator';
-import pyAgentReactConnectionGenerator from '../py/agent/react-connection/generator';
-import pyDynamoDBAgentConnectionGenerator from '../py/dynamodb/agent-connection/generator';
-import pyDynamoDBFastApiConnectionGenerator from '../py/dynamodb/fast-api-connection/generator';
-import { PY_DYNAMODB_GENERATOR_INFO } from '../py/dynamodb/generator';
-import pyDynamoDBMcpServerConnectionGenerator from '../py/dynamodb/mcp-server-connection/generator';
-import fastApiReactGenerator from '../py/fast-api/react/generator';
-import pyRdbAgentConnectionGenerator from '../py/rdb/agent-connection/generator';
-import pyRdbFastApiConnectionGenerator from '../py/rdb/fast-api-connection/generator';
-import { PY_RDB_GENERATOR_INFO } from '../py/rdb/generator';
-import pyRdbMcpServerConnectionGenerator from '../py/rdb/mcp-server-connection/generator';
-import { SMITHY_PROJECT_GENERATOR_INFO } from '../smithy/project/generator';
-import smithyReactConnectionGenerator from '../smithy/react-connection/generator';
-import { TS_SMITHY_API_GENERATOR_INFO } from '../smithy/ts/api/generator';
-import trpcReactGenerator from '../trpc/react/generator';
-import tsAgentA2aConnectionGenerator from '../ts/agent/a2a-connection/generator';
-import tsAgentGatewayConnectionGenerator from '../ts/agent/gateway-connection/generator';
-import tsAgentMcpConnectionGenerator from '../ts/agent/mcp-connection/generator';
-import tsAgentReactConnectionGenerator from '../ts/agent/react-connection/generator';
-import tsDynamoDBAgentConnectionGenerator from '../ts/dynamodb/agent-connection/generator';
-import { TS_DYNAMODB_GENERATOR_INFO } from '../ts/dynamodb/generator';
-import tsDynamoDBMcpServerConnectionGenerator from '../ts/dynamodb/mcp-server-connection/generator';
-import tsDynamoDBSmithyConnectionGenerator from '../ts/dynamodb/smithy-connection/generator';
-import tsDynamoDBTrpcConnectionGenerator from '../ts/dynamodb/trpc-connection/generator';
-import tsRdbAgentConnectionGenerator from '../ts/rdb/agent-connection/generator';
-import { TS_RDB_GENERATOR_INFO } from '../ts/rdb/generator';
-import tsRdbMcpServerConnectionGenerator from '../ts/rdb/mcp-server-connection/generator';
-import tsRdbSmithyConnectionGenerator from '../ts/rdb/smithy-connection/generator';
-import tsRdbTrpcConnectionGenerator from '../ts/rdb/trpc-connection/generator';
-import { hasExportDeclaration } from '../utils/ast';
+import agentcoreGatewayAgentConnectionGenerator from '../agentcore-gateway/agent-connection/generator.js';
+import agentcoreGatewayGatewayConnectionGenerator from '../agentcore-gateway/gateway-connection/generator.js';
+import { AGENTCORE_GATEWAY_GENERATOR_INFO } from '../agentcore-gateway/generator.js';
+import agentcoreGatewayMcpConnectionGenerator from '../agentcore-gateway/mcp-connection/generator.js';
+import agentcoreGatewayReactConnectionGenerator from '../agentcore-gateway/react-connection/generator.js';
+import pyAgentA2aConnectionGenerator from '../py/agent/a2a-connection/generator.js';
+import pyAgentGatewayConnectionGenerator from '../py/agent/gateway-connection/generator.js';
+import pyAgentMcpConnectionGenerator from '../py/agent/mcp-connection/generator.js';
+import pyAgentReactConnectionGenerator from '../py/agent/react-connection/generator.js';
+import pyDynamoDBAgentConnectionGenerator from '../py/dynamodb/agent-connection/generator.js';
+import pyDynamoDBFastApiConnectionGenerator from '../py/dynamodb/fast-api-connection/generator.js';
+import { PY_DYNAMODB_GENERATOR_INFO } from '../py/dynamodb/generator.js';
+import pyDynamoDBMcpServerConnectionGenerator from '../py/dynamodb/mcp-server-connection/generator.js';
+import fastApiReactGenerator from '../py/fast-api/react/generator.js';
+import pyRdbAgentConnectionGenerator from '../py/rdb/agent-connection/generator.js';
+import pyRdbFastApiConnectionGenerator from '../py/rdb/fast-api-connection/generator.js';
+import { PY_RDB_GENERATOR_INFO } from '../py/rdb/generator.js';
+import pyRdbMcpServerConnectionGenerator from '../py/rdb/mcp-server-connection/generator.js';
+import { SMITHY_PROJECT_GENERATOR_INFO } from '../smithy/project/generator.js';
+import smithyReactConnectionGenerator from '../smithy/react-connection/generator.js';
+import { TS_SMITHY_API_GENERATOR_INFO } from '../smithy/ts/api/generator.js';
+import trpcReactGenerator from '../trpc/react/generator.js';
+import tsAgentA2aConnectionGenerator from '../ts/agent/a2a-connection/generator.js';
+import tsAgentGatewayConnectionGenerator from '../ts/agent/gateway-connection/generator.js';
+import tsAgentMcpConnectionGenerator from '../ts/agent/mcp-connection/generator.js';
+import tsAgentReactConnectionGenerator from '../ts/agent/react-connection/generator.js';
+import tsDynamoDBAgentConnectionGenerator from '../ts/dynamodb/agent-connection/generator.js';
+import { TS_DYNAMODB_GENERATOR_INFO } from '../ts/dynamodb/generator.js';
+import tsDynamoDBMcpServerConnectionGenerator from '../ts/dynamodb/mcp-server-connection/generator.js';
+import tsDynamoDBSmithyConnectionGenerator from '../ts/dynamodb/smithy-connection/generator.js';
+import tsDynamoDBTrpcConnectionGenerator from '../ts/dynamodb/trpc-connection/generator.js';
+import tsRdbAgentConnectionGenerator from '../ts/rdb/agent-connection/generator.js';
+import { TS_RDB_GENERATOR_INFO } from '../ts/rdb/generator.js';
+import tsRdbMcpServerConnectionGenerator from '../ts/rdb/mcp-server-connection/generator.js';
+import tsRdbSmithyConnectionGenerator from '../ts/rdb/smithy-connection/generator.js';
+import tsRdbTrpcConnectionGenerator from '../ts/rdb/trpc-connection/generator.js';
+import { hasExportDeclaration } from '../utils/ast.js';
 import {
   type ComponentMetadata,
   readProjectConfigurationUnqualified,
-} from '../utils/nx';
-import { readToml } from '../utils/toml';
+} from '../utils/nx.js';
+import { readToml } from '../utils/toml.js';
 import type { ConnectionGeneratorSchema } from './schema';
 import {
   type Connection,
   type ConnectionKey,
   SUPPORTED_CONNECTIONS,
   type SUPPORTED_PROJECT_TYPES,
-} from './supported-connections';
+} from './supported-connections.js';
 
 export type { Connection };
 

--- a/packages/nx-plugin/src/connection/local-dev.spec.ts
+++ b/packages/nx-plugin/src/connection/local-dev.spec.ts
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { Tree } from '@nx/devkit';
-import { createTreeUsingTsSolutionSetup } from '../utils/test';
-import { addTargetToLocalDev, type LocalDevOptions } from './local-dev';
+import { createTreeUsingTsSolutionSetup } from '../utils/test.js';
+import { addTargetToLocalDev, type LocalDevOptions } from './local-dev.js';
 
 describe('dev', () => {
   let tree: Tree;

--- a/packages/nx-plugin/src/connection/local-dev.ts
+++ b/packages/nx-plugin/src/connection/local-dev.ts
@@ -7,12 +7,12 @@ import {
   type Tree,
   updateProjectConfiguration,
 } from '@nx/devkit';
-import { applyGritQL } from '../utils/ast';
-import { toClassName } from '../utils/names';
+import { applyGritQL } from '../utils/ast.js';
+import { toClassName } from '../utils/names.js';
 import {
   addDependencyToTargetIfNotPresent,
   readProjectConfigurationUnqualified,
-} from '../utils/nx';
+} from '../utils/nx.js';
 
 export interface LocalDevOptions {
   apiName: string;

--- a/packages/nx-plugin/src/connection/scaffold-catalog.integration.spec.ts
+++ b/packages/nx-plugin/src/connection/scaffold-catalog.integration.spec.ts
@@ -7,8 +7,8 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import type { Tree } from '@nx/devkit';
 import GeneratorsJson from '../../generators.json' with { type: 'json' };
-import { agentcoreGatewayGenerator } from '../sdk/agentcore-gateway';
-import { connectionGenerator } from '../sdk/connection';
+import { agentcoreGatewayGenerator } from '../sdk/agentcore-gateway.js';
+import { connectionGenerator } from '../sdk/connection.js';
 import {
   pyAgentGenerator,
   pyApiGenerator,
@@ -16,7 +16,7 @@ import {
   pyMcpServerGenerator,
   pyProjectGenerator,
   pyRdbGenerator,
-} from '../sdk/py';
+} from '../sdk/py.js';
 import {
   tsAgentGenerator,
   tsApiGenerator,
@@ -25,20 +25,20 @@ import {
   tsProjectGenerator,
   tsRdbGenerator,
   tsWebsiteGenerator,
-} from '../sdk/ts';
+} from '../sdk/ts.js';
 import {
   ensureAwsNxPluginConfig,
   updateAwsNxPluginConfig,
-} from '../utils/config/utils';
-import { toSnakeCase } from '../utils/names';
-import { getNpmScope } from '../utils/npm-scope';
-import { createTreeUsingTsSolutionSetup } from '../utils/test';
+} from '../utils/config/utils.js';
+import { toSnakeCase } from '../utils/names.js';
+import { getNpmScope } from '../utils/npm-scope.js';
+import { createTreeUsingTsSolutionSetup } from '../utils/test.js';
 import {
   CONNECTION_CONSTRAINTS,
   type ConnectionConstraint,
-} from './scaffold-catalog';
-import { nodeSchemaResolver, SCAFFOLD_RECIPES } from './schema-resolver';
-import { SUPPORTED_CONNECTIONS } from './supported-connections';
+} from './scaffold-catalog.js';
+import { nodeSchemaResolver, SCAFFOLD_RECIPES } from './schema-resolver.js';
+import { SUPPORTED_CONNECTIONS } from './supported-connections.js';
 
 /**
  * The docs graph builder promises that a graph it accepts is a graph that

--- a/packages/nx-plugin/src/connection/scaffold-catalog.spec.ts
+++ b/packages/nx-plugin/src/connection/scaffold-catalog.spec.ts
@@ -12,9 +12,9 @@ import {
   CONNECTION_PREFERENCES,
   deriveScaffoldRecipe,
   SELF_CONNECTION_DISALLOWED,
-} from './scaffold-catalog';
-import { nodeSchemaResolver, SCAFFOLD_RECIPES } from './schema-resolver';
-import { SUPPORTED_CONNECTIONS } from './supported-connections';
+} from './scaffold-catalog.js';
+import { nodeSchemaResolver, SCAFFOLD_RECIPES } from './schema-resolver.js';
+import { SUPPORTED_CONNECTIONS } from './supported-connections.js';
 
 /**
  * The docs graph builder derives its palette and edges from this catalogue, so a

--- a/packages/nx-plugin/src/connection/scaffold-catalog.ts
+++ b/packages/nx-plugin/src/connection/scaffold-catalog.ts
@@ -7,7 +7,7 @@ import {
   type ConnectionKey,
   SUPPORTED_CONNECTIONS,
   type SUPPORTED_PROJECT_TYPES,
-} from './supported-connections';
+} from './supported-connections.js';
 
 /**
  * How to scaffold each end of a connection, derived from the plugin's own

--- a/packages/nx-plugin/src/connection/schema-resolver.ts
+++ b/packages/nx-plugin/src/connection/schema-resolver.ts
@@ -10,7 +10,7 @@ import {
   type ScaffoldRecipe,
   type SchemaResolver,
   schemaPathOf,
-} from './scaffold-catalog';
+} from './scaffold-catalog.js';
 
 /** Reads schemas from disk, for the plugin and its tests. */
 export const nodeSchemaResolver: SchemaResolver = (() => {

--- a/packages/nx-plugin/src/index.ts
+++ b/packages/nx-plugin/src/index.ts
@@ -2,4 +2,4 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-export * from './utils/config';
+export * from './utils/config/index.js';

--- a/packages/nx-plugin/src/infra/app/generator.spec.ts
+++ b/packages/nx-plugin/src/infra/app/generator.spec.ts
@@ -8,13 +8,13 @@ import {
   readProjectConfiguration,
   type Tree,
 } from '@nx/devkit';
-import { expectHasMetricTags } from '../../utils/metrics.spec';
-import { toKebabCase } from '../../utils/names';
+import { expectHasMetricTags } from '../../utils/metrics.spec.js';
+import { toKebabCase } from '../../utils/names.js';
 import {
   createTreeUsingTsSolutionSetup,
   snapshotTreeDir,
-} from '../../utils/test';
-import { INFRA_APP_GENERATOR_INFO, tsInfraGenerator } from './generator';
+} from '../../utils/test.js';
+import { INFRA_APP_GENERATOR_INFO, tsInfraGenerator } from './generator.js';
 import type { TsInfraGeneratorSchema } from './schema';
 
 describe('infra generator', () => {

--- a/packages/nx-plugin/src/infra/app/generator.ts
+++ b/packages/nx-plugin/src/infra/app/generator.ts
@@ -13,44 +13,44 @@ import {
   updateJson,
 } from '@nx/devkit';
 import path from 'path';
-import tsProjectGenerator, { getTsLibDetails } from '../../ts/lib/generator';
-import { mergeTsReferences } from '../../ts/lib/ts-project-utils';
-import { addTsDependencies } from '../../utils/add-dependencies';
-import { resolveContainers } from '../../utils/containers';
+import tsProjectGenerator, { getTsLibDetails } from '../../ts/lib/generator.js';
+import { mergeTsReferences } from '../../ts/lib/ts-project-utils.js';
+import { addTsDependencies } from '../../utils/add-dependencies.js';
+import { resolveContainers } from '../../utils/containers.js';
 import {
   declareDependencies,
   ownedElsewhere,
-} from '../../utils/declared-dependencies';
-import { formatFilesInSubtree } from '../../utils/format';
-import { installDependencies } from '../../utils/install';
-import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
-import { esmVars } from '../../utils/module-format';
-import { kebabCase } from '../../utils/names';
-import { getNpmScopePrefix } from '../../utils/npm-scope';
+} from '../../utils/declared-dependencies.js';
+import { formatFilesInSubtree } from '../../utils/format.js';
+import { installDependencies } from '../../utils/install.js';
+import { addGeneratorMetricsIfApplicable } from '../../utils/metrics.js';
+import { esmVars } from '../../utils/module-format.js';
+import { kebabCase } from '../../utils/names.js';
+import { getNpmScopePrefix } from '../../utils/npm-scope.js';
 import {
   addDependencyToTargetIfNotPresent,
   addGeneratorMetadata,
   getGeneratorInfo,
   type NxGeneratorInfo,
   projectExists,
-} from '../../utils/nx';
-import { sortObjectKeys } from '../../utils/object';
-import { getPackageManagerDisplayCommands } from '../../utils/pkg-manager';
-import { uvxCommand } from '../../utils/py';
+} from '../../utils/nx.js';
+import { sortObjectKeys } from '../../utils/object.js';
+import { getPackageManagerDisplayCommands } from '../../utils/pkg-manager.js';
+import { uvxCommand } from '../../utils/py.js';
 import {
   SHARED_CONSTRUCTS_DEPENDENCIES,
   sharedConstructsGenerator,
-} from '../../utils/shared-constructs';
+} from '../../utils/shared-constructs.js';
 import {
   PACKAGES_DIR,
   SHARED_CONSTRUCTS_DIR,
   SHARED_INFRA_CONFIG_DIR,
-} from '../../utils/shared-constructs-constants';
-import { sharedInfraConfigGenerator } from '../../utils/shared-infra-config';
+} from '../../utils/shared-constructs-constants.js';
+import { sharedInfraConfigGenerator } from '../../utils/shared-infra-config.js';
 import {
   SHARED_INFRA_SCRIPTS_DEPENDENCIES,
   sharedInfraScriptsGenerator,
-} from '../../utils/shared-infra-scripts';
+} from '../../utils/shared-infra-scripts.js';
 import type { TsInfraGeneratorSchema } from './schema';
 
 // This generator records no metadata, so nothing a predicate could read: the

--- a/packages/nx-plugin/src/init/generator.spec.ts
+++ b/packages/nx-plugin/src/init/generator.spec.ts
@@ -6,9 +6,9 @@ import { readJson, readNxJson, type Tree } from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import yaml from 'js-yaml';
 import { beforeEach, describe, expect, it } from 'vitest';
-import { SYNC_GENERATOR_NAME as TS_SYNC_GENERATOR_NAME } from '../ts/sync/generator';
-import { readAwsNxPluginConfig } from '../utils/config/utils';
-import { initGenerator } from './generator';
+import { SYNC_GENERATOR_NAME as TS_SYNC_GENERATOR_NAME } from '../ts/sync/generator.js';
+import { readAwsNxPluginConfig } from '../utils/config/utils.js';
+import { initGenerator } from './generator.js';
 
 const NX_TYPESCRIPT_SYNC_GENERATOR = '@nx/js:typescript-sync';
 

--- a/packages/nx-plugin/src/init/generator.ts
+++ b/packages/nx-plugin/src/init/generator.ts
@@ -3,12 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { GeneratorCallback, Tree } from '@nx/devkit';
-import { declareDependencies } from '../utils/declared-dependencies';
-import { formatFilesInSubtree } from '../utils/format';
-import { applyWorkspaceInit, INIT_DEPENDENCIES } from '../utils/init';
-import { installDependencies } from '../utils/install';
-import { addGeneratorMetricsIfApplicable } from '../utils/metrics';
-import { getGeneratorInfo, type NxGeneratorInfo } from '../utils/nx';
+import { declareDependencies } from '../utils/declared-dependencies.js';
+import { formatFilesInSubtree } from '../utils/format.js';
+import { applyWorkspaceInit, INIT_DEPENDENCIES } from '../utils/init.js';
+import { installDependencies } from '../utils/install.js';
+import { addGeneratorMetricsIfApplicable } from '../utils/metrics.js';
+import { getGeneratorInfo, type NxGeneratorInfo } from '../utils/nx.js';
 import type { InitGeneratorSchema } from './schema';
 
 // `husky` comes from the preset, which is discovered as init: both mark the

--- a/packages/nx-plugin/src/init/schema.d.ts
+++ b/packages/nx-plugin/src/init/schema.d.ts
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Containers } from '../utils/containers';
-import { Iac } from '../utils/iac';
+import { Containers } from '../utils/containers.js';
+import { Iac } from '../utils/iac.js';
 
 export type InitContainersOption = Containers | 'infer';
 

--- a/packages/nx-plugin/src/internal/test-matrix/generator.ts
+++ b/packages/nx-plugin/src/internal/test-matrix/generator.ts
@@ -3,13 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { GeneratorCallback, Tree } from '@nx/devkit';
-import { agentcoreGatewayGenerator } from '../../sdk/agentcore-gateway';
-import { agentcoreHarnessGenerator } from '../../sdk/agentcore-harness';
+import { agentcoreGatewayGenerator } from '../../sdk/agentcore-gateway.js';
+import { agentcoreHarnessGenerator } from '../../sdk/agentcore-harness.js';
 import {
   type ConnectionGeneratorSchema,
   connectionGenerator,
-} from '../../sdk/connection';
-import { licenseGenerator } from '../../sdk/license';
+} from '../../sdk/connection.js';
+import { licenseGenerator } from '../../sdk/license.js';
 import {
   type PyAgentGeneratorSchema,
   type PyApiGeneratorSchema,
@@ -21,9 +21,9 @@ import {
   pyMcpServerGenerator,
   pyProjectGenerator,
   pyRdbGenerator,
-} from '../../sdk/py';
-import { smithyProjectGenerator } from '../../sdk/smithy';
-import { terraformProjectGenerator } from '../../sdk/terraform';
+} from '../../sdk/py.js';
+import { smithyProjectGenerator } from '../../sdk/smithy.js';
+import { terraformProjectGenerator } from '../../sdk/terraform.js';
 import {
   type TsAgentGeneratorSchema,
   type TsApiGeneratorSchema,
@@ -44,10 +44,10 @@ import {
   tsRdbGenerator,
   tsWebsiteAuthGenerator,
   tsWebsiteGenerator,
-} from '../../sdk/ts';
-import { installDependencies } from '../../utils/install';
-import { toSnakeCase } from '../../utils/names';
-import { getNpmScope, getNpmScopePrefix } from '../../utils/npm-scope';
+} from '../../sdk/ts.js';
+import { installDependencies } from '../../utils/install.js';
+import { toSnakeCase } from '../../utils/names.js';
+import { getNpmScope, getNpmScopePrefix } from '../../utils/npm-scope.js';
 import type { InternalTestMatrixGeneratorSchema } from './schema';
 
 /**

--- a/packages/nx-plugin/src/license/config-types.ts
+++ b/packages/nx-plugin/src/license/config-types.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { DependencyCheckConfig } from './dependency-check/types';
+import type { DependencyCheckConfig } from './dependency-check/types.js';
 import type { SPDXLicenseIdentifier } from './schema';
 
 export interface LicenseConfig {
@@ -51,7 +51,7 @@ export type {
   AllowlistEntry,
   DependencyCheckConfig,
   DependencyCheckException,
-} from './dependency-check/types';
+} from './dependency-check/types.js';
 
 /**
  * Configuration for the LICENSE file sync

--- a/packages/nx-plugin/src/license/config.spec.ts
+++ b/packages/nx-plugin/src/license/config.spec.ts
@@ -7,8 +7,8 @@ import { afterEach, beforeEach, vi } from 'vitest';
 import {
   AWS_NX_PLUGIN_CONFIG_FILE_NAME,
   readAwsNxPluginConfig,
-} from '../utils/config/utils';
-import { createTreeUsingTsSolutionSetup } from '../utils/test';
+} from '../utils/config/utils.js';
+import { createTreeUsingTsSolutionSetup } from '../utils/test.js';
 import {
   defaultLicenseConfig,
   ensureDependencyCheckBlock,
@@ -17,9 +17,9 @@ import {
   readLicenseConfig,
   removeLicenseExceptions,
   writeLicenseConfig,
-} from './config';
-import type { LicenseSourceConfig } from './config-types';
-import type { DependencyCheckException } from './dependency-check/types';
+} from './config.js';
+import type { LicenseSourceConfig } from './config-types.js';
+import type { DependencyCheckException } from './dependency-check/types.js';
 import type { SPDXLicenseIdentifier } from './schema';
 
 const LICENSES: SPDXLicenseIdentifier[] = ['Apache-2.0', 'MIT', 'ASL'];

--- a/packages/nx-plugin/src/license/config.ts
+++ b/packages/nx-plugin/src/license/config.ts
@@ -13,15 +13,15 @@ import {
   AWS_NX_PLUGIN_CONFIG_FILE_NAME,
   readAwsNxPluginConfig,
   updateAwsNxPluginConfig,
-} from '../utils/config/utils';
-import { formatFilesInSubtree } from '../utils/format';
-import { addDependencyToTargetIfNotPresent } from '../utils/nx';
+} from '../utils/config/utils.js';
+import { formatFilesInSubtree } from '../utils/format.js';
+import { addDependencyToTargetIfNotPresent } from '../utils/nx.js';
 import type {
   CommentSyntax,
   LicenseConfig,
   LicenseSourceConfig,
-} from './config-types';
-import type { DependencyCheckException } from './dependency-check/types';
+} from './config-types.js';
+import type { DependencyCheckException } from './dependency-check/types.js';
 import type { SPDXLicenseIdentifier } from './schema';
 
 /**
@@ -175,7 +175,7 @@ const prependLicenseProperty = async (
   property: string,
 ): Promise<boolean> => {
   const { insertViaGritQL, GRIT_INSERT_PLACEHOLDER } = await import(
-    '../utils/ast'
+    '../utils/ast.js'
   );
 
   // Non-empty license object: insert before the first existing property.
@@ -203,7 +203,7 @@ const prependLicenseProperty = async (
  */
 const hasDependenciesBlock = async (tree: Tree): Promise<boolean> => {
   if (!tree.exists(AWS_NX_PLUGIN_CONFIG_FILE_NAME)) return false;
-  const { matchGritQL } = await import('../utils/ast');
+  const { matchGritQL } = await import('../utils/ast.js');
   return matchGritQL(
     tree,
     AWS_NX_PLUGIN_CONFIG_FILE_NAME,
@@ -264,7 +264,7 @@ export const updateLicenseCheckTargetInputs = async (
  */
 const hasPythonCollector = async (tree: Tree): Promise<boolean> => {
   if (!tree.exists(AWS_NX_PLUGIN_CONFIG_FILE_NAME)) return false;
-  const { matchGritQL } = await import('../utils/ast');
+  const { matchGritQL } = await import('../utils/ast.js');
   return matchGritQL(tree, AWS_NX_PLUGIN_CONFIG_FILE_NAME, '`pythonCollector`');
 };
 
@@ -338,7 +338,7 @@ export const ensureDependencyCheckBlock = async (
 ): Promise<void> => {
   if (!tree.exists(AWS_NX_PLUGIN_CONFIG_FILE_NAME)) return;
 
-  const { addDestructuredImport } = await import('../utils/ast');
+  const { addDestructuredImport } = await import('../utils/ast.js');
 
   if (await hasDependenciesBlock(tree)) {
     return;
@@ -388,7 +388,7 @@ export const ensureLicenseExceptions = async (
   if (!tree.exists(AWS_NX_PLUGIN_CONFIG_FILE_NAME)) return;
 
   const { insertViaGritQL, GRIT_INSERT_PLACEHOLDER } = await import(
-    '../utils/ast'
+    '../utils/ast.js'
   );
 
   if (!(await hasDependenciesBlock(tree))) {
@@ -429,7 +429,7 @@ export const removeLicenseExceptions = async (
 ): Promise<void> => {
   if (!tree.exists(AWS_NX_PLUGIN_CONFIG_FILE_NAME)) return;
 
-  const { applyGritQL } = await import('../utils/ast');
+  const { applyGritQL } = await import('../utils/ast.js');
 
   let modified = false;
   for (const pkg of packages) {
@@ -465,7 +465,7 @@ export const ensurePythonLicenseCollector = async (
   if (!tree.exists(AWS_NX_PLUGIN_CONFIG_FILE_NAME)) return;
 
   const { addDestructuredImport, insertViaGritQL, GRIT_INSERT_PLACEHOLDER } =
-    await import('../utils/ast');
+    await import('../utils/ast.js');
 
   if (!(await hasDependenciesBlock(tree))) {
     return;
@@ -593,7 +593,7 @@ export const writeLicenseConfig = async (
   tree: Tree,
   source: LicenseSourceConfig,
 ) => {
-  const { captureGritQL } = await import('../utils/ast');
+  const { captureGritQL } = await import('../utils/ast.js');
 
   // Capture the existing `dependencies: { ... }` block before overwriting the
   // license value, so we can re-attach it afterwards. It's managed by the

--- a/packages/nx-plugin/src/license/dependency-check/check.spec.ts
+++ b/packages/nx-plugin/src/license/dependency-check/check.spec.ts
@@ -6,8 +6,8 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { formatReport, runCheck } from './check';
-import type { AllowlistEntry } from './types';
+import { formatReport, runCheck } from './check.js';
+import type { AllowlistEntry } from './types.js';
 
 const allow: AllowlistEntry[] = [
   { spdxId: 'MIT', fullName: 'MIT License', aliases: [] },

--- a/packages/nx-plugin/src/license/dependency-check/check.ts
+++ b/packages/nx-plugin/src/license/dependency-check/check.ts
@@ -3,18 +3,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { AWS_NX_PLUGIN_CONFIG_FILE_NAME } from '../../utils/config/utils';
+import { AWS_NX_PLUGIN_CONFIG_FILE_NAME } from '../../utils/config/utils.js';
 import {
   DEFAULT_COLLECTORS,
   type LicenseCollector,
-} from './collectors/collector';
-import { createEvaluator } from './evaluator';
+} from './collectors/collector.js';
+import { createEvaluator } from './evaluator.js';
 import type {
   CheckedDependency,
   CheckResult,
   DependencyCheckConfig,
   DependencyCheckException,
-} from './types';
+} from './types.js';
 
 export interface RunCheckOptions {
   projectRoot: string;

--- a/packages/nx-plugin/src/license/dependency-check/collectors/collector.ts
+++ b/packages/nx-plugin/src/license/dependency-check/collectors/collector.ts
@@ -33,7 +33,7 @@ export const npmCollector = (): LicenseCollector => ({
     return 'pnpm why <package>';
   },
   async collect({ workspaceRoot }) {
-    const { collectNpmDependencies } = await import('./npm-collector');
+    const { collectNpmDependencies } = await import('./npm-collector.js');
     return (await collectNpmDependencies({ start: workspaceRoot })).map(
       (d) => ({ ...d, ecosystem: 'npm' }),
     );
@@ -44,8 +44,10 @@ export const pythonCollector = (): LicenseCollector => ({
   name: 'python',
   traceCommand: 'uv tree --invert --package <package>',
   async collect({ workspaceRoot }) {
-    const { collectPythonDependencies } = await import('./python-collector');
-    const { findWorkspacePyProjectNames } = await import('./python-collector');
+    const { collectPythonDependencies } = await import('./python-collector.js');
+    const { findWorkspacePyProjectNames } = await import(
+      './python-collector.js'
+    );
     const excludePackages = await findWorkspacePyProjectNames(workspaceRoot);
     return (
       await collectPythonDependencies({ start: workspaceRoot, excludePackages })

--- a/packages/nx-plugin/src/license/dependency-check/collectors/python-collector.spec.ts
+++ b/packages/nx-plugin/src/license/dependency-check/collectors/python-collector.spec.ts
@@ -15,7 +15,7 @@ vi.mock('child_process', () => ({
 
 // Import after mock is set up
 const { collectPythonDependencies, findWorkspacePyProjectNames } = await import(
-  './python-collector'
+  './python-collector.js'
 );
 
 describe('python collector', () => {

--- a/packages/nx-plugin/src/license/dependency-check/collectors/python-collector.ts
+++ b/packages/nx-plugin/src/license/dependency-check/collectors/python-collector.ts
@@ -8,7 +8,7 @@ import { execSync } from 'child_process';
 import fastGlob from 'fast-glob';
 import { existsSync, readFileSync } from 'fs';
 import { join } from 'path';
-import { uvxCommand } from '../../../utils/py';
+import { uvxCommand } from '../../../utils/py.js';
 
 export interface PythonDependency {
   name: string;

--- a/packages/nx-plugin/src/license/dependency-check/evaluator.spec.ts
+++ b/packages/nx-plugin/src/license/dependency-check/evaluator.spec.ts
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { describe, expect, it } from 'vitest';
-import { createEvaluator } from './evaluator';
-import type { AllowlistEntry } from './types';
+import { createEvaluator } from './evaluator.js';
+import type { AllowlistEntry } from './types.js';
 
 const allow: AllowlistEntry[] = [
   { spdxId: 'MIT', fullName: 'MIT License', aliases: ['MIT License'] },

--- a/packages/nx-plugin/src/license/dependency-check/evaluator.ts
+++ b/packages/nx-plugin/src/license/dependency-check/evaluator.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import spdxSatisfies from 'spdx-satisfies';
-import type { AllowlistEntry, LicenseStatus } from './types';
+import type { AllowlistEntry, LicenseStatus } from './types.js';
 
 export interface EvaluatorOptions {
   allow: AllowlistEntry[];

--- a/packages/nx-plugin/src/license/dependency-check/executor.ts
+++ b/packages/nx-plugin/src/license/dependency-check/executor.ts
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { type ExecutorContext, workspaceRoot } from '@nx/devkit';
-import { readAwsNxPluginConfigFromDisk } from '../../utils/config/utils';
-import { formatReport, runCheck } from './check';
-import { type LicenseCollector, npmCollector } from './collectors/collector';
-import type { DependencyCheckConfig } from './types';
+import { readAwsNxPluginConfigFromDisk } from '../../utils/config/utils.js';
+import { formatReport, runCheck } from './check.js';
+import { type LicenseCollector, npmCollector } from './collectors/collector.js';
+import type { DependencyCheckConfig } from './types.js';
 
 export type LicenseCheckExecutorSchema = Record<string, never>;
 

--- a/packages/nx-plugin/src/license/dependency-check/pre-approved.ts
+++ b/packages/nx-plugin/src/license/dependency-check/pre-approved.ts
@@ -2,7 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import type { AllowlistEntry } from './types';
+import type { AllowlistEntry } from './types.js';
 
 export const PRE_APPROVED_LICENSES: AllowlistEntry[] = [
   {

--- a/packages/nx-plugin/src/license/dependency-check/types.ts
+++ b/packages/nx-plugin/src/license/dependency-check/types.ts
@@ -19,7 +19,7 @@ export interface DependencyCheckException {
 export interface DependencyCheckConfig {
   allow: AllowlistEntry[];
   exceptions?: DependencyCheckException[];
-  collectors?: import('./collectors/collector').LicenseCollector[];
+  collectors?: import('./collectors/collector.js').LicenseCollector[];
   /**
    * Called once for every discovered dependency, with its package name and the
    * SPDX license expression resolved for it (an exception's `spdx` takes

--- a/packages/nx-plugin/src/license/generator.spec.ts
+++ b/packages/nx-plugin/src/license/generator.spec.ts
@@ -8,17 +8,17 @@ import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import {
   AWS_NX_PLUGIN_CONFIG_FILE_NAME,
   readAwsNxPluginConfig,
-} from '../utils/config/utils';
-import { declareDependencies } from '../utils/declared-dependencies';
-import { expectHasMetricTags } from '../utils/metrics.spec';
+} from '../utils/config/utils.js';
+import { declareDependencies } from '../utils/declared-dependencies.js';
+import { expectHasMetricTags } from '../utils/metrics.spec.js';
 import {
   SHARED_CONSTRUCTS_DEPENDENCIES,
   sharedConstructsGenerator,
-} from '../utils/shared-constructs';
-import { createTreeUsingTsSolutionSetup } from '../utils/test';
-import { LICENSE_GENERATOR_INFO, licenseGenerator } from './generator';
+} from '../utils/shared-constructs.js';
+import { createTreeUsingTsSolutionSetup } from '../utils/test.js';
+import { LICENSE_GENERATOR_INFO, licenseGenerator } from './generator.js';
 import type { LicenseGeneratorSchema } from './schema';
-import { SYNC_GENERATOR_NAME } from './sync/generator';
+import { SYNC_GENERATOR_NAME } from './sync/generator.js';
 
 const sharedConstructsDeclaration = declareDependencies()({
   ts: [...SHARED_CONSTRUCTS_DEPENDENCIES],
@@ -345,7 +345,7 @@ describe('license generator', () => {
     });
 
     it('should add pythonCollector when py#project runs after license generator', async () => {
-      const { ensurePythonLicenseCollector } = await import('./config');
+      const { ensurePythonLicenseCollector } = await import('./config.js');
 
       tree.write('pnpm-lock.yaml', '');
       await licenseGenerator(tree, options);
@@ -370,8 +370,10 @@ describe('license generator', () => {
 
     it('should be no-op when ensure functions run before license generator', async () => {
       const { ensurePythonLicenseCollector, ensureLicenseExceptions } =
-        await import('./config');
-      const { AG_UI_LANGGRAPH_EXCEPTIONS } = await import('./known-exceptions');
+        await import('./config.js');
+      const { AG_UI_LANGGRAPH_EXCEPTIONS } = await import(
+        './known-exceptions.js'
+      );
 
       await ensurePythonLicenseCollector(tree);
       await ensureLicenseExceptions(tree, AG_UI_LANGGRAPH_EXCEPTIONS);

--- a/packages/nx-plugin/src/license/generator.ts
+++ b/packages/nx-plugin/src/license/generator.ts
@@ -3,15 +3,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { getProjects, readNxJson, type Tree, updateNxJson } from '@nx/devkit';
-import { PY_AGENT_GENERATOR_INFO } from '../py/agent/generator';
-import { ensureAwsNxPluginConfig } from '../utils/config/utils';
-import { formatFilesInSubtree } from '../utils/format';
-import { addGeneratorMetricsIfApplicable } from '../utils/metrics';
+import { PY_AGENT_GENERATOR_INFO } from '../py/agent/generator.js';
+import { ensureAwsNxPluginConfig } from '../utils/config/utils.js';
+import { formatFilesInSubtree } from '../utils/format.js';
+import { addGeneratorMetricsIfApplicable } from '../utils/metrics.js';
 import {
   getGeneratorInfo,
   mergeTargetDefault,
   type NxGeneratorInfo,
-} from '../utils/nx';
+} from '../utils/nx.js';
 import {
   addLicenseCheckToAllLintTargets,
   defaultLicenseConfig,
@@ -20,10 +20,10 @@ import {
   ensurePythonLicenseCollector,
   updateLicenseCheckTargetInputs,
   writeLicenseConfig,
-} from './config';
-import { AG_UI_LANGGRAPH_EXCEPTIONS } from './known-exceptions';
+} from './config.js';
+import { AG_UI_LANGGRAPH_EXCEPTIONS } from './known-exceptions.js';
 import type { LicenseGeneratorSchema } from './schema';
-import { SYNC_GENERATOR_NAME } from './sync/generator';
+import { SYNC_GENERATOR_NAME } from './sync/generator.js';
 
 export const LICENSE_GENERATOR_INFO: NxGeneratorInfo = getGeneratorInfo(
   import.meta.filename,

--- a/packages/nx-plugin/src/license/index.ts
+++ b/packages/nx-plugin/src/license/index.ts
@@ -6,14 +6,14 @@
 export type {
   CollectedDependency,
   LicenseCollector,
-} from './dependency-check/collectors/collector';
+} from './dependency-check/collectors/collector.js';
 export {
   npmCollector,
   pythonCollector,
-} from './dependency-check/collectors/collector';
-export { PRE_APPROVED_LICENSES as DEFAULT_LICENSE_ALLOWLIST } from './dependency-check/pre-approved';
+} from './dependency-check/collectors/collector.js';
+export { PRE_APPROVED_LICENSES as DEFAULT_LICENSE_ALLOWLIST } from './dependency-check/pre-approved.js';
 export type {
   AllowlistEntry,
   DependencyCheckConfig,
   DependencyCheckException,
-} from './dependency-check/types';
+} from './dependency-check/types.js';

--- a/packages/nx-plugin/src/license/known-exceptions.ts
+++ b/packages/nx-plugin/src/license/known-exceptions.ts
@@ -2,7 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import type { DependencyCheckException } from './dependency-check/types';
+import type { DependencyCheckException } from './dependency-check/types.js';
 
 export const AG_UI_LANGGRAPH_EXCEPTIONS: DependencyCheckException[] = [
   {

--- a/packages/nx-plugin/src/license/sync/generator.spec.ts
+++ b/packages/nx-plugin/src/license/sync/generator.spec.ts
@@ -11,11 +11,11 @@ import path from 'path';
 import {
   ensureAwsNxPluginConfig,
   updateAwsNxPluginConfig,
-} from '../../utils/config/utils';
-import { createTreeUsingTsSolutionSetup } from '../../utils/test';
-import { initTestGitRepo, useIsolatedGitEnv } from '../../utils/test-git';
-import type { LicenseSourceConfig } from '../config-types';
-import { licenseSyncGenerator } from './generator';
+} from '../../utils/config/utils.js';
+import { createTreeUsingTsSolutionSetup } from '../../utils/test.js';
+import { initTestGitRepo, useIsolatedGitEnv } from '../../utils/test-git.js';
+import type { LicenseSourceConfig } from '../config-types.js';
+import { licenseSyncGenerator } from './generator.js';
 
 describe('licenseSyncGenerator', () => {
   let tree: Tree;

--- a/packages/nx-plugin/src/license/sync/generator.ts
+++ b/packages/nx-plugin/src/license/sync/generator.ts
@@ -13,20 +13,20 @@ import { minimatch } from 'minimatch';
 import type { SyncGeneratorResult } from 'nx/src/utils/sync-generators';
 import { basename } from 'path';
 import PackageJson from '../../../package.json' with { type: 'json' };
-import { AWS_NX_PLUGIN_CONFIG_FILE_NAME } from '../../utils/config/utils';
-import { getGitIncludedFiles, isWithinGitRepo } from '../../utils/git';
-import { getGeneratorInfo } from '../../utils/nx';
-import { LANGUAGE_COMMENT_SYNTAX, readLicenseConfig } from '../config';
+import { AWS_NX_PLUGIN_CONFIG_FILE_NAME } from '../../utils/config/utils.js';
+import { getGitIncludedFiles, isWithinGitRepo } from '../../utils/git.js';
+import { getGeneratorInfo } from '../../utils/nx.js';
+import { LANGUAGE_COMMENT_SYNTAX, readLicenseConfig } from '../config.js';
 import type {
   CommentSyntax,
   LicenseHeaderConfig,
   LicenseHeaderFormat,
-} from '../config-types';
+} from '../config-types.js';
 import {
   PROJECT_FILES_TO_SYNC,
   type ProjectFileToSync,
   syncProjectFile,
-} from './project-file-sync';
+} from './project-file-sync.js';
 
 export const SYNC_GENERATOR_NAME = `${PackageJson.name}:${getGeneratorInfo(import.meta.filename).id}`;
 

--- a/packages/nx-plugin/src/license/sync/project-file-sync.ts
+++ b/packages/nx-plugin/src/license/sync/project-file-sync.ts
@@ -8,8 +8,8 @@ import {
   type Tree,
   updateJson,
 } from '@nx/devkit';
-import { updateToml } from '../../utils/toml';
-import type { LicenseSourceConfig } from '../config-types';
+import { updateToml } from '../../utils/toml.js';
+import type { LicenseSourceConfig } from '../config-types.js';
 
 /**
  * Different project files with licensing information to be synchronised

--- a/packages/nx-plugin/src/mcp-server/connection-guide-coverage.spec.ts
+++ b/packages/nx-plugin/src/mcp-server/connection-guide-coverage.spec.ts
@@ -5,12 +5,12 @@
 
 import { readdirSync } from 'fs';
 import { join } from 'path';
-import { SUPPORTED_CONNECTIONS } from '../connection/supported-connections';
-import { buildGeneratorInfoList } from '../utils/generators';
+import { SUPPORTED_CONNECTIONS } from '../connection/supported-connections.js';
+import { buildGeneratorInfoList } from '../utils/generators.js';
 import {
   fetchGuidePagesForGenerator,
   renderFilterableOptionsAsync,
-} from './generator-info';
+} from './generator-info.js';
 
 /**
  * `generator-guide` promises that a combination it accepts is one the

--- a/packages/nx-plugin/src/mcp-server/dev-server.ts
+++ b/packages/nx-plugin/src/mcp-server/dev-server.ts
@@ -2,7 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import { startMcpServer } from '.';
+import { startMcpServer } from './index.js';
 
 /**
  * Entry point for the `mcp-inspect` target, which runs the server from source

--- a/packages/nx-plugin/src/mcp-server/generator-info.spec.ts
+++ b/packages/nx-plugin/src/mcp-server/generator-info.spec.ts
@@ -4,12 +4,12 @@
  */
 
 import fs from 'fs';
-import type { NxGeneratorInfo } from '../utils/generators';
+import type { NxGeneratorInfo } from '../utils/generators.js';
 import {
   fetchGuidePagesForGenerator,
   postProcessGuide,
   renderFilterableOptionsAsync,
-} from './generator-info';
+} from './generator-info.js';
 
 describe('postProcessGuide', () => {
   const generators: NxGeneratorInfo[] = [

--- a/packages/nx-plugin/src/mcp-server/generator-info.ts
+++ b/packages/nx-plugin/src/mcp-server/generator-info.ts
@@ -5,23 +5,23 @@
 
 import fs from 'fs';
 import path from 'path';
-import type { NxGeneratorInfo } from '../utils/generators';
-import { kebabCase } from '../utils/names';
-import { parseMdx, postProcessGuideWithRemark } from './guide-pipeline';
+import type { NxGeneratorInfo } from '../utils/generators.js';
+import { kebabCase } from '../utils/names.js';
+import { parseMdx, postProcessGuideWithRemark } from './guide-pipeline.js';
 import {
   buildNxCommand,
   renderGeneratorCommand,
   renderSchema,
-} from './guide-render';
-import { collectFilterableKeysFromJsx, extractFrontmatter } from './mdx-ast';
-import { evaluatePredicate } from './option-filter';
+} from './guide-render.js';
+import { collectFilterableKeysFromJsx, extractFrontmatter } from './mdx-ast.js';
+import { evaluatePredicate } from './option-filter.js';
 import {
   filterableOptionsFromSchema,
   type GeneratorSchema,
-} from './schema-registry';
+} from './schema-registry.js';
 
 // Re-export so existing callers of `generator-info` continue working.
-export { buildNxCommand } from './guide-render';
+export { buildNxCommand } from './guide-render.js';
 
 /**
  * Render summary information about a generator
@@ -44,7 +44,7 @@ ${renderGeneratorCommand(info.id, schema, packageManager)}
 `;
 };
 
-export type FilterableOption = import('./schema-registry').FilterableOption;
+export type FilterableOption = import('./schema-registry.js').FilterableOption;
 
 /**
  * Enum properties from the generator's JSON schema — the options a user

--- a/packages/nx-plugin/src/mcp-server/guide-pipeline.ts
+++ b/packages/nx-plugin/src/mcp-server/guide-pipeline.ts
@@ -24,13 +24,13 @@ import {
   buildNxInitCommand,
   buildPackageManagerExecCommand,
   buildPackageManagerShortCommand,
-} from '../utils/commands';
-import type { NxGeneratorInfo } from '../utils/generators';
+} from '../utils/commands.js';
+import type { NxGeneratorInfo } from '../utils/generators.js';
 import {
   buildNxCommand,
   renderGeneratorCommand,
   renderSchema,
-} from './guide-render';
+} from './guide-render.js';
 import {
   hasBareAttr,
   isJsxElement,
@@ -39,14 +39,14 @@ import {
   readEstreeAttr,
   readExpressionAttr,
   readStringAttr,
-} from './mdx-ast';
+} from './mdx-ast.js';
 import {
   describePredicate,
   evaluatePredicate,
   extractStringArrayExpression,
   type Predicate,
   parseWhenExpression,
-} from './option-filter';
+} from './option-filter.js';
 
 export interface PipelineOptions {
   generators: NxGeneratorInfo[];

--- a/packages/nx-plugin/src/mcp-server/guide-render.ts
+++ b/packages/nx-plugin/src/mcp-server/guide-render.ts
@@ -9,7 +9,7 @@
  * `renderGeneratorInfo` for list-generators) and the pipeline both render
  * identical command strings without either re-implementing the other.
  */
-import { buildPackageManagerExecCommand } from '../utils/commands';
+import { buildPackageManagerExecCommand } from '../utils/commands.js';
 
 /**
  * Build an nx command, optionally prefixed by the package manager's exec

--- a/packages/nx-plugin/src/mcp-server/index.ts
+++ b/packages/nx-plugin/src/mcp-server/index.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import { createServer } from './server';
+import { createServer } from './server.js';
 
 export const startMcpServer = async () => {
   const transport = new StdioServerTransport();

--- a/packages/nx-plugin/src/mcp-server/mdx-ast.ts
+++ b/packages/nx-plugin/src/mcp-server/mdx-ast.ts
@@ -11,7 +11,7 @@ import type {
   MdxJsxFlowElement,
   MdxJsxTextElement,
 } from 'mdast-util-mdx-jsx';
-import { parseWhenExpression } from './option-filter';
+import { parseWhenExpression } from './option-filter.js';
 
 export type JsxParent = Root | MdxJsxFlowElement | MdxJsxTextElement;
 export type JsxElement = MdxJsxFlowElement | MdxJsxTextElement;

--- a/packages/nx-plugin/src/mcp-server/server.spec.ts
+++ b/packages/nx-plugin/src/mcp-server/server.spec.ts
@@ -8,7 +8,7 @@ import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import fs from 'fs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { createServer } from './server';
+import { createServer } from './server.js';
 
 describe('MCP Server', () => {
   let client: Client;

--- a/packages/nx-plugin/src/mcp-server/server.ts
+++ b/packages/nx-plugin/src/mcp-server/server.ts
@@ -4,16 +4,16 @@
  */
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import PackageJson from '../../package.json' with { type: 'json' };
-import { listGenerators } from '../utils/nx';
-import { addToExistingProjectTool } from './tools/add-to-existing-project';
-import { addCreateWorkspaceCommandTool } from './tools/create-workspace-command';
+import { listGenerators } from '../utils/nx.js';
+import { addToExistingProjectTool } from './tools/add-to-existing-project.js';
+import { addCreateWorkspaceCommandTool } from './tools/create-workspace-command.js';
 import {
   addGeneralGuidanceTool,
   TOOL_SELECTION_GUIDE,
-} from './tools/general-guidance';
-import { addGeneratorGuideTool } from './tools/generator-guide';
-import { addListGeneratorsTool } from './tools/list-generators';
-import { addUpgradeWorkspaceTool } from './tools/upgrade-workspace';
+} from './tools/general-guidance.js';
+import { addGeneratorGuideTool } from './tools/generator-guide.js';
+import { addListGeneratorsTool } from './tools/list-generators.js';
+import { addUpgradeWorkspaceTool } from './tools/upgrade-workspace.js';
 
 /**
  * Create the MCP Server

--- a/packages/nx-plugin/src/mcp-server/tools/add-to-existing-project.spec.ts
+++ b/packages/nx-plugin/src/mcp-server/tools/add-to-existing-project.spec.ts
@@ -6,7 +6,7 @@ import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { beforeEach, describe, expect, it } from 'vitest';
-import { addToExistingProjectTool } from './add-to-existing-project';
+import { addToExistingProjectTool } from './add-to-existing-project.js';
 
 describe('add-to-existing-project tool', () => {
   let client: Client;

--- a/packages/nx-plugin/src/mcp-server/tools/add-to-existing-project.ts
+++ b/packages/nx-plugin/src/mcp-server/tools/add-to-existing-project.ts
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import type { NxGeneratorInfo } from '../../utils/generators';
-import { fetchGuidePages } from '../generator-info';
-import { PackageManagerSchema } from '../schema';
+import type { NxGeneratorInfo } from '../../utils/generators.js';
+import { fetchGuidePages } from '../generator-info.js';
+import { PackageManagerSchema } from '../schema.js';
 
 /**
  * The guide page (under `get_started/`) that backs this tool, so the tool and

--- a/packages/nx-plugin/src/mcp-server/tools/create-workspace-command.ts
+++ b/packages/nx-plugin/src/mcp-server/tools/create-workspace-command.ts
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { buildCreateNxWorkspaceCommand } from '../../utils/commands';
-import { IAC_PROVIDERS } from '../../utils/iac-providers';
-import { PackageManagerSchema } from '../schema';
+import { buildCreateNxWorkspaceCommand } from '../../utils/commands.js';
+import { IAC_PROVIDERS } from '../../utils/iac-providers.js';
+import { PackageManagerSchema } from '../schema.js';
 
 /**
  * Add a tool which tells a model how to create an Nx workspace

--- a/packages/nx-plugin/src/mcp-server/tools/general-guidance.ts
+++ b/packages/nx-plugin/src/mcp-server/tools/general-guidance.ts
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import type { NxGeneratorInfo } from '../../utils/generators';
-import { IAC_PROVIDERS } from '../../utils/iac-providers';
-import { buildNxCommand, fetchGuidePages } from '../generator-info';
-import { PACKAGE_MANAGERS } from '../schema';
+import type { NxGeneratorInfo } from '../../utils/generators.js';
+import { IAC_PROVIDERS } from '../../utils/iac-providers.js';
+import { buildNxCommand, fetchGuidePages } from '../generator-info.js';
+import { PACKAGE_MANAGERS } from '../schema.js';
 
 export const TOOL_SELECTION_GUIDE = `## Tool Selection Guide
 

--- a/packages/nx-plugin/src/mcp-server/tools/generator-guide.ts
+++ b/packages/nx-plugin/src/mcp-server/tools/generator-guide.ts
@@ -4,12 +4,12 @@
  */
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
-import type { NxGeneratorInfo } from '../../utils/generators';
+import type { NxGeneratorInfo } from '../../utils/generators.js';
 import {
   fetchGuidePagesForGenerator,
   renderGeneratorInfo,
-} from '../generator-info';
-import { PackageManagerSchema } from '../schema';
+} from '../generator-info.js';
+import { PackageManagerSchema } from '../schema.js';
 
 /**
  * Add a tool which provides a detailed guide for an individual generator.

--- a/packages/nx-plugin/src/mcp-server/tools/list-generators.ts
+++ b/packages/nx-plugin/src/mcp-server/tools/list-generators.ts
@@ -3,12 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import type { NxGeneratorInfo } from '../../utils/generators';
+import type { NxGeneratorInfo } from '../../utils/generators.js';
 import {
   renderFilterableOptionsAsync,
   renderGeneratorInfo,
-} from '../generator-info';
-import { PackageManagerSchema } from '../schema';
+} from '../generator-info.js';
+import { PackageManagerSchema } from '../schema.js';
 
 /**
  * Adds a tool which lists details about the available generators.

--- a/packages/nx-plugin/src/mcp-server/tools/upgrade-workspace.spec.ts
+++ b/packages/nx-plugin/src/mcp-server/tools/upgrade-workspace.spec.ts
@@ -6,7 +6,7 @@ import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { beforeEach, describe, expect, it } from 'vitest';
-import { addUpgradeWorkspaceTool } from './upgrade-workspace';
+import { addUpgradeWorkspaceTool } from './upgrade-workspace.js';
 
 describe('upgrade-workspace tool', () => {
   let client: Client;

--- a/packages/nx-plugin/src/mcp-server/tools/upgrade-workspace.ts
+++ b/packages/nx-plugin/src/mcp-server/tools/upgrade-workspace.ts
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import type { NxGeneratorInfo } from '../../utils/generators';
-import { fetchGuidePages } from '../generator-info';
-import { PackageManagerSchema } from '../schema';
+import type { NxGeneratorInfo } from '../../utils/generators.js';
+import { fetchGuidePages } from '../generator-info.js';
+import { PackageManagerSchema } from '../schema.js';
 
 /** The guide page backing this tool, so it never drifts from the docs. */
 const UPGRADING_GUIDE = 'upgrading';

--- a/packages/nx-plugin/src/migrations/latest/apt-security-updates-in-container-images/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/latest/apt-security-updates-in-container-images/migration.spec.ts
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { addProjectConfiguration, type Tree } from '@nx/devkit';
-import { createTreeUsingTsSolutionSetup } from '../../../utils/test';
-import migration from './migration';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test.js';
+import migration from './migration.js';
 
 const PY_PROJECT_ROOT = 'packages/py-project/proj_py_project';
 const TS_PROJECT_ROOT = 'packages/ts-project';

--- a/packages/nx-plugin/src/migrations/latest/apt-security-updates-in-container-images/migration.ts
+++ b/packages/nx-plugin/src/migrations/latest/apt-security-updates-in-container-images/migration.ts
@@ -9,8 +9,8 @@ import {
   type ProjectConfiguration,
   type Tree,
 } from '@nx/devkit';
-import { formatFilesInSubtree } from '../../../utils/format';
-import type { ComponentMetadata } from '../../../utils/nx';
+import { formatFilesInSubtree } from '../../../utils/format.js';
+import type { ComponentMetadata } from '../../../utils/nx.js';
 
 /**
  * Apply the distribution's security updates in the vended agent / MCP server

--- a/packages/nx-plugin/src/migrations/latest/dynamodb-configurable-encryption/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/latest/dynamodb-configurable-encryption/migration.spec.ts
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { Tree } from '@nx/devkit';
-import { createTreeUsingTsSolutionSetup } from '../../../utils/test';
-import migration from './migration';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test.js';
+import migration from './migration.js';
 
 const CDK_DYNAMODB_FILE = 'packages/common/constructs/src/core/dynamodb.ts';
 const TF_DYNAMODB_FILE =

--- a/packages/nx-plugin/src/migrations/latest/dynamodb-configurable-encryption/migration.ts
+++ b/packages/nx-plugin/src/migrations/latest/dynamodb-configurable-encryption/migration.ts
@@ -13,13 +13,13 @@ import {
   GRIT_INSERT_PLACEHOLDER,
   insertViaGritQL,
   matchGritQL,
-} from '../../../utils/ast';
-import { formatFilesInSubtree } from '../../../utils/format';
+} from '../../../utils/ast.js';
+import { formatFilesInSubtree } from '../../../utils/format.js';
 import {
   PACKAGES_DIR,
   SHARED_CONSTRUCTS_DIR,
   SHARED_TERRAFORM_DIR,
-} from '../../../utils/shared-constructs-constants';
+} from '../../../utils/shared-constructs-constants.js';
 
 /**
  * Bring existing workspaces up to the generators' current DynamoDBTable

--- a/packages/nx-plugin/src/migrations/latest/py-agent-ag-ui-hooks/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/latest/py-agent-ag-ui-hooks/migration.spec.ts
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { addProjectConfiguration, type Tree } from '@nx/devkit';
-import { PY_AGENT_GENERATOR_INFO } from '../../../py/agent/generator';
-import { createTreeUsingTsSolutionSetup } from '../../../utils/test';
-import migration from './migration';
+import { PY_AGENT_GENERATOR_INFO } from '../../../py/agent/generator.js';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test.js';
+import migration from './migration.js';
 
 const PROJECT_ROOT = 'apps/test-project';
 const AGENT_DIR = `${PROJECT_ROOT}/proj_test_project/agent`;

--- a/packages/nx-plugin/src/migrations/latest/py-agent-ag-ui-hooks/migration.ts
+++ b/packages/nx-plugin/src/migrations/latest/py-agent-ag-ui-hooks/migration.ts
@@ -8,7 +8,7 @@ import {
   type MigrationReturnObject,
   type Tree,
 } from '@nx/devkit';
-import { PY_AGENT_GENERATOR_INFO } from '../../../py/agent/generator';
+import { PY_AGENT_GENERATOR_INFO } from '../../../py/agent/generator.js';
 import {
   addPythonDestructuredImport,
   applyGritQL,
@@ -16,9 +16,9 @@ import {
   GRIT_INSERT_PLACEHOLDER,
   insertViaGritQL,
   matchGritQL,
-} from '../../../utils/ast';
-import { formatFilesInSubtree } from '../../../utils/format';
-import type { ComponentMetadata } from '../../../utils/nx';
+} from '../../../utils/ast.js';
+import { formatFilesInSubtree } from '../../../utils/format.js';
+import type { ComponentMetadata } from '../../../utils/nx.js';
 
 /**
  * Forward a Strands py#agent's hooks to the AG-UI adapter.

--- a/packages/nx-plugin/src/migrations/latest/py-agent-session-id-middleware-extraction/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/latest/py-agent-session-id-middleware-extraction/migration.spec.ts
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { addProjectConfiguration, type Tree } from '@nx/devkit';
-import { PY_AGENT_GENERATOR_INFO } from '../../../py/agent/generator';
-import { createTreeUsingTsSolutionSetup } from '../../../utils/test';
-import migration from './migration';
+import { PY_AGENT_GENERATOR_INFO } from '../../../py/agent/generator.js';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test.js';
+import migration from './migration.js';
 
 const PROJECT_ROOT = 'apps/test-project';
 const AGENT_DIR = `${PROJECT_ROOT}/proj_test_project/agent`;

--- a/packages/nx-plugin/src/migrations/latest/py-agent-session-id-middleware-extraction/migration.ts
+++ b/packages/nx-plugin/src/migrations/latest/py-agent-session-id-middleware-extraction/migration.ts
@@ -10,15 +10,15 @@ import {
   type MigrationReturnObject,
   type Tree,
 } from '@nx/devkit';
-import { PY_AGENT_GENERATOR_INFO } from '../../../py/agent/generator';
+import { PY_AGENT_GENERATOR_INFO } from '../../../py/agent/generator.js';
 import {
   addPythonDestructuredImport,
   applyGritQL,
   captureGritQLVariable,
   matchGritQL,
-} from '../../../utils/ast';
-import { formatFilesInSubtree } from '../../../utils/format';
-import type { ComponentMetadata } from '../../../utils/nx';
+} from '../../../utils/ast.js';
+import { formatFilesInSubtree } from '../../../utils/format.js';
+import type { ComponentMetadata } from '../../../utils/nx.js';
 
 /**
  * Extract the `_SessionIdMiddleware` class - previously duplicated verbatim

--- a/packages/nx-plugin/src/migrations/latest/remove-mcp-inspector-license-exceptions/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/latest/remove-mcp-inspector-license-exceptions/migration.spec.ts
@@ -5,9 +5,9 @@
 import { type Tree, updateJson } from '@nx/devkit';
 import yaml from 'js-yaml';
 import { beforeEach, describe, expect, it } from 'vitest';
-import { AWS_NX_PLUGIN_CONFIG_FILE_NAME } from '../../../utils/config/utils';
-import { createTreeUsingTsSolutionSetup } from '../../../utils/test';
-import migration from './migration';
+import { AWS_NX_PLUGIN_CONFIG_FILE_NAME } from '../../../utils/config/utils.js';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test.js';
+import migration from './migration.js';
 
 describe('remove mcp inspector license exceptions migration', () => {
   let tree: Tree;

--- a/packages/nx-plugin/src/migrations/latest/remove-mcp-inspector-license-exceptions/migration.ts
+++ b/packages/nx-plugin/src/migrations/latest/remove-mcp-inspector-license-exceptions/migration.ts
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { readJson, type Tree } from '@nx/devkit';
-import { removeLicenseExceptions } from '../../../license/config';
-import { registerPnpmBuiltDependencies } from '../../../utils/pnpm-workspace';
+import { removeLicenseExceptions } from '../../../license/config.js';
+import { registerPnpmBuiltDependencies } from '../../../utils/pnpm-workspace.js';
 
 const INSPECTOR = '@modelcontextprotocol/inspector';
 

--- a/packages/nx-plugin/src/migrations/latest/static-website-configurable-waf-encryption/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/latest/static-website-configurable-waf-encryption/migration.spec.ts
@@ -4,8 +4,8 @@
  */
 import type { Tree } from '@nx/devkit';
 import { joinPathFragments } from '@nx/devkit';
-import { createTreeUsingTsSolutionSetup } from '../../../utils/test';
-import migration from './migration';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test.js';
+import migration from './migration.js';
 
 const CDK_FILE = 'packages/common/constructs/src/core/static-website.ts';
 const APP_DIR = 'packages/common/constructs/src/app/static-websites';

--- a/packages/nx-plugin/src/migrations/latest/static-website-configurable-waf-encryption/migration.ts
+++ b/packages/nx-plugin/src/migrations/latest/static-website-configurable-waf-encryption/migration.ts
@@ -14,13 +14,13 @@ import {
   GRIT_INSERT_PLACEHOLDER,
   insertViaGritQL,
   matchGritQL,
-} from '../../../utils/ast';
-import { formatFilesInSubtree } from '../../../utils/format';
+} from '../../../utils/ast.js';
+import { formatFilesInSubtree } from '../../../utils/format.js';
 import {
   PACKAGES_DIR,
   SHARED_CONSTRUCTS_DIR,
   SHARED_TERRAFORM_DIR,
-} from '../../../utils/shared-constructs-constants';
+} from '../../../utils/shared-constructs-constants.js';
 
 /**
  * Bring existing workspaces up to the generators' current StaticWebsite

--- a/packages/nx-plugin/src/migrations/latest/ts-agent-session-id-middleware-extraction/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/latest/ts-agent-session-id-middleware-extraction/migration.spec.ts
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { addProjectConfiguration, type Tree } from '@nx/devkit';
-import { TS_AGENT_GENERATOR_INFO } from '../../../ts/agent/generator';
-import { createTreeUsingTsSolutionSetup } from '../../../utils/test';
-import migration from './migration';
+import { TS_AGENT_GENERATOR_INFO } from '../../../ts/agent/generator.js';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test.js';
+import migration from './migration.js';
 
 const registerAgentProject = (
   tree: Tree,

--- a/packages/nx-plugin/src/migrations/latest/ts-agent-session-id-middleware-extraction/migration.ts
+++ b/packages/nx-plugin/src/migrations/latest/ts-agent-session-id-middleware-extraction/migration.ts
@@ -10,15 +10,15 @@ import {
   type MigrationReturnObject,
   type Tree,
 } from '@nx/devkit';
-import { TS_AGENT_GENERATOR_INFO } from '../../../ts/agent/generator';
+import { TS_AGENT_GENERATOR_INFO } from '../../../ts/agent/generator.js';
 import {
   addDestructuredImport,
   applyGritQL,
   captureGritQLVariable,
   matchGritQL,
-} from '../../../utils/ast';
-import { formatFilesInSubtree } from '../../../utils/format';
-import type { ComponentMetadata } from '../../../utils/nx';
+} from '../../../utils/ast.js';
+import { formatFilesInSubtree } from '../../../utils/format.js';
+import type { ComponentMetadata } from '../../../utils/nx.js';
 
 /**
  * Extract the inline session-id Express middleware - previously duplicated

--- a/packages/nx-plugin/src/migrations/latest/user-identity-configurable-mfa/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/latest/user-identity-configurable-mfa/migration.spec.ts
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { Tree } from '@nx/devkit';
-import { createTreeUsingTsSolutionSetup } from '../../../utils/test';
-import migration from './migration';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test.js';
+import migration from './migration.js';
 
 const CDK_FILE = 'packages/common/constructs/src/core/user-identity.ts';
 const TERRAFORM_IDENTITY_FILE =

--- a/packages/nx-plugin/src/migrations/latest/user-identity-configurable-mfa/migration.ts
+++ b/packages/nx-plugin/src/migrations/latest/user-identity-configurable-mfa/migration.ts
@@ -7,13 +7,13 @@ import {
   addDestructuredImport,
   applyGritQL,
   matchGritQL,
-} from '../../../utils/ast';
-import { formatFilesInSubtree } from '../../../utils/format';
+} from '../../../utils/ast.js';
+import { formatFilesInSubtree } from '../../../utils/format.js';
 import {
   PACKAGES_DIR,
   SHARED_CONSTRUCTS_DIR,
   SHARED_TERRAFORM_DIR,
-} from '../../../utils/shared-constructs-constants';
+} from '../../../utils/shared-constructs-constants.js';
 
 /**
  * Surface mfa and mfaSecondFactor on the vended UserIdentity construct/module

--- a/packages/nx-plugin/src/migrations/v1.0.0-rc.50/0001-modernize-function-props-cast/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/v1.0.0-rc.50/0001-modernize-function-props-cast/migration.spec.ts
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { Tree } from '@nx/devkit';
-import { createTreeUsingTsSolutionSetup } from '../../../utils/test';
-import migration from './migration';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test.js';
+import migration from './migration.js';
 
 const API_APP_FILE = 'packages/common/constructs/src/app/apis/test-api.ts';
 

--- a/packages/nx-plugin/src/migrations/v1.0.0-rc.50/0001-modernize-function-props-cast/migration.ts
+++ b/packages/nx-plugin/src/migrations/v1.0.0-rc.50/0001-modernize-function-props-cast/migration.ts
@@ -7,11 +7,11 @@ import {
   type Tree,
   visitNotIgnoredFiles,
 } from '@nx/devkit';
-import { formatFilesInSubtree } from '../../../utils/format';
+import { formatFilesInSubtree } from '../../../utils/format.js';
 import {
   PACKAGES_DIR,
   SHARED_CONSTRUCTS_DIR,
-} from '../../../utils/shared-constructs-constants';
+} from '../../../utils/shared-constructs-constants.js';
 
 /**
  * Replace the legacy angle-bracket FunctionProps type assertion with the modern as syntax in generated API constructs

--- a/packages/nx-plugin/src/migrations/v1.0.0-rc.50/0002-restrict-cors-to-custom-domains/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/v1.0.0-rc.50/0002-restrict-cors-to-custom-domains/migration.spec.ts
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { Tree } from '@nx/devkit';
-import { createTreeUsingTsSolutionSetup } from '../../../utils/test';
-import migration from './migration';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test.js';
+import migration from './migration.js';
 
 const CORE_INDEX = 'packages/common/constructs/src/core/index.ts';
 const CLOUDFRONT_CORE_FILE =

--- a/packages/nx-plugin/src/migrations/v1.0.0-rc.50/0002-restrict-cors-to-custom-domains/migration.ts
+++ b/packages/nx-plugin/src/migrations/v1.0.0-rc.50/0002-restrict-cors-to-custom-domains/migration.ts
@@ -11,13 +11,13 @@ import {
   addDestructuredImport,
   addStarExport,
   applyGritQL,
-} from '../../../utils/ast';
-import { formatFilesInSubtree } from '../../../utils/format';
-import { isEsmWorkspace } from '../../../utils/module-format';
+} from '../../../utils/ast.js';
+import { formatFilesInSubtree } from '../../../utils/format.js';
+import { isEsmWorkspace } from '../../../utils/module-format.js';
 import {
   PACKAGES_DIR,
   SHARED_CONSTRUCTS_DIR,
-} from '../../../utils/shared-constructs-constants';
+} from '../../../utils/shared-constructs-constants.js';
 
 /**
  * Include CloudFront custom domain aliases in restrictCorsTo and UserIdentity callback URLs

--- a/packages/nx-plugin/src/migrations/v1.0.0-rc.50/0003-terraform-bootstrap-adopt-existing-bucket/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/v1.0.0-rc.50/0003-terraform-bootstrap-adopt-existing-bucket/migration.spec.ts
@@ -5,9 +5,9 @@
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import type { Tree } from '@nx/devkit';
-import { terraformProjectGenerator } from '../../../terraform/project/generator';
-import { createTreeUsingTsSolutionSetup } from '../../../utils/test';
-import migration from './migration';
+import { terraformProjectGenerator } from '../../../terraform/project/generator.js';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test.js';
+import migration from './migration.js';
 
 const BOOTSTRAP_FILE = 'packages/infra/scripts/bootstrap.ts';
 

--- a/packages/nx-plugin/src/migrations/v1.0.0-rc.50/0003-terraform-bootstrap-adopt-existing-bucket/migration.ts
+++ b/packages/nx-plugin/src/migrations/v1.0.0-rc.50/0003-terraform-bootstrap-adopt-existing-bucket/migration.ts
@@ -8,14 +8,14 @@ import {
   type MigrationReturnObject,
   type Tree,
 } from '@nx/devkit';
-import { TERRAFORM_PROJECT_GENERATOR_INFO } from '../../../terraform/project/generator';
+import { TERRAFORM_PROJECT_GENERATOR_INFO } from '../../../terraform/project/generator.js';
 import {
   applyGritQL,
   GRIT_INSERT_PLACEHOLDER,
   insertViaGritQL,
   matchGritQL,
-} from '../../../utils/ast';
-import { formatFilesInSubtree } from '../../../utils/format';
+} from '../../../utils/ast.js';
+import { formatFilesInSubtree } from '../../../utils/format.js';
 
 /**
  * Adopt an existing Terraform state bucket in the vended bootstrap script when its state object is missing

--- a/packages/nx-plugin/src/migrations/v1.0.0-rc.52/0001-user-identity-waf-allow-localhost-callback/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/v1.0.0-rc.52/0001-user-identity-waf-allow-localhost-callback/migration.spec.ts
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { Tree } from '@nx/devkit';
-import { tsReactWebsiteGenerator } from '../../../ts/react-website/app/generator';
-import { tsWebsiteAuthGenerator } from '../../../ts/website/auth/generator';
-import { createTreeUsingTsSolutionSetup } from '../../../utils/test';
-import migration from './migration';
+import { tsReactWebsiteGenerator } from '../../../ts/react-website/app/generator.js';
+import { tsWebsiteAuthGenerator } from '../../../ts/website/auth/generator.js';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test.js';
+import migration from './migration.js';
 
 const CDK_FILE = 'packages/common/constructs/src/core/user-identity.ts';
 const TERRAFORM_FILE =

--- a/packages/nx-plugin/src/migrations/v1.0.0-rc.52/0001-user-identity-waf-allow-localhost-callback/migration.ts
+++ b/packages/nx-plugin/src/migrations/v1.0.0-rc.52/0001-user-identity-waf-allow-localhost-callback/migration.ts
@@ -3,13 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { MigrationReturnObject, Tree } from '@nx/devkit';
-import { applyGritQL, matchGritQL } from '../../../utils/ast';
-import { formatFilesInSubtree } from '../../../utils/format';
+import { applyGritQL, matchGritQL } from '../../../utils/ast.js';
+import { formatFilesInSubtree } from '../../../utils/format.js';
 import {
   PACKAGES_DIR,
   SHARED_CONSTRUCTS_DIR,
   SHARED_TERRAFORM_DIR,
-} from '../../../utils/shared-constructs-constants';
+} from '../../../utils/shared-constructs-constants.js';
 
 /**
  * Count the EC2MetaDataSSRF_QUERYARGUMENTS WAF rule on the UserIdentity Web ACL

--- a/packages/nx-plugin/src/migrations/v1.0.0-rc.54/0001-order-access-log-delivery-after-bucket-policy/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/v1.0.0-rc.54/0001-order-access-log-delivery-after-bucket-policy/migration.spec.ts
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { Tree } from '@nx/devkit';
-import { createTreeUsingTsSolutionSetup } from '../../../utils/test';
-import migration from './migration';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test.js';
+import migration from './migration.js';
 
 const STATIC_WEBSITE_FILE =
   'packages/common/constructs/src/core/static-website.ts';

--- a/packages/nx-plugin/src/migrations/v1.0.0-rc.54/0001-order-access-log-delivery-after-bucket-policy/migration.ts
+++ b/packages/nx-plugin/src/migrations/v1.0.0-rc.54/0001-order-access-log-delivery-after-bucket-policy/migration.ts
@@ -8,12 +8,12 @@ import {
   applyGritQL,
   captureGritQL,
   matchGritQL,
-} from '../../../utils/ast';
-import { formatFilesInSubtree } from '../../../utils/format';
+} from '../../../utils/ast.js';
+import { formatFilesInSubtree } from '../../../utils/format.js';
 import {
   PACKAGES_DIR,
   SHARED_CONSTRUCTS_DIR,
-} from '../../../utils/shared-constructs-constants';
+} from '../../../utils/shared-constructs-constants.js';
 
 /**
  * Order the S3 server access log delivery source after the bucket policy.

--- a/packages/nx-plugin/src/migrations/v1.0.0-rc.55/0001-backfill-generator-metadata/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/v1.0.0-rc.55/0001-backfill-generator-metadata/migration.spec.ts
@@ -11,9 +11,9 @@ import {
 } from '@nx/devkit';
 import { beforeEach, describe, expect, it } from 'vitest';
 import generatorsJson from '../../../../generators.json';
-import { DCR_PROXY_HANDLERS } from '../../../utils/dcr-proxy-constructs/dcr-proxy-constructs';
-import { createTreeUsingTsSolutionSetup } from '../../../utils/test';
-import migration, { CONNECTION_KINDS } from './migration';
+import { DCR_PROXY_HANDLERS } from '../../../utils/dcr-proxy-constructs/dcr-proxy-constructs.js';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test.js';
+import migration, { CONNECTION_KINDS } from './migration.js';
 
 /**
  * A workspace whose shared infrastructure project was generated with the given

--- a/packages/nx-plugin/src/migrations/v1.0.0-rc.55/0001-backfill-generator-metadata/migration.ts
+++ b/packages/nx-plugin/src/migrations/v1.0.0-rc.55/0001-backfill-generator-metadata/migration.ts
@@ -13,72 +13,72 @@ import {
   type Tree,
   updateProjectConfiguration,
 } from '@nx/devkit';
-import { AGENTCORE_GATEWAY_GATEWAY_CONNECTION_GENERATOR_INFO } from '../../../agentcore-gateway/gateway-connection/generator';
-import { AGENTCORE_GATEWAY_GENERATOR_INFO } from '../../../agentcore-gateway/generator';
-import { AGENTCORE_GATEWAY_MCP_CONNECTION_GENERATOR_INFO } from '../../../agentcore-gateway/mcp-connection/generator';
-import { PY_AGENT_A2A_CONNECTION_GENERATOR_INFO } from '../../../py/agent/a2a-connection/generator';
-import { PY_AGENT_GATEWAY_CONNECTION_GENERATOR_INFO } from '../../../py/agent/gateway-connection/generator';
-import { PY_AGENT_GENERATOR_INFO } from '../../../py/agent/generator';
-import { PY_AGENT_MCP_CONNECTION_GENERATOR_INFO } from '../../../py/agent/mcp-connection/generator';
-import { PY_AGENT_REACT_CONNECTION_GENERATOR_INFO } from '../../../py/agent/react-connection/generator';
-import { PY_DYNAMODB_AGENT_CONNECTION_GENERATOR_INFO } from '../../../py/dynamodb/agent-connection/generator';
-import { PY_DYNAMODB_FAST_API_CONNECTION_GENERATOR_INFO } from '../../../py/dynamodb/fast-api-connection/generator';
-import { PY_DYNAMODB_GENERATOR_INFO } from '../../../py/dynamodb/generator';
-import { PY_DYNAMODB_MCP_SERVER_CONNECTION_GENERATOR_INFO } from '../../../py/dynamodb/mcp-server-connection/generator';
-import { FAST_API_GENERATOR_INFO } from '../../../py/fast-api/generator';
-import { FAST_API_REACT_GENERATOR_INFO } from '../../../py/fast-api/react/generator';
-import { LAMBDA_FUNCTION_GENERATOR_INFO as PY_LAMBDA_FUNCTION_GENERATOR_INFO } from '../../../py/lambda-function/generator';
-import { PY_MCP_SERVER_GENERATOR_INFO } from '../../../py/mcp-server/generator';
-import { PY_RDB_AGENT_CONNECTION_GENERATOR_INFO } from '../../../py/rdb/agent-connection/generator';
-import { PY_RDB_FAST_API_CONNECTION_GENERATOR_INFO } from '../../../py/rdb/fast-api-connection/generator';
-import { PY_RDB_GENERATOR_INFO } from '../../../py/rdb/generator';
-import { PY_RDB_MCP_SERVER_CONNECTION_GENERATOR_INFO } from '../../../py/rdb/mcp-server-connection/generator';
-import { SMITHY_PROJECT_GENERATOR_INFO } from '../../../smithy/project/generator';
-import { SMITHY_REACT_CONNECTION_GENERATOR_INFO } from '../../../smithy/react-connection/generator';
-import { TS_SMITHY_API_GENERATOR_INFO } from '../../../smithy/ts/api/generator';
-import { TRPC_BACKEND_GENERATOR_INFO } from '../../../trpc/backend/generator';
-import { TRPC_REACT_GENERATOR_INFO } from '../../../trpc/react/generator';
-import { TS_AGENT_A2A_CONNECTION_GENERATOR_INFO } from '../../../ts/agent/a2a-connection/generator';
-import { TS_AGENT_GATEWAY_CONNECTION_GENERATOR_INFO } from '../../../ts/agent/gateway-connection/generator';
-import { TS_AGENT_GENERATOR_INFO } from '../../../ts/agent/generator';
-import { TS_AGENT_MCP_CONNECTION_GENERATOR_INFO } from '../../../ts/agent/mcp-connection/generator';
-import { TS_AGENT_REACT_CONNECTION_GENERATOR_INFO } from '../../../ts/agent/react-connection/generator';
-import { TS_DCR_PROXY_GENERATOR_INFO } from '../../../ts/dcr-proxy/generator';
-import { TS_DYNAMODB_AGENT_CONNECTION_GENERATOR_INFO } from '../../../ts/dynamodb/agent-connection/generator';
-import { TS_DYNAMODB_GENERATOR_INFO } from '../../../ts/dynamodb/generator';
-import { TS_DYNAMODB_MCP_SERVER_CONNECTION_GENERATOR_INFO } from '../../../ts/dynamodb/mcp-server-connection/generator';
-import { TS_DYNAMODB_SMITHY_CONNECTION_GENERATOR_INFO } from '../../../ts/dynamodb/smithy-connection/generator';
-import { TS_DYNAMODB_TRPC_CONNECTION_GENERATOR_INFO } from '../../../ts/dynamodb/trpc-connection/generator';
-import { TS_LAMBDA_FUNCTION_GENERATOR_INFO } from '../../../ts/lambda-function/generator';
-import { TS_LIB_GENERATOR_INFO } from '../../../ts/lib/generator';
-import { TS_MCP_SERVER_GENERATOR_INFO } from '../../../ts/mcp-server/generator';
-import { TS_RDB_AGENT_CONNECTION_GENERATOR_INFO } from '../../../ts/rdb/agent-connection/generator';
-import { TS_RDB_GENERATOR_INFO } from '../../../ts/rdb/generator';
-import { TS_RDB_MCP_SERVER_CONNECTION_GENERATOR_INFO } from '../../../ts/rdb/mcp-server-connection/generator';
-import { TS_RDB_SMITHY_CONNECTION_GENERATOR_INFO } from '../../../ts/rdb/smithy-connection/generator';
-import { TS_RDB_TRPC_CONNECTION_GENERATOR_INFO } from '../../../ts/rdb/trpc-connection/generator';
-import { REACT_WEBSITE_APP_GENERATOR_INFO } from '../../../ts/react-website/app/generator';
-import { COGNITO_AUTH_GENERATOR_INFO } from '../../../ts/react-website/cognito-auth/generator';
+import { AGENTCORE_GATEWAY_GATEWAY_CONNECTION_GENERATOR_INFO } from '../../../agentcore-gateway/gateway-connection/generator.js';
+import { AGENTCORE_GATEWAY_GENERATOR_INFO } from '../../../agentcore-gateway/generator.js';
+import { AGENTCORE_GATEWAY_MCP_CONNECTION_GENERATOR_INFO } from '../../../agentcore-gateway/mcp-connection/generator.js';
+import { PY_AGENT_A2A_CONNECTION_GENERATOR_INFO } from '../../../py/agent/a2a-connection/generator.js';
+import { PY_AGENT_GATEWAY_CONNECTION_GENERATOR_INFO } from '../../../py/agent/gateway-connection/generator.js';
+import { PY_AGENT_GENERATOR_INFO } from '../../../py/agent/generator.js';
+import { PY_AGENT_MCP_CONNECTION_GENERATOR_INFO } from '../../../py/agent/mcp-connection/generator.js';
+import { PY_AGENT_REACT_CONNECTION_GENERATOR_INFO } from '../../../py/agent/react-connection/generator.js';
+import { PY_DYNAMODB_AGENT_CONNECTION_GENERATOR_INFO } from '../../../py/dynamodb/agent-connection/generator.js';
+import { PY_DYNAMODB_FAST_API_CONNECTION_GENERATOR_INFO } from '../../../py/dynamodb/fast-api-connection/generator.js';
+import { PY_DYNAMODB_GENERATOR_INFO } from '../../../py/dynamodb/generator.js';
+import { PY_DYNAMODB_MCP_SERVER_CONNECTION_GENERATOR_INFO } from '../../../py/dynamodb/mcp-server-connection/generator.js';
+import { FAST_API_GENERATOR_INFO } from '../../../py/fast-api/generator.js';
+import { FAST_API_REACT_GENERATOR_INFO } from '../../../py/fast-api/react/generator.js';
+import { LAMBDA_FUNCTION_GENERATOR_INFO as PY_LAMBDA_FUNCTION_GENERATOR_INFO } from '../../../py/lambda-function/generator.js';
+import { PY_MCP_SERVER_GENERATOR_INFO } from '../../../py/mcp-server/generator.js';
+import { PY_RDB_AGENT_CONNECTION_GENERATOR_INFO } from '../../../py/rdb/agent-connection/generator.js';
+import { PY_RDB_FAST_API_CONNECTION_GENERATOR_INFO } from '../../../py/rdb/fast-api-connection/generator.js';
+import { PY_RDB_GENERATOR_INFO } from '../../../py/rdb/generator.js';
+import { PY_RDB_MCP_SERVER_CONNECTION_GENERATOR_INFO } from '../../../py/rdb/mcp-server-connection/generator.js';
+import { SMITHY_PROJECT_GENERATOR_INFO } from '../../../smithy/project/generator.js';
+import { SMITHY_REACT_CONNECTION_GENERATOR_INFO } from '../../../smithy/react-connection/generator.js';
+import { TS_SMITHY_API_GENERATOR_INFO } from '../../../smithy/ts/api/generator.js';
+import { TRPC_BACKEND_GENERATOR_INFO } from '../../../trpc/backend/generator.js';
+import { TRPC_REACT_GENERATOR_INFO } from '../../../trpc/react/generator.js';
+import { TS_AGENT_A2A_CONNECTION_GENERATOR_INFO } from '../../../ts/agent/a2a-connection/generator.js';
+import { TS_AGENT_GATEWAY_CONNECTION_GENERATOR_INFO } from '../../../ts/agent/gateway-connection/generator.js';
+import { TS_AGENT_GENERATOR_INFO } from '../../../ts/agent/generator.js';
+import { TS_AGENT_MCP_CONNECTION_GENERATOR_INFO } from '../../../ts/agent/mcp-connection/generator.js';
+import { TS_AGENT_REACT_CONNECTION_GENERATOR_INFO } from '../../../ts/agent/react-connection/generator.js';
+import { TS_DCR_PROXY_GENERATOR_INFO } from '../../../ts/dcr-proxy/generator.js';
+import { TS_DYNAMODB_AGENT_CONNECTION_GENERATOR_INFO } from '../../../ts/dynamodb/agent-connection/generator.js';
+import { TS_DYNAMODB_GENERATOR_INFO } from '../../../ts/dynamodb/generator.js';
+import { TS_DYNAMODB_MCP_SERVER_CONNECTION_GENERATOR_INFO } from '../../../ts/dynamodb/mcp-server-connection/generator.js';
+import { TS_DYNAMODB_SMITHY_CONNECTION_GENERATOR_INFO } from '../../../ts/dynamodb/smithy-connection/generator.js';
+import { TS_DYNAMODB_TRPC_CONNECTION_GENERATOR_INFO } from '../../../ts/dynamodb/trpc-connection/generator.js';
+import { TS_LAMBDA_FUNCTION_GENERATOR_INFO } from '../../../ts/lambda-function/generator.js';
+import { TS_LIB_GENERATOR_INFO } from '../../../ts/lib/generator.js';
+import { TS_MCP_SERVER_GENERATOR_INFO } from '../../../ts/mcp-server/generator.js';
+import { TS_RDB_AGENT_CONNECTION_GENERATOR_INFO } from '../../../ts/rdb/agent-connection/generator.js';
+import { TS_RDB_GENERATOR_INFO } from '../../../ts/rdb/generator.js';
+import { TS_RDB_MCP_SERVER_CONNECTION_GENERATOR_INFO } from '../../../ts/rdb/mcp-server-connection/generator.js';
+import { TS_RDB_SMITHY_CONNECTION_GENERATOR_INFO } from '../../../ts/rdb/smithy-connection/generator.js';
+import { TS_RDB_TRPC_CONNECTION_GENERATOR_INFO } from '../../../ts/rdb/trpc-connection/generator.js';
+import { REACT_WEBSITE_APP_GENERATOR_INFO } from '../../../ts/react-website/app/generator.js';
+import { COGNITO_AUTH_GENERATOR_INFO } from '../../../ts/react-website/cognito-auth/generator.js';
 import {
   PY_CLIENT_NAMING,
   resolveAgentFramework,
-} from '../../../utils/agent-connection/agent-connection';
-import { matchGritQL } from '../../../utils/ast';
-import { DCR_PROXY_HANDLERS } from '../../../utils/dcr-proxy-constructs/dcr-proxy-constructs';
-import { formatFilesInSubtree } from '../../../utils/format';
+} from '../../../utils/agent-connection/agent-connection.js';
+import { matchGritQL } from '../../../utils/ast.js';
+import { DCR_PROXY_HANDLERS } from '../../../utils/dcr-proxy-constructs/dcr-proxy-constructs.js';
+import { formatFilesInSubtree } from '../../../utils/format.js';
 import {
   camelCase,
   kebabCase,
   pascalCase,
   toClassName,
   toSnakeCase,
-} from '../../../utils/names';
-import type { ComponentMetadata } from '../../../utils/nx';
+} from '../../../utils/names.js';
+import type { ComponentMetadata } from '../../../utils/nx.js';
 import {
   PACKAGES_DIR,
   SHARED_CONSTRUCTS_DIR,
   SHARED_TERRAFORM_DIR,
-} from '../../../utils/shared-constructs-constants';
+} from '../../../utils/shared-constructs-constants.js';
 
 /**
  * Backfill the project metadata the version sync reads.

--- a/packages/nx-plugin/src/migrations/v1.0.0-rc.56/0001-dynamodb-local-remove-optimize-flag/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/v1.0.0-rc.56/0001-dynamodb-local-remove-optimize-flag/migration.spec.ts
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { Tree } from '@nx/devkit';
-import { createTreeUsingTsSolutionSetup } from '../../../utils/test';
-import migration from './migration';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test.js';
+import migration from './migration.js';
 
 const START_CONTAINER_FILE =
   'packages/common/scripts/src/dynamodb/start-container.ts';

--- a/packages/nx-plugin/src/migrations/v1.0.0-rc.56/0001-dynamodb-local-remove-optimize-flag/migration.ts
+++ b/packages/nx-plugin/src/migrations/v1.0.0-rc.56/0001-dynamodb-local-remove-optimize-flag/migration.ts
@@ -3,12 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { MigrationReturnObject, Tree } from '@nx/devkit';
-import { applyGritQL } from '../../../utils/ast';
-import { formatFilesInSubtree } from '../../../utils/format';
+import { applyGritQL } from '../../../utils/ast.js';
+import { formatFilesInSubtree } from '../../../utils/format.js';
 import {
   PACKAGES_DIR,
   SHARED_SCRIPTS_DIR,
-} from '../../../utils/shared-constructs-constants';
+} from '../../../utils/shared-constructs-constants.js';
 
 /**
  * Drop -optimizeDbBeforeStartup from the vended DynamoDB Local container script

--- a/packages/nx-plugin/src/migrations/v1.0.0-rc.57/0001-ts-agent-session-management-support/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/v1.0.0-rc.57/0001-ts-agent-session-management-support/migration.spec.ts
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { addProjectConfiguration, type Tree } from '@nx/devkit';
-import { TS_AGENT_GENERATOR_INFO } from '../../../ts/agent/generator';
-import { createTreeUsingTsSolutionSetup } from '../../../utils/test';
-import migration from './migration';
+import { TS_AGENT_GENERATOR_INFO } from '../../../ts/agent/generator.js';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test.js';
+import migration from './migration.js';
 
 // Registers a project with the ComponentMetadata the ts#agent generator
 // itself writes, since the migration now reads protocol/name from it rather

--- a/packages/nx-plugin/src/migrations/v1.0.0-rc.57/0001-ts-agent-session-management-support/migration.ts
+++ b/packages/nx-plugin/src/migrations/v1.0.0-rc.57/0001-ts-agent-session-management-support/migration.ts
@@ -10,21 +10,21 @@ import {
   type Tree,
   visitNotIgnoredFiles,
 } from '@nx/devkit';
-import { TS_AGENT_GENERATOR_INFO } from '../../../ts/agent/generator';
-import { AGENT_CONNECTION_PROJECT_DIR } from '../../../utils/agent-connection/agent-connection';
+import { TS_AGENT_GENERATOR_INFO } from '../../../ts/agent/generator.js';
+import { AGENT_CONNECTION_PROJECT_DIR } from '../../../utils/agent-connection/agent-connection.js';
 import {
   applyGritQL,
   captureGritQLVariable,
   matchGritQL,
-} from '../../../utils/ast';
-import { formatFilesInSubtree } from '../../../utils/format';
-import { isEsmWorkspace } from '../../../utils/module-format';
-import { kebabCase } from '../../../utils/names';
-import type { ComponentMetadata } from '../../../utils/nx';
+} from '../../../utils/ast.js';
+import { formatFilesInSubtree } from '../../../utils/format.js';
+import { isEsmWorkspace } from '../../../utils/module-format.js';
+import { kebabCase } from '../../../utils/names.js';
+import type { ComponentMetadata } from '../../../utils/nx.js';
 import {
   getRelativePathToRootByDirectory,
   toProjectRelativePath,
-} from '../../../utils/paths';
+} from '../../../utils/paths.js';
 
 /**
  * Add session management support to ts#agent.

--- a/packages/nx-plugin/src/migrations/v1.0.0-rc.58/0001-smithy-ssdk-bundle-pins/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/v1.0.0-rc.58/0001-smithy-ssdk-bundle-pins/migration.spec.ts
@@ -5,9 +5,9 @@
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { addProjectConfiguration, type Tree } from '@nx/devkit';
-import { smithyProjectGenerator } from '../../../smithy/project/generator';
-import { createTreeUsingTsSolutionSetup } from '../../../utils/test';
-import migration from './migration';
+import { smithyProjectGenerator } from '../../../smithy/project/generator.js';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test.js';
+import migration from './migration.js';
 
 const BUILD_DOCKERFILE = 'test-api/build.Dockerfile';
 

--- a/packages/nx-plugin/src/migrations/v1.0.0-rc.58/0001-smithy-ssdk-bundle-pins/migration.ts
+++ b/packages/nx-plugin/src/migrations/v1.0.0-rc.58/0001-smithy-ssdk-bundle-pins/migration.ts
@@ -8,10 +8,10 @@ import {
   type MigrationReturnObject,
   type Tree,
 } from '@nx/devkit';
-import { SMITHY_PROJECT_GENERATOR_INFO } from '../../../smithy/project/generator';
-import { applyGritQL } from '../../../utils/ast';
-import { formatFilesInSubtree } from '../../../utils/format';
-import { isVendedUpgrade } from '../../../utils/version-upgrade-migration/vended-upgrade';
+import { SMITHY_PROJECT_GENERATOR_INFO } from '../../../smithy/project/generator.js';
+import { applyGritQL } from '../../../utils/ast.js';
+import { formatFilesInSubtree } from '../../../utils/format.js';
+import { isVendedUpgrade } from '../../../utils/version-upgrade-migration/vended-upgrade.js';
 
 /**
  * Move a Smithy `build.Dockerfile` onto the SSDK bundle pins this release fixes.

--- a/packages/nx-plugin/src/migrations/v1.0.0-rc.59/0001-gateway-agent-targets/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/v1.0.0-rc.59/0001-gateway-agent-targets/migration.spec.ts
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { Tree } from '@nx/devkit';
-import { createTreeUsingTsSolutionSetup } from '../../../utils/test';
-import migration from './migration';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test.js';
+import migration from './migration.js';
 
 const GATEWAY_CONSTRUCT_FILE =
   'packages/common/constructs/src/core/agentcore-gateway/agentcore-gateway.ts';

--- a/packages/nx-plugin/src/migrations/v1.0.0-rc.59/0001-gateway-agent-targets/migration.ts
+++ b/packages/nx-plugin/src/migrations/v1.0.0-rc.59/0001-gateway-agent-targets/migration.ts
@@ -8,12 +8,12 @@ import {
   GRIT_INSERT_PLACEHOLDER,
   insertViaGritQL,
   matchGritQL,
-} from '../../../utils/ast';
-import { formatFilesInSubtree } from '../../../utils/format';
+} from '../../../utils/ast.js';
+import { formatFilesInSubtree } from '../../../utils/format.js';
 import {
   PACKAGES_DIR,
   SHARED_CONSTRUCTS_DIR,
-} from '../../../utils/shared-constructs-constants';
+} from '../../../utils/shared-constructs-constants.js';
 
 /**
  * Bring existing workspaces up to the generators' current gateway-target

--- a/packages/nx-plugin/src/migrations/v1.0.0-rc.60/0001-gateway-cognito-passthrough/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/v1.0.0-rc.60/0001-gateway-cognito-passthrough/migration.spec.ts
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { Tree } from '@nx/devkit';
-import { createTreeUsingTsSolutionSetup } from '../../../utils/test';
-import migration from './migration';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test.js';
+import migration from './migration.js';
 
 const GATEWAY_CONSTRUCT_FILE =
   'packages/common/constructs/src/core/agentcore-gateway/agentcore-gateway.ts';

--- a/packages/nx-plugin/src/migrations/v1.0.0-rc.60/0001-gateway-cognito-passthrough/migration.ts
+++ b/packages/nx-plugin/src/migrations/v1.0.0-rc.60/0001-gateway-cognito-passthrough/migration.ts
@@ -8,13 +8,13 @@ import {
   GRIT_INSERT_PLACEHOLDER,
   insertViaGritQL,
   matchGritQL,
-} from '../../../utils/ast';
-import { formatFilesInSubtree } from '../../../utils/format';
+} from '../../../utils/ast.js';
+import { formatFilesInSubtree } from '../../../utils/format.js';
 import {
   PACKAGES_DIR,
   SHARED_CONSTRUCTS_DIR,
   SHARED_TERRAFORM_DIR,
-} from '../../../utils/shared-constructs-constants';
+} from '../../../utils/shared-constructs-constants.js';
 
 /**
  * Bring existing workspaces up to the generators' current gateway->agent

--- a/packages/nx-plugin/src/migrations/v1.0.0-rc.60/0002-waf-log-group-removal/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/v1.0.0-rc.60/0002-waf-log-group-removal/migration.spec.ts
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { Tree } from '@nx/devkit';
-import { createTreeUsingTsSolutionSetup } from '../../../utils/test';
-import migration from './migration';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test.js';
+import migration from './migration.js';
 
 const GATEWAY_CONSTRUCT_FILE =
   'packages/common/constructs/src/core/agentcore-gateway/agentcore-gateway.ts';

--- a/packages/nx-plugin/src/migrations/v1.0.0-rc.60/0002-waf-log-group-removal/migration.ts
+++ b/packages/nx-plugin/src/migrations/v1.0.0-rc.60/0002-waf-log-group-removal/migration.ts
@@ -7,12 +7,12 @@ import {
   addDestructuredImport,
   insertViaGritQL,
   matchGritQL,
-} from '../../../utils/ast';
-import { formatFilesInSubtree } from '../../../utils/format';
+} from '../../../utils/ast.js';
+import { formatFilesInSubtree } from '../../../utils/format.js';
 import {
   PACKAGES_DIR,
   SHARED_CONSTRUCTS_DIR,
-} from '../../../utils/shared-constructs-constants';
+} from '../../../utils/shared-constructs-constants.js';
 
 /**
  * Vended WAF log groups have a deterministic name (WAFv2 requires the

--- a/packages/nx-plugin/src/migrations/v1.0.0-rc.60/0003-strip-pip-from-python-images/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/v1.0.0-rc.60/0003-strip-pip-from-python-images/migration.spec.ts
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { addProjectConfiguration, type Tree } from '@nx/devkit';
-import { createTreeUsingTsSolutionSetup } from '../../../utils/test';
-import migration from './migration';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test.js';
+import migration from './migration.js';
 
 const PROJECT_ROOT = 'packages/py-project/proj_py_project';
 const AGENT_DIR = 'my_agent';

--- a/packages/nx-plugin/src/migrations/v1.0.0-rc.60/0003-strip-pip-from-python-images/migration.ts
+++ b/packages/nx-plugin/src/migrations/v1.0.0-rc.60/0003-strip-pip-from-python-images/migration.ts
@@ -9,8 +9,8 @@ import {
   type ProjectConfiguration,
   type Tree,
 } from '@nx/devkit';
-import { formatFilesInSubtree } from '../../../utils/format';
-import type { ComponentMetadata } from '../../../utils/nx';
+import { formatFilesInSubtree } from '../../../utils/format.js';
+import type { ComponentMetadata } from '../../../utils/nx.js';
 
 /**
  * Remove pip from the vended Python agent / MCP server images.

--- a/packages/nx-plugin/src/migrations/v1.0.0-rc.61/0001-py-agent-lifespan-construction/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/v1.0.0-rc.61/0001-py-agent-lifespan-construction/migration.spec.ts
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { addProjectConfiguration, type Tree } from '@nx/devkit';
-import { PY_AGENT_GENERATOR_INFO } from '../../../py/agent/generator';
-import { createTreeUsingTsSolutionSetup } from '../../../utils/test';
-import migration from './migration';
+import { PY_AGENT_GENERATOR_INFO } from '../../../py/agent/generator.js';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test.js';
+import migration from './migration.js';
 
 const AGENT_DIR = 'apps/test-project/proj_test_project/agent';
 const AGENT_CONNECTION_MODULE = 'proj_agent_connection';

--- a/packages/nx-plugin/src/migrations/v1.0.0-rc.61/0001-py-agent-lifespan-construction/migration.ts
+++ b/packages/nx-plugin/src/migrations/v1.0.0-rc.61/0001-py-agent-lifespan-construction/migration.ts
@@ -8,15 +8,15 @@ import {
   type MigrationReturnObject,
   type Tree,
 } from '@nx/devkit';
-import { PY_AGENT_GENERATOR_INFO } from '../../../py/agent/generator';
+import { PY_AGENT_GENERATOR_INFO } from '../../../py/agent/generator.js';
 import {
   addPythonDestructuredImport,
   applyGritQL,
   captureGritQLVariable,
   matchGritQL,
-} from '../../../utils/ast';
-import { formatFilesInSubtree } from '../../../utils/format';
-import type { ComponentMetadata } from '../../../utils/nx';
+} from '../../../utils/ast.js';
+import { formatFilesInSubtree } from '../../../utils/format.js';
+import type { ComponentMetadata } from '../../../utils/nx.js';
 
 /**
  * Move py#agent HTTP/AG-UI agent construction out of module import time and

--- a/packages/nx-plugin/src/migrations/v1.0.0-rc.62/0001-rename-load-runtime-config-target/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/v1.0.0-rc.62/0001-rename-load-runtime-config-target/migration.spec.ts
@@ -7,8 +7,8 @@ import {
   readProjectConfiguration,
   type Tree,
 } from '@nx/devkit';
-import { createTreeUsingTsSolutionSetup } from '../../../utils/test';
-import migration from './migration';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test.js';
+import migration from './migration.js';
 
 const OLD_TARGET = 'load:runtime-config';
 const NEW_TARGET = 'load-runtime-config';

--- a/packages/nx-plugin/src/migrations/v1.0.0-rc.62/0001-rename-load-runtime-config-target/migration.ts
+++ b/packages/nx-plugin/src/migrations/v1.0.0-rc.62/0001-rename-load-runtime-config-target/migration.ts
@@ -8,7 +8,7 @@ import {
   type Tree,
   updateProjectConfiguration,
 } from '@nx/devkit';
-import { formatFilesInSubtree } from '../../../utils/format';
+import { formatFilesInSubtree } from '../../../utils/format.js';
 
 /**
  * React website projects gained a `load-runtime-config` target so the config

--- a/packages/nx-plugin/src/migrations/v1.0.0-rc.63/0001-add-deploy-sandbox-target/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/v1.0.0-rc.63/0001-add-deploy-sandbox-target/migration.spec.ts
@@ -8,9 +8,9 @@ import {
   type Tree,
   updateProjectConfiguration,
 } from '@nx/devkit';
-import { INFRA_APP_GENERATOR_INFO } from '../../../infra/app/generator';
-import { createTreeUsingTsSolutionSetup } from '../../../utils/test';
-import migration from './migration';
+import { INFRA_APP_GENERATOR_INFO } from '../../../infra/app/generator.js';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test.js';
+import migration from './migration.js';
 
 const TARGET = 'deploy-sandbox';
 

--- a/packages/nx-plugin/src/migrations/v1.0.0-rc.63/0001-add-deploy-sandbox-target/migration.ts
+++ b/packages/nx-plugin/src/migrations/v1.0.0-rc.63/0001-add-deploy-sandbox-target/migration.ts
@@ -9,11 +9,11 @@ import {
   type Tree,
   updateProjectConfiguration,
 } from '@nx/devkit';
-import { INFRA_APP_GENERATOR_INFO } from '../../../infra/app/generator';
-import { captureGritQLVariable } from '../../../utils/ast';
-import { formatFilesInSubtree } from '../../../utils/format';
-import { normalizeTargetKeyOrder } from '../../../utils/nx';
-import { sortObjectKeys } from '../../../utils/object';
+import { INFRA_APP_GENERATOR_INFO } from '../../../infra/app/generator.js';
+import { captureGritQLVariable } from '../../../utils/ast.js';
+import { formatFilesInSubtree } from '../../../utils/format.js';
+import { normalizeTargetKeyOrder } from '../../../utils/nx.js';
+import { sortObjectKeys } from '../../../utils/object.js';
 
 /**
  * CDK infrastructure projects gained a `deploy-sandbox` target, which deploys the

--- a/packages/nx-plugin/src/migrations/v1.0.0-rc.64/0001-smithy-build-without-docker/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/v1.0.0-rc.64/0001-smithy-build-without-docker/migration.spec.ts
@@ -8,10 +8,10 @@ import { addProjectConfiguration, readJson, type Tree } from '@nx/devkit';
 import {
   SMITHY_PROJECT_GENERATOR_INFO,
   smithyProjectGenerator,
-} from '../../../smithy/project/generator';
-import { createTreeUsingTsSolutionSetup } from '../../../utils/test';
-import { MISE_VERSIONS, TS_VERSIONS } from '../../../utils/versions';
-import migration from './migration';
+} from '../../../smithy/project/generator.js';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test.js';
+import { MISE_VERSIONS, TS_VERSIONS } from '../../../utils/versions.js';
+import migration from './migration.js';
 
 /**
  * The `build.Dockerfile` a legacy container-building service project holds, and

--- a/packages/nx-plugin/src/migrations/v1.0.0-rc.64/0001-smithy-build-without-docker/migration.ts
+++ b/packages/nx-plugin/src/migrations/v1.0.0-rc.64/0001-smithy-build-without-docker/migration.ts
@@ -18,11 +18,11 @@ import {
   smithyCompileOutputs,
   smithyGenerateSsdkTarget,
   writeSsdkBundleConfig,
-} from '../../../smithy/project/generator';
-import { addTsDependencies } from '../../../utils/add-dependencies';
-import { formatFilesInSubtree } from '../../../utils/format';
-import { FsCommands } from '../../../utils/fs';
-import { warnIfSmithyMissing } from '../../../utils/smithy';
+} from '../../../smithy/project/generator.js';
+import { addTsDependencies } from '../../../utils/add-dependencies.js';
+import { formatFilesInSubtree } from '../../../utils/format.js';
+import { FsCommands } from '../../../utils/fs.js';
+import { warnIfSmithyMissing } from '../../../utils/smithy.js';
 
 /**
  * Move Smithy projects off the container build onto the Smithy CLI.

--- a/packages/nx-plugin/src/migrations/v1.0.0-rc.65/0001-vite-config-import-meta-dirname/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/v1.0.0-rc.65/0001-vite-config-import-meta-dirname/migration.spec.ts
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { addProjectConfiguration, type Tree } from '@nx/devkit';
-import { createTreeUsingTsSolutionSetup } from '../../../utils/test';
-import migration from './migration';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test.js';
+import migration from './migration.js';
 
 const LIB_CONFIG = 'packages/lib/vitest.config.mts';
 const WEBSITE_CONFIG = 'packages/website/vite.config.mts';

--- a/packages/nx-plugin/src/migrations/v1.0.0-rc.65/0001-vite-config-import-meta-dirname/migration.ts
+++ b/packages/nx-plugin/src/migrations/v1.0.0-rc.65/0001-vite-config-import-meta-dirname/migration.ts
@@ -8,8 +8,8 @@ import {
   type MigrationReturnObject,
   type Tree,
 } from '@nx/devkit';
-import { applyGritQL } from '../../../utils/ast';
-import { formatFilesInSubtree } from '../../../utils/format';
+import { applyGritQL } from '../../../utils/ast.js';
+import { formatFilesInSubtree } from '../../../utils/format.js';
 
 /**
  * Resolve the vended vite and vitest config paths from `import.meta.dirname`

--- a/packages/nx-plugin/src/migrations/v1.0.0-rc.65/0002-rolldown-code-splitting/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/v1.0.0-rc.65/0002-rolldown-code-splitting/migration.spec.ts
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { addProjectConfiguration, type Tree } from '@nx/devkit';
-import { createTreeUsingTsSolutionSetup } from '../../../utils/test';
-import migration from './migration';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test.js';
+import migration from './migration.js';
 
 const CONFIG = 'apps/test-project/rolldown.config.ts';
 

--- a/packages/nx-plugin/src/migrations/v1.0.0-rc.65/0002-rolldown-code-splitting/migration.ts
+++ b/packages/nx-plugin/src/migrations/v1.0.0-rc.65/0002-rolldown-code-splitting/migration.ts
@@ -8,8 +8,8 @@ import {
   type MigrationReturnObject,
   type Tree,
 } from '@nx/devkit';
-import { applyGritQL } from '../../../utils/ast';
-import { formatFilesInSubtree } from '../../../utils/format';
+import { applyGritQL } from '../../../utils/ast.js';
+import { formatFilesInSubtree } from '../../../utils/format.js';
 
 /**
  * Move generated rolldown configs onto `codeSplitting: false`.

--- a/packages/nx-plugin/src/migrations/v1.0.0-rc.67/0001-smithy-server-package-rename/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/v1.0.0-rc.67/0001-smithy-server-package-rename/migration.spec.ts
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { addProjectConfiguration, readJson, type Tree } from '@nx/devkit';
-import { createTreeUsingTsSolutionSetup } from '../../../utils/test';
-import migration from './migration';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test.js';
+import migration from './migration.js';
 
 const PROJECT_ROOT = 'packages/test-api/backend';
 const HANDLER = `${PROJECT_ROOT}/src/handler.ts`;

--- a/packages/nx-plugin/src/migrations/v1.0.0-rc.67/0001-smithy-server-package-rename/migration.ts
+++ b/packages/nx-plugin/src/migrations/v1.0.0-rc.67/0001-smithy-server-package-rename/migration.ts
@@ -10,8 +10,8 @@ import {
   type Tree,
   updateJson,
 } from '@nx/devkit';
-import { applyGritQL, matchGritQL } from '../../../utils/ast';
-import { formatFilesInSubtree } from '../../../utils/format';
+import { applyGritQL, matchGritQL } from '../../../utils/ast.js';
+import { formatFilesInSubtree } from '../../../utils/format.js';
 
 /**
  * Move a Smithy API onto the renamed `@smithy/server-*` packages.

--- a/packages/nx-plugin/src/migrations/v1.0.0-rc.68/0001-translate-script-whole-file-writes/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/v1.0.0-rc.68/0001-translate-script-whole-file-writes/migration.spec.ts
@@ -5,9 +5,9 @@
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { addProjectConfiguration, type Tree, updateJson } from '@nx/devkit';
-import { TS_ASTRO_DOCS_GENERATOR_INFO } from '../../../ts/astro-docs/generator';
-import { createTreeUsingTsSolutionSetup } from '../../../utils/test';
-import migration from './migration';
+import { TS_ASTRO_DOCS_GENERATOR_INFO } from '../../../ts/astro-docs/generator.js';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test.js';
+import migration from './migration.js';
 
 const SCRIPT = 'docs/scripts/translate.ts';
 

--- a/packages/nx-plugin/src/migrations/v1.0.0-rc.68/0001-translate-script-whole-file-writes/migration.ts
+++ b/packages/nx-plugin/src/migrations/v1.0.0-rc.68/0001-translate-script-whole-file-writes/migration.ts
@@ -10,11 +10,11 @@ import {
   type MigrationReturnObject,
   type Tree,
 } from '@nx/devkit';
-import { TS_ASTRO_DOCS_GENERATOR_INFO } from '../../../ts/astro-docs/generator';
-import { insertViaGritQL, matchGritQL } from '../../../utils/ast';
-import { formatFilesInSubtree } from '../../../utils/format';
-import { isEsmWorkspace } from '../../../utils/module-format';
-import { getPackageManagerDisplayCommands } from '../../../utils/pkg-manager';
+import { TS_ASTRO_DOCS_GENERATOR_INFO } from '../../../ts/astro-docs/generator.js';
+import { insertViaGritQL, matchGritQL } from '../../../utils/ast.js';
+import { formatFilesInSubtree } from '../../../utils/format.js';
+import { isEsmWorkspace } from '../../../utils/module-format.js';
+import { getPackageManagerDisplayCommands } from '../../../utils/pkg-manager.js';
 
 /**
  * Rewrite the docs translate script so it writes whole translated files.

--- a/packages/nx-plugin/src/migrations/v1.0.0-rc.70/0001-py-agent-a2a-lifespan-construction/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/v1.0.0-rc.70/0001-py-agent-a2a-lifespan-construction/migration.spec.ts
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { addProjectConfiguration, type Tree } from '@nx/devkit';
-import { PY_AGENT_GENERATOR_INFO } from '../../../py/agent/generator';
-import { createTreeUsingTsSolutionSetup } from '../../../utils/test';
-import migration from './migration';
+import { PY_AGENT_GENERATOR_INFO } from '../../../py/agent/generator.js';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test.js';
+import migration from './migration.js';
 
 const PROJECT_ROOT = 'apps/test-project';
 const AGENT_DIR = `${PROJECT_ROOT}/proj_test_project/agent`;

--- a/packages/nx-plugin/src/migrations/v1.0.0-rc.70/0001-py-agent-a2a-lifespan-construction/migration.ts
+++ b/packages/nx-plugin/src/migrations/v1.0.0-rc.70/0001-py-agent-a2a-lifespan-construction/migration.ts
@@ -9,15 +9,15 @@ import {
   type Tree,
   visitNotIgnoredFiles,
 } from '@nx/devkit';
-import { PY_AGENT_GENERATOR_INFO } from '../../../py/agent/generator';
+import { PY_AGENT_GENERATOR_INFO } from '../../../py/agent/generator.js';
 import {
   addPythonDestructuredImport,
   applyGritQL,
   captureGritQLVariable,
   matchGritQL,
-} from '../../../utils/ast';
-import { formatFilesInSubtree } from '../../../utils/format';
-import type { ComponentMetadata } from '../../../utils/nx';
+} from '../../../utils/ast.js';
+import { formatFilesInSubtree } from '../../../utils/format.js';
+import type { ComponentMetadata } from '../../../utils/nx.js';
 
 /**
  * Move py#agent A2A agent construction (Strands and LangChain) out of module

--- a/packages/nx-plugin/src/migrations/v1.0.0-rc.71/0001-py-agent-a2a-httpx-client-per-call/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/v1.0.0-rc.71/0001-py-agent-a2a-httpx-client-per-call/migration.spec.ts
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { Tree } from '@nx/devkit';
-import { createTreeUsingTsSolutionSetup } from '../../../utils/test';
-import migration from './migration';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test.js';
+import migration from './migration.js';
 
 const AC_DIR = 'packages/common/agent_connection/proj_agent_connection/core';
 const LANGCHAIN_PATH = `${AC_DIR}/agentcore_a2a_client_langchain.py`;

--- a/packages/nx-plugin/src/migrations/v1.0.0-rc.71/0001-py-agent-a2a-httpx-client-per-call/migration.ts
+++ b/packages/nx-plugin/src/migrations/v1.0.0-rc.71/0001-py-agent-a2a-httpx-client-per-call/migration.ts
@@ -7,8 +7,8 @@ import {
   type Tree,
   visitNotIgnoredFiles,
 } from '@nx/devkit';
-import { applyGritQL, matchGritQL } from '../../../utils/ast';
-import { formatFilesInSubtree } from '../../../utils/format';
+import { applyGritQL, matchGritQL } from '../../../utils/ast.js';
+import { formatFilesInSubtree } from '../../../utils/format.js';
 
 /**
  * Rebuild the `httpx.AsyncClient` (and, for Strands, the `A2AAgent`) fresh on

--- a/packages/nx-plugin/src/migrations/v1.0.0-rc.72/0001-py-agent-session-management-support/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/v1.0.0-rc.72/0001-py-agent-session-management-support/migration.spec.ts
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { addProjectConfiguration, type Tree } from '@nx/devkit';
-import { PY_AGENT_GENERATOR_INFO } from '../../../py/agent/generator';
-import { createTreeUsingTsSolutionSetup } from '../../../utils/test';
-import migration from './migration';
+import { PY_AGENT_GENERATOR_INFO } from '../../../py/agent/generator.js';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test.js';
+import migration from './migration.js';
 
 // Registers a project with the ComponentMetadata the py#agent generator
 // itself writes, since the migration reads protocol/framework/name from it

--- a/packages/nx-plugin/src/migrations/v1.0.0-rc.72/0001-py-agent-session-management-support/migration.ts
+++ b/packages/nx-plugin/src/migrations/v1.0.0-rc.72/0001-py-agent-session-management-support/migration.ts
@@ -12,26 +12,26 @@ import {
   type Tree,
   visitNotIgnoredFiles,
 } from '@nx/devkit';
-import { PY_AGENT_GENERATOR_INFO } from '../../../py/agent/generator';
-import { addPyDependencies } from '../../../utils/add-dependencies';
+import { PY_AGENT_GENERATOR_INFO } from '../../../py/agent/generator.js';
+import { addPyDependencies } from '../../../utils/add-dependencies.js';
 import {
   addPythonReExport,
   getPythonAgentConnectionModuleName,
   getPythonAgentConnectionProjectDir,
-} from '../../../utils/agent-connection/agent-connection';
+} from '../../../utils/agent-connection/agent-connection.js';
 import {
   applyGritQL,
   captureGritQLVariable,
   matchGritQL,
-} from '../../../utils/ast';
-import { declareDependencies } from '../../../utils/declared-dependencies';
-import { formatFilesInSubtree } from '../../../utils/format';
-import { kebabCase } from '../../../utils/names';
-import type { ComponentMetadata } from '../../../utils/nx';
+} from '../../../utils/ast.js';
+import { declareDependencies } from '../../../utils/declared-dependencies.js';
+import { formatFilesInSubtree } from '../../../utils/format.js';
+import { kebabCase } from '../../../utils/names.js';
+import type { ComponentMetadata } from '../../../utils/nx.js';
 import {
   getRelativePathToRootByDirectory,
   toProjectRelativePath,
-} from '../../../utils/paths';
+} from '../../../utils/paths.js';
 
 /**
  * Add session management support to py#agent.

--- a/packages/nx-plugin/src/open-api/ts-client/generator.additional-properties.spec.ts
+++ b/packages/nx-plugin/src/open-api/ts-client/generator.additional-properties.spec.ts
@@ -4,11 +4,11 @@
  */
 
 import type { Tree } from '@nx/devkit';
-import { createTreeUsingTsSolutionSetup } from '../../utils/test';
-import { expectTypeScriptToCompile } from '../../utils/test/ts.spec';
-import type { Spec } from '../utils/types';
-import { openApiTsClientGenerator } from './generator';
-import { baseUrl, callGeneratedClient } from './generator.utils.spec';
+import { createTreeUsingTsSolutionSetup } from '../../utils/test.js';
+import { expectTypeScriptToCompile } from '../../utils/test/ts.spec.js';
+import type { Spec } from '../utils/types.js';
+import { openApiTsClientGenerator } from './generator.js';
+import { baseUrl, callGeneratedClient } from './generator.utils.spec.js';
 
 describe('openApiTsClientGenerator - complex types', () => {
   let tree: Tree;

--- a/packages/nx-plugin/src/open-api/ts-client/generator.arrays.spec.ts
+++ b/packages/nx-plugin/src/open-api/ts-client/generator.arrays.spec.ts
@@ -4,11 +4,11 @@
  */
 
 import type { Tree } from '@nx/devkit';
-import { createTreeUsingTsSolutionSetup } from '../../utils/test';
-import { expectTypeScriptToCompile } from '../../utils/test/ts.spec';
-import type { Spec } from '../utils/types';
-import { openApiTsClientGenerator } from './generator';
-import { baseUrl, callGeneratedClient } from './generator.utils.spec';
+import { createTreeUsingTsSolutionSetup } from '../../utils/test.js';
+import { expectTypeScriptToCompile } from '../../utils/test/ts.spec.js';
+import type { Spec } from '../utils/types.js';
+import { openApiTsClientGenerator } from './generator.js';
+import { baseUrl, callGeneratedClient } from './generator.utils.spec.js';
 
 describe('openApiTsClientGenerator - arrays', () => {
   let tree: Tree;

--- a/packages/nx-plugin/src/open-api/ts-client/generator.complex-types.spec.ts
+++ b/packages/nx-plugin/src/open-api/ts-client/generator.complex-types.spec.ts
@@ -4,11 +4,11 @@
  */
 
 import type { Tree } from '@nx/devkit';
-import { createTreeUsingTsSolutionSetup } from '../../utils/test';
-import { expectTypeScriptToCompile } from '../../utils/test/ts.spec';
-import type { Spec } from '../utils/types';
-import { openApiTsClientGenerator } from './generator';
-import { baseUrl, callGeneratedClient } from './generator.utils.spec';
+import { createTreeUsingTsSolutionSetup } from '../../utils/test.js';
+import { expectTypeScriptToCompile } from '../../utils/test/ts.spec.js';
+import type { Spec } from '../utils/types.js';
+import { openApiTsClientGenerator } from './generator.js';
+import { baseUrl, callGeneratedClient } from './generator.utils.spec.js';
 
 describe('openApiTsClientGenerator - complex types', () => {
   let tree: Tree;

--- a/packages/nx-plugin/src/open-api/ts-client/generator.composite-types.spec.ts
+++ b/packages/nx-plugin/src/open-api/ts-client/generator.composite-types.spec.ts
@@ -4,12 +4,12 @@
  */
 
 import type { Tree } from '@nx/devkit';
-import { importTypeScriptModule } from '../../utils/js';
-import { createTreeUsingTsSolutionSetup } from '../../utils/test';
-import { expectTypeScriptToCompile } from '../../utils/test/ts.spec';
-import type { Spec } from '../utils/types';
-import { openApiTsClientGenerator } from './generator';
-import { baseUrl, callGeneratedClient } from './generator.utils.spec';
+import { importTypeScriptModule } from '../../utils/js.js';
+import { createTreeUsingTsSolutionSetup } from '../../utils/test.js';
+import { expectTypeScriptToCompile } from '../../utils/test/ts.spec.js';
+import type { Spec } from '../utils/types.js';
+import { openApiTsClientGenerator } from './generator.js';
+import { baseUrl, callGeneratedClient } from './generator.utils.spec.js';
 
 describe('openApiTsClientGenerator - composite schemas', () => {
   let tree: Tree;

--- a/packages/nx-plugin/src/open-api/ts-client/generator.content-type.spec.ts
+++ b/packages/nx-plugin/src/open-api/ts-client/generator.content-type.spec.ts
@@ -4,12 +4,12 @@
  */
 
 import type { Tree } from '@nx/devkit';
-import { importTypeScriptModule } from '../../utils/js';
-import { createTreeUsingTsSolutionSetup } from '../../utils/test';
-import { expectTypeScriptToCompile } from '../../utils/test/ts.spec';
-import type { Spec } from '../utils/types';
-import { openApiTsClientGenerator } from './generator';
-import { baseUrl, callGeneratedClient } from './generator.utils.spec';
+import { importTypeScriptModule } from '../../utils/js.js';
+import { createTreeUsingTsSolutionSetup } from '../../utils/test.js';
+import { expectTypeScriptToCompile } from '../../utils/test/ts.spec.js';
+import type { Spec } from '../utils/types.js';
+import { openApiTsClientGenerator } from './generator.js';
+import { baseUrl, callGeneratedClient } from './generator.utils.spec.js';
 
 describe('openApiTsClientGenerator - content type header', () => {
   let tree: Tree;

--- a/packages/nx-plugin/src/open-api/ts-client/generator.duplicate-types.spec.ts
+++ b/packages/nx-plugin/src/open-api/ts-client/generator.duplicate-types.spec.ts
@@ -4,10 +4,10 @@
  */
 
 import type { Tree } from '@nx/devkit';
-import { createTreeUsingTsSolutionSetup } from '../../utils/test';
-import { expectTypeScriptToCompile } from '../../utils/test/ts.spec';
-import type { Spec } from '../utils/types';
-import { openApiTsClientGenerator } from './generator';
+import { createTreeUsingTsSolutionSetup } from '../../utils/test.js';
+import { expectTypeScriptToCompile } from '../../utils/test/ts.spec.js';
+import type { Spec } from '../utils/types.js';
+import { openApiTsClientGenerator } from './generator.js';
 
 describe('openApiTsClientGenerator - duplicate types', () => {
   let tree: Tree;

--- a/packages/nx-plugin/src/open-api/ts-client/generator.edge-cases.spec.ts
+++ b/packages/nx-plugin/src/open-api/ts-client/generator.edge-cases.spec.ts
@@ -4,16 +4,16 @@
  */
 
 import type { Tree } from '@nx/devkit';
-import { createTreeUsingTsSolutionSetup } from '../../utils/test';
-import { expectTypeScriptToCompile } from '../../utils/test/ts.spec';
-import type { Spec } from '../utils/types';
-import { openApiTsClientGenerator } from './generator';
+import { createTreeUsingTsSolutionSetup } from '../../utils/test.js';
+import { expectTypeScriptToCompile } from '../../utils/test/ts.spec.js';
+import type { Spec } from '../utils/types.js';
+import { openApiTsClientGenerator } from './generator.js';
 import {
   baseUrl,
   callGeneratedClient,
   callGeneratedClientStreaming,
   mockJsonlStreamingFetch,
-} from './generator.utils.spec';
+} from './generator.utils.spec.js';
 
 /**
  * Regression coverage for edge cases surfaced by differentially testing a

--- a/packages/nx-plugin/src/open-api/ts-client/generator.fast-api-gaps.spec.ts
+++ b/packages/nx-plugin/src/open-api/ts-client/generator.fast-api-gaps.spec.ts
@@ -4,11 +4,11 @@
  */
 
 import type { Tree } from '@nx/devkit';
-import { createTreeUsingTsSolutionSetup } from '../../utils/test';
-import { expectTypeScriptToCompile } from '../../utils/test/ts.spec';
-import type { Spec } from '../utils/types';
-import { openApiTsClientGenerator } from './generator';
-import { baseUrl, callGeneratedClient } from './generator.utils.spec';
+import { createTreeUsingTsSolutionSetup } from '../../utils/test.js';
+import { expectTypeScriptToCompile } from '../../utils/test/ts.spec.js';
+import type { Spec } from '../utils/types.js';
+import { openApiTsClientGenerator } from './generator.js';
+import { baseUrl, callGeneratedClient } from './generator.utils.spec.js';
 
 describe('openApiTsClientGenerator - FastAPI gaps', () => {
   let tree: Tree;

--- a/packages/nx-plugin/src/open-api/ts-client/generator.fast-api.spec.ts
+++ b/packages/nx-plugin/src/open-api/ts-client/generator.fast-api.spec.ts
@@ -4,11 +4,11 @@
  */
 
 import type { Tree } from '@nx/devkit';
-import { createTreeUsingTsSolutionSetup } from '../../utils/test';
-import { expectTypeScriptToCompile } from '../../utils/test/ts.spec';
-import type { Spec } from '../utils/types';
-import { openApiTsClientGenerator } from './generator';
-import { baseUrl, callGeneratedClient } from './generator.utils.spec';
+import { createTreeUsingTsSolutionSetup } from '../../utils/test.js';
+import { expectTypeScriptToCompile } from '../../utils/test/ts.spec.js';
+import type { Spec } from '../utils/types.js';
+import { openApiTsClientGenerator } from './generator.js';
+import { baseUrl, callGeneratedClient } from './generator.utils.spec.js';
 
 describe('openApiTsClientGenerator - FastAPI', () => {
   let tree: Tree;

--- a/packages/nx-plugin/src/open-api/ts-client/generator.multipart.spec.ts
+++ b/packages/nx-plugin/src/open-api/ts-client/generator.multipart.spec.ts
@@ -4,11 +4,11 @@
  */
 
 import type { Tree } from '@nx/devkit';
-import { createTreeUsingTsSolutionSetup } from '../../utils/test';
-import { expectTypeScriptToCompile } from '../../utils/test/ts.spec';
-import type { Spec } from '../utils/types';
-import { openApiTsClientGenerator } from './generator';
-import { baseUrl, callGeneratedClient } from './generator.utils.spec';
+import { createTreeUsingTsSolutionSetup } from '../../utils/test.js';
+import { expectTypeScriptToCompile } from '../../utils/test/ts.spec.js';
+import type { Spec } from '../utils/types.js';
+import { openApiTsClientGenerator } from './generator.js';
+import { baseUrl, callGeneratedClient } from './generator.utils.spec.js';
 
 describe('openApiTsClientGenerator - multipart/form-data', () => {
   let tree: Tree;

--- a/packages/nx-plugin/src/open-api/ts-client/generator.petstore.spec.ts
+++ b/packages/nx-plugin/src/open-api/ts-client/generator.petstore.spec.ts
@@ -4,10 +4,10 @@
  */
 
 import type { Tree } from '@nx/devkit';
-import { createTreeUsingTsSolutionSetup } from '../../utils/test';
-import { expectTypeScriptToCompile } from '../../utils/test/ts.spec';
-import type { Spec } from '../utils/types';
-import { openApiTsClientGenerator } from './generator';
+import { createTreeUsingTsSolutionSetup } from '../../utils/test.js';
+import { expectTypeScriptToCompile } from '../../utils/test/ts.spec.js';
+import type { Spec } from '../utils/types.js';
+import { openApiTsClientGenerator } from './generator.js';
 
 export const PET_STORE_SPEC: Spec = {
   openapi: '3.0.4',

--- a/packages/nx-plugin/src/open-api/ts-client/generator.primitive-types.spec.ts
+++ b/packages/nx-plugin/src/open-api/ts-client/generator.primitive-types.spec.ts
@@ -4,12 +4,12 @@
  */
 
 import type { Tree } from '@nx/devkit';
-import { importTypeScriptModule } from '../../utils/js';
-import { createTreeUsingTsSolutionSetup } from '../../utils/test';
-import { expectTypeScriptToCompile } from '../../utils/test/ts.spec';
-import type { Spec } from '../utils/types';
-import { openApiTsClientGenerator } from './generator';
-import { baseUrl, callGeneratedClient } from './generator.utils.spec';
+import { importTypeScriptModule } from '../../utils/js.js';
+import { createTreeUsingTsSolutionSetup } from '../../utils/test.js';
+import { expectTypeScriptToCompile } from '../../utils/test/ts.spec.js';
+import type { Spec } from '../utils/types.js';
+import { openApiTsClientGenerator } from './generator.js';
+import { baseUrl, callGeneratedClient } from './generator.utils.spec.js';
 
 describe('openApiTsClientGenerator - primitive types', () => {
   let tree: Tree;

--- a/packages/nx-plugin/src/open-api/ts-client/generator.regressions.spec.ts
+++ b/packages/nx-plugin/src/open-api/ts-client/generator.regressions.spec.ts
@@ -4,10 +4,10 @@
  */
 
 import type { Tree } from '@nx/devkit';
-import { createTreeUsingTsSolutionSetup } from '../../utils/test';
-import { expectTypeScriptToCompile } from '../../utils/test/ts.spec';
-import type { Spec } from '../utils/types';
-import { openApiTsClientGenerator } from './generator';
+import { createTreeUsingTsSolutionSetup } from '../../utils/test.js';
+import { expectTypeScriptToCompile } from '../../utils/test/ts.spec.js';
+import type { Spec } from '../utils/types.js';
+import { openApiTsClientGenerator } from './generator.js';
 
 /**
  * Regression coverage for parser defects surfaced by differentially testing a

--- a/packages/nx-plugin/src/open-api/ts-client/generator.request.spec.ts
+++ b/packages/nx-plugin/src/open-api/ts-client/generator.request.spec.ts
@@ -4,11 +4,11 @@
  */
 
 import type { Tree } from '@nx/devkit';
-import { createTreeUsingTsSolutionSetup } from '../../utils/test';
-import { expectTypeScriptToCompile } from '../../utils/test/ts.spec';
-import type { Spec } from '../utils/types';
-import { openApiTsClientGenerator } from './generator';
-import { baseUrl, callGeneratedClient } from './generator.utils.spec';
+import { createTreeUsingTsSolutionSetup } from '../../utils/test.js';
+import { expectTypeScriptToCompile } from '../../utils/test/ts.spec.js';
+import type { Spec } from '../utils/types.js';
+import { openApiTsClientGenerator } from './generator.js';
+import { baseUrl, callGeneratedClient } from './generator.utils.spec.js';
 
 describe('openApiTsClientGenerator - requests', () => {
   let tree: Tree;

--- a/packages/nx-plugin/src/open-api/ts-client/generator.reserved-keywords.spec.ts
+++ b/packages/nx-plugin/src/open-api/ts-client/generator.reserved-keywords.spec.ts
@@ -4,10 +4,10 @@
  */
 
 import type { Tree } from '@nx/devkit';
-import { createTreeUsingTsSolutionSetup } from '../../utils/test';
-import { expectTypeScriptToCompile } from '../../utils/test/ts.spec';
-import type { Spec } from '../utils/types';
-import { openApiTsClientGenerator } from './generator';
+import { createTreeUsingTsSolutionSetup } from '../../utils/test.js';
+import { expectTypeScriptToCompile } from '../../utils/test/ts.spec.js';
+import type { Spec } from '../utils/types.js';
+import { openApiTsClientGenerator } from './generator.js';
 
 describe('openApiTsClientGenerator - reserved keywords', () => {
   let tree: Tree;

--- a/packages/nx-plugin/src/open-api/ts-client/generator.response.spec.ts
+++ b/packages/nx-plugin/src/open-api/ts-client/generator.response.spec.ts
@@ -4,11 +4,11 @@
  */
 
 import type { Tree } from '@nx/devkit';
-import { createTreeUsingTsSolutionSetup } from '../../utils/test';
-import { expectTypeScriptToCompile } from '../../utils/test/ts.spec';
-import type { Spec } from '../utils/types';
-import { openApiTsClientGenerator } from './generator';
-import { baseUrl, callGeneratedClient } from './generator.utils.spec';
+import { createTreeUsingTsSolutionSetup } from '../../utils/test.js';
+import { expectTypeScriptToCompile } from '../../utils/test/ts.spec.js';
+import type { Spec } from '../utils/types.js';
+import { openApiTsClientGenerator } from './generator.js';
+import { baseUrl, callGeneratedClient } from './generator.utils.spec.js';
 
 describe('openApiTsClientGenerator - responses', () => {
   let tree: Tree;

--- a/packages/nx-plugin/src/open-api/ts-client/generator.spec-compliance.spec.ts
+++ b/packages/nx-plugin/src/open-api/ts-client/generator.spec-compliance.spec.ts
@@ -4,11 +4,11 @@
  */
 
 import type { Tree } from '@nx/devkit';
-import { createTreeUsingTsSolutionSetup } from '../../utils/test';
-import { expectTypeScriptToCompile } from '../../utils/test/ts.spec';
-import type { Spec } from '../utils/types';
-import { openApiTsClientGenerator } from './generator';
-import { baseUrl, callGeneratedClient } from './generator.utils.spec';
+import { createTreeUsingTsSolutionSetup } from '../../utils/test.js';
+import { expectTypeScriptToCompile } from '../../utils/test/ts.spec.js';
+import type { Spec } from '../utils/types.js';
+import { openApiTsClientGenerator } from './generator.js';
+import { baseUrl, callGeneratedClient } from './generator.utils.spec.js';
 
 describe('openApiTsClientGenerator - spec compliance', () => {
   let tree: Tree;

--- a/packages/nx-plugin/src/open-api/ts-client/generator.streaming.spec.ts
+++ b/packages/nx-plugin/src/open-api/ts-client/generator.streaming.spec.ts
@@ -3,15 +3,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { Tree } from '@nx/devkit';
-import { createTreeUsingTsSolutionSetup } from '../../utils/test';
-import { expectTypeScriptToCompile } from '../../utils/test/ts.spec';
-import type { Spec } from '../utils/types';
-import openApiTsClientGenerator from './generator';
+import { createTreeUsingTsSolutionSetup } from '../../utils/test.js';
+import { expectTypeScriptToCompile } from '../../utils/test/ts.spec.js';
+import type { Spec } from '../utils/types.js';
+import openApiTsClientGenerator from './generator.js';
 import {
   callGeneratedClientStreaming,
   mockJsonlStreamingFetch,
   mockStreamingFetch,
-} from './generator.utils.spec';
+} from './generator.utils.spec.js';
 
 describe('openApiTsClientGenerator - streaming', () => {
   let tree: Tree;

--- a/packages/nx-plugin/src/open-api/ts-client/generator.tags.spec.ts
+++ b/packages/nx-plugin/src/open-api/ts-client/generator.tags.spec.ts
@@ -4,12 +4,12 @@
  */
 
 import type { Tree } from '@nx/devkit';
-import { importTypeScriptModule } from '../../utils/js';
-import { createTreeUsingTsSolutionSetup } from '../../utils/test';
-import { expectTypeScriptToCompile } from '../../utils/test/ts.spec';
-import type { Spec } from '../utils/types';
-import { openApiTsClientGenerator } from './generator';
-import { baseUrl, callGeneratedClient } from './generator.utils.spec';
+import { importTypeScriptModule } from '../../utils/js.js';
+import { createTreeUsingTsSolutionSetup } from '../../utils/test.js';
+import { expectTypeScriptToCompile } from '../../utils/test/ts.spec.js';
+import type { Spec } from '../utils/types.js';
+import { openApiTsClientGenerator } from './generator.js';
+import { baseUrl, callGeneratedClient } from './generator.utils.spec.js';
 
 describe('openApiTsClientGenerator - tags', () => {
   let tree: Tree;

--- a/packages/nx-plugin/src/open-api/ts-client/generator.ts
+++ b/packages/nx-plugin/src/open-api/ts-client/generator.ts
@@ -4,12 +4,12 @@
  */
 import { generateFiles, logger, type Tree } from '@nx/devkit';
 import * as path from 'path';
-import { formatFilesInSubtree } from '../../utils/format';
-import { esmVars } from '../../utils/module-format';
-import { buildOpenApiCodeGenData } from '../utils/codegen-data';
-import type { CodeGenData } from '../utils/codegen-data/types';
-import { parseOpenApiSpec } from '../utils/parse';
-import type { Spec } from '../utils/types';
+import { formatFilesInSubtree } from '../../utils/format.js';
+import { esmVars } from '../../utils/module-format.js';
+import { buildOpenApiCodeGenData } from '../utils/codegen-data.js';
+import type { CodeGenData } from '../utils/codegen-data/types.js';
+import { parseOpenApiSpec } from '../utils/parse.js';
+import type { Spec } from '../utils/types.js';
 import type { OpenApiTsClientGeneratorSchema } from './schema';
 
 /**

--- a/packages/nx-plugin/src/open-api/ts-client/generator.utils.spec.ts
+++ b/packages/nx-plugin/src/open-api/ts-client/generator.utils.spec.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { Mock } from 'vitest';
-import { importTypeScriptModule } from '../../utils/js';
+import { importTypeScriptModule } from '../../utils/js.js';
 
 export const baseUrl = 'https://example.com';
 

--- a/packages/nx-plugin/src/open-api/ts-hooks/generator.duplicate-types.spec.ts
+++ b/packages/nx-plugin/src/open-api/ts-hooks/generator.duplicate-types.spec.ts
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { Tree } from '@nx/devkit';
-import { createTreeUsingTsSolutionSetup } from '../../utils/test';
-import { TypeScriptVerifier } from '../../utils/test/ts.spec';
-import type { Spec } from '../utils/types';
-import { openApiTsHooksGenerator } from './generator';
+import { createTreeUsingTsSolutionSetup } from '../../utils/test.js';
+import { TypeScriptVerifier } from '../../utils/test/ts.spec.js';
+import type { Spec } from '../utils/types.js';
+import { openApiTsHooksGenerator } from './generator.js';
 
 describe('openApiTsHooksGenerator - Duplicate Types', () => {
   let tree: Tree;

--- a/packages/nx-plugin/src/open-api/ts-hooks/generator.spec.tsx
+++ b/packages/nx-plugin/src/open-api/ts-hooks/generator.spec.tsx
@@ -16,12 +16,12 @@ import {
 import { fireEvent, render, waitFor } from '@testing-library/react';
 import type React from 'react';
 import type { Mock } from 'vitest';
-import { importTypeScriptModule } from '../../utils/js';
-import { createTreeUsingTsSolutionSetup } from '../../utils/test';
-import { TypeScriptVerifier } from '../../utils/test/ts.spec';
-import { PET_STORE_SPEC } from '../ts-client/generator.petstore.spec';
-import type { Spec } from '../utils/types';
-import { openApiTsHooksGenerator } from './generator';
+import { importTypeScriptModule } from '../../utils/js.js';
+import { createTreeUsingTsSolutionSetup } from '../../utils/test.js';
+import { TypeScriptVerifier } from '../../utils/test/ts.spec.js';
+import { PET_STORE_SPEC } from '../ts-client/generator.petstore.spec.js';
+import type { Spec } from '../utils/types.js';
+import { openApiTsHooksGenerator } from './generator.js';
 
 describe('openApiTsHooksGenerator', () => {
   let tree: Tree;

--- a/packages/nx-plugin/src/open-api/ts-hooks/generator.ts
+++ b/packages/nx-plugin/src/open-api/ts-hooks/generator.ts
@@ -4,13 +4,13 @@
  */
 import { generateFiles, type Tree } from '@nx/devkit';
 import path from 'path';
-import { formatFilesInSubtree } from '../../utils/format';
-import { esmVars } from '../../utils/module-format';
+import { formatFilesInSubtree } from '../../utils/format.js';
+import { esmVars } from '../../utils/module-format.js';
 import {
   buildOpenApiCodeGenerationData,
   generateOpenApiTsClient,
-} from '../ts-client/generator';
-import type { CodeGenData } from '../utils/codegen-data/types';
+} from '../ts-client/generator.js';
+import type { CodeGenData } from '../utils/codegen-data/types.js';
 import type { OpenApiTsHooksGeneratorSchema } from './schema';
 
 /**

--- a/packages/nx-plugin/src/open-api/ts-metadata/generator.spec.ts
+++ b/packages/nx-plugin/src/open-api/ts-metadata/generator.spec.ts
@@ -3,11 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { Tree } from '@nx/devkit';
-import { importTypeScriptModule } from '../../utils/js';
-import { createTreeUsingTsSolutionSetup } from '../../utils/test';
-import { TypeScriptVerifier } from '../../utils/test/ts.spec';
-import type { Spec } from '../utils/types';
-import { openApiTsMetadataGenerator } from './generator';
+import { importTypeScriptModule } from '../../utils/js.js';
+import { createTreeUsingTsSolutionSetup } from '../../utils/test.js';
+import { TypeScriptVerifier } from '../../utils/test/ts.spec.js';
+import type { Spec } from '../utils/types.js';
+import { openApiTsMetadataGenerator } from './generator.js';
 
 describe('openApiTsMetadataGenerator', () => {
   let tree: Tree;

--- a/packages/nx-plugin/src/open-api/ts-metadata/generator.ts
+++ b/packages/nx-plugin/src/open-api/ts-metadata/generator.ts
@@ -4,9 +4,9 @@
  */
 import { generateFiles, type Tree } from '@nx/devkit';
 import path from 'path';
-import { formatFilesInSubtree } from '../../utils/format';
-import { buildOpenApiCodeGenerationData } from '../ts-client/generator';
-import type { CodeGenData } from '../utils/codegen-data/types';
+import { formatFilesInSubtree } from '../../utils/format.js';
+import { buildOpenApiCodeGenerationData } from '../ts-client/generator.js';
+import type { CodeGenData } from '../utils/codegen-data/types.js';
 import type { OpenApiTsMetadataGeneratorSchema } from './schema';
 
 /**

--- a/packages/nx-plugin/src/open-api/utils/codegen-data.spec.ts
+++ b/packages/nx-plugin/src/open-api/utils/codegen-data.spec.ts
@@ -2,8 +2,8 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import { buildOpenApiCodeGenData } from './codegen-data';
-import type { Spec } from './types';
+import { buildOpenApiCodeGenData } from './codegen-data.js';
+import type { Spec } from './types.js';
 
 describe('openapi codegen data utils', () => {
   describe('buildOpenApiCodeGenData', () => {

--- a/packages/nx-plugin/src/open-api/utils/codegen-data.ts
+++ b/packages/nx-plugin/src/open-api/utils/codegen-data.ts
@@ -13,14 +13,14 @@ import {
   snakeCase,
   toClassName,
   upperFirst,
-} from '../../utils/names';
+} from '../../utils/names.js';
 import {
   toPythonName,
   toPythonType,
   toTypeScriptModelName,
   toTypeScriptName,
   toTypeScriptType,
-} from './codegen-data/languages';
+} from './codegen-data/languages.js';
 import {
   COLLECTION_TYPES,
   COMPOSED_SCHEMA_TYPES,
@@ -38,8 +38,8 @@ import {
   STREAMING_CONTENT_TYPES,
   VENDOR_EXTENSIONS,
   type VendorExtensions,
-} from './codegen-data/types';
-import { normaliseOpenApiSpecForCodeGen } from './normalise';
+} from './codegen-data/types.js';
+import { normaliseOpenApiSpecForCodeGen } from './normalise.js';
 import {
   buildClientData,
   buildInlineModel,
@@ -49,9 +49,9 @@ import {
   getSpecPathParameters,
   linkModel,
   specParameterKey,
-} from './parser';
-import { isRef, resolveIfRef, splitRef } from './refs';
-import type { OpenApiSchema, OpenApiSchemaOrRef, Spec } from './types';
+} from './parser.js';
+import { isRef, resolveIfRef, splitRef } from './refs.js';
+import type { OpenApiSchema, OpenApiSchemaOrRef, Spec } from './types.js';
 
 /**
  * Build the data structure used to generate code from an OpenAPI spec.

--- a/packages/nx-plugin/src/open-api/utils/codegen-data/languages.spec.ts
+++ b/packages/nx-plugin/src/open-api/utils/codegen-data/languages.spec.ts
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { describe, expect, it } from 'vitest';
-import { toPythonName, toPythonType, toTypeScriptType } from './languages';
-import type { Model } from './types';
+import { toPythonName, toPythonType, toTypeScriptType } from './languages.js';
+import type { Model } from './types.js';
 
 const createModel = (partial: Partial<Model>): Model => ({
   $refs: [],

--- a/packages/nx-plugin/src/open-api/utils/codegen-data/languages.ts
+++ b/packages/nx-plugin/src/open-api/utils/codegen-data/languages.ts
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { camelCase, snakeCase, toClassName } from '../../../utils/names';
-import { type Model, PRIMITIVE_TYPES } from './types';
+import { camelCase, snakeCase, toClassName } from '../../../utils/names.js';
+import { type Model, PRIMITIVE_TYPES } from './types.js';
 
 const toTypescriptPrimitive = (property: Model): string => {
   if (

--- a/packages/nx-plugin/src/open-api/utils/normalise.spec.ts
+++ b/packages/nx-plugin/src/open-api/utils/normalise.spec.ts
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { describe, expect, it } from 'vitest';
-import { normaliseOpenApiSpecForCodeGen } from './normalise';
-import type { Spec } from './types';
+import { normaliseOpenApiSpecForCodeGen } from './normalise.js';
+import type { Spec } from './types.js';
 
 describe('normaliseOpenApiSpecForCodeGen', () => {
   it('should initialize empty components and schemas if not present', () => {

--- a/packages/nx-plugin/src/open-api/utils/normalise.ts
+++ b/packages/nx-plugin/src/open-api/utils/normalise.ts
@@ -10,10 +10,10 @@ import {
   pascalCase,
   toClassName,
   upperFirst,
-} from '../../utils/names';
-import { STREAMING_CONTENT_TYPES } from './codegen-data/types';
-import { isRef, resolveIfRef, resolveRef, splitRef } from './refs';
-import type { Spec } from './types';
+} from '../../utils/names.js';
+import { STREAMING_CONTENT_TYPES } from './codegen-data/types.js';
+import { isRef, resolveIfRef, resolveRef, splitRef } from './refs.js';
+import type { Spec } from './types.js';
 
 interface SubSchema {
   readonly nameParts: string[];

--- a/packages/nx-plugin/src/open-api/utils/parse.spec.ts
+++ b/packages/nx-plugin/src/open-api/utils/parse.spec.ts
@@ -4,8 +4,8 @@
  */
 import type { Tree } from '@nx/devkit';
 import type { OpenAPIV3 } from 'openapi-types';
-import { createTreeUsingTsSolutionSetup } from '../../utils/test';
-import { parseOpenApiSpec } from './parse';
+import { createTreeUsingTsSolutionSetup } from '../../utils/test.js';
+import { parseOpenApiSpec } from './parse.js';
 
 describe('openapi parse utils', () => {
   describe('parseOpenApiSpec', () => {

--- a/packages/nx-plugin/src/open-api/utils/parse.ts
+++ b/packages/nx-plugin/src/open-api/utils/parse.ts
@@ -5,7 +5,7 @@
 
 import SwaggerParser from '@apidevtools/swagger-parser';
 import type { Tree } from '@nx/devkit';
-import type { Spec } from './types';
+import type { Spec } from './types.js';
 
 const TREE_PROTOCOL_PREFIX = 'workspace://';
 

--- a/packages/nx-plugin/src/open-api/utils/parser.ts
+++ b/packages/nx-plugin/src/open-api/utils/parser.ts
@@ -23,13 +23,13 @@ import {
   type Operation,
   PRIMITIVE_TYPES,
   type Service,
-} from './codegen-data/types';
-import { isRef, resolveIfRef, splitRef } from './refs';
+} from './codegen-data/types.js';
+import { isRef, resolveIfRef, splitRef } from './refs.js';
 import type {
   OpenApiSchemaOrRef,
   OpenApiSchema as Schema,
   Spec,
-} from './types';
+} from './types.js';
 
 /**
  * OpenAPI primitive `type` values mapped to the internal model `type`.

--- a/packages/nx-plugin/src/open-api/utils/refs.spec.ts
+++ b/packages/nx-plugin/src/open-api/utils/refs.spec.ts
@@ -5,8 +5,8 @@
 
 import type { OpenAPIV3 } from 'openapi-types';
 import { describe, expect, it } from 'vitest';
-import { isRef, resolveIfRef, resolveRef, splitRef } from './refs';
-import type { Spec } from './types';
+import { isRef, resolveIfRef, resolveRef, splitRef } from './refs.js';
+import type { Spec } from './types.js';
 
 const testSpec: Spec = {
   openapi: '3.0.3',

--- a/packages/nx-plugin/src/open-api/utils/refs.ts
+++ b/packages/nx-plugin/src/open-api/utils/refs.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { OpenAPIV3 } from 'openapi-types';
-import type { Spec } from './types';
+import type { Spec } from './types.js';
 
 /**
  * Return whether or not the given OpenAPI object is a reference

--- a/packages/nx-plugin/src/preset/generator.spec.ts
+++ b/packages/nx-plugin/src/preset/generator.spec.ts
@@ -5,9 +5,12 @@
 import { readJson, readNxJson, type Tree } from '@nx/devkit';
 import yaml from 'js-yaml';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { SYNC_GENERATOR_NAME as TS_SYNC_GENERATOR_NAME } from '../ts/sync/generator';
-import { createTreeUsingTsSolutionSetup, snapshotTreeDir } from '../utils/test';
-import { isAmazonian, presetGenerator } from './generator';
+import { SYNC_GENERATOR_NAME as TS_SYNC_GENERATOR_NAME } from '../ts/sync/generator.js';
+import {
+  createTreeUsingTsSolutionSetup,
+  snapshotTreeDir,
+} from '../utils/test.js';
+import { isAmazonian, presetGenerator } from './generator.js';
 
 const NX_TYPESCRIPT_SYNC_GENERATOR = '@nx/js:typescript-sync';
 
@@ -26,7 +29,7 @@ vi.mock('child_process', async (importOriginal) => {
 });
 
 import { execSync } from 'child_process';
-import { readAwsNxPluginConfig } from '../utils/config/utils';
+import { readAwsNxPluginConfig } from '../utils/config/utils.js';
 
 const mockExecSync = execSync as ReturnType<typeof vi.fn>;
 

--- a/packages/nx-plugin/src/preset/generator.ts
+++ b/packages/nx-plugin/src/preset/generator.ts
@@ -15,14 +15,14 @@ import { readFileSync } from 'fs';
 import {
   ensureAwsNxPluginConfig,
   updateAwsNxPluginConfig,
-} from '../utils/config/utils';
-import { declareDependencies } from '../utils/declared-dependencies';
-import { addDependenciesToPackageJson } from '../utils/dependencies';
-import { formatFilesInSubtree } from '../utils/format';
-import { applyWorkspaceInit, INIT_DEPENDENCIES } from '../utils/init';
-import { installDependencies } from '../utils/install';
-import { getGeneratorInfo, type NxGeneratorInfo } from '../utils/nx';
-import { withVersions } from '../utils/versions';
+} from '../utils/config/utils.js';
+import { declareDependencies } from '../utils/declared-dependencies.js';
+import { addDependenciesToPackageJson } from '../utils/dependencies.js';
+import { formatFilesInSubtree } from '../utils/format.js';
+import { applyWorkspaceInit, INIT_DEPENDENCIES } from '../utils/init.js';
+import { installDependencies } from '../utils/install.js';
+import { getGeneratorInfo, type NxGeneratorInfo } from '../utils/nx.js';
+import { withVersions } from '../utils/versions.js';
 import type { PresetGeneratorSchema } from './schema';
 
 export const DEPENDENCIES = declareDependencies()({

--- a/packages/nx-plugin/src/preset/schema.d.ts
+++ b/packages/nx-plugin/src/preset/schema.d.ts
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Containers } from '../utils/containers';
-import { Iac } from '../utils/iac';
-import type { ModuleFormat } from '../utils/module-format';
+import { Containers } from '../utils/containers.js';
+import { Iac } from '../utils/iac.js';
+import type { ModuleFormat } from '../utils/module-format.js';
 
 export type PresetContainersOption = Containers | 'infer';
 

--- a/packages/nx-plugin/src/py/agent/a2a-connection/generator.spec.ts
+++ b/packages/nx-plugin/src/py/agent/a2a-connection/generator.spec.ts
@@ -3,17 +3,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { Tree } from '@nx/devkit';
-import { declareDependencies } from '../../../utils/declared-dependencies';
-import { expectHasMetricTags } from '../../../utils/metrics.spec';
+import { declareDependencies } from '../../../utils/declared-dependencies.js';
+import { expectHasMetricTags } from '../../../utils/metrics.spec.js';
 import {
   SHARED_CONSTRUCTS_DEPENDENCIES,
   sharedConstructsGenerator,
-} from '../../../utils/shared-constructs';
-import { createTreeUsingTsSolutionSetup } from '../../../utils/test';
+} from '../../../utils/shared-constructs.js';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test.js';
 import {
   PY_AGENT_A2A_CONNECTION_GENERATOR_INFO,
   pyAgentA2aConnectionGenerator,
-} from './generator';
+} from './generator.js';
 
 const sharedConstructsDeclaration = declareDependencies()({
   ts: [...SHARED_CONSTRUCTS_DEPENDENCIES],

--- a/packages/nx-plugin/src/py/agent/a2a-connection/generator.ts
+++ b/packages/nx-plugin/src/py/agent/a2a-connection/generator.ts
@@ -10,7 +10,7 @@ import {
   type Tree,
   updateProjectConfiguration,
 } from '@nx/devkit';
-import { addPyDependencies } from '../../../utils/add-dependencies';
+import { addPyDependencies } from '../../../utils/add-dependencies.js';
 import {
   AGENT_CONNECTION_PY_DEPENDENCIES,
   type AgentFramework,
@@ -22,30 +22,30 @@ import {
   getPythonAgentConnectionProjectDir,
   PY_CLIENT_NAMING,
   resolveAgentFramework,
-} from '../../../utils/agent-connection/agent-connection';
+} from '../../../utils/agent-connection/agent-connection.js';
 import {
   addPythonDestructuredImport,
   appendToArrayViaGritQL,
   applyGritQL,
   matchGritQL,
-} from '../../../utils/ast';
+} from '../../../utils/ast.js';
 import {
   declareDependencies,
   ownedElsewhere,
-} from '../../../utils/declared-dependencies';
-import { formatFilesInSubtree } from '../../../utils/format';
-import { installDependencies } from '../../../utils/install';
-import { addGeneratorMetricsIfApplicable } from '../../../utils/metrics';
-import { snakeCase } from '../../../utils/names';
+} from '../../../utils/declared-dependencies.js';
+import { formatFilesInSubtree } from '../../../utils/format.js';
+import { installDependencies } from '../../../utils/install.js';
+import { addGeneratorMetricsIfApplicable } from '../../../utils/metrics.js';
+import { snakeCase } from '../../../utils/names.js';
 import {
   addComponentGeneratorMetadata,
   addDependencyToTargetIfNotPresent,
   getGeneratorInfo,
   type NxGeneratorInfo,
   readProjectConfigurationUnqualified,
-} from '../../../utils/nx';
-import { toProjectRelativePath } from '../../../utils/paths';
-import { addWorkspaceDependencyToPyProject } from '../../../utils/py';
+} from '../../../utils/nx.js';
+import { toProjectRelativePath } from '../../../utils/paths.js';
+import { addWorkspaceDependencyToPyProject } from '../../../utils/py.js';
 import type { PyAgentA2aConnectionGeneratorSchema } from './schema';
 
 /** Prefix a GritQL pattern with `language python` */

--- a/packages/nx-plugin/src/py/agent/a2a-connection/schema.d.ts
+++ b/packages/nx-plugin/src/py/agent/a2a-connection/schema.d.ts
@@ -2,7 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import { ComponentMetadata } from '../../../utils/nx';
+import { ComponentMetadata } from '../../../utils/nx.js';
 
 /**
  * TypeScript types for options defined in schema.json

--- a/packages/nx-plugin/src/py/agent/gateway-connection/generator.spec.ts
+++ b/packages/nx-plugin/src/py/agent/gateway-connection/generator.spec.ts
@@ -3,11 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { Tree } from '@nx/devkit';
-import { createTreeUsingTsSolutionSetup } from '../../../utils/test';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test.js';
 import {
   PY_AGENT_GATEWAY_CONNECTION_GENERATOR_INFO,
   pyAgentGatewayConnectionGenerator,
-} from './generator';
+} from './generator.js';
 
 describe('py#agent#gateway-connection generator', () => {
   let tree: Tree;

--- a/packages/nx-plugin/src/py/agent/gateway-connection/generator.ts
+++ b/packages/nx-plugin/src/py/agent/gateway-connection/generator.ts
@@ -10,8 +10,8 @@ import {
   type Tree,
   updateProjectConfiguration,
 } from '@nx/devkit';
-import { readAgentCoreGatewayMetadata } from '../../../agentcore-gateway/generator';
-import { addPyDependencies } from '../../../utils/add-dependencies';
+import { readAgentCoreGatewayMetadata } from '../../../agentcore-gateway/generator.js';
+import { addPyDependencies } from '../../../utils/add-dependencies.js';
 import {
   AGENT_CONNECTION_PY_DEPENDENCIES,
   type AgentFramework,
@@ -23,25 +23,25 @@ import {
   getPythonAgentConnectionProjectDir,
   PY_MCP_FAMILY_CONNECTIONS,
   resolveAgentFramework,
-} from '../../../utils/agent-connection/agent-connection';
-import { addPythonDestructuredImport } from '../../../utils/ast';
+} from '../../../utils/agent-connection/agent-connection.js';
+import { addPythonDestructuredImport } from '../../../utils/ast.js';
 import {
   declareDependencies,
   ownedElsewhere,
-} from '../../../utils/declared-dependencies';
-import { formatFilesInSubtree } from '../../../utils/format';
-import { installDependencies } from '../../../utils/install';
-import { addGeneratorMetricsIfApplicable } from '../../../utils/metrics';
-import { snakeCase } from '../../../utils/names';
+} from '../../../utils/declared-dependencies.js';
+import { formatFilesInSubtree } from '../../../utils/format.js';
+import { installDependencies } from '../../../utils/install.js';
+import { addGeneratorMetricsIfApplicable } from '../../../utils/metrics.js';
+import { snakeCase } from '../../../utils/names.js';
 import {
   addComponentGeneratorMetadata,
   addDependencyToTargetIfNotPresent,
   getGeneratorInfo,
   type NxGeneratorInfo,
   readProjectConfigurationUnqualified,
-} from '../../../utils/nx';
-import { toProjectRelativePath } from '../../../utils/paths';
-import { addWorkspaceDependencyToPyProject } from '../../../utils/py';
+} from '../../../utils/nx.js';
+import { toProjectRelativePath } from '../../../utils/paths.js';
+import { addWorkspaceDependencyToPyProject } from '../../../utils/py.js';
 import type { PyAgentGatewayConnectionGeneratorSchema } from './schema';
 
 /** The metadata this generator records, which its predicates read. */

--- a/packages/nx-plugin/src/py/agent/gateway-connection/schema.d.ts
+++ b/packages/nx-plugin/src/py/agent/gateway-connection/schema.d.ts
@@ -2,7 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import type { ComponentMetadata } from '../../../utils/nx';
+import type { ComponentMetadata } from '../../../utils/nx.js';
 
 export interface PyAgentGatewayConnectionGeneratorSchema {
   sourceProject: string;

--- a/packages/nx-plugin/src/py/agent/generator.constructs.spec.ts
+++ b/packages/nx-plugin/src/py/agent/generator.constructs.spec.ts
@@ -8,18 +8,18 @@ import {
   joinPathFragments,
   type Tree,
 } from '@nx/devkit';
-import { declareDependencies } from '../../utils/declared-dependencies';
-import { expectHasMetricTags } from '../../utils/metrics.spec';
+import { declareDependencies } from '../../utils/declared-dependencies.js';
+import { expectHasMetricTags } from '../../utils/metrics.spec.js';
 import {
   SHARED_CONSTRUCTS_DEPENDENCIES,
   sharedConstructsGenerator,
-} from '../../utils/shared-constructs';
+} from '../../utils/shared-constructs.js';
 import {
   PACKAGES_DIR,
   SHARED_CONSTRUCTS_DIR,
-} from '../../utils/shared-constructs-constants';
-import { createTreeUsingTsSolutionSetup } from '../../utils/test';
-import { PY_AGENT_GENERATOR_INFO, pyAgentGenerator } from './generator';
+} from '../../utils/shared-constructs-constants.js';
+import { createTreeUsingTsSolutionSetup } from '../../utils/test.js';
+import { PY_AGENT_GENERATOR_INFO, pyAgentGenerator } from './generator.js';
 
 const sharedConstructsDeclaration = declareDependencies()({
   ts: [...SHARED_CONSTRUCTS_DEPENDENCIES],

--- a/packages/nx-plugin/src/py/agent/generator.core.spec.ts
+++ b/packages/nx-plugin/src/py/agent/generator.core.spec.ts
@@ -5,10 +5,10 @@
 
 import { parse } from '@iarna/toml';
 import { addProjectConfiguration, type Tree } from '@nx/devkit';
-import type { UVPyprojectToml } from '../../utils/nxlv-python';
-import { createTreeUsingTsSolutionSetup } from '../../utils/test';
-import { CONTAINER_VERSIONS } from '../../utils/versions';
-import { pyAgentGenerator } from './generator';
+import type { UVPyprojectToml } from '../../utils/nxlv-python.js';
+import { createTreeUsingTsSolutionSetup } from '../../utils/test.js';
+import { CONTAINER_VERSIONS } from '../../utils/versions.js';
+import { pyAgentGenerator } from './generator.js';
 
 describe('py#agent generator', () => {
   let tree: Tree;

--- a/packages/nx-plugin/src/py/agent/generator.frameworks.spec.ts
+++ b/packages/nx-plugin/src/py/agent/generator.frameworks.spec.ts
@@ -5,9 +5,9 @@
 
 import { parse } from '@iarna/toml';
 import { addProjectConfiguration, type Tree } from '@nx/devkit';
-import type { UVPyprojectToml } from '../../utils/nxlv-python';
-import { createTreeUsingTsSolutionSetup } from '../../utils/test';
-import { pyAgentGenerator } from './generator';
+import type { UVPyprojectToml } from '../../utils/nxlv-python.js';
+import { createTreeUsingTsSolutionSetup } from '../../utils/test.js';
+import { pyAgentGenerator } from './generator.js';
 
 describe('py#agent generator', () => {
   let tree: Tree;

--- a/packages/nx-plugin/src/py/agent/generator.protocols.spec.ts
+++ b/packages/nx-plugin/src/py/agent/generator.protocols.spec.ts
@@ -7,9 +7,9 @@ import { addProjectConfiguration, type Tree } from '@nx/devkit';
 import {
   ensureAwsNxPluginConfig,
   updateAwsNxPluginConfig,
-} from '../../utils/config/utils';
-import { createTreeUsingTsSolutionSetup } from '../../utils/test';
-import { PY_AGENT_GENERATOR_INFO, pyAgentGenerator } from './generator';
+} from '../../utils/config/utils.js';
+import { createTreeUsingTsSolutionSetup } from '../../utils/test.js';
+import { PY_AGENT_GENERATOR_INFO, pyAgentGenerator } from './generator.js';
 
 describe('py#agent generator', () => {
   let tree: Tree;

--- a/packages/nx-plugin/src/py/agent/generator.ts
+++ b/packages/nx-plugin/src/py/agent/generator.ts
@@ -10,13 +10,13 @@ import {
   type Tree,
   updateProjectConfiguration,
 } from '@nx/devkit';
-import { ensureLicenseExceptions } from '../../license/config';
-import { AG_UI_LANGGRAPH_EXCEPTIONS } from '../../license/known-exceptions';
+import { ensureLicenseExceptions } from '../../license/config.js';
+import { AG_UI_LANGGRAPH_EXCEPTIONS } from '../../license/known-exceptions.js';
 import {
   addPyDependencies,
   addTsDependencies,
-} from '../../utils/add-dependencies';
-import { addAgentChatScripts } from '../../utils/agent-chat/agent-chat';
+} from '../../utils/add-dependencies.js';
+import { addAgentChatScripts } from '../../utils/agent-chat/agent-chat.js';
 import {
   AGENT_CONNECTION_PY_DEPENDENCIES,
   addPythonFrameworkBase,
@@ -24,23 +24,26 @@ import {
   ensurePythonAgentConnectionProject,
   getPythonAgentConnectionModuleName,
   getPythonAgentConnectionProject,
-} from '../../utils/agent-connection/agent-connection';
-import { addAgentInfra } from '../../utils/agent-core-constructs/agent-core-constructs';
-import { addPythonBundleTarget } from '../../utils/bundle/bundle';
-import { resolveContainers } from '../../utils/containers';
+} from '../../utils/agent-connection/agent-connection.js';
+import { addAgentInfra } from '../../utils/agent-core-constructs/agent-core-constructs.js';
+import { addPythonBundleTarget } from '../../utils/bundle/bundle.js';
+import { resolveContainers } from '../../utils/containers.js';
 import {
   declareDependencies,
   ownedElsewhere,
-} from '../../utils/declared-dependencies';
-import { addDockerScanTarget, DOCKER_DEPENDENCIES } from '../../utils/docker';
-import { formatFilesInSubtree } from '../../utils/format';
-import { FS_DEPENDENCIES, FsCommands } from '../../utils/fs';
-import { updateGitIgnore } from '../../utils/git';
-import { resolveIac } from '../../utils/iac';
-import { installDependencies } from '../../utils/install';
-import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
-import { kebabCase, toClassName, toSnakeCase } from '../../utils/names';
-import { getNpmScope } from '../../utils/npm-scope';
+} from '../../utils/declared-dependencies.js';
+import {
+  addDockerScanTarget,
+  DOCKER_DEPENDENCIES,
+} from '../../utils/docker.js';
+import { formatFilesInSubtree } from '../../utils/format.js';
+import { FS_DEPENDENCIES, FsCommands } from '../../utils/fs.js';
+import { updateGitIgnore } from '../../utils/git.js';
+import { resolveIac } from '../../utils/iac.js';
+import { installDependencies } from '../../utils/install.js';
+import { addGeneratorMetricsIfApplicable } from '../../utils/metrics.js';
+import { kebabCase, toClassName, toSnakeCase } from '../../utils/names.js';
+import { getNpmScope } from '../../utils/npm-scope.js';
 import {
   addComponentDevTarget,
   addComponentGeneratorMetadata,
@@ -49,20 +52,20 @@ import {
   type NxGeneratorInfo,
   normalizeTargetKeyOrder,
   readProjectConfigurationUnqualified,
-} from '../../utils/nx';
-import { sortObjectKeys } from '../../utils/object';
+} from '../../utils/nx.js';
+import { sortObjectKeys } from '../../utils/object.js';
 import {
   getRelativePathToRootByDirectory,
   toProjectRelativePath,
-} from '../../utils/paths';
-import { assignPort } from '../../utils/port';
-import { addWorkspaceDependencyToPyProject } from '../../utils/py';
+} from '../../utils/paths.js';
+import { assignPort } from '../../utils/port.js';
+import { addWorkspaceDependencyToPyProject } from '../../utils/py.js';
 import {
   SHARED_CONSTRUCTS_DEPENDENCIES,
   sharedConstructsGenerator,
-} from '../../utils/shared-constructs';
-import type { IacMetadata } from '../../utils/shared-constructs-constants';
-import { BASE_IMAGES } from '../../utils/versions';
+} from '../../utils/shared-constructs.js';
+import type { IacMetadata } from '../../utils/shared-constructs-constants.js';
+import { BASE_IMAGES } from '../../utils/versions.js';
 import type {
   AgentProtocol,
   PyAgentFramework,

--- a/packages/nx-plugin/src/py/agent/mcp-connection/generator.spec.ts
+++ b/packages/nx-plugin/src/py/agent/mcp-connection/generator.spec.ts
@@ -3,17 +3,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { Tree } from '@nx/devkit';
-import { declareDependencies } from '../../../utils/declared-dependencies';
-import { expectHasMetricTags } from '../../../utils/metrics.spec';
+import { declareDependencies } from '../../../utils/declared-dependencies.js';
+import { expectHasMetricTags } from '../../../utils/metrics.spec.js';
 import {
   SHARED_CONSTRUCTS_DEPENDENCIES,
   sharedConstructsGenerator,
-} from '../../../utils/shared-constructs';
-import { createTreeUsingTsSolutionSetup } from '../../../utils/test';
+} from '../../../utils/shared-constructs.js';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test.js';
 import {
   PY_AGENT_MCP_CONNECTION_GENERATOR_INFO,
   pyAgentMcpConnectionGenerator,
-} from './generator';
+} from './generator.js';
 
 const sharedConstructsDeclaration = declareDependencies()({
   ts: [...SHARED_CONSTRUCTS_DEPENDENCIES],

--- a/packages/nx-plugin/src/py/agent/mcp-connection/generator.ts
+++ b/packages/nx-plugin/src/py/agent/mcp-connection/generator.ts
@@ -10,7 +10,7 @@ import {
   type Tree,
   updateProjectConfiguration,
 } from '@nx/devkit';
-import { addPyDependencies } from '../../../utils/add-dependencies';
+import { addPyDependencies } from '../../../utils/add-dependencies.js';
 import {
   AGENT_CONNECTION_PY_DEPENDENCIES,
   type AgentFramework,
@@ -22,25 +22,25 @@ import {
   getPythonAgentConnectionProjectDir,
   PY_MCP_FAMILY_CONNECTIONS,
   resolveAgentFramework,
-} from '../../../utils/agent-connection/agent-connection';
-import { addPythonDestructuredImport } from '../../../utils/ast';
+} from '../../../utils/agent-connection/agent-connection.js';
+import { addPythonDestructuredImport } from '../../../utils/ast.js';
 import {
   declareDependencies,
   ownedElsewhere,
-} from '../../../utils/declared-dependencies';
-import { formatFilesInSubtree } from '../../../utils/format';
-import { installDependencies } from '../../../utils/install';
-import { addGeneratorMetricsIfApplicable } from '../../../utils/metrics';
-import { snakeCase } from '../../../utils/names';
+} from '../../../utils/declared-dependencies.js';
+import { formatFilesInSubtree } from '../../../utils/format.js';
+import { installDependencies } from '../../../utils/install.js';
+import { addGeneratorMetricsIfApplicable } from '../../../utils/metrics.js';
+import { snakeCase } from '../../../utils/names.js';
 import {
   addComponentGeneratorMetadata,
   addDependencyToTargetIfNotPresent,
   getGeneratorInfo,
   type NxGeneratorInfo,
   readProjectConfigurationUnqualified,
-} from '../../../utils/nx';
-import { toProjectRelativePath } from '../../../utils/paths';
-import { addWorkspaceDependencyToPyProject } from '../../../utils/py';
+} from '../../../utils/nx.js';
+import { toProjectRelativePath } from '../../../utils/paths.js';
+import { addWorkspaceDependencyToPyProject } from '../../../utils/py.js';
 import type { PyAgentMcpConnectionGeneratorSchema } from './schema';
 
 /** The metadata this generator records, which its predicates read. */

--- a/packages/nx-plugin/src/py/agent/mcp-connection/schema.d.ts
+++ b/packages/nx-plugin/src/py/agent/mcp-connection/schema.d.ts
@@ -2,7 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import { ComponentMetadata } from '../../../utils/nx';
+import { ComponentMetadata } from '../../../utils/nx.js';
 
 /**
  * TypeScript types for options defined in schema.json

--- a/packages/nx-plugin/src/py/agent/react-connection/generator.spec.ts
+++ b/packages/nx-plugin/src/py/agent/react-connection/generator.spec.ts
@@ -3,21 +3,21 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { readProjectConfiguration, type Tree } from '@nx/devkit';
-import { tsReactWebsiteGenerator } from '../../../ts/react-website/app/generator';
-import { matchGritQL } from '../../../utils/ast';
-import { declareDependencies } from '../../../utils/declared-dependencies';
-import { expectHasMetricTags } from '../../../utils/metrics.spec';
+import { tsReactWebsiteGenerator } from '../../../ts/react-website/app/generator.js';
+import { matchGritQL } from '../../../utils/ast.js';
+import { declareDependencies } from '../../../utils/declared-dependencies.js';
+import { expectHasMetricTags } from '../../../utils/metrics.spec.js';
 import {
   SHARED_CONSTRUCTS_DEPENDENCIES,
   sharedConstructsGenerator,
-} from '../../../utils/shared-constructs';
-import { createTreeUsingTsSolutionSetup } from '../../../utils/test';
-import { pyProjectGenerator } from '../../project/generator';
-import { pyAgentGenerator } from '../generator';
+} from '../../../utils/shared-constructs.js';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test.js';
+import { pyProjectGenerator } from '../../project/generator.js';
+import { pyAgentGenerator } from '../generator.js';
 import {
   PY_AGENT_REACT_CONNECTION_GENERATOR_INFO,
   pyAgentReactConnectionGenerator,
-} from './generator';
+} from './generator.js';
 
 const sharedConstructsDeclaration = declareDependencies()({
   ts: [...SHARED_CONSTRUCTS_DEPENDENCIES],

--- a/packages/nx-plugin/src/py/agent/react-connection/generator.ts
+++ b/packages/nx-plugin/src/py/agent/react-connection/generator.ts
@@ -9,27 +9,27 @@ import {
   type Tree,
   updateProjectConfiguration,
 } from '@nx/devkit';
-import { addAgentRuntimeToConnectionNamespace } from '../../../connection/agent-runtime-config';
-import type { ResolvedConnectionOptions } from '../../../connection/generator';
-import type { AgentGatewayRoute } from '../../../ts/agent/react-connection/generator';
+import { addAgentRuntimeToConnectionNamespace } from '../../../connection/agent-runtime-config.js';
+import type { ResolvedConnectionOptions } from '../../../connection/generator.js';
+import type { AgentGatewayRoute } from '../../../ts/agent/react-connection/generator.js';
 import {
   DEPENDENCIES as AGUI_DEPENDENCIES,
   type AgUiAuth,
   addAgUiReactConnection,
   resolveAgUiTheme,
-} from '../../../ts/react-website/agui/generator';
+} from '../../../ts/react-website/agui/generator.js';
 import {
   addOpenApiReactClient,
   OPEN_API_REACT_DEPENDENCIES,
-} from '../../../utils/connection/open-api/react';
+} from '../../../utils/connection/open-api/react.js';
 import {
   declareDependencies,
   onlyWhen,
-} from '../../../utils/declared-dependencies';
-import { formatFilesInSubtree } from '../../../utils/format';
-import { installDependencies } from '../../../utils/install';
-import { addGeneratorMetricsIfApplicable } from '../../../utils/metrics';
-import { kebabCase, toClassName, toSnakeCase } from '../../../utils/names';
+} from '../../../utils/declared-dependencies.js';
+import { formatFilesInSubtree } from '../../../utils/format.js';
+import { installDependencies } from '../../../utils/install.js';
+import { addGeneratorMetricsIfApplicable } from '../../../utils/metrics.js';
+import { kebabCase, toClassName, toSnakeCase } from '../../../utils/names.js';
 import {
   addComponentGeneratorMetadata,
   addDependencyToTargetIfNotPresent,
@@ -37,13 +37,13 @@ import {
   getGeneratorInfo,
   type NxGeneratorInfo,
   readProjectConfigurationUnqualified,
-} from '../../../utils/nx';
-import { sortObjectKeys } from '../../../utils/object';
-import { toProjectRelativePath } from '../../../utils/paths';
+} from '../../../utils/nx.js';
+import { sortObjectKeys } from '../../../utils/object.js';
+import { toProjectRelativePath } from '../../../utils/paths.js';
 import {
   addPyAgentTargetToLocalDev,
   openApiClientLocalDevDeps,
-} from './local-dev';
+} from './local-dev.js';
 
 /** The metadata this generator records, which its predicates read. */
 export interface PyAgentReactConnectionMetadata {

--- a/packages/nx-plugin/src/py/agent/react-connection/local-dev.ts
+++ b/packages/nx-plugin/src/py/agent/react-connection/local-dev.ts
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { Tree } from '@nx/devkit';
-import { addAgentTargetToLocalDev } from '../../../connection/agent-local-dev';
-import { kebabCase } from '../../../utils/names';
-import type { ComponentMetadata } from '../../../utils/nx';
+import { addAgentTargetToLocalDev } from '../../../connection/agent-local-dev.js';
+import { kebabCase } from '../../../utils/names.js';
+import type { ComponentMetadata } from '../../../utils/nx.js';
 
 export interface PyAgentLocalDevOptions {
   agentName: string;

--- a/packages/nx-plugin/src/py/agent/react-connection/schema.d.ts
+++ b/packages/nx-plugin/src/py/agent/react-connection/schema.d.ts
@@ -2,7 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import { ComponentMetadata } from '../../../utils/nx';
+import { ComponentMetadata } from '../../../utils/nx.js';
 
 /**
  * TypeScript types for options defined in schema.json

--- a/packages/nx-plugin/src/py/agent/schema.d.ts
+++ b/packages/nx-plugin/src/py/agent/schema.d.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { IacOption } from '../../utils/iac';
+import { IacOption } from '../../utils/iac.js';
 
 export type PyAgentFramework = 'strands' | 'langchain';
 export type PyAgentInfra = 'agentcore' | 'none';

--- a/packages/nx-plugin/src/py/api/generator.spec.ts
+++ b/packages/nx-plugin/src/py/api/generator.spec.ts
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { Tree } from '@nx/devkit';
-import { createTreeUsingTsSolutionSetup } from '../../utils/test';
-import { pyApiGenerator } from './generator';
+import { createTreeUsingTsSolutionSetup } from '../../utils/test.js';
+import { pyApiGenerator } from './generator.js';
 import { PyApiGeneratorSchema } from './schema';
 
 describe('py#api generator', () => {

--- a/packages/nx-plugin/src/py/api/generator.ts
+++ b/packages/nx-plugin/src/py/api/generator.ts
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { Tree } from '@nx/devkit';
-import { getGeneratorInfo, type NxGeneratorInfo } from '../../utils/nx';
-import { pyFastApiProjectGenerator } from '../fast-api/generator';
+import { getGeneratorInfo, type NxGeneratorInfo } from '../../utils/nx.js';
+import { pyFastApiProjectGenerator } from '../fast-api/generator.js';
 import type { PyApiGeneratorSchema } from './schema';
 
 export const PY_API_GENERATOR_INFO: NxGeneratorInfo = getGeneratorInfo(

--- a/packages/nx-plugin/src/py/api/schema.d.ts
+++ b/packages/nx-plugin/src/py/api/schema.d.ts
@@ -2,7 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import { IacOption } from '../../utils/iac';
+import { IacOption } from '../../utils/iac.js';
 
 export interface PyApiGeneratorSchema {
   readonly name: string;

--- a/packages/nx-plugin/src/py/dynamodb/agent-connection/generator.spec.ts
+++ b/packages/nx-plugin/src/py/dynamodb/agent-connection/generator.spec.ts
@@ -4,8 +4,8 @@
  */
 import { readProjectConfiguration, type Tree } from '@nx/devkit';
 import { beforeEach, describe, expect, it } from 'vitest';
-import { createTreeUsingTsSolutionSetup } from '../../../utils/test';
-import { pyDynamoDBAgentConnectionGenerator } from './generator';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test.js';
+import { pyDynamoDBAgentConnectionGenerator } from './generator.js';
 
 describe('py#dynamodb agent-connection generator', () => {
   let tree: Tree;

--- a/packages/nx-plugin/src/py/dynamodb/agent-connection/generator.ts
+++ b/packages/nx-plugin/src/py/dynamodb/agent-connection/generator.ts
@@ -7,17 +7,17 @@ import {
   type Tree,
   updateProjectConfiguration,
 } from '@nx/devkit';
-import { formatFilesInSubtree } from '../../../utils/format';
-import { installDependencies } from '../../../utils/install';
-import { addGeneratorMetricsIfApplicable } from '../../../utils/metrics';
+import { formatFilesInSubtree } from '../../../utils/format.js';
+import { installDependencies } from '../../../utils/install.js';
+import { addGeneratorMetricsIfApplicable } from '../../../utils/metrics.js';
 import {
   addComponentGeneratorMetadata,
   addDependencyToTargetIfNotPresent,
   getGeneratorInfo,
   type NxGeneratorInfo,
   readProjectConfigurationUnqualified,
-} from '../../../utils/nx';
-import { addWorkspaceDependencyToPyProject } from '../../../utils/py';
+} from '../../../utils/nx.js';
+import { addWorkspaceDependencyToPyProject } from '../../../utils/py.js';
 import type { PyDynamoDBAgentConnectionGeneratorSchema } from './schema';
 
 export const PY_DYNAMODB_AGENT_CONNECTION_GENERATOR_INFO: NxGeneratorInfo =

--- a/packages/nx-plugin/src/py/dynamodb/agent-connection/schema.d.ts
+++ b/packages/nx-plugin/src/py/dynamodb/agent-connection/schema.d.ts
@@ -2,7 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import { ComponentMetadata } from '../../../utils/nx';
+import { ComponentMetadata } from '../../../utils/nx.js';
 
 /**
  * TypeScript types for options defined in schema.json

--- a/packages/nx-plugin/src/py/dynamodb/fast-api-connection/generator.spec.ts
+++ b/packages/nx-plugin/src/py/dynamodb/fast-api-connection/generator.spec.ts
@@ -4,8 +4,8 @@
  */
 import { readProjectConfiguration, type Tree } from '@nx/devkit';
 import { beforeEach, describe, expect, it } from 'vitest';
-import { createTreeUsingTsSolutionSetup } from '../../../utils/test';
-import { pyDynamoDBFastApiConnectionGenerator } from './generator';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test.js';
+import { pyDynamoDBFastApiConnectionGenerator } from './generator.js';
 
 describe('py#dynamodb fast-api-connection generator', () => {
   let tree: Tree;

--- a/packages/nx-plugin/src/py/dynamodb/fast-api-connection/generator.ts
+++ b/packages/nx-plugin/src/py/dynamodb/fast-api-connection/generator.ts
@@ -7,17 +7,17 @@ import {
   type Tree,
   updateProjectConfiguration,
 } from '@nx/devkit';
-import { formatFilesInSubtree } from '../../../utils/format';
-import { installDependencies } from '../../../utils/install';
-import { addGeneratorMetricsIfApplicable } from '../../../utils/metrics';
+import { formatFilesInSubtree } from '../../../utils/format.js';
+import { installDependencies } from '../../../utils/install.js';
+import { addGeneratorMetricsIfApplicable } from '../../../utils/metrics.js';
 import {
   addComponentGeneratorMetadata,
   addDependencyToTargetIfNotPresent,
   getGeneratorInfo,
   type NxGeneratorInfo,
   readProjectConfigurationUnqualified,
-} from '../../../utils/nx';
-import { addWorkspaceDependencyToPyProject } from '../../../utils/py';
+} from '../../../utils/nx.js';
+import { addWorkspaceDependencyToPyProject } from '../../../utils/py.js';
 import type { PyDynamoDBFastApiConnectionGeneratorSchema } from './schema';
 
 export const PY_DYNAMODB_FAST_API_CONNECTION_GENERATOR_INFO: NxGeneratorInfo =

--- a/packages/nx-plugin/src/py/dynamodb/generator.spec.ts
+++ b/packages/nx-plugin/src/py/dynamodb/generator.spec.ts
@@ -3,19 +3,22 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { Tree } from '@nx/devkit';
-import { resolveContainers } from '../../utils/containers';
-import { declareDependencies } from '../../utils/declared-dependencies';
-import { expectHasMetricTags } from '../../utils/metrics.spec';
-import { readProjectConfigurationUnqualified } from '../../utils/nx';
+import { resolveContainers } from '../../utils/containers.js';
+import { declareDependencies } from '../../utils/declared-dependencies.js';
+import { expectHasMetricTags } from '../../utils/metrics.spec.js';
+import { readProjectConfigurationUnqualified } from '../../utils/nx.js';
 import {
   SHARED_CONSTRUCTS_DEPENDENCIES,
   sharedConstructsGenerator,
-} from '../../utils/shared-constructs';
+} from '../../utils/shared-constructs.js';
 import {
   createTreeUsingTsSolutionSetup,
   snapshotTreeDir,
-} from '../../utils/test';
-import { PY_DYNAMODB_GENERATOR_INFO, pyDynamoDBGenerator } from './generator';
+} from '../../utils/test.js';
+import {
+  PY_DYNAMODB_GENERATOR_INFO,
+  pyDynamoDBGenerator,
+} from './generator.js';
 
 const sharedConstructsDeclaration = declareDependencies()({
   ts: [...SHARED_CONSTRUCTS_DEPENDENCIES],

--- a/packages/nx-plugin/src/py/dynamodb/generator.ts
+++ b/packages/nx-plugin/src/py/dynamodb/generator.ts
@@ -12,40 +12,42 @@ import {
   type Tree,
   updateProjectConfiguration,
 } from '@nx/devkit';
-import { addPyDependencies } from '../../utils/add-dependencies';
-import { resolveContainers } from '../../utils/containers';
+import { addPyDependencies } from '../../utils/add-dependencies.js';
+import { resolveContainers } from '../../utils/containers.js';
 import {
   declareDependencies,
   ownedElsewhere,
-} from '../../utils/declared-dependencies';
-import { addDynamoDBInfra } from '../../utils/dynamodb-constructs/dynamodb-constructs';
-import { formatFilesInSubtree } from '../../utils/format';
-import { resolveIac } from '../../utils/iac';
-import { installDependencies } from '../../utils/install';
-import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
-import { kebabCase, toClassName } from '../../utils/names';
-import { getNpmScope } from '../../utils/npm-scope';
+} from '../../utils/declared-dependencies.js';
+import { addDynamoDBInfra } from '../../utils/dynamodb-constructs/dynamodb-constructs.js';
+import { formatFilesInSubtree } from '../../utils/format.js';
+import { resolveIac } from '../../utils/iac.js';
+import { installDependencies } from '../../utils/install.js';
+import { addGeneratorMetricsIfApplicable } from '../../utils/metrics.js';
+import { kebabCase, toClassName } from '../../utils/names.js';
+import { getNpmScope } from '../../utils/npm-scope.js';
 import {
   addGeneratorMetadata,
   getGeneratorInfo,
   type NxGeneratorInfo,
   projectExists,
-} from '../../utils/nx';
-import { assignSharedPort } from '../../utils/port';
+} from '../../utils/nx.js';
+import { assignSharedPort } from '../../utils/port.js';
 import {
   SHARED_CONSTRUCTS_DEPENDENCIES,
   sharedConstructsGenerator,
-} from '../../utils/shared-constructs';
+} from '../../utils/shared-constructs.js';
 import {
   DYNAMODB_GENERATOR_IDS,
   PACKAGES_DIR,
   SHARED_SCRIPTS_DIR,
-} from '../../utils/shared-constructs-constants';
+} from '../../utils/shared-constructs-constants.js';
 import {
   SHARED_DYNAMODB_SCRIPTS_DEPENDENCIES,
   sharedDynamoDBScriptsGenerator,
-} from '../../utils/shared-dynamodb-scripts';
-import pyProjectGenerator, { getPyProjectDetails } from '../project/generator';
+} from '../../utils/shared-dynamodb-scripts.js';
+import pyProjectGenerator, {
+  getPyProjectDetails,
+} from '../project/generator.js';
 import type { PyDynamoDBGeneratorSchema } from './schema';
 
 export const DEPENDENCIES = declareDependencies()({

--- a/packages/nx-plugin/src/py/dynamodb/mcp-server-connection/generator.spec.ts
+++ b/packages/nx-plugin/src/py/dynamodb/mcp-server-connection/generator.spec.ts
@@ -4,8 +4,8 @@
  */
 import { readProjectConfiguration, type Tree } from '@nx/devkit';
 import { beforeEach, describe, expect, it } from 'vitest';
-import { createTreeUsingTsSolutionSetup } from '../../../utils/test';
-import { pyDynamoDBMcpServerConnectionGenerator } from './generator';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test.js';
+import { pyDynamoDBMcpServerConnectionGenerator } from './generator.js';
 
 describe('py#dynamodb mcp-server-connection generator', () => {
   let tree: Tree;

--- a/packages/nx-plugin/src/py/dynamodb/mcp-server-connection/generator.ts
+++ b/packages/nx-plugin/src/py/dynamodb/mcp-server-connection/generator.ts
@@ -7,17 +7,17 @@ import {
   type Tree,
   updateProjectConfiguration,
 } from '@nx/devkit';
-import { formatFilesInSubtree } from '../../../utils/format';
-import { installDependencies } from '../../../utils/install';
-import { addGeneratorMetricsIfApplicable } from '../../../utils/metrics';
+import { formatFilesInSubtree } from '../../../utils/format.js';
+import { installDependencies } from '../../../utils/install.js';
+import { addGeneratorMetricsIfApplicable } from '../../../utils/metrics.js';
 import {
   addComponentGeneratorMetadata,
   addDependencyToTargetIfNotPresent,
   getGeneratorInfo,
   type NxGeneratorInfo,
   readProjectConfigurationUnqualified,
-} from '../../../utils/nx';
-import { addWorkspaceDependencyToPyProject } from '../../../utils/py';
+} from '../../../utils/nx.js';
+import { addWorkspaceDependencyToPyProject } from '../../../utils/py.js';
 import type { PyDynamoDBMcpServerConnectionGeneratorSchema } from './schema';
 
 export const PY_DYNAMODB_MCP_SERVER_CONNECTION_GENERATOR_INFO: NxGeneratorInfo =

--- a/packages/nx-plugin/src/py/dynamodb/mcp-server-connection/schema.d.ts
+++ b/packages/nx-plugin/src/py/dynamodb/mcp-server-connection/schema.d.ts
@@ -2,7 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import { ComponentMetadata } from '../../../utils/nx';
+import { ComponentMetadata } from '../../../utils/nx.js';
 
 /**
  * TypeScript types for options defined in schema.json

--- a/packages/nx-plugin/src/py/dynamodb/schema.d.ts
+++ b/packages/nx-plugin/src/py/dynamodb/schema.d.ts
@@ -2,7 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import { IacOption } from '../../utils/iac';
+import { IacOption } from '../../utils/iac.js';
 
 export interface PyDynamoDBGeneratorSchema {
   name: string;

--- a/packages/nx-plugin/src/py/fast-api/generator.spec.ts
+++ b/packages/nx-plugin/src/py/fast-api/generator.spec.ts
@@ -8,19 +8,19 @@ import { joinPathFragments, type Tree } from '@nx/devkit';
 import {
   ensureAwsNxPluginConfig,
   updateAwsNxPluginConfig,
-} from '../../utils/config/utils';
-import { expectHasMetricTags } from '../../utils/metrics.spec';
-import type { UVPyprojectToml } from '../../utils/nxlv-python';
-import { sortObjectKeys } from '../../utils/object';
+} from '../../utils/config/utils.js';
+import { expectHasMetricTags } from '../../utils/metrics.spec.js';
+import type { UVPyprojectToml } from '../../utils/nxlv-python.js';
+import { sortObjectKeys } from '../../utils/object.js';
 import {
   PACKAGES_DIR,
   SHARED_CONSTRUCTS_DIR,
-} from '../../utils/shared-constructs-constants';
-import { createTreeUsingTsSolutionSetup } from '../../utils/test';
+} from '../../utils/shared-constructs-constants.js';
+import { createTreeUsingTsSolutionSetup } from '../../utils/test.js';
 import {
   FAST_API_GENERATOR_INFO,
   pyFastApiProjectGenerator,
-} from './generator';
+} from './generator.js';
 
 describe('fastapi project generator', () => {
   let tree: Tree;

--- a/packages/nx-plugin/src/py/fast-api/generator.terraform.spec.ts
+++ b/packages/nx-plugin/src/py/fast-api/generator.terraform.spec.ts
@@ -4,8 +4,8 @@
  */
 
 import type { Tree } from '@nx/devkit';
-import { createTreeUsingTsSolutionSetup } from '../../utils/test';
-import { pyFastApiProjectGenerator } from './generator';
+import { createTreeUsingTsSolutionSetup } from '../../utils/test.js';
+import { pyFastApiProjectGenerator } from './generator.js';
 
 describe('fastapi project generator', () => {
   let tree: Tree;

--- a/packages/nx-plugin/src/py/fast-api/generator.ts
+++ b/packages/nx-plugin/src/py/fast-api/generator.ts
@@ -12,38 +12,40 @@ import {
   type Tree,
   updateProjectConfiguration,
 } from '@nx/devkit';
-import { addPyDependencies } from '../../utils/add-dependencies';
+import { addPyDependencies } from '../../utils/add-dependencies.js';
 import {
   API_CONSTRUCTS_DEPENDENCIES,
   API_CONSTRUCTS_PY_DEPENDENCIES,
   addApiGatewayInfra,
-} from '../../utils/api-constructs/api-constructs';
-import { addSharedConstructsOpenApiMetadataGenerateTarget } from '../../utils/api-constructs/open-api-metadata';
-import { addPythonBundleTarget } from '../../utils/bundle/bundle';
+} from '../../utils/api-constructs/api-constructs.js';
+import { addSharedConstructsOpenApiMetadataGenerateTarget } from '../../utils/api-constructs/open-api-metadata.js';
+import { addPythonBundleTarget } from '../../utils/bundle/bundle.js';
 import {
   declareDependencies,
   ownedElsewhere,
-} from '../../utils/declared-dependencies';
-import { formatFilesInSubtree } from '../../utils/format';
-import { FS_DEPENDENCIES, FsCommands } from '../../utils/fs';
-import { resolveIac } from '../../utils/iac';
-import { installDependencies } from '../../utils/install';
-import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
-import { toClassName, toKebabCase } from '../../utils/names';
+} from '../../utils/declared-dependencies.js';
+import { formatFilesInSubtree } from '../../utils/format.js';
+import { FS_DEPENDENCIES, FsCommands } from '../../utils/fs.js';
+import { resolveIac } from '../../utils/iac.js';
+import { installDependencies } from '../../utils/install.js';
+import { addGeneratorMetricsIfApplicable } from '../../utils/metrics.js';
+import { toClassName, toKebabCase } from '../../utils/names.js';
 import {
   addGeneratorMetadata,
   getGeneratorInfo,
   type NxGeneratorInfo,
-} from '../../utils/nx';
-import { sortObjectKeys } from '../../utils/object';
-import { assignPort } from '../../utils/port';
+} from '../../utils/nx.js';
+import { sortObjectKeys } from '../../utils/object.js';
+import { assignPort } from '../../utils/port.js';
 import {
   SHARED_CONSTRUCTS_DEPENDENCIES,
   sharedConstructsGenerator,
-} from '../../utils/shared-constructs';
-import type { IacMetadata } from '../../utils/shared-constructs-constants';
-import pyProjectGenerator, { getPyProjectDetails } from '../project/generator';
-import { addOpenApiGeneration } from './react/open-api';
+} from '../../utils/shared-constructs.js';
+import type { IacMetadata } from '../../utils/shared-constructs-constants.js';
+import pyProjectGenerator, {
+  getPyProjectDetails,
+} from '../project/generator.js';
+import { addOpenApiGeneration } from './react/open-api.js';
 import type { PyFastApiProjectGeneratorSchema } from './schema';
 
 /** The metadata this generator records, which its predicates read. */

--- a/packages/nx-plugin/src/py/fast-api/react/generator.spec.ts
+++ b/packages/nx-plugin/src/py/fast-api/react/generator.spec.ts
@@ -3,20 +3,20 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { type Tree, updateJson } from '@nx/devkit';
-import { tsReactWebsiteGenerator } from '../../../ts/react-website/app/generator';
-import { matchGritQL } from '../../../utils/ast';
-import { declareDependencies } from '../../../utils/declared-dependencies';
-import { expectHasMetricTags } from '../../../utils/metrics.spec';
+import { tsReactWebsiteGenerator } from '../../../ts/react-website/app/generator.js';
+import { matchGritQL } from '../../../utils/ast.js';
+import { declareDependencies } from '../../../utils/declared-dependencies.js';
+import { expectHasMetricTags } from '../../../utils/metrics.spec.js';
 import {
   SHARED_CONSTRUCTS_DEPENDENCIES,
   sharedConstructsGenerator,
-} from '../../../utils/shared-constructs';
-import { createTreeUsingTsSolutionSetup } from '../../../utils/test';
-import { pyFastApiProjectGenerator } from '../generator';
+} from '../../../utils/shared-constructs.js';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test.js';
+import { pyFastApiProjectGenerator } from '../generator.js';
 import {
   FAST_API_REACT_GENERATOR_INFO,
   fastApiReactGenerator,
-} from './generator';
+} from './generator.js';
 
 const sharedConstructsDeclaration = declareDependencies()({
   ts: [...SHARED_CONSTRUCTS_DEPENDENCIES],

--- a/packages/nx-plugin/src/py/fast-api/react/generator.ts
+++ b/packages/nx-plugin/src/py/fast-api/react/generator.ts
@@ -6,20 +6,20 @@ import { joinPathFragments, type Tree } from '@nx/devkit';
 import {
   addOpenApiReactClient,
   OPEN_API_REACT_DEPENDENCIES,
-} from '../../../utils/connection/open-api/react';
-import { declareDependencies } from '../../../utils/declared-dependencies';
-import { formatFilesInSubtree } from '../../../utils/format';
-import { installDependencies } from '../../../utils/install';
-import { addGeneratorMetricsIfApplicable } from '../../../utils/metrics';
-import { toClassName } from '../../../utils/names';
+} from '../../../utils/connection/open-api/react.js';
+import { declareDependencies } from '../../../utils/declared-dependencies.js';
+import { formatFilesInSubtree } from '../../../utils/format.js';
+import { installDependencies } from '../../../utils/install.js';
+import { addGeneratorMetricsIfApplicable } from '../../../utils/metrics.js';
+import { toClassName } from '../../../utils/names.js';
 import {
   addComponentGeneratorMetadata,
   getGeneratorInfo,
   type NxGeneratorInfo,
   readProjectConfigurationUnqualified,
-} from '../../../utils/nx';
-import { toProjectRelativePath } from '../../../utils/paths';
-import { addOpenApiGeneration } from './open-api';
+} from '../../../utils/nx.js';
+import { toProjectRelativePath } from '../../../utils/paths.js';
+import { addOpenApiGeneration } from './open-api.js';
 import type { FastApiReactGeneratorSchema } from './schema';
 
 export const DEPENDENCIES = declareDependencies()({

--- a/packages/nx-plugin/src/py/fast-api/react/open-api.ts
+++ b/packages/nx-plugin/src/py/fast-api/react/open-api.ts
@@ -10,8 +10,8 @@ import {
   type Tree,
   updateProjectConfiguration,
 } from '@nx/devkit';
-import { snakeCase } from '../../../utils/names';
-import { sortObjectKeys } from '../../../utils/object';
+import { snakeCase } from '../../../utils/names.js';
+import { sortObjectKeys } from '../../../utils/object.js';
 
 export interface AddOpenApiGenerationOptions {
   project: ProjectConfiguration;

--- a/packages/nx-plugin/src/py/fast-api/schema.d.ts
+++ b/packages/nx-plugin/src/py/fast-api/schema.d.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { IacOption } from '../../utils/iac';
+import { IacOption } from '../../utils/iac.js';
 
 export interface PyFastApiProjectGeneratorSchema {
   readonly name: string;

--- a/packages/nx-plugin/src/py/lambda-function/event-models.spec.ts
+++ b/packages/nx-plugin/src/py/lambda-function/event-models.spec.ts
@@ -5,7 +5,7 @@
 
 import { readFileSync } from 'fs';
 import { join } from 'path';
-import { eventModuleFor } from './generator';
+import { eventModuleFor } from './generator.js';
 
 /**
  * The handler template interpolates the chosen event model straight into an

--- a/packages/nx-plugin/src/py/lambda-function/generator.spec.ts
+++ b/packages/nx-plugin/src/py/lambda-function/generator.spec.ts
@@ -8,20 +8,20 @@ import { joinPathFragments, type Tree, updateJson } from '@nx/devkit';
 import {
   ensureAwsNxPluginConfig,
   updateAwsNxPluginConfig,
-} from '../../utils/config/utils';
-import { expectHasMetricTags } from '../../utils/metrics.spec';
-import type { UVPyprojectToml } from '../../utils/nxlv-python';
-import { sortObjectKeys } from '../../utils/object';
+} from '../../utils/config/utils.js';
+import { expectHasMetricTags } from '../../utils/metrics.spec.js';
+import type { UVPyprojectToml } from '../../utils/nxlv-python.js';
+import { sortObjectKeys } from '../../utils/object.js';
 import {
   PACKAGES_DIR,
   SHARED_CONSTRUCTS_DIR,
-} from '../../utils/shared-constructs-constants';
-import { createTreeUsingTsSolutionSetup } from '../../utils/test';
-import { pyMcpServerGenerator } from '../mcp-server/generator';
+} from '../../utils/shared-constructs-constants.js';
+import { createTreeUsingTsSolutionSetup } from '../../utils/test.js';
+import { pyMcpServerGenerator } from '../mcp-server/generator.js';
 import {
   LAMBDA_FUNCTION_GENERATOR_INFO,
   pyLambdaFunctionGenerator,
-} from './generator';
+} from './generator.js';
 
 describe('lambda-handler project generator', () => {
   let tree: Tree;

--- a/packages/nx-plugin/src/py/lambda-function/generator.ts
+++ b/packages/nx-plugin/src/py/lambda-function/generator.ts
@@ -10,36 +10,36 @@ import {
   type Tree,
   updateProjectConfiguration,
 } from '@nx/devkit';
-import { addPyDependencies } from '../../utils/add-dependencies';
-import { addPythonBundleTarget } from '../../utils/bundle/bundle';
+import { addPyDependencies } from '../../utils/add-dependencies.js';
+import { addPythonBundleTarget } from '../../utils/bundle/bundle.js';
 import {
   declareDependencies,
   ownedElsewhere,
-} from '../../utils/declared-dependencies';
-import { formatFilesInSubtree } from '../../utils/format';
-import { addLambdaFunctionInfra } from '../../utils/function-constructs/function-constructs';
-import { resolveIac } from '../../utils/iac';
-import { installDependencies } from '../../utils/install';
-import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
+} from '../../utils/declared-dependencies.js';
+import { formatFilesInSubtree } from '../../utils/format.js';
+import { addLambdaFunctionInfra } from '../../utils/function-constructs/function-constructs.js';
+import { resolveIac } from '../../utils/iac.js';
+import { installDependencies } from '../../utils/install.js';
+import { addGeneratorMetricsIfApplicable } from '../../utils/metrics.js';
 import {
   toClassName,
   toDotNotation,
   toKebabCase,
   toSnakeCase,
-} from '../../utils/names';
-import { getNpmScope } from '../../utils/npm-scope';
+} from '../../utils/names.js';
+import { getNpmScope } from '../../utils/npm-scope.js';
 import {
   addComponentGeneratorMetadata,
   getGeneratorInfo,
   type NxGeneratorInfo,
   readProjectConfigurationUnqualified,
-} from '../../utils/nx';
-import { sortObjectKeys } from '../../utils/object';
-import { toProjectRelativePath } from '../../utils/paths';
+} from '../../utils/nx.js';
+import { sortObjectKeys } from '../../utils/object.js';
+import { toProjectRelativePath } from '../../utils/paths.js';
 import {
   SHARED_CONSTRUCTS_DEPENDENCIES,
   sharedConstructsGenerator,
-} from '../../utils/shared-constructs';
+} from '../../utils/shared-constructs.js';
 import type { PyLambdaFunctionGeneratorSchema } from './schema';
 
 export const DEPENDENCIES = declareDependencies()({

--- a/packages/nx-plugin/src/py/lambda-function/schema.d.ts
+++ b/packages/nx-plugin/src/py/lambda-function/schema.d.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { IacOption } from '../../utils/iac';
+import { IacOption } from '../../utils/iac.js';
 
 type EventSource =
   | 'Any'

--- a/packages/nx-plugin/src/py/mcp-server/generator.spec.ts
+++ b/packages/nx-plugin/src/py/mcp-server/generator.spec.ts
@@ -14,24 +14,24 @@ import yaml from 'js-yaml';
 import {
   ensureAwsNxPluginConfig,
   updateAwsNxPluginConfig,
-} from '../../utils/config/utils';
-import { declareDependencies } from '../../utils/declared-dependencies';
-import { expectHasMetricTags } from '../../utils/metrics.spec';
-import type { UVPyprojectToml } from '../../utils/nxlv-python';
+} from '../../utils/config/utils.js';
+import { declareDependencies } from '../../utils/declared-dependencies.js';
+import { expectHasMetricTags } from '../../utils/metrics.spec.js';
+import type { UVPyprojectToml } from '../../utils/nxlv-python.js';
 import {
   SHARED_CONSTRUCTS_DEPENDENCIES,
   sharedConstructsGenerator,
-} from '../../utils/shared-constructs';
+} from '../../utils/shared-constructs.js';
 import {
   PACKAGES_DIR,
   SHARED_CONSTRUCTS_DIR,
-} from '../../utils/shared-constructs-constants';
-import { createTreeUsingTsSolutionSetup } from '../../utils/test';
-import { CONTAINER_VERSIONS } from '../../utils/versions';
+} from '../../utils/shared-constructs-constants.js';
+import { createTreeUsingTsSolutionSetup } from '../../utils/test.js';
+import { CONTAINER_VERSIONS } from '../../utils/versions.js';
 import {
   PY_MCP_SERVER_GENERATOR_INFO,
   pyMcpServerGenerator,
-} from './generator';
+} from './generator.js';
 
 const sharedConstructsDeclaration = declareDependencies()({
   ts: [...SHARED_CONSTRUCTS_DEPENDENCIES],

--- a/packages/nx-plugin/src/py/mcp-server/generator.ts
+++ b/packages/nx-plugin/src/py/mcp-server/generator.ts
@@ -13,22 +13,25 @@ import {
 import {
   addPyDependencies,
   addTsDependencies,
-} from '../../utils/add-dependencies';
-import { addMcpServerInfra } from '../../utils/agent-core-constructs/agent-core-constructs';
-import { addPythonBundleTarget } from '../../utils/bundle/bundle';
-import { resolveContainers } from '../../utils/containers';
+} from '../../utils/add-dependencies.js';
+import { addMcpServerInfra } from '../../utils/agent-core-constructs/agent-core-constructs.js';
+import { addPythonBundleTarget } from '../../utils/bundle/bundle.js';
+import { resolveContainers } from '../../utils/containers.js';
 import {
   declareDependencies,
   ownedElsewhere,
-} from '../../utils/declared-dependencies';
-import { addDockerScanTarget, DOCKER_DEPENDENCIES } from '../../utils/docker';
-import { formatFilesInSubtree } from '../../utils/format';
-import { FS_DEPENDENCIES, FsCommands } from '../../utils/fs';
-import { resolveIac } from '../../utils/iac';
-import { installDependencies } from '../../utils/install';
-import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
-import { kebabCase, toClassName, toSnakeCase } from '../../utils/names';
-import { getNpmScope } from '../../utils/npm-scope';
+} from '../../utils/declared-dependencies.js';
+import {
+  addDockerScanTarget,
+  DOCKER_DEPENDENCIES,
+} from '../../utils/docker.js';
+import { formatFilesInSubtree } from '../../utils/format.js';
+import { FS_DEPENDENCIES, FsCommands } from '../../utils/fs.js';
+import { resolveIac } from '../../utils/iac.js';
+import { installDependencies } from '../../utils/install.js';
+import { addGeneratorMetricsIfApplicable } from '../../utils/metrics.js';
+import { kebabCase, toClassName, toSnakeCase } from '../../utils/names.js';
+import { getNpmScope } from '../../utils/npm-scope.js';
 import {
   addComponentDevTarget,
   addComponentGeneratorMetadata,
@@ -36,16 +39,16 @@ import {
   getGeneratorInfo,
   type NxGeneratorInfo,
   readProjectConfigurationUnqualified,
-} from '../../utils/nx';
-import { toProjectRelativePath } from '../../utils/paths';
-import { registerPnpmBuiltDependencies } from '../../utils/pnpm-workspace';
-import { assignPort } from '../../utils/port';
+} from '../../utils/nx.js';
+import { toProjectRelativePath } from '../../utils/paths.js';
+import { registerPnpmBuiltDependencies } from '../../utils/pnpm-workspace.js';
+import { assignPort } from '../../utils/port.js';
 import {
   SHARED_CONSTRUCTS_DEPENDENCIES,
   sharedConstructsGenerator,
-} from '../../utils/shared-constructs';
-import type { IacMetadata } from '../../utils/shared-constructs-constants';
-import { BASE_IMAGES } from '../../utils/versions';
+} from '../../utils/shared-constructs.js';
+import type { IacMetadata } from '../../utils/shared-constructs-constants.js';
+import { BASE_IMAGES } from '../../utils/versions.js';
 import type { PyMcpServerGeneratorSchema } from './schema';
 
 /** The metadata this generator records, which its predicates read. */

--- a/packages/nx-plugin/src/py/mcp-server/schema.d.ts
+++ b/packages/nx-plugin/src/py/mcp-server/schema.d.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { IacOption } from '../../utils/iac';
+import { IacOption } from '../../utils/iac.js';
 
 export type PyMcpServerInfra = 'none' | 'agentcore';
 

--- a/packages/nx-plugin/src/py/project/generator.spec.ts
+++ b/packages/nx-plugin/src/py/project/generator.spec.ts
@@ -5,14 +5,14 @@
 
 import { parse } from '@iarna/toml';
 import { getProjects, readJson, type Tree } from '@nx/devkit';
-import { declareDependencies } from '../../utils/declared-dependencies';
-import { expectHasMetricTags } from '../../utils/metrics.spec';
+import { declareDependencies } from '../../utils/declared-dependencies.js';
+import { expectHasMetricTags } from '../../utils/metrics.spec.js';
 import {
   SHARED_CONSTRUCTS_DEPENDENCIES,
   sharedConstructsGenerator,
-} from '../../utils/shared-constructs';
-import { createTreeUsingTsSolutionSetup } from '../../utils/test';
-import { PY_PROJECT_GENERATOR_INFO, pyProjectGenerator } from './generator';
+} from '../../utils/shared-constructs.js';
+import { createTreeUsingTsSolutionSetup } from '../../utils/test.js';
+import { PY_PROJECT_GENERATOR_INFO, pyProjectGenerator } from './generator.js';
 
 const sharedConstructsDeclaration = declareDependencies()({
   ts: [...SHARED_CONSTRUCTS_DEPENDENCIES],

--- a/packages/nx-plugin/src/py/project/generator.ts
+++ b/packages/nx-plugin/src/py/project/generator.ts
@@ -15,32 +15,32 @@ import {
 import {
   addLicenseCheckToLintTarget,
   ensurePythonLicenseCollector,
-} from '../../license/config';
+} from '../../license/config.js';
 import {
   addPyDependencies,
   addTsDependencies,
-} from '../../utils/add-dependencies';
-import { declareDependencies } from '../../utils/declared-dependencies';
-import { updateGitIgnore } from '../../utils/git';
-import { installDependencies } from '../../utils/install';
-import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
-import { normalizeDistributionName, toSnakeCase } from '../../utils/names';
-import { getNpmScope } from '../../utils/npm-scope';
+} from '../../utils/add-dependencies.js';
+import { declareDependencies } from '../../utils/declared-dependencies.js';
+import { updateGitIgnore } from '../../utils/git.js';
+import { installDependencies } from '../../utils/install.js';
+import { addGeneratorMetricsIfApplicable } from '../../utils/metrics.js';
+import { normalizeDistributionName, toSnakeCase } from '../../utils/names.js';
+import { getNpmScope } from '../../utils/npm-scope.js';
 import {
   addDependencyToTargetIfNotPresent,
   addGeneratorMetadata,
   getGeneratorInfo,
   type NxGeneratorInfo,
   projectExists,
-} from '../../utils/nx';
-import type { UVPyprojectToml } from '../../utils/nxlv-python';
+} from '../../utils/nx.js';
+import type { UVPyprojectToml } from '../../utils/nxlv-python.js';
 import {
   migrateToSharedVenvGenerator,
   uvProjectGenerator,
-} from '../../utils/nxlv-python';
-import { sortObjectKeys } from '../../utils/object';
-import { updateToml } from '../../utils/toml';
-import { withVersions } from '../../utils/versions';
+} from '../../utils/nxlv-python.js';
+import { sortObjectKeys } from '../../utils/object.js';
+import { updateToml } from '../../utils/toml.js';
+import { withVersions } from '../../utils/versions.js';
 import type { PyProjectGeneratorSchema } from './schema';
 
 export const DEPENDENCIES = declareDependencies()({

--- a/packages/nx-plugin/src/py/rdb/agent-connection/generator.spec.ts
+++ b/packages/nx-plugin/src/py/rdb/agent-connection/generator.spec.ts
@@ -4,8 +4,8 @@
  */
 import { readProjectConfiguration, type Tree } from '@nx/devkit';
 import { beforeEach, describe, expect, it } from 'vitest';
-import { createTreeUsingTsSolutionSetup } from '../../../utils/test';
-import { pyRdbAgentConnectionGenerator } from './generator';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test.js';
+import { pyRdbAgentConnectionGenerator } from './generator.js';
 
 describe('py#rdb agent-connection generator', () => {
   let tree: Tree;

--- a/packages/nx-plugin/src/py/rdb/agent-connection/generator.ts
+++ b/packages/nx-plugin/src/py/rdb/agent-connection/generator.ts
@@ -8,19 +8,19 @@ import {
   type Tree,
   updateProjectConfiguration,
 } from '@nx/devkit';
-import { formatFilesInSubtree } from '../../../utils/format';
-import { installDependencies } from '../../../utils/install';
-import { addGeneratorMetricsIfApplicable } from '../../../utils/metrics';
-import { toSnakeCase } from '../../../utils/names';
+import { formatFilesInSubtree } from '../../../utils/format.js';
+import { installDependencies } from '../../../utils/install.js';
+import { addGeneratorMetricsIfApplicable } from '../../../utils/metrics.js';
+import { toSnakeCase } from '../../../utils/names.js';
 import {
   addComponentGeneratorMetadata,
   addDependencyToTargetIfNotPresent,
   getGeneratorInfo,
   type NxGeneratorInfo,
   readProjectConfigurationUnqualified,
-} from '../../../utils/nx';
-import { addWorkspaceDependencyToPyProject } from '../../../utils/py';
-import { injectRdsCaBundleIntoDockerfile } from '../utils';
+} from '../../../utils/nx.js';
+import { addWorkspaceDependencyToPyProject } from '../../../utils/py.js';
+import { injectRdsCaBundleIntoDockerfile } from '../utils.js';
 import type { PyRdbAgentConnectionGeneratorSchema } from './schema';
 
 export const PY_RDB_AGENT_CONNECTION_GENERATOR_INFO: NxGeneratorInfo =

--- a/packages/nx-plugin/src/py/rdb/agent-connection/schema.d.ts
+++ b/packages/nx-plugin/src/py/rdb/agent-connection/schema.d.ts
@@ -2,7 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import { ComponentMetadata } from '../../../utils/nx';
+import { ComponentMetadata } from '../../../utils/nx.js';
 
 /**
  * TypeScript types for options defined in schema.json

--- a/packages/nx-plugin/src/py/rdb/fast-api-connection/generator.spec.ts
+++ b/packages/nx-plugin/src/py/rdb/fast-api-connection/generator.spec.ts
@@ -4,8 +4,8 @@
  */
 import { readProjectConfiguration, type Tree } from '@nx/devkit';
 import { beforeEach, describe, expect, it } from 'vitest';
-import { createTreeUsingTsSolutionSetup } from '../../../utils/test';
-import { pyRdbFastApiConnectionGenerator } from './generator';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test.js';
+import { pyRdbFastApiConnectionGenerator } from './generator.js';
 
 describe('py#rdb fast-api-connection generator', () => {
   let tree: Tree;

--- a/packages/nx-plugin/src/py/rdb/fast-api-connection/generator.ts
+++ b/packages/nx-plugin/src/py/rdb/fast-api-connection/generator.ts
@@ -10,19 +10,19 @@ import {
   type Tree,
   updateProjectConfiguration,
 } from '@nx/devkit';
-import { formatFilesInSubtree } from '../../../utils/format';
-import { installDependencies } from '../../../utils/install';
-import { addGeneratorMetricsIfApplicable } from '../../../utils/metrics';
-import { toClassName, toSnakeCase } from '../../../utils/names';
-import { getNpmScope } from '../../../utils/npm-scope';
+import { formatFilesInSubtree } from '../../../utils/format.js';
+import { installDependencies } from '../../../utils/install.js';
+import { addGeneratorMetricsIfApplicable } from '../../../utils/metrics.js';
+import { toClassName, toSnakeCase } from '../../../utils/names.js';
+import { getNpmScope } from '../../../utils/npm-scope.js';
 import {
   addComponentGeneratorMetadata,
   addDependencyToTargetIfNotPresent,
   getGeneratorInfo,
   type NxGeneratorInfo,
   readProjectConfigurationUnqualified,
-} from '../../../utils/nx';
-import { addWorkspaceDependencyToPyProject } from '../../../utils/py';
+} from '../../../utils/nx.js';
+import { addWorkspaceDependencyToPyProject } from '../../../utils/py.js';
 import type { PyRdbFastApiConnectionGeneratorSchema } from './schema';
 
 export const PY_RDB_FAST_API_CONNECTION_GENERATOR_INFO: NxGeneratorInfo =

--- a/packages/nx-plugin/src/py/rdb/generator.spec.ts
+++ b/packages/nx-plugin/src/py/rdb/generator.spec.ts
@@ -3,20 +3,20 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { Tree } from '@nx/devkit';
-import { resolveContainers } from '../../utils/containers';
-import { expectHasMetricTags } from '../../utils/metrics.spec';
-import { readProjectConfigurationUnqualified } from '../../utils/nx';
-import { sharedConstructsGenerator } from '../../utils/shared-constructs';
+import { resolveContainers } from '../../utils/containers.js';
+import { expectHasMetricTags } from '../../utils/metrics.spec.js';
+import { readProjectConfigurationUnqualified } from '../../utils/nx.js';
+import { sharedConstructsGenerator } from '../../utils/shared-constructs.js';
 import {
   createTreeUsingTsSolutionSetup,
   snapshotTreeDir,
-} from '../../utils/test';
-import { CONTAINER_VERSIONS, withPyVersions } from '../../utils/versions';
+} from '../../utils/test.js';
+import { CONTAINER_VERSIONS, withPyVersions } from '../../utils/versions.js';
 import {
   DEPENDENCIES,
   PY_RDB_GENERATOR_INFO,
   pyRdbGenerator,
-} from './generator';
+} from './generator.js';
 
 vi.mock('../../utils/containers', () => ({
   resolveContainers: vi.fn(),

--- a/packages/nx-plugin/src/py/rdb/generator.ts
+++ b/packages/nx-plugin/src/py/rdb/generator.ts
@@ -16,46 +16,51 @@ import {
 import {
   addPyDependencies,
   addTsDependencies,
-} from '../../utils/add-dependencies';
-import { addPythonReExport } from '../../utils/agent-connection/agent-connection';
-import { addPythonBundleTarget } from '../../utils/bundle/bundle';
-import { resolveContainers } from '../../utils/containers';
+} from '../../utils/add-dependencies.js';
+import { addPythonReExport } from '../../utils/agent-connection/agent-connection.js';
+import { addPythonBundleTarget } from '../../utils/bundle/bundle.js';
+import { resolveContainers } from '../../utils/containers.js';
 import {
   declareDependencies,
   ownedElsewhere,
-} from '../../utils/declared-dependencies';
-import { addDockerScanTarget, DOCKER_DEPENDENCIES } from '../../utils/docker';
-import { formatFilesInSubtree } from '../../utils/format';
-import { FS_DEPENDENCIES, FsCommands } from '../../utils/fs';
-import { resolveIac } from '../../utils/iac';
-import { installDependencies } from '../../utils/install';
-import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
-import { kebabCase, snakeCase, toClassName } from '../../utils/names';
-import { getNpmScope } from '../../utils/npm-scope';
+} from '../../utils/declared-dependencies.js';
+import {
+  addDockerScanTarget,
+  DOCKER_DEPENDENCIES,
+} from '../../utils/docker.js';
+import { formatFilesInSubtree } from '../../utils/format.js';
+import { FS_DEPENDENCIES, FsCommands } from '../../utils/fs.js';
+import { resolveIac } from '../../utils/iac.js';
+import { installDependencies } from '../../utils/install.js';
+import { addGeneratorMetricsIfApplicable } from '../../utils/metrics.js';
+import { kebabCase, snakeCase, toClassName } from '../../utils/names.js';
+import { getNpmScope } from '../../utils/npm-scope.js';
 import {
   addDependencyToTargetIfNotPresent,
   addGeneratorMetadata,
   getGeneratorInfo,
   type NxGeneratorInfo,
   projectExists,
-} from '../../utils/nx';
-import { assignPort } from '../../utils/port';
-import { addRdbInfra } from '../../utils/rdb-constructs/rdb-constructs';
+} from '../../utils/nx.js';
+import { assignPort } from '../../utils/port.js';
+import { addRdbInfra } from '../../utils/rdb-constructs/rdb-constructs.js';
 import {
   SHARED_CONSTRUCTS_DEPENDENCIES,
   sharedConstructsGenerator,
-} from '../../utils/shared-constructs';
+} from '../../utils/shared-constructs.js';
 import {
   type IacMetadata,
   PACKAGES_DIR,
   SHARED_SCRIPTS_DIR,
-} from '../../utils/shared-constructs-constants';
+} from '../../utils/shared-constructs-constants.js';
 import {
   SHARED_RDB_SCRIPTS_DEPENDENCIES,
   sharedRdbScriptsGenerator,
-} from '../../utils/shared-rdb-scripts';
-import { PY_VERSIONS } from '../../utils/versions';
-import pyProjectGenerator, { getPyProjectDetails } from '../project/generator';
+} from '../../utils/shared-rdb-scripts.js';
+import { PY_VERSIONS } from '../../utils/versions.js';
+import pyProjectGenerator, {
+  getPyProjectDetails,
+} from '../project/generator.js';
 import type { PyRdbGeneratorSchema } from './schema';
 
 /** The metadata this generator records, which its predicates read. */

--- a/packages/nx-plugin/src/py/rdb/mcp-server-connection/generator.spec.ts
+++ b/packages/nx-plugin/src/py/rdb/mcp-server-connection/generator.spec.ts
@@ -4,8 +4,8 @@
  */
 import { readProjectConfiguration, type Tree } from '@nx/devkit';
 import { beforeEach, describe, expect, it } from 'vitest';
-import { createTreeUsingTsSolutionSetup } from '../../../utils/test';
-import { pyRdbMcpServerConnectionGenerator } from './generator';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test.js';
+import { pyRdbMcpServerConnectionGenerator } from './generator.js';
 
 describe('py#rdb mcp-server-connection generator', () => {
   let tree: Tree;

--- a/packages/nx-plugin/src/py/rdb/mcp-server-connection/generator.ts
+++ b/packages/nx-plugin/src/py/rdb/mcp-server-connection/generator.ts
@@ -8,19 +8,19 @@ import {
   type Tree,
   updateProjectConfiguration,
 } from '@nx/devkit';
-import { formatFilesInSubtree } from '../../../utils/format';
-import { installDependencies } from '../../../utils/install';
-import { addGeneratorMetricsIfApplicable } from '../../../utils/metrics';
-import { toSnakeCase } from '../../../utils/names';
+import { formatFilesInSubtree } from '../../../utils/format.js';
+import { installDependencies } from '../../../utils/install.js';
+import { addGeneratorMetricsIfApplicable } from '../../../utils/metrics.js';
+import { toSnakeCase } from '../../../utils/names.js';
 import {
   addComponentGeneratorMetadata,
   addDependencyToTargetIfNotPresent,
   getGeneratorInfo,
   type NxGeneratorInfo,
   readProjectConfigurationUnqualified,
-} from '../../../utils/nx';
-import { addWorkspaceDependencyToPyProject } from '../../../utils/py';
-import { injectRdsCaBundleIntoDockerfile } from '../utils';
+} from '../../../utils/nx.js';
+import { addWorkspaceDependencyToPyProject } from '../../../utils/py.js';
+import { injectRdsCaBundleIntoDockerfile } from '../utils.js';
 import type { PyRdbMcpServerConnectionGeneratorSchema } from './schema';
 
 export const PY_RDB_MCP_SERVER_CONNECTION_GENERATOR_INFO: NxGeneratorInfo =

--- a/packages/nx-plugin/src/py/rdb/mcp-server-connection/schema.d.ts
+++ b/packages/nx-plugin/src/py/rdb/mcp-server-connection/schema.d.ts
@@ -2,7 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import { ComponentMetadata } from '../../../utils/nx';
+import { ComponentMetadata } from '../../../utils/nx.js';
 
 /**
  * TypeScript types for options defined in schema.json

--- a/packages/nx-plugin/src/sdk/agentcore-gateway.ts
+++ b/packages/nx-plugin/src/sdk/agentcore-gateway.ts
@@ -4,5 +4,5 @@
  */
 
 // AgentCore Gateway Generator
-export { agentcoreGatewayGenerator } from '../agentcore-gateway/generator';
+export { agentcoreGatewayGenerator } from '../agentcore-gateway/generator.js';
 export type { AgentcoreGatewayGeneratorSchema } from '../agentcore-gateway/schema';

--- a/packages/nx-plugin/src/sdk/agentcore-harness.ts
+++ b/packages/nx-plugin/src/sdk/agentcore-harness.ts
@@ -4,5 +4,5 @@
  */
 
 // AgentCore Harness Generator
-export { agentcoreHarnessGenerator } from '../agentcore-harness/generator';
+export { agentcoreHarnessGenerator } from '../agentcore-harness/generator.js';
 export type { AgentcoreHarnessGeneratorSchema } from '../agentcore-harness/schema';

--- a/packages/nx-plugin/src/sdk/connection.ts
+++ b/packages/nx-plugin/src/sdk/connection.ts
@@ -3,5 +3,5 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export { connectionGenerator } from '../connection/generator';
+export { connectionGenerator } from '../connection/generator.js';
 export type { ConnectionGeneratorSchema } from '../connection/schema';

--- a/packages/nx-plugin/src/sdk/license.ts
+++ b/packages/nx-plugin/src/sdk/license.ts
@@ -2,17 +2,17 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-export { licenseGenerator } from '../license/generator';
+export { licenseGenerator } from '../license/generator.js';
 export type {
   AllowlistEntry,
   CollectedDependency,
   DependencyCheckConfig,
   DependencyCheckException,
   LicenseCollector,
-} from '../license/index';
+} from '../license/index.js';
 export {
   DEFAULT_LICENSE_ALLOWLIST,
   npmCollector,
   pythonCollector,
-} from '../license/index';
+} from '../license/index.js';
 export type { LicenseGeneratorSchema } from '../license/schema';

--- a/packages/nx-plugin/src/sdk/open-api.ts
+++ b/packages/nx-plugin/src/sdk/open-api.ts
@@ -6,11 +6,11 @@
 export {
   buildOpenApiCodeGenerationData,
   openApiTsClientGenerator,
-} from '../open-api/ts-client/generator';
+} from '../open-api/ts-client/generator.js';
 export type { OpenApiTsClientGeneratorSchema } from '../open-api/ts-client/schema';
 
-export { openApiTsHooksGenerator } from '../open-api/ts-hooks/generator';
+export { openApiTsHooksGenerator } from '../open-api/ts-hooks/generator.js';
 export type { OpenApiTsHooksGeneratorSchema } from '../open-api/ts-hooks/schema';
 
-export { openApiTsMetadataGenerator } from '../open-api/ts-metadata/generator';
+export { openApiTsMetadataGenerator } from '../open-api/ts-metadata/generator.js';
 export type { OpenApiTsMetadataGeneratorSchema } from '../open-api/ts-metadata/schema';

--- a/packages/nx-plugin/src/sdk/py.ts
+++ b/packages/nx-plugin/src/sdk/py.ts
@@ -3,22 +3,22 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export { pyAgentGenerator } from '../py/agent/generator';
+export { pyAgentGenerator } from '../py/agent/generator.js';
 export type { PyAgentGeneratorSchema } from '../py/agent/schema';
 
-export { pyApiGenerator } from '../py/api/generator';
+export { pyApiGenerator } from '../py/api/generator.js';
 export type { PyApiGeneratorSchema } from '../py/api/schema';
 
-export { pyDynamoDBGenerator } from '../py/dynamodb/generator';
+export { pyDynamoDBGenerator } from '../py/dynamodb/generator.js';
 export type { PyDynamoDBGeneratorSchema } from '../py/dynamodb/schema';
 
-export { pyLambdaFunctionGenerator } from '../py/lambda-function/generator';
+export { pyLambdaFunctionGenerator } from '../py/lambda-function/generator.js';
 export type { PyLambdaFunctionGeneratorSchema } from '../py/lambda-function/schema';
 
-export { pyMcpServerGenerator } from '../py/mcp-server/generator';
+export { pyMcpServerGenerator } from '../py/mcp-server/generator.js';
 export type { PyMcpServerGeneratorSchema } from '../py/mcp-server/schema';
-export { pyProjectGenerator } from '../py/project/generator';
+export { pyProjectGenerator } from '../py/project/generator.js';
 export type { PyProjectGeneratorSchema } from '../py/project/schema';
 
-export { pyRdbGenerator } from '../py/rdb/generator';
+export { pyRdbGenerator } from '../py/rdb/generator.js';
 export type { PyRdbGeneratorSchema } from '../py/rdb/schema';

--- a/packages/nx-plugin/src/sdk/smithy.ts
+++ b/packages/nx-plugin/src/sdk/smithy.ts
@@ -4,5 +4,5 @@
  */
 
 // Smithy Project Generator
-export { smithyProjectGenerator } from '../smithy/project/generator';
+export { smithyProjectGenerator } from '../smithy/project/generator.js';
 export type { SmithyProjectGeneratorSchema } from '../smithy/project/schema';

--- a/packages/nx-plugin/src/sdk/terraform.ts
+++ b/packages/nx-plugin/src/sdk/terraform.ts
@@ -4,5 +4,5 @@
  */
 
 // Terraform Project Generator
-export { terraformProjectGenerator } from '../terraform/project/generator';
+export { terraformProjectGenerator } from '../terraform/project/generator.js';
 export type { TerraformProjectGeneratorSchema } from '../terraform/project/schema';

--- a/packages/nx-plugin/src/sdk/ts.ts
+++ b/packages/nx-plugin/src/sdk/ts.ts
@@ -4,56 +4,56 @@
  */
 
 // TypeScript Infrastructure
-export { tsInfraGenerator } from '../infra/app/generator';
+export { tsInfraGenerator } from '../infra/app/generator.js';
 export type { TsInfraGeneratorSchema } from '../infra/app/schema';
 // TypeScript Agent Generator
-export { tsAgentGenerator } from '../ts/agent/generator';
+export { tsAgentGenerator } from '../ts/agent/generator.js';
 export type { TsAgentGeneratorSchema } from '../ts/agent/schema';
 // TypeScript API
-export { tsApiGenerator } from '../ts/api/generator';
+export { tsApiGenerator } from '../ts/api/generator.js';
 export type { TsApiGeneratorSchema } from '../ts/api/schema';
 // Astro Documentation Site Generator
-export { tsAstroDocsGenerator } from '../ts/astro-docs/generator';
+export { tsAstroDocsGenerator } from '../ts/astro-docs/generator.js';
 export type { TsAstroDocsGeneratorSchema } from '../ts/astro-docs/schema';
 // TypeScript DCR Proxy Generator
-export { tsDcrProxyGenerator } from '../ts/dcr-proxy/generator';
+export { tsDcrProxyGenerator } from '../ts/dcr-proxy/generator.js';
 export type { TsDcrProxyGeneratorSchema } from '../ts/dcr-proxy/schema';
 // Documentation Site Generator
-export { tsDocsGenerator } from '../ts/docs/generator';
+export { tsDocsGenerator } from '../ts/docs/generator.js';
 export type { TsDocsGeneratorSchema } from '../ts/docs/schema';
 // DynamoDB Generator
-export { tsDynamoDBGenerator } from '../ts/dynamodb/generator';
+export { tsDynamoDBGenerator } from '../ts/dynamodb/generator.js';
 export type { TsDynamoDBGeneratorSchema } from '../ts/dynamodb/schema';
 // TypeScript Lambda Function
-export { tsLambdaFunctionGenerator } from '../ts/lambda-function/generator';
+export { tsLambdaFunctionGenerator } from '../ts/lambda-function/generator.js';
 export type { TsLambdaFunctionGeneratorSchema } from '../ts/lambda-function/schema';
 // TypeScript Project Generator
-export { tsProjectGenerator } from '../ts/lib/generator';
+export { tsProjectGenerator } from '../ts/lib/generator.js';
 export type { TsProjectGeneratorSchema } from '../ts/lib/schema';
 // TypeScript MCP Server Generator
-export { tsMcpServerGenerator } from '../ts/mcp-server/generator';
+export { tsMcpServerGenerator } from '../ts/mcp-server/generator.js';
 export type { TsMcpServerGeneratorSchema } from '../ts/mcp-server/schema';
 // TypeScript Nx Generator Generator
-export { tsNxGeneratorGenerator } from '../ts/nx-generator/generator';
+export { tsNxGeneratorGenerator } from '../ts/nx-generator/generator.js';
 export type { TsNxGeneratorGeneratorSchema } from '../ts/nx-generator/schema';
 // TypeScript Nx Migration Generator
-export { tsNxMigrationGenerator } from '../ts/nx-migration/generator';
+export { tsNxMigrationGenerator } from '../ts/nx-migration/generator.js';
 export type { TsNxMigrationGeneratorSchema } from '../ts/nx-migration/schema';
 // TypeScript Nx Plugin Generator
-export { tsNxPluginGenerator } from '../ts/nx-plugin/generator';
+export { tsNxPluginGenerator } from '../ts/nx-plugin/generator.js';
 export type { TsNxPluginGeneratorSchema } from '../ts/nx-plugin/schema';
 // Relational Database Generator
-export { tsRdbGenerator } from '../ts/rdb/generator';
+export { tsRdbGenerator } from '../ts/rdb/generator.js';
 export type { TsRdbGeneratorSchema } from '../ts/rdb/schema';
 // Runtime Config
-export { runtimeConfigGenerator } from '../ts/react-website/runtime-config/generator';
+export { runtimeConfigGenerator } from '../ts/react-website/runtime-config/generator.js';
 export type { RuntimeConfigGeneratorSchema } from '../ts/react-website/runtime-config/schema';
 // TypeScript Website Generator
-export { tsWebsiteGenerator } from '../ts/website/app/generator';
+export { tsWebsiteGenerator } from '../ts/website/app/generator.js';
 export type { TsWebsiteGeneratorSchema } from '../ts/website/app/schema';
 // TypeScript Website Auth Generator
-export { tsWebsiteAuthGenerator } from '../ts/website/auth/generator';
+export { tsWebsiteAuthGenerator } from '../ts/website/auth/generator.js';
 export type { TsWebsiteAuthGeneratorSchema } from '../ts/website/auth/schema';
 
 // Shared Constructs
-export { sharedConstructsGenerator } from '../utils/shared-constructs';
+export { sharedConstructsGenerator } from '../utils/shared-constructs.js';

--- a/packages/nx-plugin/src/sdk/utils/ast.ts
+++ b/packages/nx-plugin/src/sdk/utils/ast.ts
@@ -2,4 +2,4 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-export { applyGritQL, matchGritQL } from '../../utils/ast';
+export { applyGritQL, matchGritQL } from '../../utils/ast.js';

--- a/packages/nx-plugin/src/sdk/utils/format.ts
+++ b/packages/nx-plugin/src/sdk/utils/format.ts
@@ -6,4 +6,4 @@
 export {
   type FormatFilesInSubtreeOptions,
   formatFilesInSubtree,
-} from '../../utils/format';
+} from '../../utils/format.js';

--- a/packages/nx-plugin/src/sdk/utils/test.ts
+++ b/packages/nx-plugin/src/sdk/utils/test.ts
@@ -3,4 +3,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export { createTreeUsingTsSolutionSetup } from '../../utils/test';
+export { createTreeUsingTsSolutionSetup } from '../../utils/test.js';

--- a/packages/nx-plugin/src/smithy/project/generator.spec.ts
+++ b/packages/nx-plugin/src/smithy/project/generator.spec.ts
@@ -3,22 +3,22 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { getProjects, readJson, type Tree } from '@nx/devkit';
-import { declareDependencies } from '../../utils/declared-dependencies';
-import { expectHasMetricTags } from '../../utils/metrics.spec';
+import { declareDependencies } from '../../utils/declared-dependencies.js';
+import { expectHasMetricTags } from '../../utils/metrics.spec.js';
 import {
   SHARED_CONSTRUCTS_DEPENDENCIES,
   sharedConstructsGenerator,
-} from '../../utils/shared-constructs';
-import { createTreeUsingTsSolutionSetup } from '../../utils/test';
+} from '../../utils/shared-constructs.js';
+import { createTreeUsingTsSolutionSetup } from '../../utils/test.js';
 import {
   javaMavenDependency,
   MISE_VERSIONS,
   TS_VERSIONS,
-} from '../../utils/versions';
+} from '../../utils/versions.js';
 import {
   SMITHY_PROJECT_GENERATOR_INFO,
   smithyProjectGenerator,
-} from './generator';
+} from './generator.js';
 
 const sharedConstructsDeclaration = declareDependencies()({
   ts: [...SHARED_CONSTRUCTS_DEPENDENCIES],

--- a/packages/nx-plugin/src/smithy/project/generator.ts
+++ b/packages/nx-plugin/src/smithy/project/generator.ts
@@ -10,30 +10,30 @@ import {
   OverwriteStrategy,
   type Tree,
 } from '@nx/devkit';
-import { getTsLibDetails } from '../../ts/lib/generator';
-import { addTsDependencies } from '../../utils/add-dependencies';
+import { getTsLibDetails } from '../../ts/lib/generator.js';
+import { addTsDependencies } from '../../utils/add-dependencies.js';
 import {
   declareDependencies,
   ownedElsewhere,
-} from '../../utils/declared-dependencies';
-import { formatFilesInSubtree } from '../../utils/format';
-import { FS_DEPENDENCIES, FsCommands } from '../../utils/fs';
-import { installDependencies } from '../../utils/install';
-import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
-import { toClassName, toKebabCase } from '../../utils/names';
-import { getNpmScope } from '../../utils/npm-scope';
+} from '../../utils/declared-dependencies.js';
+import { formatFilesInSubtree } from '../../utils/format.js';
+import { FS_DEPENDENCIES, FsCommands } from '../../utils/fs.js';
+import { installDependencies } from '../../utils/install.js';
+import { addGeneratorMetricsIfApplicable } from '../../utils/metrics.js';
+import { toClassName, toKebabCase } from '../../utils/names.js';
+import { getNpmScope } from '../../utils/npm-scope.js';
 import {
   addGeneratorMetadata,
   getGeneratorInfo,
   type NxGeneratorInfo,
   projectExists,
-} from '../../utils/nx';
-import { getRelativePathToRootByDirectory } from '../../utils/paths';
+} from '../../utils/nx.js';
+import { getRelativePathToRootByDirectory } from '../../utils/paths.js';
 import {
   smithyCliCommand,
   smithyMavenVersions,
   warnIfSmithyMissing,
-} from '../../utils/smithy';
+} from '../../utils/smithy.js';
 import type { SmithyProjectGeneratorSchema } from './schema';
 
 /** The metadata this generator records, which its predicates read. */

--- a/packages/nx-plugin/src/smithy/react-connection/generator.spec.ts
+++ b/packages/nx-plugin/src/smithy/react-connection/generator.spec.ts
@@ -4,24 +4,24 @@
  */
 import { type Tree, updateJson } from '@nx/devkit';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { tsReactWebsiteGenerator } from '../../ts/react-website/app/generator';
-import { matchGritQL } from '../../utils/ast';
-import { declareDependencies } from '../../utils/declared-dependencies';
-import { expectHasMetricTags } from '../../utils/metrics.spec';
+import { tsReactWebsiteGenerator } from '../../ts/react-website/app/generator.js';
+import { matchGritQL } from '../../utils/ast.js';
+import { declareDependencies } from '../../utils/declared-dependencies.js';
+import { expectHasMetricTags } from '../../utils/metrics.spec.js';
 import {
   SHARED_CONSTRUCTS_DEPENDENCIES,
   sharedConstructsGenerator,
-} from '../../utils/shared-constructs';
-import { createTreeUsingTsSolutionSetup } from '../../utils/test';
-import { SMITHY_PROJECT_GENERATOR_INFO } from '../project/generator';
+} from '../../utils/shared-constructs.js';
+import { createTreeUsingTsSolutionSetup } from '../../utils/test.js';
+import { SMITHY_PROJECT_GENERATOR_INFO } from '../project/generator.js';
 import {
   TS_SMITHY_API_GENERATOR_INFO,
   tsSmithyApiGenerator,
-} from '../ts/api/generator';
+} from '../ts/api/generator.js';
 import {
   SMITHY_REACT_CONNECTION_GENERATOR_INFO,
   smithyReactConnectionGenerator,
-} from './generator';
+} from './generator.js';
 
 const sharedConstructsDeclaration = declareDependencies()({
   ts: [...SHARED_CONSTRUCTS_DEPENDENCIES],

--- a/packages/nx-plugin/src/smithy/react-connection/generator.ts
+++ b/packages/nx-plugin/src/smithy/react-connection/generator.ts
@@ -13,21 +13,21 @@ import {
 import {
   addOpenApiReactClient,
   OPEN_API_REACT_DEPENDENCIES,
-} from '../../utils/connection/open-api/react';
-import { declareDependencies } from '../../utils/declared-dependencies';
-import { formatFilesInSubtree } from '../../utils/format';
-import { installDependencies } from '../../utils/install';
-import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
-import { toClassName } from '../../utils/names';
+} from '../../utils/connection/open-api/react.js';
+import { declareDependencies } from '../../utils/declared-dependencies.js';
+import { formatFilesInSubtree } from '../../utils/format.js';
+import { installDependencies } from '../../utils/install.js';
+import { addGeneratorMetricsIfApplicable } from '../../utils/metrics.js';
+import { toClassName } from '../../utils/names.js';
 import {
   addComponentGeneratorMetadata,
   getGeneratorInfo,
   type NxGeneratorInfo,
   readProjectConfigurationUnqualified,
-} from '../../utils/nx';
-import { toProjectRelativePath } from '../../utils/paths';
-import { SMITHY_PROJECT_GENERATOR_INFO } from '../project/generator';
-import { TS_SMITHY_API_GENERATOR_INFO } from '../ts/api/generator';
+} from '../../utils/nx.js';
+import { toProjectRelativePath } from '../../utils/paths.js';
+import { SMITHY_PROJECT_GENERATOR_INFO } from '../project/generator.js';
+import { TS_SMITHY_API_GENERATOR_INFO } from '../ts/api/generator.js';
 import type { SmithyReactConnectionGeneratorSchema } from './schema';
 
 // `addOpenApiReactClient` conditions these on the API's auth, which this

--- a/packages/nx-plugin/src/smithy/ts/api/generator.spec.ts
+++ b/packages/nx-plugin/src/smithy/ts/api/generator.spec.ts
@@ -6,18 +6,18 @@ import { readJson, type Tree } from '@nx/devkit';
 import {
   ensureAwsNxPluginConfig,
   updateAwsNxPluginConfig,
-} from '../../../utils/config/utils';
-import { declareDependencies } from '../../../utils/declared-dependencies';
-import { expectHasMetricTags } from '../../../utils/metrics.spec';
+} from '../../../utils/config/utils.js';
+import { declareDependencies } from '../../../utils/declared-dependencies.js';
+import { expectHasMetricTags } from '../../../utils/metrics.spec.js';
 import {
   SHARED_CONSTRUCTS_DEPENDENCIES,
   sharedConstructsGenerator,
-} from '../../../utils/shared-constructs';
-import { createTreeUsingTsSolutionSetup } from '../../../utils/test';
+} from '../../../utils/shared-constructs.js';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test.js';
 import {
   TS_SMITHY_API_GENERATOR_INFO,
   tsSmithyApiGenerator,
-} from './generator';
+} from './generator.js';
 
 const sharedConstructsDeclaration = declareDependencies()({
   ts: [...SHARED_CONSTRUCTS_DEPENDENCIES],

--- a/packages/nx-plugin/src/smithy/ts/api/generator.ts
+++ b/packages/nx-plugin/src/smithy/ts/api/generator.ts
@@ -10,30 +10,32 @@ import {
   type Tree,
   updateProjectConfiguration,
 } from '@nx/devkit';
-import tsProjectGenerator, { getTsLibDetails } from '../../../ts/lib/generator';
-import { addTsDependencies } from '../../../utils/add-dependencies';
+import tsProjectGenerator, {
+  getTsLibDetails,
+} from '../../../ts/lib/generator.js';
+import { addTsDependencies } from '../../../utils/add-dependencies.js';
 import {
   API_CONSTRUCTS_DEPENDENCIES,
   API_CONSTRUCTS_PY_DEPENDENCIES,
   addApiGatewayInfra,
-} from '../../../utils/api-constructs/api-constructs';
-import { addSharedConstructsOpenApiMetadataGenerateTarget } from '../../../utils/api-constructs/open-api-metadata';
+} from '../../../utils/api-constructs/api-constructs.js';
+import { addSharedConstructsOpenApiMetadataGenerateTarget } from '../../../utils/api-constructs/open-api-metadata.js';
 import {
   addTypeScriptBundleTarget,
   BUNDLE_DEPENDENCIES,
-} from '../../../utils/bundle/bundle';
+} from '../../../utils/bundle/bundle.js';
 import {
   declareDependencies,
   ownedElsewhere,
-} from '../../../utils/declared-dependencies';
-import { formatFilesInSubtree } from '../../../utils/format';
-import { FS_DEPENDENCIES, FsCommands } from '../../../utils/fs';
-import { updateGitIgnore } from '../../../utils/git';
-import { resolveIac } from '../../../utils/iac';
-import { installDependencies } from '../../../utils/install';
-import { addGeneratorMetricsIfApplicable } from '../../../utils/metrics';
-import { esmVars } from '../../../utils/module-format';
-import { toClassName, toKebabCase } from '../../../utils/names';
+} from '../../../utils/declared-dependencies.js';
+import { formatFilesInSubtree } from '../../../utils/format.js';
+import { FS_DEPENDENCIES, FsCommands } from '../../../utils/fs.js';
+import { updateGitIgnore } from '../../../utils/git.js';
+import { resolveIac } from '../../../utils/iac.js';
+import { installDependencies } from '../../../utils/install.js';
+import { addGeneratorMetricsIfApplicable } from '../../../utils/metrics.js';
+import { esmVars } from '../../../utils/module-format.js';
+import { toClassName, toKebabCase } from '../../../utils/names.js';
 import {
   addDependencyToTargetIfNotPresent,
   addGeneratorMetadata,
@@ -41,14 +43,14 @@ import {
   type NxGeneratorInfo,
   normalizeTargetKeyOrder,
   readProjectConfigurationUnqualified,
-} from '../../../utils/nx';
-import { assignPort } from '../../../utils/port';
+} from '../../../utils/nx.js';
+import { assignPort } from '../../../utils/port.js';
 import {
   SHARED_CONSTRUCTS_DEPENDENCIES,
   sharedConstructsGenerator,
-} from '../../../utils/shared-constructs';
-import type { IacMetadata } from '../../../utils/shared-constructs-constants';
-import smithyProjectGenerator from '../../project/generator';
+} from '../../../utils/shared-constructs.js';
+import type { IacMetadata } from '../../../utils/shared-constructs-constants.js';
+import smithyProjectGenerator from '../../project/generator.js';
 import type { TsSmithyApiGeneratorSchema } from './schema';
 
 /** The metadata this generator records, which its predicates read. */

--- a/packages/nx-plugin/src/smithy/ts/api/schema.d.ts
+++ b/packages/nx-plugin/src/smithy/ts/api/schema.d.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { TsProjectGeneratorSchema } from '../../../ts/lib/schema';
-import { IacOption } from '../../../utils/iac';
+import { IacOption } from '../../../utils/iac.js';
 
 export interface TsSmithyApiGeneratorSchema {
   name: string;

--- a/packages/nx-plugin/src/terraform/project/generator.spec.ts
+++ b/packages/nx-plugin/src/terraform/project/generator.spec.ts
@@ -10,13 +10,13 @@ import {
   updateProjectConfiguration,
 } from '@nx/devkit';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import * as tsLibGenerator from '../../ts/lib/generator';
-import * as gitUtils from '../../utils/git';
-import { createTreeUsingTsSolutionSetup } from '../../utils/test';
+import * as tsLibGenerator from '../../ts/lib/generator.js';
+import * as gitUtils from '../../utils/git.js';
+import { createTreeUsingTsSolutionSetup } from '../../utils/test.js';
 import {
   TERRAFORM_PROJECT_GENERATOR_INFO,
   terraformProjectGenerator,
-} from './generator';
+} from './generator.js';
 import type { TerraformProjectGeneratorSchema } from './schema';
 
 describe('terraformProjectGenerator', () => {

--- a/packages/nx-plugin/src/terraform/project/generator.ts
+++ b/packages/nx-plugin/src/terraform/project/generator.ts
@@ -16,31 +16,34 @@ import {
   updateNxJson,
 } from '@nx/devkit';
 import { join, relative } from 'path';
-import { getTsLibDetails } from '../../ts/lib/generator';
-import { addTsDependencies } from '../../utils/add-dependencies';
+import { getTsLibDetails } from '../../ts/lib/generator.js';
+import { addTsDependencies } from '../../utils/add-dependencies.js';
 import {
   declareDependencies,
   ownedElsewhere,
-} from '../../utils/declared-dependencies';
-import { updateGitIgnore } from '../../utils/git';
-import { installDependencies } from '../../utils/install';
-import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
-import { kebabCase } from '../../utils/names';
+} from '../../utils/declared-dependencies.js';
+import { updateGitIgnore } from '../../utils/git.js';
+import { installDependencies } from '../../utils/install.js';
+import { addGeneratorMetricsIfApplicable } from '../../utils/metrics.js';
+import { kebabCase } from '../../utils/names.js';
 import {
   addGeneratorMetadata,
   getGeneratorInfo,
   type NxGeneratorInfo,
   projectExists,
-} from '../../utils/nx';
-import { sortObjectKeys } from '../../utils/object';
-import { uvxCommand } from '../../utils/py';
-import { sharedConstructsGenerator } from '../../utils/shared-constructs';
+} from '../../utils/nx.js';
+import { sortObjectKeys } from '../../utils/object.js';
+import { uvxCommand } from '../../utils/py.js';
+import { sharedConstructsGenerator } from '../../utils/shared-constructs.js';
 import {
   SHARED_CONSTRUCTS_DEPENDENCIES,
   SHARED_TERRAFORM_DIR,
   SHARED_TERRAFORM_NAME,
-} from '../../utils/shared-constructs-constants';
-import { terraformProviderVersions, withVersions } from '../../utils/versions';
+} from '../../utils/shared-constructs-constants.js';
+import {
+  terraformProviderVersions,
+  withVersions,
+} from '../../utils/versions.js';
 import type { TerraformProjectGeneratorSchema } from './schema';
 
 // Terraform projects carry no package.json, so their build tooling and the AWS

--- a/packages/nx-plugin/src/trpc/backend/generator.spec.ts
+++ b/packages/nx-plugin/src/trpc/backend/generator.spec.ts
@@ -6,13 +6,16 @@ import { readJson, readProjectConfiguration, type Tree } from '@nx/devkit';
 import {
   ensureAwsNxPluginConfig,
   updateAwsNxPluginConfig,
-} from '../../utils/config/utils';
-import { expectHasMetricTags } from '../../utils/metrics.spec';
+} from '../../utils/config/utils.js';
+import { expectHasMetricTags } from '../../utils/metrics.spec.js';
 import {
   createTreeUsingTsSolutionSetup,
   snapshotTreeDir,
-} from '../../utils/test';
-import { TRPC_BACKEND_GENERATOR_INFO, tsTrpcApiGenerator } from './generator';
+} from '../../utils/test.js';
+import {
+  TRPC_BACKEND_GENERATOR_INFO,
+  tsTrpcApiGenerator,
+} from './generator.js';
 import type { TsTrpcApiGeneratorSchema } from './schema';
 
 describe('trpc backend generator', () => {

--- a/packages/nx-plugin/src/trpc/backend/generator.ts
+++ b/packages/nx-plugin/src/trpc/backend/generator.ts
@@ -9,43 +9,43 @@ import {
   type Tree,
   updateProjectConfiguration,
 } from '@nx/devkit';
-import tsProjectGenerator from '../../ts/lib/generator';
-import { addTsDependencies } from '../../utils/add-dependencies';
+import tsProjectGenerator from '../../ts/lib/generator.js';
+import { addTsDependencies } from '../../utils/add-dependencies.js';
 import {
   API_CONSTRUCTS_DEPENDENCIES,
   API_CONSTRUCTS_PY_DEPENDENCIES,
   addApiGatewayInfra,
-} from '../../utils/api-constructs/api-constructs';
+} from '../../utils/api-constructs/api-constructs.js';
 import {
   addTypeScriptBundleTarget,
   BUNDLE_DEPENDENCIES,
-} from '../../utils/bundle/bundle';
+} from '../../utils/bundle/bundle.js';
 import {
   declareDependencies,
   ownedElsewhere,
-} from '../../utils/declared-dependencies';
-import { formatFilesInSubtree } from '../../utils/format';
-import { resolveIac } from '../../utils/iac';
-import { installDependencies } from '../../utils/install';
-import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
-import { esmVars } from '../../utils/module-format';
-import { kebabCase, toClassName } from '../../utils/names';
-import { getNpmScopePrefix } from '../../utils/npm-scope';
+} from '../../utils/declared-dependencies.js';
+import { formatFilesInSubtree } from '../../utils/format.js';
+import { resolveIac } from '../../utils/iac.js';
+import { installDependencies } from '../../utils/install.js';
+import { addGeneratorMetricsIfApplicable } from '../../utils/metrics.js';
+import { esmVars } from '../../utils/module-format.js';
+import { kebabCase, toClassName } from '../../utils/names.js';
+import { getNpmScopePrefix } from '../../utils/npm-scope.js';
 import {
   addDependencyToTargetIfNotPresent,
   addGeneratorMetadata,
   getGeneratorInfo,
   type NxGeneratorInfo,
   readProjectConfigurationUnqualified,
-} from '../../utils/nx';
-import { sortObjectKeys } from '../../utils/object';
-import { getPackageManagerDisplayCommands } from '../../utils/pkg-manager';
-import { assignPort } from '../../utils/port';
+} from '../../utils/nx.js';
+import { sortObjectKeys } from '../../utils/object.js';
+import { getPackageManagerDisplayCommands } from '../../utils/pkg-manager.js';
+import { assignPort } from '../../utils/port.js';
 import {
   SHARED_CONSTRUCTS_DEPENDENCIES,
   sharedConstructsGenerator,
-} from '../../utils/shared-constructs';
-import type { IacMetadata } from '../../utils/shared-constructs-constants';
+} from '../../utils/shared-constructs.js';
+import type { IacMetadata } from '../../utils/shared-constructs-constants.js';
 import type { TsTrpcApiGeneratorSchema } from './schema';
 
 /** The metadata this generator records, which its predicates read. */

--- a/packages/nx-plugin/src/trpc/backend/schema.d.ts
+++ b/packages/nx-plugin/src/trpc/backend/schema.d.ts
@@ -4,7 +4,7 @@
  */
 
 import { TsProjectGeneratorSchema } from '../../ts/lib/schema';
-import { IacOption } from '../../utils/iac';
+import { IacOption } from '../../utils/iac.js';
 
 export interface TsTrpcApiGeneratorSchema {
   name: string;

--- a/packages/nx-plugin/src/trpc/react/generator.spec.ts
+++ b/packages/nx-plugin/src/trpc/react/generator.spec.ts
@@ -3,16 +3,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { type Tree, updateJson } from '@nx/devkit';
-import { tsReactWebsiteGenerator } from '../../ts/react-website/app/generator';
-import { declareDependencies } from '../../utils/declared-dependencies';
-import { expectHasMetricTags } from '../../utils/metrics.spec';
+import { tsReactWebsiteGenerator } from '../../ts/react-website/app/generator.js';
+import { declareDependencies } from '../../utils/declared-dependencies.js';
+import { expectHasMetricTags } from '../../utils/metrics.spec.js';
 import {
   SHARED_CONSTRUCTS_DEPENDENCIES,
   sharedConstructsGenerator,
-} from '../../utils/shared-constructs';
-import { createTreeUsingTsSolutionSetup } from '../../utils/test';
-import { tsTrpcApiGenerator } from '../backend/generator';
-import { reactGenerator, TRPC_REACT_GENERATOR_INFO } from './generator';
+} from '../../utils/shared-constructs.js';
+import { createTreeUsingTsSolutionSetup } from '../../utils/test.js';
+import { tsTrpcApiGenerator } from '../backend/generator.js';
+import { reactGenerator, TRPC_REACT_GENERATOR_INFO } from './generator.js';
 
 const sharedConstructsDeclaration = declareDependencies()({
   ts: [...SHARED_CONSTRUCTS_DEPENDENCIES],

--- a/packages/nx-plugin/src/trpc/react/generator.ts
+++ b/packages/nx-plugin/src/trpc/react/generator.ts
@@ -8,22 +8,22 @@ import {
   OverwriteStrategy,
   type Tree,
 } from '@nx/devkit';
-import { addTargetToLocalDev } from '../../connection/local-dev';
-import { runtimeConfigGenerator } from '../../ts/react-website/runtime-config/generator';
-import { addTsDependencies } from '../../utils/add-dependencies';
-import { addSingleImport, applyGritQL } from '../../utils/ast';
-import { declareDependencies } from '../../utils/declared-dependencies';
-import { formatFilesInSubtree } from '../../utils/format';
-import { installDependencies } from '../../utils/install';
-import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
-import { toClassName } from '../../utils/names';
+import { addTargetToLocalDev } from '../../connection/local-dev.js';
+import { runtimeConfigGenerator } from '../../ts/react-website/runtime-config/generator.js';
+import { addTsDependencies } from '../../utils/add-dependencies.js';
+import { addSingleImport, applyGritQL } from '../../utils/ast.js';
+import { declareDependencies } from '../../utils/declared-dependencies.js';
+import { formatFilesInSubtree } from '../../utils/format.js';
+import { installDependencies } from '../../utils/install.js';
+import { addGeneratorMetricsIfApplicable } from '../../utils/metrics.js';
+import { toClassName } from '../../utils/names.js';
 import {
   addComponentGeneratorMetadata,
   getGeneratorInfo,
   type NxGeneratorInfo,
   readProjectConfigurationUnqualified,
-} from '../../utils/nx';
-import { toProjectRelativePath } from '../../utils/paths';
+} from '../../utils/nx.js';
+import { toProjectRelativePath } from '../../utils/paths.js';
 import type { ReactGeneratorSchema } from './schema';
 
 /** The metadata this generator records, which its predicates read. */

--- a/packages/nx-plugin/src/ts/agent/a2a-connection/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/agent/a2a-connection/generator.spec.ts
@@ -3,17 +3,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { Tree } from '@nx/devkit';
-import { declareDependencies } from '../../../utils/declared-dependencies';
-import { expectHasMetricTags } from '../../../utils/metrics.spec';
+import { declareDependencies } from '../../../utils/declared-dependencies.js';
+import { expectHasMetricTags } from '../../../utils/metrics.spec.js';
 import {
   SHARED_CONSTRUCTS_DEPENDENCIES,
   sharedConstructsGenerator,
-} from '../../../utils/shared-constructs';
-import { createTreeUsingTsSolutionSetup } from '../../../utils/test';
+} from '../../../utils/shared-constructs.js';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test.js';
 import {
   TS_AGENT_A2A_CONNECTION_GENERATOR_INFO,
   tsAgentA2aConnectionGenerator,
-} from './generator';
+} from './generator.js';
 
 const sharedConstructsDeclaration = declareDependencies()({
   ts: [...SHARED_CONSTRUCTS_DEPENDENCIES],

--- a/packages/nx-plugin/src/ts/agent/a2a-connection/generator.ts
+++ b/packages/nx-plugin/src/ts/agent/a2a-connection/generator.ts
@@ -10,37 +10,37 @@ import {
   type Tree,
   updateProjectConfiguration,
 } from '@nx/devkit';
-import { addTsDependencies } from '../../../utils/add-dependencies';
+import { addTsDependencies } from '../../../utils/add-dependencies.js';
 import {
   AGENT_CONNECTION_DEPENDENCIES,
   AGENT_CONNECTION_PROJECT_DIR,
   addTypeScriptCoreClient,
   ensureTypeScriptAgentConnectionProject,
-} from '../../../utils/agent-connection/agent-connection';
+} from '../../../utils/agent-connection/agent-connection.js';
 import {
   addDestructuredImport,
   addStarExport,
   appendToArrayViaGritQL,
   applyGritQL,
-} from '../../../utils/ast';
+} from '../../../utils/ast.js';
 import {
   declareDependencies,
   ownedElsewhere,
-} from '../../../utils/declared-dependencies';
-import { formatFilesInSubtree } from '../../../utils/format';
-import { installDependencies } from '../../../utils/install';
-import { addGeneratorMetricsIfApplicable } from '../../../utils/metrics';
-import { esmVars } from '../../../utils/module-format';
-import { kebabCase } from '../../../utils/names';
-import { getNpmScope } from '../../../utils/npm-scope';
+} from '../../../utils/declared-dependencies.js';
+import { formatFilesInSubtree } from '../../../utils/format.js';
+import { installDependencies } from '../../../utils/install.js';
+import { addGeneratorMetricsIfApplicable } from '../../../utils/metrics.js';
+import { esmVars } from '../../../utils/module-format.js';
+import { kebabCase } from '../../../utils/names.js';
+import { getNpmScope } from '../../../utils/npm-scope.js';
 import {
   addComponentGeneratorMetadata,
   addDependencyToTargetIfNotPresent,
   getGeneratorInfo,
   type NxGeneratorInfo,
   readProjectConfigurationUnqualified,
-} from '../../../utils/nx';
-import { toProjectRelativePath } from '../../../utils/paths';
+} from '../../../utils/nx.js';
+import { toProjectRelativePath } from '../../../utils/paths.js';
 import type { TsAgentA2aConnectionGeneratorSchema } from './schema';
 
 // The A2A core client + vended client need these whatever the connection's

--- a/packages/nx-plugin/src/ts/agent/a2a-connection/schema.d.ts
+++ b/packages/nx-plugin/src/ts/agent/a2a-connection/schema.d.ts
@@ -2,7 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import { ComponentMetadata } from '../../../utils/nx';
+import { ComponentMetadata } from '../../../utils/nx.js';
 
 /**
  * TypeScript types for options defined in schema.json

--- a/packages/nx-plugin/src/ts/agent/gateway-connection/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/agent/gateway-connection/generator.spec.ts
@@ -3,11 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { Tree } from '@nx/devkit';
-import { createTreeUsingTsSolutionSetup } from '../../../utils/test';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test.js';
 import {
   TS_AGENT_GATEWAY_CONNECTION_GENERATOR_INFO,
   tsAgentGatewayConnectionGenerator,
-} from './generator';
+} from './generator.js';
 
 describe('ts#agent#gateway-connection generator', () => {
   let tree: Tree;

--- a/packages/nx-plugin/src/ts/agent/gateway-connection/generator.ts
+++ b/packages/nx-plugin/src/ts/agent/gateway-connection/generator.ts
@@ -10,34 +10,34 @@ import {
   type Tree,
   updateProjectConfiguration,
 } from '@nx/devkit';
-import { readAgentCoreGatewayMetadata } from '../../../agentcore-gateway/generator';
-import { addTsDependencies } from '../../../utils/add-dependencies';
+import { readAgentCoreGatewayMetadata } from '../../../agentcore-gateway/generator.js';
+import { addTsDependencies } from '../../../utils/add-dependencies.js';
 import {
   AGENT_CONNECTION_DEPENDENCIES,
   AGENT_CONNECTION_PROJECT_DIR,
   addTypeScriptClientToAgent,
   addTypeScriptCoreClient,
   ensureTypeScriptAgentConnectionProject,
-} from '../../../utils/agent-connection/agent-connection';
-import { addDestructuredImport, addStarExport } from '../../../utils/ast';
+} from '../../../utils/agent-connection/agent-connection.js';
+import { addDestructuredImport, addStarExport } from '../../../utils/ast.js';
 import {
   declareDependencies,
   ownedElsewhere,
-} from '../../../utils/declared-dependencies';
-import { formatFilesInSubtree } from '../../../utils/format';
-import { installDependencies } from '../../../utils/install';
-import { addGeneratorMetricsIfApplicable } from '../../../utils/metrics';
-import { esmVars } from '../../../utils/module-format';
-import { kebabCase } from '../../../utils/names';
-import { getNpmScope } from '../../../utils/npm-scope';
+} from '../../../utils/declared-dependencies.js';
+import { formatFilesInSubtree } from '../../../utils/format.js';
+import { installDependencies } from '../../../utils/install.js';
+import { addGeneratorMetricsIfApplicable } from '../../../utils/metrics.js';
+import { esmVars } from '../../../utils/module-format.js';
+import { kebabCase } from '../../../utils/names.js';
+import { getNpmScope } from '../../../utils/npm-scope.js';
 import {
   addComponentGeneratorMetadata,
   addDependencyToTargetIfNotPresent,
   getGeneratorInfo,
   type NxGeneratorInfo,
   readProjectConfigurationUnqualified,
-} from '../../../utils/nx';
-import { toProjectRelativePath } from '../../../utils/paths';
+} from '../../../utils/nx.js';
+import { toProjectRelativePath } from '../../../utils/paths.js';
 import type { TsAgentGatewayConnectionGeneratorSchema } from './schema';
 
 // The gateway core client + vended client need these whatever the connection's

--- a/packages/nx-plugin/src/ts/agent/gateway-connection/schema.d.ts
+++ b/packages/nx-plugin/src/ts/agent/gateway-connection/schema.d.ts
@@ -2,7 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import type { ComponentMetadata } from '../../../utils/nx';
+import type { ComponentMetadata } from '../../../utils/nx.js';
 
 export interface TsAgentGatewayConnectionGeneratorSchema {
   sourceProject: string;

--- a/packages/nx-plugin/src/ts/agent/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/agent/generator.spec.ts
@@ -6,16 +6,16 @@ import { addProjectConfiguration, type Tree, writeJson } from '@nx/devkit';
 import {
   ensureAwsNxPluginConfig,
   updateAwsNxPluginConfig,
-} from '../../utils/config/utils';
-import { declareDependencies } from '../../utils/declared-dependencies';
-import { expectHasMetricTags } from '../../utils/metrics.spec';
+} from '../../utils/config/utils.js';
+import { declareDependencies } from '../../utils/declared-dependencies.js';
+import { expectHasMetricTags } from '../../utils/metrics.spec.js';
 import {
   SHARED_CONSTRUCTS_DEPENDENCIES,
   sharedConstructsGenerator,
-} from '../../utils/shared-constructs';
-import { createTreeUsingTsSolutionSetup } from '../../utils/test';
-import { CONTAINER_VERSIONS } from '../../utils/versions';
-import { TS_AGENT_GENERATOR_INFO, tsAgentGenerator } from './generator';
+} from '../../utils/shared-constructs.js';
+import { createTreeUsingTsSolutionSetup } from '../../utils/test.js';
+import { CONTAINER_VERSIONS } from '../../utils/versions.js';
+import { TS_AGENT_GENERATOR_INFO, tsAgentGenerator } from './generator.js';
 
 const sharedConstructsDeclaration = declareDependencies()({
   ts: [...SHARED_CONSTRUCTS_DEPENDENCIES],

--- a/packages/nx-plugin/src/ts/agent/generator.ts
+++ b/packages/nx-plugin/src/ts/agent/generator.ts
@@ -10,41 +10,41 @@ import {
   type Tree,
   updateProjectConfiguration,
 } from '@nx/devkit';
-import { addTsDependencies } from '../../utils/add-dependencies';
-import { addAgentChatScripts } from '../../utils/agent-chat/agent-chat';
+import { addTsDependencies } from '../../utils/add-dependencies.js';
+import { addAgentChatScripts } from '../../utils/agent-chat/agent-chat.js';
 import {
   AGENT_CONNECTION_DEPENDENCIES,
   addTypeScriptFrameworkBase,
   ensureTypeScriptAgentConnectionProject,
-} from '../../utils/agent-connection/agent-connection';
+} from '../../utils/agent-connection/agent-connection.js';
 import {
   AGENT_CORE_CONSTRUCTS_PY_DEPENDENCIES,
   addAgentInfra,
-} from '../../utils/agent-core-constructs/agent-core-constructs';
+} from '../../utils/agent-core-constructs/agent-core-constructs.js';
 import {
   addTypeScriptBundleTarget,
   BUNDLE_DEPENDENCIES,
-} from '../../utils/bundle/bundle';
-import { resolveContainers } from '../../utils/containers';
+} from '../../utils/bundle/bundle.js';
+import { resolveContainers } from '../../utils/containers.js';
 import {
   declareDependencies,
   ownedElsewhere,
-} from '../../utils/declared-dependencies';
+} from '../../utils/declared-dependencies.js';
 import {
   ADOT_IMAGE_DEPENDENCIES,
   addDockerScanTarget,
   DOCKER_DEPENDENCIES,
   NODE_IMAGE_DEPENDENCIES,
   nodeImageVersions,
-} from '../../utils/docker';
-import { formatFilesInSubtree } from '../../utils/format';
-import { FS_DEPENDENCIES, FsCommands } from '../../utils/fs';
-import { resolveIac } from '../../utils/iac';
-import { installDependencies } from '../../utils/install';
-import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
-import { esmVars } from '../../utils/module-format';
-import { kebabCase, toClassName } from '../../utils/names';
-import { getNpmScope } from '../../utils/npm-scope';
+} from '../../utils/docker.js';
+import { formatFilesInSubtree } from '../../utils/format.js';
+import { FS_DEPENDENCIES, FsCommands } from '../../utils/fs.js';
+import { resolveIac } from '../../utils/iac.js';
+import { installDependencies } from '../../utils/install.js';
+import { addGeneratorMetricsIfApplicable } from '../../utils/metrics.js';
+import { esmVars } from '../../utils/module-format.js';
+import { kebabCase, toClassName } from '../../utils/names.js';
+import { getNpmScope } from '../../utils/npm-scope.js';
 import {
   addComponentDevTarget,
   addComponentGeneratorMetadata,
@@ -52,16 +52,16 @@ import {
   getGeneratorInfo,
   type NxGeneratorInfo,
   readProjectConfigurationUnqualified,
-} from '../../utils/nx';
-import { sortObjectKeys } from '../../utils/object';
-import { getRelativePathToRootByDirectory } from '../../utils/paths';
-import { assignPort } from '../../utils/port';
+} from '../../utils/nx.js';
+import { sortObjectKeys } from '../../utils/object.js';
+import { getRelativePathToRootByDirectory } from '../../utils/paths.js';
+import { assignPort } from '../../utils/port.js';
 import {
   SHARED_CONSTRUCTS_DEPENDENCIES,
   sharedConstructsGenerator,
-} from '../../utils/shared-constructs';
-import type { IacMetadata } from '../../utils/shared-constructs-constants';
-import { BASE_IMAGES, TS_VERSIONS } from '../../utils/versions';
+} from '../../utils/shared-constructs.js';
+import type { IacMetadata } from '../../utils/shared-constructs-constants.js';
+import { BASE_IMAGES, TS_VERSIONS } from '../../utils/versions.js';
 import type { TsAgentGeneratorSchema } from './schema';
 
 /** The metadata this generator records, which its predicates read. */

--- a/packages/nx-plugin/src/ts/agent/mcp-connection/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/agent/mcp-connection/generator.spec.ts
@@ -3,17 +3,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { Tree } from '@nx/devkit';
-import { declareDependencies } from '../../../utils/declared-dependencies';
-import { expectHasMetricTags } from '../../../utils/metrics.spec';
+import { declareDependencies } from '../../../utils/declared-dependencies.js';
+import { expectHasMetricTags } from '../../../utils/metrics.spec.js';
 import {
   SHARED_CONSTRUCTS_DEPENDENCIES,
   sharedConstructsGenerator,
-} from '../../../utils/shared-constructs';
-import { createTreeUsingTsSolutionSetup } from '../../../utils/test';
+} from '../../../utils/shared-constructs.js';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test.js';
 import {
   TS_AGENT_MCP_CONNECTION_GENERATOR_INFO,
   tsAgentMcpConnectionGenerator,
-} from './generator';
+} from './generator.js';
 
 const sharedConstructsDeclaration = declareDependencies()({
   ts: [...SHARED_CONSTRUCTS_DEPENDENCIES],

--- a/packages/nx-plugin/src/ts/agent/mcp-connection/generator.ts
+++ b/packages/nx-plugin/src/ts/agent/mcp-connection/generator.ts
@@ -10,33 +10,33 @@ import {
   type Tree,
   updateProjectConfiguration,
 } from '@nx/devkit';
-import { addTsDependencies } from '../../../utils/add-dependencies';
+import { addTsDependencies } from '../../../utils/add-dependencies.js';
 import {
   AGENT_CONNECTION_DEPENDENCIES,
   AGENT_CONNECTION_PROJECT_DIR,
   addTypeScriptClientToAgent,
   addTypeScriptCoreClient,
   ensureTypeScriptAgentConnectionProject,
-} from '../../../utils/agent-connection/agent-connection';
-import { addDestructuredImport, addStarExport } from '../../../utils/ast';
+} from '../../../utils/agent-connection/agent-connection.js';
+import { addDestructuredImport, addStarExport } from '../../../utils/ast.js';
 import {
   declareDependencies,
   ownedElsewhere,
-} from '../../../utils/declared-dependencies';
-import { formatFilesInSubtree } from '../../../utils/format';
-import { installDependencies } from '../../../utils/install';
-import { addGeneratorMetricsIfApplicable } from '../../../utils/metrics';
-import { esmVars } from '../../../utils/module-format';
-import { kebabCase } from '../../../utils/names';
-import { getNpmScope } from '../../../utils/npm-scope';
+} from '../../../utils/declared-dependencies.js';
+import { formatFilesInSubtree } from '../../../utils/format.js';
+import { installDependencies } from '../../../utils/install.js';
+import { addGeneratorMetricsIfApplicable } from '../../../utils/metrics.js';
+import { esmVars } from '../../../utils/module-format.js';
+import { kebabCase } from '../../../utils/names.js';
+import { getNpmScope } from '../../../utils/npm-scope.js';
 import {
   addComponentGeneratorMetadata,
   addDependencyToTargetIfNotPresent,
   getGeneratorInfo,
   type NxGeneratorInfo,
   readProjectConfigurationUnqualified,
-} from '../../../utils/nx';
-import { toProjectRelativePath } from '../../../utils/paths';
+} from '../../../utils/nx.js';
+import { toProjectRelativePath } from '../../../utils/paths.js';
 import type { TsAgentMcpConnectionGeneratorSchema } from './schema';
 
 // The MCP core client + vended client need these whatever the connection's

--- a/packages/nx-plugin/src/ts/agent/mcp-connection/schema.d.ts
+++ b/packages/nx-plugin/src/ts/agent/mcp-connection/schema.d.ts
@@ -2,7 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import { ComponentMetadata } from '../../../utils/nx';
+import { ComponentMetadata } from '../../../utils/nx.js';
 
 /**
  * TypeScript types for options defined in schema.json

--- a/packages/nx-plugin/src/ts/agent/react-connection/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/agent/react-connection/generator.spec.ts
@@ -3,20 +3,20 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { type Tree, updateJson } from '@nx/devkit';
-import { declareDependencies } from '../../../utils/declared-dependencies';
-import { expectHasMetricTags } from '../../../utils/metrics.spec';
+import { declareDependencies } from '../../../utils/declared-dependencies.js';
+import { expectHasMetricTags } from '../../../utils/metrics.spec.js';
 import {
   SHARED_CONSTRUCTS_DEPENDENCIES,
   sharedConstructsGenerator,
-} from '../../../utils/shared-constructs';
-import { createTreeUsingTsSolutionSetup } from '../../../utils/test';
-import { tsProjectGenerator } from '../../lib/generator';
-import { tsReactWebsiteGenerator } from '../../react-website/app/generator';
-import { tsAgentGenerator } from '../generator';
+} from '../../../utils/shared-constructs.js';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test.js';
+import { tsProjectGenerator } from '../../lib/generator.js';
+import { tsReactWebsiteGenerator } from '../../react-website/app/generator.js';
+import { tsAgentGenerator } from '../generator.js';
 import {
   TS_AGENT_REACT_CONNECTION_GENERATOR_INFO,
   tsAgentReactConnectionGenerator,
-} from './generator';
+} from './generator.js';
 
 const sharedConstructsDeclaration = declareDependencies()({
   ts: [...SHARED_CONSTRUCTS_DEPENDENCIES],

--- a/packages/nx-plugin/src/ts/agent/react-connection/generator.ts
+++ b/packages/nx-plugin/src/ts/agent/react-connection/generator.ts
@@ -9,35 +9,35 @@ import {
   type Tree,
   updateJson,
 } from '@nx/devkit';
-import { addAgentRuntimeToConnectionNamespace } from '../../../connection/agent-runtime-config';
-import type { ResolvedConnectionOptions } from '../../../connection/generator';
-import { addTsDependencies } from '../../../utils/add-dependencies';
-import { addSingleImport, applyGritQL } from '../../../utils/ast';
+import { addAgentRuntimeToConnectionNamespace } from '../../../connection/agent-runtime-config.js';
+import type { ResolvedConnectionOptions } from '../../../connection/generator.js';
+import { addTsDependencies } from '../../../utils/add-dependencies.js';
+import { addSingleImport, applyGritQL } from '../../../utils/ast.js';
 import {
   declareDependencies,
   onlyWhen,
   ownedElsewhere,
-} from '../../../utils/declared-dependencies';
-import { formatFilesInSubtree } from '../../../utils/format';
-import { installDependencies } from '../../../utils/install';
-import { addGeneratorMetricsIfApplicable } from '../../../utils/metrics';
-import { kebabCase, toClassName } from '../../../utils/names';
+} from '../../../utils/declared-dependencies.js';
+import { formatFilesInSubtree } from '../../../utils/format.js';
+import { installDependencies } from '../../../utils/install.js';
+import { addGeneratorMetricsIfApplicable } from '../../../utils/metrics.js';
+import { kebabCase, toClassName } from '../../../utils/names.js';
 import {
   addComponentGeneratorMetadata,
   type ComponentMetadata,
   getGeneratorInfo,
   type NxGeneratorInfo,
   readProjectConfigurationUnqualified,
-} from '../../../utils/nx';
-import { toProjectRelativePath } from '../../../utils/paths';
+} from '../../../utils/nx.js';
+import { toProjectRelativePath } from '../../../utils/paths.js';
 import {
   DEPENDENCIES as AGUI_DEPENDENCIES,
   type AgUiAuth,
   addAgUiReactConnection,
   resolveAgUiTheme,
-} from '../../react-website/agui/generator';
-import { runtimeConfigGenerator } from '../../react-website/runtime-config/generator';
-import { addTsAgentTargetToLocalDev } from './local-dev';
+} from '../../react-website/agui/generator.js';
+import { runtimeConfigGenerator } from '../../react-website/runtime-config/generator.js';
+import { addTsAgentTargetToLocalDev } from './local-dev.js';
 
 /** The metadata this generator records, which its predicates read. */
 export interface TsAgentReactConnectionMetadata {

--- a/packages/nx-plugin/src/ts/agent/react-connection/local-dev.ts
+++ b/packages/nx-plugin/src/ts/agent/react-connection/local-dev.ts
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { Tree } from '@nx/devkit';
-import { addAgentTargetToLocalDev } from '../../../connection/agent-local-dev';
-import type { ComponentMetadata } from '../../../utils/nx';
+import { addAgentTargetToLocalDev } from '../../../connection/agent-local-dev.js';
+import type { ComponentMetadata } from '../../../utils/nx.js';
 
 export interface TsAgentLocalDevOptions {
   agentName: string;

--- a/packages/nx-plugin/src/ts/agent/react-connection/schema.d.ts
+++ b/packages/nx-plugin/src/ts/agent/react-connection/schema.d.ts
@@ -2,7 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import { ComponentMetadata } from '../../../utils/nx';
+import { ComponentMetadata } from '../../../utils/nx.js';
 
 /**
  * TypeScript types for options defined in schema.json

--- a/packages/nx-plugin/src/ts/agent/schema.d.ts
+++ b/packages/nx-plugin/src/ts/agent/schema.d.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { IacOption } from '../../utils/iac';
+import { IacOption } from '../../utils/iac.js';
 
 export type TsAgentFramework = 'strands';
 export type TsAgentInfra = 'agentcore' | 'none';

--- a/packages/nx-plugin/src/ts/api/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/api/generator.spec.ts
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { Tree } from '@nx/devkit';
-import { createTreeUsingTsSolutionSetup } from '../../utils/test';
-import { tsApiGenerator } from './generator';
+import { createTreeUsingTsSolutionSetup } from '../../utils/test.js';
+import { tsApiGenerator } from './generator.js';
 import { TsApiGeneratorSchema } from './schema';
 
 describe('ts#api generator', () => {

--- a/packages/nx-plugin/src/ts/api/generator.ts
+++ b/packages/nx-plugin/src/ts/api/generator.ts
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { Tree } from '@nx/devkit';
-import { tsSmithyApiGenerator } from '../../smithy/ts/api/generator';
-import { tsTrpcApiGenerator } from '../../trpc/backend/generator';
-import { getGeneratorInfo, type NxGeneratorInfo } from '../../utils/nx';
+import { tsSmithyApiGenerator } from '../../smithy/ts/api/generator.js';
+import { tsTrpcApiGenerator } from '../../trpc/backend/generator.js';
+import { getGeneratorInfo, type NxGeneratorInfo } from '../../utils/nx.js';
 import type { TsApiGeneratorSchema } from './schema';
 
 export const TS_API_GENERATOR_INFO: NxGeneratorInfo = getGeneratorInfo(

--- a/packages/nx-plugin/src/ts/api/schema.d.ts
+++ b/packages/nx-plugin/src/ts/api/schema.d.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { IacOption } from '../../utils/iac';
+import { IacOption } from '../../utils/iac.js';
 import { TsProjectGeneratorSchema } from '../lib/schema';
 
 export interface TsApiGeneratorSchema {

--- a/packages/nx-plugin/src/ts/astro-docs/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/astro-docs/generator.spec.ts
@@ -3,18 +3,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { getProjects, readJson, type Tree, updateJson } from '@nx/devkit';
-import { declareDependencies } from '../../utils/declared-dependencies';
-import { expectHasMetricTags } from '../../utils/metrics.spec';
+import { declareDependencies } from '../../utils/declared-dependencies.js';
+import { expectHasMetricTags } from '../../utils/metrics.spec.js';
 import {
   SHARED_CONSTRUCTS_DEPENDENCIES,
   sharedConstructsGenerator,
-} from '../../utils/shared-constructs';
-import { createTreeUsingTsSolutionSetup } from '../../utils/test';
-import { TypeScriptVerifier } from '../../utils/test/ts.spec';
+} from '../../utils/shared-constructs.js';
+import { createTreeUsingTsSolutionSetup } from '../../utils/test.js';
+import { TypeScriptVerifier } from '../../utils/test/ts.spec.js';
 import {
   TS_ASTRO_DOCS_GENERATOR_INFO,
   tsAstroDocsGenerator,
-} from './generator';
+} from './generator.js';
 
 const sharedConstructsDeclaration = declareDependencies()({
   ts: [...SHARED_CONSTRUCTS_DEPENDENCIES],

--- a/packages/nx-plugin/src/ts/astro-docs/generator.ts
+++ b/packages/nx-plugin/src/ts/astro-docs/generator.ts
@@ -11,22 +11,22 @@ import {
   type ProjectConfiguration,
   type Tree,
 } from '@nx/devkit';
-import { addTsDependencies } from '../../utils/add-dependencies';
-import { declareDependencies } from '../../utils/declared-dependencies';
-import { formatFilesInSubtree } from '../../utils/format';
-import { installDependencies } from '../../utils/install';
-import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
-import { isEsmWorkspace } from '../../utils/module-format';
-import { toKebabCase } from '../../utils/names';
-import { getNpmScopePrefix } from '../../utils/npm-scope';
+import { addTsDependencies } from '../../utils/add-dependencies.js';
+import { declareDependencies } from '../../utils/declared-dependencies.js';
+import { formatFilesInSubtree } from '../../utils/format.js';
+import { installDependencies } from '../../utils/install.js';
+import { addGeneratorMetricsIfApplicable } from '../../utils/metrics.js';
+import { isEsmWorkspace } from '../../utils/module-format.js';
+import { toKebabCase } from '../../utils/names.js';
+import { getNpmScopePrefix } from '../../utils/npm-scope.js';
 import {
   addGeneratorMetadata,
   getGeneratorInfo,
   type NxGeneratorInfo,
   projectExists,
-} from '../../utils/nx';
-import { getPackageManagerDisplayCommands } from '../../utils/pkg-manager';
-import { ensureProjectPackageJson } from '../../utils/project-package-json';
+} from '../../utils/nx.js';
+import { getPackageManagerDisplayCommands } from '../../utils/pkg-manager.js';
+import { ensureProjectPackageJson } from '../../utils/project-package-json.js';
 import type { TsAstroDocsGeneratorSchema } from './schema';
 
 /** The metadata this generator records, which its predicates read. */

--- a/packages/nx-plugin/src/ts/dcr-proxy/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/dcr-proxy/generator.spec.ts
@@ -6,11 +6,14 @@ import type { Tree } from '@nx/devkit';
 import {
   ensureAwsNxPluginConfig,
   updateAwsNxPluginConfig,
-} from '../../utils/config/utils';
-import { expectHasMetricTags } from '../../utils/metrics.spec';
-import { getNpmScopePrefix } from '../../utils/npm-scope';
-import { createTreeUsingTsSolutionSetup } from '../../utils/test';
-import { TS_DCR_PROXY_GENERATOR_INFO, tsDcrProxyGenerator } from './generator';
+} from '../../utils/config/utils.js';
+import { expectHasMetricTags } from '../../utils/metrics.spec.js';
+import { getNpmScopePrefix } from '../../utils/npm-scope.js';
+import { createTreeUsingTsSolutionSetup } from '../../utils/test.js';
+import {
+  TS_DCR_PROXY_GENERATOR_INFO,
+  tsDcrProxyGenerator,
+} from './generator.js';
 
 describe('ts#dcr-proxy generator', () => {
   let tree: Tree;

--- a/packages/nx-plugin/src/ts/dcr-proxy/generator.ts
+++ b/packages/nx-plugin/src/ts/dcr-proxy/generator.ts
@@ -10,38 +10,38 @@ import {
   type Tree,
   updateProjectConfiguration,
 } from '@nx/devkit';
-import tsProjectGenerator from '../../ts/lib/generator';
-import { addTsDependencies } from '../../utils/add-dependencies';
+import tsProjectGenerator from '../../ts/lib/generator.js';
+import { addTsDependencies } from '../../utils/add-dependencies.js';
 import {
   addTypeScriptBundleTarget,
   BUNDLE_DEPENDENCIES,
-} from '../../utils/bundle/bundle';
+} from '../../utils/bundle/bundle.js';
 import {
   addDcrProxyInfra,
   DCR_PROXY_HANDLERS,
   type DcrProxyHandler,
-} from '../../utils/dcr-proxy-constructs/dcr-proxy-constructs';
+} from '../../utils/dcr-proxy-constructs/dcr-proxy-constructs.js';
 import {
   declareDependencies,
   ownedElsewhere,
-} from '../../utils/declared-dependencies';
-import { formatFilesInSubtree } from '../../utils/format';
-import { resolveIac } from '../../utils/iac';
-import { installDependencies } from '../../utils/install';
-import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
-import { kebabCase, toClassName } from '../../utils/names';
-import { getNpmScopePrefix } from '../../utils/npm-scope';
+} from '../../utils/declared-dependencies.js';
+import { formatFilesInSubtree } from '../../utils/format.js';
+import { resolveIac } from '../../utils/iac.js';
+import { installDependencies } from '../../utils/install.js';
+import { addGeneratorMetricsIfApplicable } from '../../utils/metrics.js';
+import { kebabCase, toClassName } from '../../utils/names.js';
+import { getNpmScopePrefix } from '../../utils/npm-scope.js';
 import {
   addGeneratorMetadata,
   getGeneratorInfo,
   type NxGeneratorInfo,
   readProjectConfigurationUnqualified,
-} from '../../utils/nx';
-import { sortObjectKeys } from '../../utils/object';
+} from '../../utils/nx.js';
+import { sortObjectKeys } from '../../utils/object.js';
 import {
   SHARED_CONSTRUCTS_DEPENDENCIES,
   sharedConstructsGenerator,
-} from '../../utils/shared-constructs';
+} from '../../utils/shared-constructs.js';
 import type { TsDcrProxyGeneratorSchema } from './schema';
 
 export const DEPENDENCIES = declareDependencies()({

--- a/packages/nx-plugin/src/ts/dcr-proxy/schema.d.ts
+++ b/packages/nx-plugin/src/ts/dcr-proxy/schema.d.ts
@@ -2,7 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import type { IacOption } from '../../utils/iac';
+import type { IacOption } from '../../utils/iac.js';
 
 export interface TsDcrProxyGeneratorSchema {
   name?: string;

--- a/packages/nx-plugin/src/ts/docs/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/docs/generator.spec.ts
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { readJson, type Tree } from '@nx/devkit';
-import { createTreeUsingTsSolutionSetup } from '../../utils/test';
-import { tsDocsGenerator } from './generator';
+import { createTreeUsingTsSolutionSetup } from '../../utils/test.js';
+import { tsDocsGenerator } from './generator.js';
 
 describe('ts#docs generator', () => {
   let tree: Tree;

--- a/packages/nx-plugin/src/ts/docs/generator.ts
+++ b/packages/nx-plugin/src/ts/docs/generator.ts
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { GeneratorCallback, Tree } from '@nx/devkit';
-import { getGeneratorInfo, type NxGeneratorInfo } from '../../utils/nx';
-import { tsAstroDocsGenerator } from '../astro-docs/generator';
+import { getGeneratorInfo, type NxGeneratorInfo } from '../../utils/nx.js';
+import { tsAstroDocsGenerator } from '../astro-docs/generator.js';
 import type { TsDocsGeneratorSchema } from './schema';
 
 export const TS_DOCS_GENERATOR_INFO: NxGeneratorInfo = getGeneratorInfo(

--- a/packages/nx-plugin/src/ts/dynamodb/agent-connection/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/dynamodb/agent-connection/generator.spec.ts
@@ -4,8 +4,8 @@
  */
 import { readProjectConfiguration, type Tree } from '@nx/devkit';
 import { beforeEach, describe, expect, it } from 'vitest';
-import { createTreeUsingTsSolutionSetup } from '../../../utils/test';
-import { tsDynamoDBAgentConnectionGenerator } from './generator';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test.js';
+import { tsDynamoDBAgentConnectionGenerator } from './generator.js';
 
 describe('ts#dynamodb agent-connection generator', () => {
   let tree: Tree;

--- a/packages/nx-plugin/src/ts/dynamodb/agent-connection/generator.ts
+++ b/packages/nx-plugin/src/ts/dynamodb/agent-connection/generator.ts
@@ -3,15 +3,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { type Tree, updateProjectConfiguration } from '@nx/devkit';
-import { formatFilesInSubtree } from '../../../utils/format';
-import { addGeneratorMetricsIfApplicable } from '../../../utils/metrics';
+import { formatFilesInSubtree } from '../../../utils/format.js';
+import { addGeneratorMetricsIfApplicable } from '../../../utils/metrics.js';
 import {
   addComponentGeneratorMetadata,
   addDependencyToTargetIfNotPresent,
   getGeneratorInfo,
   type NxGeneratorInfo,
   readProjectConfigurationUnqualified,
-} from '../../../utils/nx';
+} from '../../../utils/nx.js';
 import type { TsDynamoDBAgentConnectionGeneratorSchema } from './schema';
 
 export const TS_DYNAMODB_AGENT_CONNECTION_GENERATOR_INFO: NxGeneratorInfo =

--- a/packages/nx-plugin/src/ts/dynamodb/agent-connection/schema.d.ts
+++ b/packages/nx-plugin/src/ts/dynamodb/agent-connection/schema.d.ts
@@ -2,7 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import { ComponentMetadata } from '../../../utils/nx';
+import { ComponentMetadata } from '../../../utils/nx.js';
 
 /**
  * TypeScript types for options defined in schema.json

--- a/packages/nx-plugin/src/ts/dynamodb/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/dynamodb/generator.spec.ts
@@ -3,19 +3,22 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { Tree } from '@nx/devkit';
-import { resolveContainers } from '../../utils/containers';
-import { declareDependencies } from '../../utils/declared-dependencies';
-import { expectHasMetricTags } from '../../utils/metrics.spec';
-import { readProjectConfigurationUnqualified } from '../../utils/nx';
+import { resolveContainers } from '../../utils/containers.js';
+import { declareDependencies } from '../../utils/declared-dependencies.js';
+import { expectHasMetricTags } from '../../utils/metrics.spec.js';
+import { readProjectConfigurationUnqualified } from '../../utils/nx.js';
 import {
   SHARED_CONSTRUCTS_DEPENDENCIES,
   sharedConstructsGenerator,
-} from '../../utils/shared-constructs';
+} from '../../utils/shared-constructs.js';
 import {
   createTreeUsingTsSolutionSetup,
   snapshotTreeDir,
-} from '../../utils/test';
-import { TS_DYNAMODB_GENERATOR_INFO, tsDynamoDBGenerator } from './generator';
+} from '../../utils/test.js';
+import {
+  TS_DYNAMODB_GENERATOR_INFO,
+  tsDynamoDBGenerator,
+} from './generator.js';
 
 const sharedConstructsDeclaration = declareDependencies()({
   ts: [...SHARED_CONSTRUCTS_DEPENDENCIES],

--- a/packages/nx-plugin/src/ts/dynamodb/generator.ts
+++ b/packages/nx-plugin/src/ts/dynamodb/generator.ts
@@ -12,40 +12,40 @@ import {
   type Tree,
   updateProjectConfiguration,
 } from '@nx/devkit';
-import { addTsDependencies } from '../../utils/add-dependencies';
-import { resolveContainers } from '../../utils/containers';
+import { addTsDependencies } from '../../utils/add-dependencies.js';
+import { resolveContainers } from '../../utils/containers.js';
 import {
   declareDependencies,
   ownedElsewhere,
-} from '../../utils/declared-dependencies';
-import { addDynamoDBInfra } from '../../utils/dynamodb-constructs/dynamodb-constructs';
-import { formatFilesInSubtree } from '../../utils/format';
-import { resolveIac } from '../../utils/iac';
-import { installDependencies } from '../../utils/install';
-import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
-import { esmVars } from '../../utils/module-format';
-import { kebabCase, toClassName } from '../../utils/names';
-import { getNpmScope } from '../../utils/npm-scope';
+} from '../../utils/declared-dependencies.js';
+import { addDynamoDBInfra } from '../../utils/dynamodb-constructs/dynamodb-constructs.js';
+import { formatFilesInSubtree } from '../../utils/format.js';
+import { resolveIac } from '../../utils/iac.js';
+import { installDependencies } from '../../utils/install.js';
+import { addGeneratorMetricsIfApplicable } from '../../utils/metrics.js';
+import { esmVars } from '../../utils/module-format.js';
+import { kebabCase, toClassName } from '../../utils/names.js';
+import { getNpmScope } from '../../utils/npm-scope.js';
 import {
   addGeneratorMetadata,
   getGeneratorInfo,
   type NxGeneratorInfo,
-} from '../../utils/nx';
-import { assignSharedPort } from '../../utils/port';
+} from '../../utils/nx.js';
+import { assignSharedPort } from '../../utils/port.js';
 import {
   SHARED_CONSTRUCTS_DEPENDENCIES,
   sharedConstructsGenerator,
-} from '../../utils/shared-constructs';
+} from '../../utils/shared-constructs.js';
 import {
   DYNAMODB_GENERATOR_IDS,
   PACKAGES_DIR,
   SHARED_SCRIPTS_DIR,
-} from '../../utils/shared-constructs-constants';
+} from '../../utils/shared-constructs-constants.js';
 import {
   SHARED_DYNAMODB_SCRIPTS_DEPENDENCIES,
   sharedDynamoDBScriptsGenerator,
-} from '../../utils/shared-dynamodb-scripts';
-import tsProjectGenerator, { getTsLibDetails } from '../lib/generator';
+} from '../../utils/shared-dynamodb-scripts.js';
+import tsProjectGenerator, { getTsLibDetails } from '../lib/generator.js';
 import type { TsDynamoDBGeneratorSchema } from './schema';
 
 export const DEPENDENCIES = declareDependencies()({

--- a/packages/nx-plugin/src/ts/dynamodb/mcp-server-connection/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/dynamodb/mcp-server-connection/generator.spec.ts
@@ -4,8 +4,8 @@
  */
 import { readProjectConfiguration, type Tree } from '@nx/devkit';
 import { beforeEach, describe, expect, it } from 'vitest';
-import { createTreeUsingTsSolutionSetup } from '../../../utils/test';
-import { tsDynamoDBMcpServerConnectionGenerator } from './generator';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test.js';
+import { tsDynamoDBMcpServerConnectionGenerator } from './generator.js';
 
 describe('ts#dynamodb mcp-server-connection generator', () => {
   let tree: Tree;

--- a/packages/nx-plugin/src/ts/dynamodb/mcp-server-connection/generator.ts
+++ b/packages/nx-plugin/src/ts/dynamodb/mcp-server-connection/generator.ts
@@ -3,15 +3,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { type Tree, updateProjectConfiguration } from '@nx/devkit';
-import { formatFilesInSubtree } from '../../../utils/format';
-import { addGeneratorMetricsIfApplicable } from '../../../utils/metrics';
+import { formatFilesInSubtree } from '../../../utils/format.js';
+import { addGeneratorMetricsIfApplicable } from '../../../utils/metrics.js';
 import {
   addComponentGeneratorMetadata,
   addDependencyToTargetIfNotPresent,
   getGeneratorInfo,
   type NxGeneratorInfo,
   readProjectConfigurationUnqualified,
-} from '../../../utils/nx';
+} from '../../../utils/nx.js';
 import type { TsDynamoDBMcpServerConnectionGeneratorSchema } from './schema';
 
 export const TS_DYNAMODB_MCP_SERVER_CONNECTION_GENERATOR_INFO: NxGeneratorInfo =

--- a/packages/nx-plugin/src/ts/dynamodb/mcp-server-connection/schema.d.ts
+++ b/packages/nx-plugin/src/ts/dynamodb/mcp-server-connection/schema.d.ts
@@ -2,7 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import { ComponentMetadata } from '../../../utils/nx';
+import { ComponentMetadata } from '../../../utils/nx.js';
 
 /**
  * TypeScript types for options defined in schema.json

--- a/packages/nx-plugin/src/ts/dynamodb/schema.d.ts
+++ b/packages/nx-plugin/src/ts/dynamodb/schema.d.ts
@@ -2,7 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import { IacOption } from '../../utils/iac';
+import { IacOption } from '../../utils/iac.js';
 
 export interface TsDynamoDBGeneratorSchema {
   name: string;

--- a/packages/nx-plugin/src/ts/dynamodb/smithy-connection/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/dynamodb/smithy-connection/generator.spec.ts
@@ -4,8 +4,8 @@
  */
 import { readProjectConfiguration, type Tree } from '@nx/devkit';
 import { beforeEach, describe, expect, it } from 'vitest';
-import { createTreeUsingTsSolutionSetup } from '../../../utils/test';
-import { tsDynamoDBSmithyConnectionGenerator } from './generator';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test.js';
+import { tsDynamoDBSmithyConnectionGenerator } from './generator.js';
 
 describe('ts#dynamodb smithy-connection generator', () => {
   let tree: Tree;

--- a/packages/nx-plugin/src/ts/dynamodb/smithy-connection/generator.ts
+++ b/packages/nx-plugin/src/ts/dynamodb/smithy-connection/generator.ts
@@ -3,15 +3,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { type Tree, updateProjectConfiguration } from '@nx/devkit';
-import { formatFilesInSubtree } from '../../../utils/format';
-import { addGeneratorMetricsIfApplicable } from '../../../utils/metrics';
+import { formatFilesInSubtree } from '../../../utils/format.js';
+import { addGeneratorMetricsIfApplicable } from '../../../utils/metrics.js';
 import {
   addComponentGeneratorMetadata,
   addDependencyToTargetIfNotPresent,
   getGeneratorInfo,
   type NxGeneratorInfo,
   readProjectConfigurationUnqualified,
-} from '../../../utils/nx';
+} from '../../../utils/nx.js';
 import type { TsDynamoDBSmithyConnectionGeneratorSchema } from './schema';
 
 export const TS_DYNAMODB_SMITHY_CONNECTION_GENERATOR_INFO: NxGeneratorInfo =

--- a/packages/nx-plugin/src/ts/dynamodb/trpc-connection/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/dynamodb/trpc-connection/generator.spec.ts
@@ -4,8 +4,8 @@
  */
 import { readProjectConfiguration, type Tree } from '@nx/devkit';
 import { beforeEach, describe, expect, it } from 'vitest';
-import { createTreeUsingTsSolutionSetup } from '../../../utils/test';
-import { tsDynamoDBTrpcConnectionGenerator } from './generator';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test.js';
+import { tsDynamoDBTrpcConnectionGenerator } from './generator.js';
 
 describe('ts#dynamodb trpc-connection generator', () => {
   let tree: Tree;

--- a/packages/nx-plugin/src/ts/dynamodb/trpc-connection/generator.ts
+++ b/packages/nx-plugin/src/ts/dynamodb/trpc-connection/generator.ts
@@ -3,15 +3,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { type Tree, updateProjectConfiguration } from '@nx/devkit';
-import { formatFilesInSubtree } from '../../../utils/format';
-import { addGeneratorMetricsIfApplicable } from '../../../utils/metrics';
+import { formatFilesInSubtree } from '../../../utils/format.js';
+import { addGeneratorMetricsIfApplicable } from '../../../utils/metrics.js';
 import {
   addComponentGeneratorMetadata,
   addDependencyToTargetIfNotPresent,
   getGeneratorInfo,
   type NxGeneratorInfo,
   readProjectConfigurationUnqualified,
-} from '../../../utils/nx';
+} from '../../../utils/nx.js';
 import type { TsDynamoDBTrpcConnectionGeneratorSchema } from './schema';
 
 export const TS_DYNAMODB_TRPC_CONNECTION_GENERATOR_INFO: NxGeneratorInfo =

--- a/packages/nx-plugin/src/ts/lambda-function/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/lambda-function/generator.spec.ts
@@ -6,15 +6,15 @@ import { addProjectConfiguration, type Tree } from '@nx/devkit';
 import {
   ensureAwsNxPluginConfig,
   updateAwsNxPluginConfig,
-} from '../../utils/config/utils';
-import { expectHasMetricTags } from '../../utils/metrics.spec';
-import { createTreeUsingTsSolutionSetup } from '../../utils/test';
-import { TypeScriptVerifier } from '../../utils/test/ts.spec';
+} from '../../utils/config/utils.js';
+import { expectHasMetricTags } from '../../utils/metrics.spec.js';
+import { createTreeUsingTsSolutionSetup } from '../../utils/test.js';
+import { TypeScriptVerifier } from '../../utils/test/ts.spec.js';
 import {
   TS_LAMBDA_FUNCTION_GENERATOR_INFO,
   tsLambdaFunctionGenerator,
-} from './generator';
-import { TS_HANDLER_RETURN_TYPES } from './io';
+} from './generator.js';
+import { TS_HANDLER_RETURN_TYPES } from './io.js';
 import type { EventSource, TsLambdaFunctionGeneratorSchema } from './schema';
 
 describe('ts-lambda-function generator', () => {

--- a/packages/nx-plugin/src/ts/lambda-function/generator.ts
+++ b/packages/nx-plugin/src/ts/lambda-function/generator.ts
@@ -11,33 +11,33 @@ import {
   updateProjectConfiguration,
 } from '@nx/devkit';
 import camelCase from 'lodash.camelcase';
-import { addTsDependencies } from '../../utils/add-dependencies';
+import { addTsDependencies } from '../../utils/add-dependencies.js';
 import {
   addTypeScriptBundleTarget,
   BUNDLE_DEPENDENCIES,
-} from '../../utils/bundle/bundle';
+} from '../../utils/bundle/bundle.js';
 import {
   declareDependencies,
   ownedElsewhere,
-} from '../../utils/declared-dependencies';
-import { formatFilesInSubtree } from '../../utils/format';
-import { addLambdaFunctionInfra } from '../../utils/function-constructs/function-constructs';
-import { resolveIac } from '../../utils/iac';
-import { installDependencies } from '../../utils/install';
-import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
-import { pascalCase, toClassName, toKebabCase } from '../../utils/names';
+} from '../../utils/declared-dependencies.js';
+import { formatFilesInSubtree } from '../../utils/format.js';
+import { addLambdaFunctionInfra } from '../../utils/function-constructs/function-constructs.js';
+import { resolveIac } from '../../utils/iac.js';
+import { installDependencies } from '../../utils/install.js';
+import { addGeneratorMetricsIfApplicable } from '../../utils/metrics.js';
+import { pascalCase, toClassName, toKebabCase } from '../../utils/names.js';
 import {
   addComponentGeneratorMetadata,
   getGeneratorInfo,
   type NxGeneratorInfo,
   readProjectConfigurationUnqualified,
-} from '../../utils/nx';
-import { sortObjectKeys } from '../../utils/object';
+} from '../../utils/nx.js';
+import { sortObjectKeys } from '../../utils/object.js';
 import {
   SHARED_CONSTRUCTS_DEPENDENCIES,
   sharedConstructsGenerator,
-} from '../../utils/shared-constructs';
-import { TS_HANDLER_RETURN_TYPES } from './io';
+} from '../../utils/shared-constructs.js';
+import { TS_HANDLER_RETURN_TYPES } from './io.js';
 import type { TsLambdaFunctionGeneratorSchema } from './schema';
 
 export const DEPENDENCIES = declareDependencies()({

--- a/packages/nx-plugin/src/ts/lambda-function/schema.d.ts
+++ b/packages/nx-plugin/src/ts/lambda-function/schema.d.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { IacOption } from '../../utils/iac';
+import { IacOption } from '../../utils/iac.js';
 
 export type EventSource =
   | 'Any'

--- a/packages/nx-plugin/src/ts/lib/biome.spec.ts
+++ b/packages/nx-plugin/src/ts/lib/biome.spec.ts
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { readProjectConfiguration, type Tree } from '@nx/devkit';
-import { createTreeUsingTsSolutionSetup } from '../../utils/test';
-import { configureBiomeLint } from './biome';
-import tsProjectGenerator from './generator';
+import { createTreeUsingTsSolutionSetup } from '../../utils/test.js';
+import { configureBiomeLint } from './biome.js';
+import tsProjectGenerator from './generator.js';
 
 describe('configureBiomeLint', () => {
   let tree: Tree;

--- a/packages/nx-plugin/src/ts/lib/biome.ts
+++ b/packages/nx-plugin/src/ts/lib/biome.ts
@@ -8,9 +8,9 @@ import {
   updateNxJson,
   updateProjectConfiguration,
 } from '@nx/devkit';
-import { readProjectConfigurationUnqualified } from '../../utils/nx';
-import { sortObjectKeys } from '../../utils/object';
-import type { ConfigureProjectOptions } from './types';
+import { readProjectConfigurationUnqualified } from '../../utils/nx.js';
+import { sortObjectKeys } from '../../utils/object.js';
+import type { ConfigureProjectOptions } from './types.js';
 
 export const configureBiomeLint = async (
   tree: Tree,

--- a/packages/nx-plugin/src/ts/lib/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/lib/generator.spec.ts
@@ -4,14 +4,14 @@
  */
 import { readJson, readNxJson, type Tree, writeJson } from '@nx/devkit';
 import uniqBy from 'lodash.uniqby';
-import { declareDependencies } from '../../utils/declared-dependencies';
-import { expectHasMetricTags } from '../../utils/metrics.spec';
+import { declareDependencies } from '../../utils/declared-dependencies.js';
+import { expectHasMetricTags } from '../../utils/metrics.spec.js';
 import {
   SHARED_CONSTRUCTS_DEPENDENCIES,
   sharedConstructsGenerator,
-} from '../../utils/shared-constructs';
-import { createTreeUsingTsSolutionSetup } from '../../utils/test';
-import { TS_LIB_GENERATOR_INFO, tsProjectGenerator } from './generator';
+} from '../../utils/shared-constructs.js';
+import { createTreeUsingTsSolutionSetup } from '../../utils/test.js';
+import { TS_LIB_GENERATOR_INFO, tsProjectGenerator } from './generator.js';
 
 const sharedConstructsDeclaration = declareDependencies()({
   ts: [...SHARED_CONSTRUCTS_DEPENDENCIES],

--- a/packages/nx-plugin/src/ts/lib/generator.ts
+++ b/packages/nx-plugin/src/ts/lib/generator.ts
@@ -15,25 +15,25 @@ import {
   updateProjectConfiguration,
 } from '@nx/devkit';
 import { libraryGenerator } from '@nx/js';
-import { declareDependencies } from '../../utils/declared-dependencies';
-import { formatFilesInSubtree } from '../../utils/format';
-import { installDependencies } from '../../utils/install';
-import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
-import { isEsmWorkspace } from '../../utils/module-format';
-import { toKebabCase } from '../../utils/names';
-import { getNpmScopePrefix } from '../../utils/npm-scope';
+import { declareDependencies } from '../../utils/declared-dependencies.js';
+import { formatFilesInSubtree } from '../../utils/format.js';
+import { installDependencies } from '../../utils/install.js';
+import { addGeneratorMetricsIfApplicable } from '../../utils/metrics.js';
+import { isEsmWorkspace } from '../../utils/module-format.js';
+import { toKebabCase } from '../../utils/names.js';
+import { getNpmScopePrefix } from '../../utils/npm-scope.js';
 import {
   addGeneratorMetadata,
   getGeneratorInfo,
   mergeTargetDefault,
   type NxGeneratorInfo,
   projectExists,
-} from '../../utils/nx';
-import { sortObjectKeys } from '../../utils/object';
-import { getPackageManagerDisplayCommands } from '../../utils/pkg-manager';
+} from '../../utils/nx.js';
+import { sortObjectKeys } from '../../utils/object.js';
+import { getPackageManagerDisplayCommands } from '../../utils/pkg-manager.js';
 import type { TsProjectGeneratorSchema } from './schema';
-import { configureTsProject } from './ts-project-utils';
-import { VITEST_DEPENDENCIES } from './vitest';
+import { configureTsProject } from './ts-project-utils.js';
+import { VITEST_DEPENDENCIES } from './vitest.js';
 
 export const DEPENDENCIES = declareDependencies()({
   ts: [...VITEST_DEPENDENCIES],

--- a/packages/nx-plugin/src/ts/lib/ts-project-utils.spec.ts
+++ b/packages/nx-plugin/src/ts/lib/ts-project-utils.spec.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { describe, expect, it } from 'vitest';
-import { mergeTsReferences } from './ts-project-utils';
+import { mergeTsReferences } from './ts-project-utils.js';
 
 describe('mergeTsReferences', () => {
   it('appends new references to the end', () => {

--- a/packages/nx-plugin/src/ts/lib/ts-project-utils.ts
+++ b/packages/nx-plugin/src/ts/lib/ts-project-utils.ts
@@ -4,18 +4,18 @@
  */
 import { joinPathFragments, logger, type Tree, updateJson } from '@nx/devkit';
 import { join, relative } from 'path';
-import { addLicenseCheckToLintTarget } from '../../license/config';
-import { AWS_NX_PLUGIN_CONFIG_FILE_NAME } from '../../utils/config/utils';
+import { addLicenseCheckToLintTarget } from '../../license/config.js';
+import { AWS_NX_PLUGIN_CONFIG_FILE_NAME } from '../../utils/config/utils.js';
 import {
   type DependencyDeclaration,
   forDependencies,
   type MustDeclare,
-} from '../../utils/declared-dependencies';
-import { isEsmWorkspace } from '../../utils/module-format';
-import { ensureProjectPackageJson } from '../../utils/project-package-json';
-import { configureBiomeLint } from './biome';
-import type { ConfigureProjectOptions } from './types';
-import { configureVitest, type VITEST_DEPENDENCIES } from './vitest';
+} from '../../utils/declared-dependencies.js';
+import { isEsmWorkspace } from '../../utils/module-format.js';
+import { ensureProjectPackageJson } from '../../utils/project-package-json.js';
+import { configureBiomeLint } from './biome.js';
+import type { ConfigureProjectOptions } from './types.js';
+import { configureVitest, type VITEST_DEPENDENCIES } from './vitest.js';
 
 interface TsConfigReference {
   path: string;

--- a/packages/nx-plugin/src/ts/lib/vitest.spec.ts
+++ b/packages/nx-plugin/src/ts/lib/vitest.spec.ts
@@ -3,11 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { Tree } from '@nx/devkit';
-import { declareDependencies } from '../../utils/declared-dependencies';
-import { createTreeUsingTsSolutionSetup } from '../../utils/test';
-import { expectTypeScriptToCompile } from '../../utils/test/ts.spec';
-import tsProjectGenerator from './generator';
-import { configureVitest, VITEST_DEPENDENCIES } from './vitest';
+import { declareDependencies } from '../../utils/declared-dependencies.js';
+import { createTreeUsingTsSolutionSetup } from '../../utils/test.js';
+import { expectTypeScriptToCompile } from '../../utils/test/ts.spec.js';
+import tsProjectGenerator from './generator.js';
+import { configureVitest, VITEST_DEPENDENCIES } from './vitest.js';
 
 const declaration = declareDependencies()({ ts: [...VITEST_DEPENDENCIES] });
 

--- a/packages/nx-plugin/src/ts/lib/vitest.ts
+++ b/packages/nx-plugin/src/ts/lib/vitest.ts
@@ -5,15 +5,15 @@
 import { readNxJson, type Tree, updateNxJson } from '@nx/devkit';
 import { readFileSync } from 'fs';
 import { join } from 'path';
-import { applyGritQL } from '../../utils/ast';
+import { applyGritQL } from '../../utils/ast.js';
 import {
   type DependencyDeclaration,
   forDependencies,
   type MustDeclare,
-} from '../../utils/declared-dependencies';
-import { addDependenciesToPackageJson } from '../../utils/dependencies';
-import { type ITsDepVersion, withVersions } from '../../utils/versions';
-import type { ConfigureProjectOptions } from './types';
+} from '../../utils/declared-dependencies.js';
+import { addDependenciesToPackageJson } from '../../utils/dependencies.js';
+import { type ITsDepVersion, withVersions } from '../../utils/versions.js';
+import type { ConfigureProjectOptions } from './types.js';
 
 const readGritPattern = (name: string): string =>
   readFileSync(

--- a/packages/nx-plugin/src/ts/mcp-server/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/mcp-server/generator.spec.ts
@@ -14,19 +14,19 @@ import { vi } from 'vitest';
 import {
   ensureAwsNxPluginConfig,
   updateAwsNxPluginConfig,
-} from '../../utils/config/utils';
-import { declareDependencies } from '../../utils/declared-dependencies';
-import { expectHasMetricTags } from '../../utils/metrics.spec';
+} from '../../utils/config/utils.js';
+import { declareDependencies } from '../../utils/declared-dependencies.js';
+import { expectHasMetricTags } from '../../utils/metrics.spec.js';
 import {
   SHARED_CONSTRUCTS_DEPENDENCIES,
   sharedConstructsGenerator,
-} from '../../utils/shared-constructs';
-import { createTreeUsingTsSolutionSetup } from '../../utils/test';
-import { CONTAINER_VERSIONS } from '../../utils/versions';
+} from '../../utils/shared-constructs.js';
+import { createTreeUsingTsSolutionSetup } from '../../utils/test.js';
+import { CONTAINER_VERSIONS } from '../../utils/versions.js';
 import {
   TS_MCP_SERVER_GENERATOR_INFO,
   tsMcpServerGenerator,
-} from './generator';
+} from './generator.js';
 
 const sharedConstructsDeclaration = declareDependencies()({
   ts: [...SHARED_CONSTRUCTS_DEPENDENCIES],

--- a/packages/nx-plugin/src/ts/mcp-server/generator.ts
+++ b/packages/nx-plugin/src/ts/mcp-server/generator.ts
@@ -13,35 +13,35 @@ import {
   updateJson,
   updateProjectConfiguration,
 } from '@nx/devkit';
-import { addTsDependencies } from '../../utils/add-dependencies';
+import { addTsDependencies } from '../../utils/add-dependencies.js';
 import {
   AGENT_CORE_CONSTRUCTS_PY_DEPENDENCIES,
   addMcpServerInfra,
-} from '../../utils/agent-core-constructs/agent-core-constructs';
+} from '../../utils/agent-core-constructs/agent-core-constructs.js';
 import {
   addTypeScriptBundleTarget,
   BUNDLE_DEPENDENCIES,
-} from '../../utils/bundle/bundle';
-import { resolveContainers } from '../../utils/containers';
+} from '../../utils/bundle/bundle.js';
+import { resolveContainers } from '../../utils/containers.js';
 import {
   declareDependencies,
   ownedElsewhere,
-} from '../../utils/declared-dependencies';
+} from '../../utils/declared-dependencies.js';
 import {
   ADOT_IMAGE_DEPENDENCIES,
   addDockerScanTarget,
   DOCKER_DEPENDENCIES,
   NODE_IMAGE_DEPENDENCIES,
   nodeImageVersions,
-} from '../../utils/docker';
-import { formatFilesInSubtree } from '../../utils/format';
-import { FS_DEPENDENCIES, FsCommands } from '../../utils/fs';
-import { resolveIac } from '../../utils/iac';
-import { installDependencies } from '../../utils/install';
-import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
-import { isEsmWorkspace } from '../../utils/module-format';
-import { kebabCase, toClassName } from '../../utils/names';
-import { getNpmScope } from '../../utils/npm-scope';
+} from '../../utils/docker.js';
+import { formatFilesInSubtree } from '../../utils/format.js';
+import { FS_DEPENDENCIES, FsCommands } from '../../utils/fs.js';
+import { resolveIac } from '../../utils/iac.js';
+import { installDependencies } from '../../utils/install.js';
+import { addGeneratorMetricsIfApplicable } from '../../utils/metrics.js';
+import { isEsmWorkspace } from '../../utils/module-format.js';
+import { kebabCase, toClassName } from '../../utils/names.js';
+import { getNpmScope } from '../../utils/npm-scope.js';
 import {
   addComponentDevTarget,
   addComponentGeneratorMetadata,
@@ -49,16 +49,16 @@ import {
   getGeneratorInfo,
   type NxGeneratorInfo,
   readProjectConfigurationUnqualified,
-} from '../../utils/nx';
-import { sortObjectKeys } from '../../utils/object';
-import { registerPnpmBuiltDependencies } from '../../utils/pnpm-workspace';
-import { assignPort } from '../../utils/port';
+} from '../../utils/nx.js';
+import { sortObjectKeys } from '../../utils/object.js';
+import { registerPnpmBuiltDependencies } from '../../utils/pnpm-workspace.js';
+import { assignPort } from '../../utils/port.js';
 import {
   SHARED_CONSTRUCTS_DEPENDENCIES,
   sharedConstructsGenerator,
-} from '../../utils/shared-constructs';
-import type { IacMetadata } from '../../utils/shared-constructs-constants';
-import { BASE_IMAGES, TS_VERSIONS } from '../../utils/versions';
+} from '../../utils/shared-constructs.js';
+import type { IacMetadata } from '../../utils/shared-constructs-constants.js';
+import { BASE_IMAGES, TS_VERSIONS } from '../../utils/versions.js';
 import type { TsMcpServerGeneratorSchema } from './schema';
 
 /** The metadata this generator records, which its predicates read. */

--- a/packages/nx-plugin/src/ts/mcp-server/schema.d.ts
+++ b/packages/nx-plugin/src/ts/mcp-server/schema.d.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { IacOption } from '../../utils/iac';
+import { IacOption } from '../../utils/iac.js';
 
 export type TsMcpServerInfra = 'none' | 'agentcore';
 

--- a/packages/nx-plugin/src/ts/nx-generator/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/nx-generator/generator.spec.ts
@@ -16,17 +16,17 @@ import NxPluginForAwsPackageJson from '../../../package.json' with {
 import NxPluginForAwsProjectJson from '../../../project.json' with {
   type: 'json',
 };
-import { declareDependencies } from '../../utils/declared-dependencies';
-import { expectHasMetricTags } from '../../utils/metrics.spec';
+import { declareDependencies } from '../../utils/declared-dependencies.js';
+import { expectHasMetricTags } from '../../utils/metrics.spec.js';
 import {
   SHARED_CONSTRUCTS_DEPENDENCIES,
   sharedConstructsGenerator,
-} from '../../utils/shared-constructs';
-import { createTreeUsingTsSolutionSetup } from '../../utils/test';
+} from '../../utils/shared-constructs.js';
+import { createTreeUsingTsSolutionSetup } from '../../utils/test.js';
 import {
   NX_GENERATOR_GENERATOR_INFO,
   tsNxGeneratorGenerator,
-} from './generator';
+} from './generator.js';
 
 const sharedConstructsDeclaration = declareDependencies()({
   ts: [...SHARED_CONSTRUCTS_DEPENDENCIES],

--- a/packages/nx-plugin/src/ts/nx-generator/generator.ts
+++ b/packages/nx-plugin/src/ts/nx-generator/generator.ts
@@ -13,24 +13,24 @@ import {
 } from '@nx/devkit';
 import camelCase from 'lodash.camelcase';
 import PackageJson from '../../../package.json' with { type: 'json' };
-import { addStarExport, applyGritQL } from '../../utils/ast';
-import { declareDependencies } from '../../utils/declared-dependencies';
-import { formatFilesInSubtree } from '../../utils/format';
-import { installDependencies } from '../../utils/install';
-import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
-import { esmVars } from '../../utils/module-format';
-import { kebabCase, pascalCase, snakeCase } from '../../utils/names';
+import { addStarExport, applyGritQL } from '../../utils/ast.js';
+import { declareDependencies } from '../../utils/declared-dependencies.js';
+import { formatFilesInSubtree } from '../../utils/format.js';
+import { installDependencies } from '../../utils/install.js';
+import { addGeneratorMetricsIfApplicable } from '../../utils/metrics.js';
+import { esmVars } from '../../utils/module-format.js';
+import { kebabCase, pascalCase, snakeCase } from '../../utils/names.js';
 import {
   addComponentGeneratorMetadata,
   getGeneratorInfo,
   readProjectConfigurationUnqualified,
-} from '../../utils/nx';
-import { sortObjectKeys } from '../../utils/object';
-import { getRelativePathToRootByDirectory } from '../../utils/paths';
+} from '../../utils/nx.js';
+import { sortObjectKeys } from '../../utils/object.js';
+import { getRelativePathToRootByDirectory } from '../../utils/paths.js';
 import {
   configureTsProjectAsNxPlugin,
   NX_PLUGIN_DEPENDENCIES,
-} from '../nx-plugin/utils';
+} from '../nx-plugin/utils.js';
 import type { TsNxGeneratorGeneratorSchema } from './schema';
 
 export const DEPENDENCIES = declareDependencies()({

--- a/packages/nx-plugin/src/ts/nx-migration/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/nx-migration/generator.spec.ts
@@ -8,17 +8,17 @@ import {
   updateJson,
   writeJson,
 } from '@nx/devkit';
-import { declareDependencies } from '../../utils/declared-dependencies';
-import { expectHasMetricTags } from '../../utils/metrics.spec';
+import { declareDependencies } from '../../utils/declared-dependencies.js';
+import { expectHasMetricTags } from '../../utils/metrics.spec.js';
 import {
   SHARED_CONSTRUCTS_DEPENDENCIES,
   sharedConstructsGenerator,
-} from '../../utils/shared-constructs';
-import { createTreeUsingTsSolutionSetup } from '../../utils/test';
+} from '../../utils/shared-constructs.js';
+import { createTreeUsingTsSolutionSetup } from '../../utils/test.js';
 import {
   NX_MIGRATION_GENERATOR_INFO,
   tsNxMigrationGenerator,
-} from './generator';
+} from './generator.js';
 
 const sharedConstructsDeclaration = declareDependencies()({
   ts: [...SHARED_CONSTRUCTS_DEPENDENCIES],

--- a/packages/nx-plugin/src/ts/nx-migration/generator.ts
+++ b/packages/nx-plugin/src/ts/nx-migration/generator.ts
@@ -12,28 +12,28 @@ import {
   writeJson,
 } from '@nx/devkit';
 import PackageJson from '../../../package.json' with { type: 'json' };
-import { declareDependencies } from '../../utils/declared-dependencies';
-import { formatFilesInSubtree } from '../../utils/format';
-import { installDependencies } from '../../utils/install';
-import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
+import { declareDependencies } from '../../utils/declared-dependencies.js';
+import { formatFilesInSubtree } from '../../utils/format.js';
+import { installDependencies } from '../../utils/install.js';
+import { addGeneratorMetricsIfApplicable } from '../../utils/metrics.js';
 import {
   LATEST_MIGRATIONS_DIR,
   migrationKey,
-} from '../../utils/migration-versions';
-import { isEsmWorkspace } from '../../utils/module-format';
-import { kebabCase } from '../../utils/names';
+} from '../../utils/migration-versions.js';
+import { isEsmWorkspace } from '../../utils/module-format.js';
+import { kebabCase } from '../../utils/names.js';
 import {
   getGeneratorInfo,
   isNxPluginForAwsWorkspace,
   type NxGeneratorInfo,
-} from '../../utils/nx';
-import { sortObjectKeys } from '../../utils/object';
+} from '../../utils/nx.js';
+import { sortObjectKeys } from '../../utils/object.js';
 import {
   addNxPluginDependencies,
   configureNxPluginPackageJson,
   NX_PLUGIN_DEPENDENCIES,
   readNxPluginProject,
-} from '../nx-plugin/utils';
+} from '../nx-plugin/utils.js';
 import type { TsNxMigrationGeneratorSchema } from './schema';
 
 export const DEPENDENCIES = declareDependencies()({

--- a/packages/nx-plugin/src/ts/nx-plugin/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/nx-plugin/generator.spec.ts
@@ -3,17 +3,20 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { readJson, readProjectConfiguration, type Tree } from '@nx/devkit';
-import { declareDependencies } from '../../utils/declared-dependencies';
-import { expectHasMetricTags } from '../../utils/metrics.spec';
+import { declareDependencies } from '../../utils/declared-dependencies.js';
+import { expectHasMetricTags } from '../../utils/metrics.spec.js';
 import {
   SHARED_CONSTRUCTS_DEPENDENCIES,
   sharedConstructsGenerator,
-} from '../../utils/shared-constructs';
+} from '../../utils/shared-constructs.js';
 import {
   createTreeUsingTsSolutionSetup,
   snapshotTreeDir,
-} from '../../utils/test';
-import { TS_NX_PLUGIN_GENERATOR_INFO, tsNxPluginGenerator } from './generator';
+} from '../../utils/test.js';
+import {
+  TS_NX_PLUGIN_GENERATOR_INFO,
+  tsNxPluginGenerator,
+} from './generator.js';
 
 const sharedConstructsDeclaration = declareDependencies()({
   ts: [...SHARED_CONSTRUCTS_DEPENDENCIES],

--- a/packages/nx-plugin/src/ts/nx-plugin/generator.ts
+++ b/packages/nx-plugin/src/ts/nx-plugin/generator.ts
@@ -11,23 +11,26 @@ import {
   updateJson,
   updateProjectConfiguration,
 } from '@nx/devkit';
-import { declareDependencies } from '../../utils/declared-dependencies';
-import { formatFilesInSubtree } from '../../utils/format';
-import { installDependencies } from '../../utils/install';
-import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
-import { esmVars } from '../../utils/module-format';
+import { declareDependencies } from '../../utils/declared-dependencies.js';
+import { formatFilesInSubtree } from '../../utils/format.js';
+import { installDependencies } from '../../utils/install.js';
+import { addGeneratorMetricsIfApplicable } from '../../utils/metrics.js';
+import { esmVars } from '../../utils/module-format.js';
 import {
   addDependencyToTargetIfNotPresent,
   addGeneratorMetadata,
   getGeneratorInfo,
   type NxGeneratorInfo,
   readProjectConfigurationUnqualified,
-} from '../../utils/nx';
-import { sortObjectKeys } from '../../utils/object';
-import tsProjectGenerator, { getTsLibDetails } from '../lib/generator';
-import tsMcpServerGenerator from '../mcp-server/generator';
+} from '../../utils/nx.js';
+import { sortObjectKeys } from '../../utils/object.js';
+import tsProjectGenerator, { getTsLibDetails } from '../lib/generator.js';
+import tsMcpServerGenerator from '../mcp-server/generator.js';
 import type { TsNxPluginGeneratorSchema } from './schema';
-import { configureTsProjectAsNxPlugin, NX_PLUGIN_DEPENDENCIES } from './utils';
+import {
+  configureTsProjectAsNxPlugin,
+  NX_PLUGIN_DEPENDENCIES,
+} from './utils.js';
 
 export const DEPENDENCIES = declareDependencies()({
   ts: [...NX_PLUGIN_DEPENDENCIES],

--- a/packages/nx-plugin/src/ts/nx-plugin/utils.ts
+++ b/packages/nx-plugin/src/ts/nx-plugin/utils.ts
@@ -14,14 +14,14 @@ import {
   type DependencyDeclaration,
   forDependencies,
   type MustDeclare,
-} from '../../utils/declared-dependencies';
-import { addDependenciesToPackageJson } from '../../utils/dependencies';
-import { isEsmWorkspace } from '../../utils/module-format';
+} from '../../utils/declared-dependencies.js';
+import { addDependenciesToPackageJson } from '../../utils/dependencies.js';
+import { isEsmWorkspace } from '../../utils/module-format.js';
 import {
   nxPluginSelfDependency,
   readProjectConfigurationUnqualified,
-} from '../../utils/nx';
-import { type ITsDepVersion, withVersions } from '../../utils/versions';
+} from '../../utils/nx.js';
+import { type ITsDepVersion, withVersions } from '../../utils/versions.js';
 
 /** Dependencies a caller must declare to configure an Nx Plugin project. */
 export const NX_PLUGIN_DEPENDENCIES = [

--- a/packages/nx-plugin/src/ts/rdb/agent-connection/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/rdb/agent-connection/generator.spec.ts
@@ -4,8 +4,8 @@
  */
 import { readProjectConfiguration, type Tree } from '@nx/devkit';
 import { beforeEach, describe, expect, it } from 'vitest';
-import { createTreeUsingTsSolutionSetup } from '../../../utils/test';
-import { tsRdbAgentConnectionGenerator } from './generator';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test.js';
+import { tsRdbAgentConnectionGenerator } from './generator.js';
 
 describe('ts#rdb agent-connection generator', () => {
   let tree: Tree;

--- a/packages/nx-plugin/src/ts/rdb/agent-connection/generator.ts
+++ b/packages/nx-plugin/src/ts/rdb/agent-connection/generator.ts
@@ -8,19 +8,19 @@ import {
   updateProjectConfiguration,
 } from '@nx/devkit';
 import camelCase from 'lodash.camelcase';
-import { addDestructuredImport, applyGritQL } from '../../../utils/ast';
-import { formatFilesInSubtree } from '../../../utils/format';
-import { addGeneratorMetricsIfApplicable } from '../../../utils/metrics';
-import { pascalCase } from '../../../utils/names';
+import { addDestructuredImport, applyGritQL } from '../../../utils/ast.js';
+import { formatFilesInSubtree } from '../../../utils/format.js';
+import { addGeneratorMetricsIfApplicable } from '../../../utils/metrics.js';
+import { pascalCase } from '../../../utils/names.js';
 import {
   addComponentGeneratorMetadata,
   addDependencyToTargetIfNotPresent,
   getGeneratorInfo,
   type NxGeneratorInfo,
   readProjectConfigurationUnqualified,
-} from '../../../utils/nx';
-import { toProjectRelativePath } from '../../../utils/paths';
-import { injectRdsCaBundleIntoDockerfile } from '../utils';
+} from '../../../utils/nx.js';
+import { toProjectRelativePath } from '../../../utils/paths.js';
+import { injectRdsCaBundleIntoDockerfile } from '../utils.js';
 import type { TsRdbAgentConnectionGeneratorSchema } from './schema';
 
 export const TS_RDB_AGENT_CONNECTION_GENERATOR_INFO: NxGeneratorInfo =

--- a/packages/nx-plugin/src/ts/rdb/agent-connection/schema.d.ts
+++ b/packages/nx-plugin/src/ts/rdb/agent-connection/schema.d.ts
@@ -2,7 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import { ComponentMetadata } from '../../../utils/nx';
+import { ComponentMetadata } from '../../../utils/nx.js';
 
 /**
  * TypeScript types for options defined in schema.json

--- a/packages/nx-plugin/src/ts/rdb/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/rdb/generator.spec.ts
@@ -5,19 +5,19 @@
 
 import type { Tree } from '@nx/devkit';
 import * as devkit from '@nx/devkit';
-import { declareDependencies } from '../../utils/declared-dependencies';
-import { expectHasMetricTags } from '../../utils/metrics.spec';
-import { readProjectConfigurationUnqualified } from '../../utils/nx';
+import { declareDependencies } from '../../utils/declared-dependencies.js';
+import { expectHasMetricTags } from '../../utils/metrics.spec.js';
+import { readProjectConfigurationUnqualified } from '../../utils/nx.js';
 import {
   SHARED_CONSTRUCTS_DEPENDENCIES,
   sharedConstructsGenerator,
-} from '../../utils/shared-constructs';
+} from '../../utils/shared-constructs.js';
 import {
   createTreeUsingTsSolutionSetup,
   snapshotTreeDir,
-} from '../../utils/test';
-import { TS_VERSIONS } from '../../utils/versions';
-import { TS_RDB_GENERATOR_INFO, tsRdbGenerator } from './generator';
+} from '../../utils/test.js';
+import { TS_VERSIONS } from '../../utils/versions.js';
+import { TS_RDB_GENERATOR_INFO, tsRdbGenerator } from './generator.js';
 
 const sharedConstructsDeclaration = declareDependencies()({
   ts: [...SHARED_CONSTRUCTS_DEPENDENCIES],

--- a/packages/nx-plugin/src/ts/rdb/generator.ts
+++ b/packages/nx-plugin/src/ts/rdb/generator.ts
@@ -15,57 +15,57 @@ import {
   updateProjectConfiguration,
   writeJson,
 } from '@nx/devkit';
-import { addTsDependencies } from '../../utils/add-dependencies';
-import { addStarExport } from '../../utils/ast';
+import { addTsDependencies } from '../../utils/add-dependencies.js';
+import { addStarExport } from '../../utils/ast.js';
 import {
   addTypeScriptBundleTarget,
   BUNDLE_DEPENDENCIES,
-} from '../../utils/bundle/bundle';
-import { resolveContainers } from '../../utils/containers';
+} from '../../utils/bundle/bundle.js';
+import { resolveContainers } from '../../utils/containers.js';
 import {
   declareDependencies,
   ownedElsewhere,
-} from '../../utils/declared-dependencies';
+} from '../../utils/declared-dependencies.js';
 import {
   addDockerScanTarget,
   DOCKER_DEPENDENCIES,
   NODE_IMAGE_DEPENDENCIES,
   nodeImageVersions,
-} from '../../utils/docker';
-import { formatFilesInSubtree } from '../../utils/format';
-import { FS_DEPENDENCIES, FsCommands } from '../../utils/fs';
-import { updateGitIgnore } from '../../utils/git';
-import { resolveIac } from '../../utils/iac';
-import { installDependencies } from '../../utils/install';
-import { addGeneratorMetricsIfApplicable } from '../../utils/metrics';
-import { esmVars } from '../../utils/module-format';
-import { kebabCase, snakeCase, toClassName } from '../../utils/names';
-import { getNpmScope } from '../../utils/npm-scope';
+} from '../../utils/docker.js';
+import { formatFilesInSubtree } from '../../utils/format.js';
+import { FS_DEPENDENCIES, FsCommands } from '../../utils/fs.js';
+import { updateGitIgnore } from '../../utils/git.js';
+import { resolveIac } from '../../utils/iac.js';
+import { installDependencies } from '../../utils/install.js';
+import { addGeneratorMetricsIfApplicable } from '../../utils/metrics.js';
+import { esmVars } from '../../utils/module-format.js';
+import { kebabCase, snakeCase, toClassName } from '../../utils/names.js';
+import { getNpmScope } from '../../utils/npm-scope.js';
 import {
   addDependencyToTargetIfNotPresent,
   addGeneratorMetadata,
   getGeneratorInfo,
   type NxGeneratorInfo,
-} from '../../utils/nx';
-import { getRelativePathToRootByDirectory } from '../../utils/paths';
-import { registerPnpmBuiltDependencies } from '../../utils/pnpm-workspace';
-import { assignPort } from '../../utils/port';
-import { addRdbInfra } from '../../utils/rdb-constructs/rdb-constructs';
+} from '../../utils/nx.js';
+import { getRelativePathToRootByDirectory } from '../../utils/paths.js';
+import { registerPnpmBuiltDependencies } from '../../utils/pnpm-workspace.js';
+import { assignPort } from '../../utils/port.js';
+import { addRdbInfra } from '../../utils/rdb-constructs/rdb-constructs.js';
 import {
   SHARED_CONSTRUCTS_DEPENDENCIES,
   sharedConstructsGenerator,
-} from '../../utils/shared-constructs';
+} from '../../utils/shared-constructs.js';
 import {
   type IacMetadata,
   PACKAGES_DIR,
   SHARED_SCRIPTS_DIR,
-} from '../../utils/shared-constructs-constants';
+} from '../../utils/shared-constructs-constants.js';
 import {
   SHARED_RDB_SCRIPTS_DEPENDENCIES,
   sharedRdbScriptsGenerator,
-} from '../../utils/shared-rdb-scripts';
-import { TS_VERSIONS } from '../../utils/versions';
-import tsProjectGenerator, { getTsLibDetails } from '../lib/generator';
+} from '../../utils/shared-rdb-scripts.js';
+import { TS_VERSIONS } from '../../utils/versions.js';
+import tsProjectGenerator, { getTsLibDetails } from '../lib/generator.js';
 import type { TsRdbGeneratorSchema } from './schema';
 
 /** The metadata this generator records, which its predicates read. */

--- a/packages/nx-plugin/src/ts/rdb/mcp-server-connection/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/rdb/mcp-server-connection/generator.spec.ts
@@ -4,8 +4,8 @@
  */
 import { readProjectConfiguration, type Tree } from '@nx/devkit';
 import { beforeEach, describe, expect, it } from 'vitest';
-import { createTreeUsingTsSolutionSetup } from '../../../utils/test';
-import { tsRdbMcpServerConnectionGenerator } from './generator';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test.js';
+import { tsRdbMcpServerConnectionGenerator } from './generator.js';
 
 describe('ts#rdb mcp-server-connection generator', () => {
   let tree: Tree;

--- a/packages/nx-plugin/src/ts/rdb/mcp-server-connection/generator.ts
+++ b/packages/nx-plugin/src/ts/rdb/mcp-server-connection/generator.ts
@@ -8,19 +8,19 @@ import {
   updateProjectConfiguration,
 } from '@nx/devkit';
 import camelCase from 'lodash.camelcase';
-import { addDestructuredImport, applyGritQL } from '../../../utils/ast';
-import { formatFilesInSubtree } from '../../../utils/format';
-import { addGeneratorMetricsIfApplicable } from '../../../utils/metrics';
-import { pascalCase } from '../../../utils/names';
+import { addDestructuredImport, applyGritQL } from '../../../utils/ast.js';
+import { formatFilesInSubtree } from '../../../utils/format.js';
+import { addGeneratorMetricsIfApplicable } from '../../../utils/metrics.js';
+import { pascalCase } from '../../../utils/names.js';
 import {
   addComponentGeneratorMetadata,
   addDependencyToTargetIfNotPresent,
   getGeneratorInfo,
   type NxGeneratorInfo,
   readProjectConfigurationUnqualified,
-} from '../../../utils/nx';
-import { toProjectRelativePath } from '../../../utils/paths';
-import { injectRdsCaBundleIntoDockerfile } from '../utils';
+} from '../../../utils/nx.js';
+import { toProjectRelativePath } from '../../../utils/paths.js';
+import { injectRdsCaBundleIntoDockerfile } from '../utils.js';
 import type { TsRdbMcpServerConnectionGeneratorSchema } from './schema';
 
 export const TS_RDB_MCP_SERVER_CONNECTION_GENERATOR_INFO: NxGeneratorInfo =

--- a/packages/nx-plugin/src/ts/rdb/mcp-server-connection/schema.d.ts
+++ b/packages/nx-plugin/src/ts/rdb/mcp-server-connection/schema.d.ts
@@ -2,7 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import { ComponentMetadata } from '../../../utils/nx';
+import { ComponentMetadata } from '../../../utils/nx.js';
 
 /**
  * TypeScript types for options defined in schema.json

--- a/packages/nx-plugin/src/ts/rdb/schema.d.ts
+++ b/packages/nx-plugin/src/ts/rdb/schema.d.ts
@@ -2,7 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import { IacOption } from '../../utils/iac';
+import { IacOption } from '../../utils/iac.js';
 
 export interface TsRdbGeneratorSchema {
   name: string;

--- a/packages/nx-plugin/src/ts/rdb/smithy-connection/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/rdb/smithy-connection/generator.spec.ts
@@ -4,8 +4,8 @@
  */
 import { readProjectConfiguration, type Tree } from '@nx/devkit';
 import { beforeEach, describe, expect, it } from 'vitest';
-import { createTreeUsingTsSolutionSetup } from '../../../utils/test';
-import { tsRdbSmithyConnectionGenerator } from './generator';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test.js';
+import { tsRdbSmithyConnectionGenerator } from './generator.js';
 
 describe('ts#rdb smithy-connection generator', () => {
   let tree: Tree;

--- a/packages/nx-plugin/src/ts/rdb/smithy-connection/generator.ts
+++ b/packages/nx-plugin/src/ts/rdb/smithy-connection/generator.ts
@@ -12,18 +12,18 @@ import {
   addDestructuredImport,
   applyGritQL,
   matchGritQL,
-} from '../../../utils/ast';
-import { formatFilesInSubtree } from '../../../utils/format';
-import { addGeneratorMetricsIfApplicable } from '../../../utils/metrics';
-import { pascalCase } from '../../../utils/names';
+} from '../../../utils/ast.js';
+import { formatFilesInSubtree } from '../../../utils/format.js';
+import { addGeneratorMetricsIfApplicable } from '../../../utils/metrics.js';
+import { pascalCase } from '../../../utils/names.js';
 import {
   addComponentGeneratorMetadata,
   addDependencyToTargetIfNotPresent,
   getGeneratorInfo,
   type NxGeneratorInfo,
   readProjectConfigurationUnqualified,
-} from '../../../utils/nx';
-import { toProjectRelativePath } from '../../../utils/paths';
+} from '../../../utils/nx.js';
+import { toProjectRelativePath } from '../../../utils/paths.js';
 import type { TsRdbSmithyConnectionGeneratorSchema } from './schema';
 
 export const TS_RDB_SMITHY_CONNECTION_GENERATOR_INFO: NxGeneratorInfo =

--- a/packages/nx-plugin/src/ts/rdb/trpc-connection/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/rdb/trpc-connection/generator.spec.ts
@@ -4,8 +4,8 @@
  */
 import { readProjectConfiguration, type Tree } from '@nx/devkit';
 import { beforeEach, describe, expect, it } from 'vitest';
-import { createTreeUsingTsSolutionSetup } from '../../../utils/test';
-import { tsRdbTrpcConnectionGenerator } from './generator';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test.js';
+import { tsRdbTrpcConnectionGenerator } from './generator.js';
 
 describe('ts#rdb trpc-connection generator', () => {
   let tree: Tree;

--- a/packages/nx-plugin/src/ts/rdb/trpc-connection/generator.ts
+++ b/packages/nx-plugin/src/ts/rdb/trpc-connection/generator.ts
@@ -10,16 +10,16 @@ import {
   updateProjectConfiguration,
 } from '@nx/devkit';
 import camelCase from 'lodash.camelcase';
-import { formatFilesInSubtree } from '../../../utils/format';
-import { addGeneratorMetricsIfApplicable } from '../../../utils/metrics';
-import { kebabCase, pascalCase } from '../../../utils/names';
+import { formatFilesInSubtree } from '../../../utils/format.js';
+import { addGeneratorMetricsIfApplicable } from '../../../utils/metrics.js';
+import { kebabCase, pascalCase } from '../../../utils/names.js';
 import {
   addComponentGeneratorMetadata,
   addDependencyToTargetIfNotPresent,
   getGeneratorInfo,
   type NxGeneratorInfo,
   readProjectConfigurationUnqualified,
-} from '../../../utils/nx';
+} from '../../../utils/nx.js';
 import type { TsRdbTrpcConnectionGeneratorSchema } from './schema';
 
 export const TS_RDB_TRPC_CONNECTION_GENERATOR_INFO: NxGeneratorInfo =

--- a/packages/nx-plugin/src/ts/react-website/agui/generator.ts
+++ b/packages/nx-plugin/src/ts/react-website/agui/generator.ts
@@ -9,25 +9,25 @@ import {
   type ProjectConfiguration,
   type Tree,
 } from '@nx/devkit';
-import { addAgentRuntimeToConnectionNamespace } from '../../../connection/agent-runtime-config';
-import { addTsDependencies } from '../../../utils/add-dependencies';
+import { addAgentRuntimeToConnectionNamespace } from '../../../connection/agent-runtime-config.js';
+import { addTsDependencies } from '../../../utils/add-dependencies.js';
 import {
   addDestructuredImport,
   addSingleImport,
   applyGritQL,
-} from '../../../utils/ast';
+} from '../../../utils/ast.js';
 import {
   declareDependencies,
   ownedElsewhere,
-} from '../../../utils/declared-dependencies';
-import { kebabCase } from '../../../utils/names';
-import { getNpmScopePrefix } from '../../../utils/npm-scope';
-import { registerPnpmBuiltDependencies } from '../../../utils/pnpm-workspace';
+} from '../../../utils/declared-dependencies.js';
+import { kebabCase } from '../../../utils/names.js';
+import { getNpmScopePrefix } from '../../../utils/npm-scope.js';
+import { registerPnpmBuiltDependencies } from '../../../utils/pnpm-workspace.js';
 import {
   SHADCN_DEPENDENCIES,
   sharedShadcnGenerator,
-} from '../../../utils/shared-shadcn';
-import { runtimeConfigGenerator } from '../runtime-config/generator';
+} from '../../../utils/shared-shadcn.js';
+import { runtimeConfigGenerator } from '../runtime-config/generator.js';
 
 /**
  * The values this helper's predicates read. Its callers record them, so the

--- a/packages/nx-plugin/src/ts/react-website/app/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/react-website/app/generator.spec.ts
@@ -6,17 +6,17 @@ import { readJson, type Tree } from '@nx/devkit';
 import {
   ensureAwsNxPluginConfig,
   updateAwsNxPluginConfig,
-} from '../../../utils/config/utils';
-import { expectHasMetricTags } from '../../../utils/metrics.spec';
+} from '../../../utils/config/utils.js';
+import { expectHasMetricTags } from '../../../utils/metrics.spec.js';
 import {
   createTreeUsingTsSolutionSetup,
   snapshotTreeDir,
-} from '../../../utils/test';
+} from '../../../utils/test.js';
 import {
   REACT_WEBSITE_APP_GENERATOR_INFO,
   SUPPORTED_UX_PROVIDERS,
   tsReactWebsiteGenerator,
-} from './generator';
+} from './generator.js';
 import type { TsReactWebsiteGeneratorSchema } from './schema';
 
 describe('react-website generator', () => {

--- a/packages/nx-plugin/src/ts/react-website/app/generator.ts
+++ b/packages/nx-plugin/src/ts/react-website/app/generator.ts
@@ -15,50 +15,50 @@ import {
 } from '@nx/devkit';
 import { applicationGenerator } from '@nx/react';
 import { relative, sep } from 'path';
-import { addTsDependencies } from '../../../utils/add-dependencies';
+import { addTsDependencies } from '../../../utils/add-dependencies.js';
 import {
   addDestructuredImport,
   addSingleImport,
   appendToArrayViaGritQL,
   applyGritQL,
-} from '../../../utils/ast';
+} from '../../../utils/ast.js';
 import {
   declareDependencies,
   ownedElsewhere,
-} from '../../../utils/declared-dependencies';
-import { formatFilesInSubtree } from '../../../utils/format';
-import { resolveIac } from '../../../utils/iac';
-import { installDependencies } from '../../../utils/install';
-import { addGeneratorMetricsIfApplicable } from '../../../utils/metrics';
-import { kebabCase, toClassName, toKebabCase } from '../../../utils/names';
-import { getNpmScopePrefix } from '../../../utils/npm-scope';
+} from '../../../utils/declared-dependencies.js';
+import { formatFilesInSubtree } from '../../../utils/format.js';
+import { resolveIac } from '../../../utils/iac.js';
+import { installDependencies } from '../../../utils/install.js';
+import { addGeneratorMetricsIfApplicable } from '../../../utils/metrics.js';
+import { kebabCase, toClassName, toKebabCase } from '../../../utils/names.js';
+import { getNpmScopePrefix } from '../../../utils/npm-scope.js';
 import {
   addGeneratorMetadata,
   getGeneratorInfo,
   type NxGeneratorInfo,
-} from '../../../utils/nx';
-import { sortObjectKeys } from '../../../utils/object';
-import { getRelativePathToRoot } from '../../../utils/paths';
-import { getPackageManagerDisplayCommands } from '../../../utils/pkg-manager';
+} from '../../../utils/nx.js';
+import { sortObjectKeys } from '../../../utils/object.js';
+import { getRelativePathToRoot } from '../../../utils/paths.js';
+import { getPackageManagerDisplayCommands } from '../../../utils/pkg-manager.js';
 import {
   SHARED_CONSTRUCTS_DEPENDENCIES,
   sharedConstructsGenerator,
-} from '../../../utils/shared-constructs';
+} from '../../../utils/shared-constructs.js';
 import {
   type IacMetadata,
   PACKAGES_DIR,
   SHARED_SHADCN_DIR,
-} from '../../../utils/shared-constructs-constants';
+} from '../../../utils/shared-constructs-constants.js';
 import {
   SHADCN_DEPENDENCIES,
   sharedShadcnGenerator,
-} from '../../../utils/shared-shadcn';
+} from '../../../utils/shared-shadcn.js';
 import {
   addWebsiteInfra,
   WEBSITE_CONSTRUCTS_PY_DEPENDENCIES,
-} from '../../../utils/website-constructs/website-constructs';
-import { configureTsProject } from '../../lib/ts-project-utils';
-import { VITEST_DEPENDENCIES } from '../../lib/vitest';
+} from '../../../utils/website-constructs/website-constructs.js';
+import { configureTsProject } from '../../lib/ts-project-utils.js';
+import { VITEST_DEPENDENCIES } from '../../lib/vitest.js';
 // typescript factory imports removed — now using GritQL for vite config transforms
 import type {
   TsReactWebsiteGeneratorSchema,

--- a/packages/nx-plugin/src/ts/react-website/app/schema.d.ts
+++ b/packages/nx-plugin/src/ts/react-website/app/schema.d.ts
@@ -2,8 +2,8 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import { IacOption } from '../../../utils/iac';
-import { UxOption } from './generator';
+import { IacOption } from '../../../utils/iac.js';
+import { UxOption } from './generator.js';
 
 export type WebsiteInfraOption = 'cloudfront-s3' | 'none';
 

--- a/packages/nx-plugin/src/ts/react-website/cognito-auth/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/react-website/cognito-auth/generator.spec.ts
@@ -3,17 +3,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { type Tree, updateJson } from '@nx/devkit';
-import { declareDependencies } from '../../../utils/declared-dependencies';
-import { expectHasMetricTags } from '../../../utils/metrics.spec';
+import { declareDependencies } from '../../../utils/declared-dependencies.js';
+import { expectHasMetricTags } from '../../../utils/metrics.spec.js';
 import {
   SHARED_CONSTRUCTS_DEPENDENCIES,
   sharedConstructsGenerator,
-} from '../../../utils/shared-constructs';
-import { createTreeUsingTsSolutionSetup } from '../../../utils/test';
+} from '../../../utils/shared-constructs.js';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test.js';
 import {
   COGNITO_AUTH_GENERATOR_INFO,
   tsReactWebsiteAuthGenerator,
-} from './generator';
+} from './generator.js';
 import type { TsReactWebsiteAuthGeneratorSchema } from './schema';
 
 const sharedConstructsDeclaration = declareDependencies()({

--- a/packages/nx-plugin/src/ts/react-website/cognito-auth/generator.terraform.spec.ts
+++ b/packages/nx-plugin/src/ts/react-website/cognito-auth/generator.terraform.spec.ts
@@ -6,13 +6,13 @@ import type { Tree } from '@nx/devkit';
 import {
   ensureAwsNxPluginConfig,
   updateAwsNxPluginConfig,
-} from '../../../utils/config/utils';
-import { createTreeUsingTsSolutionSetup } from '../../../utils/test';
-import { RUNTIME_CONFIG_GENERATOR_INFO } from '../runtime-config/generator';
+} from '../../../utils/config/utils.js';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test.js';
+import { RUNTIME_CONFIG_GENERATOR_INFO } from '../runtime-config/generator.js';
 import {
   COGNITO_AUTH_GENERATOR_INFO,
   tsReactWebsiteAuthGenerator,
-} from './generator';
+} from './generator.js';
 import type { TsReactWebsiteAuthGeneratorSchema } from './schema';
 
 describe('cognito-auth generator terraform iac', () => {

--- a/packages/nx-plugin/src/ts/react-website/cognito-auth/generator.ts
+++ b/packages/nx-plugin/src/ts/react-website/cognito-auth/generator.ts
@@ -10,45 +10,45 @@ import {
 } from '@nx/devkit';
 import { readFileSync } from 'fs';
 import { join } from 'path';
-import { addTsDependencies } from '../../../utils/add-dependencies';
+import { addTsDependencies } from '../../../utils/add-dependencies.js';
 import {
   addDestructuredImport,
   addSingleImport,
   applyGritQL,
-} from '../../../utils/ast';
-import { addHookResultToRouterProviderContext } from '../../../utils/ast/website';
+} from '../../../utils/ast.js';
+import { addHookResultToRouterProviderContext } from '../../../utils/ast/website.js';
 import {
   declareDependencies,
   ownedElsewhere,
-} from '../../../utils/declared-dependencies';
-import { formatFilesInSubtree } from '../../../utils/format';
-import { resolveIac } from '../../../utils/iac';
+} from '../../../utils/declared-dependencies.js';
+import { formatFilesInSubtree } from '../../../utils/format.js';
+import { resolveIac } from '../../../utils/iac.js';
 import {
   addIdentityInfra,
   IDENTITY_CONSTRUCTS_PY_DEPENDENCIES,
-} from '../../../utils/identity-constructs/identity-constructs';
-import { installDependencies } from '../../../utils/install';
-import { addGeneratorMetricsIfApplicable } from '../../../utils/metrics';
-import { getNpmScope } from '../../../utils/npm-scope';
+} from '../../../utils/identity-constructs/identity-constructs.js';
+import { installDependencies } from '../../../utils/install.js';
+import { addGeneratorMetricsIfApplicable } from '../../../utils/metrics.js';
+import { getNpmScope } from '../../../utils/npm-scope.js';
 import {
   addComponentGeneratorMetadata,
   getGeneratorInfo,
   type NxGeneratorInfo,
   readProjectConfigurationUnqualified,
-} from '../../../utils/nx';
-import { toProjectRelativePath } from '../../../utils/paths';
+} from '../../../utils/nx.js';
+import { toProjectRelativePath } from '../../../utils/paths.js';
 import {
   SHARED_CONSTRUCTS_DEPENDENCIES,
   sharedConstructsGenerator,
-} from '../../../utils/shared-constructs';
-import { runtimeConfigGenerator } from '../runtime-config/generator';
+} from '../../../utils/shared-constructs.js';
+import { runtimeConfigGenerator } from '../runtime-config/generator.js';
 import type { TsReactWebsiteAuthGeneratorSchema } from './schema';
 import {
   addCloudscapeAuthMenu,
   addNoneAuthMenu,
   addShadcnAuthMenu,
   deriveCognitoDomainPrefix,
-} from './utils';
+} from './utils.js';
 
 const readGritPattern = (name: string): string =>
   readFileSync(

--- a/packages/nx-plugin/src/ts/react-website/cognito-auth/generator.ux-provider.spec.ts
+++ b/packages/nx-plugin/src/ts/react-website/cognito-auth/generator.ux-provider.spec.ts
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { Tree } from '@nx/devkit';
-import { createTreeUsingTsSolutionSetup } from '../../../utils/test';
-import { SUPPORTED_UX_PROVIDERS } from '../app/generator';
-import { tsReactWebsiteAuthGenerator } from './generator';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test.js';
+import { SUPPORTED_UX_PROVIDERS } from '../app/generator.js';
+import { tsReactWebsiteAuthGenerator } from './generator.js';
 import type { TsReactWebsiteAuthGeneratorSchema } from './schema';
 
 describe('cognito-auth generator ux tests', () => {

--- a/packages/nx-plugin/src/ts/react-website/cognito-auth/schema.d.ts
+++ b/packages/nx-plugin/src/ts/react-website/cognito-auth/schema.d.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { IacOption } from '../../../utils/iac';
+import { IacOption } from '../../../utils/iac.js';
 
 export interface TsReactWebsiteAuthGeneratorSchema {
   project: string;

--- a/packages/nx-plugin/src/ts/react-website/cognito-auth/utils.ts
+++ b/packages/nx-plugin/src/ts/react-website/cognito-auth/utils.ts
@@ -5,8 +5,8 @@
 import type { Tree } from '@nx/devkit';
 import { readFileSync } from 'fs';
 import { join } from 'path';
-import { addDestructuredImport, applyGritQL } from '../../../utils/ast';
-import { kebabCase } from '../../../utils/names';
+import { addDestructuredImport, applyGritQL } from '../../../utils/ast.js';
+import { kebabCase } from '../../../utils/names.js';
 
 const readGritPattern = (name: string): string =>
   readFileSync(

--- a/packages/nx-plugin/src/ts/react-website/runtime-config/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/react-website/runtime-config/generator.spec.ts
@@ -3,17 +3,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { Tree } from '@nx/devkit';
-import { declareDependencies } from '../../../utils/declared-dependencies';
-import { expectHasMetricTags } from '../../../utils/metrics.spec';
+import { declareDependencies } from '../../../utils/declared-dependencies.js';
+import { expectHasMetricTags } from '../../../utils/metrics.spec.js';
 import {
   SHARED_CONSTRUCTS_DEPENDENCIES,
   sharedConstructsGenerator,
-} from '../../../utils/shared-constructs';
-import { createTreeUsingTsSolutionSetup } from '../../../utils/test';
+} from '../../../utils/shared-constructs.js';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test.js';
 import {
   RUNTIME_CONFIG_GENERATOR_INFO,
   runtimeConfigGenerator,
-} from './generator';
+} from './generator.js';
 import type { RuntimeConfigGeneratorSchema } from './schema';
 
 const sharedConstructsDeclaration = declareDependencies()({

--- a/packages/nx-plugin/src/ts/react-website/runtime-config/generator.ts
+++ b/packages/nx-plugin/src/ts/react-website/runtime-config/generator.ts
@@ -8,18 +8,22 @@ import {
   OverwriteStrategy,
   type Tree,
 } from '@nx/devkit';
-import { addSingleImport, applyGritQL, matchGritQL } from '../../../utils/ast';
-import { addHookResultToRouterProviderContext } from '../../../utils/ast/website';
-import { formatFilesInSubtree } from '../../../utils/format';
-import { addGeneratorMetricsIfApplicable } from '../../../utils/metrics';
-import { getNpmScopePrefix } from '../../../utils/npm-scope';
+import {
+  addSingleImport,
+  applyGritQL,
+  matchGritQL,
+} from '../../../utils/ast.js';
+import { addHookResultToRouterProviderContext } from '../../../utils/ast/website.js';
+import { formatFilesInSubtree } from '../../../utils/format.js';
+import { addGeneratorMetricsIfApplicable } from '../../../utils/metrics.js';
+import { getNpmScopePrefix } from '../../../utils/npm-scope.js';
 import {
   addComponentGeneratorMetadata,
   getGeneratorInfo,
   type NxGeneratorInfo,
   readProjectConfigurationUnqualified,
-} from '../../../utils/nx';
-import { toProjectRelativePath } from '../../../utils/paths';
+} from '../../../utils/nx.js';
+import { toProjectRelativePath } from '../../../utils/paths.js';
 import type { RuntimeConfigGeneratorSchema } from './schema';
 
 export const RUNTIME_CONFIG_GENERATOR_INFO: NxGeneratorInfo = getGeneratorInfo(

--- a/packages/nx-plugin/src/ts/sync/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/sync/generator.spec.ts
@@ -11,8 +11,8 @@ import {
   type Tree,
 } from '@nx/devkit';
 import { afterEach, vi } from 'vitest';
-import { createTreeUsingTsSolutionSetup } from '../../utils/test';
-import { tsSyncGeneratorGenerator } from './generator';
+import { createTreeUsingTsSolutionSetup } from '../../utils/test.js';
+import { tsSyncGeneratorGenerator } from './generator.js';
 
 vi.mock('@nx/devkit', async (importOriginal) => {
   const original = await importOriginal<typeof devkit>();

--- a/packages/nx-plugin/src/ts/sync/generator.ts
+++ b/packages/nx-plugin/src/ts/sync/generator.ts
@@ -15,8 +15,8 @@ import {
 import type { SyncGeneratorResult } from 'nx/src/utils/sync-generators';
 import { relative } from 'path';
 import PackageJson from '../../../package.json' with { type: 'json' };
-import { getLocalDependencySpecifier } from '../../utils/dependencies';
-import { getGeneratorInfo, type NxGeneratorInfo } from '../../utils/nx';
+import { getLocalDependencySpecifier } from '../../utils/dependencies.js';
+import { getGeneratorInfo, type NxGeneratorInfo } from '../../utils/nx.js';
 
 export const TS_SYNC_GENERATOR_INFO: NxGeneratorInfo = getGeneratorInfo(
   import.meta.filename,

--- a/packages/nx-plugin/src/ts/website/app/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/website/app/generator.spec.ts
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { readJson, type Tree } from '@nx/devkit';
-import { createTreeUsingTsSolutionSetup } from '../../../utils/test';
-import { tsWebsiteGenerator } from './generator';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test.js';
+import { tsWebsiteGenerator } from './generator.js';
 
 describe('ts#website generator', () => {
   let tree: Tree;

--- a/packages/nx-plugin/src/ts/website/app/generator.ts
+++ b/packages/nx-plugin/src/ts/website/app/generator.ts
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { GeneratorCallback, Tree } from '@nx/devkit';
-import { getGeneratorInfo, type NxGeneratorInfo } from '../../../utils/nx';
-import { tsReactWebsiteGenerator } from '../../react-website/app/generator';
+import { getGeneratorInfo, type NxGeneratorInfo } from '../../../utils/nx.js';
+import { tsReactWebsiteGenerator } from '../../react-website/app/generator.js';
 import type { TsWebsiteGeneratorSchema } from './schema';
 
 export const TS_WEBSITE_GENERATOR_INFO: NxGeneratorInfo = getGeneratorInfo(

--- a/packages/nx-plugin/src/ts/website/app/schema.d.ts
+++ b/packages/nx-plugin/src/ts/website/app/schema.d.ts
@@ -2,8 +2,8 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import { IacOption } from '../../../utils/iac';
-import { UxOption } from '../../react-website/app/generator';
+import { IacOption } from '../../../utils/iac.js';
+import { UxOption } from '../../react-website/app/generator.js';
 
 export type WebsiteFramework = 'react';
 export type WebsiteInfraOption = 'cloudfront-s3' | 'none';

--- a/packages/nx-plugin/src/ts/website/auth/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/website/auth/generator.spec.ts
@@ -3,12 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { Tree } from '@nx/devkit';
-import { createTreeUsingTsSolutionSetup } from '../../../utils/test';
-import { tsReactWebsiteGenerator } from '../../react-website/app/generator';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test.js';
+import { tsReactWebsiteGenerator } from '../../react-website/app/generator.js';
 import {
   TS_WEBSITE_AUTH_GENERATOR_INFO,
   tsWebsiteAuthGenerator,
-} from './generator';
+} from './generator.js';
 import type { TsWebsiteAuthGeneratorSchema } from './schema';
 
 describe('ts#website#auth generator', () => {

--- a/packages/nx-plugin/src/ts/website/auth/generator.ts
+++ b/packages/nx-plugin/src/ts/website/auth/generator.ts
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { Tree } from '@nx/devkit';
-import { getGeneratorInfo, type NxGeneratorInfo } from '../../../utils/nx';
-import { tsReactWebsiteAuthGenerator } from '../../react-website/cognito-auth/generator';
+import { getGeneratorInfo, type NxGeneratorInfo } from '../../../utils/nx.js';
+import { tsReactWebsiteAuthGenerator } from '../../react-website/cognito-auth/generator.js';
 import type { TsWebsiteAuthGeneratorSchema } from './schema';
 
 export const TS_WEBSITE_AUTH_GENERATOR_INFO: NxGeneratorInfo = getGeneratorInfo(

--- a/packages/nx-plugin/src/ts/website/auth/schema.d.ts
+++ b/packages/nx-plugin/src/ts/website/auth/schema.d.ts
@@ -2,7 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import { IacOption } from '../../../utils/iac';
+import { IacOption } from '../../../utils/iac.js';
 
 export interface TsWebsiteAuthGeneratorSchema {
   project: string;

--- a/packages/nx-plugin/src/utils/add-dependencies.spec.ts
+++ b/packages/nx-plugin/src/utils/add-dependencies.spec.ts
@@ -4,9 +4,9 @@
  */
 import { readJson, type Tree, writeJson } from '@nx/devkit';
 import { beforeEach, describe, expect, it } from 'vitest';
-import { addPyDependencies, addTsDependencies } from './add-dependencies';
-import { declareDependencies } from './declared-dependencies';
-import { createTreeUsingTsSolutionSetup } from './test';
+import { addPyDependencies, addTsDependencies } from './add-dependencies.js';
+import { declareDependencies } from './declared-dependencies.js';
+import { createTreeUsingTsSolutionSetup } from './test.js';
 
 describe('add-dependencies', () => {
   let tree: Tree;

--- a/packages/nx-plugin/src/utils/add-dependencies.ts
+++ b/packages/nx-plugin/src/utils/add-dependencies.ts
@@ -11,13 +11,13 @@ import {
   applicableDependencies,
   type DependencyDeclaration,
   type DependencyMetadata,
-} from './declared-dependencies';
-import { addDependenciesToPackageJson } from './dependencies';
+} from './declared-dependencies.js';
+import { addDependenciesToPackageJson } from './dependencies.js';
 import {
   addDependenciesToDependencyGroupInPyProjectToml,
   addDependenciesToPyProjectToml,
-} from './py';
-import { TS_VERSIONS } from './versions';
+} from './py.js';
+import { TS_VERSIONS } from './versions.js';
 
 /**
  * Add the dependencies a declaration says apply, so the declaration is the only

--- a/packages/nx-plugin/src/utils/agent-chat/agent-chat.ts
+++ b/packages/nx-plugin/src/utils/agent-chat/agent-chat.ts
@@ -9,7 +9,7 @@ import {
   joinPathFragments,
   OverwriteStrategy,
 } from '@nx/devkit';
-import { esmVars } from '../module-format';
+import { esmVars } from '../module-format.js';
 
 export type AgentChatProtocol = 'http' | 'a2a' | 'ag-ui';
 export type AgentChatAuth = 'iam' | 'cognito';

--- a/packages/nx-plugin/src/utils/agent-connection/agent-connection.ts
+++ b/packages/nx-plugin/src/utils/agent-connection/agent-connection.ts
@@ -10,28 +10,28 @@ import {
 } from '@nx/devkit';
 import pyProjectGenerator, {
   getPyProjectDetails,
-} from '../../py/project/generator';
-import tsProjectGenerator from '../../ts/lib/generator';
+} from '../../py/project/generator.js';
+import tsProjectGenerator from '../../ts/lib/generator.js';
 import {
   addStarExport,
   appendToArrayViaGritQL,
   applyGritQL,
   matchGritQL,
-} from '../ast';
+} from '../ast.js';
 import {
   type DependencyDeclaration,
   forDependencies,
   type MustDeclare,
   type MustDeclarePy,
-} from '../declared-dependencies';
-import { addDependenciesToPackageJson } from '../dependencies';
-import { esmVars } from '../module-format';
-import { addDependenciesToPyProjectToml } from '../py';
+} from '../declared-dependencies.js';
+import { addDependenciesToPackageJson } from '../dependencies.js';
+import { esmVars } from '../module-format.js';
+import { addDependenciesToPyProjectToml } from '../py.js';
 import {
   type IPyDepVersion,
   type ITsDepVersion,
   withVersions,
-} from '../versions';
+} from '../versions.js';
 
 /** TypeScript dependencies a caller must declare to emit agent-connection clients. */
 export const AGENT_CONNECTION_DEPENDENCIES = [

--- a/packages/nx-plugin/src/utils/agent-core-constructs/agent-core-constructs.ts
+++ b/packages/nx-plugin/src/utils/agent-core-constructs/agent-core-constructs.ts
@@ -10,19 +10,19 @@ import {
   type Tree,
   updateJson,
 } from '@nx/devkit';
-import { addStarExport } from '../ast';
-import type { Containers } from '../containers';
+import { addStarExport } from '../ast.js';
+import type { Containers } from '../containers.js';
 import {
   type DeclaredPyDependency,
   type DeclaredTsDependency,
   type DependencyDeclaration,
   forDependencies,
   type MustDeclare,
-} from '../declared-dependencies';
-import { addDependenciesToPackageJson } from '../dependencies';
-import type { Iac } from '../iac';
-import { esmVars } from '../module-format';
-import { addDependencyToTargetIfNotPresent } from '../nx';
+} from '../declared-dependencies.js';
+import { addDependenciesToPackageJson } from '../dependencies.js';
+import type { Iac } from '../iac.js';
+import { esmVars } from '../module-format.js';
+import { addDependencyToTargetIfNotPresent } from '../nx.js';
 import {
   generatedInfrastructure,
   generatedTerraform,
@@ -30,14 +30,14 @@ import {
   PACKAGES_DIR,
   SHARED_CONSTRUCTS_DIR,
   SHARED_TERRAFORM_DIR,
-} from '../shared-constructs-constants';
+} from '../shared-constructs-constants.js';
 import {
   type IPyDepVersion,
   type ITsDepVersion,
   PY_VERSIONS,
   terraformProviderVersions,
   withVersions,
-} from '../versions';
+} from '../versions.js';
 
 type IACProvider = { iac: Iac };
 

--- a/packages/nx-plugin/src/utils/api-constructs/api-constructs.ts
+++ b/packages/nx-plugin/src/utils/api-constructs/api-constructs.ts
@@ -10,18 +10,18 @@ import {
   type Tree,
   updateJson,
 } from '@nx/devkit';
-import { addStarExport } from '../ast';
+import { addStarExport } from '../ast.js';
 import {
   type DeclaredPyDependency,
   type DeclaredTsDependency,
   type DependencyDeclaration,
   forDependencies,
   type MustDeclare,
-} from '../declared-dependencies';
-import { addDependenciesToPackageJson } from '../dependencies';
-import type { Iac } from '../iac';
-import { esmVars } from '../module-format';
-import { addDependencyToTargetIfNotPresent } from '../nx';
+} from '../declared-dependencies.js';
+import { addDependenciesToPackageJson } from '../dependencies.js';
+import type { Iac } from '../iac.js';
+import { esmVars } from '../module-format.js';
+import { addDependencyToTargetIfNotPresent } from '../nx.js';
 import {
   generatedInfrastructure,
   generatedTerraform,
@@ -29,14 +29,14 @@ import {
   PACKAGES_DIR,
   SHARED_CONSTRUCTS_DIR,
   SHARED_TERRAFORM_DIR,
-} from '../shared-constructs-constants';
+} from '../shared-constructs-constants.js';
 import {
   type IPyDepVersion,
   type ITsDepVersion,
   PY_VERSIONS,
   terraformProviderVersions,
   withVersions,
-} from '../versions';
+} from '../versions.js';
 
 /**
  * Dependencies a caller must declare to add API Gateway infrastructure.

--- a/packages/nx-plugin/src/utils/api-constructs/integration-builder.spec.ts
+++ b/packages/nx-plugin/src/utils/api-constructs/integration-builder.spec.ts
@@ -5,8 +5,8 @@
 import type { Tree } from '@nx/devkit';
 import { readFileSync } from 'fs';
 import { join } from 'path';
-import { createTreeUsingTsSolutionSetup } from '../test';
-import { TypeScriptVerifier } from '../test/ts.spec';
+import { createTreeUsingTsSolutionSetup } from '../test.js';
+import { TypeScriptVerifier } from '../test/ts.spec.js';
 
 /**
  * These tests verify the type-safety of the generated IntegrationBuilder, in particular

--- a/packages/nx-plugin/src/utils/api-constructs/open-api-metadata.ts
+++ b/packages/nx-plugin/src/utils/api-constructs/open-api-metadata.ts
@@ -8,13 +8,13 @@ import {
   type Tree,
   updateJson,
 } from '@nx/devkit';
-import { updateGitIgnore } from '../git';
-import type { Iac } from '../iac';
-import { addDependencyToTargetIfNotPresent } from '../nx';
+import { updateGitIgnore } from '../git.js';
+import type { Iac } from '../iac.js';
+import { addDependencyToTargetIfNotPresent } from '../nx.js';
 import {
   PACKAGES_DIR,
   SHARED_CONSTRUCTS_DIR,
-} from '../shared-constructs-constants';
+} from '../shared-constructs-constants.js';
 
 export interface AddOpenApiMetadataGenerateTargetOptions {
   iac: Iac;

--- a/packages/nx-plugin/src/utils/ast.spec.ts
+++ b/packages/nx-plugin/src/utils/ast.spec.ts
@@ -15,7 +15,7 @@ import {
   applyGritQL,
   hasExportDeclaration,
   matchGritQL,
-} from './ast';
+} from './ast.js';
 
 describe('ast utils', () => {
   let tree: Tree;

--- a/packages/nx-plugin/src/utils/ast.ts
+++ b/packages/nx-plugin/src/utils/ast.ts
@@ -6,8 +6,8 @@
 import { QueryBuilder } from '@getgrit/gritql';
 import type { Tree } from '@nx/devkit';
 import * as path from 'path';
-import { updateGitIgnore } from './git';
-import { isEsmWorkspace } from './module-format';
+import { updateGitIgnore } from './git.js';
+import { isEsmWorkspace } from './module-format.js';
 
 const GRIT_DIR = '.grit';
 

--- a/packages/nx-plugin/src/utils/ast/website.spec.ts
+++ b/packages/nx-plugin/src/utils/ast/website.spec.ts
@@ -6,7 +6,7 @@
 import type { Tree } from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import { beforeEach, describe, expect, it } from 'vitest';
-import { addHookResultToRouterProviderContext } from './website';
+import { addHookResultToRouterProviderContext } from './website.js';
 
 describe('website ast utils', () => {
   let tree: Tree;

--- a/packages/nx-plugin/src/utils/ast/website.ts
+++ b/packages/nx-plugin/src/utils/ast/website.ts
@@ -4,7 +4,7 @@
  */
 
 import type { Tree } from '@nx/devkit';
-import { addDestructuredImport, applyGritQL, matchGritQL } from '../ast';
+import { addDestructuredImport, applyGritQL, matchGritQL } from '../ast.js';
 
 export interface AddHookResultToRouterProviderContextProps {
   hook: string; // eg useAuth

--- a/packages/nx-plugin/src/utils/bundle/bundle.spec.ts
+++ b/packages/nx-plugin/src/utils/bundle/bundle.spec.ts
@@ -9,13 +9,13 @@ import {
   readJson,
   type Tree,
 } from '@nx/devkit';
-import { declareDependencies } from '../declared-dependencies';
-import { createTreeUsingTsSolutionSetup } from '../test';
+import { declareDependencies } from '../declared-dependencies.js';
+import { createTreeUsingTsSolutionSetup } from '../test.js';
 import {
   addPythonBundleTarget,
   addTypeScriptBundleTarget,
   BUNDLE_DEPENDENCIES,
-} from './bundle';
+} from './bundle.js';
 
 const declaration = declareDependencies()({ ts: [...BUNDLE_DEPENDENCIES] });
 

--- a/packages/nx-plugin/src/utils/bundle/bundle.ts
+++ b/packages/nx-plugin/src/utils/bundle/bundle.ts
@@ -11,19 +11,19 @@ import {
   type TargetConfiguration,
   type Tree,
 } from '@nx/devkit';
-import { applyGritQL } from '../ast';
+import { applyGritQL } from '../ast.js';
 import {
   type DependencyDeclaration,
   forDependencies,
   type MustDeclare,
-} from '../declared-dependencies';
-import { addDependenciesToPackageJson } from '../dependencies';
+} from '../declared-dependencies.js';
+import { addDependenciesToPackageJson } from '../dependencies.js';
 import {
   addDependencyToTargetIfNotPresent,
   normalizeTargetKeyOrder,
-} from '../nx';
-import { getRelativePathToRoot } from '../paths';
-import { type ITsDepVersion, withVersions } from '../versions';
+} from '../nx.js';
+import { getRelativePathToRoot } from '../paths.js';
+import { type ITsDepVersion, withVersions } from '../versions.js';
 
 /** Dependencies a caller must declare to add a TypeScript bundle target. */
 export const BUNDLE_DEPENDENCIES = [

--- a/packages/nx-plugin/src/utils/commands.ts
+++ b/packages/nx-plugin/src/utils/commands.ts
@@ -2,7 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import { NX_VERSION } from './versions';
+import { NX_VERSION } from './versions.js';
 
 /** Re-exported for callers that already import it from here. */
 export { NX_VERSION };

--- a/packages/nx-plugin/src/utils/config/index.ts
+++ b/packages/nx-plugin/src/utils/config/index.ts
@@ -2,13 +2,13 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import type { LicenseConfig } from '../../license/config-types';
-import type { ContainersConfig } from '../containers';
-import type { IacConfig } from '../iac';
+import type { LicenseConfig } from '../../license/config-types.js';
+import type { ContainersConfig } from '../containers.js';
+import type { IacConfig } from '../iac.js';
 
-export * from '../../license/config-types';
-export type { Containers, ContainersConfig } from '../containers';
-export type { Iac, IacConfig } from '../iac';
+export * from '../../license/config-types.js';
+export type { Containers, ContainersConfig } from '../containers.js';
+export type { Iac, IacConfig } from '../iac.js';
 
 /**
  * Configuration for how generators manage dependencies via the package manager

--- a/packages/nx-plugin/src/utils/config/utils.spec.ts
+++ b/packages/nx-plugin/src/utils/config/utils.spec.ts
@@ -5,13 +5,13 @@
 
 import type { Tree } from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
-import type { LicenseLinesContent } from '../../license/config-types';
+import type { LicenseLinesContent } from '../../license/config-types.js';
 import {
   AWS_NX_PLUGIN_CONFIG_FILE_NAME,
   ensureAwsNxPluginConfig,
   readAwsNxPluginConfig,
   updateAwsNxPluginConfig,
-} from './utils';
+} from './utils.js';
 
 describe('config utils', () => {
   let tree: Tree;

--- a/packages/nx-plugin/src/utils/config/utils.ts
+++ b/packages/nx-plugin/src/utils/config/utils.ts
@@ -6,9 +6,9 @@ import { generateFiles, joinPathFragments, type Tree } from '@nx/devkit';
 import { existsSync, readFileSync } from 'fs';
 import { createJiti } from 'jiti';
 import { join } from 'path';
-import { applyGritQL, matchGritQL } from '../ast';
-import { formatFilesInSubtree } from '../format';
-import type { AwsNxPluginConfig } from '.';
+import { applyGritQL, matchGritQL } from '../ast.js';
+import { formatFilesInSubtree } from '../format.js';
+import type { AwsNxPluginConfig } from './index.js';
 
 export const AWS_NX_PLUGIN_CONFIG_FILE_NAME = 'aws-nx-plugin.config.mts';
 

--- a/packages/nx-plugin/src/utils/connection/open-api/react.ts
+++ b/packages/nx-plugin/src/utils/connection/open-api/react.ts
@@ -10,19 +10,19 @@ import {
   type Tree,
   updateProjectConfiguration,
 } from '@nx/devkit';
-import { addTargetToLocalDev } from '../../../connection/local-dev';
-import runtimeConfigGenerator from '../../../ts/react-website/runtime-config/generator';
-import { addSingleImport, applyGritQL } from '../../ast';
+import { addTargetToLocalDev } from '../../../connection/local-dev.js';
+import runtimeConfigGenerator from '../../../ts/react-website/runtime-config/generator.js';
+import { addSingleImport, applyGritQL } from '../../ast.js';
 import {
   type DependencyDeclaration,
   forDependencies,
   type MustDeclare,
-} from '../../declared-dependencies';
-import { addDependenciesToPackageJson } from '../../dependencies';
-import { updateGitIgnore } from '../../git';
-import { kebabCase, toClassName } from '../../names';
-import { sortObjectKeys } from '../../object';
-import { type ITsDepVersion, withVersions } from '../../versions';
+} from '../../declared-dependencies.js';
+import { addDependenciesToPackageJson } from '../../dependencies.js';
+import { updateGitIgnore } from '../../git.js';
+import { kebabCase, toClassName } from '../../names.js';
+import { sortObjectKeys } from '../../object.js';
+import { type ITsDepVersion, withVersions } from '../../versions.js';
 
 /** Dependencies a caller must declare to add an OpenAPI React client. */
 export const OPEN_API_REACT_DEPENDENCIES = [

--- a/packages/nx-plugin/src/utils/containers.spec.ts
+++ b/packages/nx-plugin/src/utils/containers.spec.ts
@@ -7,9 +7,9 @@ import {
   AWS_NX_PLUGIN_CONFIG_FILE_NAME,
   ensureAwsNxPluginConfig,
   updateAwsNxPluginConfig,
-} from './config/utils';
-import { resolveContainers } from './containers';
-import { createTreeUsingTsSolutionSetup } from './test';
+} from './config/utils.js';
+import { resolveContainers } from './containers.js';
+import { createTreeUsingTsSolutionSetup } from './test.js';
 
 describe('containers utils', () => {
   let tree: Tree;

--- a/packages/nx-plugin/src/utils/containers.ts
+++ b/packages/nx-plugin/src/utils/containers.ts
@@ -7,7 +7,7 @@ import { execSync } from 'child_process';
 import {
   AWS_NX_PLUGIN_CONFIG_FILE_NAME,
   readAwsNxPluginConfig,
-} from './config/utils';
+} from './config/utils.js';
 
 export const CONTAINER_ENGINES = ['docker', 'finch'] as const;
 

--- a/packages/nx-plugin/src/utils/dcr-proxy-constructs/dcr-proxy-constructs.ts
+++ b/packages/nx-plugin/src/utils/dcr-proxy-constructs/dcr-proxy-constructs.ts
@@ -10,16 +10,16 @@ import {
   type Tree,
   updateJson,
 } from '@nx/devkit';
-import { addStarExport } from '../ast';
-import type { Iac } from '../iac';
-import { esmVars } from '../module-format';
-import { addDependencyToTargetIfNotPresent } from '../nx';
+import { addStarExport } from '../ast.js';
+import type { Iac } from '../iac.js';
+import { esmVars } from '../module-format.js';
+import { addDependencyToTargetIfNotPresent } from '../nx.js';
 import {
   PACKAGES_DIR,
   SHARED_CONSTRUCTS_DIR,
   SHARED_TERRAFORM_DIR,
-} from '../shared-constructs-constants';
-import { terraformProviderVersions } from '../versions';
+} from '../shared-constructs-constants.js';
+import { terraformProviderVersions } from '../versions.js';
 
 /**
  * The DCR proxy Lambda handlers. Each is bundled independently and wired to a

--- a/packages/nx-plugin/src/utils/declared-dependencies.spec.ts
+++ b/packages/nx-plugin/src/utils/declared-dependencies.spec.ts
@@ -10,7 +10,7 @@ import {
   onlyWhen,
   ownedDependencyEntries,
   ownedElsewhere,
-} from './declared-dependencies';
+} from './declared-dependencies.js';
 
 interface AgentMetadata {
   readonly protocol: string;

--- a/packages/nx-plugin/src/utils/declared-dependencies.ts
+++ b/packages/nx-plugin/src/utils/declared-dependencies.ts
@@ -2,7 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import type { IPyDepVersion, ITsDepVersion } from './versions';
+import type { IPyDepVersion, ITsDepVersion } from './versions.js';
 
 /**
  * Which vended dependencies each generator is responsible for, and when each

--- a/packages/nx-plugin/src/utils/dependencies.spec.ts
+++ b/packages/nx-plugin/src/utils/dependencies.spec.ts
@@ -9,8 +9,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   addDependenciesToPackageJson,
   resetCatalogSupportCache,
-} from './dependencies';
-import { createTreeUsingTsSolutionSetup } from './test';
+} from './dependencies.js';
+import { createTreeUsingTsSolutionSetup } from './test.js';
 
 vi.mock('@nx/devkit', async (importOriginal) => {
   const original = await importOriginal<typeof devkit>();

--- a/packages/nx-plugin/src/utils/dependencies.ts
+++ b/packages/nx-plugin/src/utils/dependencies.ts
@@ -14,7 +14,7 @@ import {
 } from '@nx/devkit';
 import yaml from 'js-yaml';
 import { coerce, gt, gte } from 'semver';
-import { readAwsNxPluginConfig } from './config/utils';
+import { readAwsNxPluginConfig } from './config/utils.js';
 
 // Minimum version that introduced catalog support per package manager (npm has none).
 const CATALOG_SUPPORT: Partial<Record<PackageManager, string>> = {

--- a/packages/nx-plugin/src/utils/docker.spec.ts
+++ b/packages/nx-plugin/src/utils/docker.spec.ts
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { ProjectConfiguration, Tree } from '@nx/devkit';
-import { declareDependencies } from './declared-dependencies';
-import { addDockerScanTarget, DOCKER_DEPENDENCIES } from './docker';
-import { createTreeUsingTsSolutionSetup } from './test';
-import { CONTAINER_VERSIONS } from './versions';
+import { declareDependencies } from './declared-dependencies.js';
+import { addDockerScanTarget, DOCKER_DEPENDENCIES } from './docker.js';
+import { createTreeUsingTsSolutionSetup } from './test.js';
+import { CONTAINER_VERSIONS } from './versions.js';
 
 const declaration = declareDependencies()({ ts: [...DOCKER_DEPENDENCIES] });
 

--- a/packages/nx-plugin/src/utils/docker.ts
+++ b/packages/nx-plugin/src/utils/docker.ts
@@ -11,10 +11,10 @@ import {
   type DependencyDeclaration,
   forDependencies,
   type MustDeclare,
-} from './declared-dependencies';
-import { FS_DEPENDENCIES, FsCommands } from './fs';
-import { addDependencyToTargetIfNotPresent } from './nx';
-import { containerImage, type ITsDepVersion, TS_VERSIONS } from './versions';
+} from './declared-dependencies.js';
+import { FS_DEPENDENCIES, FsCommands } from './fs.js';
+import { addDependencyToTargetIfNotPresent } from './nx.js';
+import { containerImage, type ITsDepVersion, TS_VERSIONS } from './versions.js';
 
 /** Dependencies a caller must declare to add a Docker scan target. */
 export const DOCKER_DEPENDENCIES = [...FS_DEPENDENCIES] as const;

--- a/packages/nx-plugin/src/utils/dynamodb-constructs/dynamodb-constructs.ts
+++ b/packages/nx-plugin/src/utils/dynamodb-constructs/dynamodb-constructs.ts
@@ -10,16 +10,16 @@ import {
   type Tree,
   updateJson,
 } from '@nx/devkit';
-import { addStarExport } from '../ast';
-import type { Iac } from '../iac';
-import { esmVars } from '../module-format';
-import { addDependencyToTargetIfNotPresent } from '../nx';
+import { addStarExport } from '../ast.js';
+import type { Iac } from '../iac.js';
+import { esmVars } from '../module-format.js';
+import { addDependencyToTargetIfNotPresent } from '../nx.js';
 import {
   PACKAGES_DIR,
   SHARED_CONSTRUCTS_DIR,
   SHARED_TERRAFORM_DIR,
-} from '../shared-constructs-constants';
-import { terraformProviderVersions } from '../versions';
+} from '../shared-constructs-constants.js';
+import { terraformProviderVersions } from '../versions.js';
 
 export interface AddDynamoDBConstructOptions {
   projectName: string;

--- a/packages/nx-plugin/src/utils/format.spec.ts
+++ b/packages/nx-plugin/src/utils/format.spec.ts
@@ -9,8 +9,8 @@ import { FsTree } from 'nx/src/generators/tree';
 import { tmpdir } from 'os';
 import path from 'path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { formatFilesInSubtree, requiresPythonToRuffTarget } from './format';
-import { createTreeUsingTsSolutionSetup } from './test';
+import { formatFilesInSubtree, requiresPythonToRuffTarget } from './format.js';
+import { createTreeUsingTsSolutionSetup } from './test.js';
 
 describe('requiresPythonToRuffTarget', () => {
   it('maps a lower-bound specifier to a ruff target', () => {

--- a/packages/nx-plugin/src/utils/format.ts
+++ b/packages/nx-plugin/src/utils/format.ts
@@ -6,9 +6,9 @@
 import { Biome } from '@biomejs/js-api/nodejs';
 import { getProjects, type Tree } from '@nx/devkit';
 import path from 'path';
-import { type RuffOptions, ruffFixAndFormat } from './ruff';
-import { tryReadToml } from './toml';
-import { TS_VERSIONS } from './versions';
+import { type RuffOptions, ruffFixAndFormat } from './ruff.js';
+import { tryReadToml } from './toml.js';
+import { TS_VERSIONS } from './versions.js';
 
 /**
  * The biome.json vended into a new workspace. The pnpm catalog resolver is only

--- a/packages/nx-plugin/src/utils/fs.ts
+++ b/packages/nx-plugin/src/utils/fs.ts
@@ -7,9 +7,9 @@ import {
   type DependencyDeclaration,
   forDependencies,
   type MustDeclare,
-} from './declared-dependencies';
-import { addDependenciesToPackageJson } from './dependencies';
-import { type ITsDepVersion, withVersions } from './versions';
+} from './declared-dependencies.js';
+import { addDependenciesToPackageJson } from './dependencies.js';
+import { type ITsDepVersion, withVersions } from './versions.js';
 
 /** Dependencies a caller must declare to use `FsCommands`. */
 export const FS_DEPENDENCIES = [

--- a/packages/nx-plugin/src/utils/function-constructs/function-constructs.ts
+++ b/packages/nx-plugin/src/utils/function-constructs/function-constructs.ts
@@ -10,16 +10,16 @@ import {
   type Tree,
   updateJson,
 } from '@nx/devkit';
-import { addStarExport } from '../ast';
-import type { Iac } from '../iac';
-import { esmVars } from '../module-format';
-import { addDependencyToTargetIfNotPresent } from '../nx';
+import { addStarExport } from '../ast.js';
+import type { Iac } from '../iac.js';
+import { esmVars } from '../module-format.js';
+import { addDependencyToTargetIfNotPresent } from '../nx.js';
 import {
   PACKAGES_DIR,
   SHARED_CONSTRUCTS_DIR,
   SHARED_TERRAFORM_DIR,
-} from '../shared-constructs-constants';
-import { terraformProviderVersions } from '../versions';
+} from '../shared-constructs-constants.js';
+import { terraformProviderVersions } from '../versions.js';
 
 export interface AddLambdaFunctionConstructOptions {
   functionProjectName: string;

--- a/packages/nx-plugin/src/utils/generators.spec.ts
+++ b/packages/nx-plugin/src/utils/generators.spec.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { buildGeneratorInfoList } from './generators';
+import { buildGeneratorInfoList } from './generators.js';
 
 describe('generators', () => {
   it('should not have duplicate metrics across generators', () => {

--- a/packages/nx-plugin/src/utils/git.spec.ts
+++ b/packages/nx-plugin/src/utils/git.spec.ts
@@ -7,9 +7,13 @@ import { mkdtempSync, rmSync } from 'fs';
 import { FsTree, flushChanges, type Tree } from 'nx/src/generators/tree';
 import * as os from 'os';
 import * as path from 'path';
-import { getGitIncludedFiles, isWithinGitRepo, updateGitIgnore } from './git';
-import { createTreeUsingTsSolutionSetup } from './test';
-import { initTestGitRepo, runGit, useIsolatedGitEnv } from './test-git';
+import {
+  getGitIncludedFiles,
+  isWithinGitRepo,
+  updateGitIgnore,
+} from './git.js';
+import { createTreeUsingTsSolutionSetup } from './test.js';
+import { initTestGitRepo, runGit, useIsolatedGitEnv } from './test-git.js';
 
 describe('git utils', () => {
   describe('getGitIncludedFiles', () => {

--- a/packages/nx-plugin/src/utils/iac.spec.ts
+++ b/packages/nx-plugin/src/utils/iac.spec.ts
@@ -7,9 +7,9 @@ import {
   AWS_NX_PLUGIN_CONFIG_FILE_NAME,
   ensureAwsNxPluginConfig,
   updateAwsNxPluginConfig,
-} from './config/utils';
-import { resolveIac } from './iac';
-import { createTreeUsingTsSolutionSetup } from './test';
+} from './config/utils.js';
+import { resolveIac } from './iac.js';
+import { createTreeUsingTsSolutionSetup } from './test.js';
 
 describe('iac utils', () => {
   let tree: Tree;

--- a/packages/nx-plugin/src/utils/iac.ts
+++ b/packages/nx-plugin/src/utils/iac.ts
@@ -6,11 +6,11 @@ import type { Tree } from '@nx/devkit';
 import {
   AWS_NX_PLUGIN_CONFIG_FILE_NAME,
   readAwsNxPluginConfig,
-} from './config/utils';
+} from './config/utils.js';
 
-export { IAC_PROVIDERS, type Iac, type IacOption } from './iac-providers';
+export { IAC_PROVIDERS, type Iac, type IacOption } from './iac-providers.js';
 
-import { IAC_PROVIDERS } from './iac-providers';
+import { IAC_PROVIDERS } from './iac-providers.js';
 
 /**
  * Configuration for infrastructure as code

--- a/packages/nx-plugin/src/utils/identity-constructs/identity-constructs.ts
+++ b/packages/nx-plugin/src/utils/identity-constructs/identity-constructs.ts
@@ -8,22 +8,22 @@ import {
   OverwriteStrategy,
   type Tree,
 } from '@nx/devkit';
-import { addStarExport } from '../ast';
-import type { DeclaredPyDependency } from '../declared-dependencies';
-import type { Iac } from '../iac';
-import { esmVars } from '../module-format';
+import { addStarExport } from '../ast.js';
+import type { DeclaredPyDependency } from '../declared-dependencies.js';
+import type { Iac } from '../iac.js';
+import { esmVars } from '../module-format.js';
 import {
   generatedTerraform,
   type IacMetadata,
   PACKAGES_DIR,
   SHARED_CONSTRUCTS_DIR,
   SHARED_TERRAFORM_DIR,
-} from '../shared-constructs-constants';
+} from '../shared-constructs-constants.js';
 import {
   type IPyDepVersion,
   PY_VERSIONS,
   terraformProviderVersions,
-} from '../versions';
+} from '../versions.js';
 
 /**
  * Python version the generated Terraform pins in the callback URL module's inline

--- a/packages/nx-plugin/src/utils/infra-scripts.spec.ts
+++ b/packages/nx-plugin/src/utils/infra-scripts.spec.ts
@@ -6,7 +6,7 @@
 import { readFileSync } from 'fs';
 import { join } from 'path';
 import { describe, expect, it } from 'vitest';
-import { importTypeScriptModule } from './js';
+import { importTypeScriptModule } from './js.js';
 
 // Load the actual template files and strip EJS tags for import
 const loadTemplate = (relativePath: string): string => {

--- a/packages/nx-plugin/src/utils/init.ts
+++ b/packages/nx-plugin/src/utils/init.ts
@@ -15,34 +15,34 @@ import { initGenerator } from '@nx/js';
 import { readFileSync } from 'fs';
 import yaml from 'js-yaml';
 import GeneratorsJson from '../../generators.json' with { type: 'json' };
-import { SYNC_GENERATOR_NAME as TS_SYNC_GENERATOR_NAME } from '../ts/sync/generator';
-import { BASE_TSCONFIG_COMPILER_OPTIONS } from './base-tsconfig';
+import { SYNC_GENERATOR_NAME as TS_SYNC_GENERATOR_NAME } from '../ts/sync/generator.js';
+import { BASE_TSCONFIG_COMPILER_OPTIONS } from './base-tsconfig.js';
 import {
   ensureAwsNxPluginConfig,
   updateAwsNxPluginConfig,
-} from './config/utils';
-import { type Containers, inferContainers } from './containers';
+} from './config/utils.js';
+import { type Containers, inferContainers } from './containers.js';
 import {
   type DependencyDeclaration,
   forDependencies,
   type MustDeclare,
-} from './declared-dependencies';
+} from './declared-dependencies.js';
 import {
   addDependenciesToPackageJson,
   detectWorkspacePackageManager,
-} from './dependencies';
-import { getDefaultBiomeConfig } from './format';
-import type { Iac } from './iac';
-import { configureMcpServers } from './mcp';
-import { getNpmScope } from './npm-scope';
+} from './dependencies.js';
+import { getDefaultBiomeConfig } from './format.js';
+import type { Iac } from './iac.js';
+import { configureMcpServers } from './mcp.js';
+import { getNpmScope } from './npm-scope.js';
 import {
   mergeTargetDefault,
   nxPluginMcpDependency,
   nxPluginSelfDependency,
-} from './nx';
-import { getPackageManagerDisplayCommands } from './pkg-manager';
-import { workspaceGlobs } from './project-package-json';
-import { type ITsDepVersion, withVersions } from './versions';
+} from './nx.js';
+import { getPackageManagerDisplayCommands } from './pkg-manager.js';
+import { workspaceGlobs } from './project-package-json.js';
+import { type ITsDepVersion, withVersions } from './versions.js';
 
 const WORKSPACES = ['packages/*'];
 const NX_TYPESCRIPT_SYNC_GENERATOR = '@nx/js:typescript-sync';

--- a/packages/nx-plugin/src/utils/install.spec.ts
+++ b/packages/nx-plugin/src/utils/install.spec.ts
@@ -7,7 +7,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import * as devkit from '@nx/devkit';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { installDependencies } from './install';
+import { installDependencies } from './install.js';
 
 const install = vi.fn();
 

--- a/packages/nx-plugin/src/utils/install.ts
+++ b/packages/nx-plugin/src/utils/install.ts
@@ -5,8 +5,8 @@
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { installPackagesTask, type Tree } from '@nx/devkit';
-import { Logger, UVProvider } from './nxlv-python';
-import type { ITsDepVersion } from './versions';
+import { Logger, UVProvider } from './nxlv-python.js';
+import type { ITsDepVersion } from './versions.js';
 
 /**
  * Languages whose dependencies a generator may install.

--- a/packages/nx-plugin/src/utils/js.spec.ts
+++ b/packages/nx-plugin/src/utils/js.spec.ts
@@ -2,7 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import { importJavaScriptModule } from './js';
+import { importJavaScriptModule } from './js.js';
 
 describe('js utils', () => {
   describe('importJavaScriptModule', () => {

--- a/packages/nx-plugin/src/utils/mcp.spec.ts
+++ b/packages/nx-plugin/src/utils/mcp.spec.ts
@@ -7,7 +7,7 @@ import TOML from '@iarna/toml';
 import { readJson, type Tree, writeJson } from '@nx/devkit';
 import { createTree } from '@nx/devkit/testing';
 import { describe, expect, it } from 'vitest';
-import { configureMcpServers, NX_PLUGIN_MCP_SERVER_NAME } from './mcp';
+import { configureMcpServers, NX_PLUGIN_MCP_SERVER_NAME } from './mcp.js';
 
 describe('mcp utils', () => {
   describe('configureMcpServers', () => {

--- a/packages/nx-plugin/src/utils/mcp.ts
+++ b/packages/nx-plugin/src/utils/mcp.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { readJson, type Tree, writeJson } from '@nx/devkit';
-import { updateToml } from './toml';
+import { updateToml } from './toml.js';
 
 /**
  * Name of the Nx Plugin for AWS MCP server, used as the key in each agent's config.

--- a/packages/nx-plugin/src/utils/metrics.spec.ts
+++ b/packages/nx-plugin/src/utils/metrics.spec.ts
@@ -3,18 +3,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { Tree } from '@nx/devkit';
-import { declareDependencies } from './declared-dependencies';
+import { declareDependencies } from './declared-dependencies.js';
 import {
   addGeneratorMetricsIfApplicable,
   METRIC_ID,
   METRICS_ASPECT_FILE_PATH,
   TERRAFORM_METRICS_FILE_PATH,
-} from './metrics';
+} from './metrics.js';
 import {
   SHARED_CONSTRUCTS_DEPENDENCIES,
   sharedConstructsGenerator,
-} from './shared-constructs';
-import { createTreeUsingTsSolutionSetup } from './test';
+} from './shared-constructs.js';
+import { createTreeUsingTsSolutionSetup } from './test.js';
 
 const declaration = declareDependencies()({
   ts: [...SHARED_CONSTRUCTS_DEPENDENCIES],

--- a/packages/nx-plugin/src/utils/metrics.ts
+++ b/packages/nx-plugin/src/utils/metrics.ts
@@ -3,14 +3,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { joinPathFragments, type Tree } from '@nx/devkit';
-import { appendToArrayViaGritQL, applyGritQL, captureAllGritQL } from './ast';
-import { formatFilesInSubtree } from './format';
-import { getPackageVersion, type NxGeneratorInfo } from './nx';
+import {
+  appendToArrayViaGritQL,
+  applyGritQL,
+  captureAllGritQL,
+} from './ast.js';
+import { formatFilesInSubtree } from './format.js';
+import { getPackageVersion, type NxGeneratorInfo } from './nx.js';
 import {
   PACKAGES_DIR,
   SHARED_CONSTRUCTS_DIR,
   SHARED_TERRAFORM_DIR,
-} from './shared-constructs-constants';
+} from './shared-constructs-constants.js';
 
 // Used to identify @aws/nx-plugin in AWS metrics
 export const METRIC_ID = 'uksb-4wk0bqpg5s';

--- a/packages/nx-plugin/src/utils/migration-manifest.spec.ts
+++ b/packages/nx-plugin/src/utils/migration-manifest.spec.ts
@@ -8,7 +8,7 @@ import {
   type DiscoveredMigration,
   MIGRATIONS_JSON_SCHEMA,
   SYNC_VENDED_MIGRATION_KEY,
-} from './migration-manifest';
+} from './migration-manifest.js';
 
 const migration = (
   overrides: Partial<DiscoveredMigration> = {},

--- a/packages/nx-plugin/src/utils/migration-manifest.ts
+++ b/packages/nx-plugin/src/utils/migration-manifest.ts
@@ -2,13 +2,13 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import type { MigrationsJson } from './migration-versions';
+import type { MigrationsJson } from './migration-versions.js';
 import {
   isValidVersion,
   LATEST_MIGRATIONS_DIR,
   migrationKey,
-} from './migration-versions';
-import { sortObjectKeys } from './object';
+} from './migration-versions.js';
+import { sortObjectKeys } from './object.js';
 
 /**
  * `migrations.json` is assembled from the plugin's source rather than committed,

--- a/packages/nx-plugin/src/utils/migration-versions.spec.ts
+++ b/packages/nx-plugin/src/utils/migration-versions.spec.ts
@@ -9,7 +9,7 @@ import {
   orderPrefix,
   readShippedMigrationVersions,
   stampMigrationVersions,
-} from './migration-versions';
+} from './migration-versions.js';
 
 describe('migration versions', () => {
   describe('readShippedMigrationVersions', () => {

--- a/packages/nx-plugin/src/utils/module-format.spec.ts
+++ b/packages/nx-plugin/src/utils/module-format.spec.ts
@@ -5,7 +5,7 @@
 import { addProjectConfiguration, type Tree, writeJson } from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import { beforeEach, describe, expect, it } from 'vitest';
-import { esmVars, isEsmWorkspace } from './module-format';
+import { esmVars, isEsmWorkspace } from './module-format.js';
 
 /**
  * Register a project with its own package.json declaring the given module

--- a/packages/nx-plugin/src/utils/names.spec.ts
+++ b/packages/nx-plugin/src/utils/names.spec.ts
@@ -11,7 +11,7 @@ import {
   toDotNotation,
   toKebabCase,
   toSnakeCase,
-} from './names';
+} from './names.js';
 
 describe('names utils', () => {
   describe('toClassName', () => {

--- a/packages/nx-plugin/src/utils/npm-scope.spec.ts
+++ b/packages/nx-plugin/src/utils/npm-scope.spec.ts
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { describe, expect, it } from 'vitest';
-import { getNpmScope, getNpmScopePrefix } from './npm-scope';
-import { createTreeUsingTsSolutionSetup } from './test';
+import { getNpmScope, getNpmScopePrefix } from './npm-scope.js';
+import { createTreeUsingTsSolutionSetup } from './test.js';
 
 describe('npm-scope utils', () => {
   describe('getNpmScope', () => {

--- a/packages/nx-plugin/src/utils/nx.spec.ts
+++ b/packages/nx-plugin/src/utils/nx.spec.ts
@@ -13,8 +13,8 @@ import {
   type NxGeneratorInfo,
   normalizeTargetKeyOrder,
   readProjectConfigurationUnqualified,
-} from './nx';
-import { createTreeUsingTsSolutionSetup } from './test';
+} from './nx.js';
+import { createTreeUsingTsSolutionSetup } from './test.js';
 
 describe('readProjectConfigurationUnqualified', () => {
   let tree: Tree;

--- a/packages/nx-plugin/src/utils/nx.ts
+++ b/packages/nx-plugin/src/utils/nx.ts
@@ -14,14 +14,14 @@ import {
 } from '@nx/devkit';
 import * as path from 'path';
 import PackageJson from '../../package.json' with { type: 'json' };
-import { NX_PLUGIN_MCP_PACKAGE_NAME } from './mcp';
-import { toSnakeCase } from './names';
-import { getNpmScope, getNpmScopePrefix } from './npm-scope';
+import { NX_PLUGIN_MCP_PACKAGE_NAME } from './mcp.js';
+import { toSnakeCase } from './names.js';
+import { getNpmScope, getNpmScopePrefix } from './npm-scope.js';
 
-export type { GeneratorInfo, NxGeneratorInfo } from './generators';
-export { buildGeneratorInfoList } from './generators';
+export type { GeneratorInfo, NxGeneratorInfo } from './generators.js';
+export { buildGeneratorInfoList } from './generators.js';
 
-import { buildGeneratorInfoList, type GeneratorInfo } from './generators';
+import { buildGeneratorInfoList, type GeneratorInfo } from './generators.js';
 
 const GENERATORS = buildGeneratorInfoList(
   path.resolve(import.meta.dirname, '..', '..'),

--- a/packages/nx-plugin/src/utils/object.spec.ts
+++ b/packages/nx-plugin/src/utils/object.spec.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { describe, expect, it } from 'vitest';
-import { sortObjectKeys } from './object';
+import { sortObjectKeys } from './object.js';
 
 describe('sortObjectKeys', () => {
   it('sorts keys alphabetically', () => {

--- a/packages/nx-plugin/src/utils/paths.spec.ts
+++ b/packages/nx-plugin/src/utils/paths.spec.ts
@@ -8,8 +8,8 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   getRelativePathToRoot,
   getRelativePathToRootByDirectory,
-} from './paths';
-import { createTreeUsingTsSolutionSetup } from './test';
+} from './paths.js';
+import { createTreeUsingTsSolutionSetup } from './test.js';
 
 vi.mock('@nx/devkit', async () => {
   const actual = await vi.importActual('@nx/devkit');

--- a/packages/nx-plugin/src/utils/paths.ts
+++ b/packages/nx-plugin/src/utils/paths.ts
@@ -4,7 +4,7 @@
  */
 import type { ProjectConfiguration, Tree } from '@nx/devkit';
 import * as path from 'path';
-import { readProjectConfigurationUnqualified } from './nx';
+import { readProjectConfigurationUnqualified } from './nx.js';
 
 export const getRelativePathToRoot = (
   tree: Tree,

--- a/packages/nx-plugin/src/utils/pkg-manager.ts
+++ b/packages/nx-plugin/src/utils/pkg-manager.ts
@@ -6,7 +6,7 @@ import { detectPackageManager } from '@nx/devkit';
 import {
   PACKAGE_MANAGER_COMMANDS,
   type PackageManagerDisplayCommands,
-} from './commands';
+} from './commands.js';
 
 export type { PackageManagerDisplayCommands };
 

--- a/packages/nx-plugin/src/utils/pnpm-workspace.ts
+++ b/packages/nx-plugin/src/utils/pnpm-workspace.ts
@@ -4,7 +4,7 @@
  */
 import type { Tree } from '@nx/devkit';
 import yaml from 'js-yaml';
-import { detectWorkspacePackageManager } from './dependencies';
+import { detectWorkspacePackageManager } from './dependencies.js';
 
 const WORKSPACE_FILE = 'pnpm-workspace.yaml';
 

--- a/packages/nx-plugin/src/utils/port.spec.ts
+++ b/packages/nx-plugin/src/utils/port.spec.ts
@@ -4,7 +4,7 @@
  */
 import type { ProjectConfiguration, Tree } from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
-import { assignPort } from './port';
+import { assignPort } from './port.js';
 
 describe('port utilities', () => {
   let tree: Tree;

--- a/packages/nx-plugin/src/utils/project-package-json.spec.ts
+++ b/packages/nx-plugin/src/utils/project-package-json.spec.ts
@@ -8,8 +8,8 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import {
   ensureProjectPackageJson,
   ensureWorkspaceGlobCovers,
-} from './project-package-json';
-import { createTreeUsingTsSolutionSetup } from './test';
+} from './project-package-json.js';
+import { createTreeUsingTsSolutionSetup } from './test.js';
 
 describe('ensureProjectPackageJson', () => {
   let tree: Tree;

--- a/packages/nx-plugin/src/utils/project-package-json.ts
+++ b/packages/nx-plugin/src/utils/project-package-json.ts
@@ -11,8 +11,8 @@ import {
 } from '@nx/devkit';
 import yaml from 'js-yaml';
 import { minimatch } from 'minimatch';
-import { detectWorkspacePackageManager } from './dependencies';
-import { isEsmWorkspace } from './module-format';
+import { detectWorkspacePackageManager } from './dependencies.js';
+import { isEsmWorkspace } from './module-format.js';
 
 export interface EnsureProjectPackageJsonOptions {
   /** Directory of the project relative to the workspace root */

--- a/packages/nx-plugin/src/utils/py.spec.ts
+++ b/packages/nx-plugin/src/utils/py.spec.ts
@@ -6,12 +6,15 @@
 import { parse, stringify } from '@iarna/toml';
 import type { Tree } from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
-import { type DeclaredPy, declareDependencies } from './declared-dependencies';
-import type { UVPyprojectToml } from './nxlv-python';
+import {
+  type DeclaredPy,
+  declareDependencies,
+} from './declared-dependencies.js';
+import type { UVPyprojectToml } from './nxlv-python.js';
 import {
   addDependenciesToPyProjectToml,
   addWorkspaceDependencyToPyProject,
-} from './py';
+} from './py.js';
 
 const declaration = declareDependencies()({
   py: [

--- a/packages/nx-plugin/src/utils/py.ts
+++ b/packages/nx-plugin/src/utils/py.ts
@@ -8,11 +8,11 @@ import { parsePipRequirementsLine } from 'pip-requirements-js';
 import type {
   DeclaredPy,
   DependencyDeclaration,
-} from './declared-dependencies';
-import { normalizeDistributionName } from './names';
-import type { UVPyprojectToml } from './nxlv-python';
-import { readToml, updateToml } from './toml';
-import { type IPyDepVersion, PY_VERSIONS, withPyVersions } from './versions';
+} from './declared-dependencies.js';
+import { normalizeDistributionName } from './names.js';
+import type { UVPyprojectToml } from './nxlv-python.js';
+import { readToml, updateToml } from './toml.js';
+import { type IPyDepVersion, PY_VERSIONS, withPyVersions } from './versions.js';
 
 // Dedup key that distinguishes bare packages from the same package with
 // extras (e.g. `foo` vs `foo[bar]`), so adding a bare dep doesn't drop a

--- a/packages/nx-plugin/src/utils/rdb-constructs/rdb-constructs.ts
+++ b/packages/nx-plugin/src/utils/rdb-constructs/rdb-constructs.ts
@@ -10,17 +10,17 @@ import {
   type Tree,
   updateJson,
 } from '@nx/devkit';
-import { addStarExport } from '../ast';
-import type { Containers } from '../containers';
-import type { Iac } from '../iac';
-import { esmVars } from '../module-format';
-import { addDependencyToTargetIfNotPresent } from '../nx';
+import { addStarExport } from '../ast.js';
+import type { Containers } from '../containers.js';
+import type { Iac } from '../iac.js';
+import { esmVars } from '../module-format.js';
+import { addDependencyToTargetIfNotPresent } from '../nx.js';
 import {
   PACKAGES_DIR,
   SHARED_CONSTRUCTS_DIR,
   SHARED_TERRAFORM_DIR,
-} from '../shared-constructs-constants';
-import { terraformProviderVersions } from '../versions';
+} from '../shared-constructs-constants.js';
+import { terraformProviderVersions } from '../versions.js';
 
 export interface AddRdbConstructOptions {
   projectName: string;

--- a/packages/nx-plugin/src/utils/ruff.spec.ts
+++ b/packages/nx-plugin/src/utils/ruff.spec.ts
@@ -6,9 +6,9 @@
 import { execFileSync } from 'child_process';
 import { createRequire } from 'module';
 import { describe, expect, it } from 'vitest';
-import { declareDependencies } from './declared-dependencies';
-import { FIXABLE_RULES, RUFF_WASM_VERSION, ruffFixAndFormat } from './ruff';
-import { PY_VERSIONS, withPyVersions } from './versions';
+import { declareDependencies } from './declared-dependencies.js';
+import { FIXABLE_RULES, RUFF_WASM_VERSION, ruffFixAndFormat } from './ruff.js';
+import { PY_VERSIONS, withPyVersions } from './versions.js';
 
 const declaration = declareDependencies()({ py: [{ name: 'ruff' }] });
 

--- a/packages/nx-plugin/src/utils/shared-constructs-constants.ts
+++ b/packages/nx-plugin/src/utils/shared-constructs-constants.ts
@@ -2,8 +2,8 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import type { DeclaredTsDependency } from './declared-dependencies';
-import type { ITsDepVersion } from './versions';
+import type { DeclaredTsDependency } from './declared-dependencies.js';
+import type { ITsDepVersion } from './versions.js';
 
 export const PACKAGES_DIR = 'packages';
 export const SHARED_CONSTRUCTS_NAME = 'common-constructs';

--- a/packages/nx-plugin/src/utils/shared-constructs.spec.ts
+++ b/packages/nx-plugin/src/utils/shared-constructs.spec.ts
@@ -5,18 +5,18 @@
 
 import { joinPathFragments, type Tree } from '@nx/devkit';
 import { beforeEach, describe, expect, it } from 'vitest';
-import { declareDependencies } from './declared-dependencies';
+import { declareDependencies } from './declared-dependencies.js';
 import {
   SHARED_CONSTRUCTS_DEPENDENCIES,
   sharedConstructsGenerator,
-} from './shared-constructs';
+} from './shared-constructs.js';
 import {
   PACKAGES_DIR,
   SHARED_CONSTRUCTS_DIR,
   SHARED_CONSTRUCTS_NAME,
   SHARED_TERRAFORM_DIR,
-} from './shared-constructs-constants';
-import { createTreeUsingTsSolutionSetup, snapshotTreeDir } from './test';
+} from './shared-constructs-constants.js';
+import { createTreeUsingTsSolutionSetup, snapshotTreeDir } from './test.js';
 
 const declaration = declareDependencies()({
   ts: [...SHARED_CONSTRUCTS_DEPENDENCIES],

--- a/packages/nx-plugin/src/utils/shared-constructs.ts
+++ b/packages/nx-plugin/src/utils/shared-constructs.ts
@@ -10,19 +10,19 @@ import {
   type Tree,
   updateJson,
 } from '@nx/devkit';
-import terraformProjectGenerator from '../terraform/project/generator';
-import tsProjectGenerator from '../ts/lib/generator';
-import { readAwsNxPluginConfig } from './config/utils';
+import terraformProjectGenerator from '../terraform/project/generator.js';
+import tsProjectGenerator from '../ts/lib/generator.js';
+import { readAwsNxPluginConfig } from './config/utils.js';
 import type {
   DependencyDeclaration,
   MustDeclare,
-} from './declared-dependencies';
-import { addDependenciesToPackageJson } from './dependencies';
-import { formatFilesInSubtree } from './format';
-import type { Iac } from './iac';
-import { esmVars } from './module-format';
-import { getNpmScopePrefix } from './npm-scope';
-import { getPackageManagerDisplayCommands } from './pkg-manager';
+} from './declared-dependencies.js';
+import { addDependenciesToPackageJson } from './dependencies.js';
+import { formatFilesInSubtree } from './format.js';
+import type { Iac } from './iac.js';
+import { esmVars } from './module-format.js';
+import { getNpmScopePrefix } from './npm-scope.js';
+import { getPackageManagerDisplayCommands } from './pkg-manager.js';
 import {
   PACKAGES_DIR,
   SHARED_CONSTRUCTS_DEPENDENCIES,
@@ -30,11 +30,11 @@ import {
   SHARED_CONSTRUCTS_NAME,
   SHARED_TERRAFORM_DIR,
   SHARED_TERRAFORM_NAME,
-} from './shared-constructs-constants';
+} from './shared-constructs-constants.js';
 
 export { SHARED_CONSTRUCTS_DEPENDENCIES };
 
-import { terraformProviderVersions, withVersions } from './versions';
+import { terraformProviderVersions, withVersions } from './versions.js';
 
 export interface SharedConstructsGeneratorOptions {
   iac: Iac;

--- a/packages/nx-plugin/src/utils/shared-dynamodb-scripts.ts
+++ b/packages/nx-plugin/src/utils/shared-dynamodb-scripts.ts
@@ -11,14 +11,14 @@ import {
 import type {
   DependencyDeclaration,
   MustDeclare,
-} from './declared-dependencies';
-import { addDependenciesToPackageJson } from './dependencies';
+} from './declared-dependencies.js';
+import { addDependenciesToPackageJson } from './dependencies.js';
 import {
   PACKAGES_DIR,
   SHARED_SCRIPTS_DIR,
-} from './shared-constructs-constants';
-import { ensureSharedScriptsProject } from './shared-scripts';
-import { type ITsDepVersion, withVersions } from './versions';
+} from './shared-constructs-constants.js';
+import { ensureSharedScriptsProject } from './shared-scripts.js';
+import { type ITsDepVersion, withVersions } from './versions.js';
 
 /** Dependencies a caller must declare to use the shared DynamoDB scripts. */
 export const SHARED_DYNAMODB_SCRIPTS_DEPENDENCIES = [

--- a/packages/nx-plugin/src/utils/shared-infra-config.ts
+++ b/packages/nx-plugin/src/utils/shared-infra-config.ts
@@ -8,16 +8,16 @@ import {
   OverwriteStrategy,
   type Tree,
 } from '@nx/devkit';
-import tsProjectGenerator from '../ts/lib/generator';
-import { formatFilesInSubtree } from './format';
-import { esmVars } from './module-format';
-import { getNpmScopePrefix } from './npm-scope';
-import { getPackageManagerDisplayCommands } from './pkg-manager';
+import tsProjectGenerator from '../ts/lib/generator.js';
+import { formatFilesInSubtree } from './format.js';
+import { esmVars } from './module-format.js';
+import { getNpmScopePrefix } from './npm-scope.js';
+import { getPackageManagerDisplayCommands } from './pkg-manager.js';
 import {
   PACKAGES_DIR,
   SHARED_INFRA_CONFIG_DIR,
   SHARED_INFRA_CONFIG_NAME,
-} from './shared-constructs-constants';
+} from './shared-constructs-constants.js';
 
 /**
  * Lazily creates the shared infra-config package at packages/common/infra-config/.

--- a/packages/nx-plugin/src/utils/shared-infra-scripts.ts
+++ b/packages/nx-plugin/src/utils/shared-infra-scripts.ts
@@ -12,21 +12,21 @@ import type {
   DeclaredTsDependency,
   DependencyDeclaration,
   MustDeclare,
-} from './declared-dependencies';
-import { addDependenciesToPackageJson } from './dependencies';
-import { formatFilesInSubtree } from './format';
-import { esmVars } from './module-format';
-import { getNpmScopePrefix } from './npm-scope';
-import { getPackageManagerDisplayCommands } from './pkg-manager';
+} from './declared-dependencies.js';
+import { addDependenciesToPackageJson } from './dependencies.js';
+import { formatFilesInSubtree } from './format.js';
+import { esmVars } from './module-format.js';
+import { getNpmScopePrefix } from './npm-scope.js';
+import { getPackageManagerDisplayCommands } from './pkg-manager.js';
 import {
   generatedInfrastructure,
   type IacMetadata,
   PACKAGES_DIR,
   SHARED_SCRIPTS_DIR,
   SHARED_SCRIPTS_NAME,
-} from './shared-constructs-constants';
-import { ensureSharedScriptsProject } from './shared-scripts';
-import { type ITsDepVersion, withVersions } from './versions';
+} from './shared-constructs-constants.js';
+import { ensureSharedScriptsProject } from './shared-scripts.js';
+import { type ITsDepVersion, withVersions } from './versions.js';
 
 /**
  * Dependencies a caller must declare to use the shared infra scripts.

--- a/packages/nx-plugin/src/utils/shared-rdb-scripts.ts
+++ b/packages/nx-plugin/src/utils/shared-rdb-scripts.ts
@@ -11,14 +11,14 @@ import {
 import type {
   DependencyDeclaration,
   MustDeclare,
-} from './declared-dependencies';
-import { addDependenciesToPackageJson } from './dependencies';
+} from './declared-dependencies.js';
+import { addDependenciesToPackageJson } from './dependencies.js';
 import {
   PACKAGES_DIR,
   SHARED_SCRIPTS_DIR,
-} from './shared-constructs-constants';
-import { ensureSharedScriptsProject } from './shared-scripts';
-import { type ITsDepVersion, withVersions } from './versions';
+} from './shared-constructs-constants.js';
+import { ensureSharedScriptsProject } from './shared-scripts.js';
+import { type ITsDepVersion, withVersions } from './versions.js';
 
 /** Dependencies a caller must declare to use the shared RDB scripts. */
 export const SHARED_RDB_SCRIPTS_DEPENDENCIES = [

--- a/packages/nx-plugin/src/utils/shared-scripts.ts
+++ b/packages/nx-plugin/src/utils/shared-scripts.ts
@@ -3,12 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { joinPathFragments, type Tree } from '@nx/devkit';
-import tsProjectGenerator from '../ts/lib/generator';
+import tsProjectGenerator from '../ts/lib/generator.js';
 import {
   PACKAGES_DIR,
   SHARED_SCRIPTS_DIR,
   SHARED_SCRIPTS_NAME,
-} from './shared-constructs-constants';
+} from './shared-constructs-constants.js';
 
 /**
  * Lazily creates the shared scripts package at packages/common/scripts/.

--- a/packages/nx-plugin/src/utils/shared-shadcn.ts
+++ b/packages/nx-plugin/src/utils/shared-shadcn.ts
@@ -9,25 +9,25 @@ import {
   type Tree,
   updateJson,
 } from '@nx/devkit';
-import tsProjectGenerator from '../ts/lib/generator';
-import { configureTsProject } from '../ts/lib/ts-project-utils';
-import { VITEST_DEPENDENCIES } from '../ts/lib/vitest';
+import tsProjectGenerator from '../ts/lib/generator.js';
+import { configureTsProject } from '../ts/lib/ts-project-utils.js';
+import { VITEST_DEPENDENCIES } from '../ts/lib/vitest.js';
 import {
   type DependencyDeclaration,
   declaredNames,
   forDependencies,
   type MustDeclare,
-} from './declared-dependencies';
-import { addDependenciesToPackageJson } from './dependencies';
-import { formatFilesInSubtree } from './format';
-import { esmVars } from './module-format';
-import { getNpmScopePrefix } from './npm-scope';
+} from './declared-dependencies.js';
+import { addDependenciesToPackageJson } from './dependencies.js';
+import { formatFilesInSubtree } from './format.js';
+import { esmVars } from './module-format.js';
+import { getNpmScopePrefix } from './npm-scope.js';
 import {
   PACKAGES_DIR,
   SHARED_SHADCN_DIR,
   SHARED_SHADCN_NAME,
-} from './shared-constructs-constants';
-import { type ITsDepVersion, withVersions } from './versions';
+} from './shared-constructs-constants.js';
+import { type ITsDepVersion, withVersions } from './versions.js';
 
 /** Dependencies a caller must declare to use the shared shadcn project. */
 export const SHADCN_DEPENDENCIES = [

--- a/packages/nx-plugin/src/utils/smithy.spec.ts
+++ b/packages/nx-plugin/src/utils/smithy.spec.ts
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { logger } from '@nx/devkit';
-import { smithyCliCommand, warnIfSmithyMissing } from './smithy';
-import { MISE_VERSIONS, TS_VERSIONS } from './versions';
+import { smithyCliCommand, warnIfSmithyMissing } from './smithy.js';
+import { MISE_VERSIONS, TS_VERSIONS } from './versions.js';
 
 /**
  * The Windows behaviour, which CI cannot exercise from a Linux runner: `mise`

--- a/packages/nx-plugin/src/utils/smithy.ts
+++ b/packages/nx-plugin/src/utils/smithy.ts
@@ -5,7 +5,7 @@
 
 import * as childProcess from 'node:child_process';
 import { logger } from '@nx/devkit';
-import { javaMavenDependency, MISE_VERSIONS, TS_VERSIONS } from './versions';
+import { javaMavenDependency, MISE_VERSIONS, TS_VERSIONS } from './versions.js';
 
 /**
  * How a generated Smithy project runs the Smithy CLI.

--- a/packages/nx-plugin/src/utils/test-git.spec.ts
+++ b/packages/nx-plugin/src/utils/test-git.spec.ts
@@ -6,7 +6,7 @@
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { initTestGitRepo, runGit, useIsolatedGitEnv } from './test-git';
+import { initTestGitRepo, runGit, useIsolatedGitEnv } from './test-git.js';
 
 describe('test-git', () => {
   describe('useIsolatedGitEnv', () => {

--- a/packages/nx-plugin/src/utils/test.ts
+++ b/packages/nx-plugin/src/utils/test.ts
@@ -12,7 +12,7 @@ import {
 } from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import { expect } from 'vitest';
-import { getDefaultBiomeConfig } from './format';
+import { getDefaultBiomeConfig } from './format.js';
 
 /**
  * Create a workspace tree configured so that nx's `isUsingTsSolutionSetup`

--- a/packages/nx-plugin/src/utils/test/ts.spec.ts
+++ b/packages/nx-plugin/src/utils/test/ts.spec.ts
@@ -7,7 +7,7 @@ import { createProjectSync, type Project, ts } from '@ts-morph/bootstrap';
 import { execSync } from 'child_process';
 import fs from 'fs';
 import path from 'path';
-import { createTreeUsingTsSolutionSetup } from '../test';
+import { createTreeUsingTsSolutionSetup } from '../test.js';
 
 /**
  * Utility for verifying typescript files compile

--- a/packages/nx-plugin/src/utils/toml.spec.ts
+++ b/packages/nx-plugin/src/utils/toml.spec.ts
@@ -5,7 +5,7 @@
 
 import TOML from '@iarna/toml';
 import { createTree } from '@nx/devkit/testing';
-import { tryReadToml, updateToml } from './toml';
+import { tryReadToml, updateToml } from './toml.js';
 
 describe('toml utils', () => {
   describe('updateToml', () => {

--- a/packages/nx-plugin/src/utils/version-upgrade-migration/migration.ts
+++ b/packages/nx-plugin/src/utils/version-upgrade-migration/migration.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { MigrationReturnObject, Tree } from '@nx/devkit';
-import { syncVendedVersions } from './sync-vended-versions';
+import { syncVendedVersions } from './sync-vended-versions.js';
 
 /**
  * Syncs the workspace's vended versions to those the installed plugin vends.

--- a/packages/nx-plugin/src/utils/version-upgrade-migration/nx-package-updates.spec.ts
+++ b/packages/nx-plugin/src/utils/version-upgrade-migration/nx-package-updates.spec.ts
@@ -7,14 +7,14 @@ import {
   backfillMigrationVersions,
   LATEST_MIGRATIONS_DIR,
   stampMigrationVersions,
-} from '../migration-versions';
-import { NX_PACKAGES, NX_VERSION } from '../versions';
+} from '../migration-versions.js';
+import { NX_PACKAGES, NX_VERSION } from '../versions.js';
 import {
   isNxPackage,
   nxPackageJsonUpdates,
   nxPackageUpdatesKey,
   type PackageJsonUpdates,
-} from './nx-package-updates';
+} from './nx-package-updates.js';
 
 describe('nx package updates', () => {
   describe('isNxPackage', () => {

--- a/packages/nx-plugin/src/utils/version-upgrade-migration/nx-package-updates.ts
+++ b/packages/nx-plugin/src/utils/version-upgrade-migration/nx-package-updates.ts
@@ -2,8 +2,8 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import { migrationKey } from '../migration-versions';
-import { NX_PACKAGES, NX_VERSION } from '../versions';
+import { migrationKey } from '../migration-versions.js';
+import { NX_PACKAGES, NX_VERSION } from '../versions.js';
 
 /**
  * `packageJsonUpdates` for the nx packages a generated workspace pins.

--- a/packages/nx-plugin/src/utils/version-upgrade-migration/owned-dependencies.spec.ts
+++ b/packages/nx-plugin/src/utils/version-upgrade-migration/owned-dependencies.spec.ts
@@ -10,17 +10,17 @@ import {
   type Tree,
 } from '@nx/devkit';
 import { beforeEach, describe, expect, it } from 'vitest';
-import { captureAllGritQL, matchGritQL } from '../ast';
-import { AWS_NX_PLUGIN_CONFIG_FILE_NAME } from '../config/utils';
-import { declaredNames } from '../declared-dependencies';
-import { buildGeneratorInfoList } from '../generators';
-import { createTreeUsingTsSolutionSetup } from '../test';
-import { PY_VERSIONS, TS_VERSIONS } from '../versions';
+import { captureAllGritQL, matchGritQL } from '../ast.js';
+import { AWS_NX_PLUGIN_CONFIG_FILE_NAME } from '../config/utils.js';
+import { declaredNames } from '../declared-dependencies.js';
+import { buildGeneratorInfoList } from '../generators.js';
+import { createTreeUsingTsSolutionSetup } from '../test.js';
+import { PY_VERSIONS, TS_VERSIONS } from '../versions.js';
 import {
   generatorsRun,
   ownedDependencies,
   PLUGIN_ROOT,
-} from './owned-dependencies';
+} from './owned-dependencies.js';
 
 const addProject = (
   tree: Tree,

--- a/packages/nx-plugin/src/utils/version-upgrade-migration/owned-dependencies.ts
+++ b/packages/nx-plugin/src/utils/version-upgrade-migration/owned-dependencies.ts
@@ -4,18 +4,18 @@
  */
 import * as path from 'node:path';
 import { getProjects, type Tree } from '@nx/devkit';
-import { AWS_NX_PLUGIN_CONFIG_FILE_NAME } from '../config/utils';
+import { AWS_NX_PLUGIN_CONFIG_FILE_NAME } from '../config/utils.js';
 import {
   type DependencyDeclaration,
   type DependencyMetadata,
   ownedDependencyEntries,
-} from '../declared-dependencies';
-import { buildGeneratorInfoList } from '../generators';
+} from '../declared-dependencies.js';
+import { buildGeneratorInfoList } from '../generators.js';
 import {
   PACKAGES_DIR,
   SHARED_CONSTRUCTS_DIR,
   SHARED_TERRAFORM_DIR,
-} from '../shared-constructs-constants';
+} from '../shared-constructs-constants.js';
 
 /** Directory holding `generators.json`, which maps ids to their modules. */
 export const PLUGIN_ROOT = path.resolve(import.meta.dirname, '..', '..', '..');

--- a/packages/nx-plugin/src/utils/version-upgrade-migration/real-templates.spec.ts
+++ b/packages/nx-plugin/src/utils/version-upgrade-migration/real-templates.spec.ts
@@ -5,15 +5,15 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { addProjectConfiguration, type Tree } from '@nx/devkit';
-import { createTreeUsingTsSolutionSetup } from '../test';
+import { createTreeUsingTsSolutionSetup } from '../test.js';
 import {
   BASE_IMAGES,
   CONTAINER_VERSIONS,
   PY_VERSIONS,
   TS_VERSIONS,
-} from '../versions';
-import { isDockerfile } from './sync-embedded-versions';
-import { syncVendedVersions } from './sync-vended-versions';
+} from '../versions.js';
+import { isDockerfile } from './sync-embedded-versions.js';
+import { syncVendedVersions } from './sync-vended-versions.js';
 
 const PLUGIN_SRC = path.resolve(import.meta.dirname, '..', '..');
 

--- a/packages/nx-plugin/src/utils/version-upgrade-migration/register.spec.ts
+++ b/packages/nx-plugin/src/utils/version-upgrade-migration/register.spec.ts
@@ -8,13 +8,13 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import {
   LATEST_MIGRATIONS_DIR,
   stampMigrationVersions,
-} from '../migration-versions';
-import { NX_PACKAGES, NX_VERSION } from '../versions';
+} from '../migration-versions.js';
+import { NX_PACKAGES, NX_VERSION } from '../versions.js';
 import {
   nxPackageUpdatesKey,
   type PackageJsonUpdates,
-} from './nx-package-updates';
-import { registerNxPackageUpdates } from './register';
+} from './nx-package-updates.js';
+import { registerNxPackageUpdates } from './register.js';
 
 const PACKAGE_JSON_UPDATES_PATH = 'packages/nx-plugin/packageJsonUpdates.json';
 const NX_KEY = nxPackageUpdatesKey(NX_VERSION);

--- a/packages/nx-plugin/src/utils/version-upgrade-migration/register.ts
+++ b/packages/nx-plugin/src/utils/version-upgrade-migration/register.ts
@@ -3,11 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { type Tree, writeJson } from '@nx/devkit';
-import { LATEST_MIGRATIONS_DIR } from '../migration-versions';
+import { LATEST_MIGRATIONS_DIR } from '../migration-versions.js';
 import {
   nxPackageJsonUpdates,
   type PackageJsonUpdates,
-} from './nx-package-updates';
+} from './nx-package-updates.js';
 
 const PACKAGE_JSON_UPDATES_PATH = 'packages/nx-plugin/packageJsonUpdates.json';
 

--- a/packages/nx-plugin/src/utils/version-upgrade-migration/robustness.spec.ts
+++ b/packages/nx-plugin/src/utils/version-upgrade-migration/robustness.spec.ts
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { addProjectConfiguration, type Tree, writeJson } from '@nx/devkit';
-import { createTreeUsingTsSolutionSetup } from '../test';
-import { BASE_IMAGES, TS_VERSIONS } from '../versions';
-import { syncVendedVersions } from './sync-vended-versions';
+import { createTreeUsingTsSolutionSetup } from '../test.js';
+import { BASE_IMAGES, TS_VERSIONS } from '../versions.js';
+import { syncVendedVersions } from './sync-vended-versions.js';
 
 // A thrown migration aborts the whole `nx migrate`, stranding the user mid
 // upgrade. These files are the user's to hand-edit, so the sync's contract —

--- a/packages/nx-plugin/src/utils/version-upgrade-migration/sync-embedded-versions.spec.ts
+++ b/packages/nx-plugin/src/utils/version-upgrade-migration/sync-embedded-versions.spec.ts
@@ -3,15 +3,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { addProjectConfiguration, type Tree, writeJson } from '@nx/devkit';
-import { createTreeUsingTsSolutionSetup } from '../test';
+import { createTreeUsingTsSolutionSetup } from '../test.js';
 import {
   BASE_IMAGES,
   CONTAINER_REPOSITORIES,
   CONTAINER_VERSIONS,
   PY_VERSIONS,
   TS_VERSIONS,
-} from '../versions';
-import { syncVendedVersions } from './sync-vended-versions';
+} from '../versions.js';
+import { syncVendedVersions } from './sync-vended-versions.js';
 
 // Versions the plugin vends, read from the manifest so the tests track it.
 const VENDED_NPM = TS_VERSIONS.npm;

--- a/packages/nx-plugin/src/utils/version-upgrade-migration/sync-embedded-versions.ts
+++ b/packages/nx-plugin/src/utils/version-upgrade-migration/sync-embedded-versions.ts
@@ -8,8 +8,8 @@ import {
   joinPathFragments,
   visitNotIgnoredFiles,
 } from '@nx/devkit';
-import { SMITHY_PROJECT_GENERATOR_INFO } from '../../smithy/project/generator';
-import { applyGritQL } from '../ast';
+import { SMITHY_PROJECT_GENERATOR_INFO } from '../../smithy/project/generator.js';
+import { applyGritQL } from '../ast.js';
 import {
   BASE_IMAGES,
   CONTAINER_REPOSITORIES,
@@ -19,9 +19,9 @@ import {
   MISE_VERSIONS,
   PY_VERSIONS,
   TS_VERSIONS,
-} from '../versions';
-import { type OwnedDependencies, ownedForFile } from './owned-dependencies';
-import { isVendedUpgrade } from './vended-upgrade';
+} from '../versions.js';
+import { type OwnedDependencies, ownedForFile } from './owned-dependencies.js';
+import { isVendedUpgrade } from './vended-upgrade.js';
 
 /**
  * Sync the vended versions generators bake into the body of a file rather than

--- a/packages/nx-plugin/src/utils/version-upgrade-migration/sync-metrics-version.ts
+++ b/packages/nx-plugin/src/utils/version-upgrade-migration/sync-metrics-version.ts
@@ -3,12 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { Tree } from '@nx/devkit';
-import { applyGritQL } from '../ast';
+import { applyGritQL } from '../ast.js';
 import {
   METRICS_ASPECT_FILE_PATH,
   TERRAFORM_METRICS_FILE_PATH,
-} from '../metrics';
-import { getPackageVersion } from '../nx';
+} from '../metrics.js';
+import { getPackageVersion } from '../nx.js';
 
 /**
  * Sync the plugin version the metrics files report, so usage is attributed to

--- a/packages/nx-plugin/src/utils/version-upgrade-migration/sync-vended-versions.spec.ts
+++ b/packages/nx-plugin/src/utils/version-upgrade-migration/sync-vended-versions.spec.ts
@@ -13,16 +13,16 @@ import yaml from 'js-yaml';
 import {
   METRICS_ASPECT_FILE_PATH,
   TERRAFORM_METRICS_FILE_PATH,
-} from '../metrics';
-import { getPackageVersion } from '../nx';
-import { createTreeUsingTsSolutionSetup } from '../test';
+} from '../metrics.js';
+import { getPackageVersion } from '../nx.js';
+import { createTreeUsingTsSolutionSetup } from '../test.js';
 import {
   NX_PACKAGES,
   PY_VERSIONS,
   TERRAFORM_VERSIONS,
   TS_VERSIONS,
-} from '../versions';
-import { syncVendedVersions } from './sync-vended-versions';
+} from '../versions.js';
+import { syncVendedVersions } from './sync-vended-versions.js';
 
 // Versions the plugin vends, read from the manifest so the tests track it.
 const VENDED_ZOD = TS_VERSIONS.zod;

--- a/packages/nx-plugin/src/utils/version-upgrade-migration/sync-vended-versions.ts
+++ b/packages/nx-plugin/src/utils/version-upgrade-migration/sync-vended-versions.ts
@@ -15,19 +15,19 @@ import yaml from 'js-yaml';
 import { getCatalogManager } from 'nx/src/utils/catalog';
 import { parsePipRequirementsLine } from 'pip-requirements-js';
 import { coerce, parse, satisfies, validRange } from 'semver';
-import { applyGritQL, captureAllGritQL } from '../ast';
-import { buildInstallCommand } from '../commands';
-import { formatFilesInSubtree } from '../format';
-import { updateToml } from '../toml';
-import { PY_VERSIONS, TERRAFORM_VERSIONS, TS_VERSIONS } from '../versions';
-import { isNxPackage } from './nx-package-updates';
+import { applyGritQL, captureAllGritQL } from '../ast.js';
+import { buildInstallCommand } from '../commands.js';
+import { formatFilesInSubtree } from '../format.js';
+import { updateToml } from '../toml.js';
+import { PY_VERSIONS, TERRAFORM_VERSIONS, TS_VERSIONS } from '../versions.js';
+import { isNxPackage } from './nx-package-updates.js';
 import {
   type OwnedDependencies,
   ownedDependencies,
-} from './owned-dependencies';
-import { syncEmbeddedVersions } from './sync-embedded-versions';
-import { syncMetricsVersion } from './sync-metrics-version';
-import { isVendedUpgrade } from './vended-upgrade';
+} from './owned-dependencies.js';
+import { syncEmbeddedVersions } from './sync-embedded-versions.js';
+import { syncMetricsVersion } from './sync-metrics-version.js';
+import { isVendedUpgrade } from './vended-upgrade.js';
 
 /**
  * Syncs the versions a generated workspace pins to those this release vends:

--- a/packages/nx-plugin/src/utils/version-upgrade-migration/template-pin-ownership.spec.ts
+++ b/packages/nx-plugin/src/utils/version-upgrade-migration/template-pin-ownership.spec.ts
@@ -5,17 +5,17 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { addProjectConfiguration, type Tree } from '@nx/devkit';
-import { smithyProjectGenerator } from '../../smithy/project/generator';
-import { createTreeUsingTsSolutionSetup } from '../test';
+import { smithyProjectGenerator } from '../../smithy/project/generator.js';
+import { createTreeUsingTsSolutionSetup } from '../test.js';
 import {
   BASE_IMAGES,
   JAVA_ARTIFACTS,
   MISE_VERSIONS,
   TS_VERSIONS,
-} from '../versions';
-import { ownedDependencies, ownedForFile } from './owned-dependencies';
-import { isDockerfile } from './sync-embedded-versions';
-import { syncVendedVersions } from './sync-vended-versions';
+} from '../versions.js';
+import { ownedDependencies, ownedForFile } from './owned-dependencies.js';
+import { isDockerfile } from './sync-embedded-versions.js';
+import { syncVendedVersions } from './sync-vended-versions.js';
 
 const PLUGIN_SRC = path.resolve(import.meta.dirname, '..', '..');
 

--- a/packages/nx-plugin/src/utils/version-upgrade-migration/vended-upgrade.spec.ts
+++ b/packages/nx-plugin/src/utils/version-upgrade-migration/vended-upgrade.spec.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { describe, expect, it } from 'vitest';
-import { isVendedUpgrade } from './vended-upgrade';
+import { isVendedUpgrade } from './vended-upgrade.js';
 
 describe('isVendedUpgrade', () => {
   it('should upgrade an exact version below the vended one', () => {

--- a/packages/nx-plugin/src/utils/versions.spec.ts
+++ b/packages/nx-plugin/src/utils/versions.spec.ts
@@ -4,8 +4,16 @@
  */
 import { describe, expect, it } from 'vitest';
 import PluginPackageJson from '../../package.json' with { type: 'json' };
-import { type DeclaredTs, declareDependencies } from './declared-dependencies';
-import { NX_PACKAGES, NX_VERSION, TS_VERSIONS, withVersions } from './versions';
+import {
+  type DeclaredTs,
+  declareDependencies,
+} from './declared-dependencies.js';
+import {
+  NX_PACKAGES,
+  NX_VERSION,
+  TS_VERSIONS,
+  withVersions,
+} from './versions.js';
 
 const declaration = declareDependencies()({
   ts: [

--- a/packages/nx-plugin/src/utils/versions.ts
+++ b/packages/nx-plugin/src/utils/versions.ts
@@ -7,7 +7,7 @@ import {
   type DeclaredTs,
   type DependencyDeclaration,
   declaredNames,
-} from './declared-dependencies';
+} from './declared-dependencies.js';
 
 /**
  * Versons for TypeScript dependencies added by generators

--- a/packages/nx-plugin/src/utils/website-constructs/website-constructs.ts
+++ b/packages/nx-plugin/src/utils/website-constructs/website-constructs.ts
@@ -10,23 +10,23 @@ import {
   type Tree,
   updateJson,
 } from '@nx/devkit';
-import { addStarExport } from '../ast';
-import type { DeclaredPyDependency } from '../declared-dependencies';
-import type { Iac } from '../iac';
-import { esmVars } from '../module-format';
-import { addDependencyToTargetIfNotPresent } from '../nx';
+import { addStarExport } from '../ast.js';
+import type { DeclaredPyDependency } from '../declared-dependencies.js';
+import type { Iac } from '../iac.js';
+import { esmVars } from '../module-format.js';
+import { addDependencyToTargetIfNotPresent } from '../nx.js';
 import {
   generatedTerraform,
   type IacMetadata,
   PACKAGES_DIR,
   SHARED_CONSTRUCTS_DIR,
   SHARED_TERRAFORM_DIR,
-} from '../shared-constructs-constants';
+} from '../shared-constructs-constants.js';
 import {
   type IPyDepVersion,
   PY_VERSIONS,
   terraformProviderVersions,
-} from '../versions';
+} from '../versions.js';
 
 /**
  * Python version the generated Terraform pins in the static website module's


### PR DESCRIPTION
### Reason for this change

Running `ts#nx-generator` from a clone of this repo — the first thing the
"Contribute a Generator" tutorial asks you to do — fails:

```
NX  Directory import '.../packages/nx-plugin/src/utils/ast' is not supported
    resolving ES modules imported from .../ts/nx-generator/generator.ts
NX  Failed to load .../generator.ts under Node's native TypeScript stripping.
```

The plugin is ESM (`"type": "module"`) but its relative import specifiers are
extensionless. That is fine for the build and for `tsc` (this repo resolves with
`bundler`), and swc's `resolveFully` appends the extensions on the way out, so
**the published package is unaffected and this PR does not change it** — the
emitted `.js` is byte-identical to `main`. The problem is only at runtime when
Nx loads a generator from `.ts` source.

There, three modules are shadowed by a directory of the same name
(`utils/ast.ts` + `utils/ast/`, `utils/test.ts` + `utils/test/`,
`open-api/utils/codegen-data.ts` + `codegen-data/`). Node resolves the
extensionless specifier to the **directory** and throws
`ERR_UNSUPPORTED_DIR_IMPORT`. 18 generators import `utils/ast`, including
`connection`, `ts#website` and `ts#nx-generator`.

Generators that don't import a shadowed module (e.g. `ts#project`) load fine on
`main` — this only bites the ones that do.

### Description of changes

Added explicit extensions to every relative specifier in the plugin source,
matching what swc already emits: `./foo` -> `./foo.js`, and `./bar` ->
`./bar/index.js` where `bar/index.ts` is the entry point. This makes each
specifier unambiguous, so the shadowed modules resolve to the intended file.

Renaming the three directories would also have fixed the collisions with a far
smaller diff; explicit extensions were chosen because they fix the underlying
ESM correctness issue rather than just the three instances of it, and because
the emitted `.d.ts` files then carry extensions too — which consumers resolving
under `nodenext` need. Happy to switch to the rename if you'd prefer the
smaller change.

Also adds a root `.env` setting `NX_PREFER_NODE_STRIP_TYPES=false`. **This is
load-bearing, not a convenience**: Nx defaults to Node's native type stripping,
which deliberately does not remap NodeNext `.js` specifiers back to their `.ts`
sources, so without it the new specifiers dangle. Nx ships resolver hooks for
exactly this, but registers the ESM one only via `registerPluginTSTranspiler`;
generators load through `loadTsFile`, which patches the CJS resolver only.
Opting into the swc path registers both.

Worth a maintainer's call, since it is a real trade-off: `main` tolerates either
loader setting for unaffected generators, whereas this PR requires the swc path.
`.env` is repo-local (not published, not vended into generated workspaces), but
it is only auto-loaded from the workspace root, so an invocation with a
different cwd would lose the override. If you'd rather not depend on `.env`,
setting it in `nx.json` or the affected CI jobs would be more explicit.

### Description of how you validated changes

- Confirmed the failure on `main` for `ts#nx-generator`, and that it and
  `ts#nx-migration` both run from source after the change.
- Diffed compiled output against `main`: **zero** differences in emitted `.js`.
  The only `.d.ts` changes are the added extensions.
- Verified no `.ts` specifiers leaked into source or `dist` (swc emits those
  verbatim, which would break the published package).
- Verified the sweep touched no `files/**` EJS templates, snapshots or GritQL
  patterns, and that the one rewritten test assertion (the CommonJS-workspace
  case in `ts#nx-generator`, which must stay extensionless) was restored.
- `nx run @aws/nx-plugin:compile`, `:lint` and `:test` all pass
  (197 files, 3699 tests).

### Known gaps

- ~191 relative specifiers remain extensionless, nearly all `./schema`
  resolving to a `schema.d.ts`. These are type-only and erased at build, so none
  survive into `dist`, but the sweep is not exhaustive.
- `vi.mock()` paths were left extensionless while the imports they intercept
  gained `.js`. Vite normalises both to the same module id so mocking still
  works, but it is an inconsistency.

### Checklist
- [x] My code adheres to the CONTRIBUTING GUIDE and DESIGN GUIDELINES

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*