### PR TITLE
docs(connection): match the graph builder's agent/gateway constraints to the guards

### DIFF
--- a/docs/src/content/docs/en/guides/connection/py-agent-gateway.mdx
+++ b/docs/src/content/docs/en/guides/connection/py-agent-gateway.mdx
@@ -21,9 +21,13 @@ The generator wires the agent so it authenticates to the Gateway with IAM SigV4 
 Before using this generator, ensure you have:
 
 1. A Python project with a <Link path="guides/py-agent">Agent</Link> component (`infra: agentcore`)
-2. A <Link path="guides/agentcore-gateway">`agentcore-gateway`</Link> project with `auth: iam`
+2. A <Link path="guides/agentcore-gateway">`agentcore-gateway`</Link> project with `protocol: mcp` and `auth: iam`
 
-The Gateway must use IAM authentication — the agent signs its requests with SigV4 using its own execution role. The generator rejects Cognito-authenticated gateways.
+The Gateway must serve the `mcp` protocol — the agent reaches it as an MCP client, so its targets are exposed as tools. The Gateway must also use IAM authentication: the agent signs its requests with SigV4 using its own execution role. The generator rejects Cognito-authenticated gateways.
+
+:::note[One direction per Gateway]
+A single Gateway cannot both be called by an agent and front one. Fronting agent runtimes needs `protocol: http` (see <Link path="guides/connection/agentcore-gateway-agent">Gateway to Agent</Link>), whereas being called by an agent needs `protocol: mcp`. Use a separate Gateway for each direction.
+:::
 
 ## Usage
 

--- a/docs/src/content/docs/en/guides/connection/ts-agent-gateway.mdx
+++ b/docs/src/content/docs/en/guides/connection/ts-agent-gateway.mdx
@@ -21,9 +21,13 @@ The generator wires the agent so it authenticates to the Gateway with IAM SigV4 
 Before using this generator, ensure you have:
 
 1. A TypeScript project with a <Link path="guides/ts-agent">Agent</Link> component (`infra: agentcore`)
-2. A <Link path="guides/agentcore-gateway">`agentcore-gateway`</Link> project with `auth: iam`
+2. A <Link path="guides/agentcore-gateway">`agentcore-gateway`</Link> project with `protocol: mcp` and `auth: iam`
 
-The Gateway must use IAM authentication — the agent signs its requests with SigV4 using its own execution role. The generator rejects Cognito-authenticated gateways.
+The Gateway must serve the `mcp` protocol — the agent reaches it as an MCP client, so its targets are exposed as tools. The Gateway must also use IAM authentication: the agent signs its requests with SigV4 using its own execution role. The generator rejects Cognito-authenticated gateways.
+
+:::note[One direction per Gateway]
+A single Gateway cannot both be called by an agent and front one. Fronting agent runtimes needs `protocol: http` (see <Link path="guides/connection/agentcore-gateway-agent">Gateway to Agent</Link>), whereas being called by an agent needs `protocol: mcp`. Use a separate Gateway for each direction.
+:::
 
 ## Usage
 

--- a/docs/src/content/docs/es/guides/connection/py-agent-gateway.mdx
+++ b/docs/src/content/docs/es/guides/connection/py-agent-gateway.mdx
@@ -21,9 +21,13 @@ El generador configura el agente para que se autentique en el Gateway con IAM Si
 Antes de usar este generador, asegúrate de tener:
 
 1. Un proyecto Python con un componente <Link path="guides/py-agent">Agent</Link> (`infra: agentcore`)
-2. Un proyecto <Link path="guides/agentcore-gateway">`agentcore-gateway`</Link> con `auth: iam`
+2. Un proyecto <Link path="guides/agentcore-gateway">`agentcore-gateway`</Link> con `protocol: mcp` y `auth: iam`
 
-El Gateway debe usar autenticación IAM — el agente firma sus solicitudes con SigV4 usando su propio rol de ejecución. El generador rechaza gateways autenticados con Cognito.
+El Gateway debe servir el protocolo `mcp` — el agente lo alcanza como un cliente MCP, por lo que sus targets se exponen como herramientas. El Gateway también debe usar autenticación IAM: el agente firma sus solicitudes con SigV4 usando su propio rol de ejecución. El generador rechaza gateways autenticados con Cognito.
+
+:::note[Una dirección por Gateway]
+Un solo Gateway no puede ser llamado por un agente y frontar uno al mismo tiempo. Frontar runtimes de agente necesita `protocol: http` (ver <Link path="guides/connection/agentcore-gateway-agent">Gateway a Agent</Link>), mientras que ser llamado por un agente necesita `protocol: mcp`. Usa un Gateway separado para cada dirección.
+:::
 
 ## Uso
 

--- a/docs/src/content/docs/es/guides/connection/ts-agent-gateway.mdx
+++ b/docs/src/content/docs/es/guides/connection/ts-agent-gateway.mdx
@@ -21,9 +21,13 @@ El generador configura el agente para que se autentique en el Gateway con IAM Si
 Antes de usar este generador, asegúrate de tener:
 
 1. Un proyecto TypeScript con un componente <Link path="guides/ts-agent">Agent</Link> (`infra: agentcore`)
-2. Un proyecto <Link path="guides/agentcore-gateway">`agentcore-gateway`</Link> con `auth: iam`
+2. Un proyecto <Link path="guides/agentcore-gateway">`agentcore-gateway`</Link> con `protocol: mcp` y `auth: iam`
 
-El Gateway debe usar autenticación IAM — el agente firma sus solicitudes con SigV4 usando su propio rol de ejecución. El generador rechaza gateways autenticados con Cognito.
+El Gateway debe servir el protocolo `mcp` — el agente lo alcanza como un cliente MCP, por lo que sus targets se exponen como herramientas. El Gateway también debe usar autenticación IAM: el agente firma sus solicitudes con SigV4 usando su propio rol de ejecución. El generador rechaza gateways autenticados con Cognito.
+
+:::note[Una dirección por Gateway]
+Un solo Gateway no puede ser llamado por un agente y frontar uno al mismo tiempo. Frontar runtimes de agente necesita `protocol: http` (ver <Link path="guides/connection/agentcore-gateway-agent">Gateway a Agente</Link>), mientras que ser llamado por un agente necesita `protocol: mcp`. Usa un Gateway separado para cada dirección.
+:::
 
 ## Uso
 

--- a/docs/src/content/docs/fr/guides/connection/py-agent-gateway.mdx
+++ b/docs/src/content/docs/fr/guides/connection/py-agent-gateway.mdx
@@ -21,9 +21,13 @@ Le générateur configure l'agent pour qu'il s'authentifie auprès de la Gateway
 Avant d'utiliser ce générateur, assurez-vous d'avoir :
 
 1. Un projet Python avec un composant <Link path="guides/py-agent">Agent</Link> (`infra: agentcore`)
-2. Un projet <Link path="guides/agentcore-gateway">`agentcore-gateway`</Link> avec `auth: iam`
+2. Un projet <Link path="guides/agentcore-gateway">`agentcore-gateway`</Link> avec `protocol: mcp` et `auth: iam`
 
-La Gateway doit utiliser l'authentification IAM — l'agent signe ses requêtes avec SigV4 en utilisant son propre rôle d'exécution. Le générateur rejette les gateways authentifiées par Cognito.
+La Gateway doit servir le protocole `mcp` — l'agent l'atteint en tant que client MCP, de sorte que ses cibles sont exposées en tant qu'outils. La Gateway doit également utiliser l'authentification IAM : l'agent signe ses requêtes avec SigV4 en utilisant son propre rôle d'exécution. Le générateur rejette les gateways authentifiées par Cognito.
+
+:::note[Une direction par Gateway]
+Une seule Gateway ne peut pas à la fois être appelée par un agent et en fronter un. Fronter des runtimes d'agent nécessite `protocol: http` (voir <Link path="guides/connection/agentcore-gateway-agent">Gateway vers Agent</Link>), tandis qu'être appelée par un agent nécessite `protocol: mcp`. Utilisez une Gateway distincte pour chaque direction.
+:::
 
 ## Utilisation
 

--- a/docs/src/content/docs/fr/guides/connection/ts-agent-gateway.mdx
+++ b/docs/src/content/docs/fr/guides/connection/ts-agent-gateway.mdx
@@ -21,9 +21,13 @@ Le générateur configure l'agent pour qu'il s'authentifie auprès de la Gateway
 Avant d'utiliser ce générateur, assurez-vous d'avoir :
 
 1. Un projet TypeScript avec un composant <Link path="guides/ts-agent">Agent</Link> (`infra: agentcore`)
-2. Un projet <Link path="guides/agentcore-gateway">`agentcore-gateway`</Link> avec `auth: iam`
+2. Un projet <Link path="guides/agentcore-gateway">`agentcore-gateway`</Link> avec `protocol: mcp` et `auth: iam`
 
-La Gateway doit utiliser l'authentification IAM — l'agent signe ses requêtes avec SigV4 en utilisant son propre rôle d'exécution. Le générateur rejette les gateways authentifiées par Cognito.
+La Gateway doit servir le protocole `mcp` — l'agent l'atteint en tant que client MCP, de sorte que ses cibles sont exposées en tant qu'outils. La Gateway doit également utiliser l'authentification IAM : l'agent signe ses requêtes avec SigV4 en utilisant son propre rôle d'exécution. Le générateur rejette les gateways authentifiées par Cognito.
+
+:::note[Une direction par Gateway]
+Une seule Gateway ne peut pas à la fois être appelée par un agent et en fronter un. Fronter des runtimes d'agent nécessite `protocol: http` (voir <Link path="guides/connection/agentcore-gateway-agent">Gateway vers Agent</Link>), tandis qu'être appelé par un agent nécessite `protocol: mcp`. Utilisez une Gateway distincte pour chaque direction.
+:::
 
 ## Utilisation
 

--- a/docs/src/content/docs/it/guides/connection/py-agent-gateway.mdx
+++ b/docs/src/content/docs/it/guides/connection/py-agent-gateway.mdx
@@ -21,9 +21,13 @@ Il generatore configura l'agent in modo che si autentichi al Gateway con IAM Sig
 Prima di utilizzare questo generatore, assicurati di avere:
 
 1. Un progetto Python con un componente <Link path="guides/py-agent">Agent</Link> (`infra: agentcore`)
-2. Un progetto <Link path="guides/agentcore-gateway">`agentcore-gateway`</Link> con `auth: iam`
+2. Un progetto <Link path="guides/agentcore-gateway">`agentcore-gateway`</Link> con `protocol: mcp` e `auth: iam`
 
-Il Gateway deve utilizzare l'autenticazione IAM — l'agent firma le sue richieste con SigV4 utilizzando il proprio ruolo di esecuzione. Il generatore rifiuta i gateway autenticati con Cognito.
+Il Gateway deve servire il protocollo `mcp` — l'agent lo raggiunge come client MCP, quindi i suoi target sono esposti come strumenti. Il Gateway deve anche utilizzare l'autenticazione IAM: l'agent firma le sue richieste con SigV4 utilizzando il proprio ruolo di esecuzione. Il generatore rifiuta i gateway autenticati con Cognito.
+
+:::note[Una direzione per Gateway]
+Un singolo Gateway non può essere sia chiamato da un agent che fronteggiarne uno. Fronteggiare i runtime degli agent richiede `protocol: http` (vedi <Link path="guides/connection/agentcore-gateway-agent">Gateway a Agent</Link>), mentre essere chiamato da un agent richiede `protocol: mcp`. Utilizza un Gateway separato per ogni direzione.
+:::
 
 ## Utilizzo
 

--- a/docs/src/content/docs/it/guides/connection/ts-agent-gateway.mdx
+++ b/docs/src/content/docs/it/guides/connection/ts-agent-gateway.mdx
@@ -21,9 +21,13 @@ Il generatore configura l'agent in modo che si autentichi al Gateway con IAM Sig
 Prima di utilizzare questo generatore, assicurati di avere:
 
 1. Un progetto TypeScript con un componente <Link path="guides/ts-agent">Agent</Link> (`infra: agentcore`)
-2. Un progetto <Link path="guides/agentcore-gateway">`agentcore-gateway`</Link> con `auth: iam`
+2. Un progetto <Link path="guides/agentcore-gateway">`agentcore-gateway`</Link> con `protocol: mcp` e `auth: iam`
 
-Il Gateway deve utilizzare l'autenticazione IAM — l'agent firma le sue richieste con SigV4 utilizzando il proprio ruolo di esecuzione. Il generatore rifiuta i gateway autenticati con Cognito.
+Il Gateway deve servire il protocollo `mcp` — l'agent lo raggiunge come client MCP, quindi i suoi target sono esposti come tool. Il Gateway deve anche utilizzare l'autenticazione IAM: l'agent firma le sue richieste con SigV4 utilizzando il proprio ruolo di esecuzione. Il generatore rifiuta i gateway autenticati con Cognito.
+
+:::note[Una direzione per Gateway]
+Un singolo Gateway non può essere sia chiamato da un agent che fronteggiarne uno. Fronteggiare runtime agent richiede `protocol: http` (vedi <Link path="guides/connection/agentcore-gateway-agent">Gateway a Agent</Link>), mentre essere chiamato da un agent richiede `protocol: mcp`. Utilizza un Gateway separato per ogni direzione.
+:::
 
 ## Utilizzo
 

--- a/docs/src/content/docs/jp/guides/connection/py-agent-gateway.mdx
+++ b/docs/src/content/docs/jp/guides/connection/py-agent-gateway.mdx
@@ -21,9 +21,13 @@ import Infrastructure from '@components/infrastructure.astro';
 このジェネレーターを使用する前に、以下を確認してください：
 
 1. <Link path="guides/py-agent">Agent</Link> コンポーネント（`infra: agentcore`）を持つ Python プロジェクト
-2. `auth: iam` を持つ <Link path="guides/agentcore-gateway">`agentcore-gateway`</Link> プロジェクト
+2. `protocol: mcp` と `auth: iam` を持つ <Link path="guides/agentcore-gateway">`agentcore-gateway`</Link> プロジェクト
 
-Gateway は IAM 認証を使用する必要があります — エージェントは自身の実行ロールを使用して SigV4 でリクエストに署名します。ジェネレーターは Cognito 認証のゲートウェイを拒否します。
+Gateway は `mcp` プロトコルを提供する必要があります — エージェントは MCP クライアントとして Gateway に到達するため、そのターゲットはツールとして公開されます。Gateway は IAM 認証も使用する必要があります：エージェントは自身の実行ロールを使用して SigV4 でリクエストに署名します。ジェネレーターは Cognito 認証のゲートウェイを拒否します。
+
+:::note[Gateway ごとに一方向]
+単一の Gateway は、エージェントによって呼び出されることと、エージェントをフロントすることの両方を行うことはできません。エージェントランタイムをフロントするには `protocol: http` が必要です（<Link path="guides/connection/agentcore-gateway-agent">Gateway から Agent への接続</Link>を参照）が、エージェントによって呼び出されるには `protocol: mcp` が必要です。各方向に対して別々の Gateway を使用してください。
+:::
 
 ## 使用方法
 

--- a/docs/src/content/docs/jp/guides/connection/ts-agent-gateway.mdx
+++ b/docs/src/content/docs/jp/guides/connection/ts-agent-gateway.mdx
@@ -21,9 +21,13 @@ import Infrastructure from '@components/infrastructure.astro';
 このジェネレーターを使用する前に、以下を確認してください：
 
 1. <Link path="guides/ts-agent">Agent</Link> コンポーネント（`infra: agentcore`）を持つ TypeScript プロジェクト
-2. `auth: iam` を持つ <Link path="guides/agentcore-gateway">`agentcore-gateway`</Link> プロジェクト
+2. `protocol: mcp` と `auth: iam` を持つ <Link path="guides/agentcore-gateway">`agentcore-gateway`</Link> プロジェクト
 
-Gateway は IAM 認証を使用する必要があります — エージェントは自身の実行ロールを使用して SigV4 でリクエストに署名します。ジェネレーターは Cognito 認証のゲートウェイを拒否します。
+Gateway は `mcp` プロトコルを提供する必要があります — エージェントは MCP クライアントとしてそれに到達するため、そのターゲットはツールとして公開されます。Gateway は IAM 認証も使用する必要があります：エージェントは自身の実行ロールを使用して SigV4 でリクエストに署名します。ジェネレーターは Cognito 認証のゲートウェイを拒否します。
+
+:::note[Gateway ごとに一方向]
+単一の Gateway は、エージェントによって呼び出されることと、エージェントをフロントすることの両方を行うことはできません。エージェントランタイムをフロントするには `protocol: http` が必要です（<Link path="guides/connection/agentcore-gateway-agent">Gateway to Agent</Link> を参照）が、エージェントによって呼び出されるには `protocol: mcp` が必要です。各方向に対して別々の Gateway を使用してください。
+:::
 
 ## 使用方法
 

--- a/docs/src/content/docs/ko/guides/connection/py-agent-gateway.mdx
+++ b/docs/src/content/docs/ko/guides/connection/py-agent-gateway.mdx
@@ -21,9 +21,13 @@ import Infrastructure from '@components/infrastructure.astro';
 이 생성기를 사용하기 전에 다음이 필요합니다:
 
 1. <Link path="guides/py-agent">Agent</Link> 컴포넌트(`infra: agentcore`)가 있는 Python 프로젝트
-2. `auth: iam`이 설정된 <Link path="guides/agentcore-gateway">`agentcore-gateway`</Link> 프로젝트
+2. `protocol: mcp` 및 `auth: iam`이 설정된 <Link path="guides/agentcore-gateway">`agentcore-gateway`</Link> 프로젝트
 
-Gateway는 IAM 인증을 사용해야 합니다 — 에이전트는 자체 실행 역할을 사용하여 SigV4로 요청에 서명합니다. 생성기는 Cognito 인증 게이트웨이를 거부합니다.
+Gateway는 `mcp` 프로토콜을 제공해야 합니다 — 에이전트는 MCP 클라이언트로서 Gateway에 도달하므로 대상이 도구로 노출됩니다. Gateway는 또한 IAM 인증을 사용해야 합니다: 에이전트는 자체 실행 역할을 사용하여 SigV4로 요청에 서명합니다. 생성기는 Cognito 인증 게이트웨이를 거부합니다.
+
+:::note[Gateway당 하나의 방향]
+단일 Gateway는 에이전트에 의해 호출되는 동시에 에이전트를 프론트할 수 없습니다. 에이전트 런타임을 프론트하려면 `protocol: http`가 필요하고(<Link path="guides/connection/agentcore-gateway-agent">Gateway에서 Agent로</Link> 참조), 에이전트에 의해 호출되려면 `protocol: mcp`가 필요합니다. 각 방향에 대해 별도의 Gateway를 사용하세요.
+:::
 
 ## 사용법
 

--- a/docs/src/content/docs/ko/guides/connection/ts-agent-gateway.mdx
+++ b/docs/src/content/docs/ko/guides/connection/ts-agent-gateway.mdx
@@ -21,9 +21,13 @@ import Infrastructure from '@components/infrastructure.astro';
 이 생성기를 사용하기 전에 다음이 필요합니다:
 
 1. <Link path="guides/ts-agent">Agent</Link> 컴포넌트(`infra: agentcore`)가 있는 TypeScript 프로젝트
-2. `auth: iam`이 설정된 <Link path="guides/agentcore-gateway">`agentcore-gateway`</Link> 프로젝트
+2. `protocol: mcp` 및 `auth: iam`이 설정된 <Link path="guides/agentcore-gateway">`agentcore-gateway`</Link> 프로젝트
 
-Gateway는 IAM 인증을 사용해야 합니다 — 에이전트는 자체 실행 역할을 사용하여 SigV4로 요청에 서명합니다. 생성기는 Cognito 인증 게이트웨이를 거부합니다.
+Gateway는 `mcp` 프로토콜을 제공해야 합니다 — 에이전트는 MCP 클라이언트로서 Gateway에 접근하므로 Gateway의 타겟이 도구로 노출됩니다. Gateway는 또한 IAM 인증을 사용해야 합니다: 에이전트는 자체 실행 역할을 사용하여 SigV4로 요청에 서명합니다. 생성기는 Cognito 인증 게이트웨이를 거부합니다.
+
+:::note[Gateway당 하나의 방향]
+단일 Gateway는 에이전트에 의해 호출되는 동시에 에이전트를 프론트할 수 없습니다. 에이전트 런타임을 프론트하려면 `protocol: http`가 필요하고(<Link path="guides/connection/agentcore-gateway-agent">Gateway to Agent</Link> 참조), 에이전트에 의해 호출되려면 `protocol: mcp`가 필요합니다. 각 방향에 대해 별도의 Gateway를 사용하세요.
+:::
 
 ## 사용법
 

--- a/docs/src/content/docs/pt/guides/connection/py-agent-gateway.mdx
+++ b/docs/src/content/docs/pt/guides/connection/py-agent-gateway.mdx
@@ -21,9 +21,13 @@ O gerador configura o agente para que ele se autentique no Gateway com IAM SigV4
 Antes de usar este gerador, certifique-se de ter:
 
 1. Um projeto Python com um componente <Link path="guides/py-agent">Agent</Link> (`infra: agentcore`)
-2. Um projeto <Link path="guides/agentcore-gateway">`agentcore-gateway`</Link> com `auth: iam`
+2. Um projeto <Link path="guides/agentcore-gateway">`agentcore-gateway`</Link> com `protocol: mcp` e `auth: iam`
 
-O Gateway deve usar autenticação IAM — o agente assina suas requisições com SigV4 usando sua própria função de execução. O gerador rejeita gateways autenticados com Cognito.
+O Gateway deve servir o protocolo `mcp` — o agente o alcança como um cliente MCP, então seus alvos são expostos como ferramentas. O Gateway também deve usar autenticação IAM: o agente assina suas requisições com SigV4 usando sua própria função de execução. O gerador rejeita gateways autenticados com Cognito.
+
+:::note[Uma direção por Gateway]
+Um único Gateway não pode ser chamado por um agente e frontar um ao mesmo tempo. Frontar runtimes de agente precisa de `protocol: http` (veja <Link path="guides/connection/agentcore-gateway-agent">Gateway para Agent</Link>), enquanto ser chamado por um agente precisa de `protocol: mcp`. Use um Gateway separado para cada direção.
+:::
 
 ## Uso
 

--- a/docs/src/content/docs/pt/guides/connection/ts-agent-gateway.mdx
+++ b/docs/src/content/docs/pt/guides/connection/ts-agent-gateway.mdx
@@ -21,9 +21,13 @@ O gerador configura o agente para que ele autentique no Gateway com IAM SigV4 qu
 Antes de usar este gerador, certifique-se de ter:
 
 1. Um projeto TypeScript com um componente <Link path="guides/ts-agent">Agent</Link> (`infra: agentcore`)
-2. Um projeto <Link path="guides/agentcore-gateway">`agentcore-gateway`</Link> com `auth: iam`
+2. Um projeto <Link path="guides/agentcore-gateway">`agentcore-gateway`</Link> com `protocol: mcp` e `auth: iam`
 
-O Gateway deve usar autenticação IAM — o agente assina suas requisições com SigV4 usando sua própria função de execução. O gerador rejeita gateways autenticados com Cognito.
+O Gateway deve servir o protocolo `mcp` — o agente o alcança como um cliente MCP, então seus targets são expostos como ferramentas. O Gateway também deve usar autenticação IAM: o agente assina suas requisições com SigV4 usando sua própria função de execução. O gerador rejeita gateways autenticados com Cognito.
+
+:::note[Uma direção por Gateway]
+Um único Gateway não pode ser chamado por um agente e frontar um ao mesmo tempo. Frontar runtimes de agente precisa de `protocol: http` (veja <Link path="guides/connection/agentcore-gateway-agent">Gateway para Agent</Link>), enquanto ser chamado por um agente precisa de `protocol: mcp`. Use um Gateway separado para cada direção.
+:::
 
 ## Uso
 

--- a/docs/src/content/docs/vi/guides/connection/py-agent-gateway.mdx
+++ b/docs/src/content/docs/vi/guides/connection/py-agent-gateway.mdx
@@ -21,9 +21,13 @@ Trình tạo kết nối agent để nó xác thực với Gateway bằng IAM Si
 Trước khi sử dụng trình tạo này, hãy đảm bảo bạn có:
 
 1. Một dự án Python với thành phần <Link path="guides/py-agent">Agent</Link> (`infra: agentcore`)
-2. Một dự án <Link path="guides/agentcore-gateway">`agentcore-gateway`</Link> với `auth: iam`
+2. Một dự án <Link path="guides/agentcore-gateway">`agentcore-gateway`</Link> với `protocol: mcp` và `auth: iam`
 
-Gateway phải sử dụng xác thực IAM — agent ký các yêu cầu của nó bằng SigV4 sử dụng vai trò thực thi của chính nó. Trình tạo từ chối các gateway được xác thực bằng Cognito.
+Gateway phải phục vụ giao thức `mcp` — agent tiếp cận nó như một MCP client, vì vậy các target của nó được hiển thị dưới dạng công cụ. Gateway cũng phải sử dụng xác thực IAM: agent ký các yêu cầu của nó bằng SigV4 sử dụng vai trò thực thi của chính nó. Trình tạo từ chối các gateway được xác thực bằng Cognito.
+
+:::note[Một hướng cho mỗi Gateway]
+Một Gateway duy nhất không thể vừa được gọi bởi một agent vừa đứng trước một agent. Đứng trước các agent runtime cần `protocol: http` (xem <Link path="guides/connection/agentcore-gateway-agent">Gateway to Agent</Link>), trong khi được gọi bởi một agent cần `protocol: mcp`. Sử dụng một Gateway riêng biệt cho mỗi hướng.
+:::
 
 ## Cách sử dụng
 

--- a/docs/src/content/docs/vi/guides/connection/ts-agent-gateway.mdx
+++ b/docs/src/content/docs/vi/guides/connection/ts-agent-gateway.mdx
@@ -21,9 +21,13 @@ Generator này kết nối agent để nó xác thực với Gateway bằng IAM 
 Trước khi sử dụng generator này, hãy đảm bảo bạn có:
 
 1. Một dự án TypeScript với thành phần <Link path="guides/ts-agent">Agent</Link> (`infra: agentcore`)
-2. Một dự án <Link path="guides/agentcore-gateway">`agentcore-gateway`</Link> với `auth: iam`
+2. Một dự án <Link path="guides/agentcore-gateway">`agentcore-gateway`</Link> với `protocol: mcp` và `auth: iam`
 
-Gateway phải sử dụng xác thực IAM — agent ký các yêu cầu của nó bằng SigV4 sử dụng vai trò thực thi của chính nó. Generator sẽ từ chối các gateway được xác thực bằng Cognito.
+Gateway phải phục vụ giao thức `mcp` — agent tiếp cận nó như một MCP client, vì vậy các target của nó được hiển thị dưới dạng công cụ. Gateway cũng phải sử dụng xác thực IAM: agent ký các yêu cầu của nó bằng SigV4 sử dụng vai trò thực thi của chính nó. Generator sẽ từ chối các gateway được xác thực bằng Cognito.
+
+:::note[Một hướng cho mỗi Gateway]
+Một Gateway duy nhất không thể vừa được gọi bởi một agent vừa đứng trước một agent. Đứng trước các agent runtime cần `protocol: http` (xem <Link path="guides/connection/agentcore-gateway-agent">Gateway to Agent</Link>), trong khi được gọi bởi một agent cần `protocol: mcp`. Sử dụng một Gateway riêng biệt cho mỗi hướng.
+:::
 
 ## Cách sử dụng
 

--- a/docs/src/content/docs/zh/guides/connection/py-agent-gateway.mdx
+++ b/docs/src/content/docs/zh/guides/connection/py-agent-gateway.mdx
@@ -21,9 +21,13 @@ import Infrastructure from '@components/infrastructure.astro';
 在使用此生成器之前，请确保您具备：
 
 1. 一个包含 <Link path="guides/py-agent">Agent</Link> 组件的 Python 项目（`infra: agentcore`）
-2. 一个使用 `auth: iam` 的 <Link path="guides/agentcore-gateway">`agentcore-gateway`</Link> 项目
+2. 一个使用 `protocol: mcp` 和 `auth: iam` 的 <Link path="guides/agentcore-gateway">`agentcore-gateway`</Link> 项目
 
-Gateway 必须使用 IAM 身份验证 — agent 使用其自己的执行角色通过 SigV4 签名其请求。生成器会拒绝使用 Cognito 身份验证的 gateway。
+Gateway 必须提供 `mcp` 协议 — agent 作为 MCP 客户端访问它，因此其目标会作为工具公开。Gateway 还必须使用 IAM 身份验证：agent 使用其自己的执行角色通过 SigV4 签名其请求。生成器会拒绝使用 Cognito 身份验证的 gateway。
+
+:::note[每个 Gateway 一个方向]
+单个 Gateway 不能同时被 agent 调用和作为 agent 的前端。作为 agent 运行时的前端需要 `protocol: http`（参见 <Link path="guides/connection/agentcore-gateway-agent">Gateway 到 Agent</Link>），而被 agent 调用则需要 `protocol: mcp`。请为每个方向使用单独的 Gateway。
+:::
 
 ## 用法
 

--- a/docs/src/content/docs/zh/guides/connection/ts-agent-gateway.mdx
+++ b/docs/src/content/docs/zh/guides/connection/ts-agent-gateway.mdx
@@ -21,9 +21,13 @@ import Infrastructure from '@components/infrastructure.astro';
 在使用此生成器之前，请确保您具有：
 
 1. 一个带有 <Link path="guides/ts-agent">Agent</Link> 组件的 TypeScript 项目（`infra: agentcore`）
-2. 一个带有 `auth: iam` 的 <Link path="guides/agentcore-gateway">`agentcore-gateway`</Link> 项目
+2. 一个带有 `protocol: mcp` 和 `auth: iam` 的 <Link path="guides/agentcore-gateway">`agentcore-gateway`</Link> 项目
 
-Gateway 必须使用 IAM 身份验证 — agent 使用其自己的执行角色通过 SigV4 对请求进行签名。生成器会拒绝使用 Cognito 身份验证的网关。
+Gateway 必须提供 `mcp` 协议 — agent 作为 MCP 客户端访问它，因此其目标会作为工具公开。Gateway 还必须使用 IAM 身份验证：agent 使用其自己的执行角色通过 SigV4 对请求进行签名。生成器会拒绝使用 Cognito 身份验证的网关。
+
+:::note[每个 Gateway 一个方向]
+单个 Gateway 不能同时被 agent 调用和作为 agent 的前端。作为 agent 运行时的前端需要 `protocol: http`（参见 <Link path="guides/connection/agentcore-gateway-agent">Gateway 到 Agent</Link>），而被 agent 调用则需要 `protocol: mcp`。为每个方向使用单独的 Gateway。
+:::
 
 ## 用法
 

--- a/packages/nx-plugin/src/connection/catalog-guard-parity.spec.ts
+++ b/packages/nx-plugin/src/connection/catalog-guard-parity.spec.ts
@@ -1,0 +1,182 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Tree } from '@nx/devkit';
+import { agentcoreGatewayGenerator } from '../sdk/agentcore-gateway';
+import { connectionGenerator } from '../sdk/connection';
+import { pyAgentGenerator, pyProjectGenerator } from '../sdk/py';
+import { tsAgentGenerator, tsProjectGenerator } from '../sdk/ts';
+import {
+  ensureAwsNxPluginConfig,
+  updateAwsNxPluginConfig,
+} from '../utils/config/utils';
+import { createTreeUsingTsSolutionSetup } from '../utils/test';
+import { CONNECTION_CONSTRAINTS } from './scaffold-catalog';
+
+/**
+ * `CONNECTION_CONSTRAINTS` exists so a caller choosing options up front — the
+ * docs graph builder — can check them before emitting commands. That only holds
+ * while each entry matches the guard its connection generator actually
+ * enforces, and the drift is invisible to a test that reads the catalog alone:
+ * a missing entry lets the builder emit a command that throws, and a stale
+ * entry makes it reject a topology that works.
+ *
+ * These tests pin the two agent/gateway rules by running the generators, so
+ * either kind of drift fails here.
+ */
+describe('catalog guard parity', () => {
+  const setup = async (): Promise<Tree> => {
+    const tree = createTreeUsingTsSolutionSetup();
+    await ensureAwsNxPluginConfig(tree);
+    await updateAwsNxPluginConfig(tree, { iac: { provider: 'cdk' } });
+    await tsProjectGenerator(tree, {
+      name: 'ts-host',
+      directory: 'packages',
+      preferInstallDependencies: false,
+    });
+    await pyProjectGenerator(tree, {
+      name: 'py-host',
+      directory: 'packages',
+      type: 'application',
+      preferInstallDependencies: false,
+    });
+    return tree;
+  };
+
+  const gateway = (tree: Tree, name: string, protocol: string, auth: string) =>
+    agentcoreGatewayGenerator(tree, {
+      name,
+      directory: 'packages',
+      protocol: protocol as never,
+      auth: auth as never,
+      cedarPolicy: false,
+      infra: 'agentcore',
+      iac: 'inherit',
+      preferInstallDependencies: false,
+    });
+
+  const tsAgent = (tree: Tree, name: string, protocol: string, auth: string) =>
+    tsAgentGenerator(tree, {
+      project: 'ts-host',
+      name,
+      framework: 'strands',
+      protocol: protocol as never,
+      auth: auth as never,
+      infra: 'agentcore',
+      session: 'in-memory',
+      iac: 'inherit',
+      preferInstallDependencies: false,
+    });
+
+  const pyAgent = (tree: Tree, name: string, protocol: string, auth: string) =>
+    pyAgentGenerator(tree, {
+      project: 'py_host',
+      name,
+      framework: 'strands',
+      protocol: protocol as never,
+      auth: auth as never,
+      infra: 'agentcore',
+      session: 'in-memory',
+      iac: 'inherit',
+      preferInstallDependencies: false,
+    });
+
+  const constraintsFor = (key: string) =>
+    (CONNECTION_CONSTRAINTS as Record<string, readonly any[]>)[key] ?? [];
+
+  describe('agent -> gateway requires an mcp gateway', () => {
+    // The generators reject a non-mcp gateway, so the catalog has to say so —
+    // otherwise the builder emits a command that dies after creating projects.
+    it.each([
+      ['ts#agent -> agentcore-gateway'],
+      ['py#agent -> agentcore-gateway'],
+    ])('is declared for %s', (key) => {
+      expect(constraintsFor(key)).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            side: 'target',
+            option: 'protocol',
+            equals: 'mcp',
+          }),
+        ]),
+      );
+    });
+
+    it('is enforced by the ts#agent generator', async () => {
+      const tree = await setup();
+      await tsAgent(tree, 'tool-agent', 'ag-ui', 'iam');
+      await gateway(tree, 'http-gw', 'http', 'iam');
+
+      await expect(
+        connectionGenerator(tree, {
+          sourceProject: 'ts-host',
+          sourceComponent: 'tool-agent',
+          targetProject: 'http-gw',
+          preferInstallDependencies: false,
+        }),
+      ).rejects.toThrow(/Only MCP-protocol gateways are supported/);
+    });
+
+    it('is enforced by the py#agent generator', async () => {
+      const tree = await setup();
+      await pyAgent(tree, 'tool-agent', 'ag-ui', 'iam');
+      await gateway(tree, 'http-gw', 'http', 'iam');
+
+      await expect(
+        connectionGenerator(tree, {
+          sourceProject: 'py_host',
+          sourceComponent: 'tool-agent',
+          targetProject: 'http-gw',
+          preferInstallDependencies: false,
+        }),
+      ).rejects.toThrow(/Only MCP-protocol gateways are supported/);
+    });
+  });
+
+  describe('gateway -> agent accepts a cognito agent', () => {
+    // A gateway fronts a cognito agent by forwarding the caller's JWT, so
+    // pinning the agent to IAM would rule out a topology that works.
+    it.each([
+      ['agentcore-gateway -> ts#agent'],
+      ['agentcore-gateway -> py#agent'],
+    ])('is not constrained to iam for %s', (key) => {
+      expect(
+        constraintsFor(key).filter(
+          (c) => c.side === 'target' && c.option === 'auth',
+        ),
+      ).toEqual([]);
+    });
+
+    it('connects a cognito ts#agent behind a gateway', async () => {
+      const tree = await setup();
+      await gateway(tree, 'http-gw', 'http', 'iam');
+      await tsAgent(tree, 'cog-agent', 'ag-ui', 'cognito');
+
+      await expect(
+        connectionGenerator(tree, {
+          sourceProject: 'http-gw',
+          targetProject: 'ts-host',
+          targetComponent: 'cog-agent',
+          preferInstallDependencies: false,
+        }),
+      ).resolves.toBeDefined();
+    });
+
+    it('connects a cognito py#agent behind a gateway', async () => {
+      const tree = await setup();
+      await gateway(tree, 'http-gw', 'http', 'iam');
+      await pyAgent(tree, 'cog-agent', 'ag-ui', 'cognito');
+
+      await expect(
+        connectionGenerator(tree, {
+          sourceProject: 'http-gw',
+          targetProject: 'py_host',
+          targetComponent: 'cog-agent',
+          preferInstallDependencies: false,
+        }),
+      ).resolves.toBeDefined();
+    });
+  });
+});

--- a/packages/nx-plugin/src/connection/scaffold-catalog.ts
+++ b/packages/nx-plugin/src/connection/scaffold-catalog.ts
@@ -339,6 +339,13 @@ const AGENT_TO_GATEWAY: readonly ConnectionConstraint[] = [
     equals: 'iam',
     reason: 'Agent connections require the gateway to authenticate with IAM.',
   },
+  {
+    side: 'target',
+    option: 'protocol',
+    equals: 'mcp',
+    reason:
+      'An agent reaches a gateway as an MCP client, so the gateway must serve the mcp protocol. Note a single gateway cannot both front an agent and be called by one, since fronting requires the http protocol.',
+  },
 ];
 
 const GATEWAY_TO_MCP: readonly ConnectionConstraint[] = [
@@ -364,12 +371,6 @@ const GATEWAY_TO_AGENT: readonly ConnectionConstraint[] = [
     equals: 'http',
     reason:
       'Agent runtime targets can only be attached to an http-protocol gateway.',
-  },
-  {
-    side: 'target',
-    option: 'auth',
-    equals: 'iam',
-    reason: 'The gateway signs requests to its agent targets with IAM.',
   },
 ];
 


### PR DESCRIPTION
### Reason for this change

`CONNECTION_CONSTRAINTS` in `scaffold-catalog.ts` exists for the docs graph builder, which reads it to promise that *a graph it accepts is a graph that scaffolds*. Two of its agent/gateway entries had drifted from the guards the connection generators enforce — in opposite directions, so each broke that promise differently.

**The generators themselves are correct.** Only the catalogue the builder reads was wrong, which is why this is `docs:` rather than `fix:` — no generated code or product behaviour changes.

This is theme (2) from the bug bash reported in #1112. The drift class is only findable by executing both sides: the existing catalogue test checks that a constrained option exists and that its value is in the schema enum, but never that a generator agrees.

**A missing rule.** Both agent → gateway generators require the gateway to serve the `mcp` protocol, but the catalogue declared only the two `auth` rules. The builder validated an agent → `http` gateway graph clean (`issues: []`) and emitted a script whose final `connection` command threw `Gateway 'gw' has protocol='http'. Only MCP-protocol gateways are supported` — *after* the projects had already been created. The bidirectional case was worse, because the builder's own auto-fix sets the gateway to `http` in order to attach the agent, actively steering users into it.

**A rule that does not exist.** The catalogue pinned a gateway's agent target to `auth: iam`, so the builder hard-errored on a Cognito agent behind a gateway (`a: auth must be 'iam' for this connection`) with no auto-fix available. The generator deliberately accepts both, and says so in its own comment: an IAM agent is invoked with the gateway's own role, a Cognito one has the caller's JWT forwarded. The vended `addAgent` backs the implementation, picking `credentials: agent.auth === 'cognito' ? 'jwt-passthrough' : 'gateway-iam'` — so the catalogue was the stale side, and `agentcore-gateway-agent.mdx` already documented Cognito as supported.

### Description of changes

- **`docs(connection)`: catalogue** — adds the `target protocol = mcp` constraint to `AGENT_TO_GATEWAY`, and drops the `target auth = iam` constraint from `GATEWAY_TO_AGENT`. The agent schema's `auth` enum is exactly `iam | cognito` and the generator accepts both, so the constraint is removed rather than rewritten (expressing "one of" would need a shape `ConnectionConstraint` does not have).

  Adding the `mcp` rule makes the two agent↔gateway directions mutually exclusive, which is the real product constraint: **one gateway cannot both front an agent and be called by one.** That is now surfaced while drawing rather than emitted — verified that both the single-edge and bidirectional graphs report an error naming both protocols, and that the auto-fix does not fight it (`mcp` is already the gateway default, so attaching an agent *to* a gateway needs no fix).

- **`docs(connection)`: guides** — the `ts-agent-gateway` / `py-agent-gateway` guides listed only `auth: iam` as the gateway prerequisite, so following either page with a gateway on another protocol failed at the connection step. Both now name the protocol and note that a gateway serves one direction only.

- **`docs: update translations`** — generated locally with `scripts/translate.ts` and committed here, so merging this does not trigger a translation-bot commit and a CI restart.

### Description of how you validated changes

- **A new test pins both rules by running the generators**, and I confirmed it fails against the current catalogue *before* the change: the 4 generator-behaviour assertions passed while all 4 catalogue assertions failed, which is what establishes the catalogue as the stale side rather than the code. After the change, 8/8 pass.
- **Full plugin suite green: 198 files, 3707 tests.** `docs:test` green: 124 tests. Formatting clean.
- Verified all 16 translated files contain both changes, with code tokens, `<Link>` paths and `:::note` syntax preserved.

Worth flagging for review: dropping the `auth` constraint is the narrow change, but the underlying `ConnectionConstraint` shape cannot express "one of a set", which is why a genuine `iam | cognito` rule has to be modelled as *no* rule. If you would rather it stayed explicit, adding a `oneOf` field is a small change I'm happy to make instead. The finding also suggested a broader integration test that, for every `CONNECTION_CONSTRAINTS` entry, scaffolds the endpoints with a *violating* value and asserts the generator throws — that would catch this class wholesale, but it is a larger change than this, so I have left it out.

### Issue # (if applicable)

N/A — theme (2) of the bug bash reported in #1112.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
