### PR TITLE
docs: translate the changes that landed after #1115's translation commit

### DIFF
--- a/docs/src/content/docs/es/guides/py-agent.mdx
+++ b/docs/src/content/docs/es/guides/py-agent.mdx
@@ -385,7 +385,7 @@ Dado que el generador proporciona infraestructura CDK o Terraform que gestiona e
 <OptionFilter when={{ protocol: 'a2a' }} description="A2A server details">
 ## Servidor A2A (protocolo A2A)
 
-El `main.py` generado monta un servidor A2A en una aplicación FastAPI padre que también expone `/ping`. Los agentes Strands usan el `A2AServer` de Strands; los agentes LangChain envuelven el grafo compilado en un `AgentExecutor` de [`a2a-sdk`](https://a2a-protocol.org/). La URL anunciada en la tarjeta del agente proviene de la variable de entorno `AGENTCORE_RUNTIME_URL`, recurriendo a `http://localhost:<port>/` para desarrollo local. Configúrala en el runtime para anunciar la URL pública del agente desplegado.
+El `main.py` generado monta un servidor A2A en una aplicación FastAPI padre que también expone `/ping`. Los agentes Strands usan el `A2AServer` de Strands; los agentes LangChain envuelven el grafo compilado en un `AgentExecutor` de [`a2a-sdk`](https://a2a-protocol.org/). La URL anunciada en la tarjeta del agente proviene de la variable de entorno `AGENTCORE_RUNTIME_URL`, recurriendo a `http://localhost:<port>/` para desarrollo local.
 
 La mayoría de los usuarios no necesitarán modificar este archivo; edita `agent.py` para cambiar herramientas o el prompt del sistema. El servidor A2A completa la tarjeta del agente (`/.well-known/agent-card.json`) a partir del `name` y `description` del agente.
 </OptionFilter>

--- a/docs/src/content/docs/es/guides/trpc.mdx
+++ b/docs/src/content/docs/es/guides/trpc.mdx
@@ -468,12 +468,6 @@ export const createIdentityPlugin = () => {
 <OptionFilter when={{ auth: 'cognito' }} description="Identity middleware example for Cognito-authenticated APIs">
 Cuando despliegas con `auth: 'cognito'`, el autorizador de Cognito de API Gateway verifica el JWT que el llamador proporciona en el encabezado `Authorization` y coloca las reclamaciones verificadas en el evento Lambda. Nuestro middleware simplemente lee esas reclamaciones: sin llamadas adicionales al AWS SDK, sin verificación manual de JWT.
 
-:::caution[La ubicación de las reclamaciones difiere según el tipo de API]
-El ejemplo a continuación es para una **REST API** (`infra: 'rest-lambda'`), donde las reclamaciones están en `event.requestContext.authorizer.claims` y el tipo de evento es `APIGatewayProxyEvent`.
-
-Para una **HTTP API** (`infra: 'http-lambda'`), las reclamaciones están anidadas un nivel más profundo en `event.requestContext.authorizer.jwt.claims`, y el tipo de evento es `APIGatewayProxyEventV2WithJWTAuthorizer`. Ajusta tanto la importación como la ruta de las reclamaciones en consecuencia.
-:::
-
 Primero, definimos lo que agregaremos al contexto:
 
 ```ts
@@ -826,17 +820,6 @@ const client = createMyApiClient({ url: 'https://my-api-url.example.com/' });
 
 await client.echo.query({ message: 'Hello world!' });
 ```
-
-:::note[Autenticación Cognito]
-Con `auth: 'cognito'`, la configuración del cliente requiere adicionalmente un `token` — el JWT de Cognito del llamador, que se envía en el encabezado `Authorization`:
-
-```ts
-const client = createMyApiClient({
-  url: 'https://my-api-url.example.com/',
-  token: myCognitoIdToken,
-});
-```
-:::
 
 Si estás llamando a tu API desde un sitio web React, considera usar el generador de <Link path="es/guides/connection/react-trpc">Connection</Link> para configurar el cliente.
 

--- a/docs/src/content/docs/es/guides/ts-agent.mdx
+++ b/docs/src/content/docs/es/guides/ts-agent.mdx
@@ -247,7 +247,7 @@ Para una guía más detallada sobre cómo escribir agentes Strands, consulta la 
 <OptionFilter when={{ protocol: 'a2a' }} description="A2A Express server details">
 ## Servidor A2A (protocolo A2A)
 
-El `index.ts` generado monta el [Strands A2A Express Server](https://strandsagents.com/docs/user-guide/concepts/multi-agent/agent-to-agent) en una aplicación Express para que el agente generado exponga los endpoints del protocolo A2A junto con un health check `/ping`. La URL anunciada en la tarjeta del agente proviene de la variable de entorno `AGENTCORE_RUNTIME_URL`, recurriendo a `http://localhost:<port>/` para desarrollo local. Establécela en el runtime para anunciar la URL pública del agente desplegado.
+El `index.ts` generado monta el [Strands A2A Express Server](https://strandsagents.com/docs/user-guide/concepts/multi-agent/agent-to-agent) en una aplicación Express para que el agente generado exponga los endpoints del protocolo A2A junto con un health check `/ping`. La URL anunciada en la tarjeta del agente proviene de la variable de entorno `AGENTCORE_RUNTIME_URL`, recurriendo a `http://localhost:<port>/` para desarrollo local.
 
 La mayoría de los usuarios no necesitarán modificar este archivo — edita `agent.ts` para cambiar herramientas o el prompt del sistema. Los agentes A2A escuchan en el puerto `9000` (vs `8080` para HTTP), para lo cual el Dockerfile y la infraestructura generados ya están configurados.
 </OptionFilter>
@@ -255,7 +255,7 @@ La mayoría de los usuarios no necesitarán modificar este archivo — edita `ag
 <OptionFilter when={{ protocol: 'ag-ui' }} description="AG-UI server details">
 ## Servidor AG-UI (protocolo AG-UI)
 
-El `index.ts` generado envuelve tu `Agent` de Strands en un `StrandsAgent` de [`@ag-ui/aws-strands`](https://www.npmjs.com/package/@ag-ui/aws-strands) y crea una aplicación Express con `addPing`, `addCapabilities` y `addStrandsExpressEndpoint`, reflejando los valores predeterminados de `createStrandsApp()`. La aplicación resultante expone un único endpoint POST que transmite eventos [AG-UI](https://docs.ag-ui.com/) sobre Server-Sent Events (SSE), así como `/ping` para el health check del runtime AgentCore.
+El `index.ts` generado envuelve tu `Agent` de Strands en un `StrandsAgent` de [`@ag-ui/aws-strands`](https://www.npmjs.com/package/@ag-ui/aws-strands) y crea una aplicación Express. La aplicación resultante expone un único endpoint POST que transmite eventos [AG-UI](https://docs.ag-ui.com/) sobre Server-Sent Events (SSE), así como `/ping` para el health check del runtime AgentCore.
 
 Los agentes AG-UI están diseñados para ser consumidos directamente por un frontend. Usa el <Link path="/guides/connection/react-agui">generador `connection`</Link> para conectar tu sitio web React al agente con un proveedor [CopilotKit](https://docs.copilotkit.ai/aws-strands) y un cliente [AG-UI HttpAgent](https://docs.ag-ui.com/).
 

--- a/docs/src/content/docs/fr/guides/py-agent.mdx
+++ b/docs/src/content/docs/fr/guides/py-agent.mdx
@@ -385,7 +385,7 @@ Vous pouvez trouver plus de détails sur les capacités du SDK dans la [document
 <OptionFilter when={{ protocol: 'a2a' }} description="A2A server details">
 ## Serveur A2A (protocole A2A)
 
-Le `main.py` généré monte un serveur A2A sur une application FastAPI parente qui expose également `/ping`. Les agents Strands utilisent le `A2AServer` de Strands ; les agents LangChain enveloppent le graphe compilé dans un `AgentExecutor` [`a2a-sdk`](https://a2a-protocol.org/). L'URL annoncée dans la carte d'agent provient de la variable d'environnement `AGENTCORE_RUNTIME_URL`, avec un repli sur `http://localhost:<port>/` pour le développement local. Définissez-la sur le runtime pour annoncer l'URL publique de l'agent déployé.
+Le `main.py` généré monte un serveur A2A sur une application FastAPI parente qui expose également `/ping`. Les agents Strands utilisent le `A2AServer` de Strands ; les agents LangChain enveloppent le graphe compilé dans un `AgentExecutor` [`a2a-sdk`](https://a2a-protocol.org/). L'URL annoncée dans la carte d'agent provient de la variable d'environnement `AGENTCORE_RUNTIME_URL`, avec un repli sur `http://localhost:<port>/` pour le développement local.
 
 La plupart des utilisateurs n'auront pas besoin de modifier ce fichier ; éditez `agent.py` pour changer les outils ou le prompt système. Le serveur A2A remplit la carte d'agent (`/.well-known/agent-card.json`) à partir du `name` et de la `description` de l'agent.
 </OptionFilter>

--- a/docs/src/content/docs/fr/guides/trpc.mdx
+++ b/docs/src/content/docs/fr/guides/trpc.mdx
@@ -468,12 +468,6 @@ export const createIdentityPlugin = () => {
 <OptionFilter when={{ auth: 'cognito' }} description="Identity middleware example for Cognito-authenticated APIs">
 Lorsque vous déployez avec `auth: 'cognito'`, l'autorisateur Cognito d'API Gateway vérifie le JWT que l'appelant fournit dans l'en-tête `Authorization` et place les revendications vérifiées sur l'événement Lambda. Notre middleware lit simplement ces revendications — pas d'appels SDK AWS supplémentaires, pas de vérification JWT manuelle.
 
-:::caution[L'emplacement des revendications diffère selon le type d'API]
-L'exemple ci-dessous est pour une **API REST** (`infra: 'rest-lambda'`), où les revendications se trouvent à `event.requestContext.authorizer.claims` et le type d'événement est `APIGatewayProxyEvent`.
-
-Pour une **API HTTP** (`infra: 'http-lambda'`), les revendications sont imbriquées un niveau plus profond à `event.requestContext.authorizer.jwt.claims`, et le type d'événement est `APIGatewayProxyEventV2WithJWTAuthorizer`. Ajustez à la fois l'import et le chemin des revendications en conséquence.
-:::
-
 Tout d'abord, nous définissons ce que nous ajouterons au contexte :
 
 ```ts
@@ -826,17 +820,6 @@ const client = createMyApiClient({ url: 'https://my-api-url.example.com/' });
 
 await client.echo.query({ message: 'Hello world!' });
 ```
-
-:::note[Authentification Cognito]
-Avec `auth: 'cognito'`, la configuration du client nécessite en plus un `token` — le JWT Cognito de l'appelant, qui est envoyé dans l'en-tête `Authorization` :
-
-```ts
-const client = createMyApiClient({
-  url: 'https://my-api-url.example.com/',
-  token: myCognitoIdToken,
-});
-```
-:::
 
 Si vous appelez votre API depuis un site web React, envisagez d'utiliser le générateur <Link path="fr/guides/connection/react-trpc">Connection</Link> pour configurer le client.
 

--- a/docs/src/content/docs/fr/guides/ts-agent.mdx
+++ b/docs/src/content/docs/fr/guides/ts-agent.mdx
@@ -247,7 +247,7 @@ Pour un guide plus approfondi sur l'écriture d'agents Strands, consultez la [do
 <OptionFilter when={{ protocol: 'a2a' }} description="A2A Express server details">
 ## Serveur A2A (protocole A2A)
 
-Le fichier `index.ts` généré monte le [Strands A2A Express Server](https://strandsagents.com/docs/user-guide/concepts/multi-agent/agent-to-agent) sur une application Express afin que l'agent généré expose les points de terminaison du protocole A2A ainsi qu'un contrôle de santé `/ping`. L'URL annoncée dans la carte de l'agent provient de la variable d'environnement `AGENTCORE_RUNTIME_URL`, avec un repli sur `http://localhost:<port>/` pour le développement local. Définissez-la sur le runtime pour annoncer l'URL publique de l'agent déployé.
+Le fichier `index.ts` généré monte le [Strands A2A Express Server](https://strandsagents.com/docs/user-guide/concepts/multi-agent/agent-to-agent) sur une application Express afin que l'agent généré expose les points de terminaison du protocole A2A ainsi qu'un contrôle de santé `/ping`. L'URL annoncée dans la carte de l'agent provient de la variable d'environnement `AGENTCORE_RUNTIME_URL`, avec un repli sur `http://localhost:<port>/` pour le développement local.
 
 La plupart des utilisateurs n'auront pas besoin de modifier ce fichier — modifiez `agent.ts` pour changer les outils ou le prompt système. Les agents A2A écoutent sur le port `9000` (contre `8080` pour HTTP), ce pour quoi le Dockerfile et l'infrastructure générés sont déjà configurés.
 </OptionFilter>
@@ -255,7 +255,7 @@ La plupart des utilisateurs n'auront pas besoin de modifier ce fichier — modif
 <OptionFilter when={{ protocol: 'ag-ui' }} description="AG-UI server details">
 ## Serveur AG-UI (protocole AG-UI)
 
-Le fichier `index.ts` généré enveloppe votre `Agent` Strands dans un [`@ag-ui/aws-strands`](https://www.npmjs.com/package/@ag-ui/aws-strands) `StrandsAgent` et crée une application Express avec `addPing`, `addCapabilities` et `addStrandsExpressEndpoint`, reflétant les valeurs par défaut de `createStrandsApp()`. L'application résultante expose un seul point de terminaison POST qui diffuse des événements [AG-UI](https://docs.ag-ui.com/) via Server-Sent Events (SSE), ainsi que `/ping` pour le contrôle de santé du runtime AgentCore.
+Le fichier `index.ts` généré enveloppe votre `Agent` Strands dans un [`@ag-ui/aws-strands`](https://www.npmjs.com/package/@ag-ui/aws-strands) `StrandsAgent` et crée une application Express. L'application résultante expose un seul point de terminaison POST qui diffuse des événements [AG-UI](https://docs.ag-ui.com/) via Server-Sent Events (SSE), ainsi que `/ping` pour le contrôle de santé du runtime AgentCore.
 
 Les agents AG-UI sont conçus pour être consommés directement par un frontend. Utilisez le <Link path="/guides/connection/react-agui">générateur `connection`</Link> pour connecter votre site web React à l'agent avec un fournisseur [CopilotKit](https://docs.copilotkit.ai/aws-strands) et un client [AG-UI HttpAgent](https://docs.ag-ui.com/).
 

--- a/docs/src/content/docs/it/guides/py-agent.mdx
+++ b/docs/src/content/docs/it/guides/py-agent.mdx
@@ -385,7 +385,7 @@ Poiché il generatore fornisce infrastruttura CDK o Terraform che gestisce la di
 <OptionFilter when={{ protocol: 'a2a' }} description="A2A server details">
 ## Server A2A (protocollo A2A)
 
-Il `main.py` generato monta un server A2A su un'app FastAPI padre che espone anche `/ping`. Gli agenti Strands utilizzano lo Strands `A2AServer`; gli agenti LangChain avvolgono il grafo compilato in un `AgentExecutor` [`a2a-sdk`](https://a2a-protocol.org/). L'URL pubblicizzato nella scheda dell'agente proviene dalla variabile d'ambiente `AGENTCORE_RUNTIME_URL`, con fallback a `http://localhost:<port>/` per lo sviluppo locale. Impostala sul runtime per pubblicizzare l'URL pubblico dell'agente distribuito.
+Il `main.py` generato monta un server A2A su un'app FastAPI padre che espone anche `/ping`. Gli agenti Strands utilizzano lo Strands `A2AServer`; gli agenti LangChain avvolgono il grafo compilato in un `AgentExecutor` [`a2a-sdk`](https://a2a-protocol.org/). L'URL pubblicizzato nella scheda dell'agente proviene dalla variabile d'ambiente `AGENTCORE_RUNTIME_URL`, con fallback a `http://localhost:<port>/` per lo sviluppo locale.
 
 La maggior parte degli utenti non avrà bisogno di modificare questo file; modifica `agent.py` per cambiare strumenti o il prompt di sistema. Il server A2A popola la scheda dell'agente (`/.well-known/agent-card.json`) dal `name` e dalla `description` dell'agente.
 </OptionFilter>

--- a/docs/src/content/docs/it/guides/trpc.mdx
+++ b/docs/src/content/docs/it/guides/trpc.mdx
@@ -468,12 +468,6 @@ export const createIdentityPlugin = () => {
 <OptionFilter when={{ auth: 'cognito' }} description="Identity middleware example for Cognito-authenticated APIs">
 Quando effettui il deploy con `auth: 'cognito'`, l'autorizzatore Cognito di API Gateway verifica il JWT che il chiamante fornisce nell'header `Authorization` e posiziona i claim verificati sull'evento Lambda. Il nostro middleware legge semplicemente quei claim — nessuna chiamata AWS SDK extra, nessuna verifica JWT manuale.
 
-:::caution[La posizione dei claim differisce per tipo di API]
-L'esempio seguente è per una **REST API** (`infra: 'rest-lambda'`), dove i claim si trovano in `event.requestContext.authorizer.claims` e il tipo di evento è `APIGatewayProxyEvent`.
-
-Per un'**HTTP API** (`infra: 'http-lambda'`), i claim sono annidati un livello più in profondità in `event.requestContext.authorizer.jwt.claims`, e il tipo di evento è `APIGatewayProxyEventV2WithJWTAuthorizer`. Modifica sia l'import che il percorso dei claim di conseguenza.
-:::
-
 Prima, definiamo cosa aggiungeremo al contesto:
 
 ```ts
@@ -826,17 +820,6 @@ const client = createMyApiClient({ url: 'https://my-api-url.example.com/' });
 
 await client.echo.query({ message: 'Hello world!' });
 ```
-
-:::note[Autenticazione Cognito]
-Con `auth: 'cognito'`, la configurazione del client richiede inoltre un `token` — il JWT Cognito del chiamante, che viene inviato nell'header `Authorization`:
-
-```ts
-const client = createMyApiClient({
-  url: 'https://my-api-url.example.com/',
-  token: myCognitoIdToken,
-});
-```
-:::
 
 Se stai chiamando la tua API da un sito web React, considera l'utilizzo del generatore <Link path="guides/connection/react-trpc">Connection</Link> per configurare il client.
 

--- a/docs/src/content/docs/it/guides/ts-agent.mdx
+++ b/docs/src/content/docs/it/guides/ts-agent.mdx
@@ -247,7 +247,7 @@ Per una guida più approfondita sulla scrittura di agenti Strands, fai riferimen
 <OptionFilter when={{ protocol: 'a2a' }} description="A2A Express server details">
 ## Server A2A (protocollo A2A)
 
-Il file `index.ts` generato monta il [Strands A2A Express Server](https://strandsagents.com/docs/user-guide/concepts/multi-agent/agent-to-agent) su un'app Express in modo che l'agente generato esponga gli endpoint del protocollo A2A insieme a un controllo di salute `/ping`. L'URL pubblicizzato nella scheda dell'agente proviene dalla variabile d'ambiente `AGENTCORE_RUNTIME_URL`, con fallback a `http://localhost:<port>/` per lo sviluppo locale. Impostala sul runtime per pubblicizzare l'URL pubblico dell'agente distribuito.
+Il file `index.ts` generato monta il [Strands A2A Express Server](https://strandsagents.com/docs/user-guide/concepts/multi-agent/agent-to-agent) su un'app Express in modo che l'agente generato esponga gli endpoint del protocollo A2A insieme a un controllo di salute `/ping`. L'URL pubblicizzato nella scheda dell'agente proviene dalla variabile d'ambiente `AGENTCORE_RUNTIME_URL`, con fallback a `http://localhost:<port>/` per lo sviluppo locale.
 
 La maggior parte degli utenti non avrà bisogno di modificare questo file — modifica `agent.ts` per cambiare gli strumenti o il prompt di sistema. Gli agenti A2A ascoltano sulla porta `9000` (rispetto a `8080` per HTTP), per cui il Dockerfile e l'infrastruttura generati sono già configurati.
 </OptionFilter>
@@ -255,7 +255,7 @@ La maggior parte degli utenti non avrà bisogno di modificare questo file — mo
 <OptionFilter when={{ protocol: 'ag-ui' }} description="AG-UI server details">
 ## Server AG-UI (protocollo AG-UI)
 
-Il file `index.ts` generato avvolge il tuo `Agent` Strands in uno [`@ag-ui/aws-strands`](https://www.npmjs.com/package/@ag-ui/aws-strands) `StrandsAgent` e costruisce un'app Express con `addPing`, `addCapabilities` e `addStrandsExpressEndpoint`, rispecchiando i valori predefiniti di `createStrandsApp()`. L'app risultante espone un singolo endpoint POST che trasmette eventi [AG-UI](https://docs.ag-ui.com/) tramite Server-Sent Events (SSE), oltre a `/ping` per il controllo di salute del runtime AgentCore.
+Il file `index.ts` generato avvolge il tuo `Agent` Strands in uno [`@ag-ui/aws-strands`](https://www.npmjs.com/package/@ag-ui/aws-strands) `StrandsAgent` e crea un'app Express. L'app risultante espone un singolo endpoint POST che trasmette eventi [AG-UI](https://docs.ag-ui.com/) tramite Server-Sent Events (SSE), oltre a `/ping` per il controllo di salute del runtime AgentCore.
 
 Gli agenti AG-UI sono progettati per essere consumati direttamente da un frontend. Utilizza il <Link path="/guides/connection/react-agui">generatore `connection`</Link> per collegare il tuo sito web React all'agente con un provider [CopilotKit](https://docs.copilotkit.ai/aws-strands) e un client [AG-UI HttpAgent](https://docs.ag-ui.com/).
 

--- a/docs/src/content/docs/jp/guides/py-agent.mdx
+++ b/docs/src/content/docs/jp/guides/py-agent.mdx
@@ -385,7 +385,7 @@ SDKの機能の詳細については、[こちらのドキュメント](https://
 <OptionFilter when={{ protocol: 'a2a' }} description="A2A server details">
 ## A2Aサーバー（A2Aプロトコル）
 
-生成された `main.py` は、`/ping` も公開する親FastAPIアプリにA2Aサーバーをマウントします。StrandsエージェントはStrands `A2AServer` を使用し、LangChainエージェントはコンパイルされたグラフを [`a2a-sdk`](https://a2a-protocol.org/) `AgentExecutor` でラップします。エージェントカードにアドバタイズされるURLは `AGENTCORE_RUNTIME_URL` 環境変数から取得され、ローカル開発では `http://localhost:<port>/` にフォールバックします。デプロイされたエージェントのパブリックURLをアドバタイズするには、ランタイムで設定してください。
+生成された `main.py` は、`/ping` も公開する親FastAPIアプリにA2Aサーバーをマウントします。StrandsエージェントはStrands `A2AServer` を使用し、LangChainエージェントはコンパイルされたグラフを [`a2a-sdk`](https://a2a-protocol.org/) `AgentExecutor` でラップします。エージェントカードにアドバタイズされるURLは `AGENTCORE_RUNTIME_URL` 環境変数から取得され、ローカル開発では `http://localhost:<port>/` にフォールバックします。
 
 ほとんどのユーザーはこのファイルを変更する必要はありません。ツールやシステムプロンプトを変更するには `agent.py` を編集してください。A2Aサーバーはエージェントの `name` と `description` からエージェントカード（`/.well-known/agent-card.json`）を生成します。
 </OptionFilter>

--- a/docs/src/content/docs/jp/guides/trpc.mdx
+++ b/docs/src/content/docs/jp/guides/trpc.mdx
@@ -468,12 +468,6 @@ export const createIdentityPlugin = () => {
 <OptionFilter when={{ auth: 'cognito' }} description="Identity middleware example for Cognito-authenticated APIs">
 `auth: 'cognito'`でデプロイすると、API Gateway Cognitoオーソライザーは、呼び出し元が`Authorization`ヘッダーで提供するJWTを検証し、検証されたクレームをLambdaイベントに配置します。ミドルウェアはこれらのクレームを読み取るだけで、追加のAWS SDK呼び出しや手動のJWT検証は必要ありません。
 
-:::caution[クレームの場所はAPIタイプによって異なります]
-以下の例は**REST API**（`infra: 'rest-lambda'`）用で、クレームは`event.requestContext.authorizer.claims`にあり、イベントタイプは`APIGatewayProxyEvent`です。
-
-**HTTP API**（`infra: 'http-lambda'`）の場合、クレームは`event.requestContext.authorizer.jwt.claims`に1レベル深くネストされており、イベントタイプは`APIGatewayProxyEventV2WithJWTAuthorizer`です。インポートとクレームパスの両方を適宜調整してください。
-:::
-
 まず、コンテキストに追加する内容を定義します：
 
 ```ts
@@ -826,17 +820,6 @@ const client = createMyApiClient({ url: 'https://my-api-url.example.com/' });
 
 await client.echo.query({ message: 'Hello world!' });
 ```
-
-:::note[Cognito認証]
-`auth: 'cognito'`の場合、クライアント構成には追加で`token`が必要です。これは呼び出し元のCognito JWTで、`Authorization`ヘッダーで送信されます：
-
-```ts
-const client = createMyApiClient({
-  url: 'https://my-api-url.example.com/',
-  token: myCognitoIdToken,
-});
-```
-:::
 
 ReactウェブサイトからAPIを呼び出す場合は、<Link path="jp/guides/connection/react-trpc">Connection</Link>ジェネレーターを使用してクライアントを構成することを検討してください。
 

--- a/docs/src/content/docs/jp/guides/ts-agent.mdx
+++ b/docs/src/content/docs/jp/guides/ts-agent.mdx
@@ -247,7 +247,7 @@ Strands エージェントの作成に関するより詳細なガイドについ
 <OptionFilter when={{ protocol: 'a2a' }} description="A2A Express server details">
 ## A2A サーバー（A2A プロトコル）
 
-生成された `index.ts` は、[Strands A2A Express Server](https://strandsagents.com/docs/user-guide/concepts/multi-agent/agent-to-agent) を Express アプリにマウントするため、生成されたエージェントは A2A プロトコルエンドポイントと `/ping` ヘルスチェックを公開します。エージェントカードでアドバタイズされる URL は `AGENTCORE_RUNTIME_URL` 環境変数から取得され、ローカル開発の場合は `http://localhost:<port>/` にフォールバックします。デプロイされたエージェントのパブリック URL をアドバタイズするには、ランタイムで設定してください。
+生成された `index.ts` は、[Strands A2A Express Server](https://strandsagents.com/docs/user-guide/concepts/multi-agent/agent-to-agent) を Express アプリにマウントするため、生成されたエージェントは A2A プロトコルエンドポイントと `/ping` ヘルスチェックを公開します。エージェントカードでアドバタイズされる URL は `AGENTCORE_RUNTIME_URL` 環境変数から取得され、ローカル開発の場合は `http://localhost:<port>/` にフォールバックします。
 
 ほとんどのユーザーはこのファイルを変更する必要はありません。ツールやシステムプロンプトを変更するには `agent.ts` を編集してください。A2A エージェントはポート `9000` でリッスンします（HTTP の `8080` に対して）。生成された Dockerfile とインフラストラクチャはすでにこれに対応して設定されています。
 </OptionFilter>

--- a/docs/src/content/docs/ko/guides/py-agent.mdx
+++ b/docs/src/content/docs/ko/guides/py-agent.mdx
@@ -385,7 +385,7 @@ SDK 기능에 대한 자세한 내용은 [여기 문서](https://aws.github.io/b
 <OptionFilter when={{ protocol: 'a2a' }} description="A2A server details">
 ## A2A 서버 (A2A 프로토콜)
 
-생성된 `main.py`는 `/ping`도 노출하는 상위 FastAPI 앱에 A2A 서버를 마운트합니다. Strands 에이전트는 Strands `A2AServer`를 사용하고, LangChain 에이전트는 컴파일된 그래프를 [`a2a-sdk`](https://a2a-protocol.org/) `AgentExecutor`로 래핑합니다. 에이전트 카드에 광고되는 URL은 `AGENTCORE_RUNTIME_URL` 환경 변수에서 가져오며, 로컬 개발의 경우 `http://localhost:<port>/`로 대체됩니다. 배포된 에이전트의 공개 URL을 광고하려면 런타임에 설정하세요.
+생성된 `main.py`는 `/ping`도 노출하는 상위 FastAPI 앱에 A2A 서버를 마운트합니다. Strands 에이전트는 Strands `A2AServer`를 사용하고, LangChain 에이전트는 컴파일된 그래프를 [`a2a-sdk`](https://a2a-protocol.org/) `AgentExecutor`로 래핑합니다. 에이전트 카드에 광고되는 URL은 `AGENTCORE_RUNTIME_URL` 환경 변수에서 가져오며, 로컬 개발의 경우 `http://localhost:<port>/`로 대체됩니다.
 
 대부분의 사용자는 이 파일을 수정할 필요가 없습니다. 도구나 시스템 프롬프트를 변경하려면 `agent.py`를 편집하세요. A2A 서버는 에이전트의 `name`과 `description`에서 에이전트 카드(`/.well-known/agent-card.json`)를 채웁니다.
 </OptionFilter>

--- a/docs/src/content/docs/ko/guides/trpc.mdx
+++ b/docs/src/content/docs/ko/guides/trpc.mdx
@@ -468,12 +468,6 @@ export const createIdentityPlugin = () => {
 <OptionFilter when={{ auth: 'cognito' }} description="Identity middleware example for Cognito-authenticated APIs">
 `auth: 'cognito'`로 배포하면 API Gateway Cognito 권한 부여자가 호출자가 `Authorization` 헤더에 제공하는 JWT를 확인하고 확인된 클레임을 Lambda 이벤트에 배치합니다. 우리의 미들웨어는 이러한 클레임을 읽기만 하면 됩니다 — 추가 AWS SDK 호출이나 수동 JWT 확인이 필요하지 않습니다.
 
-:::caution[API 유형에 따라 클레임 위치가 다름]
-아래 예제는 **REST API**(`infra: 'rest-lambda'`)용이며, 클레임은 `event.requestContext.authorizer.claims`에 있고 이벤트 타입은 `APIGatewayProxyEvent`입니다.
-
-**HTTP API**(`infra: 'http-lambda'`)의 경우 클레임은 `event.requestContext.authorizer.jwt.claims`에 한 단계 더 깊게 중첩되어 있으며, 이벤트 타입은 `APIGatewayProxyEventV2WithJWTAuthorizer`입니다. import와 클레임 경로를 모두 적절히 조정하세요.
-:::
-
 먼저 컨텍스트에 추가할 내용을 정의합니다:
 
 ```ts
@@ -826,17 +820,6 @@ const client = createMyApiClient({ url: 'https://my-api-url.example.com/' });
 
 await client.echo.query({ message: 'Hello world!' });
 ```
-
-:::note[Cognito 인증]
-`auth: 'cognito'`를 사용하는 경우 클라이언트 구성에는 추가로 `token`이 필요합니다 — 호출자의 Cognito JWT이며, `Authorization` 헤더로 전송됩니다:
-
-```ts
-const client = createMyApiClient({
-  url: 'https://my-api-url.example.com/',
-  token: myCognitoIdToken,
-});
-```
-:::
 
 React 웹사이트에서 API를 호출하는 경우 <Link path="guides/connection/react-trpc">Connection</Link> 생성기를 사용하여 클라이언트를 구성하는 것을 고려하세요.
 

--- a/docs/src/content/docs/ko/guides/ts-agent.mdx
+++ b/docs/src/content/docs/ko/guides/ts-agent.mdx
@@ -247,7 +247,7 @@ Strands 에이전트 작성에 대한 더 심층적인 가이드는 [Strands 문
 <OptionFilter when={{ protocol: 'a2a' }} description="A2A Express server details">
 ## A2A 서버 (A2A 프로토콜)
 
-생성된 `index.ts`는 [Strands A2A Express Server](https://strandsagents.com/docs/user-guide/concepts/multi-agent/agent-to-agent)를 Express 앱에 마운트하여 생성된 에이전트가 `/ping` 헬스 체크와 함께 A2A 프로토콜 엔드포인트를 노출하도록 합니다. 에이전트 카드에 광고되는 URL은 `AGENTCORE_RUNTIME_URL` 환경 변수에서 가져오며, 로컬 개발의 경우 `http://localhost:<port>/`로 폴백됩니다. 배포된 에이전트의 공개 URL을 광고하려면 런타임에서 이를 설정하세요.
+생성된 `index.ts`는 [Strands A2A Express Server](https://strandsagents.com/docs/user-guide/concepts/multi-agent/agent-to-agent)를 Express 앱에 마운트하여 생성된 에이전트가 `/ping` 헬스 체크와 함께 A2A 프로토콜 엔드포인트를 노출하도록 합니다. 에이전트 카드에 광고되는 URL은 `AGENTCORE_RUNTIME_URL` 환경 변수에서 가져오며, 로컬 개발의 경우 `http://localhost:<port>/`로 대체됩니다.
 
 대부분의 사용자는 이 파일을 수정할 필요가 없습니다. 도구나 시스템 프롬프트를 변경하려면 `agent.ts`를 편집하세요. A2A 에이전트는 포트 `9000`에서 수신 대기하며(HTTP의 경우 `8080`), 생성된 Dockerfile 및 인프라가 이미 이에 맞게 구성되어 있습니다.
 </OptionFilter>
@@ -255,7 +255,7 @@ Strands 에이전트 작성에 대한 더 심층적인 가이드는 [Strands 문
 <OptionFilter when={{ protocol: 'ag-ui' }} description="AG-UI server details">
 ## AG-UI 서버 (AG-UI 프로토콜)
 
-생성된 `index.ts`는 Strands `Agent`를 [`@ag-ui/aws-strands`](https://www.npmjs.com/package/@ag-ui/aws-strands) `StrandsAgent`로 래핑하고 `addPing`, `addCapabilities` 및 `addStrandsExpressEndpoint`를 사용하여 Express 앱을 빌드하며, `createStrandsApp()`의 기본값을 미러링합니다. 결과 앱은 Server-Sent Events (SSE)를 통해 [AG-UI](https://docs.ag-ui.com/) 이벤트를 스트리밍하는 단일 POST 엔드포인트와 AgentCore 런타임 헬스 체크를 위한 `/ping`을 노출합니다.
+생성된 `index.ts`는 Strands `Agent`를 [`@ag-ui/aws-strands`](https://www.npmjs.com/package/@ag-ui/aws-strands) `StrandsAgent`로 래핑하고 Express 앱을 생성합니다. 결과 앱은 Server-Sent Events (SSE)를 통해 [AG-UI](https://docs.ag-ui.com/) 이벤트를 스트리밍하는 단일 POST 엔드포인트와 AgentCore 런타임 헬스 체크를 위한 `/ping`을 노출합니다.
 
 AG-UI 에이전트는 프론트엔드에서 직접 사용되도록 설계되었습니다. <Link path="/guides/connection/react-agui">`connection` 생성기</Link>를 사용하여 [CopilotKit](https://docs.copilotkit.ai/aws-strands) 제공자 및 [AG-UI HttpAgent](https://docs.ag-ui.com/) 클라이언트로 React 웹사이트를 에이전트에 연결하세요.
 

--- a/docs/src/content/docs/pt/guides/py-agent.mdx
+++ b/docs/src/content/docs/pt/guides/py-agent.mdx
@@ -385,7 +385,7 @@ Como o gerador fornece infraestrutura CDK ou Terraform que gerencia a implantaç
 <OptionFilter when={{ protocol: 'a2a' }} description="A2A server details">
 ## Servidor A2A (protocolo A2A)
 
-O `main.py` gerado monta um servidor A2A em uma aplicação FastAPI pai que também expõe `/ping`. Agentes Strands usam o `A2AServer` do Strands; agentes LangChain envolvem o grafo compilado em um `AgentExecutor` [`a2a-sdk`](https://a2a-protocol.org/). A URL anunciada no cartão do agente vem da variável de ambiente `AGENTCORE_RUNTIME_URL`, recorrendo a `http://localhost:<port>/` para desenvolvimento local. Defina-a no runtime para anunciar a URL pública do agente implantado.
+O `main.py` gerado monta um servidor A2A em uma aplicação FastAPI pai que também expõe `/ping`. Agentes Strands usam o `A2AServer` do Strands; agentes LangChain envolvem o grafo compilado em um `AgentExecutor` [`a2a-sdk`](https://a2a-protocol.org/). A URL anunciada no cartão do agente vem da variável de ambiente `AGENTCORE_RUNTIME_URL`, recorrendo a `http://localhost:<port>/` para desenvolvimento local.
 
 A maioria dos usuários não precisará modificar este arquivo; edite `agent.py` para alterar ferramentas ou o prompt do sistema. O servidor A2A preenche o cartão do agente (`/.well-known/agent-card.json`) a partir do `name` e `description` do agente.
 </OptionFilter>

--- a/docs/src/content/docs/pt/guides/trpc.mdx
+++ b/docs/src/content/docs/pt/guides/trpc.mdx
@@ -468,12 +468,6 @@ export const createIdentityPlugin = () => {
 <OptionFilter when={{ auth: 'cognito' }} description="Identity middleware example for Cognito-authenticated APIs">
 Quando você implanta com `auth: 'cognito'`, o autorizador Cognito do API Gateway verifica o JWT que o chamador fornece no cabeçalho `Authorization` e coloca as reivindicações verificadas no evento Lambda. Nosso middleware apenas lê essas reivindicações — sem chamadas extras do AWS SDK, sem verificação manual de JWT.
 
-:::caution[A localização das reivindicações difere por tipo de API]
-O exemplo abaixo é para uma **REST API** (`infra: 'rest-lambda'`), onde as reivindicações estão em `event.requestContext.authorizer.claims` e o tipo de evento é `APIGatewayProxyEvent`.
-
-Para uma **HTTP API** (`infra: 'http-lambda'`), as reivindicações estão aninhadas um nível mais profundo em `event.requestContext.authorizer.jwt.claims`, e o tipo de evento é `APIGatewayProxyEventV2WithJWTAuthorizer`. Ajuste tanto a importação quanto o caminho das reivindicações de acordo.
-:::
-
 Primeiro, definimos o que adicionaremos ao contexto:
 
 ```ts
@@ -826,17 +820,6 @@ const client = createMyApiClient({ url: 'https://my-api-url.example.com/' });
 
 await client.echo.query({ message: 'Hello world!' });
 ```
-
-:::note[Autenticação Cognito]
-Com `auth: 'cognito'`, a configuração do cliente requer adicionalmente um `token` — o JWT Cognito do chamador, que é enviado no cabeçalho `Authorization`:
-
-```ts
-const client = createMyApiClient({
-  url: 'https://my-api-url.example.com/',
-  token: myCognitoIdToken,
-});
-```
-:::
 
 Se você estiver chamando sua API de um site React, considere usar o gerador <Link path="guides/connection/react-trpc">Connection</Link> para configurar o cliente.
 

--- a/docs/src/content/docs/pt/guides/ts-agent.mdx
+++ b/docs/src/content/docs/pt/guides/ts-agent.mdx
@@ -247,7 +247,7 @@ Para um guia mais aprofundado sobre como escrever agentes Strands, consulte a [d
 <OptionFilter when={{ protocol: 'a2a' }} description="A2A Express server details">
 ## Servidor A2A (protocolo A2A)
 
-O `index.ts` gerado monta o [Strands A2A Express Server](https://strandsagents.com/docs/user-guide/concepts/multi-agent/agent-to-agent) em um aplicativo Express para que o agente gerado exponha os endpoints do protocolo A2A junto com uma verificação de saúde `/ping`. A URL anunciada no cartão do agente vem da variável de ambiente `AGENTCORE_RUNTIME_URL`, voltando para `http://localhost:<port>/` para desenvolvimento local. Defina-a no runtime para anunciar a URL pública do agente implantado.
+O `index.ts` gerado monta o [Strands A2A Express Server](https://strandsagents.com/docs/user-guide/concepts/multi-agent/agent-to-agent) em um aplicativo Express para que o agente gerado exponha os endpoints do protocolo A2A junto com uma verificação de saúde `/ping`. A URL anunciada no cartão do agente vem da variável de ambiente `AGENTCORE_RUNTIME_URL`, retornando para `http://localhost:<port>/` para desenvolvimento local.
 
 A maioria dos usuários não precisará modificar este arquivo — edite `agent.ts` para alterar ferramentas ou o prompt do sistema. Os agentes A2A escutam na porta `9000` (vs `8080` para HTTP), para a qual o Dockerfile e a infraestrutura gerados já estão configurados.
 </OptionFilter>
@@ -255,7 +255,7 @@ A maioria dos usuários não precisará modificar este arquivo — edite `agent.
 <OptionFilter when={{ protocol: 'ag-ui' }} description="AG-UI server details">
 ## Servidor AG-UI (protocolo AG-UI)
 
-O `index.ts` gerado envolve seu `Agent` Strands em um [`@ag-ui/aws-strands`](https://www.npmjs.com/package/@ag-ui/aws-strands) `StrandsAgent` e cria um aplicativo Express com `addPing`, `addCapabilities` e `addStrandsExpressEndpoint`, espelhando os padrões de `createStrandsApp()`. O aplicativo resultante expõe um único endpoint POST que transmite eventos [AG-UI](https://docs.ag-ui.com/) via Server-Sent Events (SSE), além de `/ping` para a verificação de saúde do runtime AgentCore.
+O `index.ts` gerado envolve seu `Agent` Strands em um [`@ag-ui/aws-strands`](https://www.npmjs.com/package/@ag-ui/aws-strands) `StrandsAgent` e cria um aplicativo Express. O aplicativo resultante expõe um único endpoint POST que transmite eventos [AG-UI](https://docs.ag-ui.com/) via Server-Sent Events (SSE), além de `/ping` para a verificação de saúde do runtime AgentCore.
 
 Os agentes AG-UI são projetados para serem consumidos diretamente por um frontend. Use o <Link path="/guides/connection/react-agui">gerador `connection`</Link> para conectar seu site React ao agente com um provedor [CopilotKit](https://docs.copilotkit.ai/aws-strands) e cliente [AG-UI HttpAgent](https://docs.ag-ui.com/).
 

--- a/docs/src/content/docs/vi/guides/py-agent.mdx
+++ b/docs/src/content/docs/vi/guides/py-agent.mdx
@@ -385,7 +385,7 @@ Vì generator cung cấp hạ tầng CDK hoặc Terraform để quản lý việ
 <OptionFilter when={{ protocol: 'a2a' }} description="A2A server details">
 ## Máy chủ A2A (giao thức A2A)
 
-`main.py` được tạo ra gắn một máy chủ A2A vào một ứng dụng FastAPI cha cũng hiển thị `/ping`. Các agent Strands sử dụng `A2AServer` của Strands; các agent LangChain bọc graph đã biên dịch trong một `AgentExecutor` của [`a2a-sdk`](https://a2a-protocol.org/). URL được quảng cáo trong agent card đến từ biến môi trường `AGENTCORE_RUNTIME_URL`, quay lại `http://localhost:<port>/` cho phát triển cục bộ. Đặt nó trên runtime để quảng cáo URL công khai của agent đã triển khai.
+`main.py` được tạo ra gắn một máy chủ A2A vào một ứng dụng FastAPI cha cũng hiển thị `/ping`. Các agent Strands sử dụng `A2AServer` của Strands; các agent LangChain bọc graph đã biên dịch trong một `AgentExecutor` của [`a2a-sdk`](https://a2a-protocol.org/). URL được quảng cáo trong agent card đến từ biến môi trường `AGENTCORE_RUNTIME_URL`, quay lại `http://localhost:<port>/` cho phát triển cục bộ.
 
 Hầu hết người dùng sẽ không cần sửa đổi tệp này; chỉnh sửa `agent.py` để thay đổi công cụ hoặc system prompt. Máy chủ A2A điền vào agent card (`/.well-known/agent-card.json`) từ `name` và `description` của agent.
 </OptionFilter>

--- a/docs/src/content/docs/vi/guides/trpc.mdx
+++ b/docs/src/content/docs/vi/guides/trpc.mdx
@@ -468,12 +468,6 @@ export const createIdentityPlugin = () => {
 <OptionFilter when={{ auth: 'cognito' }} description="Identity middleware example for Cognito-authenticated APIs">
 Khi bạn triển khai với `auth: 'cognito'`, API Gateway Cognito authorizer xác minh JWT mà người gọi cung cấp trong header `Authorization` và đặt các claim đã xác minh trên Lambda event. Middleware của chúng ta chỉ đọc các claim đó — không cần thêm lời gọi AWS SDK, không cần xác minh JWT thủ công.
 
-:::caution[Vị trí claim khác nhau theo loại API]
-Ví dụ dưới đây dành cho **REST API** (`infra: 'rest-lambda'`), trong đó các claim nằm ở `event.requestContext.authorizer.claims` và kiểu event là `APIGatewayProxyEvent`.
-
-Đối với **HTTP API** (`infra: 'http-lambda'`), các claim được lồng sâu hơn một cấp tại `event.requestContext.authorizer.jwt.claims`, và kiểu event là `APIGatewayProxyEventV2WithJWTAuthorizer`. Điều chỉnh cả import và đường dẫn claim cho phù hợp.
-:::
-
 Đầu tiên, chúng ta định nghĩa những gì chúng ta sẽ thêm vào context:
 
 ```ts
@@ -826,17 +820,6 @@ const client = createMyApiClient({ url: 'https://my-api-url.example.com/' });
 
 await client.echo.query({ message: 'Hello world!' });
 ```
-
-:::note[Xác thực Cognito]
-Với `auth: 'cognito'`, cấu hình client yêu cầu thêm một `token` — JWT Cognito của người gọi, được gửi trong header `Authorization`:
-
-```ts
-const client = createMyApiClient({
-  url: 'https://my-api-url.example.com/',
-  token: myCognitoIdToken,
-});
-```
-:::
 
 Nếu bạn đang gọi API của mình từ một website React, hãy xem xét sử dụng generator <Link path="vi/guides/connection/react-trpc">Connection</Link> để cấu hình client.
 

--- a/docs/src/content/docs/vi/guides/ts-agent.mdx
+++ b/docs/src/content/docs/vi/guides/ts-agent.mdx
@@ -247,7 +247,7 @@ Tham khảo <Link path="/guides/connection/ts-agent-mcp">hướng dẫn `connect
 <OptionFilter when={{ protocol: 'a2a' }} description="A2A Express server details">
 ## A2A Server (giao thức A2A)
 
-File `index.ts` được tạo mount [Strands A2A Express Server](https://strandsagents.com/docs/user-guide/concepts/multi-agent/agent-to-agent) lên một Express app để agent được tạo expose các endpoint giao thức A2A cùng với health check `/ping`. URL được quảng cáo trong agent card đến từ biến môi trường `AGENTCORE_RUNTIME_URL`, quay lại `http://localhost:<port>/` cho phát triển cục bộ. Thiết lập nó trên runtime để quảng cáo URL công khai của agent đã triển khai.
+File `index.ts` được tạo mount [Strands A2A Express Server](https://strandsagents.com/docs/user-guide/concepts/multi-agent/agent-to-agent) lên một Express app để agent được tạo expose các endpoint giao thức A2A cùng với health check `/ping`. URL được quảng cáo trong agent card đến từ biến môi trường `AGENTCORE_RUNTIME_URL`, quay lại `http://localhost:<port>/` cho phát triển cục bộ.
 
 Hầu hết người dùng sẽ không cần sửa đổi file này — chỉnh sửa `agent.ts` để thay đổi công cụ hoặc system prompt. Các A2A agent lắng nghe trên cổng `9000` (so với `8080` cho HTTP), mà Dockerfile và hạ tầng được tạo đã được cấu hình sẵn.
 </OptionFilter>
@@ -255,7 +255,7 @@ Hầu hết người dùng sẽ không cần sửa đổi file này — chỉnh 
 <OptionFilter when={{ protocol: 'ag-ui' }} description="AG-UI server details">
 ## AG-UI Server (giao thức AG-UI)
 
-File `index.ts` được tạo bọc Strands `Agent` của bạn trong một [`@ag-ui/aws-strands`](https://www.npmjs.com/package/@ag-ui/aws-strands) `StrandsAgent` và xây dựng một Express app với `addPing`, `addCapabilities` và `addStrandsExpressEndpoint`, phản ánh các giá trị mặc định của `createStrandsApp()`. App kết quả expose một POST endpoint duy nhất stream các sự kiện [AG-UI](https://docs.ag-ui.com/) qua Server-Sent Events (SSE), cũng như `/ping` cho health check của AgentCore runtime.
+File `index.ts` được tạo bọc Strands `Agent` của bạn trong một [`@ag-ui/aws-strands`](https://www.npmjs.com/package/@ag-ui/aws-strands) `StrandsAgent` và tạo một Express app. App kết quả expose một POST endpoint duy nhất stream các sự kiện [AG-UI](https://docs.ag-ui.com/) qua Server-Sent Events (SSE), cũng như `/ping` cho health check của AgentCore runtime.
 
 Các AG-UI agent được thiết kế để được sử dụng trực tiếp bởi frontend. Sử dụng <Link path="/guides/connection/react-agui">`connection` generator</Link> để kết nối React website của bạn với agent thông qua [CopilotKit](https://docs.copilotkit.ai/aws-strands) provider và [AG-UI HttpAgent](https://docs.ag-ui.com/) client.
 

--- a/docs/src/content/docs/zh/guides/py-agent.mdx
+++ b/docs/src/content/docs/zh/guides/py-agent.mdx
@@ -385,7 +385,7 @@ FastAPI 中有一个[原生支持的开放功能请求](https://github.com/fasta
 <OptionFilter when={{ protocol: 'a2a' }} description="A2A server details">
 ## A2A 服务器（A2A 协议）
 
-生成的 `main.py` 将 A2A 服务器挂载到也公开 `/ping` 的父 FastAPI 应用程序上。Strands 代理使用 Strands `A2AServer`；LangChain 代理将编译的图包装在 [`a2a-sdk`](https://a2a-protocol.org/) `AgentExecutor` 中。代理卡中公布的 URL 来自 `AGENTCORE_RUNTIME_URL` 环境变量，对于本地开发则回退到 `http://localhost:<port>/`。在运行时设置它以公布已部署代理的公共 URL。
+生成的 `main.py` 将 A2A 服务器挂载到也公开 `/ping` 的父 FastAPI 应用程序上。Strands 代理使用 Strands `A2AServer`；LangChain 代理将编译的图包装在 [`a2a-sdk`](https://a2a-protocol.org/) `AgentExecutor` 中。代理卡中公布的 URL 来自 `AGENTCORE_RUNTIME_URL` 环境变量，对于本地开发则回退到 `http://localhost:<port>/`。
 
 大多数用户不需要修改此文件；编辑 `agent.py` 以更改工具或系统提示。A2A 服务器从代理的 `name` 和 `description` 填充代理卡（`/.well-known/agent-card.json`）。
 </OptionFilter>

--- a/docs/src/content/docs/zh/guides/trpc.mdx
+++ b/docs/src/content/docs/zh/guides/trpc.mdx
@@ -468,12 +468,6 @@ export const createIdentityPlugin = () => {
 <OptionFilter when={{ auth: 'cognito' }} description="Cognito 身份验证 API 的身份中间件示例">
 当您使用 `auth: 'cognito'` 部署时,API Gateway Cognito 授权器会验证调用者在 `Authorization` 标头中提供的 JWT,并将验证的声明放在 Lambda 事件上。我们的中间件只是读取这些声明 — 无需额外的 AWS SDK 调用,无需手动 JWT 验证。
 
-:::caution[声明位置因 API 类型而异]
-下面的示例适用于 **REST API**(`infra: 'rest-lambda'`),其中声明位于 `event.requestContext.authorizer.claims`,事件类型为 `APIGatewayProxyEvent`。
-
-对于 **HTTP API**(`infra: 'http-lambda'`),声明嵌套在更深一层,位于 `event.requestContext.authorizer.jwt.claims`,事件类型为 `APIGatewayProxyEventV2WithJWTAuthorizer`。请相应地调整导入和声明路径。
-:::
-
 首先,我们定义要添加到上下文的内容:
 
 ```ts
@@ -826,17 +820,6 @@ const client = createMyApiClient({ url: 'https://my-api-url.example.com/' });
 
 await client.echo.query({ message: 'Hello world!' });
 ```
-
-:::note[Cognito 身份验证]
-使用 `auth: 'cognito'` 时,客户端配置还需要一个 `token` — 调用者的 Cognito JWT,它在 `Authorization` 标头中发送:
-
-```ts
-const client = createMyApiClient({
-  url: 'https://my-api-url.example.com/',
-  token: myCognitoIdToken,
-});
-```
-:::
 
 如果您从 React 网站调用 API,请考虑使用 <Link path="/zh/guides/connection/react-trpc">Connection</Link> 生成器来配置客户端。
 

--- a/docs/src/content/docs/zh/guides/ts-agent.mdx
+++ b/docs/src/content/docs/zh/guides/ts-agent.mdx
@@ -247,7 +247,7 @@ response = await agent.invoke('What can you help me with?');
 <OptionFilter when={{ protocol: 'a2a' }} description="A2A Express server details">
 ## A2A 服务器（A2A 协议）
 
-生成的 `index.ts` 将 [Strands A2A Express Server](https://strandsagents.com/docs/user-guide/concepts/multi-agent/agent-to-agent) 挂载到 Express 应用程序上，因此生成的代理会公开 A2A 协议端点以及 `/ping` 健康检查。代理卡中公布的 URL 来自 `AGENTCORE_RUNTIME_URL` 环境变量，对于本地开发则回退到 `http://localhost:<port>/`。在运行时设置它以公布已部署代理的公共 URL。
+生成的 `index.ts` 将 [Strands A2A Express Server](https://strandsagents.com/docs/user-guide/concepts/multi-agent/agent-to-agent) 挂载到 Express 应用程序上，因此生成的代理会公开 A2A 协议端点以及 `/ping` 健康检查。代理卡中公布的 URL 来自 `AGENTCORE_RUNTIME_URL` 环境变量，对于本地开发则回退到 `http://localhost:<port>/`。
 
 大多数用户不需要修改此文件 — 编辑 `agent.ts` 以更改工具或系统提示。A2A 代理监听端口 `9000`（而 HTTP 为 `8080`），生成的 Dockerfile 和基础设施已经为此进行了配置。
 </OptionFilter>
@@ -255,7 +255,7 @@ response = await agent.invoke('What can you help me with?');
 <OptionFilter when={{ protocol: 'ag-ui' }} description="AG-UI server details">
 ## AG-UI 服务器（AG-UI 协议）
 
-生成的 `index.ts` 将您的 Strands `Agent` 包装在 [`@ag-ui/aws-strands`](https://www.npmjs.com/package/@ag-ui/aws-strands) `StrandsAgent` 中，并使用 `addPing`、`addCapabilities` 和 `addStrandsExpressEndpoint` 构建 Express 应用程序，镜像 `createStrandsApp()` 的默认值。生成的应用程序公开一个单一的 POST 端点，通过服务器发送事件（SSE）流式传输 [AG-UI](https://docs.ag-ui.com/) 事件，以及用于 AgentCore 运行时健康检查的 `/ping`。
+生成的 `index.ts` 将您的 Strands `Agent` 包装在 [`@ag-ui/aws-strands`](https://www.npmjs.com/package/@ag-ui/aws-strands) `StrandsAgent` 中，并构建一个 Express 应用程序。生成的应用程序公开一个单一的 POST 端点，通过服务器发送事件（SSE）流式传输 [AG-UI](https://docs.ag-ui.com/) 事件，以及用于 AgentCore 运行时健康检查的 `/ping`。
 
 AG-UI 代理旨在直接由前端使用。使用 <Link path="/guides/connection/react-agui">`connection` 生成器</Link>将您的 React 网站与代理连接，使用 [CopilotKit](https://docs.copilotkit.ai/aws-strands) 提供程序和 [AG-UI HttpAgent](https://docs.ag-ui.com/) 客户端。
 


### PR DESCRIPTION
### Reason for this change

#1115 landed its `docs: update translations` commit *before* its final review-feedback commit, so the English changes in that last commit were never translated. The eight non-English copies of three guides still carry content that no longer exists in the English source.

Concretely, `dede1d9` (the last commit on #1115) edited `en/guides/py-agent.mdx`, `en/guides/trpc.mdx` and `en/guides/ts-agent.mdx`, and the translation workflow had already run at that point. On `main` today:

- **`trpc.mdx`** — all 8 languages still contain two blocks the reviewer deliberately removed: the `:::caution[Claims location differs by API type]` admonition and the `:::note[Cognito authentication]` client-token example.
- **`ts-agent.mdx` / `py-agent.mdx`** — all 8 languages still contain the trailing sentence *"Set it on the runtime to advertise the deployed agent's public URL."*, dropped from the A2A server sections.

This is a translation catch-up only; no English or source changes.

### Description of changes

Ran `scripts/translate.ts` locally against the three guides, which retranslated them into all eight target languages (24 files).

The translating agent also made a number of edits unrelated to the diff it was given, which I reverted so the commit contains only the intended catch-up:

- `zh/guides/trpc.mdx` — rewrote ASCII commas and colons as full-width CJK punctuation throughout the file (147 lines touched). Rebuilt from `main` with only the two blocks excised.
- `es/guides/py-agent.mdx` and `jp/guides/ts-agent.mdx` — rewrote `Astro.currentLocale || 'en'` fallbacks in `<Link>` hrefs to `|| 'es'` / `|| 'jp'`, which would change routing behaviour. Rebuilt from `main` with only the sentence removed.
- `es/` and `pt/guides/ts-agent.mdx` — reworded an unchanged sentence about client class naming. Reverted.

The result is uniform across languages: `0/17` for every `trpc.mdx`, and 1–2 lines for each agent guide.

### Description of how you validated changes

- Confirmed the stale content is gone in all 8 languages, and that each affected sentence now ends where the English does.
- `docs:build` passes with no errors (the remaining `astro-expressive-code` warnings about `gitignore`/`ejs` languages are pre-existing on `main` and unrelated).
- Audited the per-file diffstat to check every remaining change corresponds to a real English change — the one multi-line agent-guide change that is *not* a pure removal is the AG-UI paragraph, which #1115 genuinely simplified in English (it no longer mentions `addPing` / `createStrandsApp`), so translating it is correct.

Committing the translations here rather than letting the bot generate them means merging this does not trigger a follow-up translation commit and CI restart.

### Issue # (if applicable)

N/A — follow-up to #1115.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
