### PR TITLE
fix(ts#dynamodb): provision appconfig profiles for every terraform runtime-config namespace

### DIFF
--- a/docs/src/content/docs/en/guides/connection/py-agent-rdb.mdx
+++ b/docs/src/content/docs/en/guides/connection/py-agent-rdb.mdx
@@ -146,16 +146,7 @@ resource "aws_vpc_security_group_egress_rule" "agent_to_database" {
 }
 ```
 
-`appconfig_application_id`/`appconfig_application_arn` come from the shared <Link path="guides/runtime-config">runtime configuration</Link> AppConfig application declared once in your root module, not from the database module. Include the `database` namespace when instantiating it so the database module's runtime configuration entry is deployed:
-
-```hcl title="packages/infra/src/main.tf"
-module "runtime_config_appconfig" {
-  source = "../../common/terraform/src/core/runtime-config/appconfig"
-
-  application_name = "my-app-runtime-config"
-  namespaces       = ["connection", "agentcore", "database"]
-}
-```
+`appconfig_application_id`/`appconfig_application_arn` come from the shared <Link path="guides/runtime-config">runtime configuration</Link> AppConfig application declared once in your root module, not from the database module. That application exposes the `database` namespace by default, so the database module's runtime configuration entry is deployed without further configuration.
 
 </Fragment>
 </Infrastructure>

--- a/docs/src/content/docs/en/guides/connection/py-fast-api-rdb.mdx
+++ b/docs/src/content/docs/en/guides/connection/py-fast-api-rdb.mdx
@@ -163,16 +163,7 @@ resource "aws_vpc_security_group_egress_rule" "api_to_database" {
 
 Deploy the API Lambda functions into **private subnets with egress**, not private isolated subnets. `appconfig_application_id`/`appconfig_application_arn` come from the shared <Link path="guides/runtime-config">runtime configuration</Link> AppConfig application declared once in your root module, not from the database module — passing them sets `RUNTIME_CONFIG_APP_ID` on the Lambda functions and grants them read access to the application.
 
-The AppConfig application must expose the `database` namespace so the database module's runtime configuration entry is deployed. Include it in the `namespaces` when instantiating the `runtime-config/appconfig` module:
-
-```hcl title="packages/infra/src/main.tf"
-module "runtime_config_appconfig" {
-  source = "../../common/terraform/src/core/runtime-config/appconfig"
-
-  application_name = "my-app-runtime-config"
-  namespaces       = ["connection", "agentcore", "database"]
-}
-```
+The AppConfig application exposes the `database` namespace by default, so the database module's runtime configuration entry is deployed without further configuration.
 
 </Fragment>
 </Infrastructure>

--- a/docs/src/content/docs/en/guides/connection/py-mcp-server-rdb.mdx
+++ b/docs/src/content/docs/en/guides/connection/py-mcp-server-rdb.mdx
@@ -155,16 +155,7 @@ resource "aws_vpc_security_group_egress_rule" "mcp_server_to_database" {
 }
 ```
 
-`appconfig_application_id`/`appconfig_application_arn` come from the shared <Link path="guides/runtime-config">runtime configuration</Link> AppConfig application declared once in your root module, not from the database module. Include the `database` namespace when instantiating it so the database module's runtime configuration entry is deployed:
-
-```hcl title="packages/infra/src/main.tf"
-module "runtime_config_appconfig" {
-  source = "../../common/terraform/src/core/runtime-config/appconfig"
-
-  application_name = "my-app-runtime-config"
-  namespaces       = ["connection", "agentcore", "database"]
-}
-```
+`appconfig_application_id`/`appconfig_application_arn` come from the shared <Link path="guides/runtime-config">runtime configuration</Link> AppConfig application declared once in your root module, not from the database module. That application exposes the `database` namespace by default, so the database module's runtime configuration entry is deployed without further configuration.
 
 </Fragment>
 </Infrastructure>

--- a/docs/src/content/docs/en/guides/connection/ts-agent-rdb.mdx
+++ b/docs/src/content/docs/en/guides/connection/ts-agent-rdb.mdx
@@ -161,16 +161,7 @@ resource "aws_vpc_security_group_egress_rule" "agent_to_database" {
 }
 ```
 
-`appconfig_application_id`/`appconfig_application_arn` come from the shared <Link path="guides/runtime-config">runtime configuration</Link> AppConfig application declared once in your root module, not from the database module. Include the `database` namespace when instantiating it so the database module's runtime configuration entry is deployed:
-
-```hcl title="packages/infra/src/main.tf"
-module "runtime_config_appconfig" {
-  source = "../../common/terraform/src/core/runtime-config/appconfig"
-
-  application_name = "my-app-runtime-config"
-  namespaces       = ["connection", "agentcore", "database"]
-}
-```
+`appconfig_application_id`/`appconfig_application_arn` come from the shared <Link path="guides/runtime-config">runtime configuration</Link> AppConfig application declared once in your root module, not from the database module. That application exposes the `database` namespace by default, so the database module's runtime configuration entry is deployed without further configuration.
 
 </Fragment>
 </Infrastructure>

--- a/docs/src/content/docs/en/guides/connection/ts-mcp-server-rdb.mdx
+++ b/docs/src/content/docs/en/guides/connection/ts-mcp-server-rdb.mdx
@@ -160,16 +160,7 @@ resource "aws_vpc_security_group_egress_rule" "mcp_server_to_database" {
 }
 ```
 
-`appconfig_application_id`/`appconfig_application_arn` come from the shared <Link path="guides/runtime-config">runtime configuration</Link> AppConfig application declared once in your root module, not from the database module. Include the `database` namespace when instantiating it so the database module's runtime configuration entry is deployed:
-
-```hcl title="packages/infra/src/main.tf"
-module "runtime_config_appconfig" {
-  source = "../../common/terraform/src/core/runtime-config/appconfig"
-
-  application_name = "my-app-runtime-config"
-  namespaces       = ["connection", "agentcore", "database"]
-}
-```
+`appconfig_application_id`/`appconfig_application_arn` come from the shared <Link path="guides/runtime-config">runtime configuration</Link> AppConfig application declared once in your root module, not from the database module. That application exposes the `database` namespace by default, so the database module's runtime configuration entry is deployed without further configuration.
 
 </Fragment>
 </Infrastructure>

--- a/docs/src/content/docs/en/guides/runtime-config.mdx
+++ b/docs/src/content/docs/en/guides/runtime-config.mdx
@@ -12,17 +12,19 @@ Runtime configuration is the mechanism used by Nx Plugin for AWS to pass deploy-
 
 Runtime configuration is organised into **namespaces**. Each namespace is a logical grouping of related configuration values. At deploy time, all namespaces are stored in **AWS AppConfig** as Configuration Profiles.
 
-Two built-in namespaces are used by generated constructs:
+Four built-in namespaces are used by generated constructs:
 
 - **`connection`** — configuration that enables generated projects to connect to each other:
   - **API URLs** — registered automatically by API constructs
   - **Cognito settings** — registered automatically by the UserIdentity construct
   - **Agent runtime ARNs** — added by the connection generator when you connect a React website to an Agent
 - **`agentcore`** — AgentCore runtime ARNs for agents and MCP servers. Registered automatically by the agent/MCP constructs and used for server-side discovery (agent → agent via A2A, agent → MCP server).
+- **`dynamodb`** — table names, registered automatically by DynamoDB table constructs and read by the generated table client.
+- **`database`** — Aurora connection details, registered automatically by relational database constructs and read by the generated database client.
 
-The `connection` namespace is also deployed as a `runtime-config.json` file to your website's S3 bucket, enabling client-side discovery of backend resources. The `agentcore` namespace is server-side only (via AppConfig) so agent runtime ARNs are not exposed to the frontend unless you explicitly connect a website to an agent.
+The `connection` namespace is also deployed as a `runtime-config.json` file to your website's S3 bucket, enabling client-side discovery of backend resources. The other namespaces are server-side only (via AppConfig), so values such as agent runtime ARNs and table names are not exposed to the frontend unless you explicitly connect a website to them.
 
-You can define as many additional namespaces as you like, providing a convenient alternative to environment variables for passing deploy-time values such as DynamoDB table names to your Lambda functions or other compute resources.
+You can define as many additional namespaces as you like, providing a convenient alternative to environment variables for passing deploy-time values to your Lambda functions or other compute resources.
 
 ```d2
 direction: down
@@ -104,6 +106,17 @@ Terraform wires runtime configuration across three `core/runtime-config/*` modul
      source = "../../common/terraform/src/core/runtime-config/appconfig"
 
      application_name = "my-app-runtime-config"
+   }
+   ```
+
+   The `namespaces` variable defaults to every built-in namespace, so generated modules work without configuring it. To add namespaces of your own, list them alongside the built-in ones:
+
+   ```hcl title="packages/infra/src/main.tf"
+   module "runtime_config_appconfig" {
+     source = "../../common/terraform/src/core/runtime-config/appconfig"
+
+     application_name = "my-app-runtime-config"
+     namespaces       = ["connection", "agentcore", "database", "dynamodb", "tables"]
    }
    ```
 

--- a/docs/src/content/docs/en/snippets/connection/rdb-api-infrastructure.mdx
+++ b/docs/src/content/docs/en/snippets/connection/rdb-api-infrastructure.mdx
@@ -89,16 +89,7 @@ resource "aws_vpc_security_group_egress_rule" "api_to_database" {
 }
 ```
 
-Deploy the API Lambda functions into **private subnets with egress**, not private isolated subnets. `appconfig_application_id`/`appconfig_application_arn` come from the shared <Link path="guides/runtime-config">runtime configuration</Link> AppConfig application declared once in your root module, not from the database module — passing them sets `RUNTIME_CONFIG_APP_ID` on the Lambda functions and grants them read access to the application. Include the `database` namespace when instantiating it so the database module's runtime configuration entry is deployed:
-
-```hcl title="packages/infra/src/main.tf"
-module "runtime_config_appconfig" {
-  source = "../../common/terraform/src/core/runtime-config/appconfig"
-
-  application_name = "my-app-runtime-config"
-  namespaces       = ["connection", "agentcore", "database"]
-}
-```
+Deploy the API Lambda functions into **private subnets with egress**, not private isolated subnets. `appconfig_application_id`/`appconfig_application_arn` come from the shared <Link path="guides/runtime-config">runtime configuration</Link> AppConfig application declared once in your root module, not from the database module — passing them sets `RUNTIME_CONFIG_APP_ID` on the Lambda functions and grants them read access to the application. That application exposes the `database` namespace by default, so the database module's runtime configuration entry is deployed without further configuration.
 
 </Fragment>
 </Infrastructure>

--- a/docs/src/content/docs/en/snippets/dynamodb/deploying-table.mdx
+++ b/docs/src/content/docs/en/snippets/dynamodb/deploying-table.mdx
@@ -47,7 +47,9 @@ This provisions a DynamoDB table with:
 - Customer-managed KMS encryption with automatic key rotation
 - Point-in-time recovery enabled
 - Deletion protection enabled
-- Table name registered in Runtime Config
+- Table name registered in Runtime Config under the `dynamodb` namespace in AWS AppConfig
+
+The `core/runtime-config/appconfig` module exposes the `dynamodb` namespace by default, so the table name is deployed without further configuration. If you pass `namespaces` to that module explicitly, keep `dynamodb` in the list — otherwise no configuration profile is created for it and the generated table client cannot resolve the table name.
 </Fragment>
 </Infrastructure>
 

--- a/docs/src/content/docs/en/snippets/rdb/deploying.mdx
+++ b/docs/src/content/docs/en/snippets/rdb/deploying.mdx
@@ -52,16 +52,7 @@ module "my_database" {
 
 This provisions an Aurora cluster with RDS Proxy, admin credentials, create-db-user Lambda, runtime config registration, migration Lambda, and container registry resources.
 
-The database module registers its connection details under the `database` runtime configuration namespace. Include this namespace when instantiating the shared runtime configuration AppConfig application:
-
-```hcl title="packages/infra/src/main.tf"
-module "runtime_config_appconfig" {
-  source = "../../common/terraform/src/core/runtime-config/appconfig"
-
-  application_name = "my-app-runtime-config"
-  namespaces       = ["connection", "agentcore", "database"]
-}
-```
+The database module registers its connection details under the `database` <Link path="guides/runtime-config">runtime configuration</Link> namespace, which the shared runtime configuration AppConfig application exposes by default.
 
 The generated infrastructure creates two database users:
 - **Admin user** - Created during cluster provisioning with credentials stored in AWS Secrets Manager

--- a/docs/src/content/docs/es/guides/connection/py-agent-rdb.mdx
+++ b/docs/src/content/docs/es/guides/connection/py-agent-rdb.mdx
@@ -146,16 +146,7 @@ resource "aws_vpc_security_group_egress_rule" "agent_to_database" {
 }
 ```
 
-`appconfig_application_id`/`appconfig_application_arn` provienen de la aplicación AppConfig de <Link path="guides/runtime-config">configuración de runtime</Link> compartida declarada una vez en tu módulo raíz, no del módulo de base de datos. Incluye el namespace `database` al instanciarla para que la entrada de configuración de runtime del módulo de base de datos sea desplegada:
-
-```hcl title="packages/infra/src/main.tf"
-module "runtime_config_appconfig" {
-  source = "../../common/terraform/src/core/runtime-config/appconfig"
-
-  application_name = "my-app-runtime-config"
-  namespaces       = ["connection", "agentcore", "database"]
-}
-```
+`appconfig_application_id`/`appconfig_application_arn` provienen de la aplicación AppConfig de <Link path="guides/runtime-config">configuración de runtime</Link> compartida declarada una vez en tu módulo raíz, no del módulo de base de datos. Esa aplicación expone el namespace `database` por defecto, por lo que la entrada de configuración de runtime del módulo de base de datos se despliega sin configuración adicional.
 
 </Fragment>
 </Infrastructure>

--- a/docs/src/content/docs/es/guides/connection/py-fast-api-rdb.mdx
+++ b/docs/src/content/docs/es/guides/connection/py-fast-api-rdb.mdx
@@ -163,16 +163,7 @@ resource "aws_vpc_security_group_egress_rule" "api_to_database" {
 
 Despliega las funciones Lambda de la API en **subredes privadas con salida**, no en subredes privadas aisladas. `appconfig_application_id`/`appconfig_application_arn` provienen de la aplicación AppConfig de <Link path="guides/runtime-config">configuración en tiempo de ejecución</Link> compartida declarada una vez en tu módulo raíz, no del módulo de base de datos — pasarlos establece `RUNTIME_CONFIG_APP_ID` en las funciones Lambda y les otorga acceso de lectura a la aplicación.
 
-La aplicación AppConfig debe exponer el namespace `database` para que la entrada de configuración en tiempo de ejecución del módulo de base de datos sea desplegada. Inclúyelo en los `namespaces` al instanciar el módulo `runtime-config/appconfig`:
-
-```hcl title="packages/infra/src/main.tf"
-module "runtime_config_appconfig" {
-  source = "../../common/terraform/src/core/runtime-config/appconfig"
-
-  application_name = "my-app-runtime-config"
-  namespaces       = ["connection", "agentcore", "database"]
-}
-```
+La aplicación AppConfig expone el namespace `database` por defecto, por lo que la entrada de configuración en tiempo de ejecución del módulo de base de datos se despliega sin configuración adicional.
 
 </Fragment>
 </Infrastructure>

--- a/docs/src/content/docs/es/guides/connection/py-mcp-server-rdb.mdx
+++ b/docs/src/content/docs/es/guides/connection/py-mcp-server-rdb.mdx
@@ -155,16 +155,7 @@ resource "aws_vpc_security_group_egress_rule" "mcp_server_to_database" {
 }
 ```
 
-`appconfig_application_id`/`appconfig_application_arn` provienen de la aplicación AppConfig de <Link path="guides/runtime-config">configuración de tiempo de ejecución</Link> compartida declarada una vez en tu módulo raíz, no del módulo de base de datos. Incluye el espacio de nombres `database` al instanciarla para que se implemente la entrada de configuración de tiempo de ejecución del módulo de base de datos:
-
-```hcl title="packages/infra/src/main.tf"
-module "runtime_config_appconfig" {
-  source = "../../common/terraform/src/core/runtime-config/appconfig"
-
-  application_name = "my-app-runtime-config"
-  namespaces       = ["connection", "agentcore", "database"]
-}
-```
+`appconfig_application_id`/`appconfig_application_arn` provienen de la aplicación AppConfig de <Link path="guides/runtime-config">configuración de tiempo de ejecución</Link> compartida declarada una vez en tu módulo raíz, no del módulo de base de datos. Esa aplicación expone el espacio de nombres `database` por defecto, por lo que la entrada de configuración de tiempo de ejecución del módulo de base de datos se implementa sin configuración adicional.
 
 </Fragment>
 </Infrastructure>

--- a/docs/src/content/docs/es/guides/connection/ts-agent-rdb.mdx
+++ b/docs/src/content/docs/es/guides/connection/ts-agent-rdb.mdx
@@ -161,16 +161,7 @@ resource "aws_vpc_security_group_egress_rule" "agent_to_database" {
 }
 ```
 
-`appconfig_application_id`/`appconfig_application_arn` provienen de la aplicación AppConfig de <Link path="guides/runtime-config">configuración de runtime</Link> compartida declarada una vez en tu módulo raíz, no del módulo de base de datos. Incluye el namespace `database` al instanciarla para que se despliegue la entrada de configuración de runtime del módulo de base de datos:
-
-```hcl title="packages/infra/src/main.tf"
-module "runtime_config_appconfig" {
-  source = "../../common/terraform/src/core/runtime-config/appconfig"
-
-  application_name = "my-app-runtime-config"
-  namespaces       = ["connection", "agentcore", "database"]
-}
-```
+`appconfig_application_id`/`appconfig_application_arn` provienen de la aplicación AppConfig de <Link path="guides/runtime-config">configuración de runtime</Link> compartida declarada una vez en tu módulo raíz, no del módulo de base de datos. Esa aplicación expone el namespace `database` por defecto, por lo que la entrada de configuración de runtime del módulo de base de datos se despliega sin configuración adicional.
 
 </Fragment>
 </Infrastructure>

--- a/docs/src/content/docs/es/guides/connection/ts-mcp-server-rdb.mdx
+++ b/docs/src/content/docs/es/guides/connection/ts-mcp-server-rdb.mdx
@@ -160,16 +160,7 @@ resource "aws_vpc_security_group_egress_rule" "mcp_server_to_database" {
 }
 ```
 
-`appconfig_application_id`/`appconfig_application_arn` provienen de la aplicación AppConfig de <Link path="guides/runtime-config">configuración de tiempo de ejecución</Link> compartida declarada una vez en tu módulo raíz, no del módulo de base de datos. Incluye el espacio de nombres `database` al instanciarla para que se implemente la entrada de configuración de tiempo de ejecución del módulo de base de datos:
-
-```hcl title="packages/infra/src/main.tf"
-module "runtime_config_appconfig" {
-  source = "../../common/terraform/src/core/runtime-config/appconfig"
-
-  application_name = "my-app-runtime-config"
-  namespaces       = ["connection", "agentcore", "database"]
-}
-```
+`appconfig_application_id`/`appconfig_application_arn` provienen de la aplicación AppConfig de <Link path="guides/runtime-config">configuración de tiempo de ejecución</Link> compartida declarada una vez en tu módulo raíz, no del módulo de base de datos. Esa aplicación expone el espacio de nombres `database` por defecto, por lo que la entrada de configuración de tiempo de ejecución del módulo de base de datos se implementa sin configuración adicional.
 
 </Fragment>
 </Infrastructure>

--- a/docs/src/content/docs/es/guides/runtime-config.mdx
+++ b/docs/src/content/docs/es/guides/runtime-config.mdx
@@ -12,17 +12,19 @@ La configuración en tiempo de ejecución es el mecanismo utilizado por Nx Plugi
 
 La configuración en tiempo de ejecución está organizada en **espacios de nombres**. Cada espacio de nombres es una agrupación lógica de valores de configuración relacionados. En tiempo de despliegue, todos los espacios de nombres se almacenan en **AWS AppConfig** como Perfiles de Configuración.
 
-Dos espacios de nombres integrados son utilizados por los constructos generados:
+Cuatro espacios de nombres integrados son utilizados por los constructos generados:
 
 - **`connection`** — configuración que permite a los proyectos generados conectarse entre sí:
   - **URLs de API** — registradas automáticamente por los constructos de API
   - **Configuración de Cognito** — registrada automáticamente por el constructo UserIdentity
   - **ARNs de tiempo de ejecución de agentes** — agregados por el generador de conexión cuando conectas un sitio web React a un agente
 - **`agentcore`** — ARNs de tiempo de ejecución de AgentCore para agentes y servidores MCP. Registrados automáticamente por los constructos de agente/MCP y utilizados para descubrimiento del lado del servidor (agente → agente vía A2A, agente → servidor MCP).
+- **`dynamodb`** — nombres de tablas, registrados automáticamente por los constructos de tabla DynamoDB y leídos por el cliente de tabla generado.
+- **`database`** — detalles de conexión de Aurora, registrados automáticamente por los constructos de base de datos relacional y leídos por el cliente de base de datos generado.
 
-El espacio de nombres `connection` también se despliega como un archivo `runtime-config.json` en el bucket S3 de tu sitio web, permitiendo el descubrimiento del lado del cliente de recursos backend. El espacio de nombres `agentcore` es solo del lado del servidor (vía AppConfig) por lo que los ARNs de tiempo de ejecución de agentes no se exponen al frontend a menos que conectes explícitamente un sitio web a un agente.
+El espacio de nombres `connection` también se despliega como un archivo `runtime-config.json` en el bucket S3 de tu sitio web, permitiendo el descubrimiento del lado del cliente de recursos backend. Los otros espacios de nombres son solo del lado del servidor (vía AppConfig), por lo que valores como ARNs de tiempo de ejecución de agentes y nombres de tablas no se exponen al frontend a menos que conectes explícitamente un sitio web a ellos.
 
-Puedes definir tantos espacios de nombres adicionales como desees, proporcionando una alternativa conveniente a las variables de entorno para pasar valores en tiempo de despliegue como nombres de tablas DynamoDB a tus funciones Lambda u otros recursos de cómputo.
+Puedes definir tantos espacios de nombres adicionales como desees, proporcionando una alternativa conveniente a las variables de entorno para pasar valores en tiempo de despliegue a tus funciones Lambda u otros recursos de cómputo.
 
 ```d2
 direction: down
@@ -104,6 +106,17 @@ Terraform conecta la configuración en tiempo de ejecución a través de tres m�
      source = "../../common/terraform/src/core/runtime-config/appconfig"
 
      application_name = "my-app-runtime-config"
+   }
+   ```
+
+   La variable `namespaces` tiene como valor predeterminado todos los espacios de nombres integrados, por lo que los módulos generados funcionan sin configurarla. Para agregar espacios de nombres propios, enuméralos junto con los integrados:
+
+   ```hcl title="packages/infra/src/main.tf"
+   module "runtime_config_appconfig" {
+     source = "../../common/terraform/src/core/runtime-config/appconfig"
+
+     application_name = "my-app-runtime-config"
+     namespaces       = ["connection", "agentcore", "database", "dynamodb", "tables"]
    }
    ```
 

--- a/docs/src/content/docs/es/snippets/connection/rdb-api-infrastructure.mdx
+++ b/docs/src/content/docs/es/snippets/connection/rdb-api-infrastructure.mdx
@@ -89,16 +89,7 @@ resource "aws_vpc_security_group_egress_rule" "api_to_database" {
 }
 ```
 
-Despliega las funciones Lambda de la API en **subredes privadas con salida**, no en subredes privadas aisladas. `appconfig_application_id`/`appconfig_application_arn` provienen de la aplicación AppConfig de <Link path="guides/runtime-config">configuración en tiempo de ejecución</Link> compartida declarada una vez en tu módulo raíz, no del módulo de base de datos — pasarlos establece `RUNTIME_CONFIG_APP_ID` en las funciones Lambda y les otorga acceso de lectura a la aplicación. Incluye el namespace `database` al instanciarla para que se despliegue la entrada de configuración en tiempo de ejecución del módulo de base de datos:
-
-```hcl title="packages/infra/src/main.tf"
-module "runtime_config_appconfig" {
-  source = "../../common/terraform/src/core/runtime-config/appconfig"
-
-  application_name = "my-app-runtime-config"
-  namespaces       = ["connection", "agentcore", "database"]
-}
-```
+Despliega las funciones Lambda de la API en **subredes privadas con salida**, no en subredes privadas aisladas. `appconfig_application_id`/`appconfig_application_arn` provienen de la aplicación AppConfig de <Link path="guides/runtime-config">configuración en tiempo de ejecución</Link> compartida declarada una vez en tu módulo raíz, no del módulo de base de datos — pasarlos establece `RUNTIME_CONFIG_APP_ID` en las funciones Lambda y les otorga acceso de lectura a la aplicación. Esa aplicación expone el namespace `database` por defecto, por lo que la entrada de configuración en tiempo de ejecución del módulo de base de datos se despliega sin configuración adicional.
 
 </Fragment>
 </Infrastructure>

--- a/docs/src/content/docs/es/snippets/dynamodb/deploying-table.mdx
+++ b/docs/src/content/docs/es/snippets/dynamodb/deploying-table.mdx
@@ -47,7 +47,9 @@ Esto aprovisiona una tabla de DynamoDB con:
 - Cifrado KMS gestionado por el cliente con rotación automática de claves
 - Recuperación a un punto en el tiempo habilitada
 - Protección contra eliminación habilitada
-- Nombre de tabla registrado en Runtime Config
+- Nombre de tabla registrado en Runtime Config bajo el espacio de nombres `dynamodb` en AWS AppConfig
+
+El módulo `core/runtime-config/appconfig` expone el espacio de nombres `dynamodb` por defecto, por lo que el nombre de la tabla se despliega sin configuración adicional. Si pasas `namespaces` a ese módulo explícitamente, mantén `dynamodb` en la lista; de lo contrario, no se crea ningún perfil de configuración para él y el cliente de tabla generado no puede resolver el nombre de la tabla.
 </Fragment>
 </Infrastructure>
 

--- a/docs/src/content/docs/es/snippets/rdb/deploying.mdx
+++ b/docs/src/content/docs/es/snippets/rdb/deploying.mdx
@@ -52,16 +52,7 @@ module "my_database" {
 
 Esto aprovisiona un clúster Aurora con RDS Proxy, credenciales de administrador, Lambda create-db-user, registro de configuración en tiempo de ejecución, Lambda de migración y recursos de registro de contenedores.
 
-El módulo de base de datos registra sus detalles de conexión bajo el espacio de nombres de configuración en tiempo de ejecución `database`. Incluye este espacio de nombres al instanciar la aplicación AppConfig de configuración en tiempo de ejecución compartida:
-
-```hcl title="packages/infra/src/main.tf"
-module "runtime_config_appconfig" {
-  source = "../../common/terraform/src/core/runtime-config/appconfig"
-
-  application_name = "my-app-runtime-config"
-  namespaces       = ["connection", "agentcore", "database"]
-}
-```
+El módulo de base de datos registra sus detalles de conexión bajo el espacio de nombres de <Link path="guides/runtime-config">configuración en tiempo de ejecución</Link> `database`, que la aplicación AppConfig de configuración en tiempo de ejecución compartida expone por defecto.
 
 La infraestructura generada crea dos usuarios de base de datos:
 - **Usuario administrador** - Creado durante el aprovisionamiento del clúster con credenciales almacenadas en AWS Secrets Manager

--- a/docs/src/content/docs/fr/guides/connection/py-agent-rdb.mdx
+++ b/docs/src/content/docs/fr/guides/connection/py-agent-rdb.mdx
@@ -146,16 +146,7 @@ resource "aws_vpc_security_group_egress_rule" "agent_to_database" {
 }
 ```
 
-`appconfig_application_id`/`appconfig_application_arn` proviennent de l'application AppConfig de <Link path="guides/runtime-config">configuration d'exécution</Link> partagée déclarée une fois dans votre module racine, et non du module de base de données. Incluez l'espace de noms `database` lors de son instanciation afin que l'entrée de configuration d'exécution du module de base de données soit déployée :
-
-```hcl title="packages/infra/src/main.tf"
-module "runtime_config_appconfig" {
-  source = "../../common/terraform/src/core/runtime-config/appconfig"
-
-  application_name = "my-app-runtime-config"
-  namespaces       = ["connection", "agentcore", "database"]
-}
-```
+`appconfig_application_id`/`appconfig_application_arn` proviennent de l'application AppConfig de <Link path="guides/runtime-config">configuration d'exécution</Link> partagée déclarée une fois dans votre module racine, et non du module de base de données. Cette application expose l'espace de noms `database` par défaut, de sorte que l'entrée de configuration d'exécution du module de base de données est déployée sans configuration supplémentaire.
 
 </Fragment>
 </Infrastructure>

--- a/docs/src/content/docs/fr/guides/connection/py-fast-api-rdb.mdx
+++ b/docs/src/content/docs/fr/guides/connection/py-fast-api-rdb.mdx
@@ -163,16 +163,7 @@ resource "aws_vpc_security_group_egress_rule" "api_to_database" {
 
 Déployez les fonctions Lambda de l'API dans des **sous-réseaux privés avec sortie**, et non dans des sous-réseaux privés isolés. `appconfig_application_id`/`appconfig_application_arn` proviennent de l'application AppConfig de <Link path="guides/runtime-config">configuration d'exécution</Link> partagée déclarée une fois dans votre module racine, et non du module de base de données — les transmettre définit `RUNTIME_CONFIG_APP_ID` sur les fonctions Lambda et leur accorde un accès en lecture à l'application.
 
-L'application AppConfig doit exposer l'espace de noms `database` pour que l'entrée de configuration d'exécution du module de base de données soit déployée. Incluez-le dans les `namespaces` lors de l'instanciation du module `runtime-config/appconfig` :
-
-```hcl title="packages/infra/src/main.tf"
-module "runtime_config_appconfig" {
-  source = "../../common/terraform/src/core/runtime-config/appconfig"
-
-  application_name = "my-app-runtime-config"
-  namespaces       = ["connection", "agentcore", "database"]
-}
-```
+L'application AppConfig expose l'espace de noms `database` par défaut, de sorte que l'entrée de configuration d'exécution du module de base de données est déployée sans configuration supplémentaire.
 
 </Fragment>
 </Infrastructure>

--- a/docs/src/content/docs/fr/guides/connection/py-mcp-server-rdb.mdx
+++ b/docs/src/content/docs/fr/guides/connection/py-mcp-server-rdb.mdx
@@ -155,16 +155,7 @@ resource "aws_vpc_security_group_egress_rule" "mcp_server_to_database" {
 }
 ```
 
-`appconfig_application_id`/`appconfig_application_arn` proviennent de l'application AppConfig de <Link path="guides/runtime-config">configuration d'exécution</Link> partagée déclarée une fois dans votre module racine, et non du module de base de données. Incluez l'espace de noms `database` lors de son instanciation afin que l'entrée de configuration d'exécution du module de base de données soit déployée :
-
-```hcl title="packages/infra/src/main.tf"
-module "runtime_config_appconfig" {
-  source = "../../common/terraform/src/core/runtime-config/appconfig"
-
-  application_name = "my-app-runtime-config"
-  namespaces       = ["connection", "agentcore", "database"]
-}
-```
+`appconfig_application_id`/`appconfig_application_arn` proviennent de l'application AppConfig de <Link path="guides/runtime-config">configuration d'exécution</Link> partagée déclarée une fois dans votre module racine, et non du module de base de données. Cette application expose l'espace de noms `database` par défaut, de sorte que l'entrée de configuration d'exécution du module de base de données est déployée sans configuration supplémentaire.
 
 </Fragment>
 </Infrastructure>

--- a/docs/src/content/docs/fr/guides/connection/ts-agent-rdb.mdx
+++ b/docs/src/content/docs/fr/guides/connection/ts-agent-rdb.mdx
@@ -161,16 +161,7 @@ resource "aws_vpc_security_group_egress_rule" "agent_to_database" {
 }
 ```
 
-`appconfig_application_id`/`appconfig_application_arn` proviennent de l'application AppConfig de <Link path="guides/runtime-config">configuration d'exécution</Link> partagée déclarée une fois dans votre module racine, et non du module de base de données. Incluez l'espace de noms `database` lors de son instanciation afin que l'entrée de configuration d'exécution du module de base de données soit déployée :
-
-```hcl title="packages/infra/src/main.tf"
-module "runtime_config_appconfig" {
-  source = "../../common/terraform/src/core/runtime-config/appconfig"
-
-  application_name = "my-app-runtime-config"
-  namespaces       = ["connection", "agentcore", "database"]
-}
-```
+`appconfig_application_id`/`appconfig_application_arn` proviennent de l'application AppConfig de <Link path="guides/runtime-config">configuration d'exécution</Link> partagée déclarée une fois dans votre module racine, et non du module de base de données. Cette application expose l'espace de noms `database` par défaut, de sorte que l'entrée de configuration d'exécution du module de base de données est déployée sans configuration supplémentaire.
 
 </Fragment>
 </Infrastructure>

--- a/docs/src/content/docs/fr/guides/connection/ts-mcp-server-rdb.mdx
+++ b/docs/src/content/docs/fr/guides/connection/ts-mcp-server-rdb.mdx
@@ -160,16 +160,7 @@ resource "aws_vpc_security_group_egress_rule" "mcp_server_to_database" {
 }
 ```
 
-`appconfig_application_id`/`appconfig_application_arn` proviennent de l'application AppConfig de <Link path="guides/runtime-config">configuration d'exécution</Link> partagée déclarée une fois dans votre module racine, et non du module de base de données. Incluez l'espace de noms `database` lors de son instanciation afin que l'entrée de configuration d'exécution du module de base de données soit déployée :
-
-```hcl title="packages/infra/src/main.tf"
-module "runtime_config_appconfig" {
-  source = "../../common/terraform/src/core/runtime-config/appconfig"
-
-  application_name = "my-app-runtime-config"
-  namespaces       = ["connection", "agentcore", "database"]
-}
-```
+`appconfig_application_id`/`appconfig_application_arn` proviennent de l'application AppConfig de <Link path="guides/runtime-config">configuration d'exécution</Link> partagée déclarée une fois dans votre module racine, et non du module de base de données. Cette application expose l'espace de noms `database` par défaut, de sorte que l'entrée de configuration d'exécution du module de base de données est déployée sans configuration supplémentaire.
 
 </Fragment>
 </Infrastructure>

--- a/docs/src/content/docs/fr/guides/runtime-config.mdx
+++ b/docs/src/content/docs/fr/guides/runtime-config.mdx
@@ -12,17 +12,19 @@ La configuration d'exécution est le mécanisme utilisé par Nx Plugin for AWS p
 
 La configuration d'exécution est organisée en **espaces de noms**. Chaque espace de noms est un regroupement logique de valeurs de configuration associées. Au moment du déploiement, tous les espaces de noms sont stockés dans **AWS AppConfig** en tant que profils de configuration.
 
-Deux espaces de noms intégrés sont utilisés par les constructions générées :
+Quatre espaces de noms intégrés sont utilisés par les constructions générées :
 
 - **`connection`** — configuration qui permet aux projets générés de se connecter les uns aux autres :
   - **URL d'API** — enregistrées automatiquement par les constructions d'API
   - **Paramètres Cognito** — enregistrés automatiquement par la construction UserIdentity
   - **ARN d'exécution d'agent** — ajoutés par le générateur de connexion lorsque vous connectez un site web React à un agent
 - **`agentcore`** — ARN d'exécution AgentCore pour les agents et les serveurs MCP. Enregistrés automatiquement par les constructions agent/MCP et utilisés pour la découverte côté serveur (agent → agent via A2A, agent → serveur MCP).
+- **`dynamodb`** — noms de tables, enregistrés automatiquement par les constructions de tables DynamoDB et lus par le client de table généré.
+- **`database`** — détails de connexion Aurora, enregistrés automatiquement par les constructions de bases de données relationnelles et lus par le client de base de données généré.
 
-L'espace de noms `connection` est également déployé sous forme de fichier `runtime-config.json` dans le bucket S3 de votre site web, permettant la découverte côté client des ressources backend. L'espace de noms `agentcore` est uniquement côté serveur (via AppConfig) afin que les ARN d'exécution d'agent ne soient pas exposés au frontend à moins que vous ne connectiez explicitement un site web à un agent.
+L'espace de noms `connection` est également déployé sous forme de fichier `runtime-config.json` dans le bucket S3 de votre site web, permettant la découverte côté client des ressources backend. Les autres espaces de noms sont uniquement côté serveur (via AppConfig), de sorte que les valeurs telles que les ARN d'exécution d'agent et les noms de tables ne sont pas exposées au frontend à moins que vous ne connectiez explicitement un site web à eux.
 
-Vous pouvez définir autant d'espaces de noms supplémentaires que vous le souhaitez, offrant une alternative pratique aux variables d'environnement pour transmettre des valeurs de déploiement telles que les noms de tables DynamoDB à vos fonctions Lambda ou autres ressources de calcul.
+Vous pouvez définir autant d'espaces de noms supplémentaires que vous le souhaitez, offrant une alternative pratique aux variables d'environnement pour transmettre des valeurs de déploiement à vos fonctions Lambda ou autres ressources de calcul.
 
 ```d2
 direction: down
@@ -104,6 +106,17 @@ Terraform connecte la configuration d'exécution à travers trois modules `core/
      source = "../../common/terraform/src/core/runtime-config/appconfig"
 
      application_name = "my-app-runtime-config"
+   }
+   ```
+
+   La variable `namespaces` est par défaut définie sur tous les espaces de noms intégrés, de sorte que les modules générés fonctionnent sans la configurer. Pour ajouter vos propres espaces de noms, listez-les aux côtés des espaces de noms intégrés :
+
+   ```hcl title="packages/infra/src/main.tf"
+   module "runtime_config_appconfig" {
+     source = "../../common/terraform/src/core/runtime-config/appconfig"
+
+     application_name = "my-app-runtime-config"
+     namespaces       = ["connection", "agentcore", "database", "dynamodb", "tables"]
    }
    ```
 

--- a/docs/src/content/docs/fr/snippets/connection/rdb-api-infrastructure.mdx
+++ b/docs/src/content/docs/fr/snippets/connection/rdb-api-infrastructure.mdx
@@ -89,16 +89,7 @@ resource "aws_vpc_security_group_egress_rule" "api_to_database" {
 }
 ```
 
-Déployez les fonctions Lambda de l'API dans des **sous-réseaux privés avec sortie**, et non dans des sous-réseaux privés isolés. `appconfig_application_id`/`appconfig_application_arn` proviennent de l'application AppConfig de <Link path="guides/runtime-config">configuration d'exécution</Link> partagée déclarée une fois dans votre module racine, et non du module de base de données — leur transmission définit `RUNTIME_CONFIG_APP_ID` sur les fonctions Lambda et leur accorde un accès en lecture à l'application. Incluez l'espace de noms `database` lors de son instanciation afin que l'entrée de configuration d'exécution du module de base de données soit déployée :
-
-```hcl title="packages/infra/src/main.tf"
-module "runtime_config_appconfig" {
-  source = "../../common/terraform/src/core/runtime-config/appconfig"
-
-  application_name = "my-app-runtime-config"
-  namespaces       = ["connection", "agentcore", "database"]
-}
-```
+Déployez les fonctions Lambda de l'API dans des **sous-réseaux privés avec sortie**, et non dans des sous-réseaux privés isolés. `appconfig_application_id`/`appconfig_application_arn` proviennent de l'application AppConfig de <Link path="guides/runtime-config">configuration d'exécution</Link> partagée déclarée une fois dans votre module racine, et non du module de base de données — leur transmission définit `RUNTIME_CONFIG_APP_ID` sur les fonctions Lambda et leur accorde un accès en lecture à l'application. Cette application expose l'espace de noms `database` par défaut, de sorte que l'entrée de configuration d'exécution du module de base de données est déployée sans configuration supplémentaire.
 
 </Fragment>
 </Infrastructure>

--- a/docs/src/content/docs/fr/snippets/dynamodb/deploying-table.mdx
+++ b/docs/src/content/docs/fr/snippets/dynamodb/deploying-table.mdx
@@ -47,7 +47,9 @@ Cela provisionne une table DynamoDB avec :
 - Un chiffrement KMS géré par le client avec rotation automatique des clés
 - La récupération à un instant dans le passé activée
 - La protection contre la suppression activée
-- Le nom de la table enregistré dans Runtime Config
+- Le nom de la table enregistré dans Runtime Config sous l'espace de noms `dynamodb` dans AWS AppConfig
+
+Le module `core/runtime-config/appconfig` expose l'espace de noms `dynamodb` par défaut, de sorte que le nom de la table est déployé sans configuration supplémentaire. Si vous passez explicitement `namespaces` à ce module, conservez `dynamodb` dans la liste — sinon aucun profil de configuration n'est créé pour celui-ci et le client de table généré ne peut pas résoudre le nom de la table.
 </Fragment>
 </Infrastructure>
 

--- a/docs/src/content/docs/fr/snippets/rdb/deploying.mdx
+++ b/docs/src/content/docs/fr/snippets/rdb/deploying.mdx
@@ -52,16 +52,7 @@ module "my_database" {
 
 Cela provisionne un cluster Aurora avec RDS Proxy, des identifiants administrateur, une Lambda create-db-user, l'enregistrement de configuration d'exécution, une Lambda de migration et des ressources de registre de conteneurs.
 
-Le module de base de données enregistre ses détails de connexion sous l'espace de noms de configuration d'exécution `database`. Incluez cet espace de noms lors de l'instanciation de l'application AppConfig de configuration d'exécution partagée :
-
-```hcl title="packages/infra/src/main.tf"
-module "runtime_config_appconfig" {
-  source = "../../common/terraform/src/core/runtime-config/appconfig"
-
-  application_name = "my-app-runtime-config"
-  namespaces       = ["connection", "agentcore", "database"]
-}
-```
+Le module de base de données enregistre ses détails de connexion sous l'espace de noms de <Link path="guides/runtime-config">configuration d'exécution</Link> `database`, que l'application AppConfig de configuration d'exécution partagée expose par défaut.
 
 L'infrastructure générée crée deux utilisateurs de base de données :
 - **Utilisateur administrateur** - Créé lors du provisionnement du cluster avec des identifiants stockés dans AWS Secrets Manager

--- a/docs/src/content/docs/it/guides/connection/py-agent-rdb.mdx
+++ b/docs/src/content/docs/it/guides/connection/py-agent-rdb.mdx
@@ -146,16 +146,7 @@ resource "aws_vpc_security_group_egress_rule" "agent_to_database" {
 }
 ```
 
-`appconfig_application_id`/`appconfig_application_arn` provengono dall'applicazione AppConfig di <Link path="guides/runtime-config">configurazione runtime</Link> condivisa dichiarata una volta nel tuo modulo root, non dal modulo database. Includi il namespace `database` quando la istanzi in modo che la voce di configurazione runtime del modulo database venga distribuita:
-
-```hcl title="packages/infra/src/main.tf"
-module "runtime_config_appconfig" {
-  source = "../../common/terraform/src/core/runtime-config/appconfig"
-
-  application_name = "my-app-runtime-config"
-  namespaces       = ["connection", "agentcore", "database"]
-}
-```
+`appconfig_application_id`/`appconfig_application_arn` provengono dall'applicazione AppConfig di <Link path="guides/runtime-config">configurazione runtime</Link> condivisa dichiarata una volta nel tuo modulo root, non dal modulo database. Quell'applicazione espone il namespace `database` per impostazione predefinita, quindi la voce di configurazione runtime del modulo database viene distribuita senza ulteriore configurazione.
 
 </Fragment>
 </Infrastructure>

--- a/docs/src/content/docs/it/guides/connection/py-fast-api-rdb.mdx
+++ b/docs/src/content/docs/it/guides/connection/py-fast-api-rdb.mdx
@@ -163,16 +163,7 @@ resource "aws_vpc_security_group_egress_rule" "api_to_database" {
 
 Distribuisci le funzioni Lambda dell'API in **subnet private con egress**, non in subnet private isolate. `appconfig_application_id`/`appconfig_application_arn` provengono dall'applicazione AppConfig di <Link path="guides/runtime-config">configurazione runtime</Link> condivisa dichiarata una volta nel tuo modulo root, non dal modulo del database — passarli imposta `RUNTIME_CONFIG_APP_ID` sulle funzioni Lambda e concede loro l'accesso in lettura all'applicazione.
 
-L'applicazione AppConfig deve esporre il namespace `database` in modo che la voce di configurazione runtime del modulo del database venga distribuita. Includilo nei `namespaces` quando istanzi il modulo `runtime-config/appconfig`:
-
-```hcl title="packages/infra/src/main.tf"
-module "runtime_config_appconfig" {
-  source = "../../common/terraform/src/core/runtime-config/appconfig"
-
-  application_name = "my-app-runtime-config"
-  namespaces       = ["connection", "agentcore", "database"]
-}
-```
+L'applicazione AppConfig espone il namespace `database` per impostazione predefinita, quindi la voce di configurazione runtime del modulo del database viene distribuita senza ulteriore configurazione.
 
 </Fragment>
 </Infrastructure>

--- a/docs/src/content/docs/it/guides/connection/py-mcp-server-rdb.mdx
+++ b/docs/src/content/docs/it/guides/connection/py-mcp-server-rdb.mdx
@@ -155,16 +155,7 @@ resource "aws_vpc_security_group_egress_rule" "mcp_server_to_database" {
 }
 ```
 
-`appconfig_application_id`/`appconfig_application_arn` provengono dall'applicazione AppConfig di <Link path="guides/runtime-config">configurazione runtime</Link> condivisa dichiarata una volta nel tuo modulo root, non dal modulo del database. Includi il namespace `database` quando lo istanzi in modo che l'entry di configurazione runtime del modulo del database venga distribuita:
-
-```hcl title="packages/infra/src/main.tf"
-module "runtime_config_appconfig" {
-  source = "../../common/terraform/src/core/runtime-config/appconfig"
-
-  application_name = "my-app-runtime-config"
-  namespaces       = ["connection", "agentcore", "database"]
-}
-```
+`appconfig_application_id`/`appconfig_application_arn` provengono dall'applicazione AppConfig di <Link path="guides/runtime-config">configurazione runtime</Link> condivisa dichiarata una volta nel tuo modulo root, non dal modulo del database. Tale applicazione espone il namespace `database` per impostazione predefinita, quindi l'entry di configurazione runtime del modulo del database viene distribuita senza ulteriori configurazioni.
 
 </Fragment>
 </Infrastructure>

--- a/docs/src/content/docs/it/guides/connection/ts-agent-rdb.mdx
+++ b/docs/src/content/docs/it/guides/connection/ts-agent-rdb.mdx
@@ -161,16 +161,7 @@ resource "aws_vpc_security_group_egress_rule" "agent_to_database" {
 }
 ```
 
-`appconfig_application_id`/`appconfig_application_arn` provengono dall'applicazione AppConfig di <Link path="guides/runtime-config">configurazione runtime</Link> condivisa dichiarata una volta nel tuo modulo root, non dal modulo del database. Includi il namespace `database` quando la istanzi in modo che l'entry di configurazione runtime del modulo del database venga distribuita:
-
-```hcl title="packages/infra/src/main.tf"
-module "runtime_config_appconfig" {
-  source = "../../common/terraform/src/core/runtime-config/appconfig"
-
-  application_name = "my-app-runtime-config"
-  namespaces       = ["connection", "agentcore", "database"]
-}
-```
+`appconfig_application_id`/`appconfig_application_arn` provengono dall'applicazione AppConfig di <Link path="guides/runtime-config">configurazione runtime</Link> condivisa dichiarata una volta nel tuo modulo root, non dal modulo del database. Quell'applicazione espone il namespace `database` per impostazione predefinita, quindi l'entry di configurazione runtime del modulo del database viene distribuita senza ulteriori configurazioni.
 
 </Fragment>
 </Infrastructure>

--- a/docs/src/content/docs/it/guides/connection/ts-mcp-server-rdb.mdx
+++ b/docs/src/content/docs/it/guides/connection/ts-mcp-server-rdb.mdx
@@ -160,16 +160,7 @@ resource "aws_vpc_security_group_egress_rule" "mcp_server_to_database" {
 }
 ```
 
-`appconfig_application_id`/`appconfig_application_arn` provengono dall'applicazione AppConfig di <Link path="guides/runtime-config">configurazione runtime</Link> condivisa dichiarata una volta nel tuo modulo root, non dal modulo database. Includi il namespace `database` quando la istanzi in modo che la voce di configurazione runtime del modulo database venga distribuita:
-
-```hcl title="packages/infra/src/main.tf"
-module "runtime_config_appconfig" {
-  source = "../../common/terraform/src/core/runtime-config/appconfig"
-
-  application_name = "my-app-runtime-config"
-  namespaces       = ["connection", "agentcore", "database"]
-}
-```
+`appconfig_application_id`/`appconfig_application_arn` provengono dall'applicazione AppConfig di <Link path="guides/runtime-config">configurazione runtime</Link> condivisa dichiarata una volta nel tuo modulo root, non dal modulo database. Quell'applicazione espone il namespace `database` per impostazione predefinita, quindi la voce di configurazione runtime del modulo database viene distribuita senza ulteriore configurazione.
 
 </Fragment>
 </Infrastructure>

--- a/docs/src/content/docs/it/guides/runtime-config.mdx
+++ b/docs/src/content/docs/it/guides/runtime-config.mdx
@@ -12,17 +12,19 @@ La configurazione runtime è il meccanismo utilizzato da Nx Plugin for AWS per p
 
 La configurazione runtime è organizzata in **namespace**. Ogni namespace è un raggruppamento logico di valori di configurazione correlati. Al momento del deploy, tutti i namespace vengono memorizzati in **AWS AppConfig** come Configuration Profile.
 
-Due namespace integrati vengono utilizzati dai costrutti generati:
+Quattro namespace integrati vengono utilizzati dai costrutti generati:
 
 - **`connection`** — configurazione che consente ai progetti generati di connettersi tra loro:
   - **URL delle API** — registrati automaticamente dai costrutti API
   - **Impostazioni Cognito** — registrate automaticamente dal costrutto UserIdentity
   - **ARN runtime degli Agent** — aggiunti dal generatore di connessioni quando connetti un sito web React a un Agent
 - **`agentcore`** — ARN runtime di AgentCore per agent e server MCP. Registrati automaticamente dai costrutti agent/MCP e utilizzati per la scoperta lato server (agent → agent tramite A2A, agent → server MCP).
+- **`dynamodb`** — nomi delle tabelle, registrati automaticamente dai costrutti delle tabelle DynamoDB e letti dal client della tabella generato.
+- **`database`** — dettagli di connessione Aurora, registrati automaticamente dai costrutti dei database relazionali e letti dal client del database generato.
 
-Il namespace `connection` viene anche distribuito come file `runtime-config.json` nel bucket S3 del tuo sito web, consentendo la scoperta lato client delle risorse backend. Il namespace `agentcore` è solo lato server (tramite AppConfig) quindi gli ARN runtime degli agent non vengono esposti al frontend a meno che tu non connetta esplicitamente un sito web a un agent.
+Il namespace `connection` viene anche distribuito come file `runtime-config.json` nel bucket S3 del tuo sito web, consentendo la scoperta lato client delle risorse backend. Gli altri namespace sono solo lato server (tramite AppConfig), quindi valori come gli ARN runtime degli agent e i nomi delle tabelle non vengono esposti al frontend a meno che tu non connetta esplicitamente un sito web a essi.
 
-Puoi definire tutti i namespace aggiuntivi che desideri, fornendo una comoda alternativa alle variabili d'ambiente per passare valori di deploy-time come nomi di tabelle DynamoDB alle tue funzioni Lambda o ad altre risorse di calcolo.
+Puoi definire tutti i namespace aggiuntivi che desideri, fornendo una comoda alternativa alle variabili d'ambiente per passare valori di deploy-time alle tue funzioni Lambda o ad altre risorse di calcolo.
 
 ```d2
 direction: down
@@ -104,6 +106,17 @@ Terraform collega la configurazione runtime attraverso tre moduli `core/runtime-
      source = "../../common/terraform/src/core/runtime-config/appconfig"
 
      application_name = "my-app-runtime-config"
+   }
+   ```
+
+   La variabile `namespaces` ha come default tutti i namespace integrati, quindi i moduli generati funzionano senza configurarla. Per aggiungere namespace personalizzati, elencali insieme a quelli integrati:
+
+   ```hcl title="packages/infra/src/main.tf"
+   module "runtime_config_appconfig" {
+     source = "../../common/terraform/src/core/runtime-config/appconfig"
+
+     application_name = "my-app-runtime-config"
+     namespaces       = ["connection", "agentcore", "database", "dynamodb", "tables"]
    }
    ```
 

--- a/docs/src/content/docs/it/snippets/connection/rdb-api-infrastructure.mdx
+++ b/docs/src/content/docs/it/snippets/connection/rdb-api-infrastructure.mdx
@@ -89,16 +89,7 @@ resource "aws_vpc_security_group_egress_rule" "api_to_database" {
 }
 ```
 
-Distribuisci le funzioni Lambda dell'API in **subnet private con egress**, non in subnet private isolate. `appconfig_application_id`/`appconfig_application_arn` provengono dall'applicazione <Link path="guides/runtime-config">runtime configuration</Link> AppConfig condivisa dichiarata una volta nel tuo modulo root, non dal modulo del database — passarli imposta `RUNTIME_CONFIG_APP_ID` sulle funzioni Lambda e concede loro l'accesso in lettura all'applicazione. Includi il namespace `database` quando lo istanzi in modo che l'entry di configurazione runtime del modulo del database venga distribuita:
-
-```hcl title="packages/infra/src/main.tf"
-module "runtime_config_appconfig" {
-  source = "../../common/terraform/src/core/runtime-config/appconfig"
-
-  application_name = "my-app-runtime-config"
-  namespaces       = ["connection", "agentcore", "database"]
-}
-```
+Distribuisci le funzioni Lambda dell'API in **subnet private con egress**, non in subnet private isolate. `appconfig_application_id`/`appconfig_application_arn` provengono dall'applicazione <Link path="guides/runtime-config">runtime configuration</Link> AppConfig condivisa dichiarata una volta nel tuo modulo root, non dal modulo del database — passarli imposta `RUNTIME_CONFIG_APP_ID` sulle funzioni Lambda e concede loro l'accesso in lettura all'applicazione. Tale applicazione espone il namespace `database` per impostazione predefinita, quindi l'entry di configurazione runtime del modulo del database viene distribuita senza ulteriore configurazione.
 
 </Fragment>
 </Infrastructure>

--- a/docs/src/content/docs/it/snippets/dynamodb/deploying-table.mdx
+++ b/docs/src/content/docs/it/snippets/dynamodb/deploying-table.mdx
@@ -47,7 +47,9 @@ Questo esegue il provisioning di una tabella DynamoDB con:
 - Crittografia KMS gestita dal cliente con rotazione automatica delle chiavi
 - Point-in-time recovery abilitato
 - Protezione dall'eliminazione abilitata
-- Nome della tabella registrato in Runtime Config
+- Nome della tabella registrato in Runtime Config nello spazio dei nomi `dynamodb` in AWS AppConfig
+
+Il modulo `core/runtime-config/appconfig` espone lo spazio dei nomi `dynamodb` per impostazione predefinita, quindi il nome della tabella viene distribuito senza ulteriori configurazioni. Se passi `namespaces` a quel modulo esplicitamente, mantieni `dynamodb` nell'elenco — altrimenti non viene creato alcun profilo di configurazione per esso e il client della tabella generato non può risolvere il nome della tabella.
 </Fragment>
 </Infrastructure>
 

--- a/docs/src/content/docs/it/snippets/rdb/deploying.mdx
+++ b/docs/src/content/docs/it/snippets/rdb/deploying.mdx
@@ -52,16 +52,7 @@ module "my_database" {
 
 Questo esegue il provisioning di un cluster Aurora con RDS Proxy, credenziali amministratore, Lambda create-db-user, registrazione della configurazione di runtime, Lambda di migrazione e risorse del registro dei container.
 
-Il modulo del database registra i suoi dettagli di connessione nello spazio dei nomi della configurazione di runtime `database`. Includi questo spazio dei nomi quando istanzi l'applicazione AppConfig della configurazione di runtime condivisa:
-
-```hcl title="packages/infra/src/main.tf"
-module "runtime_config_appconfig" {
-  source = "../../common/terraform/src/core/runtime-config/appconfig"
-
-  application_name = "my-app-runtime-config"
-  namespaces       = ["connection", "agentcore", "database"]
-}
-```
+Il modulo del database registra i suoi dettagli di connessione nello spazio dei nomi della <Link path="guides/runtime-config">configurazione di runtime</Link> `database`, che l'applicazione AppConfig della configurazione di runtime condivisa espone per impostazione predefinita.
 
 L'infrastruttura generata crea due utenti del database:
 - **Utente amministratore** - Creato durante il provisioning del cluster con credenziali memorizzate in AWS Secrets Manager

--- a/docs/src/content/docs/jp/guides/connection/py-agent-rdb.mdx
+++ b/docs/src/content/docs/jp/guides/connection/py-agent-rdb.mdx
@@ -146,16 +146,7 @@ resource "aws_vpc_security_group_egress_rule" "agent_to_database" {
 }
 ```
 
-`appconfig_application_id`/`appconfig_application_arn` は、データベースモジュールからではなく、ルートモジュールで一度宣言された共有 <Link path="guides/runtime-config">ランタイム設定</Link> AppConfig アプリケーションから取得されます。データベースモジュールのランタイム設定エントリがデプロイされるように、インスタンス化する際に `database` 名前空間を含めます：
-
-```hcl title="packages/infra/src/main.tf"
-module "runtime_config_appconfig" {
-  source = "../../common/terraform/src/core/runtime-config/appconfig"
-
-  application_name = "my-app-runtime-config"
-  namespaces       = ["connection", "agentcore", "database"]
-}
-```
+`appconfig_application_id`/`appconfig_application_arn` は、データベースモジュールからではなく、ルートモジュールで一度宣言された共有 <Link path="guides/runtime-config">ランタイム設定</Link> AppConfig アプリケーションから取得されます。そのアプリケーションはデフォルトで `database` 名前空間を公開するため、データベースモジュールのランタイム設定エントリは追加の設定なしでデプロイされます。
 
 </Fragment>
 </Infrastructure>

--- a/docs/src/content/docs/jp/guides/connection/py-fast-api-rdb.mdx
+++ b/docs/src/content/docs/jp/guides/connection/py-fast-api-rdb.mdx
@@ -163,16 +163,7 @@ resource "aws_vpc_security_group_egress_rule" "api_to_database" {
 
 API Lambda 関数を**エグレス付きプライベートサブネット**にデプロイし、プライベート分離サブネットにはデプロイしないでください。`appconfig_application_id`/`appconfig_application_arn` は、データベースモジュールからではなく、ルートモジュールで一度宣言された共有 <Link path="guides/runtime-config">ランタイム設定</Link> AppConfig アプリケーションから取得します。これらを渡すことで、Lambda 関数に `RUNTIME_CONFIG_APP_ID` を設定し、アプリケーションへの読み取りアクセスを許可します。
 
-AppConfig アプリケーションは、データベースモジュールのランタイム設定エントリがデプロイされるように、`database` 名前空間を公開する必要があります。`runtime-config/appconfig` モジュールをインスタンス化する際に、`namespaces` に含めてください：
-
-```hcl title="packages/infra/src/main.tf"
-module "runtime_config_appconfig" {
-  source = "../../common/terraform/src/core/runtime-config/appconfig"
-
-  application_name = "my-app-runtime-config"
-  namespaces       = ["connection", "agentcore", "database"]
-}
-```
+AppConfig アプリケーションはデフォルトで `database` 名前空間を公開するため、データベースモジュールのランタイム設定エントリは追加の設定なしでデプロイされます。
 
 </Fragment>
 </Infrastructure>

--- a/docs/src/content/docs/jp/guides/connection/py-mcp-server-rdb.mdx
+++ b/docs/src/content/docs/jp/guides/connection/py-mcp-server-rdb.mdx
@@ -155,16 +155,7 @@ resource "aws_vpc_security_group_egress_rule" "mcp_server_to_database" {
 }
 ```
 
-`appconfig_application_id`/`appconfig_application_arn` は、データベースモジュールからではなく、ルートモジュールで一度宣言された共有 <Link path="guides/runtime-config">ランタイム設定</Link> AppConfig アプリケーションから取得されます。データベースモジュールのランタイム設定エントリがデプロイされるように、インスタンス化時に `database` 名前空間を含めます：
-
-```hcl title="packages/infra/src/main.tf"
-module "runtime_config_appconfig" {
-  source = "../../common/terraform/src/core/runtime-config/appconfig"
-
-  application_name = "my-app-runtime-config"
-  namespaces       = ["connection", "agentcore", "database"]
-}
-```
+`appconfig_application_id`/`appconfig_application_arn` は、データベースモジュールからではなく、ルートモジュールで一度宣言された共有 <Link path="guides/runtime-config">ランタイム設定</Link> AppConfig アプリケーションから取得されます。そのアプリケーションはデフォルトで `database` 名前空間を公開するため、データベースモジュールのランタイム設定エントリは追加の設定なしでデプロイされます。
 
 </Fragment>
 </Infrastructure>

--- a/docs/src/content/docs/jp/guides/connection/ts-agent-rdb.mdx
+++ b/docs/src/content/docs/jp/guides/connection/ts-agent-rdb.mdx
@@ -161,16 +161,7 @@ resource "aws_vpc_security_group_egress_rule" "agent_to_database" {
 }
 ```
 
-`appconfig_application_id`/`appconfig_application_arn` は、データベースモジュールからではなく、ルートモジュールで一度宣言された共有 <Link path="guides/runtime-config">ランタイム構成</Link> AppConfig アプリケーションから取得されます。データベースモジュールのランタイム構成エントリがデプロイされるように、インスタンス化時に `database` 名前空間を含めてください：
-
-```hcl title="packages/infra/src/main.tf"
-module "runtime_config_appconfig" {
-  source = "../../common/terraform/src/core/runtime-config/appconfig"
-
-  application_name = "my-app-runtime-config"
-  namespaces       = ["connection", "agentcore", "database"]
-}
-```
+`appconfig_application_id`/`appconfig_application_arn` は、データベースモジュールからではなく、ルートモジュールで一度宣言された共有 <Link path="guides/runtime-config">ランタイム構成</Link> AppConfig アプリケーションから取得されます。そのアプリケーションはデフォルトで `database` 名前空間を公開するため、データベースモジュールのランタイム構成エントリは追加の構成なしでデプロイされます。
 
 </Fragment>
 </Infrastructure>

--- a/docs/src/content/docs/jp/guides/connection/ts-mcp-server-rdb.mdx
+++ b/docs/src/content/docs/jp/guides/connection/ts-mcp-server-rdb.mdx
@@ -160,16 +160,7 @@ resource "aws_vpc_security_group_egress_rule" "mcp_server_to_database" {
 }
 ```
 
-`appconfig_application_id`/`appconfig_application_arn`は、データベースモジュールからではなく、ルートモジュールで一度宣言された共有<Link path="guides/runtime-config">ランタイム設定</Link> AppConfigアプリケーションから取得されます。データベースモジュールのランタイム設定エントリがデプロイされるように、インスタンス化する際に`database`名前空間を含めてください：
-
-```hcl title="packages/infra/src/main.tf"
-module "runtime_config_appconfig" {
-  source = "../../common/terraform/src/core/runtime-config/appconfig"
-
-  application_name = "my-app-runtime-config"
-  namespaces       = ["connection", "agentcore", "database"]
-}
-```
+`appconfig_application_id`/`appconfig_application_arn`は、データベースモジュールからではなく、ルートモジュールで一度宣言された共有<Link path="guides/runtime-config">ランタイム設定</Link> AppConfigアプリケーションから取得されます。そのアプリケーションはデフォルトで`database`名前空間を公開するため、データベースモジュールのランタイム設定エントリは追加の設定なしでデプロイされます。
 
 </Fragment>
 </Infrastructure>

--- a/docs/src/content/docs/jp/guides/runtime-config.mdx
+++ b/docs/src/content/docs/jp/guides/runtime-config.mdx
@@ -12,17 +12,19 @@ import Link from '@components/link.astro';
 
 ランタイム設定は**名前空間**に整理されています。各名前空間は、関連する設定値の論理的なグループです。デプロイ時に、すべての名前空間は**AWS AppConfig**に設定プロファイルとして保存されます。
 
-生成されたコンストラクトによって使用される2つの組み込み名前空間があります：
+生成されたコンストラクトによって使用される4つの組み込み名前空間があります：
 
 - **`connection`** — 生成されたプロジェクトが相互に接続できるようにする設定：
   - **API URL** — APIコンストラクトによって自動的に登録されます
   - **Cognito設定** — UserIdentityコンストラクトによって自動的に登録されます
   - **エージェントランタイムARN** — Reactウェブサイトをエージェントに接続する際に、接続ジェネレーターによって追加されます
 - **`agentcore`** — エージェントとMCPサーバー用のAgentCoreランタイムARN。エージェント/MCPコンストラクトによって自動的に登録され、サーバーサイドの検出（A2A経由のエージェント→エージェント、エージェント→MCPサーバー）に使用されます。
+- **`dynamodb`** — テーブル名。DynamoDBテーブルコンストラクトによって自動的に登録され、生成されたテーブルクライアントによって読み取られます。
+- **`database`** — Auroraの接続詳細。リレーショナルデータベースコンストラクトによって自動的に登録され、生成されたデータベースクライアントによって読み取られます。
 
-`connection`名前空間は、ウェブサイトのS3バケットに`runtime-config.json`ファイルとしてもデプロイされ、バックエンドリソースのクライアントサイド検出を可能にします。`agentcore`名前空間はサーバーサイドのみ（AppConfig経由）であるため、ウェブサイトをエージェントに明示的に接続しない限り、エージェントランタイムARNはフロントエンドに公開されません。
+`connection`名前空間は、ウェブサイトのS3バケットに`runtime-config.json`ファイルとしてもデプロイされ、バックエンドリソースのクライアントサイド検出を可能にします。他の名前空間はサーバーサイドのみ（AppConfig経由）であるため、ウェブサイトを明示的に接続しない限り、エージェントランタイムARNやテーブル名などの値はフロントエンドに公開されません。
 
-必要に応じて追加の名前空間をいくつでも定義でき、DynamoDBテーブル名などのデプロイ時の値をLambda関数や他のコンピュートリソースに渡すための環境変数の便利な代替手段を提供します。
+必要に応じて追加の名前空間をいくつでも定義でき、デプロイ時の値をLambda関数や他のコンピュートリソースに渡すための環境変数の便利な代替手段を提供します。
 
 ```d2
 direction: down
@@ -104,6 +106,17 @@ Terraformは、3つの`core/runtime-config/*`モジュールを通じてラン�
      source = "../../common/terraform/src/core/runtime-config/appconfig"
 
      application_name = "my-app-runtime-config"
+   }
+   ```
+
+   `namespaces`変数はデフォルトですべての組み込み名前空間に設定されているため、生成されたモジュールは設定なしで動作します。独自の名前空間を追加するには、組み込みの名前空間と一緒にリストします：
+
+   ```hcl title="packages/infra/src/main.tf"
+   module "runtime_config_appconfig" {
+     source = "../../common/terraform/src/core/runtime-config/appconfig"
+
+     application_name = "my-app-runtime-config"
+     namespaces       = ["connection", "agentcore", "database", "dynamodb", "tables"]
    }
    ```
 

--- a/docs/src/content/docs/jp/snippets/connection/rdb-api-infrastructure.mdx
+++ b/docs/src/content/docs/jp/snippets/connection/rdb-api-infrastructure.mdx
@@ -89,16 +89,7 @@ resource "aws_vpc_security_group_egress_rule" "api_to_database" {
 }
 ```
 
-API Lambda関数は、プライベート分離サブネットではなく、**エグレス付きプライベートサブネット**にデプロイしてください。`appconfig_application_id`/`appconfig_application_arn`は、データベースモジュールからではなく、ルートモジュールで一度宣言された共有<Link path="guides/runtime-config">ランタイム設定</Link> AppConfigアプリケーションから取得されます。これらを渡すことで、Lambda関数に`RUNTIME_CONFIG_APP_ID`が設定され、アプリケーションへの読み取りアクセスが付与されます。データベースモジュールのランタイム設定エントリがデプロイされるように、インスタンス化時に`database`名前空間を含めてください：
-
-```hcl title="packages/infra/src/main.tf"
-module "runtime_config_appconfig" {
-  source = "../../common/terraform/src/core/runtime-config/appconfig"
-
-  application_name = "my-app-runtime-config"
-  namespaces       = ["connection", "agentcore", "database"]
-}
-```
+API Lambda関数は、プライベート分離サブネットではなく、**エグレス付きプライベートサブネット**にデプロイしてください。`appconfig_application_id`/`appconfig_application_arn`は、データベースモジュールからではなく、ルートモジュールで一度宣言された共有<Link path="guides/runtime-config">ランタイム設定</Link> AppConfigアプリケーションから取得されます。これらを渡すことで、Lambda関数に`RUNTIME_CONFIG_APP_ID`が設定され、アプリケーションへの読み取りアクセスが付与されます。そのアプリケーションはデフォルトで`database`名前空間を公開するため、データベースモジュールのランタイム設定エントリは追加の設定なしでデプロイされます。
 
 </Fragment>
 </Infrastructure>

--- a/docs/src/content/docs/jp/snippets/dynamodb/deploying-table.mdx
+++ b/docs/src/content/docs/jp/snippets/dynamodb/deploying-table.mdx
@@ -47,7 +47,9 @@ module "my_table" {
 - 自動キーローテーション付きのカスタマー管理 KMS 暗号化
 - ポイントインタイムリカバリが有効
 - 削除保護が有効
-- Runtime Config にテーブル名が登録される
+- AWS AppConfig の `dynamodb` 名前空間下の Runtime Config にテーブル名が登録される
+
+`core/runtime-config/appconfig` モジュールはデフォルトで `dynamodb` 名前空間を公開するため、テーブル名は追加の設定なしでデプロイされます。そのモジュールに明示的に `namespaces` を渡す場合は、リストに `dynamodb` を含めてください。そうしないと、設定プロファイルが作成されず、生成されたテーブルクライアントがテーブル名を解決できなくなります。
 </Fragment>
 </Infrastructure>
 

--- a/docs/src/content/docs/jp/snippets/rdb/deploying.mdx
+++ b/docs/src/content/docs/jp/snippets/rdb/deploying.mdx
@@ -52,16 +52,7 @@ module "my_database" {
 
 これにより、RDS Proxy を備えた Aurora クラスター、管理者認証情報、create-db-user Lambda、ランタイム設定の登録、マイグレーション Lambda、およびコンテナレジストリリソースがプロビジョニングされます。
 
-データベースモジュールは、`database` ランタイム設定名前空間の下に接続詳細を登録します。共有ランタイム設定 AppConfig アプリケーションをインスタンス化する際に、この名前空間を含めてください：
-
-```hcl title="packages/infra/src/main.tf"
-module "runtime_config_appconfig" {
-  source = "../../common/terraform/src/core/runtime-config/appconfig"
-
-  application_name = "my-app-runtime-config"
-  namespaces       = ["connection", "agentcore", "database"]
-}
-```
+データベースモジュールは、`database` <Link path="guides/runtime-config">ランタイム設定</Link>名前空間の下に接続詳細を登録します。共有ランタイム設定 AppConfig アプリケーションは、デフォルトでこれを公開します。
 
 生成されたインフラストラクチャは、2つのデータベースユーザーを作成します：
 - **管理者ユーザー** - クラスターのプロビジョニング時に作成され、認証情報は AWS Secrets Manager に保存されます

--- a/docs/src/content/docs/ko/guides/connection/py-agent-rdb.mdx
+++ b/docs/src/content/docs/ko/guides/connection/py-agent-rdb.mdx
@@ -146,16 +146,7 @@ resource "aws_vpc_security_group_egress_rule" "agent_to_database" {
 }
 ```
 
-`appconfig_application_id`/`appconfig_application_arn`은 데이터베이스 모듈이 아닌 루트 모듈에서 한 번 선언된 공유 <Link path="guides/runtime-config">런타임 구성</Link> AppConfig 애플리케이션에서 가져옵니다. 데이터베이스 모듈의 런타임 구성 항목이 배포되도록 인스턴스화할 때 `database` 네임스페이스를 포함하세요:
-
-```hcl title="packages/infra/src/main.tf"
-module "runtime_config_appconfig" {
-  source = "../../common/terraform/src/core/runtime-config/appconfig"
-
-  application_name = "my-app-runtime-config"
-  namespaces       = ["connection", "agentcore", "database"]
-}
-```
+`appconfig_application_id`/`appconfig_application_arn`은 데이터베이스 모듈이 아닌 루트 모듈에서 한 번 선언된 공유 <Link path="guides/runtime-config">런타임 구성</Link> AppConfig 애플리케이션에서 가져옵니다. 해당 애플리케이션은 기본적으로 `database` 네임스페이스를 노출하므로 데이터베이스 모듈의 런타임 구성 항목은 추가 구성 없이 배포됩니다.
 
 </Fragment>
 </Infrastructure>

--- a/docs/src/content/docs/ko/guides/connection/py-fast-api-rdb.mdx
+++ b/docs/src/content/docs/ko/guides/connection/py-fast-api-rdb.mdx
@@ -163,16 +163,7 @@ resource "aws_vpc_security_group_egress_rule" "api_to_database" {
 
 API Lambda 함수를 프라이빗 격리 서브넷이 아닌 **이그레스가 있는 프라이빗 서브넷**에 배포하세요. `appconfig_application_id`/`appconfig_application_arn`은 데이터베이스 모듈이 아닌 루트 모듈에서 한 번 선언된 공유 <Link path="guides/runtime-config">런타임 구성</Link> AppConfig 애플리케이션에서 가져옵니다. 이를 전달하면 Lambda 함수에 `RUNTIME_CONFIG_APP_ID`가 설정되고 애플리케이션에 대한 읽기 액세스 권한이 부여됩니다.
 
-AppConfig 애플리케이션은 데이터베이스 모듈의 런타임 구성 항목이 배포되도록 `database` 네임스페이스를 노출해야 합니다. `runtime-config/appconfig` 모듈을 인스턴스화할 때 `namespaces`에 포함하세요:
-
-```hcl title="packages/infra/src/main.tf"
-module "runtime_config_appconfig" {
-  source = "../../common/terraform/src/core/runtime-config/appconfig"
-
-  application_name = "my-app-runtime-config"
-  namespaces       = ["connection", "agentcore", "database"]
-}
-```
+AppConfig 애플리케이션은 기본적으로 `database` 네임스페이스를 노출하므로, 데이터베이스 모듈의 런타임 구성 항목이 추가 구성 없이 배포됩니다.
 
 </Fragment>
 </Infrastructure>

--- a/docs/src/content/docs/ko/guides/connection/py-mcp-server-rdb.mdx
+++ b/docs/src/content/docs/ko/guides/connection/py-mcp-server-rdb.mdx
@@ -155,16 +155,7 @@ resource "aws_vpc_security_group_egress_rule" "mcp_server_to_database" {
 }
 ```
 
-`appconfig_application_id`/`appconfig_application_arn`은 데이터베이스 모듈이 아닌 루트 모듈에서 한 번 선언된 공유 <Link path="guides/runtime-config">런타임 구성</Link> AppConfig 애플리케이션에서 가져옵니다. 데이터베이스 모듈의 런타임 구성 항목이 배포되도록 인스턴스화할 때 `database` 네임스페이스를 포함합니다:
-
-```hcl title="packages/infra/src/main.tf"
-module "runtime_config_appconfig" {
-  source = "../../common/terraform/src/core/runtime-config/appconfig"
-
-  application_name = "my-app-runtime-config"
-  namespaces       = ["connection", "agentcore", "database"]
-}
-```
+`appconfig_application_id`/`appconfig_application_arn`은 데이터베이스 모듈이 아닌 루트 모듈에서 한 번 선언된 공유 <Link path="guides/runtime-config">런타임 구성</Link> AppConfig 애플리케이션에서 가져옵니다. 해당 애플리케이션은 기본적으로 `database` 네임스페이스를 노출하므로, 데이터베이스 모듈의 런타임 구성 항목은 추가 구성 없이 배포됩니다.
 
 </Fragment>
 </Infrastructure>

--- a/docs/src/content/docs/ko/guides/connection/ts-agent-rdb.mdx
+++ b/docs/src/content/docs/ko/guides/connection/ts-agent-rdb.mdx
@@ -161,16 +161,7 @@ resource "aws_vpc_security_group_egress_rule" "agent_to_database" {
 }
 ```
 
-`appconfig_application_id`/`appconfig_application_arn`은 데이터베이스 모듈이 아닌 루트 모듈에서 한 번 선언된 공유 <Link path="guides/runtime-config">런타임 구성</Link> AppConfig 애플리케이션에서 가져옵니다. 데이터베이스 모듈의 런타임 구성 항목이 배포되도록 인스턴스화할 때 `database` 네임스페이스를 포함합니다:
-
-```hcl title="packages/infra/src/main.tf"
-module "runtime_config_appconfig" {
-  source = "../../common/terraform/src/core/runtime-config/appconfig"
-
-  application_name = "my-app-runtime-config"
-  namespaces       = ["connection", "agentcore", "database"]
-}
-```
+`appconfig_application_id`/`appconfig_application_arn`은 데이터베이스 모듈이 아닌 루트 모듈에서 한 번 선언된 공유 <Link path="guides/runtime-config">런타임 구성</Link> AppConfig 애플리케이션에서 가져옵니다. 해당 애플리케이션은 기본적으로 `database` 네임스페이스를 노출하므로 데이터베이스 모듈의 런타임 구성 항목은 추가 구성 없이 배포됩니다.
 
 </Fragment>
 </Infrastructure>

--- a/docs/src/content/docs/ko/guides/connection/ts-mcp-server-rdb.mdx
+++ b/docs/src/content/docs/ko/guides/connection/ts-mcp-server-rdb.mdx
@@ -160,16 +160,7 @@ resource "aws_vpc_security_group_egress_rule" "mcp_server_to_database" {
 }
 ```
 
-`appconfig_application_id`/`appconfig_application_arn`은 데이터베이스 모듈이 아닌 루트 모듈에서 한 번 선언된 공유 <Link path="guides/runtime-config">런타임 구성</Link> AppConfig 애플리케이션에서 가져옵니다. 데이터베이스 모듈의 런타임 구성 항목이 배포되도록 인스턴스화할 때 `database` 네임스페이스를 포함합니다:
-
-```hcl title="packages/infra/src/main.tf"
-module "runtime_config_appconfig" {
-  source = "../../common/terraform/src/core/runtime-config/appconfig"
-
-  application_name = "my-app-runtime-config"
-  namespaces       = ["connection", "agentcore", "database"]
-}
-```
+`appconfig_application_id`/`appconfig_application_arn`은 데이터베이스 모듈이 아닌 루트 모듈에서 한 번 선언된 공유 <Link path="guides/runtime-config">런타임 구성</Link> AppConfig 애플리케이션에서 가져옵니다. 해당 애플리케이션은 기본적으로 `database` 네임스페이스를 노출하므로, 데이터베이스 모듈의 런타임 구성 항목은 추가 구성 없이 배포됩니다.
 
 </Fragment>
 </Infrastructure>

--- a/docs/src/content/docs/ko/guides/runtime-config.mdx
+++ b/docs/src/content/docs/ko/guides/runtime-config.mdx
@@ -12,17 +12,19 @@ import Link from '@components/link.astro';
 
 런타임 구성은 **네임스페이스**로 구성됩니다. 각 네임스페이스는 관련 구성 값의 논리적 그룹입니다. 배포 시점에 모든 네임스페이스는 **AWS AppConfig**에 구성 프로필로 저장됩니다.
 
-생성된 구성 요소에서 사용하는 두 가지 내장 네임스페이스가 있습니다:
+생성된 구성 요소에서 사용하는 네 가지 내장 네임스페이스가 있습니다:
 
 - **`connection`** — 생성된 프로젝트가 서로 연결될 수 있도록 하는 구성:
   - **API URL** — API 구성 요소에 의해 자동으로 등록됨
   - **Cognito 설정** — UserIdentity 구성 요소에 의해 자동으로 등록됨
   - **Agent 런타임 ARN** — React 웹사이트를 Agent에 연결할 때 연결 생성기에 의해 추가됨
 - **`agentcore`** — 에이전트 및 MCP 서버를 위한 AgentCore 런타임 ARN. 에이전트/MCP 구성 요소에 의해 자동으로 등록되며 서버 측 검색(A2A를 통한 에이전트 → 에이전트, 에이전트 → MCP 서버)에 사용됩니다.
+- **`dynamodb`** — 테이블 이름, DynamoDB 테이블 구성 요소에 의해 자동으로 등록되며 생성된 테이블 클라이언트에 의해 읽힙니다.
+- **`database`** — Aurora 연결 세부 정보, 관계형 데이터베이스 구성 요소에 의해 자동으로 등록되며 생성된 데이터베이스 클라이언트에 의해 읽힙니다.
 
-`connection` 네임스페이스는 웹사이트의 S3 버킷에 `runtime-config.json` 파일로도 배포되어 백엔드 리소스의 클라이언트 측 검색을 가능하게 합니다. `agentcore` 네임스페이스는 서버 측 전용(AppConfig를 통해)이므로 웹사이트를 에이전트에 명시적으로 연결하지 않는 한 에이전트 런타임 ARN이 프론트엔드에 노출되지 않습니다.
+`connection` 네임스페이스는 웹사이트의 S3 버킷에 `runtime-config.json` 파일로도 배포되어 백엔드 리소스의 클라이언트 측 검색을 가능하게 합니다. 다른 네임스페이스는 서버 측 전용(AppConfig를 통해)이므로 웹사이트를 명시적으로 연결하지 않는 한 에이전트 런타임 ARN 및 테이블 이름과 같은 값이 프론트엔드에 노출되지 않습니다.
 
-원하는 만큼 추가 네임스페이스를 정의할 수 있으며, 이는 DynamoDB 테이블 이름과 같은 배포 시점 값을 Lambda 함수나 기타 컴퓨팅 리소스에 전달하기 위한 환경 변수의 편리한 대안을 제공합니다.
+원하는 만큼 추가 네임스페이스를 정의할 수 있으며, 이는 배포 시점 값을 Lambda 함수나 기타 컴퓨팅 리소스에 전달하기 위한 환경 변수의 편리한 대안을 제공합니다.
 
 ```d2
 direction: down
@@ -104,6 +106,17 @@ Terraform은 세 개의 `core/runtime-config/*` 모듈을 통해 런타임 구�
      source = "../../common/terraform/src/core/runtime-config/appconfig"
 
      application_name = "my-app-runtime-config"
+   }
+   ```
+
+   `namespaces` 변수는 기본적으로 모든 내장 네임스페이스로 설정되므로 생성된 모듈은 구성 없이 작동합니다. 자신의 네임스페이스를 추가하려면 내장 네임스페이스와 함께 나열합니다:
+
+   ```hcl title="packages/infra/src/main.tf"
+   module "runtime_config_appconfig" {
+     source = "../../common/terraform/src/core/runtime-config/appconfig"
+
+     application_name = "my-app-runtime-config"
+     namespaces       = ["connection", "agentcore", "database", "dynamodb", "tables"]
    }
    ```
 

--- a/docs/src/content/docs/ko/snippets/connection/rdb-api-infrastructure.mdx
+++ b/docs/src/content/docs/ko/snippets/connection/rdb-api-infrastructure.mdx
@@ -89,16 +89,7 @@ resource "aws_vpc_security_group_egress_rule" "api_to_database" {
 }
 ```
 
-API Lambda 함수를 프라이빗 격리 서브넷이 아닌 **이그레스가 있는 프라이빗 서브넷**에 배포하세요. `appconfig_application_id`/`appconfig_application_arn`은 데이터베이스 모듈이 아닌 루트 모듈에서 한 번 선언된 공유 <Link path="guides/runtime-config">런타임 구성</Link> AppConfig 애플리케이션에서 가져옵니다. 이를 전달하면 Lambda 함수에 `RUNTIME_CONFIG_APP_ID`가 설정되고 애플리케이션에 대한 읽기 액세스 권한이 부여됩니다. 데이터베이스 모듈의 런타임 구성 항목이 배포되도록 인스턴스화할 때 `database` 네임스페이스를 포함하세요:
-
-```hcl title="packages/infra/src/main.tf"
-module "runtime_config_appconfig" {
-  source = "../../common/terraform/src/core/runtime-config/appconfig"
-
-  application_name = "my-app-runtime-config"
-  namespaces       = ["connection", "agentcore", "database"]
-}
-```
+API Lambda 함수를 프라이빗 격리 서브넷이 아닌 **이그레스가 있는 프라이빗 서브넷**에 배포하세요. `appconfig_application_id`/`appconfig_application_arn`은 데이터베이스 모듈이 아닌 루트 모듈에서 한 번 선언된 공유 <Link path="guides/runtime-config">런타임 구성</Link> AppConfig 애플리케이션에서 가져옵니다. 이를 전달하면 Lambda 함수에 `RUNTIME_CONFIG_APP_ID`가 설정되고 애플리케이션에 대한 읽기 액세스 권한이 부여됩니다. 해당 애플리케이션은 기본적으로 `database` 네임스페이스를 노출하므로, 데이터베이스 모듈의 런타임 구성 항목은 추가 구성 없이 배포됩니다.
 
 </Fragment>
 </Infrastructure>

--- a/docs/src/content/docs/ko/snippets/dynamodb/deploying-table.mdx
+++ b/docs/src/content/docs/ko/snippets/dynamodb/deploying-table.mdx
@@ -47,7 +47,9 @@ module "my_table" {
 - 자동 키 로테이션이 활성화된 고객 관리형 KMS 암호화
 - 특정 시점 복구 활성화
 - 삭제 보호 활성화
-- Runtime Config에 등록된 테이블 이름
+- AWS AppConfig의 `dynamodb` 네임스페이스 아래 Runtime Config에 등록된 테이블 이름
+
+`core/runtime-config/appconfig` 모듈은 기본적으로 `dynamodb` 네임스페이스를 노출하므로, 추가 구성 없이 테이블 이름이 배포됩니다. 해당 모듈에 `namespaces`를 명시적으로 전달하는 경우, 목록에 `dynamodb`를 유지하세요. 그렇지 않으면 구성 프로필이 생성되지 않아 생성된 테이블 클라이언트가 테이블 이름을 확인할 수 없습니다.
 </Fragment>
 </Infrastructure>
 

--- a/docs/src/content/docs/ko/snippets/rdb/deploying.mdx
+++ b/docs/src/content/docs/ko/snippets/rdb/deploying.mdx
@@ -52,16 +52,7 @@ module "my_database" {
 
 이는 RDS Proxy, 관리자 자격 증명, create-db-user Lambda, 런타임 구성 등록, 마이그레이션 Lambda 및 컨테이너 레지스트리 리소스가 포함된 Aurora 클러스터를 프로비저닝합니다.
 
-데이터베이스 모듈은 `database` 런타임 구성 네임스페이스 아래에 연결 세부 정보를 등록합니다. 공유 런타임 구성 AppConfig 애플리케이션을 인스턴스화할 때 이 네임스페이스를 포함하세요:
-
-```hcl title="packages/infra/src/main.tf"
-module "runtime_config_appconfig" {
-  source = "../../common/terraform/src/core/runtime-config/appconfig"
-
-  application_name = "my-app-runtime-config"
-  namespaces       = ["connection", "agentcore", "database"]
-}
-```
+데이터베이스 모듈은 `database` <Link path="guides/runtime-config">런타임 구성</Link> 네임스페이스 아래에 연결 세부 정보를 등록하며, 공유 런타임 구성 AppConfig 애플리케이션은 기본적으로 이를 노출합니다.
 
 생성된 인프라는 두 개의 데이터베이스 사용자를 생성합니다:
 - **관리자 사용자** - 클러스터 프로비저닝 중에 생성되며 자격 증명은 AWS Secrets Manager에 저장됩니다

--- a/docs/src/content/docs/pt/guides/connection/py-agent-rdb.mdx
+++ b/docs/src/content/docs/pt/guides/connection/py-agent-rdb.mdx
@@ -146,16 +146,7 @@ resource "aws_vpc_security_group_egress_rule" "agent_to_database" {
 }
 ```
 
-`appconfig_application_id`/`appconfig_application_arn` vêm da aplicação AppConfig de <Link path="guides/runtime-config">configuração de runtime</Link> compartilhada declarada uma vez no seu módulo raiz, não do módulo do banco de dados. Inclua o namespace `database` ao instanciá-lo para que a entrada de configuração de runtime do módulo do banco de dados seja implantada:
-
-```hcl title="packages/infra/src/main.tf"
-module "runtime_config_appconfig" {
-  source = "../../common/terraform/src/core/runtime-config/appconfig"
-
-  application_name = "my-app-runtime-config"
-  namespaces       = ["connection", "agentcore", "database"]
-}
-```
+`appconfig_application_id`/`appconfig_application_arn` vêm da aplicação AppConfig de <Link path="guides/runtime-config">configuração de runtime</Link> compartilhada declarada uma vez no seu módulo raiz, não do módulo do banco de dados. Essa aplicação expõe o namespace `database` por padrão, então a entrada de configuração de runtime do módulo do banco de dados é implantada sem configuração adicional.
 
 </Fragment>
 </Infrastructure>

--- a/docs/src/content/docs/pt/guides/connection/py-fast-api-rdb.mdx
+++ b/docs/src/content/docs/pt/guides/connection/py-fast-api-rdb.mdx
@@ -163,16 +163,7 @@ resource "aws_vpc_security_group_egress_rule" "api_to_database" {
 
 Implante as funções Lambda da API em **sub-redes privadas com saída**, não em sub-redes privadas isoladas. `appconfig_application_id`/`appconfig_application_arn` vêm da aplicação AppConfig de <Link path="guides/runtime-config">configuração de tempo de execução</Link> compartilhada declarada uma vez em seu módulo raiz, não do módulo do banco de dados — passá-los define `RUNTIME_CONFIG_APP_ID` nas funções Lambda e concede a elas acesso de leitura à aplicação.
 
-A aplicação AppConfig deve expor o namespace `database` para que a entrada de configuração de tempo de execução do módulo do banco de dados seja implantada. Inclua-o nos `namespaces` ao instanciar o módulo `runtime-config/appconfig`:
-
-```hcl title="packages/infra/src/main.tf"
-module "runtime_config_appconfig" {
-  source = "../../common/terraform/src/core/runtime-config/appconfig"
-
-  application_name = "my-app-runtime-config"
-  namespaces       = ["connection", "agentcore", "database"]
-}
-```
+A aplicação AppConfig expõe o namespace `database` por padrão, então a entrada de configuração de tempo de execução do módulo do banco de dados é implantada sem configuração adicional.
 
 </Fragment>
 </Infrastructure>

--- a/docs/src/content/docs/pt/guides/connection/py-mcp-server-rdb.mdx
+++ b/docs/src/content/docs/pt/guides/connection/py-mcp-server-rdb.mdx
@@ -155,16 +155,7 @@ resource "aws_vpc_security_group_egress_rule" "mcp_server_to_database" {
 }
 ```
 
-`appconfig_application_id`/`appconfig_application_arn` vêm da <Link path="guides/runtime-config">configuração de runtime</Link> compartilhada do AppConfig declarada uma vez no seu módulo raiz, não do módulo do banco de dados. Inclua o namespace `database` ao instanciá-lo para que a entrada de configuração de runtime do módulo do banco de dados seja implantada:
-
-```hcl title="packages/infra/src/main.tf"
-module "runtime_config_appconfig" {
-  source = "../../common/terraform/src/core/runtime-config/appconfig"
-
-  application_name = "my-app-runtime-config"
-  namespaces       = ["connection", "agentcore", "database"]
-}
-```
+`appconfig_application_id`/`appconfig_application_arn` vêm da <Link path="guides/runtime-config">configuração de runtime</Link> compartilhada do AppConfig declarada uma vez no seu módulo raiz, não do módulo do banco de dados. Essa aplicação expõe o namespace `database` por padrão, então a entrada de configuração de runtime do módulo do banco de dados é implantada sem configuração adicional.
 
 </Fragment>
 </Infrastructure>

--- a/docs/src/content/docs/pt/guides/connection/ts-agent-rdb.mdx
+++ b/docs/src/content/docs/pt/guides/connection/ts-agent-rdb.mdx
@@ -161,16 +161,7 @@ resource "aws_vpc_security_group_egress_rule" "agent_to_database" {
 }
 ```
 
-`appconfig_application_id`/`appconfig_application_arn` vêm da <Link path="guides/runtime-config">configuração de runtime</Link> compartilhada da aplicação AppConfig declarada uma vez no seu módulo raiz, não do módulo do banco de dados. Inclua o namespace `database` ao instanciá-lo para que a entrada de configuração de runtime do módulo do banco de dados seja implantada:
-
-```hcl title="packages/infra/src/main.tf"
-module "runtime_config_appconfig" {
-  source = "../../common/terraform/src/core/runtime-config/appconfig"
-
-  application_name = "my-app-runtime-config"
-  namespaces       = ["connection", "agentcore", "database"]
-}
-```
+`appconfig_application_id`/`appconfig_application_arn` vêm da <Link path="guides/runtime-config">configuração de runtime</Link> compartilhada da aplicação AppConfig declarada uma vez no seu módulo raiz, não do módulo do banco de dados. Essa aplicação expõe o namespace `database` por padrão, então a entrada de configuração de runtime do módulo do banco de dados é implantada sem configuração adicional.
 
 </Fragment>
 </Infrastructure>

--- a/docs/src/content/docs/pt/guides/connection/ts-mcp-server-rdb.mdx
+++ b/docs/src/content/docs/pt/guides/connection/ts-mcp-server-rdb.mdx
@@ -160,16 +160,7 @@ resource "aws_vpc_security_group_egress_rule" "mcp_server_to_database" {
 }
 ```
 
-`appconfig_application_id`/`appconfig_application_arn` vêm da <Link path="guides/runtime-config">configuração de runtime</Link> compartilhada do AppConfig declarada uma vez no seu módulo raiz, não do módulo do banco de dados. Inclua o namespace `database` ao instanciá-lo para que a entrada de configuração de runtime do módulo do banco de dados seja implantada:
-
-```hcl title="packages/infra/src/main.tf"
-module "runtime_config_appconfig" {
-  source = "../../common/terraform/src/core/runtime-config/appconfig"
-
-  application_name = "my-app-runtime-config"
-  namespaces       = ["connection", "agentcore", "database"]
-}
-```
+`appconfig_application_id`/`appconfig_application_arn` vêm da <Link path="guides/runtime-config">configuração de runtime</Link> compartilhada do AppConfig declarada uma vez no seu módulo raiz, não do módulo do banco de dados. Essa aplicação expõe o namespace `database` por padrão, então a entrada de configuração de runtime do módulo do banco de dados é implantada sem configuração adicional.
 
 </Fragment>
 </Infrastructure>

--- a/docs/src/content/docs/pt/guides/runtime-config.mdx
+++ b/docs/src/content/docs/pt/guides/runtime-config.mdx
@@ -12,17 +12,19 @@ A configuração de runtime é o mecanismo usado pelo Nx Plugin for AWS para pas
 
 A configuração de runtime é organizada em **namespaces**. Cada namespace é um agrupamento lógico de valores de configuração relacionados. No momento da implantação, todos os namespaces são armazenados no **AWS AppConfig** como Configuration Profiles.
 
-Dois namespaces integrados são usados por constructs gerados:
+Quatro namespaces integrados são usados por constructs gerados:
 
 - **`connection`** — configuração que permite que projetos gerados se conectem uns aos outros:
   - **URLs de API** — registradas automaticamente por constructs de API
   - **Configurações do Cognito** — registradas automaticamente pelo construct UserIdentity
   - **ARNs de runtime de Agent** — adicionados pelo gerador de conexão quando você conecta um site React a um Agent
 - **`agentcore`** — ARNs de runtime do AgentCore para agents e servidores MCP. Registrados automaticamente pelos constructs de agent/MCP e usados para descoberta do lado do servidor (agent → agent via A2A, agent → servidor MCP).
+- **`dynamodb`** — nomes de tabelas, registrados automaticamente por constructs de tabela DynamoDB e lidos pelo cliente de tabela gerado.
+- **`database`** — detalhes de conexão do Aurora, registrados automaticamente por constructs de banco de dados relacional e lidos pelo cliente de banco de dados gerado.
 
-O namespace `connection` também é implantado como um arquivo `runtime-config.json` no bucket S3 do seu site, permitindo a descoberta de recursos de backend do lado do cliente. O namespace `agentcore` é apenas do lado do servidor (via AppConfig), portanto os ARNs de runtime de agent não são expostos ao frontend, a menos que você conecte explicitamente um site a um agent.
+O namespace `connection` também é implantado como um arquivo `runtime-config.json` no bucket S3 do seu site, permitindo a descoberta de recursos de backend do lado do cliente. Os outros namespaces são apenas do lado do servidor (via AppConfig), portanto valores como ARNs de runtime de agent e nomes de tabelas não são expostos ao frontend, a menos que você conecte explicitamente um site a eles.
 
-Você pode definir quantos namespaces adicionais desejar, fornecendo uma alternativa conveniente às variáveis de ambiente para passar valores de tempo de implantação, como nomes de tabelas DynamoDB, para suas funções Lambda ou outros recursos de computação.
+Você pode definir quantos namespaces adicionais desejar, fornecendo uma alternativa conveniente às variáveis de ambiente para passar valores de tempo de implantação para suas funções Lambda ou outros recursos de computação.
 
 ```d2
 direction: down
@@ -104,6 +106,17 @@ O Terraform conecta a configuração de runtime através de três módulos `core
      source = "../../common/terraform/src/core/runtime-config/appconfig"
 
      application_name = "my-app-runtime-config"
+   }
+   ```
+
+   A variável `namespaces` tem como padrão todos os namespaces integrados, então os módulos gerados funcionam sem configurá-la. Para adicionar seus próprios namespaces, liste-os junto com os integrados:
+
+   ```hcl title="packages/infra/src/main.tf"
+   module "runtime_config_appconfig" {
+     source = "../../common/terraform/src/core/runtime-config/appconfig"
+
+     application_name = "my-app-runtime-config"
+     namespaces       = ["connection", "agentcore", "database", "dynamodb", "tables"]
    }
    ```
 

--- a/docs/src/content/docs/pt/snippets/connection/rdb-api-infrastructure.mdx
+++ b/docs/src/content/docs/pt/snippets/connection/rdb-api-infrastructure.mdx
@@ -89,16 +89,7 @@ resource "aws_vpc_security_group_egress_rule" "api_to_database" {
 }
 ```
 
-Implante as funções Lambda da API em **sub-redes privadas com saída**, não em sub-redes privadas isoladas. `appconfig_application_id`/`appconfig_application_arn` vêm da <Link path="guides/runtime-config">configuração de tempo de execução</Link> compartilhada da aplicação AppConfig declarada uma vez no seu módulo raiz, não do módulo do banco de dados — passá-los define `RUNTIME_CONFIG_APP_ID` nas funções Lambda e concede a elas acesso de leitura à aplicação. Inclua o namespace `database` ao instanciá-la para que a entrada de configuração de tempo de execução do módulo do banco de dados seja implantada:
-
-```hcl title="packages/infra/src/main.tf"
-module "runtime_config_appconfig" {
-  source = "../../common/terraform/src/core/runtime-config/appconfig"
-
-  application_name = "my-app-runtime-config"
-  namespaces       = ["connection", "agentcore", "database"]
-}
-```
+Implante as funções Lambda da API em **sub-redes privadas com saída**, não em sub-redes privadas isoladas. `appconfig_application_id`/`appconfig_application_arn` vêm da <Link path="guides/runtime-config">configuração de tempo de execução</Link> compartilhada da aplicação AppConfig declarada uma vez no seu módulo raiz, não do módulo do banco de dados — passá-los define `RUNTIME_CONFIG_APP_ID` nas funções Lambda e concede a elas acesso de leitura à aplicação. Essa aplicação expõe o namespace `database` por padrão, então a entrada de configuração de tempo de execução do módulo do banco de dados é implantada sem configuração adicional.
 
 </Fragment>
 </Infrastructure>

--- a/docs/src/content/docs/pt/snippets/dynamodb/deploying-table.mdx
+++ b/docs/src/content/docs/pt/snippets/dynamodb/deploying-table.mdx
@@ -47,7 +47,9 @@ Isso provisiona uma tabela DynamoDB com:
 - Criptografia KMS gerenciada pelo cliente com rotação automática de chave
 - Recuperação point-in-time habilitada
 - Proteção contra exclusão habilitada
-- Nome da tabela registrado no Runtime Config
+- Nome da tabela registrado no Runtime Config sob o namespace `dynamodb` no AWS AppConfig
+
+O módulo `core/runtime-config/appconfig` expõe o namespace `dynamodb` por padrão, então o nome da tabela é implantado sem configuração adicional. Se você passar `namespaces` para esse módulo explicitamente, mantenha `dynamodb` na lista — caso contrário, nenhum perfil de configuração é criado para ele e o cliente de tabela gerado não consegue resolver o nome da tabela.
 </Fragment>
 </Infrastructure>
 

--- a/docs/src/content/docs/pt/snippets/rdb/deploying.mdx
+++ b/docs/src/content/docs/pt/snippets/rdb/deploying.mdx
@@ -52,16 +52,7 @@ module "my_database" {
 
 Isso provisiona um cluster Aurora com RDS Proxy, credenciais de administrador, Lambda create-db-user, registro de configuração de runtime, Lambda de migração e recursos de registro de contêiner.
 
-O módulo de banco de dados registra seus detalhes de conexão sob o namespace de configuração de runtime `database`. Inclua este namespace ao instanciar a aplicação AppConfig de configuração de runtime compartilhada:
-
-```hcl title="packages/infra/src/main.tf"
-module "runtime_config_appconfig" {
-  source = "../../common/terraform/src/core/runtime-config/appconfig"
-
-  application_name = "my-app-runtime-config"
-  namespaces       = ["connection", "agentcore", "database"]
-}
-```
+O módulo de banco de dados registra seus detalhes de conexão sob o namespace de <Link path="guides/runtime-config">configuração de runtime</Link> `database`, que a aplicação AppConfig de configuração de runtime compartilhada expõe por padrão.
 
 A infraestrutura gerada cria dois usuários de banco de dados:
 - **Usuário administrador** - Criado durante o provisionamento do cluster com credenciais armazenadas no AWS Secrets Manager

--- a/docs/src/content/docs/vi/guides/connection/py-agent-rdb.mdx
+++ b/docs/src/content/docs/vi/guides/connection/py-agent-rdb.mdx
@@ -146,16 +146,7 @@ resource "aws_vpc_security_group_egress_rule" "agent_to_database" {
 }
 ```
 
-`appconfig_application_id`/`appconfig_application_arn` đến từ ứng dụng <Link path="guides/runtime-config">runtime configuration</Link> AppConfig được chia sẻ được khai báo một lần trong root module của bạn, không phải từ database module. Bao gồm namespace `database` khi khởi tạo nó để entry runtime configuration của database module được triển khai:
-
-```hcl title="packages/infra/src/main.tf"
-module "runtime_config_appconfig" {
-  source = "../../common/terraform/src/core/runtime-config/appconfig"
-
-  application_name = "my-app-runtime-config"
-  namespaces       = ["connection", "agentcore", "database"]
-}
-```
+`appconfig_application_id`/`appconfig_application_arn` đến từ ứng dụng <Link path="guides/runtime-config">runtime configuration</Link> AppConfig được chia sẻ được khai báo một lần trong root module của bạn, không phải từ database module. Ứng dụng đó hiển thị namespace `database` theo mặc định, vì vậy entry runtime configuration của database module được triển khai mà không cần cấu hình thêm.
 
 </Fragment>
 </Infrastructure>

--- a/docs/src/content/docs/vi/guides/connection/py-fast-api-rdb.mdx
+++ b/docs/src/content/docs/vi/guides/connection/py-fast-api-rdb.mdx
@@ -163,16 +163,7 @@ resource "aws_vpc_security_group_egress_rule" "api_to_database" {
 
 Triển khai các hàm Lambda API vào **private subnet với egress**, không phải private isolated subnet. `appconfig_application_id`/`appconfig_application_arn` đến từ ứng dụng AppConfig <Link path="guides/runtime-config">runtime configuration</Link> được chia sẻ được khai báo một lần trong root module của bạn, không phải từ database module — việc truyền chúng sẽ đặt `RUNTIME_CONFIG_APP_ID` trên các hàm Lambda và cấp cho chúng quyền đọc vào ứng dụng.
 
-Ứng dụng AppConfig phải expose namespace `database` để entry runtime configuration của database module được triển khai. Bao gồm nó trong `namespaces` khi khởi tạo module `runtime-config/appconfig`:
-
-```hcl title="packages/infra/src/main.tf"
-module "runtime_config_appconfig" {
-  source = "../../common/terraform/src/core/runtime-config/appconfig"
-
-  application_name = "my-app-runtime-config"
-  namespaces       = ["connection", "agentcore", "database"]
-}
-```
+Ứng dụng AppConfig expose namespace `database` theo mặc định, do đó entry runtime configuration của database module được triển khai mà không cần cấu hình thêm.
 
 </Fragment>
 </Infrastructure>

--- a/docs/src/content/docs/vi/guides/connection/py-mcp-server-rdb.mdx
+++ b/docs/src/content/docs/vi/guides/connection/py-mcp-server-rdb.mdx
@@ -155,16 +155,7 @@ resource "aws_vpc_security_group_egress_rule" "mcp_server_to_database" {
 }
 ```
 
-`appconfig_application_id`/`appconfig_application_arn` đến từ ứng dụng <Link path="guides/runtime-config">runtime configuration</Link> AppConfig được chia sẻ được khai báo một lần trong root module của bạn, không phải từ database module. Bao gồm namespace `database` khi khởi tạo nó để entry runtime configuration của database module được triển khai:
-
-```hcl title="packages/infra/src/main.tf"
-module "runtime_config_appconfig" {
-  source = "../../common/terraform/src/core/runtime-config/appconfig"
-
-  application_name = "my-app-runtime-config"
-  namespaces       = ["connection", "agentcore", "database"]
-}
-```
+`appconfig_application_id`/`appconfig_application_arn` đến từ ứng dụng <Link path="guides/runtime-config">runtime configuration</Link> AppConfig được chia sẻ được khai báo một lần trong root module của bạn, không phải từ database module. Ứng dụng đó hiển thị namespace `database` theo mặc định, vì vậy entry runtime configuration của database module được triển khai mà không cần cấu hình thêm.
 
 </Fragment>
 </Infrastructure>

--- a/docs/src/content/docs/vi/guides/connection/ts-agent-rdb.mdx
+++ b/docs/src/content/docs/vi/guides/connection/ts-agent-rdb.mdx
@@ -161,16 +161,7 @@ resource "aws_vpc_security_group_egress_rule" "agent_to_database" {
 }
 ```
 
-`appconfig_application_id`/`appconfig_application_arn` đến từ ứng dụng <Link path="guides/runtime-config">runtime configuration</Link> AppConfig được chia sẻ được khai báo một lần trong root module của bạn, không phải từ database module. Bao gồm namespace `database` khi khởi tạo nó để entry runtime configuration của database module được triển khai:
-
-```hcl title="packages/infra/src/main.tf"
-module "runtime_config_appconfig" {
-  source = "../../common/terraform/src/core/runtime-config/appconfig"
-
-  application_name = "my-app-runtime-config"
-  namespaces       = ["connection", "agentcore", "database"]
-}
-```
+`appconfig_application_id`/`appconfig_application_arn` đến từ ứng dụng <Link path="guides/runtime-config">runtime configuration</Link> AppConfig được chia sẻ được khai báo một lần trong root module của bạn, không phải từ database module. Ứng dụng đó hiển thị namespace `database` theo mặc định, vì vậy entry runtime configuration của database module được triển khai mà không cần cấu hình thêm.
 
 </Fragment>
 </Infrastructure>

--- a/docs/src/content/docs/vi/guides/connection/ts-mcp-server-rdb.mdx
+++ b/docs/src/content/docs/vi/guides/connection/ts-mcp-server-rdb.mdx
@@ -160,16 +160,7 @@ resource "aws_vpc_security_group_egress_rule" "mcp_server_to_database" {
 }
 ```
 
-`appconfig_application_id`/`appconfig_application_arn` đến từ ứng dụng AppConfig <Link path="guides/runtime-config">runtime configuration</Link> được chia sẻ được khai báo một lần trong root module của bạn, không phải từ database module. Bao gồm namespace `database` khi khởi tạo nó để mục cấu hình runtime của database module được triển khai:
-
-```hcl title="packages/infra/src/main.tf"
-module "runtime_config_appconfig" {
-  source = "../../common/terraform/src/core/runtime-config/appconfig"
-
-  application_name = "my-app-runtime-config"
-  namespaces       = ["connection", "agentcore", "database"]
-}
-```
+`appconfig_application_id`/`appconfig_application_arn` đến từ ứng dụng AppConfig <Link path="guides/runtime-config">runtime configuration</Link> được chia sẻ được khai báo một lần trong root module của bạn, không phải từ database module. Ứng dụng đó mặc định hiển thị namespace `database`, vì vậy mục cấu hình runtime của database module được triển khai mà không cần cấu hình thêm.
 
 </Fragment>
 </Infrastructure>

--- a/docs/src/content/docs/vi/guides/runtime-config.mdx
+++ b/docs/src/content/docs/vi/guides/runtime-config.mdx
@@ -12,17 +12,19 @@ Cấu hình runtime là cơ chế được Nx Plugin for AWS sử dụng để t
 
 Cấu hình runtime được tổ chức thành các **namespace**. Mỗi namespace là một nhóm logic của các giá trị cấu hình liên quan. Tại thời điểm triển khai, tất cả các namespace được lưu trữ trong **AWS AppConfig** dưới dạng Configuration Profiles.
 
-Hai namespace tích hợp sẵn được sử dụng bởi các construct được tạo:
+Bốn namespace tích hợp sẵn được sử dụng bởi các construct được tạo:
 
 - **`connection`** — cấu hình cho phép các dự án được tạo kết nối với nhau:
   - **API URLs** — được đăng ký tự động bởi các construct API
   - **Cognito settings** — được đăng ký tự động bởi construct UserIdentity
   - **Agent runtime ARNs** — được thêm bởi trình tạo kết nối khi bạn kết nối một website React với một Agent
 - **`agentcore`** — AgentCore runtime ARNs cho các agent và MCP server. Được đăng ký tự động bởi các construct agent/MCP và được sử dụng để khám phá phía server (agent → agent qua A2A, agent → MCP server).
+- **`dynamodb`** — tên bảng, được đăng ký tự động bởi các construct bảng DynamoDB và được đọc bởi table client được tạo.
+- **`database`** — chi tiết kết nối Aurora, được đăng ký tự động bởi các construct cơ sở dữ liệu quan hệ và được đọc bởi database client được tạo.
 
-Namespace `connection` cũng được triển khai dưới dạng file `runtime-config.json` vào S3 bucket của website của bạn, cho phép khám phá các tài nguyên backend từ phía client. Namespace `agentcore` chỉ dành cho phía server (qua AppConfig) nên các agent runtime ARN không được tiết lộ cho frontend trừ khi bạn kết nối rõ ràng một website với một agent.
+Namespace `connection` cũng được triển khai dưới dạng file `runtime-config.json` vào S3 bucket của website của bạn, cho phép khám phá các tài nguyên backend từ phía client. Các namespace khác chỉ dành cho phía server (qua AppConfig), vì vậy các giá trị như agent runtime ARN và tên bảng không được tiết lộ cho frontend trừ khi bạn kết nối rõ ràng một website với chúng.
 
-Bạn có thể định nghĩa bao nhiêu namespace bổ sung tùy thích, cung cấp một giải pháp thay thế thuận tiện cho các biến môi trường để truyền các giá trị tại thời điểm triển khai như tên bảng DynamoDB cho các hàm Lambda hoặc tài nguyên tính toán khác của bạn.
+Bạn có thể định nghĩa bao nhiêu namespace bổ sung tùy thích, cung cấp một giải pháp thay thế thuận tiện cho các biến môi trường để truyền các giá trị tại thời điểm triển khai cho các hàm Lambda hoặc tài nguyên tính toán khác của bạn.
 
 ```d2
 direction: down
@@ -104,6 +106,17 @@ Terraform kết nối cấu hình runtime qua ba module `core/runtime-config/*`.
      source = "../../common/terraform/src/core/runtime-config/appconfig"
 
      application_name = "my-app-runtime-config"
+   }
+   ```
+
+   Biến `namespaces` mặc định là mọi namespace tích hợp sẵn, vì vậy các module được tạo hoạt động mà không cần cấu hình nó. Để thêm các namespace của riêng bạn, liệt kê chúng cùng với các namespace tích hợp sẵn:
+
+   ```hcl title="packages/infra/src/main.tf"
+   module "runtime_config_appconfig" {
+     source = "../../common/terraform/src/core/runtime-config/appconfig"
+
+     application_name = "my-app-runtime-config"
+     namespaces       = ["connection", "agentcore", "database", "dynamodb", "tables"]
    }
    ```
 

--- a/docs/src/content/docs/vi/snippets/connection/rdb-api-infrastructure.mdx
+++ b/docs/src/content/docs/vi/snippets/connection/rdb-api-infrastructure.mdx
@@ -89,16 +89,7 @@ resource "aws_vpc_security_group_egress_rule" "api_to_database" {
 }
 ```
 
-Triển khai các hàm Lambda API vào **private subnets with egress**, không phải private isolated subnets. `appconfig_application_id`/`appconfig_application_arn` đến từ <Link path="guides/runtime-config">runtime configuration</Link> AppConfig application được chia sẻ được khai báo một lần trong root module của bạn, không phải từ database module — việc truyền chúng sẽ đặt `RUNTIME_CONFIG_APP_ID` trên các hàm Lambda và cấp cho chúng quyền đọc vào application. Bao gồm namespace `database` khi khởi tạo nó để runtime configuration entry của database module được triển khai:
-
-```hcl title="packages/infra/src/main.tf"
-module "runtime_config_appconfig" {
-  source = "../../common/terraform/src/core/runtime-config/appconfig"
-
-  application_name = "my-app-runtime-config"
-  namespaces       = ["connection", "agentcore", "database"]
-}
-```
+Triển khai các hàm Lambda API vào **private subnets with egress**, không phải private isolated subnets. `appconfig_application_id`/`appconfig_application_arn` đến từ <Link path="guides/runtime-config">runtime configuration</Link> AppConfig application được chia sẻ được khai báo một lần trong root module của bạn, không phải từ database module — việc truyền chúng sẽ đặt `RUNTIME_CONFIG_APP_ID` trên các hàm Lambda và cấp cho chúng quyền đọc vào application. Application đó mặc định expose namespace `database`, do đó runtime configuration entry của database module được triển khai mà không cần cấu hình thêm.
 
 </Fragment>
 </Infrastructure>

--- a/docs/src/content/docs/vi/snippets/dynamodb/deploying-table.mdx
+++ b/docs/src/content/docs/vi/snippets/dynamodb/deploying-table.mdx
@@ -47,7 +47,9 @@ module "my_table" {
 - Mã hóa KMS do khách hàng quản lý với tự động xoay vòng khóa
 - Khôi phục theo thời điểm được bật
 - Bảo vệ xóa được bật
-- Tên bảng được đăng ký trong Runtime Config
+- Tên bảng được đăng ký trong Runtime Config dưới namespace `dynamodb` trong AWS AppConfig
+
+Module `core/runtime-config/appconfig` hiển thị namespace `dynamodb` theo mặc định, vì vậy tên bảng được triển khai mà không cần cấu hình thêm. Nếu bạn truyền `namespaces` vào module đó một cách rõ ràng, hãy giữ `dynamodb` trong danh sách — nếu không, không có configuration profile nào được tạo cho nó và table client được tạo ra không thể phân giải tên bảng.
 </Fragment>
 </Infrastructure>
 

--- a/docs/src/content/docs/vi/snippets/rdb/deploying.mdx
+++ b/docs/src/content/docs/vi/snippets/rdb/deploying.mdx
@@ -52,16 +52,7 @@ module "my_database" {
 
 Điều này cung cấp một cụm Aurora với RDS Proxy, thông tin xác thực admin, Lambda create-db-user, đăng ký cấu hình runtime, Lambda migration và các tài nguyên container registry.
 
-Module cơ sở dữ liệu đăng ký chi tiết kết nối của nó dưới namespace cấu hình runtime `database`. Bao gồm namespace này khi khởi tạo ứng dụng AppConfig cấu hình runtime được chia sẻ:
-
-```hcl title="packages/infra/src/main.tf"
-module "runtime_config_appconfig" {
-  source = "../../common/terraform/src/core/runtime-config/appconfig"
-
-  application_name = "my-app-runtime-config"
-  namespaces       = ["connection", "agentcore", "database"]
-}
-```
+Module cơ sở dữ liệu đăng ký chi tiết kết nối của nó dưới namespace <Link path="guides/runtime-config">cấu hình runtime</Link> `database`, mà ứng dụng AppConfig cấu hình runtime được chia sẻ mặc định hiển thị.
 
 Cơ sở hạ tầng được tạo ra tạo hai người dùng cơ sở dữ liệu:
 - **Người dùng Admin** - Được tạo trong quá trình cung cấp cụm với thông tin xác thực được lưu trữ trong AWS Secrets Manager

--- a/docs/src/content/docs/zh/guides/connection/py-agent-rdb.mdx
+++ b/docs/src/content/docs/zh/guides/connection/py-agent-rdb.mdx
@@ -146,16 +146,7 @@ resource "aws_vpc_security_group_egress_rule" "agent_to_database" {
 }
 ```
 
-`appconfig_application_id`/`appconfig_application_arn` 来自在根模块中声明一次的共享<Link path="guides/runtime-config">运行时配置</Link> AppConfig 应用程序，而不是来自数据库模块。在实例化它时包含 `database` 命名空间，以便部署数据库模块的运行时配置条目：
-
-```hcl title="packages/infra/src/main.tf"
-module "runtime_config_appconfig" {
-  source = "../../common/terraform/src/core/runtime-config/appconfig"
-
-  application_name = "my-app-runtime-config"
-  namespaces       = ["connection", "agentcore", "database"]
-}
-```
+`appconfig_application_id`/`appconfig_application_arn` 来自在根模块中声明一次的共享<Link path="guides/runtime-config">运行时配置</Link> AppConfig 应用程序，而不是来自数据库模块。该应用程序默认公开 `database` 命名空间，因此数据库模块的运行时配置条目无需进一步配置即可部署。
 
 </Fragment>
 </Infrastructure>

--- a/docs/src/content/docs/zh/guides/connection/py-fast-api-rdb.mdx
+++ b/docs/src/content/docs/zh/guides/connection/py-fast-api-rdb.mdx
@@ -163,16 +163,7 @@ resource "aws_vpc_security_group_egress_rule" "api_to_database" {
 
 将 API Lambda 函数部署到**具有出口的私有子网**，而不是私有隔离子网。`appconfig_application_id`/`appconfig_application_arn` 来自在根模块中声明一次的共享<Link path="guides/runtime-config">运行时配置</Link> AppConfig 应用程序，而不是来自数据库模块——传递它们会在 Lambda 函数上设置 `RUNTIME_CONFIG_APP_ID` 并授予它们对应用程序的读取访问权限。
 
-AppConfig 应用程序必须公开 `database` 命名空间，以便部署数据库模块的运行时配置条目。在实例化 `runtime-config/appconfig` 模块时，将其包含在 `namespaces` 中：
-
-```hcl title="packages/infra/src/main.tf"
-module "runtime_config_appconfig" {
-  source = "../../common/terraform/src/core/runtime-config/appconfig"
-
-  application_name = "my-app-runtime-config"
-  namespaces       = ["connection", "agentcore", "database"]
-}
-```
+AppConfig 应用程序默认公开 `database` 命名空间，因此数据库模块的运行时配置条目无需进一步配置即可部署。
 
 </Fragment>
 </Infrastructure>

--- a/docs/src/content/docs/zh/guides/connection/py-mcp-server-rdb.mdx
+++ b/docs/src/content/docs/zh/guides/connection/py-mcp-server-rdb.mdx
@@ -155,16 +155,7 @@ resource "aws_vpc_security_group_egress_rule" "mcp_server_to_database" {
 }
 ```
 
-`appconfig_application_id`/`appconfig_application_arn` 来自共享的 <Link path="guides/runtime-config">运行时配置</Link> AppConfig 应用程序，该应用程序在您的根模块中声明一次，而不是来自数据库模块。在实例化它时包含 `database` 命名空间，以便部署数据库模块的运行时配置条目：
-
-```hcl title="packages/infra/src/main.tf"
-module "runtime_config_appconfig" {
-  source = "../../common/terraform/src/core/runtime-config/appconfig"
-
-  application_name = "my-app-runtime-config"
-  namespaces       = ["connection", "agentcore", "database"]
-}
-```
+`appconfig_application_id`/`appconfig_application_arn` 来自共享的 <Link path="guides/runtime-config">运行时配置</Link> AppConfig 应用程序，该应用程序在您的根模块中声明一次，而不是来自数据库模块。该应用程序默认公开 `database` 命名空间，因此数据库模块的运行时配置条目无需进一步配置即可部署。
 
 </Fragment>
 </Infrastructure>

--- a/docs/src/content/docs/zh/guides/connection/ts-agent-rdb.mdx
+++ b/docs/src/content/docs/zh/guides/connection/ts-agent-rdb.mdx
@@ -161,16 +161,7 @@ resource "aws_vpc_security_group_egress_rule" "agent_to_database" {
 }
 ```
 
-`appconfig_application_id`/`appconfig_application_arn` 来自在根模块中声明一次的共享 <Link path="guides/runtime-config">运行时配置</Link> AppConfig 应用程序，而不是来自数据库模块。在实例化时包含 `database` 命名空间，以便部署数据库模块的运行时配置条目：
-
-```hcl title="packages/infra/src/main.tf"
-module "runtime_config_appconfig" {
-  source = "../../common/terraform/src/core/runtime-config/appconfig"
-
-  application_name = "my-app-runtime-config"
-  namespaces       = ["connection", "agentcore", "database"]
-}
-```
+`appconfig_application_id`/`appconfig_application_arn` 来自在根模块中声明一次的共享 <Link path="guides/runtime-config">运行时配置</Link> AppConfig 应用程序，而不是来自数据库模块。该应用程序默认公开 `database` 命名空间，因此数据库模块的运行时配置条目无需进一步配置即可部署。
 
 </Fragment>
 </Infrastructure>

--- a/docs/src/content/docs/zh/guides/connection/ts-mcp-server-rdb.mdx
+++ b/docs/src/content/docs/zh/guides/connection/ts-mcp-server-rdb.mdx
@@ -160,16 +160,7 @@ resource "aws_vpc_security_group_egress_rule" "mcp_server_to_database" {
 }
 ```
 
-`appconfig_application_id`/`appconfig_application_arn` 来自共享的 <Link path="guides/runtime-config">运行时配置</Link> AppConfig 应用程序，该应用程序在根模块中声明一次，而不是来自数据库模块。在实例化它时包含 `database` 命名空间，以便部署数据库模块的运行时配置条目：
-
-```hcl title="packages/infra/src/main.tf"
-module "runtime_config_appconfig" {
-  source = "../../common/terraform/src/core/runtime-config/appconfig"
-
-  application_name = "my-app-runtime-config"
-  namespaces       = ["connection", "agentcore", "database"]
-}
-```
+`appconfig_application_id`/`appconfig_application_arn` 来自共享的 <Link path="guides/runtime-config">运行时配置</Link> AppConfig 应用程序，该应用程序在根模块中声明一次，而不是来自数据库模块。该应用程序默认公开 `database` 命名空间，因此数据库模块的运行时配置条目无需进一步配置即可部署。
 
 </Fragment>
 </Infrastructure>

--- a/docs/src/content/docs/zh/guides/runtime-config.mdx
+++ b/docs/src/content/docs/zh/guides/runtime-config.mdx
@@ -12,17 +12,19 @@ import Link from '@components/link.astro';
 
 运行时配置被组织成**命名空间**。每个命名空间是相关配置值的逻辑分组。在部署时，所有命名空间都作为配置文件存储在 **AWS AppConfig** 中。
 
-生成的构造使用两个内置命名空间：
+生成的构造使用四个内置命名空间：
 
 - **`connection`** — 使生成的项目能够相互连接的配置：
   - **API URLs** — 由 API 构造自动注册
   - **Cognito 设置** — 由 UserIdentity 构造自动注册
   - **Agent 运行时 ARN** — 当您将 React 网站连接到 Agent 时，由连接生成器添加
 - **`agentcore`** — 用于 agent 和 MCP 服务器的 AgentCore 运行时 ARN。由 agent/MCP 构造自动注册，用于服务器端发现（agent → agent 通过 A2A，agent → MCP 服务器）。
+- **`dynamodb`** — 表名，由 DynamoDB 表构造自动注册，并由生成的表客户端读取。
+- **`database`** — Aurora 连接详细信息，由关系数据库构造自动注册，并由生成的数据库客户端读取。
 
-`connection` 命名空间还会作为 `runtime-config.json` 文件部署到您网站的 S3 存储桶中，从而实现后端资源的客户端发现。`agentcore` 命名空间仅用于服务器端（通过 AppConfig），因此 agent 运行时 ARN 不会暴露给前端，除非您明确将网站连接到 agent。
+`connection` 命名空间还会作为 `runtime-config.json` 文件部署到您网站的 S3 存储桶中，从而实现后端资源的客户端发现。其他命名空间仅用于服务器端（通过 AppConfig），因此 agent 运行时 ARN 和表名等值不会暴露给前端，除非您明确将网站连接到它们。
 
-您可以根据需要定义任意数量的额外命名空间，为将部署时值（如 DynamoDB 表名）传递给 Lambda 函数或其他计算资源提供了一种方便的环境变量替代方案。
+您可以根据需要定义任意数量的额外命名空间，为将部署时值传递给 Lambda 函数或其他计算资源提供了一种方便的环境变量替代方案。
 
 ```d2
 direction: down
@@ -104,6 +106,17 @@ Terraform 通过三个 `core/runtime-config/*` 模块连接运行时配置。在
      source = "../../common/terraform/src/core/runtime-config/appconfig"
 
      application_name = "my-app-runtime-config"
+   }
+   ```
+
+   `namespaces` 变量默认为每个内置命名空间，因此生成的模块无需配置即可工作。要添加您自己的命名空间，请将它们与内置命名空间一起列出：
+
+   ```hcl title="packages/infra/src/main.tf"
+   module "runtime_config_appconfig" {
+     source = "../../common/terraform/src/core/runtime-config/appconfig"
+
+     application_name = "my-app-runtime-config"
+     namespaces       = ["connection", "agentcore", "database", "dynamodb", "tables"]
    }
    ```
 

--- a/docs/src/content/docs/zh/snippets/connection/rdb-api-infrastructure.mdx
+++ b/docs/src/content/docs/zh/snippets/connection/rdb-api-infrastructure.mdx
@@ -89,16 +89,7 @@ resource "aws_vpc_security_group_egress_rule" "api_to_database" {
 }
 ```
 
-将 API Lambda 函数部署到**具有出口的私有子网**中，而不是私有隔离子网。`appconfig_application_id`/`appconfig_application_arn` 来自共享的<Link path="guides/runtime-config">运行时配置</Link> AppConfig 应用程序，该应用程序在根模块中声明一次，而不是来自数据库模块——传递它们会在 Lambda 函数上设置 `RUNTIME_CONFIG_APP_ID` 并授予它们对应用程序的读取访问权限。在实例化时包含 `database` 命名空间，以便部署数据库模块的运行时配置条目：
-
-```hcl title="packages/infra/src/main.tf"
-module "runtime_config_appconfig" {
-  source = "../../common/terraform/src/core/runtime-config/appconfig"
-
-  application_name = "my-app-runtime-config"
-  namespaces       = ["connection", "agentcore", "database"]
-}
-```
+将 API Lambda 函数部署到**具有出口的私有子网**中，而不是私有隔离子网。`appconfig_application_id`/`appconfig_application_arn` 来自共享的<Link path="guides/runtime-config">运行时配置</Link> AppConfig 应用程序，该应用程序在根模块中声明一次，而不是来自数据库模块——传递它们会在 Lambda 函数上设置 `RUNTIME_CONFIG_APP_ID` 并授予它们对应用程序的读取访问权限。该应用程序默认公开 `database` 命名空间，因此数据库模块的运行时配置条目无需进一步配置即可部署。
 
 </Fragment>
 </Infrastructure>

--- a/docs/src/content/docs/zh/snippets/dynamodb/deploying-table.mdx
+++ b/docs/src/content/docs/zh/snippets/dynamodb/deploying-table.mdx
@@ -47,7 +47,9 @@ module "my_table" {
 - 具有自动密钥轮换的客户托管 KMS 加密
 - 启用时间点恢复
 - 启用删除保护
-- 表名注册到 Runtime Config
+- 表名在 AWS AppConfig 的 `dynamodb` 命名空间下注册到 Runtime Config
+
+`core/runtime-config/appconfig` 模块默认公开 `dynamodb` 命名空间，因此表名无需进一步配置即可部署。如果您显式地向该模块传递 `namespaces`，请在列表中保留 `dynamodb` —— 否则不会为其创建配置文件，生成的表客户端将无法解析表名。
 </Fragment>
 </Infrastructure>
 

--- a/docs/src/content/docs/zh/snippets/rdb/deploying.mdx
+++ b/docs/src/content/docs/zh/snippets/rdb/deploying.mdx
@@ -52,16 +52,7 @@ module "my_database" {
 
 这将配置一个带有 RDS Proxy、管理员凭证、create-db-user Lambda、运行时配置注册、迁移 Lambda 和容器注册表资源的 Aurora 集群。
 
-数据库模块在 `database` 运行时配置命名空间下注册其连接详细信息。在实例化共享运行时配置 AppConfig 应用程序时包含此命名空间：
-
-```hcl title="packages/infra/src/main.tf"
-module "runtime_config_appconfig" {
-  source = "../../common/terraform/src/core/runtime-config/appconfig"
-
-  application_name = "my-app-runtime-config"
-  namespaces       = ["connection", "agentcore", "database"]
-}
-```
+数据库模块在 `database` <Link path="guides/runtime-config">运行时配置</Link>命名空间下注册其连接详细信息，共享运行时配置 AppConfig 应用程序默认会公开该命名空间。
 
 生成的基础设施会创建两个数据库用户：
 - **管理员用户** - 在集群配置期间创建，凭证存储在 AWS Secrets Manager 中

--- a/packages/nx-plugin/src/migrations/latest/runtime-config-namespace-defaults/metadata.json
+++ b/packages/nx-plugin/src/migrations/latest/runtime-config-namespace-defaults/metadata.json
@@ -1,0 +1,3 @@
+{
+  "description": "Provision AppConfig configuration profiles for every namespace the vended terraform modules write to"
+}

--- a/packages/nx-plugin/src/migrations/latest/runtime-config-namespace-defaults/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/latest/runtime-config-namespace-defaults/migration.spec.ts
@@ -1,0 +1,239 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import type { Tree } from '@nx/devkit';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test.js';
+import migration from './migration.js';
+
+const APPCONFIG_FILE =
+  'packages/common/terraform/src/core/runtime-config/appconfig/appconfig.tf';
+const APPCONFIG_DEPLOYMENT_FILE =
+  'packages/common/terraform/src/core/runtime-config/appconfig-deployment/appconfig-deployment.tf';
+const MAIN_TF = 'packages/infra/src/main.tf';
+
+/** The vended appconfig module, before the namespace defaults were completed. */
+const OLD_APPCONFIG = `resource "aws_appconfig_application" "runtime_config" {
+  name = var.application_name
+}
+
+variable "namespaces" {
+  description = "List of runtime-config namespaces this AppConfig application should expose (one Configuration Profile is created per namespace)."
+  type        = list(string)
+  default     = ["connection", "agentcore"]
+}
+
+resource "aws_appconfig_configuration_profile" "namespace" {
+  for_each = toset(var.namespaces)
+
+  application_id = aws_appconfig_application.runtime_config.id
+  name           = each.key
+}
+`;
+
+/** The vended appconfig-deployment module, carrying the same stale default. */
+const OLD_APPCONFIG_DEPLOYMENT = `variable "namespaces" {
+  description = "List of namespaces to aggregate + deploy. Must match the keys of \`configuration_profile_ids\`."
+  type        = list(string)
+  default     = ["connection", "agentcore"]
+}
+
+resource "aws_appconfig_deployment" "namespace" {
+  for_each = toset(var.namespaces)
+}
+`;
+
+const namespacesDefault = (contents: string): string[] => {
+  const list = /default\s*=\s*\[([^\]]*)\]/.exec(contents)?.[1];
+  if (list === undefined) {
+    throw new Error('No `namespaces` default found');
+  }
+  return [...list.matchAll(/"([^"]+)"/g)].map((m) => m[1]);
+};
+
+describe('runtime-config-namespace-defaults migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeUsingTsSolutionSetup();
+  });
+
+  it('should complete the namespace defaults in both vended modules', async () => {
+    tree.write(APPCONFIG_FILE, OLD_APPCONFIG);
+    tree.write(APPCONFIG_DEPLOYMENT_FILE, OLD_APPCONFIG_DEPLOYMENT);
+
+    const result = await migration(tree);
+
+    for (const file of [APPCONFIG_FILE, APPCONFIG_DEPLOYMENT_FILE]) {
+      expect(namespacesDefault(tree.read(file, 'utf-8')!)).toEqual([
+        'connection',
+        'agentcore',
+        'database',
+        'dynamodb',
+      ]);
+    }
+    expect(result.nextSteps).toEqual([]);
+  });
+
+  it('should document the completed defaults on the vended variable', async () => {
+    tree.write(APPCONFIG_FILE, OLD_APPCONFIG);
+
+    await migration(tree);
+
+    expect(tree.read(APPCONFIG_FILE, 'utf-8')).toContain(
+      'The default covers every namespace the generated modules write to',
+    );
+  });
+
+  it('should add only the namespaces that are missing', async () => {
+    tree.write(
+      APPCONFIG_FILE,
+      OLD_APPCONFIG.replace(
+        '["connection", "agentcore"]',
+        '["connection", "agentcore", "database"]',
+      ),
+    );
+
+    await migration(tree);
+
+    expect(namespacesDefault(tree.read(APPCONFIG_FILE, 'utf-8')!)).toEqual([
+      'connection',
+      'agentcore',
+      'database',
+      'dynamodb',
+    ]);
+  });
+
+  it('should preserve namespaces the user added', async () => {
+    tree.write(
+      APPCONFIG_FILE,
+      OLD_APPCONFIG.replace(
+        '["connection", "agentcore"]',
+        '["connection", "agentcore", "tables"]',
+      ),
+    );
+
+    await migration(tree);
+
+    expect(namespacesDefault(tree.read(APPCONFIG_FILE, 'utf-8')!)).toEqual([
+      'connection',
+      'agentcore',
+      'tables',
+      'database',
+      'dynamodb',
+    ]);
+  });
+
+  // An explicit list overrides the vended default, so a root module passing one
+  // needs the same additions.
+  it('should complete an explicit namespaces argument in a root module', async () => {
+    tree.write(APPCONFIG_FILE, OLD_APPCONFIG);
+    tree.write(
+      MAIN_TF,
+      `module "runtime_config_appconfig" {
+  source = "../../common/terraform/src/core/runtime-config/appconfig"
+
+  application_name = "my-app-runtime-config"
+  namespaces       = ["connection", "agentcore", "database"]
+}
+
+module "unrelated" {
+  source     = "./unrelated"
+  namespaces = ["mine"]
+}
+`,
+    );
+
+    const result = await migration(tree);
+
+    const mainTf = tree.read(MAIN_TF, 'utf-8')!;
+    expect(mainTf).toContain(
+      '["connection", "agentcore", "database", "dynamodb"]',
+    );
+    // A `namespaces` argument on a module that isn't the vended appconfig one
+    // belongs to the user.
+    expect(mainTf).toContain('namespaces = ["mine"]');
+    expect(result.nextSteps).toEqual([]);
+  });
+
+  it('should leave a root module that takes the defaults untouched', async () => {
+    tree.write(APPCONFIG_FILE, OLD_APPCONFIG);
+    const mainTf = `module "runtime_config_appconfig" {
+  source = "../../common/terraform/src/core/runtime-config/appconfig"
+
+  application_name = "my-app-runtime-config"
+}
+`;
+    tree.write(MAIN_TF, mainTf);
+
+    const result = await migration(tree);
+
+    expect(tree.read(MAIN_TF, 'utf-8')).toBe(mainTf);
+    expect(result.nextSteps).toEqual([]);
+  });
+
+  it('should skip and report a root module whose namespaces are not a literal list', async () => {
+    tree.write(APPCONFIG_FILE, OLD_APPCONFIG);
+    const mainTf = `module "runtime_config_appconfig" {
+  source = "../../common/terraform/src/core/runtime-config/appconfig"
+
+  application_name = "my-app-runtime-config"
+  namespaces       = local.my_namespaces
+}
+`;
+    tree.write(MAIN_TF, mainTf);
+
+    const result = await migration(tree);
+
+    expect(tree.read(MAIN_TF, 'utf-8')).toBe(mainTf);
+    expect(result.nextSteps).toHaveLength(1);
+    expect(result.nextSteps?.[0]).toContain(MAIN_TF);
+  });
+
+  it('should skip and report a customised namespaces variable', async () => {
+    const customised = `variable "namespaces" {
+  type    = list(string)
+  default = local.my_namespaces
+}
+`;
+    tree.write(APPCONFIG_FILE, customised);
+
+    const result = await migration(tree);
+
+    expect(tree.read(APPCONFIG_FILE, 'utf-8')).toBe(customised);
+    expect(result.nextSteps).toHaveLength(1);
+    expect(result.nextSteps?.[0]).toContain(APPCONFIG_FILE);
+    expect(result.nextSteps?.[0]).toContain('"database" and "dynamodb"');
+  });
+
+  it('should do nothing in a workspace with no terraform runtime config', async () => {
+    const result = await migration(tree);
+
+    expect(result.nextSteps).toEqual([]);
+    expect(tree.exists(APPCONFIG_FILE)).toBe(false);
+  });
+
+  it('should be idempotent', async () => {
+    tree.write(APPCONFIG_FILE, OLD_APPCONFIG);
+    tree.write(APPCONFIG_DEPLOYMENT_FILE, OLD_APPCONFIG_DEPLOYMENT);
+    tree.write(
+      MAIN_TF,
+      `module "runtime_config_appconfig" {
+  source = "../../common/terraform/src/core/runtime-config/appconfig"
+
+  application_name = "my-app-runtime-config"
+  namespaces       = ["connection", "agentcore"]
+}
+`,
+    );
+    const files = [APPCONFIG_FILE, APPCONFIG_DEPLOYMENT_FILE, MAIN_TF];
+
+    await migration(tree);
+    const afterFirst = files.map((file) => tree.read(file, 'utf-8'));
+
+    const result = await migration(tree);
+
+    expect(files.map((file) => tree.read(file, 'utf-8'))).toEqual(afterFirst);
+    expect(result.nextSteps).toEqual([]);
+  });
+});

--- a/packages/nx-plugin/src/migrations/latest/runtime-config-namespace-defaults/migration.ts
+++ b/packages/nx-plugin/src/migrations/latest/runtime-config-namespace-defaults/migration.ts
@@ -1,0 +1,221 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import {
+  type MigrationReturnObject,
+  type Tree,
+  visitNotIgnoredFiles,
+} from '@nx/devkit';
+import { applyGritQL, matchGritQL } from '../../../utils/ast.js';
+import { formatFilesInSubtree } from '../../../utils/format.js';
+import {
+  PACKAGES_DIR,
+  SHARED_TERRAFORM_DIR,
+} from '../../../utils/shared-constructs-constants.js';
+
+/**
+ * Provision AppConfig configuration profiles for every namespace the vended terraform modules write to
+ *
+ * `core/runtime-config/appconfig` creates one configuration profile per entry in
+ * its `namespaces` list, and `appconfig-deployment` aggregates and deploys the
+ * same list. A module contributing an entry to a namespace outside that list
+ * writes its entry file to disk and nothing more — the value never reaches
+ * AppConfig, so a consumer reading it back fails at runtime. The vended defaults
+ * now cover `dynamodb` and `database` alongside `connection` and `agentcore`.
+ *
+ * Root modules that pass `namespaces` explicitly are updated too, since an
+ * explicit list overrides the vended default.
+ *
+ * How to write a migration:
+ * - https://nx.dev/docs/kb/migration-generators
+ * - What `nextSteps` means: https://nx.dev/docs/reference/devkit/MigrationReturnObject
+ *
+ * Guardrails:
+ * - Transform source with GritQL (`applyGritQL`, `matchGritQL`), not regexes or
+ *   string replacements: it matches the AST, so it holds up against however the
+ *   user's copy has been formatted. Use `updateJson` for JSON.
+ * - Pattern-match before writing: skip files that have diverged from the shape
+ *   your generators produce and report them via `nextSteps`, or consider a
+ *   hybrid migration, rather than clobbering the user's changes.
+ * - `nextSteps` is for work left for the user to do by hand, not a log of the
+ *   edits you made: an edit that applied cleanly needs no entry.
+ * - Idempotent: re-running must be a no-op.
+ * - Format what you write: finish with `formatFilesInSubtree` so the files your
+ *   migration wrote are formatted correctly.
+ */
+
+/** Namespaces the vended modules write to that the old defaults omitted. */
+const ADDED_NAMESPACES = ['database', 'dynamodb'];
+
+const RUNTIME_CONFIG_DIR = `${PACKAGES_DIR}/${SHARED_TERRAFORM_DIR}/src/core/runtime-config`;
+const APPCONFIG_FILE = `${RUNTIME_CONFIG_DIR}/appconfig/appconfig.tf`;
+const APPCONFIG_DEPLOYMENT_FILE = `${RUNTIME_CONFIG_DIR}/appconfig-deployment/appconfig-deployment.tf`;
+
+const hcl = (pattern: string) => `language hcl\n${pattern}`;
+
+/**
+ * Where a `namespaces` list lives, as the block that encloses it and the
+ * attribute holding the list. `clauses` narrows the block further, keeping an
+ * unrelated list elsewhere in the file out of scope; `$body` is the block's body
+ * in every case, so the clauses below can all be written against it.
+ */
+interface NamespaceList {
+  readonly block: string;
+  readonly attribute: string;
+  readonly clauses?: string;
+}
+
+/** The `namespaces` variable declaration in a vended appconfig module. */
+const VENDED_DEFAULT: NamespaceList = {
+  block: 'variable "namespaces" { $body }',
+  attribute: 'default',
+};
+
+/**
+ * A call to the vended appconfig module that passes `namespaces` explicitly.
+ * `$src` binds the quoted string, so the regex ends at the closing quote — that
+ * anchor is what keeps the sibling `appconfig-deployment` call, which takes its
+ * namespaces from this module's output, out of scope.
+ */
+const ROOT_MODULE_ARGUMENT: NamespaceList = {
+  block: 'module $name { $body }',
+  attribute: 'namespaces',
+  clauses:
+    '$body <: contains `source = $src`, $src <: r".*runtime-config/appconfig\\"", $body <: contains `namespaces = $_`',
+};
+
+/** A GritQL pattern matching the enclosing block, plus any extra clauses. */
+const scopePattern = (list: NamespaceList, extraClauses?: string) => {
+  const clauses = [list.clauses, extraClauses].filter(Boolean).join(', ');
+  return hcl(`\`${list.block}\`${clauses ? ` where { ${clauses} }` : ''}`);
+};
+
+/** Whether a namespace already appears in the list. */
+const listsNamespace = (
+  tree: Tree,
+  filePath: string,
+  list: NamespaceList,
+  namespace: string,
+) =>
+  matchGritQL(
+    tree,
+    filePath,
+    scopePattern(list, `$body <: contains \`"${namespace}"\``),
+  );
+
+/**
+ * Append a namespace to the list. Appended within the list rather than
+ * re-emitting it, so no trailing hole is introduced.
+ */
+const appendNamespace = (
+  tree: Tree,
+  filePath: string,
+  list: NamespaceList,
+  namespace: string,
+) =>
+  applyGritQL(
+    tree,
+    filePath,
+    scopePattern(
+      list,
+      `$body <: contains bubble \`${list.attribute} = [$items]\` where { $items <: [$..., $last], $last += \`, "${namespace}"\` }`,
+    ),
+  );
+
+/**
+ * Add every missing namespace to a list, returning false when one could not be
+ * added. Already-listed namespaces are skipped, which is what makes a re-run a
+ * no-op.
+ */
+const addMissingNamespaces = async (
+  tree: Tree,
+  filePath: string,
+  list: NamespaceList,
+): Promise<boolean> => {
+  for (const namespace of ADDED_NAMESPACES) {
+    if (await listsNamespace(tree, filePath, list, namespace)) {
+      continue;
+    }
+    if (!(await appendNamespace(tree, filePath, list, namespace))) {
+      return false;
+    }
+  }
+  return true;
+};
+
+/** The vended module's own description, updated to document the new defaults. */
+const DESCRIPTION_REWRITE = scopePattern(
+  VENDED_DEFAULT,
+  '$body <: contains bubble `description = $desc` where { $desc <: r".*one Configuration Profile is created per namespace.*", $desc => `"List of runtime-config namespaces this AppConfig application should expose (one Configuration Profile is created per namespace). The default covers every namespace the generated modules write to, and a namespace with no contributions deploys an empty profile — when adding namespaces of your own, keep the defaults alongside them."` }',
+);
+
+const missing = ADDED_NAMESPACES.map((n) => `"${n}"`).join(' and ');
+
+const divergedNextStep = (filePath: string) =>
+  `${filePath}: the \`namespaces\` variable has diverged from the generated shape - left untouched. Add ${missing} to its \`default\` list, otherwise no configuration profile is created for them and the entries the vended dynamodb/database modules contribute are never deployed.`;
+
+const rootModuleNextStep = (filePath: string) =>
+  `${filePath}: passes \`namespaces\` to the runtime-config appconfig module in a shape this migration could not update - left untouched. Add ${missing} to that list, or drop the argument to take the module's defaults, otherwise the entries the vended dynamodb/database modules contribute are never deployed.`;
+
+/** Bring one vended appconfig module's `namespaces` default up to date. */
+const migrateVendedModule = async (
+  tree: Tree,
+  filePath: string,
+  nextSteps: string[],
+): Promise<void> => {
+  if (!tree.exists(filePath)) {
+    return; // This workspace has no Terraform runtime config.
+  }
+
+  if (!(await addMissingNamespaces(tree, filePath, VENDED_DEFAULT))) {
+    nextSteps.push(divergedNextStep(filePath));
+  }
+};
+
+/**
+ * Root modules that pass `namespaces` explicitly override the vended default, so
+ * they need the same additions.
+ */
+const migrateRootModules = async (
+  tree: Tree,
+  nextSteps: string[],
+): Promise<void> => {
+  const terraformFiles: string[] = [];
+  visitNotIgnoredFiles(tree, '', (filePath) => {
+    if (filePath.endsWith('.tf') && !filePath.startsWith(RUNTIME_CONFIG_DIR)) {
+      terraformFiles.push(filePath);
+    }
+  });
+
+  for (const filePath of terraformFiles) {
+    if (
+      !(await matchGritQL(tree, filePath, scopePattern(ROOT_MODULE_ARGUMENT)))
+    ) {
+      continue; // Takes the module's defaults, so nothing to update.
+    }
+
+    if (!(await addMissingNamespaces(tree, filePath, ROOT_MODULE_ARGUMENT))) {
+      nextSteps.push(rootModuleNextStep(filePath));
+    }
+  }
+};
+
+export default async function migration(
+  tree: Tree,
+): Promise<MigrationReturnObject> {
+  const nextSteps: string[] = [];
+
+  await migrateVendedModule(tree, APPCONFIG_FILE, nextSteps);
+  await migrateVendedModule(tree, APPCONFIG_DEPLOYMENT_FILE, nextSteps);
+
+  if (tree.exists(APPCONFIG_FILE)) {
+    await applyGritQL(tree, APPCONFIG_FILE, DESCRIPTION_REWRITE);
+  }
+
+  await migrateRootModules(tree, nextSteps);
+
+  await formatFilesInSubtree(tree);
+
+  return { nextSteps };
+}

--- a/packages/nx-plugin/src/utils/files/terraform/src/core/runtime-config/appconfig-deployment/appconfig-deployment.tf.template
+++ b/packages/nx-plugin/src/utils/files/terraform/src/core/runtime-config/appconfig-deployment/appconfig-deployment.tf.template
@@ -40,7 +40,7 @@ variable "configuration_profile_ids" {
 variable "namespaces" {
   description = "List of namespaces to aggregate + deploy. Must match the keys of `configuration_profile_ids`."
   type        = list(string)
-  default     = ["connection", "agentcore"]
+  default     = ["connection", "agentcore", "database", "dynamodb"]
 }
 
 locals {

--- a/packages/nx-plugin/src/utils/files/terraform/src/core/runtime-config/appconfig/appconfig.tf.template
+++ b/packages/nx-plugin/src/utils/files/terraform/src/core/runtime-config/appconfig/appconfig.tf.template
@@ -22,9 +22,9 @@ variable "application_name" {
 }
 
 variable "namespaces" {
-  description = "List of runtime-config namespaces this AppConfig application should expose (one Configuration Profile is created per namespace)."
+  description = "List of runtime-config namespaces this AppConfig application should expose (one Configuration Profile is created per namespace). The default covers every namespace the generated modules write to, and a namespace with no contributions deploys an empty profile — when adding namespaces of your own, keep the defaults alongside them."
   type        = list(string)
-  default     = ["connection", "agentcore"]
+  default     = ["connection", "agentcore", "database", "dynamodb"]
 }
 
 variable "deployment_strategy_id" {

--- a/packages/nx-plugin/src/utils/runtime-config-namespaces.spec.ts
+++ b/packages/nx-plugin/src/utils/runtime-config-namespaces.spec.ts
@@ -1,0 +1,187 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { joinPathFragments, type Tree } from '@nx/devkit';
+import { tsDynamoDBGenerator } from '../ts/dynamodb/generator.js';
+import { resolveContainers } from './containers.js';
+import { declareDependencies } from './declared-dependencies.js';
+import { sharedConstructsGenerator } from './shared-constructs.js';
+import {
+  PACKAGES_DIR,
+  SHARED_CONSTRUCTS_DEPENDENCIES,
+  SHARED_TERRAFORM_DIR,
+} from './shared-constructs-constants.js';
+import { createTreeUsingTsSolutionSetup } from './test.js';
+
+vi.mock('./containers', () => ({
+  resolveContainers: vi.fn(),
+}));
+
+const PLUGIN_SRC = path.resolve(import.meta.dirname, '..');
+
+const APPCONFIG_TEMPLATE =
+  'utils/files/terraform/src/core/runtime-config/appconfig/appconfig.tf.template';
+const APPCONFIG_DEPLOYMENT_TEMPLATE =
+  'utils/files/terraform/src/core/runtime-config/appconfig-deployment/appconfig-deployment.tf.template';
+
+const TERRAFORM_SRC = joinPathFragments(
+  PACKAGES_DIR,
+  SHARED_TERRAFORM_DIR,
+  'src',
+);
+const APPCONFIG_FILE = joinPathFragments(
+  TERRAFORM_SRC,
+  'core/runtime-config/appconfig/appconfig.tf',
+);
+const APPCONFIG_DEPLOYMENT_FILE = joinPathFragments(
+  TERRAFORM_SRC,
+  'core/runtime-config/appconfig-deployment/appconfig-deployment.tf',
+);
+
+/** Every vended `.tf.template` under the plugin's source tree. */
+const terraformTemplates = (): string[] => {
+  const found: string[] = [];
+  const walk = (dir: string) => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(full);
+      } else if (entry.name.endsWith('.tf.template')) {
+        found.push(path.relative(PLUGIN_SRC, full));
+      }
+    }
+  };
+  walk(PLUGIN_SRC);
+  return found;
+};
+
+/**
+ * Top-level HCL blocks in a file's text. Scanned textually rather than parsed:
+ * most of these templates carry EJS control flow, which no HCL parser accepts.
+ */
+const topLevelBlocks = (contents: string): string[] => {
+  const blocks: string[] = [];
+  let current: string[] | undefined;
+  for (const line of contents.split('\n')) {
+    if (current === undefined) {
+      if (/^\w+\s.*\{\s*$/.test(line)) {
+        current = [line];
+      }
+      continue;
+    }
+    current.push(line);
+    if (line === '}') {
+      blocks.push(current.join('\n'));
+      current = undefined;
+    }
+  }
+  return blocks;
+};
+
+/**
+ * The namespace each `core/runtime-config/entry` module invocation in a file
+ * writes to. `null` stands for an invocation whose namespace isn't a literal,
+ * which the invariant below can't verify.
+ */
+const entryNamespaces = (contents: string): (string | null)[] =>
+  topLevelBlocks(contents)
+    .filter((block) => /source\s*=\s*"[^"]*runtime-config\/entry"/.test(block))
+    .map(
+      (block) => /^\s*namespace\s*=\s*"([^"]+)"\s*$/m.exec(block)?.[1] ?? null,
+    );
+
+/** The `namespaces` variable's default list in an appconfig module's text. */
+const namespacesDefault = (contents: string): string[] => {
+  const block = topLevelBlocks(contents).find((b) =>
+    b.startsWith('variable "namespaces"'),
+  );
+  if (!block) {
+    throw new Error('No `namespaces` variable found');
+  }
+  const list = /^\s*default\s*=\s*\[([^\]]*)\]\s*$/m.exec(block)?.[1];
+  if (list === undefined) {
+    throw new Error('No `default` found on the `namespaces` variable');
+  }
+  return [...list.matchAll(/"([^"]+)"/g)].map((m) => m[1]);
+};
+
+const readTemplate = (rel: string): string =>
+  fs.readFileSync(path.join(PLUGIN_SRC, rel), 'utf-8');
+
+describe('terraform runtime-config namespaces', () => {
+  // A namespace only becomes an AppConfig configuration profile if it is in the
+  // `namespaces` default, and only a profile gets aggregated and deployed. A
+  // module contributing an entry to a namespace that isn't listed writes its
+  // entry file to disk and nothing else — the value never reaches AppConfig and
+  // the generated client throws when it reads it back.
+  it('should expose a configuration profile for every namespace a vended entry module writes to', () => {
+    const contributed = new Map<string, string[]>();
+    for (const rel of terraformTemplates()) {
+      for (const namespace of entryNamespaces(readTemplate(rel))) {
+        expect(
+          namespace,
+          `${rel}: writes a runtime-config entry to a non-literal namespace, so it cannot be checked against the appconfig namespaces default`,
+        ).not.toBeNull();
+        contributed.set(namespace!, [
+          ...(contributed.get(namespace!) ?? []),
+          rel,
+        ]);
+      }
+    }
+
+    // Guards the scan itself: the invariant is worthless if it silently stops
+    // finding the entry modules it is meant to check.
+    expect(contributed.size).toBeGreaterThan(1);
+
+    const provisioned = namespacesDefault(readTemplate(APPCONFIG_TEMPLATE));
+    for (const [namespace, templates] of contributed) {
+      expect(
+        provisioned,
+        `namespace "${namespace}" is written to by ${templates.join(', ')} but has no configuration profile — add it to the \`namespaces\` default in ${APPCONFIG_TEMPLATE}`,
+      ).toContain(namespace);
+    }
+  });
+
+  // `appconfig-deployment` drives the aggregation, hosted configuration version
+  // and deployment, and indexes `configuration_profile_ids` by namespace — a
+  // namespace in one default but not the other is either never deployed or a
+  // plan-time lookup failure.
+  it('should keep the appconfig and appconfig-deployment namespace defaults in sync', () => {
+    expect(
+      namespacesDefault(readTemplate(APPCONFIG_DEPLOYMENT_TEMPLATE)),
+    ).toEqual(namespacesDefault(readTemplate(APPCONFIG_TEMPLATE)));
+  });
+
+  it('should provision a profile for the namespace a generated dynamodb table publishes to', async () => {
+    const tree: Tree = createTreeUsingTsSolutionSetup();
+    vi.mocked(resolveContainers).mockResolvedValue('docker');
+
+    await sharedConstructsGenerator(
+      tree,
+      { iac: 'terraform' },
+      declareDependencies()({ ts: [...SHARED_CONSTRUCTS_DEPENDENCIES] }),
+    );
+    await tsDynamoDBGenerator(tree, {
+      name: 'MyTable',
+      directory: 'packages',
+      framework: 'electrodb',
+      infra: 'dynamodb',
+      iac: 'terraform',
+    });
+
+    const tableModule = tree.read(
+      joinPathFragments(TERRAFORM_SRC, 'app/dynamodb/my-table/my-table.tf'),
+      'utf-8',
+    )!;
+    expect(entryNamespaces(tableModule)).toEqual(['dynamodb']);
+
+    for (const file of [APPCONFIG_FILE, APPCONFIG_DEPLOYMENT_FILE]) {
+      expect(namespacesDefault(tree.read(file, 'utf-8')!)).toContain(
+        'dynamodb',
+      );
+    }
+  });
+});


### PR DESCRIPTION
### Reason for this change

Under `iac=terraform`, a DynamoDB table's name was published into runtime config under the `dynamodb` namespace, but never actually reached AWS AppConfig — so the generated table client threw `Could not resolve table name from runtime config` at runtime.

The vended `core/runtime-config/appconfig` module creates one AppConfig **configuration profile** per entry in its `namespaces` variable, whose default was a hardcoded `["connection", "agentcore"]`. The sibling `appconfig-deployment` module carried the same default and drives the aggregation, the hosted configuration version and the deployment. A module contributing an entry to a namespace outside that list writes its entry file to disk and nothing more: no profile is created, the entry is never aggregated, and nothing is deployed.

Two vended modules were affected:

- `app/dynamodb/<name>/<name>.tf` calls `core/runtime-config/entry` with `namespace = "dynamodb"`
- `app/dbs/<name>/<name>.tf` calls it with `namespace = "database"`

This does not happen under CDK, where namespaces are **discovered** rather than declared: `RuntimeConfig.set(ns, key, value)` creates the namespace on demand and an Aspect materialises a profile per namespace. CDK synth produced 3 profiles (`connection`, `agentcore`, `dynamodb`) where Terraform planned only 2.

### Description of changes

Add `dynamodb` and `database` to the `namespaces` default in **both** `appconfig` and `appconfig-deployment`. The two must stay in sync — `appconfig-deployment` indexes `configuration_profile_ids` by namespace, so a namespace in one default but not the other is either never deployed or a plan-time lookup failure. Its variable description already documents that constraint.

This is safe when no table or database exists: the aggregation script guards with `if entries_dir.is_dir()` and yields an empty `{}` profile — exactly the shape the `agentcore` namespace already takes in an agent-free workspace. Verified in the plan below, which creates all four profiles from a workspace containing only a DynamoDB table.

**On the `database` namespace.** The RDB modules write to `database`, which was also absent from the default — but unlike `dynamodb` it was *documented* as a manual opt-in across ~6 docs pages. I chose to add it rather than leave it as the documented opt-in:

- It is the same bug, not a design choice. Nothing about `database` is opt-in in the code: the RDB module contributes its entry unconditionally, exactly as the DynamoDB module does. The docs were compensating for a missing default, not describing intentional behaviour.
- Leaving it would make the defaults incoherent — one auto-provisioned namespace and one requiring a manual step, with no principle distinguishing them, which is precisely the trap the next contributor falls into.
- The regression test below asserts the *invariant* (every namespace a vended `entry` module writes to has a matching profile). Special-casing `database` would mean either weakening that test to an allow-list or carrying an exception, both of which defeat its purpose.
- The opt-in is strictly worse for users: forgetting it produces a silent runtime failure with no plan-time or deploy-time signal.

The docs that documented the manual step are updated to state the namespace is exposed by default, and `runtime-config.mdx`'s "Two built-in namespaces" is corrected to four with `dynamodb`/`database` described. It also now shows how to add a namespace of your own while keeping the built-in ones — the remaining footgun is overriding `namespaces` and dropping them, which the vended variable's description now warns about too. The DynamoDB snippet gains a matching note.

Also ships a migration, per the CONTRIBUTING guidance that a change to generated output needs one: the vended files are generated `KeepExisting`, so an existing workspace would otherwise keep the stale defaults. It appends only the missing namespaces (preserving any the user added), updates a root module that passes `namespaces` explicitly since that overrides the default, and reports anything it doesn't recognise via `nextSteps` rather than rewriting it.

### Description of how you validated changes

**Regression test asserting the invariant, not the string** — `packages/nx-plugin/src/utils/runtime-config-namespaces.spec.ts`. Rather than asserting a hardcoded `"dynamodb"`, it scans every vended `.tf.template` for `core/runtime-config/entry` invocations, extracts the namespace each writes to, and asserts every one has a matching configuration profile. So a *future* generator that writes to a new namespace without provisioning it fails too. It also asserts the two defaults stay in sync, guards its own scan (failing if it stops finding entry modules, or if a namespace is non-literal and can't be checked), and runs the real generators to check a generated table's module against the generated appconfig module.

Confirmed it catches the bug — with the fix reverted:

```
× should expose a configuration profile for every namespace a vended entry module writes to
  AssertionError: namespace "dynamodb" is written to by
  utils/dynamodb-constructs/files/terraform/app/dynamodb/__nameKebabCase__/__nameKebabCase__.tf.template
  but has no configuration profile — add it to the `namespaces` default in
  utils/files/terraform/src/core/runtime-config/appconfig/appconfig.tf.template:
  expected [ 'connection', 'agentcore' ] to include 'dynamodb'
× should provision a profile for the namespace a generated dynamodb table publishes to
```

Migration covered by `migration.spec.ts` (10 cases): applies to the vended shape, adds only what's missing, preserves user-added namespaces, updates an explicit root-module argument while leaving an unrelated module's `namespaces` alone, leaves a root module that takes the defaults untouched, skips + reports a customised variable and a non-literal argument, no-ops in a workspace without Terraform runtime config, and is idempotent.

Full gate: `pnpm nx run @aws/nx-plugin:test` (3720 tests, 200 files, all passing — **no snapshot changes**), `pnpm nx run-many --target build --all`, `pnpm nx run-many --target lint --all --configuration=fix`.

**End-to-end proof with a real Terraform plan.** Generated a real Terraform workspace with a DynamoDB table using the locally compiled plugin, wired the modules into a root `main.tf` following `e2e/src/files/terraform-deploy/main.tf.template`, then ran `terraform init -backend=false` + `terraform test` with every provider mocked — the credential-free plan-time check from `e2e/src/smoke-tests/terraform-plan-test.ts`. The only difference between the two runs is the `namespaces` default.

Before (both plans pass; profiles the plan creates):

```
=== [before] aws_appconfig_configuration_profile names in plan ===
agentcore
connection
=== [before] aws_appconfig_deployment namespaces in plan ===
agentcore
connection
```

After:

```
=== [after] aws_appconfig_configuration_profile names in plan ===
agentcore
connection
database
dynamodb
=== [after] aws_appconfig_deployment namespaces in plan ===
agentcore
connection
database
dynamodb
```

The before plan still creates the table's entry file — `module.my_table.module.add_to_runtime_config.local_file.entry will be created` — with no `dynamodb` profile or deployment to consume it, which is the orphaned-entry failure exactly. After the fix the entry has a profile, is aggregated, and is deployed. Both plans succeed, confirming the extra namespaces introduce no plan-time error in a workspace with no database (they deploy empty profiles).

### Issue #

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
