### PR TITLE
fix(ts#dynamodb): expose table outputs on the Terraform app module

### DIFF
--- a/docs/src/content/docs/en/guides/connection/py-agent-dynamodb.mdx
+++ b/docs/src/content/docs/en/guides/connection/py-agent-dynamodb.mdx
@@ -70,42 +70,41 @@ table.grantReadWriteData(myAgent);
 </Fragment>
 <Fragment slot="terraform">
 
+Grant the agent's runtime role access to the table and its KMS encryption key via `additional_iam_policy_statements`:
+
 ```hcl title="packages/infra/src/main.tf"
 module "my_table" {
   source = "../../common/terraform/src/app/dynamodb/my-table"
 }
 
-resource "aws_iam_role_policy" "dynamodb_access" {
-  role = module.my_agent.lambda_role_name
+module "my_agent" {
+  source = "../../common/terraform/src/app/agents/my-agent"
 
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Action = [
-          "dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:UpdateItem",
-          "dynamodb:DeleteItem", "dynamodb:Query", "dynamodb:Scan",
-          "dynamodb:BatchGetItem", "dynamodb:BatchWriteItem",
-        ]
-        Resource = [
-          module.my_table.table_arn,
-          "${module.my_table.table_arn}/index/*",
-        ]
-      },
-      {
-        Effect = "Allow"
-        Action = [
-          "kms:Encrypt",
-          "kms:Decrypt",
-          "kms:ReEncrypt*",
-          "kms:GenerateDataKey*",
-          "kms:DescribeKey"
-        ]
-        Resource = [module.my_table.kms_key_arn]
-      },
-    ]
-  })
+  additional_iam_policy_statements = [
+    {
+      Effect = "Allow"
+      Action = [
+        "dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:UpdateItem",
+        "dynamodb:DeleteItem", "dynamodb:Query", "dynamodb:Scan",
+        "dynamodb:BatchGetItem", "dynamodb:BatchWriteItem",
+      ]
+      Resource = [
+        module.my_table.table_arn,
+        "${module.my_table.table_arn}/index/*",
+      ]
+    },
+    {
+      Effect = "Allow"
+      Action = [
+        "kms:Encrypt",
+        "kms:Decrypt",
+        "kms:ReEncrypt*",
+        "kms:GenerateDataKey*",
+        "kms:DescribeKey",
+      ]
+      Resource = [module.my_table.kms_key_arn]
+    },
+  ]
 }
 ```
 </Fragment>

--- a/docs/src/content/docs/en/guides/connection/py-mcp-server-dynamodb.mdx
+++ b/docs/src/content/docs/en/guides/connection/py-mcp-server-dynamodb.mdx
@@ -70,42 +70,41 @@ table.grantReadWriteData(myMcpServer);
 </Fragment>
 <Fragment slot="terraform">
 
+Grant the MCP server's runtime role access to the table and its KMS encryption key via `additional_iam_policy_statements`:
+
 ```hcl title="packages/infra/src/main.tf"
 module "my_table" {
   source = "../../common/terraform/src/app/dynamodb/my-table"
 }
 
-resource "aws_iam_role_policy" "dynamodb_access" {
-  role = module.my_mcp_server.lambda_role_name
+module "my_mcp_server" {
+  source = "../../common/terraform/src/app/mcp-servers/my-mcp-server"
 
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Action = [
-          "dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:UpdateItem",
-          "dynamodb:DeleteItem", "dynamodb:Query", "dynamodb:Scan",
-          "dynamodb:BatchGetItem", "dynamodb:BatchWriteItem",
-        ]
-        Resource = [
-          module.my_table.table_arn,
-          "${module.my_table.table_arn}/index/*",
-        ]
-      },
-      {
-        Effect = "Allow"
-        Action = [
-          "kms:Encrypt",
-          "kms:Decrypt",
-          "kms:ReEncrypt*",
-          "kms:GenerateDataKey*",
-          "kms:DescribeKey"
-        ]
-        Resource = [module.my_table.kms_key_arn]
-      },
-    ]
-  })
+  additional_iam_policy_statements = [
+    {
+      Effect = "Allow"
+      Action = [
+        "dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:UpdateItem",
+        "dynamodb:DeleteItem", "dynamodb:Query", "dynamodb:Scan",
+        "dynamodb:BatchGetItem", "dynamodb:BatchWriteItem",
+      ]
+      Resource = [
+        module.my_table.table_arn,
+        "${module.my_table.table_arn}/index/*",
+      ]
+    },
+    {
+      Effect = "Allow"
+      Action = [
+        "kms:Encrypt",
+        "kms:Decrypt",
+        "kms:ReEncrypt*",
+        "kms:GenerateDataKey*",
+        "kms:DescribeKey",
+      ]
+      Resource = [module.my_table.kms_key_arn]
+    },
+  ]
 }
 ```
 </Fragment>

--- a/docs/src/content/docs/en/guides/connection/ts-agent-dynamodb.mdx
+++ b/docs/src/content/docs/en/guides/connection/ts-agent-dynamodb.mdx
@@ -82,42 +82,41 @@ table.grantReadWriteData(myAgent);
 </Fragment>
 <Fragment slot="terraform">
 
+Grant the agent's runtime role access to the table and its KMS encryption key via `additional_iam_policy_statements`:
+
 ```hcl title="packages/infra/src/main.tf"
 module "my_table" {
   source = "../../common/terraform/src/app/dynamodb/my-table"
 }
 
-resource "aws_iam_role_policy" "dynamodb_access" {
-  role = module.my_agent.lambda_role_name
+module "my_agent" {
+  source = "../../common/terraform/src/app/agents/my-agent"
 
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Action = [
-          "dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:UpdateItem",
-          "dynamodb:DeleteItem", "dynamodb:Query", "dynamodb:Scan",
-          "dynamodb:BatchGetItem", "dynamodb:BatchWriteItem",
-        ]
-        Resource = [
-          module.my_table.table_arn,
-          "${module.my_table.table_arn}/index/*",
-        ]
-      },
-      {
-        Effect = "Allow"
-        Action = [
-          "kms:Encrypt",
-          "kms:Decrypt",
-          "kms:ReEncrypt*",
-          "kms:GenerateDataKey*",
-          "kms:DescribeKey"
-        ]
-        Resource = [module.my_table.kms_key_arn]
-      },
-    ]
-  })
+  additional_iam_policy_statements = [
+    {
+      Effect = "Allow"
+      Action = [
+        "dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:UpdateItem",
+        "dynamodb:DeleteItem", "dynamodb:Query", "dynamodb:Scan",
+        "dynamodb:BatchGetItem", "dynamodb:BatchWriteItem",
+      ]
+      Resource = [
+        module.my_table.table_arn,
+        "${module.my_table.table_arn}/index/*",
+      ]
+    },
+    {
+      Effect = "Allow"
+      Action = [
+        "kms:Encrypt",
+        "kms:Decrypt",
+        "kms:ReEncrypt*",
+        "kms:GenerateDataKey*",
+        "kms:DescribeKey",
+      ]
+      Resource = [module.my_table.kms_key_arn]
+    },
+  ]
 }
 ```
 </Fragment>

--- a/docs/src/content/docs/en/guides/connection/ts-mcp-server-dynamodb.mdx
+++ b/docs/src/content/docs/en/guides/connection/ts-mcp-server-dynamodb.mdx
@@ -79,42 +79,41 @@ table.grantReadWriteData(myMcpServer);
 </Fragment>
 <Fragment slot="terraform">
 
+Grant the MCP server's runtime role access to the table and its KMS encryption key via `additional_iam_policy_statements`:
+
 ```hcl title="packages/infra/src/main.tf"
 module "my_table" {
   source = "../../common/terraform/src/app/dynamodb/my-table"
 }
 
-resource "aws_iam_role_policy" "dynamodb_access" {
-  role = module.my_mcp_server.lambda_role_name
+module "my_mcp_server" {
+  source = "../../common/terraform/src/app/mcp-servers/my-mcp-server"
 
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Action = [
-          "dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:UpdateItem",
-          "dynamodb:DeleteItem", "dynamodb:Query", "dynamodb:Scan",
-          "dynamodb:BatchGetItem", "dynamodb:BatchWriteItem",
-        ]
-        Resource = [
-          module.my_table.table_arn,
-          "${module.my_table.table_arn}/index/*",
-        ]
-      },
-      {
-        Effect = "Allow"
-        Action = [
-          "kms:Encrypt",
-          "kms:Decrypt",
-          "kms:ReEncrypt*",
-          "kms:GenerateDataKey*",
-          "kms:DescribeKey",
-        ]
-        Resource = [module.my_table.kms_key_arn]
-      },
-    ]
-  })
+  additional_iam_policy_statements = [
+    {
+      Effect = "Allow"
+      Action = [
+        "dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:UpdateItem",
+        "dynamodb:DeleteItem", "dynamodb:Query", "dynamodb:Scan",
+        "dynamodb:BatchGetItem", "dynamodb:BatchWriteItem",
+      ]
+      Resource = [
+        module.my_table.table_arn,
+        "${module.my_table.table_arn}/index/*",
+      ]
+    },
+    {
+      Effect = "Allow"
+      Action = [
+        "kms:Encrypt",
+        "kms:Decrypt",
+        "kms:ReEncrypt*",
+        "kms:GenerateDataKey*",
+        "kms:DescribeKey",
+      ]
+      Resource = [module.my_table.kms_key_arn]
+    },
+  ]
 }
 ```
 </Fragment>

--- a/docs/src/content/docs/en/snippets/connection/lambda-dynamodb-access.mdx
+++ b/docs/src/content/docs/en/snippets/connection/lambda-dynamodb-access.mdx
@@ -38,7 +38,7 @@ module "my_table" {
 }
 
 resource "aws_iam_role_policy" "dynamodb_access" {
-  role = module.my_api.lambda_role_name
+  role = module.my_api.lambda_execution_role_name
 
   policy = jsonencode({
     Version = "2012-10-17"

--- a/docs/src/content/docs/es/guides/connection/py-agent-dynamodb.mdx
+++ b/docs/src/content/docs/es/guides/connection/py-agent-dynamodb.mdx
@@ -70,42 +70,41 @@ table.grantReadWriteData(myAgent);
 </Fragment>
 <Fragment slot="terraform">
 
+Otorga al rol de tiempo de ejecución del agente acceso a la tabla y su clave de cifrado KMS a través de `additional_iam_policy_statements`:
+
 ```hcl title="packages/infra/src/main.tf"
 module "my_table" {
   source = "../../common/terraform/src/app/dynamodb/my-table"
 }
 
-resource "aws_iam_role_policy" "dynamodb_access" {
-  role = module.my_agent.lambda_role_name
+module "my_agent" {
+  source = "../../common/terraform/src/app/agents/my-agent"
 
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Action = [
-          "dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:UpdateItem",
-          "dynamodb:DeleteItem", "dynamodb:Query", "dynamodb:Scan",
-          "dynamodb:BatchGetItem", "dynamodb:BatchWriteItem",
-        ]
-        Resource = [
-          module.my_table.table_arn,
-          "${module.my_table.table_arn}/index/*",
-        ]
-      },
-      {
-        Effect = "Allow"
-        Action = [
-          "kms:Encrypt",
-          "kms:Decrypt",
-          "kms:ReEncrypt*",
-          "kms:GenerateDataKey*",
-          "kms:DescribeKey"
-        ]
-        Resource = [module.my_table.kms_key_arn]
-      },
-    ]
-  })
+  additional_iam_policy_statements = [
+    {
+      Effect = "Allow"
+      Action = [
+        "dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:UpdateItem",
+        "dynamodb:DeleteItem", "dynamodb:Query", "dynamodb:Scan",
+        "dynamodb:BatchGetItem", "dynamodb:BatchWriteItem",
+      ]
+      Resource = [
+        module.my_table.table_arn,
+        "${module.my_table.table_arn}/index/*",
+      ]
+    },
+    {
+      Effect = "Allow"
+      Action = [
+        "kms:Encrypt",
+        "kms:Decrypt",
+        "kms:ReEncrypt*",
+        "kms:GenerateDataKey*",
+        "kms:DescribeKey",
+      ]
+      Resource = [module.my_table.kms_key_arn]
+    },
+  ]
 }
 ```
 </Fragment>

--- a/docs/src/content/docs/es/guides/connection/py-mcp-server-dynamodb.mdx
+++ b/docs/src/content/docs/es/guides/connection/py-mcp-server-dynamodb.mdx
@@ -70,42 +70,41 @@ table.grantReadWriteData(myMcpServer);
 </Fragment>
 <Fragment slot="terraform">
 
+Otorga al rol de tiempo de ejecución del servidor MCP acceso a la tabla y su clave de cifrado KMS a través de `additional_iam_policy_statements`:
+
 ```hcl title="packages/infra/src/main.tf"
 module "my_table" {
   source = "../../common/terraform/src/app/dynamodb/my-table"
 }
 
-resource "aws_iam_role_policy" "dynamodb_access" {
-  role = module.my_mcp_server.lambda_role_name
+module "my_mcp_server" {
+  source = "../../common/terraform/src/app/mcp-servers/my-mcp-server"
 
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Action = [
-          "dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:UpdateItem",
-          "dynamodb:DeleteItem", "dynamodb:Query", "dynamodb:Scan",
-          "dynamodb:BatchGetItem", "dynamodb:BatchWriteItem",
-        ]
-        Resource = [
-          module.my_table.table_arn,
-          "${module.my_table.table_arn}/index/*",
-        ]
-      },
-      {
-        Effect = "Allow"
-        Action = [
-          "kms:Encrypt",
-          "kms:Decrypt",
-          "kms:ReEncrypt*",
-          "kms:GenerateDataKey*",
-          "kms:DescribeKey"
-        ]
-        Resource = [module.my_table.kms_key_arn]
-      },
-    ]
-  })
+  additional_iam_policy_statements = [
+    {
+      Effect = "Allow"
+      Action = [
+        "dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:UpdateItem",
+        "dynamodb:DeleteItem", "dynamodb:Query", "dynamodb:Scan",
+        "dynamodb:BatchGetItem", "dynamodb:BatchWriteItem",
+      ]
+      Resource = [
+        module.my_table.table_arn,
+        "${module.my_table.table_arn}/index/*",
+      ]
+    },
+    {
+      Effect = "Allow"
+      Action = [
+        "kms:Encrypt",
+        "kms:Decrypt",
+        "kms:ReEncrypt*",
+        "kms:GenerateDataKey*",
+        "kms:DescribeKey",
+      ]
+      Resource = [module.my_table.kms_key_arn]
+    },
+  ]
 }
 ```
 </Fragment>

--- a/docs/src/content/docs/es/guides/connection/ts-agent-dynamodb.mdx
+++ b/docs/src/content/docs/es/guides/connection/ts-agent-dynamodb.mdx
@@ -82,42 +82,41 @@ table.grantReadWriteData(myAgent);
 </Fragment>
 <Fragment slot="terraform">
 
+Otorga al rol de tiempo de ejecución del agente acceso a la tabla y su clave de cifrado KMS mediante `additional_iam_policy_statements`:
+
 ```hcl title="packages/infra/src/main.tf"
 module "my_table" {
   source = "../../common/terraform/src/app/dynamodb/my-table"
 }
 
-resource "aws_iam_role_policy" "dynamodb_access" {
-  role = module.my_agent.lambda_role_name
+module "my_agent" {
+  source = "../../common/terraform/src/app/agents/my-agent"
 
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Action = [
-          "dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:UpdateItem",
-          "dynamodb:DeleteItem", "dynamodb:Query", "dynamodb:Scan",
-          "dynamodb:BatchGetItem", "dynamodb:BatchWriteItem",
-        ]
-        Resource = [
-          module.my_table.table_arn,
-          "${module.my_table.table_arn}/index/*",
-        ]
-      },
-      {
-        Effect = "Allow"
-        Action = [
-          "kms:Encrypt",
-          "kms:Decrypt",
-          "kms:ReEncrypt*",
-          "kms:GenerateDataKey*",
-          "kms:DescribeKey"
-        ]
-        Resource = [module.my_table.kms_key_arn]
-      },
-    ]
-  })
+  additional_iam_policy_statements = [
+    {
+      Effect = "Allow"
+      Action = [
+        "dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:UpdateItem",
+        "dynamodb:DeleteItem", "dynamodb:Query", "dynamodb:Scan",
+        "dynamodb:BatchGetItem", "dynamodb:BatchWriteItem",
+      ]
+      Resource = [
+        module.my_table.table_arn,
+        "${module.my_table.table_arn}/index/*",
+      ]
+    },
+    {
+      Effect = "Allow"
+      Action = [
+        "kms:Encrypt",
+        "kms:Decrypt",
+        "kms:ReEncrypt*",
+        "kms:GenerateDataKey*",
+        "kms:DescribeKey",
+      ]
+      Resource = [module.my_table.kms_key_arn]
+    },
+  ]
 }
 ```
 </Fragment>

--- a/docs/src/content/docs/es/guides/connection/ts-mcp-server-dynamodb.mdx
+++ b/docs/src/content/docs/es/guides/connection/ts-mcp-server-dynamodb.mdx
@@ -79,42 +79,41 @@ table.grantReadWriteData(myMcpServer);
 </Fragment>
 <Fragment slot="terraform">
 
+Otorga al rol de ejecución del servidor MCP acceso a la tabla y su clave de cifrado KMS a través de `additional_iam_policy_statements`:
+
 ```hcl title="packages/infra/src/main.tf"
 module "my_table" {
   source = "../../common/terraform/src/app/dynamodb/my-table"
 }
 
-resource "aws_iam_role_policy" "dynamodb_access" {
-  role = module.my_mcp_server.lambda_role_name
+module "my_mcp_server" {
+  source = "../../common/terraform/src/app/mcp-servers/my-mcp-server"
 
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Action = [
-          "dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:UpdateItem",
-          "dynamodb:DeleteItem", "dynamodb:Query", "dynamodb:Scan",
-          "dynamodb:BatchGetItem", "dynamodb:BatchWriteItem",
-        ]
-        Resource = [
-          module.my_table.table_arn,
-          "${module.my_table.table_arn}/index/*",
-        ]
-      },
-      {
-        Effect = "Allow"
-        Action = [
-          "kms:Encrypt",
-          "kms:Decrypt",
-          "kms:ReEncrypt*",
-          "kms:GenerateDataKey*",
-          "kms:DescribeKey",
-        ]
-        Resource = [module.my_table.kms_key_arn]
-      },
-    ]
-  })
+  additional_iam_policy_statements = [
+    {
+      Effect = "Allow"
+      Action = [
+        "dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:UpdateItem",
+        "dynamodb:DeleteItem", "dynamodb:Query", "dynamodb:Scan",
+        "dynamodb:BatchGetItem", "dynamodb:BatchWriteItem",
+      ]
+      Resource = [
+        module.my_table.table_arn,
+        "${module.my_table.table_arn}/index/*",
+      ]
+    },
+    {
+      Effect = "Allow"
+      Action = [
+        "kms:Encrypt",
+        "kms:Decrypt",
+        "kms:ReEncrypt*",
+        "kms:GenerateDataKey*",
+        "kms:DescribeKey",
+      ]
+      Resource = [module.my_table.kms_key_arn]
+    },
+  ]
 }
 ```
 </Fragment>

--- a/docs/src/content/docs/es/snippets/connection/lambda-dynamodb-access.mdx
+++ b/docs/src/content/docs/es/snippets/connection/lambda-dynamodb-access.mdx
@@ -38,7 +38,7 @@ module "my_table" {
 }
 
 resource "aws_iam_role_policy" "dynamodb_access" {
-  role = module.my_api.lambda_role_name
+  role = module.my_api.lambda_execution_role_name
 
   policy = jsonencode({
     Version = "2012-10-17"

--- a/docs/src/content/docs/fr/guides/connection/py-agent-dynamodb.mdx
+++ b/docs/src/content/docs/fr/guides/connection/py-agent-dynamodb.mdx
@@ -70,42 +70,41 @@ table.grantReadWriteData(myAgent);
 </Fragment>
 <Fragment slot="terraform">
 
+Accordez au rôle d'exécution de l'agent l'accès à la table et à sa clé de chiffrement KMS via `additional_iam_policy_statements` :
+
 ```hcl title="packages/infra/src/main.tf"
 module "my_table" {
   source = "../../common/terraform/src/app/dynamodb/my-table"
 }
 
-resource "aws_iam_role_policy" "dynamodb_access" {
-  role = module.my_agent.lambda_role_name
+module "my_agent" {
+  source = "../../common/terraform/src/app/agents/my-agent"
 
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Action = [
-          "dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:UpdateItem",
-          "dynamodb:DeleteItem", "dynamodb:Query", "dynamodb:Scan",
-          "dynamodb:BatchGetItem", "dynamodb:BatchWriteItem",
-        ]
-        Resource = [
-          module.my_table.table_arn,
-          "${module.my_table.table_arn}/index/*",
-        ]
-      },
-      {
-        Effect = "Allow"
-        Action = [
-          "kms:Encrypt",
-          "kms:Decrypt",
-          "kms:ReEncrypt*",
-          "kms:GenerateDataKey*",
-          "kms:DescribeKey"
-        ]
-        Resource = [module.my_table.kms_key_arn]
-      },
-    ]
-  })
+  additional_iam_policy_statements = [
+    {
+      Effect = "Allow"
+      Action = [
+        "dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:UpdateItem",
+        "dynamodb:DeleteItem", "dynamodb:Query", "dynamodb:Scan",
+        "dynamodb:BatchGetItem", "dynamodb:BatchWriteItem",
+      ]
+      Resource = [
+        module.my_table.table_arn,
+        "${module.my_table.table_arn}/index/*",
+      ]
+    },
+    {
+      Effect = "Allow"
+      Action = [
+        "kms:Encrypt",
+        "kms:Decrypt",
+        "kms:ReEncrypt*",
+        "kms:GenerateDataKey*",
+        "kms:DescribeKey",
+      ]
+      Resource = [module.my_table.kms_key_arn]
+    },
+  ]
 }
 ```
 </Fragment>

--- a/docs/src/content/docs/fr/guides/connection/py-mcp-server-dynamodb.mdx
+++ b/docs/src/content/docs/fr/guides/connection/py-mcp-server-dynamodb.mdx
@@ -70,42 +70,41 @@ table.grantReadWriteData(myMcpServer);
 </Fragment>
 <Fragment slot="terraform">
 
+Accordez au rôle d'exécution du serveur MCP l'accès à la table et à sa clé de chiffrement KMS via `additional_iam_policy_statements` :
+
 ```hcl title="packages/infra/src/main.tf"
 module "my_table" {
   source = "../../common/terraform/src/app/dynamodb/my-table"
 }
 
-resource "aws_iam_role_policy" "dynamodb_access" {
-  role = module.my_mcp_server.lambda_role_name
+module "my_mcp_server" {
+  source = "../../common/terraform/src/app/mcp-servers/my-mcp-server"
 
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Action = [
-          "dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:UpdateItem",
-          "dynamodb:DeleteItem", "dynamodb:Query", "dynamodb:Scan",
-          "dynamodb:BatchGetItem", "dynamodb:BatchWriteItem",
-        ]
-        Resource = [
-          module.my_table.table_arn,
-          "${module.my_table.table_arn}/index/*",
-        ]
-      },
-      {
-        Effect = "Allow"
-        Action = [
-          "kms:Encrypt",
-          "kms:Decrypt",
-          "kms:ReEncrypt*",
-          "kms:GenerateDataKey*",
-          "kms:DescribeKey"
-        ]
-        Resource = [module.my_table.kms_key_arn]
-      },
-    ]
-  })
+  additional_iam_policy_statements = [
+    {
+      Effect = "Allow"
+      Action = [
+        "dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:UpdateItem",
+        "dynamodb:DeleteItem", "dynamodb:Query", "dynamodb:Scan",
+        "dynamodb:BatchGetItem", "dynamodb:BatchWriteItem",
+      ]
+      Resource = [
+        module.my_table.table_arn,
+        "${module.my_table.table_arn}/index/*",
+      ]
+    },
+    {
+      Effect = "Allow"
+      Action = [
+        "kms:Encrypt",
+        "kms:Decrypt",
+        "kms:ReEncrypt*",
+        "kms:GenerateDataKey*",
+        "kms:DescribeKey",
+      ]
+      Resource = [module.my_table.kms_key_arn]
+    },
+  ]
 }
 ```
 </Fragment>

--- a/docs/src/content/docs/fr/guides/connection/ts-agent-dynamodb.mdx
+++ b/docs/src/content/docs/fr/guides/connection/ts-agent-dynamodb.mdx
@@ -82,42 +82,41 @@ table.grantReadWriteData(myAgent);
 </Fragment>
 <Fragment slot="terraform">
 
+Accordez au rôle d'exécution de l'agent l'accès à la table et à sa clé de chiffrement KMS via `additional_iam_policy_statements` :
+
 ```hcl title="packages/infra/src/main.tf"
 module "my_table" {
   source = "../../common/terraform/src/app/dynamodb/my-table"
 }
 
-resource "aws_iam_role_policy" "dynamodb_access" {
-  role = module.my_agent.lambda_role_name
+module "my_agent" {
+  source = "../../common/terraform/src/app/agents/my-agent"
 
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Action = [
-          "dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:UpdateItem",
-          "dynamodb:DeleteItem", "dynamodb:Query", "dynamodb:Scan",
-          "dynamodb:BatchGetItem", "dynamodb:BatchWriteItem",
-        ]
-        Resource = [
-          module.my_table.table_arn,
-          "${module.my_table.table_arn}/index/*",
-        ]
-      },
-      {
-        Effect = "Allow"
-        Action = [
-          "kms:Encrypt",
-          "kms:Decrypt",
-          "kms:ReEncrypt*",
-          "kms:GenerateDataKey*",
-          "kms:DescribeKey"
-        ]
-        Resource = [module.my_table.kms_key_arn]
-      },
-    ]
-  })
+  additional_iam_policy_statements = [
+    {
+      Effect = "Allow"
+      Action = [
+        "dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:UpdateItem",
+        "dynamodb:DeleteItem", "dynamodb:Query", "dynamodb:Scan",
+        "dynamodb:BatchGetItem", "dynamodb:BatchWriteItem",
+      ]
+      Resource = [
+        module.my_table.table_arn,
+        "${module.my_table.table_arn}/index/*",
+      ]
+    },
+    {
+      Effect = "Allow"
+      Action = [
+        "kms:Encrypt",
+        "kms:Decrypt",
+        "kms:ReEncrypt*",
+        "kms:GenerateDataKey*",
+        "kms:DescribeKey",
+      ]
+      Resource = [module.my_table.kms_key_arn]
+    },
+  ]
 }
 ```
 </Fragment>

--- a/docs/src/content/docs/fr/guides/connection/ts-mcp-server-dynamodb.mdx
+++ b/docs/src/content/docs/fr/guides/connection/ts-mcp-server-dynamodb.mdx
@@ -79,42 +79,41 @@ table.grantReadWriteData(myMcpServer);
 </Fragment>
 <Fragment slot="terraform">
 
+Accordez au rôle d'exécution du serveur MCP l'accès à la table et à sa clé de chiffrement KMS via `additional_iam_policy_statements` :
+
 ```hcl title="packages/infra/src/main.tf"
 module "my_table" {
   source = "../../common/terraform/src/app/dynamodb/my-table"
 }
 
-resource "aws_iam_role_policy" "dynamodb_access" {
-  role = module.my_mcp_server.lambda_role_name
+module "my_mcp_server" {
+  source = "../../common/terraform/src/app/mcp-servers/my-mcp-server"
 
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Action = [
-          "dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:UpdateItem",
-          "dynamodb:DeleteItem", "dynamodb:Query", "dynamodb:Scan",
-          "dynamodb:BatchGetItem", "dynamodb:BatchWriteItem",
-        ]
-        Resource = [
-          module.my_table.table_arn,
-          "${module.my_table.table_arn}/index/*",
-        ]
-      },
-      {
-        Effect = "Allow"
-        Action = [
-          "kms:Encrypt",
-          "kms:Decrypt",
-          "kms:ReEncrypt*",
-          "kms:GenerateDataKey*",
-          "kms:DescribeKey",
-        ]
-        Resource = [module.my_table.kms_key_arn]
-      },
-    ]
-  })
+  additional_iam_policy_statements = [
+    {
+      Effect = "Allow"
+      Action = [
+        "dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:UpdateItem",
+        "dynamodb:DeleteItem", "dynamodb:Query", "dynamodb:Scan",
+        "dynamodb:BatchGetItem", "dynamodb:BatchWriteItem",
+      ]
+      Resource = [
+        module.my_table.table_arn,
+        "${module.my_table.table_arn}/index/*",
+      ]
+    },
+    {
+      Effect = "Allow"
+      Action = [
+        "kms:Encrypt",
+        "kms:Decrypt",
+        "kms:ReEncrypt*",
+        "kms:GenerateDataKey*",
+        "kms:DescribeKey",
+      ]
+      Resource = [module.my_table.kms_key_arn]
+    },
+  ]
 }
 ```
 </Fragment>

--- a/docs/src/content/docs/fr/snippets/connection/lambda-dynamodb-access.mdx
+++ b/docs/src/content/docs/fr/snippets/connection/lambda-dynamodb-access.mdx
@@ -38,7 +38,7 @@ module "my_table" {
 }
 
 resource "aws_iam_role_policy" "dynamodb_access" {
-  role = module.my_api.lambda_role_name
+  role = module.my_api.lambda_execution_role_name
 
   policy = jsonencode({
     Version = "2012-10-17"

--- a/docs/src/content/docs/it/guides/connection/py-agent-dynamodb.mdx
+++ b/docs/src/content/docs/it/guides/connection/py-agent-dynamodb.mdx
@@ -70,42 +70,41 @@ table.grantReadWriteData(myAgent);
 </Fragment>
 <Fragment slot="terraform">
 
+Concedi al ruolo di runtime dell'agent l'accesso alla tabella e alla sua chiave di crittografia KMS tramite `additional_iam_policy_statements`:
+
 ```hcl title="packages/infra/src/main.tf"
 module "my_table" {
   source = "../../common/terraform/src/app/dynamodb/my-table"
 }
 
-resource "aws_iam_role_policy" "dynamodb_access" {
-  role = module.my_agent.lambda_role_name
+module "my_agent" {
+  source = "../../common/terraform/src/app/agents/my-agent"
 
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Action = [
-          "dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:UpdateItem",
-          "dynamodb:DeleteItem", "dynamodb:Query", "dynamodb:Scan",
-          "dynamodb:BatchGetItem", "dynamodb:BatchWriteItem",
-        ]
-        Resource = [
-          module.my_table.table_arn,
-          "${module.my_table.table_arn}/index/*",
-        ]
-      },
-      {
-        Effect = "Allow"
-        Action = [
-          "kms:Encrypt",
-          "kms:Decrypt",
-          "kms:ReEncrypt*",
-          "kms:GenerateDataKey*",
-          "kms:DescribeKey"
-        ]
-        Resource = [module.my_table.kms_key_arn]
-      },
-    ]
-  })
+  additional_iam_policy_statements = [
+    {
+      Effect = "Allow"
+      Action = [
+        "dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:UpdateItem",
+        "dynamodb:DeleteItem", "dynamodb:Query", "dynamodb:Scan",
+        "dynamodb:BatchGetItem", "dynamodb:BatchWriteItem",
+      ]
+      Resource = [
+        module.my_table.table_arn,
+        "${module.my_table.table_arn}/index/*",
+      ]
+    },
+    {
+      Effect = "Allow"
+      Action = [
+        "kms:Encrypt",
+        "kms:Decrypt",
+        "kms:ReEncrypt*",
+        "kms:GenerateDataKey*",
+        "kms:DescribeKey",
+      ]
+      Resource = [module.my_table.kms_key_arn]
+    },
+  ]
 }
 ```
 </Fragment>

--- a/docs/src/content/docs/it/guides/connection/py-mcp-server-dynamodb.mdx
+++ b/docs/src/content/docs/it/guides/connection/py-mcp-server-dynamodb.mdx
@@ -70,42 +70,41 @@ table.grantReadWriteData(myMcpServer);
 </Fragment>
 <Fragment slot="terraform">
 
+Concedi al ruolo di runtime del MCP server l'accesso alla tabella e alla sua chiave di crittografia KMS tramite `additional_iam_policy_statements`:
+
 ```hcl title="packages/infra/src/main.tf"
 module "my_table" {
   source = "../../common/terraform/src/app/dynamodb/my-table"
 }
 
-resource "aws_iam_role_policy" "dynamodb_access" {
-  role = module.my_mcp_server.lambda_role_name
+module "my_mcp_server" {
+  source = "../../common/terraform/src/app/mcp-servers/my-mcp-server"
 
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Action = [
-          "dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:UpdateItem",
-          "dynamodb:DeleteItem", "dynamodb:Query", "dynamodb:Scan",
-          "dynamodb:BatchGetItem", "dynamodb:BatchWriteItem",
-        ]
-        Resource = [
-          module.my_table.table_arn,
-          "${module.my_table.table_arn}/index/*",
-        ]
-      },
-      {
-        Effect = "Allow"
-        Action = [
-          "kms:Encrypt",
-          "kms:Decrypt",
-          "kms:ReEncrypt*",
-          "kms:GenerateDataKey*",
-          "kms:DescribeKey"
-        ]
-        Resource = [module.my_table.kms_key_arn]
-      },
-    ]
-  })
+  additional_iam_policy_statements = [
+    {
+      Effect = "Allow"
+      Action = [
+        "dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:UpdateItem",
+        "dynamodb:DeleteItem", "dynamodb:Query", "dynamodb:Scan",
+        "dynamodb:BatchGetItem", "dynamodb:BatchWriteItem",
+      ]
+      Resource = [
+        module.my_table.table_arn,
+        "${module.my_table.table_arn}/index/*",
+      ]
+    },
+    {
+      Effect = "Allow"
+      Action = [
+        "kms:Encrypt",
+        "kms:Decrypt",
+        "kms:ReEncrypt*",
+        "kms:GenerateDataKey*",
+        "kms:DescribeKey",
+      ]
+      Resource = [module.my_table.kms_key_arn]
+    },
+  ]
 }
 ```
 </Fragment>

--- a/docs/src/content/docs/it/guides/connection/ts-agent-dynamodb.mdx
+++ b/docs/src/content/docs/it/guides/connection/ts-agent-dynamodb.mdx
@@ -82,42 +82,41 @@ table.grantReadWriteData(myAgent);
 </Fragment>
 <Fragment slot="terraform">
 
+Concedi al ruolo di runtime dell'agent l'accesso alla tabella e alla sua chiave di crittografia KMS tramite `additional_iam_policy_statements`:
+
 ```hcl title="packages/infra/src/main.tf"
 module "my_table" {
   source = "../../common/terraform/src/app/dynamodb/my-table"
 }
 
-resource "aws_iam_role_policy" "dynamodb_access" {
-  role = module.my_agent.lambda_role_name
+module "my_agent" {
+  source = "../../common/terraform/src/app/agents/my-agent"
 
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Action = [
-          "dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:UpdateItem",
-          "dynamodb:DeleteItem", "dynamodb:Query", "dynamodb:Scan",
-          "dynamodb:BatchGetItem", "dynamodb:BatchWriteItem",
-        ]
-        Resource = [
-          module.my_table.table_arn,
-          "${module.my_table.table_arn}/index/*",
-        ]
-      },
-      {
-        Effect = "Allow"
-        Action = [
-          "kms:Encrypt",
-          "kms:Decrypt",
-          "kms:ReEncrypt*",
-          "kms:GenerateDataKey*",
-          "kms:DescribeKey"
-        ]
-        Resource = [module.my_table.kms_key_arn]
-      },
-    ]
-  })
+  additional_iam_policy_statements = [
+    {
+      Effect = "Allow"
+      Action = [
+        "dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:UpdateItem",
+        "dynamodb:DeleteItem", "dynamodb:Query", "dynamodb:Scan",
+        "dynamodb:BatchGetItem", "dynamodb:BatchWriteItem",
+      ]
+      Resource = [
+        module.my_table.table_arn,
+        "${module.my_table.table_arn}/index/*",
+      ]
+    },
+    {
+      Effect = "Allow"
+      Action = [
+        "kms:Encrypt",
+        "kms:Decrypt",
+        "kms:ReEncrypt*",
+        "kms:GenerateDataKey*",
+        "kms:DescribeKey",
+      ]
+      Resource = [module.my_table.kms_key_arn]
+    },
+  ]
 }
 ```
 </Fragment>

--- a/docs/src/content/docs/it/guides/connection/ts-mcp-server-dynamodb.mdx
+++ b/docs/src/content/docs/it/guides/connection/ts-mcp-server-dynamodb.mdx
@@ -79,42 +79,41 @@ table.grantReadWriteData(myMcpServer);
 </Fragment>
 <Fragment slot="terraform">
 
+Concedi al ruolo di runtime del MCP server l'accesso alla tabella e alla sua chiave di crittografia KMS tramite `additional_iam_policy_statements`:
+
 ```hcl title="packages/infra/src/main.tf"
 module "my_table" {
   source = "../../common/terraform/src/app/dynamodb/my-table"
 }
 
-resource "aws_iam_role_policy" "dynamodb_access" {
-  role = module.my_mcp_server.lambda_role_name
+module "my_mcp_server" {
+  source = "../../common/terraform/src/app/mcp-servers/my-mcp-server"
 
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Action = [
-          "dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:UpdateItem",
-          "dynamodb:DeleteItem", "dynamodb:Query", "dynamodb:Scan",
-          "dynamodb:BatchGetItem", "dynamodb:BatchWriteItem",
-        ]
-        Resource = [
-          module.my_table.table_arn,
-          "${module.my_table.table_arn}/index/*",
-        ]
-      },
-      {
-        Effect = "Allow"
-        Action = [
-          "kms:Encrypt",
-          "kms:Decrypt",
-          "kms:ReEncrypt*",
-          "kms:GenerateDataKey*",
-          "kms:DescribeKey",
-        ]
-        Resource = [module.my_table.kms_key_arn]
-      },
-    ]
-  })
+  additional_iam_policy_statements = [
+    {
+      Effect = "Allow"
+      Action = [
+        "dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:UpdateItem",
+        "dynamodb:DeleteItem", "dynamodb:Query", "dynamodb:Scan",
+        "dynamodb:BatchGetItem", "dynamodb:BatchWriteItem",
+      ]
+      Resource = [
+        module.my_table.table_arn,
+        "${module.my_table.table_arn}/index/*",
+      ]
+    },
+    {
+      Effect = "Allow"
+      Action = [
+        "kms:Encrypt",
+        "kms:Decrypt",
+        "kms:ReEncrypt*",
+        "kms:GenerateDataKey*",
+        "kms:DescribeKey",
+      ]
+      Resource = [module.my_table.kms_key_arn]
+    },
+  ]
 }
 ```
 </Fragment>

--- a/docs/src/content/docs/it/snippets/connection/lambda-dynamodb-access.mdx
+++ b/docs/src/content/docs/it/snippets/connection/lambda-dynamodb-access.mdx
@@ -38,7 +38,7 @@ module "my_table" {
 }
 
 resource "aws_iam_role_policy" "dynamodb_access" {
-  role = module.my_api.lambda_role_name
+  role = module.my_api.lambda_execution_role_name
 
   policy = jsonencode({
     Version = "2012-10-17"

--- a/docs/src/content/docs/jp/guides/connection/py-agent-dynamodb.mdx
+++ b/docs/src/content/docs/jp/guides/connection/py-agent-dynamodb.mdx
@@ -70,42 +70,41 @@ table.grantReadWriteData(myAgent);
 </Fragment>
 <Fragment slot="terraform">
 
+`additional_iam_policy_statements` を介して、エージェントのランタイムロールにテーブルとその KMS 暗号化キーへのアクセスを付与します：
+
 ```hcl title="packages/infra/src/main.tf"
 module "my_table" {
   source = "../../common/terraform/src/app/dynamodb/my-table"
 }
 
-resource "aws_iam_role_policy" "dynamodb_access" {
-  role = module.my_agent.lambda_role_name
+module "my_agent" {
+  source = "../../common/terraform/src/app/agents/my-agent"
 
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Action = [
-          "dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:UpdateItem",
-          "dynamodb:DeleteItem", "dynamodb:Query", "dynamodb:Scan",
-          "dynamodb:BatchGetItem", "dynamodb:BatchWriteItem",
-        ]
-        Resource = [
-          module.my_table.table_arn,
-          "${module.my_table.table_arn}/index/*",
-        ]
-      },
-      {
-        Effect = "Allow"
-        Action = [
-          "kms:Encrypt",
-          "kms:Decrypt",
-          "kms:ReEncrypt*",
-          "kms:GenerateDataKey*",
-          "kms:DescribeKey"
-        ]
-        Resource = [module.my_table.kms_key_arn]
-      },
-    ]
-  })
+  additional_iam_policy_statements = [
+    {
+      Effect = "Allow"
+      Action = [
+        "dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:UpdateItem",
+        "dynamodb:DeleteItem", "dynamodb:Query", "dynamodb:Scan",
+        "dynamodb:BatchGetItem", "dynamodb:BatchWriteItem",
+      ]
+      Resource = [
+        module.my_table.table_arn,
+        "${module.my_table.table_arn}/index/*",
+      ]
+    },
+    {
+      Effect = "Allow"
+      Action = [
+        "kms:Encrypt",
+        "kms:Decrypt",
+        "kms:ReEncrypt*",
+        "kms:GenerateDataKey*",
+        "kms:DescribeKey",
+      ]
+      Resource = [module.my_table.kms_key_arn]
+    },
+  ]
 }
 ```
 </Fragment>

--- a/docs/src/content/docs/jp/guides/connection/py-mcp-server-dynamodb.mdx
+++ b/docs/src/content/docs/jp/guides/connection/py-mcp-server-dynamodb.mdx
@@ -70,42 +70,41 @@ table.grantReadWriteData(myMcpServer);
 </Fragment>
 <Fragment slot="terraform">
 
+`additional_iam_policy_statements` を介して、MCP サーバーのランタイムロールにテーブルとその KMS 暗号化キーへのアクセスを許可します：
+
 ```hcl title="packages/infra/src/main.tf"
 module "my_table" {
   source = "../../common/terraform/src/app/dynamodb/my-table"
 }
 
-resource "aws_iam_role_policy" "dynamodb_access" {
-  role = module.my_mcp_server.lambda_role_name
+module "my_mcp_server" {
+  source = "../../common/terraform/src/app/mcp-servers/my-mcp-server"
 
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Action = [
-          "dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:UpdateItem",
-          "dynamodb:DeleteItem", "dynamodb:Query", "dynamodb:Scan",
-          "dynamodb:BatchGetItem", "dynamodb:BatchWriteItem",
-        ]
-        Resource = [
-          module.my_table.table_arn,
-          "${module.my_table.table_arn}/index/*",
-        ]
-      },
-      {
-        Effect = "Allow"
-        Action = [
-          "kms:Encrypt",
-          "kms:Decrypt",
-          "kms:ReEncrypt*",
-          "kms:GenerateDataKey*",
-          "kms:DescribeKey"
-        ]
-        Resource = [module.my_table.kms_key_arn]
-      },
-    ]
-  })
+  additional_iam_policy_statements = [
+    {
+      Effect = "Allow"
+      Action = [
+        "dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:UpdateItem",
+        "dynamodb:DeleteItem", "dynamodb:Query", "dynamodb:Scan",
+        "dynamodb:BatchGetItem", "dynamodb:BatchWriteItem",
+      ]
+      Resource = [
+        module.my_table.table_arn,
+        "${module.my_table.table_arn}/index/*",
+      ]
+    },
+    {
+      Effect = "Allow"
+      Action = [
+        "kms:Encrypt",
+        "kms:Decrypt",
+        "kms:ReEncrypt*",
+        "kms:GenerateDataKey*",
+        "kms:DescribeKey",
+      ]
+      Resource = [module.my_table.kms_key_arn]
+    },
+  ]
 }
 ```
 </Fragment>

--- a/docs/src/content/docs/jp/guides/connection/ts-agent-dynamodb.mdx
+++ b/docs/src/content/docs/jp/guides/connection/ts-agent-dynamodb.mdx
@@ -82,42 +82,41 @@ table.grantReadWriteData(myAgent);
 </Fragment>
 <Fragment slot="terraform">
 
+`additional_iam_policy_statements` を使用して、エージェントのランタイムロールにテーブルとその KMS 暗号化キーへのアクセス権を付与します：
+
 ```hcl title="packages/infra/src/main.tf"
 module "my_table" {
   source = "../../common/terraform/src/app/dynamodb/my-table"
 }
 
-resource "aws_iam_role_policy" "dynamodb_access" {
-  role = module.my_agent.lambda_role_name
+module "my_agent" {
+  source = "../../common/terraform/src/app/agents/my-agent"
 
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Action = [
-          "dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:UpdateItem",
-          "dynamodb:DeleteItem", "dynamodb:Query", "dynamodb:Scan",
-          "dynamodb:BatchGetItem", "dynamodb:BatchWriteItem",
-        ]
-        Resource = [
-          module.my_table.table_arn,
-          "${module.my_table.table_arn}/index/*",
-        ]
-      },
-      {
-        Effect = "Allow"
-        Action = [
-          "kms:Encrypt",
-          "kms:Decrypt",
-          "kms:ReEncrypt*",
-          "kms:GenerateDataKey*",
-          "kms:DescribeKey"
-        ]
-        Resource = [module.my_table.kms_key_arn]
-      },
-    ]
-  })
+  additional_iam_policy_statements = [
+    {
+      Effect = "Allow"
+      Action = [
+        "dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:UpdateItem",
+        "dynamodb:DeleteItem", "dynamodb:Query", "dynamodb:Scan",
+        "dynamodb:BatchGetItem", "dynamodb:BatchWriteItem",
+      ]
+      Resource = [
+        module.my_table.table_arn,
+        "${module.my_table.table_arn}/index/*",
+      ]
+    },
+    {
+      Effect = "Allow"
+      Action = [
+        "kms:Encrypt",
+        "kms:Decrypt",
+        "kms:ReEncrypt*",
+        "kms:GenerateDataKey*",
+        "kms:DescribeKey",
+      ]
+      Resource = [module.my_table.kms_key_arn]
+    },
+  ]
 }
 ```
 </Fragment>

--- a/docs/src/content/docs/jp/guides/connection/ts-mcp-server-dynamodb.mdx
+++ b/docs/src/content/docs/jp/guides/connection/ts-mcp-server-dynamodb.mdx
@@ -79,42 +79,41 @@ table.grantReadWriteData(myMcpServer);
 </Fragment>
 <Fragment slot="terraform">
 
+`additional_iam_policy_statements` を使用して、MCP サーバーのランタイムロールにテーブルとその KMS 暗号化キーへのアクセス権を付与します：
+
 ```hcl title="packages/infra/src/main.tf"
 module "my_table" {
   source = "../../common/terraform/src/app/dynamodb/my-table"
 }
 
-resource "aws_iam_role_policy" "dynamodb_access" {
-  role = module.my_mcp_server.lambda_role_name
+module "my_mcp_server" {
+  source = "../../common/terraform/src/app/mcp-servers/my-mcp-server"
 
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Action = [
-          "dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:UpdateItem",
-          "dynamodb:DeleteItem", "dynamodb:Query", "dynamodb:Scan",
-          "dynamodb:BatchGetItem", "dynamodb:BatchWriteItem",
-        ]
-        Resource = [
-          module.my_table.table_arn,
-          "${module.my_table.table_arn}/index/*",
-        ]
-      },
-      {
-        Effect = "Allow"
-        Action = [
-          "kms:Encrypt",
-          "kms:Decrypt",
-          "kms:ReEncrypt*",
-          "kms:GenerateDataKey*",
-          "kms:DescribeKey",
-        ]
-        Resource = [module.my_table.kms_key_arn]
-      },
-    ]
-  })
+  additional_iam_policy_statements = [
+    {
+      Effect = "Allow"
+      Action = [
+        "dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:UpdateItem",
+        "dynamodb:DeleteItem", "dynamodb:Query", "dynamodb:Scan",
+        "dynamodb:BatchGetItem", "dynamodb:BatchWriteItem",
+      ]
+      Resource = [
+        module.my_table.table_arn,
+        "${module.my_table.table_arn}/index/*",
+      ]
+    },
+    {
+      Effect = "Allow"
+      Action = [
+        "kms:Encrypt",
+        "kms:Decrypt",
+        "kms:ReEncrypt*",
+        "kms:GenerateDataKey*",
+        "kms:DescribeKey",
+      ]
+      Resource = [module.my_table.kms_key_arn]
+    },
+  ]
 }
 ```
 </Fragment>

--- a/docs/src/content/docs/jp/snippets/connection/lambda-dynamodb-access.mdx
+++ b/docs/src/content/docs/jp/snippets/connection/lambda-dynamodb-access.mdx
@@ -38,7 +38,7 @@ module "my_table" {
 }
 
 resource "aws_iam_role_policy" "dynamodb_access" {
-  role = module.my_api.lambda_role_name
+  role = module.my_api.lambda_execution_role_name
 
   policy = jsonencode({
     Version = "2012-10-17"

--- a/docs/src/content/docs/ko/guides/connection/py-agent-dynamodb.mdx
+++ b/docs/src/content/docs/ko/guides/connection/py-agent-dynamodb.mdx
@@ -70,42 +70,41 @@ table.grantReadWriteData(myAgent);
 </Fragment>
 <Fragment slot="terraform">
 
+`additional_iam_policy_statements`를 통해 에이전트의 런타임 역할에 테이블 및 KMS 암호화 키에 대한 액세스 권한을 부여하세요:
+
 ```hcl title="packages/infra/src/main.tf"
 module "my_table" {
   source = "../../common/terraform/src/app/dynamodb/my-table"
 }
 
-resource "aws_iam_role_policy" "dynamodb_access" {
-  role = module.my_agent.lambda_role_name
+module "my_agent" {
+  source = "../../common/terraform/src/app/agents/my-agent"
 
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Action = [
-          "dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:UpdateItem",
-          "dynamodb:DeleteItem", "dynamodb:Query", "dynamodb:Scan",
-          "dynamodb:BatchGetItem", "dynamodb:BatchWriteItem",
-        ]
-        Resource = [
-          module.my_table.table_arn,
-          "${module.my_table.table_arn}/index/*",
-        ]
-      },
-      {
-        Effect = "Allow"
-        Action = [
-          "kms:Encrypt",
-          "kms:Decrypt",
-          "kms:ReEncrypt*",
-          "kms:GenerateDataKey*",
-          "kms:DescribeKey"
-        ]
-        Resource = [module.my_table.kms_key_arn]
-      },
-    ]
-  })
+  additional_iam_policy_statements = [
+    {
+      Effect = "Allow"
+      Action = [
+        "dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:UpdateItem",
+        "dynamodb:DeleteItem", "dynamodb:Query", "dynamodb:Scan",
+        "dynamodb:BatchGetItem", "dynamodb:BatchWriteItem",
+      ]
+      Resource = [
+        module.my_table.table_arn,
+        "${module.my_table.table_arn}/index/*",
+      ]
+    },
+    {
+      Effect = "Allow"
+      Action = [
+        "kms:Encrypt",
+        "kms:Decrypt",
+        "kms:ReEncrypt*",
+        "kms:GenerateDataKey*",
+        "kms:DescribeKey",
+      ]
+      Resource = [module.my_table.kms_key_arn]
+    },
+  ]
 }
 ```
 </Fragment>

--- a/docs/src/content/docs/ko/guides/connection/py-mcp-server-dynamodb.mdx
+++ b/docs/src/content/docs/ko/guides/connection/py-mcp-server-dynamodb.mdx
@@ -70,42 +70,41 @@ table.grantReadWriteData(myMcpServer);
 </Fragment>
 <Fragment slot="terraform">
 
+`additional_iam_policy_statements`를 통해 MCP 서버의 런타임 역할에 테이블 및 KMS 암호화 키에 대한 액세스 권한을 부여합니다:
+
 ```hcl title="packages/infra/src/main.tf"
 module "my_table" {
   source = "../../common/terraform/src/app/dynamodb/my-table"
 }
 
-resource "aws_iam_role_policy" "dynamodb_access" {
-  role = module.my_mcp_server.lambda_role_name
+module "my_mcp_server" {
+  source = "../../common/terraform/src/app/mcp-servers/my-mcp-server"
 
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Action = [
-          "dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:UpdateItem",
-          "dynamodb:DeleteItem", "dynamodb:Query", "dynamodb:Scan",
-          "dynamodb:BatchGetItem", "dynamodb:BatchWriteItem",
-        ]
-        Resource = [
-          module.my_table.table_arn,
-          "${module.my_table.table_arn}/index/*",
-        ]
-      },
-      {
-        Effect = "Allow"
-        Action = [
-          "kms:Encrypt",
-          "kms:Decrypt",
-          "kms:ReEncrypt*",
-          "kms:GenerateDataKey*",
-          "kms:DescribeKey"
-        ]
-        Resource = [module.my_table.kms_key_arn]
-      },
-    ]
-  })
+  additional_iam_policy_statements = [
+    {
+      Effect = "Allow"
+      Action = [
+        "dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:UpdateItem",
+        "dynamodb:DeleteItem", "dynamodb:Query", "dynamodb:Scan",
+        "dynamodb:BatchGetItem", "dynamodb:BatchWriteItem",
+      ]
+      Resource = [
+        module.my_table.table_arn,
+        "${module.my_table.table_arn}/index/*",
+      ]
+    },
+    {
+      Effect = "Allow"
+      Action = [
+        "kms:Encrypt",
+        "kms:Decrypt",
+        "kms:ReEncrypt*",
+        "kms:GenerateDataKey*",
+        "kms:DescribeKey",
+      ]
+      Resource = [module.my_table.kms_key_arn]
+    },
+  ]
 }
 ```
 </Fragment>

--- a/docs/src/content/docs/ko/guides/connection/ts-agent-dynamodb.mdx
+++ b/docs/src/content/docs/ko/guides/connection/ts-agent-dynamodb.mdx
@@ -82,42 +82,41 @@ table.grantReadWriteData(myAgent);
 </Fragment>
 <Fragment slot="terraform">
 
+`additional_iam_policy_statements`를 통해 에이전트의 런타임 역할에 테이블 및 KMS 암호화 키에 대한 액세스 권한을 부여하세요:
+
 ```hcl title="packages/infra/src/main.tf"
 module "my_table" {
   source = "../../common/terraform/src/app/dynamodb/my-table"
 }
 
-resource "aws_iam_role_policy" "dynamodb_access" {
-  role = module.my_agent.lambda_role_name
+module "my_agent" {
+  source = "../../common/terraform/src/app/agents/my-agent"
 
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Action = [
-          "dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:UpdateItem",
-          "dynamodb:DeleteItem", "dynamodb:Query", "dynamodb:Scan",
-          "dynamodb:BatchGetItem", "dynamodb:BatchWriteItem",
-        ]
-        Resource = [
-          module.my_table.table_arn,
-          "${module.my_table.table_arn}/index/*",
-        ]
-      },
-      {
-        Effect = "Allow"
-        Action = [
-          "kms:Encrypt",
-          "kms:Decrypt",
-          "kms:ReEncrypt*",
-          "kms:GenerateDataKey*",
-          "kms:DescribeKey"
-        ]
-        Resource = [module.my_table.kms_key_arn]
-      },
-    ]
-  })
+  additional_iam_policy_statements = [
+    {
+      Effect = "Allow"
+      Action = [
+        "dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:UpdateItem",
+        "dynamodb:DeleteItem", "dynamodb:Query", "dynamodb:Scan",
+        "dynamodb:BatchGetItem", "dynamodb:BatchWriteItem",
+      ]
+      Resource = [
+        module.my_table.table_arn,
+        "${module.my_table.table_arn}/index/*",
+      ]
+    },
+    {
+      Effect = "Allow"
+      Action = [
+        "kms:Encrypt",
+        "kms:Decrypt",
+        "kms:ReEncrypt*",
+        "kms:GenerateDataKey*",
+        "kms:DescribeKey",
+      ]
+      Resource = [module.my_table.kms_key_arn]
+    },
+  ]
 }
 ```
 </Fragment>

--- a/docs/src/content/docs/ko/guides/connection/ts-mcp-server-dynamodb.mdx
+++ b/docs/src/content/docs/ko/guides/connection/ts-mcp-server-dynamodb.mdx
@@ -79,42 +79,41 @@ table.grantReadWriteData(myMcpServer);
 </Fragment>
 <Fragment slot="terraform">
 
+`additional_iam_policy_statements`를 통해 MCP 서버의 런타임 역할에 테이블 및 KMS 암호화 키에 대한 액세스 권한을 부여하세요:
+
 ```hcl title="packages/infra/src/main.tf"
 module "my_table" {
   source = "../../common/terraform/src/app/dynamodb/my-table"
 }
 
-resource "aws_iam_role_policy" "dynamodb_access" {
-  role = module.my_mcp_server.lambda_role_name
+module "my_mcp_server" {
+  source = "../../common/terraform/src/app/mcp-servers/my-mcp-server"
 
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Action = [
-          "dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:UpdateItem",
-          "dynamodb:DeleteItem", "dynamodb:Query", "dynamodb:Scan",
-          "dynamodb:BatchGetItem", "dynamodb:BatchWriteItem",
-        ]
-        Resource = [
-          module.my_table.table_arn,
-          "${module.my_table.table_arn}/index/*",
-        ]
-      },
-      {
-        Effect = "Allow"
-        Action = [
-          "kms:Encrypt",
-          "kms:Decrypt",
-          "kms:ReEncrypt*",
-          "kms:GenerateDataKey*",
-          "kms:DescribeKey",
-        ]
-        Resource = [module.my_table.kms_key_arn]
-      },
-    ]
-  })
+  additional_iam_policy_statements = [
+    {
+      Effect = "Allow"
+      Action = [
+        "dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:UpdateItem",
+        "dynamodb:DeleteItem", "dynamodb:Query", "dynamodb:Scan",
+        "dynamodb:BatchGetItem", "dynamodb:BatchWriteItem",
+      ]
+      Resource = [
+        module.my_table.table_arn,
+        "${module.my_table.table_arn}/index/*",
+      ]
+    },
+    {
+      Effect = "Allow"
+      Action = [
+        "kms:Encrypt",
+        "kms:Decrypt",
+        "kms:ReEncrypt*",
+        "kms:GenerateDataKey*",
+        "kms:DescribeKey",
+      ]
+      Resource = [module.my_table.kms_key_arn]
+    },
+  ]
 }
 ```
 </Fragment>

--- a/docs/src/content/docs/ko/snippets/connection/lambda-dynamodb-access.mdx
+++ b/docs/src/content/docs/ko/snippets/connection/lambda-dynamodb-access.mdx
@@ -38,7 +38,7 @@ module "my_table" {
 }
 
 resource "aws_iam_role_policy" "dynamodb_access" {
-  role = module.my_api.lambda_role_name
+  role = module.my_api.lambda_execution_role_name
 
   policy = jsonencode({
     Version = "2012-10-17"

--- a/docs/src/content/docs/pt/guides/connection/py-agent-dynamodb.mdx
+++ b/docs/src/content/docs/pt/guides/connection/py-agent-dynamodb.mdx
@@ -70,42 +70,41 @@ table.grantReadWriteData(myAgent);
 </Fragment>
 <Fragment slot="terraform">
 
+Conceda à função de execução do agente acesso à tabela e sua chave de criptografia KMS via `additional_iam_policy_statements`:
+
 ```hcl title="packages/infra/src/main.tf"
 module "my_table" {
   source = "../../common/terraform/src/app/dynamodb/my-table"
 }
 
-resource "aws_iam_role_policy" "dynamodb_access" {
-  role = module.my_agent.lambda_role_name
+module "my_agent" {
+  source = "../../common/terraform/src/app/agents/my-agent"
 
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Action = [
-          "dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:UpdateItem",
-          "dynamodb:DeleteItem", "dynamodb:Query", "dynamodb:Scan",
-          "dynamodb:BatchGetItem", "dynamodb:BatchWriteItem",
-        ]
-        Resource = [
-          module.my_table.table_arn,
-          "${module.my_table.table_arn}/index/*",
-        ]
-      },
-      {
-        Effect = "Allow"
-        Action = [
-          "kms:Encrypt",
-          "kms:Decrypt",
-          "kms:ReEncrypt*",
-          "kms:GenerateDataKey*",
-          "kms:DescribeKey"
-        ]
-        Resource = [module.my_table.kms_key_arn]
-      },
-    ]
-  })
+  additional_iam_policy_statements = [
+    {
+      Effect = "Allow"
+      Action = [
+        "dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:UpdateItem",
+        "dynamodb:DeleteItem", "dynamodb:Query", "dynamodb:Scan",
+        "dynamodb:BatchGetItem", "dynamodb:BatchWriteItem",
+      ]
+      Resource = [
+        module.my_table.table_arn,
+        "${module.my_table.table_arn}/index/*",
+      ]
+    },
+    {
+      Effect = "Allow"
+      Action = [
+        "kms:Encrypt",
+        "kms:Decrypt",
+        "kms:ReEncrypt*",
+        "kms:GenerateDataKey*",
+        "kms:DescribeKey",
+      ]
+      Resource = [module.my_table.kms_key_arn]
+    },
+  ]
 }
 ```
 </Fragment>

--- a/docs/src/content/docs/pt/guides/connection/py-mcp-server-dynamodb.mdx
+++ b/docs/src/content/docs/pt/guides/connection/py-mcp-server-dynamodb.mdx
@@ -70,42 +70,41 @@ table.grantReadWriteData(myMcpServer);
 </Fragment>
 <Fragment slot="terraform">
 
+Conceda à role de runtime do servidor MCP acesso à tabela e sua chave de criptografia KMS via `additional_iam_policy_statements`:
+
 ```hcl title="packages/infra/src/main.tf"
 module "my_table" {
   source = "../../common/terraform/src/app/dynamodb/my-table"
 }
 
-resource "aws_iam_role_policy" "dynamodb_access" {
-  role = module.my_mcp_server.lambda_role_name
+module "my_mcp_server" {
+  source = "../../common/terraform/src/app/mcp-servers/my-mcp-server"
 
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Action = [
-          "dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:UpdateItem",
-          "dynamodb:DeleteItem", "dynamodb:Query", "dynamodb:Scan",
-          "dynamodb:BatchGetItem", "dynamodb:BatchWriteItem",
-        ]
-        Resource = [
-          module.my_table.table_arn,
-          "${module.my_table.table_arn}/index/*",
-        ]
-      },
-      {
-        Effect = "Allow"
-        Action = [
-          "kms:Encrypt",
-          "kms:Decrypt",
-          "kms:ReEncrypt*",
-          "kms:GenerateDataKey*",
-          "kms:DescribeKey"
-        ]
-        Resource = [module.my_table.kms_key_arn]
-      },
-    ]
-  })
+  additional_iam_policy_statements = [
+    {
+      Effect = "Allow"
+      Action = [
+        "dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:UpdateItem",
+        "dynamodb:DeleteItem", "dynamodb:Query", "dynamodb:Scan",
+        "dynamodb:BatchGetItem", "dynamodb:BatchWriteItem",
+      ]
+      Resource = [
+        module.my_table.table_arn,
+        "${module.my_table.table_arn}/index/*",
+      ]
+    },
+    {
+      Effect = "Allow"
+      Action = [
+        "kms:Encrypt",
+        "kms:Decrypt",
+        "kms:ReEncrypt*",
+        "kms:GenerateDataKey*",
+        "kms:DescribeKey",
+      ]
+      Resource = [module.my_table.kms_key_arn]
+    },
+  ]
 }
 ```
 </Fragment>

--- a/docs/src/content/docs/pt/guides/connection/ts-agent-dynamodb.mdx
+++ b/docs/src/content/docs/pt/guides/connection/ts-agent-dynamodb.mdx
@@ -82,42 +82,41 @@ table.grantReadWriteData(myAgent);
 </Fragment>
 <Fragment slot="terraform">
 
+Conceda ao papel de execução do agente acesso à tabela e sua chave de criptografia KMS via `additional_iam_policy_statements`:
+
 ```hcl title="packages/infra/src/main.tf"
 module "my_table" {
   source = "../../common/terraform/src/app/dynamodb/my-table"
 }
 
-resource "aws_iam_role_policy" "dynamodb_access" {
-  role = module.my_agent.lambda_role_name
+module "my_agent" {
+  source = "../../common/terraform/src/app/agents/my-agent"
 
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Action = [
-          "dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:UpdateItem",
-          "dynamodb:DeleteItem", "dynamodb:Query", "dynamodb:Scan",
-          "dynamodb:BatchGetItem", "dynamodb:BatchWriteItem",
-        ]
-        Resource = [
-          module.my_table.table_arn,
-          "${module.my_table.table_arn}/index/*",
-        ]
-      },
-      {
-        Effect = "Allow"
-        Action = [
-          "kms:Encrypt",
-          "kms:Decrypt",
-          "kms:ReEncrypt*",
-          "kms:GenerateDataKey*",
-          "kms:DescribeKey"
-        ]
-        Resource = [module.my_table.kms_key_arn]
-      },
-    ]
-  })
+  additional_iam_policy_statements = [
+    {
+      Effect = "Allow"
+      Action = [
+        "dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:UpdateItem",
+        "dynamodb:DeleteItem", "dynamodb:Query", "dynamodb:Scan",
+        "dynamodb:BatchGetItem", "dynamodb:BatchWriteItem",
+      ]
+      Resource = [
+        module.my_table.table_arn,
+        "${module.my_table.table_arn}/index/*",
+      ]
+    },
+    {
+      Effect = "Allow"
+      Action = [
+        "kms:Encrypt",
+        "kms:Decrypt",
+        "kms:ReEncrypt*",
+        "kms:GenerateDataKey*",
+        "kms:DescribeKey",
+      ]
+      Resource = [module.my_table.kms_key_arn]
+    },
+  ]
 }
 ```
 </Fragment>

--- a/docs/src/content/docs/pt/guides/connection/ts-mcp-server-dynamodb.mdx
+++ b/docs/src/content/docs/pt/guides/connection/ts-mcp-server-dynamodb.mdx
@@ -79,42 +79,41 @@ table.grantReadWriteData(myMcpServer);
 </Fragment>
 <Fragment slot="terraform">
 
+Conceda à função de runtime do MCP server acesso à tabela e sua chave de criptografia KMS via `additional_iam_policy_statements`:
+
 ```hcl title="packages/infra/src/main.tf"
 module "my_table" {
   source = "../../common/terraform/src/app/dynamodb/my-table"
 }
 
-resource "aws_iam_role_policy" "dynamodb_access" {
-  role = module.my_mcp_server.lambda_role_name
+module "my_mcp_server" {
+  source = "../../common/terraform/src/app/mcp-servers/my-mcp-server"
 
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Action = [
-          "dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:UpdateItem",
-          "dynamodb:DeleteItem", "dynamodb:Query", "dynamodb:Scan",
-          "dynamodb:BatchGetItem", "dynamodb:BatchWriteItem",
-        ]
-        Resource = [
-          module.my_table.table_arn,
-          "${module.my_table.table_arn}/index/*",
-        ]
-      },
-      {
-        Effect = "Allow"
-        Action = [
-          "kms:Encrypt",
-          "kms:Decrypt",
-          "kms:ReEncrypt*",
-          "kms:GenerateDataKey*",
-          "kms:DescribeKey",
-        ]
-        Resource = [module.my_table.kms_key_arn]
-      },
-    ]
-  })
+  additional_iam_policy_statements = [
+    {
+      Effect = "Allow"
+      Action = [
+        "dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:UpdateItem",
+        "dynamodb:DeleteItem", "dynamodb:Query", "dynamodb:Scan",
+        "dynamodb:BatchGetItem", "dynamodb:BatchWriteItem",
+      ]
+      Resource = [
+        module.my_table.table_arn,
+        "${module.my_table.table_arn}/index/*",
+      ]
+    },
+    {
+      Effect = "Allow"
+      Action = [
+        "kms:Encrypt",
+        "kms:Decrypt",
+        "kms:ReEncrypt*",
+        "kms:GenerateDataKey*",
+        "kms:DescribeKey",
+      ]
+      Resource = [module.my_table.kms_key_arn]
+    },
+  ]
 }
 ```
 </Fragment>

--- a/docs/src/content/docs/pt/snippets/connection/lambda-dynamodb-access.mdx
+++ b/docs/src/content/docs/pt/snippets/connection/lambda-dynamodb-access.mdx
@@ -38,7 +38,7 @@ module "my_table" {
 }
 
 resource "aws_iam_role_policy" "dynamodb_access" {
-  role = module.my_api.lambda_role_name
+  role = module.my_api.lambda_execution_role_name
 
   policy = jsonencode({
     Version = "2012-10-17"

--- a/docs/src/content/docs/vi/guides/connection/py-agent-dynamodb.mdx
+++ b/docs/src/content/docs/vi/guides/connection/py-agent-dynamodb.mdx
@@ -70,42 +70,41 @@ table.grantReadWriteData(myAgent);
 </Fragment>
 <Fragment slot="terraform">
 
+Cấp quyền truy cập cho vai trò runtime của agent vào bảng và khóa mã hóa KMS của nó thông qua `additional_iam_policy_statements`:
+
 ```hcl title="packages/infra/src/main.tf"
 module "my_table" {
   source = "../../common/terraform/src/app/dynamodb/my-table"
 }
 
-resource "aws_iam_role_policy" "dynamodb_access" {
-  role = module.my_agent.lambda_role_name
+module "my_agent" {
+  source = "../../common/terraform/src/app/agents/my-agent"
 
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Action = [
-          "dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:UpdateItem",
-          "dynamodb:DeleteItem", "dynamodb:Query", "dynamodb:Scan",
-          "dynamodb:BatchGetItem", "dynamodb:BatchWriteItem",
-        ]
-        Resource = [
-          module.my_table.table_arn,
-          "${module.my_table.table_arn}/index/*",
-        ]
-      },
-      {
-        Effect = "Allow"
-        Action = [
-          "kms:Encrypt",
-          "kms:Decrypt",
-          "kms:ReEncrypt*",
-          "kms:GenerateDataKey*",
-          "kms:DescribeKey"
-        ]
-        Resource = [module.my_table.kms_key_arn]
-      },
-    ]
-  })
+  additional_iam_policy_statements = [
+    {
+      Effect = "Allow"
+      Action = [
+        "dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:UpdateItem",
+        "dynamodb:DeleteItem", "dynamodb:Query", "dynamodb:Scan",
+        "dynamodb:BatchGetItem", "dynamodb:BatchWriteItem",
+      ]
+      Resource = [
+        module.my_table.table_arn,
+        "${module.my_table.table_arn}/index/*",
+      ]
+    },
+    {
+      Effect = "Allow"
+      Action = [
+        "kms:Encrypt",
+        "kms:Decrypt",
+        "kms:ReEncrypt*",
+        "kms:GenerateDataKey*",
+        "kms:DescribeKey",
+      ]
+      Resource = [module.my_table.kms_key_arn]
+    },
+  ]
 }
 ```
 </Fragment>

--- a/docs/src/content/docs/vi/guides/connection/py-mcp-server-dynamodb.mdx
+++ b/docs/src/content/docs/vi/guides/connection/py-mcp-server-dynamodb.mdx
@@ -70,42 +70,41 @@ table.grantReadWriteData(myMcpServer);
 </Fragment>
 <Fragment slot="terraform">
 
+Cấp quyền truy cập cho runtime role của MCP server vào bảng và khóa mã hóa KMS của nó thông qua `additional_iam_policy_statements`:
+
 ```hcl title="packages/infra/src/main.tf"
 module "my_table" {
   source = "../../common/terraform/src/app/dynamodb/my-table"
 }
 
-resource "aws_iam_role_policy" "dynamodb_access" {
-  role = module.my_mcp_server.lambda_role_name
+module "my_mcp_server" {
+  source = "../../common/terraform/src/app/mcp-servers/my-mcp-server"
 
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Action = [
-          "dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:UpdateItem",
-          "dynamodb:DeleteItem", "dynamodb:Query", "dynamodb:Scan",
-          "dynamodb:BatchGetItem", "dynamodb:BatchWriteItem",
-        ]
-        Resource = [
-          module.my_table.table_arn,
-          "${module.my_table.table_arn}/index/*",
-        ]
-      },
-      {
-        Effect = "Allow"
-        Action = [
-          "kms:Encrypt",
-          "kms:Decrypt",
-          "kms:ReEncrypt*",
-          "kms:GenerateDataKey*",
-          "kms:DescribeKey"
-        ]
-        Resource = [module.my_table.kms_key_arn]
-      },
-    ]
-  })
+  additional_iam_policy_statements = [
+    {
+      Effect = "Allow"
+      Action = [
+        "dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:UpdateItem",
+        "dynamodb:DeleteItem", "dynamodb:Query", "dynamodb:Scan",
+        "dynamodb:BatchGetItem", "dynamodb:BatchWriteItem",
+      ]
+      Resource = [
+        module.my_table.table_arn,
+        "${module.my_table.table_arn}/index/*",
+      ]
+    },
+    {
+      Effect = "Allow"
+      Action = [
+        "kms:Encrypt",
+        "kms:Decrypt",
+        "kms:ReEncrypt*",
+        "kms:GenerateDataKey*",
+        "kms:DescribeKey",
+      ]
+      Resource = [module.my_table.kms_key_arn]
+    },
+  ]
 }
 ```
 </Fragment>

--- a/docs/src/content/docs/vi/guides/connection/ts-agent-dynamodb.mdx
+++ b/docs/src/content/docs/vi/guides/connection/ts-agent-dynamodb.mdx
@@ -82,42 +82,41 @@ table.grantReadWriteData(myAgent);
 </Fragment>
 <Fragment slot="terraform">
 
+Cấp quyền truy cập cho runtime role của agent vào bảng và khóa mã hóa KMS của nó thông qua `additional_iam_policy_statements`:
+
 ```hcl title="packages/infra/src/main.tf"
 module "my_table" {
   source = "../../common/terraform/src/app/dynamodb/my-table"
 }
 
-resource "aws_iam_role_policy" "dynamodb_access" {
-  role = module.my_agent.lambda_role_name
+module "my_agent" {
+  source = "../../common/terraform/src/app/agents/my-agent"
 
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Action = [
-          "dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:UpdateItem",
-          "dynamodb:DeleteItem", "dynamodb:Query", "dynamodb:Scan",
-          "dynamodb:BatchGetItem", "dynamodb:BatchWriteItem",
-        ]
-        Resource = [
-          module.my_table.table_arn,
-          "${module.my_table.table_arn}/index/*",
-        ]
-      },
-      {
-        Effect = "Allow"
-        Action = [
-          "kms:Encrypt",
-          "kms:Decrypt",
-          "kms:ReEncrypt*",
-          "kms:GenerateDataKey*",
-          "kms:DescribeKey"
-        ]
-        Resource = [module.my_table.kms_key_arn]
-      },
-    ]
-  })
+  additional_iam_policy_statements = [
+    {
+      Effect = "Allow"
+      Action = [
+        "dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:UpdateItem",
+        "dynamodb:DeleteItem", "dynamodb:Query", "dynamodb:Scan",
+        "dynamodb:BatchGetItem", "dynamodb:BatchWriteItem",
+      ]
+      Resource = [
+        module.my_table.table_arn,
+        "${module.my_table.table_arn}/index/*",
+      ]
+    },
+    {
+      Effect = "Allow"
+      Action = [
+        "kms:Encrypt",
+        "kms:Decrypt",
+        "kms:ReEncrypt*",
+        "kms:GenerateDataKey*",
+        "kms:DescribeKey",
+      ]
+      Resource = [module.my_table.kms_key_arn]
+    },
+  ]
 }
 ```
 </Fragment>

--- a/docs/src/content/docs/vi/guides/connection/ts-mcp-server-dynamodb.mdx
+++ b/docs/src/content/docs/vi/guides/connection/ts-mcp-server-dynamodb.mdx
@@ -79,42 +79,41 @@ table.grantReadWriteData(myMcpServer);
 </Fragment>
 <Fragment slot="terraform">
 
+Cấp quyền truy cập cho runtime role của MCP server vào bảng và khóa mã hóa KMS của nó thông qua `additional_iam_policy_statements`:
+
 ```hcl title="packages/infra/src/main.tf"
 module "my_table" {
   source = "../../common/terraform/src/app/dynamodb/my-table"
 }
 
-resource "aws_iam_role_policy" "dynamodb_access" {
-  role = module.my_mcp_server.lambda_role_name
+module "my_mcp_server" {
+  source = "../../common/terraform/src/app/mcp-servers/my-mcp-server"
 
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Action = [
-          "dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:UpdateItem",
-          "dynamodb:DeleteItem", "dynamodb:Query", "dynamodb:Scan",
-          "dynamodb:BatchGetItem", "dynamodb:BatchWriteItem",
-        ]
-        Resource = [
-          module.my_table.table_arn,
-          "${module.my_table.table_arn}/index/*",
-        ]
-      },
-      {
-        Effect = "Allow"
-        Action = [
-          "kms:Encrypt",
-          "kms:Decrypt",
-          "kms:ReEncrypt*",
-          "kms:GenerateDataKey*",
-          "kms:DescribeKey",
-        ]
-        Resource = [module.my_table.kms_key_arn]
-      },
-    ]
-  })
+  additional_iam_policy_statements = [
+    {
+      Effect = "Allow"
+      Action = [
+        "dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:UpdateItem",
+        "dynamodb:DeleteItem", "dynamodb:Query", "dynamodb:Scan",
+        "dynamodb:BatchGetItem", "dynamodb:BatchWriteItem",
+      ]
+      Resource = [
+        module.my_table.table_arn,
+        "${module.my_table.table_arn}/index/*",
+      ]
+    },
+    {
+      Effect = "Allow"
+      Action = [
+        "kms:Encrypt",
+        "kms:Decrypt",
+        "kms:ReEncrypt*",
+        "kms:GenerateDataKey*",
+        "kms:DescribeKey",
+      ]
+      Resource = [module.my_table.kms_key_arn]
+    },
+  ]
 }
 ```
 </Fragment>

--- a/docs/src/content/docs/vi/snippets/connection/lambda-dynamodb-access.mdx
+++ b/docs/src/content/docs/vi/snippets/connection/lambda-dynamodb-access.mdx
@@ -38,7 +38,7 @@ module "my_table" {
 }
 
 resource "aws_iam_role_policy" "dynamodb_access" {
-  role = module.my_api.lambda_role_name
+  role = module.my_api.lambda_execution_role_name
 
   policy = jsonencode({
     Version = "2012-10-17"

--- a/docs/src/content/docs/zh/guides/connection/py-agent-dynamodb.mdx
+++ b/docs/src/content/docs/zh/guides/connection/py-agent-dynamodb.mdx
@@ -70,42 +70,41 @@ table.grantReadWriteData(myAgent);
 </Fragment>
 <Fragment slot="terraform">
 
+通过 `additional_iam_policy_statements` 授予 agent 的运行时角色访问表及其 KMS 加密密钥的权限：
+
 ```hcl title="packages/infra/src/main.tf"
 module "my_table" {
   source = "../../common/terraform/src/app/dynamodb/my-table"
 }
 
-resource "aws_iam_role_policy" "dynamodb_access" {
-  role = module.my_agent.lambda_role_name
+module "my_agent" {
+  source = "../../common/terraform/src/app/agents/my-agent"
 
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Action = [
-          "dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:UpdateItem",
-          "dynamodb:DeleteItem", "dynamodb:Query", "dynamodb:Scan",
-          "dynamodb:BatchGetItem", "dynamodb:BatchWriteItem",
-        ]
-        Resource = [
-          module.my_table.table_arn,
-          "${module.my_table.table_arn}/index/*",
-        ]
-      },
-      {
-        Effect = "Allow"
-        Action = [
-          "kms:Encrypt",
-          "kms:Decrypt",
-          "kms:ReEncrypt*",
-          "kms:GenerateDataKey*",
-          "kms:DescribeKey"
-        ]
-        Resource = [module.my_table.kms_key_arn]
-      },
-    ]
-  })
+  additional_iam_policy_statements = [
+    {
+      Effect = "Allow"
+      Action = [
+        "dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:UpdateItem",
+        "dynamodb:DeleteItem", "dynamodb:Query", "dynamodb:Scan",
+        "dynamodb:BatchGetItem", "dynamodb:BatchWriteItem",
+      ]
+      Resource = [
+        module.my_table.table_arn,
+        "${module.my_table.table_arn}/index/*",
+      ]
+    },
+    {
+      Effect = "Allow"
+      Action = [
+        "kms:Encrypt",
+        "kms:Decrypt",
+        "kms:ReEncrypt*",
+        "kms:GenerateDataKey*",
+        "kms:DescribeKey",
+      ]
+      Resource = [module.my_table.kms_key_arn]
+    },
+  ]
 }
 ```
 </Fragment>

--- a/docs/src/content/docs/zh/guides/connection/py-mcp-server-dynamodb.mdx
+++ b/docs/src/content/docs/zh/guides/connection/py-mcp-server-dynamodb.mdx
@@ -70,42 +70,41 @@ table.grantReadWriteData(myMcpServer);
 </Fragment>
 <Fragment slot="terraform">
 
+通过 `additional_iam_policy_statements` 授予 MCP server 的运行时角色访问表及其 KMS 加密密钥的权限：
+
 ```hcl title="packages/infra/src/main.tf"
 module "my_table" {
   source = "../../common/terraform/src/app/dynamodb/my-table"
 }
 
-resource "aws_iam_role_policy" "dynamodb_access" {
-  role = module.my_mcp_server.lambda_role_name
+module "my_mcp_server" {
+  source = "../../common/terraform/src/app/mcp-servers/my-mcp-server"
 
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Action = [
-          "dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:UpdateItem",
-          "dynamodb:DeleteItem", "dynamodb:Query", "dynamodb:Scan",
-          "dynamodb:BatchGetItem", "dynamodb:BatchWriteItem",
-        ]
-        Resource = [
-          module.my_table.table_arn,
-          "${module.my_table.table_arn}/index/*",
-        ]
-      },
-      {
-        Effect = "Allow"
-        Action = [
-          "kms:Encrypt",
-          "kms:Decrypt",
-          "kms:ReEncrypt*",
-          "kms:GenerateDataKey*",
-          "kms:DescribeKey"
-        ]
-        Resource = [module.my_table.kms_key_arn]
-      },
-    ]
-  })
+  additional_iam_policy_statements = [
+    {
+      Effect = "Allow"
+      Action = [
+        "dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:UpdateItem",
+        "dynamodb:DeleteItem", "dynamodb:Query", "dynamodb:Scan",
+        "dynamodb:BatchGetItem", "dynamodb:BatchWriteItem",
+      ]
+      Resource = [
+        module.my_table.table_arn,
+        "${module.my_table.table_arn}/index/*",
+      ]
+    },
+    {
+      Effect = "Allow"
+      Action = [
+        "kms:Encrypt",
+        "kms:Decrypt",
+        "kms:ReEncrypt*",
+        "kms:GenerateDataKey*",
+        "kms:DescribeKey",
+      ]
+      Resource = [module.my_table.kms_key_arn]
+    },
+  ]
 }
 ```
 </Fragment>

--- a/docs/src/content/docs/zh/guides/connection/ts-agent-dynamodb.mdx
+++ b/docs/src/content/docs/zh/guides/connection/ts-agent-dynamodb.mdx
@@ -82,42 +82,41 @@ table.grantReadWriteData(myAgent);
 </Fragment>
 <Fragment slot="terraform">
 
+通过 `additional_iam_policy_statements` 授予 agent 的运行时角色访问表及其 KMS 加密密钥的权限：
+
 ```hcl title="packages/infra/src/main.tf"
 module "my_table" {
   source = "../../common/terraform/src/app/dynamodb/my-table"
 }
 
-resource "aws_iam_role_policy" "dynamodb_access" {
-  role = module.my_agent.lambda_role_name
+module "my_agent" {
+  source = "../../common/terraform/src/app/agents/my-agent"
 
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Action = [
-          "dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:UpdateItem",
-          "dynamodb:DeleteItem", "dynamodb:Query", "dynamodb:Scan",
-          "dynamodb:BatchGetItem", "dynamodb:BatchWriteItem",
-        ]
-        Resource = [
-          module.my_table.table_arn,
-          "${module.my_table.table_arn}/index/*",
-        ]
-      },
-      {
-        Effect = "Allow"
-        Action = [
-          "kms:Encrypt",
-          "kms:Decrypt",
-          "kms:ReEncrypt*",
-          "kms:GenerateDataKey*",
-          "kms:DescribeKey"
-        ]
-        Resource = [module.my_table.kms_key_arn]
-      },
-    ]
-  })
+  additional_iam_policy_statements = [
+    {
+      Effect = "Allow"
+      Action = [
+        "dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:UpdateItem",
+        "dynamodb:DeleteItem", "dynamodb:Query", "dynamodb:Scan",
+        "dynamodb:BatchGetItem", "dynamodb:BatchWriteItem",
+      ]
+      Resource = [
+        module.my_table.table_arn,
+        "${module.my_table.table_arn}/index/*",
+      ]
+    },
+    {
+      Effect = "Allow"
+      Action = [
+        "kms:Encrypt",
+        "kms:Decrypt",
+        "kms:ReEncrypt*",
+        "kms:GenerateDataKey*",
+        "kms:DescribeKey",
+      ]
+      Resource = [module.my_table.kms_key_arn]
+    },
+  ]
 }
 ```
 </Fragment>

--- a/docs/src/content/docs/zh/guides/connection/ts-mcp-server-dynamodb.mdx
+++ b/docs/src/content/docs/zh/guides/connection/ts-mcp-server-dynamodb.mdx
@@ -79,42 +79,41 @@ table.grantReadWriteData(myMcpServer);
 </Fragment>
 <Fragment slot="terraform">
 
+通过 `additional_iam_policy_statements` 授予 MCP server 的运行时角色访问表及其 KMS 加密密钥的权限：
+
 ```hcl title="packages/infra/src/main.tf"
 module "my_table" {
   source = "../../common/terraform/src/app/dynamodb/my-table"
 }
 
-resource "aws_iam_role_policy" "dynamodb_access" {
-  role = module.my_mcp_server.lambda_role_name
+module "my_mcp_server" {
+  source = "../../common/terraform/src/app/mcp-servers/my-mcp-server"
 
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Action = [
-          "dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:UpdateItem",
-          "dynamodb:DeleteItem", "dynamodb:Query", "dynamodb:Scan",
-          "dynamodb:BatchGetItem", "dynamodb:BatchWriteItem",
-        ]
-        Resource = [
-          module.my_table.table_arn,
-          "${module.my_table.table_arn}/index/*",
-        ]
-      },
-      {
-        Effect = "Allow"
-        Action = [
-          "kms:Encrypt",
-          "kms:Decrypt",
-          "kms:ReEncrypt*",
-          "kms:GenerateDataKey*",
-          "kms:DescribeKey",
-        ]
-        Resource = [module.my_table.kms_key_arn]
-      },
-    ]
-  })
+  additional_iam_policy_statements = [
+    {
+      Effect = "Allow"
+      Action = [
+        "dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:UpdateItem",
+        "dynamodb:DeleteItem", "dynamodb:Query", "dynamodb:Scan",
+        "dynamodb:BatchGetItem", "dynamodb:BatchWriteItem",
+      ]
+      Resource = [
+        module.my_table.table_arn,
+        "${module.my_table.table_arn}/index/*",
+      ]
+    },
+    {
+      Effect = "Allow"
+      Action = [
+        "kms:Encrypt",
+        "kms:Decrypt",
+        "kms:ReEncrypt*",
+        "kms:GenerateDataKey*",
+        "kms:DescribeKey",
+      ]
+      Resource = [module.my_table.kms_key_arn]
+    },
+  ]
 }
 ```
 </Fragment>

--- a/docs/src/content/docs/zh/snippets/connection/lambda-dynamodb-access.mdx
+++ b/docs/src/content/docs/zh/snippets/connection/lambda-dynamodb-access.mdx
@@ -38,7 +38,7 @@ module "my_table" {
 }
 
 resource "aws_iam_role_policy" "dynamodb_access" {
-  role = module.my_api.lambda_role_name
+  role = module.my_api.lambda_execution_role_name
 
   policy = jsonencode({
     Version = "2012-10-17"

--- a/packages/nx-plugin/src/migrations/latest/dynamodb-terraform-app-module-outputs/metadata.json
+++ b/packages/nx-plugin/src/migrations/latest/dynamodb-terraform-app-module-outputs/metadata.json
@@ -1,0 +1,3 @@
+{
+  "description": "Re-export the DynamoDB table and KMS key attributes from the vended Terraform per-table app module"
+}

--- a/packages/nx-plugin/src/migrations/latest/dynamodb-terraform-app-module-outputs/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/latest/dynamodb-terraform-app-module-outputs/migration.spec.ts
@@ -1,0 +1,150 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import type { Tree } from '@nx/devkit';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test.js';
+import migration from './migration.js';
+
+const APP_MODULE_FILE =
+  'packages/common/terraform/src/app/dynamodb/my-table/my-table.tf';
+const APP_MODULE_FILE_2 =
+  'packages/common/terraform/src/app/dynamodb/other-table/other-table.tf';
+
+/** The vended per-table Terraform app module, before it had any outputs. */
+const oldAppModule = (tableName: string) => `terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "5.100.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "3.6.3"
+    }
+  }
+}
+
+variable "billing_mode" {
+  description = "Controls how you are charged for read and write throughput."
+  type        = string
+  default     = "PAY_PER_REQUEST"
+}
+
+resource "random_string" "suffix" {
+  length  = 8
+  special = false
+  upper   = false
+}
+
+locals {
+  dynamodb_config = jsondecode(file("\${path.module}/../../../../../../../packages/${tableName}/config.json"))
+  global_secondary_indexes = [for gsi in local.dynamodb_config.tableConfig.globalSecondaryIndexes : {
+    name            = gsi.indexName
+    hash_key        = gsi.partitionKey
+    range_key       = try(gsi.sortKey, null)
+    projection_type = "ALL"
+  }]
+}
+
+module "dynamodb_table" {
+  source                   = "../../../core/dynamodb"
+  name                     = "${tableName}-\${random_string.suffix.result}"
+  billing_mode             = var.billing_mode
+  global_secondary_indexes = local.global_secondary_indexes
+}
+
+module "add_to_runtime_config" {
+  source = "../../../core/runtime-config/entry"
+
+  namespace = "dynamodb"
+  key       = local.dynamodb_config.runtimeConfigKey
+  value = {
+    tableName = module.dynamodb_table.table_name
+  }
+}
+`;
+
+describe('dynamodb-terraform-app-module-outputs migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeUsingTsSolutionSetup();
+  });
+
+  it('does nothing when no vended dynamodb modules exist', async () => {
+    const result = await migration(tree);
+    expect(result.nextSteps).toEqual([]);
+  });
+
+  it('re-exports the table and key attributes from the app module', async () => {
+    tree.write(APP_MODULE_FILE, oldAppModule('my-table'));
+
+    const result = await migration(tree);
+    const contents = tree.read(APP_MODULE_FILE, 'utf-8')!;
+
+    expect(contents).toContain('output "table_name"');
+    expect(contents).toContain(
+      'value       = module.dynamodb_table.table_name',
+    );
+    expect(contents).toContain('output "table_arn"');
+    expect(contents).toContain('value       = module.dynamodb_table.table_arn');
+    expect(contents).toContain('output "kms_key_arn"');
+    expect(contents).toContain(
+      'value       = module.dynamodb_table.kms_key_arn',
+    );
+
+    // The existing configuration is preserved
+    expect(contents).toContain('module "add_to_runtime_config"');
+    expect(contents).toContain('module "dynamodb_table"');
+    expect(result.nextSteps).toEqual([]);
+  });
+
+  it('migrates every app module directory found', async () => {
+    tree.write(APP_MODULE_FILE, oldAppModule('my-table'));
+    tree.write(APP_MODULE_FILE_2, oldAppModule('other-table'));
+
+    await migration(tree);
+
+    for (const file of [APP_MODULE_FILE, APP_MODULE_FILE_2]) {
+      expect(tree.read(file, 'utf-8')!).toContain('output "table_arn"');
+    }
+  });
+
+  it('is idempotent', async () => {
+    tree.write(APP_MODULE_FILE, oldAppModule('my-table'));
+
+    await migration(tree);
+    const afterFirst = tree.read(APP_MODULE_FILE, 'utf-8');
+
+    await migration(tree);
+
+    expect(tree.read(APP_MODULE_FILE, 'utf-8')).toEqual(afterFirst);
+  });
+
+  it('leaves an already-migrated module untouched', async () => {
+    tree.write(APP_MODULE_FILE, oldAppModule('my-table'));
+    await migration(tree);
+    const migrated = tree.read(APP_MODULE_FILE, 'utf-8')!;
+
+    tree.write(APP_MODULE_FILE, migrated);
+    const result = await migration(tree);
+
+    expect(tree.read(APP_MODULE_FILE, 'utf-8')).toEqual(migrated);
+    expect(result.nextSteps).toEqual([]);
+  });
+
+  it('skips and reports a diverged app module', async () => {
+    tree.write(
+      APP_MODULE_FILE,
+      'module "something_else" {\n  source = "../../../core/dynamodb"\n}\n',
+    );
+
+    const result = await migration(tree);
+
+    expect(tree.read(APP_MODULE_FILE, 'utf-8')).not.toContain('output "');
+    expect(result.nextSteps).toEqual([
+      `${APP_MODULE_FILE}: has diverged from the generated shape - left untouched. To reference the table from your root Terraform configuration, add table_name, table_arn and kms_key_arn outputs here forwarding the equivalent module.dynamodb_table attributes (see the ts#dynamodb generator's dynamodb app template).`,
+    ]);
+  });
+});

--- a/packages/nx-plugin/src/migrations/latest/dynamodb-terraform-app-module-outputs/migration.ts
+++ b/packages/nx-plugin/src/migrations/latest/dynamodb-terraform-app-module-outputs/migration.ts
@@ -46,7 +46,7 @@ const OUTPUTS_TEXT = [
   '}',
   '',
   'output "table_arn" {',
-  '  description = "ARN of the DynamoDB table, for use in IAM policies granting access to the table and (suffixed with /index/*) its global secondary indexes"',
+  '  description = "ARN of the DynamoDB table, for use in IAM policies granting access to the table. Suffix with /index/* to cover its global secondary indexes."',
   '  value       = module.dynamodb_table.table_arn',
   '}',
   '',

--- a/packages/nx-plugin/src/migrations/latest/dynamodb-terraform-app-module-outputs/migration.ts
+++ b/packages/nx-plugin/src/migrations/latest/dynamodb-terraform-app-module-outputs/migration.ts
@@ -1,0 +1,105 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import {
+  joinPathFragments,
+  type MigrationReturnObject,
+  type Tree,
+} from '@nx/devkit';
+import {
+  GRIT_INSERT_PLACEHOLDER,
+  insertViaGritQL,
+  matchGritQL,
+} from '../../../utils/ast.js';
+import { formatFilesInSubtree } from '../../../utils/format.js';
+import {
+  PACKAGES_DIR,
+  SHARED_TERRAFORM_DIR,
+} from '../../../utils/shared-constructs-constants.js';
+
+/**
+ * Re-export the core dynamodb module's `table_name`, `table_arn` and
+ * `kms_key_arn` from each vended per-table Terraform app module
+ * (`app/dynamodb/<name>/<name>.tf`).
+ *
+ * The app module is what a root configuration instantiates, so without these
+ * outputs a root module cannot reference the table or its encryption key at
+ * all — for example to grant a consumer access to it.
+ *
+ * These files are generated with `KeepExisting`, so an upgraded workspace keeps
+ * a module with no outputs until this runs. Diverged files are left untouched
+ * and reported via `nextSteps`.
+ */
+
+const TERRAFORM_DYNAMODB_APP_DIR = `${PACKAGES_DIR}/${SHARED_TERRAFORM_DIR}/src/app/dynamodb`;
+
+const divergedMessage = (filePath: string) =>
+  `${filePath}: has diverged from the generated shape - left untouched. To reference the table from your root Terraform configuration, add table_name, table_arn and kms_key_arn outputs here forwarding the equivalent module.dynamodb_table attributes (see the ts#dynamodb generator's dynamodb app template).`;
+
+const hcl = (pattern: string) => `language hcl\n${pattern}`;
+
+const OUTPUTS_TEXT = [
+  'output "table_name" {',
+  '  description = "Name of the DynamoDB table"',
+  '  value       = module.dynamodb_table.table_name',
+  '}',
+  '',
+  'output "table_arn" {',
+  '  description = "ARN of the DynamoDB table, for use in IAM policies granting access to the table and (suffixed with /index/*) its global secondary indexes"',
+  '  value       = module.dynamodb_table.table_arn',
+  '}',
+  '',
+  'output "kms_key_arn" {',
+  '  description = "ARN of the KMS key used to encrypt the DynamoDB table, for use in IAM policies granting access to the table. Null when using the AWS owned key (encryption = DEFAULT)."',
+  '  value       = module.dynamodb_table.kms_key_arn',
+  '}',
+].join('\n');
+
+export default async function migration(
+  tree: Tree,
+): Promise<MigrationReturnObject> {
+  const nextSteps: string[] = [];
+
+  if (!tree.exists(TERRAFORM_DYNAMODB_APP_DIR)) {
+    return { nextSteps }; // This workspace has no Terraform dynamodb modules.
+  }
+
+  for (const dirName of tree.children(TERRAFORM_DYNAMODB_APP_DIR)) {
+    const filePath = joinPathFragments(
+      TERRAFORM_DYNAMODB_APP_DIR,
+      dirName,
+      `${dirName}.tf`,
+    );
+    if (!tree.exists(filePath)) {
+      continue; // Not a dynamodb app module directory.
+    }
+
+    if (await matchGritQL(tree, filePath, hcl('`output "table_arn" { $_ }`'))) {
+      continue; // Already migrated.
+    }
+
+    const RUNTIME_CONFIG_MODULE_BLOCK = hcl(
+      '`module "add_to_runtime_config" { $_ }`',
+    );
+    if (!(await matchGritQL(tree, filePath, RUNTIME_CONFIG_MODULE_BLOCK))) {
+      nextSteps.push(divergedMessage(filePath));
+      continue;
+    }
+
+    // Appended after the runtime config module call, which the template ends
+    // with, matching where the generator now writes the outputs.
+    await insertViaGritQL(
+      tree,
+      filePath,
+      hcl(
+        `\`module "add_to_runtime_config" { $body }\` => \`module "add_to_runtime_config" {\n  $body\n}\n\n${GRIT_INSERT_PLACEHOLDER}\``,
+      ),
+      OUTPUTS_TEXT,
+    );
+  }
+
+  await formatFilesInSubtree(tree);
+
+  return { nextSteps };
+}

--- a/packages/nx-plugin/src/py/dynamodb/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/dynamodb/__snapshots__/generator.spec.ts.snap
@@ -320,6 +320,21 @@ module "add_to_runtime_config" {
     tableName = module.dynamodb_table.table_name
   }
 }
+
+output "table_name" {
+  description = "Name of the DynamoDB table"
+  value       = module.dynamodb_table.table_name
+}
+
+output "table_arn" {
+  description = "ARN of the DynamoDB table, for use in IAM policies granting access to the table and (suffixed with /index/*) its global secondary indexes"
+  value       = module.dynamodb_table.table_arn
+}
+
+output "kms_key_arn" {
+  description = "ARN of the KMS key used to encrypt the DynamoDB table, for use in IAM policies granting access to the table. Null when using the AWS owned key (encryption = DEFAULT)."
+  value       = module.dynamodb_table.kms_key_arn
+}
 "
 `;
 

--- a/packages/nx-plugin/src/py/dynamodb/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/dynamodb/__snapshots__/generator.spec.ts.snap
@@ -327,7 +327,7 @@ output "table_name" {
 }
 
 output "table_arn" {
-  description = "ARN of the DynamoDB table, for use in IAM policies granting access to the table and (suffixed with /index/*) its global secondary indexes"
+  description = "ARN of the DynamoDB table, for use in IAM policies granting access to the table. Suffix with /index/* to cover its global secondary indexes."
   value       = module.dynamodb_table.table_arn
 }
 

--- a/packages/nx-plugin/src/ts/dynamodb/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/dynamodb/__snapshots__/generator.spec.ts.snap
@@ -320,6 +320,21 @@ module "add_to_runtime_config" {
     tableName = module.dynamodb_table.table_name
   }
 }
+
+output "table_name" {
+  description = "Name of the DynamoDB table"
+  value       = module.dynamodb_table.table_name
+}
+
+output "table_arn" {
+  description = "ARN of the DynamoDB table, for use in IAM policies granting access to the table and (suffixed with /index/*) its global secondary indexes"
+  value       = module.dynamodb_table.table_arn
+}
+
+output "kms_key_arn" {
+  description = "ARN of the KMS key used to encrypt the DynamoDB table, for use in IAM policies granting access to the table. Null when using the AWS owned key (encryption = DEFAULT)."
+  value       = module.dynamodb_table.kms_key_arn
+}
 "
 `;
 

--- a/packages/nx-plugin/src/ts/dynamodb/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/dynamodb/__snapshots__/generator.spec.ts.snap
@@ -327,7 +327,7 @@ output "table_name" {
 }
 
 output "table_arn" {
-  description = "ARN of the DynamoDB table, for use in IAM policies granting access to the table and (suffixed with /index/*) its global secondary indexes"
+  description = "ARN of the DynamoDB table, for use in IAM policies granting access to the table. Suffix with /index/* to cover its global secondary indexes."
   value       = module.dynamodb_table.table_arn
 }
 

--- a/packages/nx-plugin/src/utils/dynamodb-constructs/dynamodb-constructs.spec.ts
+++ b/packages/nx-plugin/src/utils/dynamodb-constructs/dynamodb-constructs.spec.ts
@@ -1,0 +1,163 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import type { Tree } from '@nx/devkit';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { createTreeUsingTsSolutionSetup } from '../test.js';
+import { addDynamoDBTerraformModules } from './dynamodb-constructs.js';
+
+const APP_MODULE_FILE =
+  'packages/common/terraform/src/app/dynamodb/my-table/my-table.tf';
+const CORE_MODULE_FILE =
+  'packages/common/terraform/src/core/dynamodb/dynamodb.tf';
+
+const DOCS_DIR = join(__dirname, '../../../../../docs/src/content/docs/en');
+
+/** Names of every `output "..."` block declared in a Terraform file. */
+const outputNames = (hcl: string): string[] =>
+  [...hcl.matchAll(/^output "([^"]+)" \{/gm)].map(([, name]) => name);
+
+const mdxFilesIn = (dir: string): string[] =>
+  readdirSync(dir).flatMap((entry) => {
+    const path = join(dir, entry);
+    return statSync(path).isDirectory()
+      ? mdxFilesIn(path)
+      : path.endsWith('.mdx')
+        ? [path]
+        : [];
+  });
+
+describe('dynamodb-constructs utils', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeUsingTsSolutionSetup();
+  });
+
+  const generateTerraformModules = () =>
+    addDynamoDBTerraformModules(tree, {
+      projectName: '@proj/my-table',
+      nameClassName: 'MyTable',
+      nameKebabCase: 'my-table',
+      tableName: 'my-table',
+      projectRoot: 'packages/my-table',
+    });
+
+  it('should expose the table and key attributes as outputs on the app module', () => {
+    generateTerraformModules();
+
+    const appModule = tree.read(APP_MODULE_FILE, 'utf-8') ?? '';
+
+    expect(outputNames(appModule)).toEqual(
+      expect.arrayContaining(['table_name', 'table_arn', 'kms_key_arn']),
+    );
+  });
+
+  it('should re-export every output of the core module from the app module', () => {
+    generateTerraformModules();
+
+    const coreOutputs = outputNames(tree.read(CORE_MODULE_FILE, 'utf-8') ?? '');
+    const appModule = tree.read(APP_MODULE_FILE, 'utf-8') ?? '';
+
+    expect(coreOutputs.length).toBeGreaterThan(0);
+    expect(outputNames(appModule)).toEqual(expect.arrayContaining(coreOutputs));
+    // Each re-export forwards the equivalently named core module attribute
+    for (const name of coreOutputs) {
+      expect(appModule).toContain(
+        `value       = module.dynamodb_table.${name}`,
+      );
+    }
+  });
+
+  /**
+   * The connection guides tell users to reference these attributes from their
+   * root Terraform configuration, so an attribute the docs name but the module
+   * doesn't declare is a `terraform plan` failure for anyone following them.
+   */
+  it('should declare every app module attribute the docs reference', () => {
+    generateTerraformModules();
+
+    const declared = new Set(
+      outputNames(tree.read(APP_MODULE_FILE, 'utf-8') ?? ''),
+    );
+
+    const referenced = new Map<string, string[]>();
+    for (const file of mdxFilesIn(DOCS_DIR)) {
+      for (const [, attribute] of readFileSync(file, 'utf-8').matchAll(
+        /\bmodule\.my_table\.([a-z_]+)/g,
+      )) {
+        referenced.set(attribute, [...(referenced.get(attribute) ?? []), file]);
+      }
+    }
+
+    expect([...referenced.keys()]).not.toHaveLength(0);
+    expect(
+      [...referenced.entries()]
+        .filter(([attribute]) => !declared.has(attribute))
+        .map(([attribute, files]) => `${attribute} (${files.join(', ')})`),
+    ).toEqual([]);
+  });
+
+  /**
+   * The same invariant for the consumer side of the documented grant: the role
+   * the shared Lambda snippet attaches its policy to must be an output of the
+   * API app modules it is included from, and the agent/MCP server guides grant
+   * access through the agent-core app module's own IAM input.
+   */
+  it('should reference role attributes the consumer modules declare', () => {
+    const snippet = readFileSync(
+      join(DOCS_DIR, 'snippets/connection/lambda-dynamodb-access.mdx'),
+      'utf-8',
+    );
+    const roleAttributes = [
+      ...snippet.matchAll(/^\s*role\s*=\s*module\.my_api\.(\w+)$/gm),
+    ].map(([, attribute]) => attribute);
+
+    expect(roleAttributes).not.toHaveLength(0);
+
+    for (const apiType of ['rest', 'http']) {
+      const template = readFileSync(
+        join(
+          __dirname,
+          '../api-constructs/files/terraform/app/apis',
+          apiType,
+          '__apiNameKebabCase__/__apiNameKebabCase__.tf.template',
+        ),
+        'utf-8',
+      );
+      expect(outputNames(template)).toEqual(
+        expect.arrayContaining(roleAttributes),
+      );
+    }
+
+    const agentCoreTemplate = readFileSync(
+      join(
+        __dirname,
+        '../agent-core-constructs/files/terraform/app/agent-core',
+        '__nameKebabCase__/__nameKebabCase__.tf.template',
+      ),
+      'utf-8',
+    );
+    expect(agentCoreTemplate).toContain(
+      'variable "additional_iam_policy_statements"',
+    );
+    // The agent-core app module exposes no role name, so its guides grant
+    // access through that input rather than an aws_iam_role_policy.
+    for (const guide of [
+      'ts-agent-dynamodb',
+      'py-agent-dynamodb',
+      'ts-mcp-server-dynamodb',
+      'py-mcp-server-dynamodb',
+    ]) {
+      const content = readFileSync(
+        join(DOCS_DIR, 'guides/connection', `${guide}.mdx`),
+        'utf-8',
+      );
+      expect(content).toContain('additional_iam_policy_statements');
+      expect(content).not.toMatch(/role\s*=\s*module\./);
+    }
+  });
+});

--- a/packages/nx-plugin/src/utils/dynamodb-constructs/files/terraform/app/dynamodb/__nameKebabCase__/__nameKebabCase__.tf.template
+++ b/packages/nx-plugin/src/utils/dynamodb-constructs/files/terraform/app/dynamodb/__nameKebabCase__/__nameKebabCase__.tf.template
@@ -96,3 +96,18 @@ module "add_to_runtime_config" {
     tableName = module.dynamodb_table.table_name
   }
 }
+
+output "table_name" {
+  description = "Name of the DynamoDB table"
+  value       = module.dynamodb_table.table_name
+}
+
+output "table_arn" {
+  description = "ARN of the DynamoDB table, for use in IAM policies granting access to the table and (suffixed with /index/*) its global secondary indexes"
+  value       = module.dynamodb_table.table_arn
+}
+
+output "kms_key_arn" {
+  description = "ARN of the KMS key used to encrypt the DynamoDB table, for use in IAM policies granting access to the table. Null when using the AWS owned key (encryption = DEFAULT)."
+  value       = module.dynamodb_table.kms_key_arn
+}

--- a/packages/nx-plugin/src/utils/dynamodb-constructs/files/terraform/app/dynamodb/__nameKebabCase__/__nameKebabCase__.tf.template
+++ b/packages/nx-plugin/src/utils/dynamodb-constructs/files/terraform/app/dynamodb/__nameKebabCase__/__nameKebabCase__.tf.template
@@ -103,7 +103,7 @@ output "table_name" {
 }
 
 output "table_arn" {
-  description = "ARN of the DynamoDB table, for use in IAM policies granting access to the table and (suffixed with /index/*) its global secondary indexes"
+  description = "ARN of the DynamoDB table, for use in IAM policies granting access to the table. Suffix with /index/* to cover its global secondary indexes."
   value       = module.dynamodb_table.table_arn
 }
 


### PR DESCRIPTION
### Reason for this change

Under `iac=terraform`, the generated DynamoDB **app** module (`app/dynamodb/<name>/<name>.tf`) declared **no outputs at all**. The app module is what users instantiate from their root configuration, so there was no way to reference the table from it — while the core module did expose `table_name`, `table_arn` and `kms_key_arn`, none of that was re-exported.

Every documented Terraform DynamoDB connection example therefore could not plan. The examples also referenced `module.<consumer>.lambda_role_name`, which no module exposes. The real outputs are `lambda_execution_role_name` on the API modules and `role_name` on the standalone lambda-function module; agent-core modules expose no role name at all.

CDK has no equivalent problem because the grant is a typed method call (`table.grantReadWriteData(handler)`) rather than hand-written HCL referencing attribute names nobody verified.

### Description of changes

**Terraform app module** — re-export the core module's three values, matching the naming and `description` style of the sibling API and lambda-function app modules:

- `table_name`
- `table_arn`
- `kms_key_arn`

**Docs** (`docs/src/content/docs/en/` only — no translated locales touched):

- `snippets/connection/lambda-dynamodb-access.mdx` — `lambda_role_name` → `lambda_execution_role_name`, the real API module output. This snippet is included by the trpc, smithy and py-fast-api DynamoDB guides, so it fixes all three.
- `guides/connection/{ts,py}-agent-dynamodb.mdx` and `guides/connection/{ts,py}-mcp-server-dynamodb.mdx` — switched from a standalone `aws_iam_role_policy` to granting via the agent-core module's existing `additional_iam_policy_statements` input.

**On the agent module's missing role-name output:** the brief offered a choice between adding a role-name output to the agent-core app module or changing the docs to use an existing attribute. I chose the docs. The agent-core app module already accepts `additional_iam_policy_statements`, and that is *already* the documented way to grant an agent extra IAM permissions everywhere else in the docs (`ts-agent-rdb.mdx`, `ts-agent-gateway.mdx`, `py-agent-gateway.mdx`). Adding a role-name output would introduce a second, competing idiom for the same thing and widen the generated surface for no gain; routing through the existing input keeps the DynamoDB guides consistent with the other agent guides, needs no change to the agent-core module, and is a smaller surface. It also attaches the statements to the role the module itself manages rather than having users bolt a policy onto it from outside.

**Migration** — `latest/dynamodb-terraform-app-module-outputs`. The app module is vended with `KeepExisting`, so without this an upgraded workspace keeps a module with no outputs. Deterministic; anchors on the shape the generator produces, and reports diverged files via `nextSteps` rather than rewriting them.

### Description of how you validated changes

`pnpm nx run @aws/nx-plugin:test` — 3717 tests / 200 files pass. `pnpm nx run-many --target build --all` and `pnpm nx run-many --target lint --all --configuration=fix` both green. The two snapshot updates are exactly the three new output blocks.

New tests in `packages/nx-plugin/src/utils/dynamodb-constructs/dynamodb-constructs.spec.ts`. Beyond asserting the three outputs exist, two of them guard the invariant that actually broke — that the attributes the docs tell users to reference exist on the generated modules. One parses every `module.my_table.<attr>` reference out of the `.mdx` files under `docs/.../en/` and asserts each is a declared output; another checks the snippet's role attribute against the REST and HTTP API app module templates. Plus a full spec for the migration (applies, idempotent, skips-and-reports a diverged module).

**End-to-end `terraform test`.** Generated a real Terraform workspace with a DynamoDB table and a tRPC API using the locally compiled generators, wrote a root `main.tf` containing the **exact HCL from the docs snippet**, and ran `terraform init -backend=false` then `terraform test` with every provider mocked (the pattern from `e2e/src/smoke-tests/terraform-plan-test.ts`).

Before this change — the app module with no outputs and the snippet's original `lambda_role_name`:

```
plan.tftest.hcl... in progress
  run "plan"... fail
Error: Unsupported attribute
  29:   role = module.my_api.lambda_role_name
    ├────────────────
    │ module.my_api is a object
This object does not have an attribute named "lambda_role_name".
Error: Unsupported attribute
  47:           module.my_table.table_arn,
    ├────────────────
    │ module.my_table is a object
This object does not have an attribute named "table_arn".
Error: Unsupported attribute
  48:           "${module.my_table.table_arn}/index/*",
    ├────────────────
    │ module.my_table is a object
This object does not have an attribute named "table_arn".
Error: Unsupported attribute
  60:         Resource = [module.my_table.kms_key_arn]
    ├────────────────
    │ module.my_table is a object
This object does not have an attribute named "kms_key_arn".
plan.tftest.hcl... tearing down
plan.tftest.hcl... fail

Failure! 0 passed, 1 failed.
```

After — same workspace, same wiring, with the outputs added and the corrected role attribute:

```
app module outputs after: 3
plan.tftest.hcl... in progress
  run "plan"... pass
plan.tftest.hcl... tearing down
plan.tftest.hcl... pass

Success! 1 passed, 0 failed.
```

I also verified the agent path, since I changed those guides. Generating an agent (`ts#agent`, agentcore/terraform) and granting table access through `additional_iam_policy_statements` exactly as the guide now reads plans clean:

```
plan.tftest.hcl... in progress
  run "plan"... pass
plan.tftest.hcl... tearing down
plan.tftest.hcl... pass

Success! 1 passed, 0 failed.
```

And reverting only the app module's outputs, with that same agent wiring, reproduces the failure — confirming the outputs are what fix it:

```
Error: Unsupported attribute
  33:         module.my_table.table_arn,
    ├────────────────
    │ module.my_table is a object
This object does not have an attribute named "table_arn".
...
This object does not have an attribute named "kms_key_arn".
```

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
