### PR TITLE
fix(ts#dynamodb,ts#rdb): add Terraform destroy protection to data-bearing resources

### DIFF
--- a/docs/src/content/docs/en/snippets/dynamodb/deploying-table.mdx
+++ b/docs/src/content/docs/en/snippets/dynamodb/deploying-table.mdx
@@ -46,7 +46,7 @@ This provisions a DynamoDB table with:
 - On-demand (`PAY_PER_REQUEST`) billing
 - Customer-managed KMS encryption with automatic key rotation
 - Point-in-time recovery enabled
-- Deletion protection enabled
+- Deletion protection enabled, plus a `prevent_destroy` lifecycle guard
 - Table name registered in Runtime Config under the `dynamodb` namespace in AWS AppConfig
 
 The `core/runtime-config/appconfig` module exposes the `dynamodb` namespace by default, so the table name is deployed without further configuration. If you pass `namespaces` to that module explicitly, keep `dynamodb` in the list — otherwise no configuration profile is created for it and the generated table client cannot resolve the table name.
@@ -55,20 +55,33 @@ The `core/runtime-config/appconfig` module exposes the `dynamodb` namespace by d
 
 ### Deletion Protection
 
-Deletion protection is enabled by default to prevent accidental table deletion.
+The table is protected by two independent guards, so that turning off either one alone cannot delete your data:
 
-#### Disable Deletion Protection
+<Infrastructure>
+<Fragment slot="cdk">
+- `deletionProtection`, enforced by DynamoDB.
+- `RemovalPolicy.RETAIN`, enforced by CloudFormation, which leaves the table in place when it is removed from the stack.
+</Fragment>
+<Fragment slot="terraform">
+- `deletion_protection_enabled`, enforced by DynamoDB.
+- `lifecycle { prevent_destroy = true }` on the table in `common/terraform/src/core/dynamodb/dynamodb.tf`, enforced by Terraform, which fails any plan that would destroy the table.
+</Fragment>
+</Infrastructure>
 
-Disable it for environments where table deletion is expected, such as short-lived development or preview stacks.
+#### Deleting the Table
+
+Disable protection for environments where table deletion is expected, such as short-lived development or preview stacks.
 
 <Infrastructure>
 <Fragment slot="cdk">
 
 ```ts title="packages/infra/src/stacks/application-stack.ts"
+import { RemovalPolicy } from 'aws-cdk-lib';
 import { MyTable } from '@my-scope/common-constructs';
 
 const table = new MyTable(this, 'Table', {
   deletionProtection: false,
+  removalPolicy: RemovalPolicy.DESTROY,
 });
 ```
 </Fragment>
@@ -80,6 +93,22 @@ module "my_table" {
   deletion_protection_enabled = false
 }
 ```
+
+`prevent_destroy` must be a literal — Terraform does not allow it to reference a variable — so it cannot be turned off from `main.tf`. Also remove the `lifecycle` block from the table in `common/terraform/src/core/dynamodb/dynamodb.tf`:
+
+```hcl title="packages/common/terraform/src/core/dynamodb/dynamodb.tf" del={4-6}
+resource "aws_dynamodb_table" "table" {
+  # ...
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+```
+
+:::caution
+This module is shared by every table in your workspace, so removing the block removes that guard for all of them.
+:::
 </Fragment>
 </Infrastructure>
 

--- a/docs/src/content/docs/en/snippets/rdb/deletion-protection.mdx
+++ b/docs/src/content/docs/en/snippets/rdb/deletion-protection.mdx
@@ -3,21 +3,34 @@ title: Deletion Protection
 ---
 import Infrastructure from '@components/infrastructure.astro';
 
-Deletion protection is enabled by default (`deletionProtection: true` in CDK, `deletion_protection = true` in Terraform) to protect the Aurora cluster from accidental deletion.
+The Aurora cluster is protected by two independent guards, so that turning off either one alone cannot delete your data:
 
-#### Disable Deletion Protection
+<Infrastructure>
+<Fragment slot="cdk">
+- `deletionProtection`, enforced by RDS.
+- `RemovalPolicy.RETAIN`, enforced by CloudFormation, which leaves the cluster in place when it is removed from the stack.
+</Fragment>
+<Fragment slot="terraform">
+- `deletion_protection`, enforced by RDS.
+- `lifecycle { prevent_destroy = true }` on the cluster in `common/terraform/src/core/rdb/aurora/aurora.tf`, enforced by Terraform, which fails any plan that would destroy the cluster.
+</Fragment>
+</Infrastructure>
 
-You can disable deletion protection for environments where database deletion is expected, such as short-lived development or preview stacks.
+#### Deleting the Database
+
+You can disable protection for environments where database deletion is expected, such as short-lived development or preview stacks.
 
 <Infrastructure>
 <Fragment slot="cdk">
 
 ```ts title="packages/infra/src/stacks/application-stack.ts"
+import { RemovalPolicy } from 'aws-cdk-lib';
 import { MyDatabase } from '@my-scope/common-constructs';
 
 const db = new MyDatabase(this, 'Db', {
   ...
   deletionProtection: false,
+  removalPolicy: RemovalPolicy.DESTROY,
 });
 ```
 </Fragment>
@@ -28,7 +41,24 @@ module "my_database" {
   source = "../../common/terraform/src/app/dbs/my-database"
   ...
   deletion_protection = false
+  skip_final_snapshot = true
 }
 ```
+
+`prevent_destroy` must be a literal — Terraform does not allow it to reference a variable — so it cannot be turned off from `main.tf`. Also remove the `lifecycle` block from the cluster in `common/terraform/src/core/rdb/aurora/aurora.tf`:
+
+```hcl title="packages/common/terraform/src/core/rdb/aurora/aurora.tf" del={4-6}
+resource "aws_rds_cluster" "database" {
+  # ...
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+```
+
+:::caution
+This module is shared by every database in your workspace, so removing the block removes that guard for all of them.
+:::
 </Fragment>
 </Infrastructure>

--- a/docs/src/content/docs/es/snippets/dynamodb/deploying-table.mdx
+++ b/docs/src/content/docs/es/snippets/dynamodb/deploying-table.mdx
@@ -46,7 +46,7 @@ Esto aprovisiona una tabla de DynamoDB con:
 - Facturación bajo demanda (`PAY_PER_REQUEST`)
 - Cifrado KMS gestionado por el cliente con rotación automática de claves
 - Recuperación a un punto en el tiempo habilitada
-- Protección contra eliminación habilitada
+- Protección contra eliminación habilitada, más una protección de ciclo de vida `prevent_destroy`
 - Nombre de tabla registrado en Runtime Config bajo el espacio de nombres `dynamodb` en AWS AppConfig
 
 El módulo `core/runtime-config/appconfig` expone el espacio de nombres `dynamodb` por defecto, por lo que el nombre de la tabla se despliega sin configuración adicional. Si pasas `namespaces` a ese módulo explícitamente, mantén `dynamodb` en la lista; de lo contrario, no se crea ningún perfil de configuración para él y el cliente de tabla generado no puede resolver el nombre de la tabla.
@@ -55,20 +55,33 @@ El módulo `core/runtime-config/appconfig` expone el espacio de nombres `dynamod
 
 ### Protección contra eliminación
 
-La protección contra eliminación está habilitada por defecto para prevenir la eliminación accidental de la tabla.
+La tabla está protegida por dos protecciones independientes, de modo que desactivar cualquiera de ellas por sí sola no puede eliminar tus datos:
 
-#### Deshabilitar la protección contra eliminación
+<Infrastructure>
+<Fragment slot="cdk">
+- `deletionProtection`, aplicada por DynamoDB.
+- `RemovalPolicy.RETAIN`, aplicada por CloudFormation, que deja la tabla en su lugar cuando se elimina del stack.
+</Fragment>
+<Fragment slot="terraform">
+- `deletion_protection_enabled`, aplicada por DynamoDB.
+- `lifecycle { prevent_destroy = true }` en la tabla en `common/terraform/src/core/dynamodb/dynamodb.tf`, aplicada por Terraform, que falla cualquier plan que destruiría la tabla.
+</Fragment>
+</Infrastructure>
 
-Deshabilítala para entornos donde se espera la eliminación de tablas, como stacks de desarrollo o vista previa de corta duración.
+#### Eliminando la tabla
+
+Deshabilita la protección para entornos donde se espera la eliminación de tablas, como stacks de desarrollo o vista previa de corta duración.
 
 <Infrastructure>
 <Fragment slot="cdk">
 
 ```ts title="packages/infra/src/stacks/application-stack.ts"
+import { RemovalPolicy } from 'aws-cdk-lib';
 import { MyTable } from '@my-scope/common-constructs';
 
 const table = new MyTable(this, 'Table', {
   deletionProtection: false,
+  removalPolicy: RemovalPolicy.DESTROY,
 });
 ```
 </Fragment>
@@ -80,6 +93,22 @@ module "my_table" {
   deletion_protection_enabled = false
 }
 ```
+
+`prevent_destroy` debe ser un literal — Terraform no permite que haga referencia a una variable — por lo que no se puede desactivar desde `main.tf`. También elimina el bloque `lifecycle` de la tabla en `common/terraform/src/core/dynamodb/dynamodb.tf`:
+
+```hcl title="packages/common/terraform/src/core/dynamodb/dynamodb.tf" del={4-6}
+resource "aws_dynamodb_table" "table" {
+  # ...
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+```
+
+:::caution
+Este módulo es compartido por todas las tablas en tu espacio de trabajo, por lo que eliminar el bloque elimina esa protección para todas ellas.
+:::
 </Fragment>
 </Infrastructure>
 

--- a/docs/src/content/docs/es/snippets/rdb/deletion-protection.mdx
+++ b/docs/src/content/docs/es/snippets/rdb/deletion-protection.mdx
@@ -3,21 +3,34 @@ title: Protección contra Eliminación
 ---
 import Infrastructure from '@components/infrastructure.astro';
 
-La protección contra eliminación está habilitada por defecto (`deletionProtection: true` en CDK, `deletion_protection = true` en Terraform) para proteger el clúster Aurora de eliminaciones accidentales.
+El clúster Aurora está protegido por dos guardias independientes, de modo que desactivar cualquiera de ellos por sí solo no puede eliminar sus datos:
 
-#### Deshabilitar la Protección contra Eliminación
+<Infrastructure>
+<Fragment slot="cdk">
+- `deletionProtection`, aplicado por RDS.
+- `RemovalPolicy.RETAIN`, aplicado por CloudFormation, que deja el clúster en su lugar cuando se elimina del stack.
+</Fragment>
+<Fragment slot="terraform">
+- `deletion_protection`, aplicado por RDS.
+- `lifecycle { prevent_destroy = true }` en el clúster en `common/terraform/src/core/rdb/aurora/aurora.tf`, aplicado por Terraform, que falla cualquier plan que destruiría el clúster.
+</Fragment>
+</Infrastructure>
 
-Puede deshabilitar la protección contra eliminación para entornos donde se espera la eliminación de la base de datos, como stacks de desarrollo o vista previa de corta duración.
+#### Eliminar la Base de Datos
+
+Puede deshabilitar la protección para entornos donde se espera la eliminación de la base de datos, como stacks de desarrollo o vista previa de corta duración.
 
 <Infrastructure>
 <Fragment slot="cdk">
 
 ```ts title="packages/infra/src/stacks/application-stack.ts"
+import { RemovalPolicy } from 'aws-cdk-lib';
 import { MyDatabase } from '@my-scope/common-constructs';
 
 const db = new MyDatabase(this, 'Db', {
   ...
   deletionProtection: false,
+  removalPolicy: RemovalPolicy.DESTROY,
 });
 ```
 </Fragment>
@@ -28,7 +41,24 @@ module "my_database" {
   source = "../../common/terraform/src/app/dbs/my-database"
   ...
   deletion_protection = false
+  skip_final_snapshot = true
 }
 ```
+
+`prevent_destroy` debe ser un literal — Terraform no permite que haga referencia a una variable — por lo que no se puede desactivar desde `main.tf`. También elimine el bloque `lifecycle` del clúster en `common/terraform/src/core/rdb/aurora/aurora.tf`:
+
+```hcl title="packages/common/terraform/src/core/rdb/aurora/aurora.tf" del={4-6}
+resource "aws_rds_cluster" "database" {
+  # ...
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+```
+
+:::caution
+Este módulo es compartido por todas las bases de datos en su workspace, por lo que eliminar el bloque elimina esa guardia para todas ellas.
+:::
 </Fragment>
 </Infrastructure>

--- a/docs/src/content/docs/fr/snippets/dynamodb/deploying-table.mdx
+++ b/docs/src/content/docs/fr/snippets/dynamodb/deploying-table.mdx
@@ -46,7 +46,7 @@ Cela provisionne une table DynamoDB avec :
 - Une facturation à la demande (`PAY_PER_REQUEST`)
 - Un chiffrement KMS géré par le client avec rotation automatique des clés
 - La récupération à un instant dans le passé activée
-- La protection contre la suppression activée
+- La protection contre la suppression activée, plus une garde de cycle de vie `prevent_destroy`
 - Le nom de la table enregistré dans Runtime Config sous l'espace de noms `dynamodb` dans AWS AppConfig
 
 Le module `core/runtime-config/appconfig` expose l'espace de noms `dynamodb` par défaut, de sorte que le nom de la table est déployé sans configuration supplémentaire. Si vous passez explicitement `namespaces` à ce module, conservez `dynamodb` dans la liste — sinon aucun profil de configuration n'est créé pour celui-ci et le client de table généré ne peut pas résoudre le nom de la table.
@@ -55,20 +55,33 @@ Le module `core/runtime-config/appconfig` expose l'espace de noms `dynamodb` par
 
 ### Protection contre la suppression
 
-La protection contre la suppression est activée par défaut pour éviter la suppression accidentelle de la table.
+La table est protégée par deux gardes indépendantes, de sorte que la désactivation de l'une seule ne peut pas supprimer vos données :
 
-#### Désactiver la protection contre la suppression
+<Infrastructure>
+<Fragment slot="cdk">
+- `deletionProtection`, appliquée par DynamoDB.
+- `RemovalPolicy.RETAIN`, appliquée par CloudFormation, qui laisse la table en place lorsqu'elle est retirée de la stack.
+</Fragment>
+<Fragment slot="terraform">
+- `deletion_protection_enabled`, appliquée par DynamoDB.
+- `lifecycle { prevent_destroy = true }` sur la table dans `common/terraform/src/core/dynamodb/dynamodb.tf`, appliquée par Terraform, qui fait échouer tout plan qui détruirait la table.
+</Fragment>
+</Infrastructure>
 
-Désactivez-la pour les environnements où la suppression de table est attendue, comme les stacks de développement ou de prévisualisation éphémères.
+#### Supprimer la table
+
+Désactivez la protection pour les environnements où la suppression de table est attendue, comme les stacks de développement ou de prévisualisation éphémères.
 
 <Infrastructure>
 <Fragment slot="cdk">
 
 ```ts title="packages/infra/src/stacks/application-stack.ts"
+import { RemovalPolicy } from 'aws-cdk-lib';
 import { MyTable } from '@my-scope/common-constructs';
 
 const table = new MyTable(this, 'Table', {
   deletionProtection: false,
+  removalPolicy: RemovalPolicy.DESTROY,
 });
 ```
 </Fragment>
@@ -80,6 +93,22 @@ module "my_table" {
   deletion_protection_enabled = false
 }
 ```
+
+`prevent_destroy` doit être un littéral — Terraform ne permet pas de référencer une variable — il ne peut donc pas être désactivé depuis `main.tf`. Supprimez également le bloc `lifecycle` de la table dans `common/terraform/src/core/dynamodb/dynamodb.tf` :
+
+```hcl title="packages/common/terraform/src/core/dynamodb/dynamodb.tf" del={4-6}
+resource "aws_dynamodb_table" "table" {
+  # ...
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+```
+
+:::caution
+Ce module est partagé par toutes les tables de votre workspace, donc supprimer le bloc supprime cette garde pour toutes.
+:::
 </Fragment>
 </Infrastructure>
 
@@ -145,4 +174,3 @@ module "my_table" {
 La table est chiffrée avec une clé KMS gérée par le client par défaut, créée automatiquement pour vous. Passez à une clé gérée par AWS, à la clé détenue par AWS, ou apportez votre propre clé KMS, si vous gérez le chiffrement différemment.
 
 <Snippet name="dynamodb/encryption-options" parentHeading="Chiffrement" />
-

--- a/docs/src/content/docs/fr/snippets/rdb/deletion-protection.mdx
+++ b/docs/src/content/docs/fr/snippets/rdb/deletion-protection.mdx
@@ -3,21 +3,34 @@ title: Protection contre la suppression
 ---
 import Infrastructure from '@components/infrastructure.astro';
 
-La protection contre la suppression est activée par défaut (`deletionProtection: true` dans CDK, `deletion_protection = true` dans Terraform) pour protéger le cluster Aurora contre toute suppression accidentelle.
+Le cluster Aurora est protégé par deux garde-fous indépendants, de sorte que la désactivation de l'un seul ne peut pas supprimer vos données :
 
-#### Désactiver la protection contre la suppression
+<Infrastructure>
+<Fragment slot="cdk">
+- `deletionProtection`, appliqué par RDS.
+- `RemovalPolicy.RETAIN`, appliqué par CloudFormation, qui laisse le cluster en place lorsqu'il est retiré de la stack.
+</Fragment>
+<Fragment slot="terraform">
+- `deletion_protection`, appliqué par RDS.
+- `lifecycle { prevent_destroy = true }` sur le cluster dans `common/terraform/src/core/rdb/aurora/aurora.tf`, appliqué par Terraform, qui fait échouer tout plan qui détruirait le cluster.
+</Fragment>
+</Infrastructure>
 
-Vous pouvez désactiver la protection contre la suppression pour les environnements où la suppression de la base de données est attendue, comme les stacks de développement ou de prévisualisation éphémères.
+#### Suppression de la base de données
+
+Vous pouvez désactiver la protection pour les environnements où la suppression de la base de données est attendue, comme les stacks de développement ou de prévisualisation éphémères.
 
 <Infrastructure>
 <Fragment slot="cdk">
 
 ```ts title="packages/infra/src/stacks/application-stack.ts"
+import { RemovalPolicy } from 'aws-cdk-lib';
 import { MyDatabase } from '@my-scope/common-constructs';
 
 const db = new MyDatabase(this, 'Db', {
   ...
   deletionProtection: false,
+  removalPolicy: RemovalPolicy.DESTROY,
 });
 ```
 </Fragment>
@@ -28,7 +41,24 @@ module "my_database" {
   source = "../../common/terraform/src/app/dbs/my-database"
   ...
   deletion_protection = false
+  skip_final_snapshot = true
 }
 ```
+
+`prevent_destroy` doit être un littéral — Terraform ne permet pas de référencer une variable — il ne peut donc pas être désactivé depuis `main.tf`. Supprimez également le bloc `lifecycle` du cluster dans `common/terraform/src/core/rdb/aurora/aurora.tf` :
+
+```hcl title="packages/common/terraform/src/core/rdb/aurora/aurora.tf" del={4-6}
+resource "aws_rds_cluster" "database" {
+  # ...
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+```
+
+:::caution
+Ce module est partagé par toutes les bases de données de votre workspace, donc supprimer le bloc supprime ce garde-fou pour toutes.
+:::
 </Fragment>
 </Infrastructure>

--- a/docs/src/content/docs/it/snippets/dynamodb/deploying-table.mdx
+++ b/docs/src/content/docs/it/snippets/dynamodb/deploying-table.mdx
@@ -46,7 +46,7 @@ Questo esegue il provisioning di una tabella DynamoDB con:
 - Fatturazione on-demand (`PAY_PER_REQUEST`)
 - Crittografia KMS gestita dal cliente con rotazione automatica delle chiavi
 - Point-in-time recovery abilitato
-- Protezione dall'eliminazione abilitata
+- Protezione dall'eliminazione abilitata, più una protezione del ciclo di vita `prevent_destroy`
 - Nome della tabella registrato in Runtime Config nello spazio dei nomi `dynamodb` in AWS AppConfig
 
 Il modulo `core/runtime-config/appconfig` espone lo spazio dei nomi `dynamodb` per impostazione predefinita, quindi il nome della tabella viene distribuito senza ulteriori configurazioni. Se passi `namespaces` a quel modulo esplicitamente, mantieni `dynamodb` nell'elenco — altrimenti non viene creato alcun profilo di configurazione per esso e il client della tabella generato non può risolvere il nome della tabella.
@@ -55,20 +55,33 @@ Il modulo `core/runtime-config/appconfig` espone lo spazio dei nomi `dynamodb` p
 
 ### Protezione dall'eliminazione
 
-La protezione dall'eliminazione è abilitata per impostazione predefinita per prevenire l'eliminazione accidentale della tabella.
+La tabella è protetta da due protezioni indipendenti, in modo che disattivarne una sola non possa eliminare i tuoi dati:
 
-#### Disabilitare la protezione dall'eliminazione
+<Infrastructure>
+<Fragment slot="cdk">
+- `deletionProtection`, applicata da DynamoDB.
+- `RemovalPolicy.RETAIN`, applicata da CloudFormation, che lascia la tabella al suo posto quando viene rimossa dallo stack.
+</Fragment>
+<Fragment slot="terraform">
+- `deletion_protection_enabled`, applicata da DynamoDB.
+- `lifecycle { prevent_destroy = true }` sulla tabella in `common/terraform/src/core/dynamodb/dynamodb.tf`, applicata da Terraform, che fa fallire qualsiasi piano che distruggerebbe la tabella.
+</Fragment>
+</Infrastructure>
 
-Disabilitala per ambienti in cui è prevista l'eliminazione della tabella, come stack di sviluppo o di anteprima di breve durata.
+#### Eliminazione della tabella
+
+Disabilita la protezione per ambienti in cui è prevista l'eliminazione della tabella, come stack di sviluppo o di anteprima di breve durata.
 
 <Infrastructure>
 <Fragment slot="cdk">
 
 ```ts title="packages/infra/src/stacks/application-stack.ts"
+import { RemovalPolicy } from 'aws-cdk-lib';
 import { MyTable } from '@my-scope/common-constructs';
 
 const table = new MyTable(this, 'Table', {
   deletionProtection: false,
+  removalPolicy: RemovalPolicy.DESTROY,
 });
 ```
 </Fragment>
@@ -80,6 +93,22 @@ module "my_table" {
   deletion_protection_enabled = false
 }
 ```
+
+`prevent_destroy` deve essere un letterale — Terraform non consente di fare riferimento a una variabile — quindi non può essere disattivato da `main.tf`. Rimuovi anche il blocco `lifecycle` dalla tabella in `common/terraform/src/core/dynamodb/dynamodb.tf`:
+
+```hcl title="packages/common/terraform/src/core/dynamodb/dynamodb.tf" del={4-6}
+resource "aws_dynamodb_table" "table" {
+  # ...
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+```
+
+:::caution
+Questo modulo è condiviso da ogni tabella nel tuo workspace, quindi rimuovere il blocco rimuove quella protezione per tutte.
+:::
 </Fragment>
 </Infrastructure>
 

--- a/docs/src/content/docs/it/snippets/rdb/deletion-protection.mdx
+++ b/docs/src/content/docs/it/snippets/rdb/deletion-protection.mdx
@@ -3,21 +3,34 @@ title: Protezione dalla Cancellazione
 ---
 import Infrastructure from '@components/infrastructure.astro';
 
-La protezione dalla cancellazione è abilitata per impostazione predefinita (`deletionProtection: true` in CDK, `deletion_protection = true` in Terraform) per proteggere il cluster Aurora dalla cancellazione accidentale.
+Il cluster Aurora è protetto da due protezioni indipendenti, in modo che disattivarne una sola non possa eliminare i tuoi dati:
 
-#### Disabilitare la Protezione dalla Cancellazione
+<Infrastructure>
+<Fragment slot="cdk">
+- `deletionProtection`, applicata da RDS.
+- `RemovalPolicy.RETAIN`, applicata da CloudFormation, che lascia il cluster al suo posto quando viene rimosso dallo stack.
+</Fragment>
+<Fragment slot="terraform">
+- `deletion_protection`, applicata da RDS.
+- `lifecycle { prevent_destroy = true }` sul cluster in `common/terraform/src/core/rdb/aurora/aurora.tf`, applicata da Terraform, che fa fallire qualsiasi piano che distruggerebbe il cluster.
+</Fragment>
+</Infrastructure>
 
-È possibile disabilitare la protezione dalla cancellazione per ambienti in cui la cancellazione del database è prevista, come stack di sviluppo o di anteprima di breve durata.
+#### Eliminare il Database
+
+È possibile disabilitare la protezione per ambienti in cui la cancellazione del database è prevista, come stack di sviluppo o di anteprima di breve durata.
 
 <Infrastructure>
 <Fragment slot="cdk">
 
 ```ts title="packages/infra/src/stacks/application-stack.ts"
+import { RemovalPolicy } from 'aws-cdk-lib';
 import { MyDatabase } from '@my-scope/common-constructs';
 
 const db = new MyDatabase(this, 'Db', {
   ...
   deletionProtection: false,
+  removalPolicy: RemovalPolicy.DESTROY,
 });
 ```
 </Fragment>
@@ -28,7 +41,24 @@ module "my_database" {
   source = "../../common/terraform/src/app/dbs/my-database"
   ...
   deletion_protection = false
+  skip_final_snapshot = true
 }
 ```
+
+`prevent_destroy` deve essere un letterale — Terraform non consente di fare riferimento a una variabile — quindi non può essere disattivato da `main.tf`. Rimuovi anche il blocco `lifecycle` dal cluster in `common/terraform/src/core/rdb/aurora/aurora.tf`:
+
+```hcl title="packages/common/terraform/src/core/rdb/aurora/aurora.tf" del={4-6}
+resource "aws_rds_cluster" "database" {
+  # ...
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+```
+
+:::caution
+Questo modulo è condiviso da ogni database nel tuo workspace, quindi rimuovere il blocco rimuove quella protezione per tutti.
+:::
 </Fragment>
 </Infrastructure>

--- a/docs/src/content/docs/jp/snippets/dynamodb/deploying-table.mdx
+++ b/docs/src/content/docs/jp/snippets/dynamodb/deploying-table.mdx
@@ -46,7 +46,7 @@ module "my_table" {
 - オンデマンド（`PAY_PER_REQUEST`）課金
 - 自動キーローテーション付きのカスタマー管理 KMS 暗号化
 - ポイントインタイムリカバリが有効
-- 削除保護が有効
+- 削除保護が有効、さらに `prevent_destroy` ライフサイクルガード
 - AWS AppConfig の `dynamodb` 名前空間下の Runtime Config にテーブル名が登録される
 
 `core/runtime-config/appconfig` モジュールはデフォルトで `dynamodb` 名前空間を公開するため、テーブル名は追加の設定なしでデプロイされます。そのモジュールに明示的に `namespaces` を渡す場合は、リストに `dynamodb` を含めてください。そうしないと、設定プロファイルが作成されず、生成されたテーブルクライアントがテーブル名を解決できなくなります。
@@ -55,20 +55,33 @@ module "my_table" {
 
 ### 削除保護
 
-削除保護はデフォルトで有効になっており、誤ってテーブルを削除することを防ぎます。
+テーブルは 2 つの独立したガードによって保護されているため、どちらか一方だけをオフにしてもデータを削除することはできません：
 
-#### 削除保護を無効にする
+<Infrastructure>
+<Fragment slot="cdk">
+- `deletionProtection`、DynamoDB によって強制されます。
+- `RemovalPolicy.RETAIN`、CloudFormation によって強制され、スタックから削除されてもテーブルをそのまま残します。
+</Fragment>
+<Fragment slot="terraform">
+- `deletion_protection_enabled`、DynamoDB によって強制されます。
+- `common/terraform/src/core/dynamodb/dynamodb.tf` のテーブルに対する `lifecycle { prevent_destroy = true }`、Terraform によって強制され、テーブルを破棄するプランは失敗します。
+</Fragment>
+</Infrastructure>
 
-短期間の開発環境やプレビュースタックなど、テーブルの削除が想定される環境では無効にします。
+#### テーブルの削除
+
+短期間の開発環境やプレビュースタックなど、テーブルの削除が想定される環境では保護を無効にします。
 
 <Infrastructure>
 <Fragment slot="cdk">
 
 ```ts title="packages/infra/src/stacks/application-stack.ts"
+import { RemovalPolicy } from 'aws-cdk-lib';
 import { MyTable } from '@my-scope/common-constructs';
 
 const table = new MyTable(this, 'Table', {
   deletionProtection: false,
+  removalPolicy: RemovalPolicy.DESTROY,
 });
 ```
 </Fragment>
@@ -80,6 +93,22 @@ module "my_table" {
   deletion_protection_enabled = false
 }
 ```
+
+`prevent_destroy` はリテラルでなければなりません — Terraform は変数を参照することを許可していません — そのため、`main.tf` からオフにすることはできません。また、`common/terraform/src/core/dynamodb/dynamodb.tf` のテーブルから `lifecycle` ブロックを削除してください：
+
+```hcl title="packages/common/terraform/src/core/dynamodb/dynamodb.tf" del={4-6}
+resource "aws_dynamodb_table" "table" {
+  # ...
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+```
+
+:::caution
+このモジュールはワークスペース内のすべてのテーブルで共有されているため、ブロックを削除するとすべてのテーブルのガードが削除されます。
+:::
 </Fragment>
 </Infrastructure>
 

--- a/docs/src/content/docs/jp/snippets/rdb/deletion-protection.mdx
+++ b/docs/src/content/docs/jp/snippets/rdb/deletion-protection.mdx
@@ -3,21 +3,34 @@ title: 削除保護
 ---
 import Infrastructure from '@components/infrastructure.astro';
 
-削除保護はデフォルトで有効になっており（CDKでは`deletionProtection: true`、Terraformでは`deletion_protection = true`）、Auroraクラスターを誤って削除することから保護します。
+Auroraクラスターは2つの独立したガードによって保護されているため、どちらか一方をオフにしただけではデータを削除できません：
 
-#### 削除保護を無効にする
+<Infrastructure>
+<Fragment slot="cdk">
+- `deletionProtection`、RDSによって強制されます。
+- `RemovalPolicy.RETAIN`、CloudFormationによって強制され、スタックから削除されてもクラスターをそのまま残します。
+</Fragment>
+<Fragment slot="terraform">
+- `deletion_protection`、RDSによって強制されます。
+- `common/terraform/src/core/rdb/aurora/aurora.tf`のクラスターに対する`lifecycle { prevent_destroy = true }`、Terraformによって強制され、クラスターを破棄するプランを失敗させます。
+</Fragment>
+</Infrastructure>
 
-短期間の開発環境やプレビュースタックなど、データベースの削除が想定される環境では、削除保護を無効にすることができます。
+#### データベースの削除
+
+短期間の開発環境やプレビュースタックなど、データベースの削除が想定される環境では、保護を無効にすることができます。
 
 <Infrastructure>
 <Fragment slot="cdk">
 
 ```ts title="packages/infra/src/stacks/application-stack.ts"
+import { RemovalPolicy } from 'aws-cdk-lib';
 import { MyDatabase } from '@my-scope/common-constructs';
 
 const db = new MyDatabase(this, 'Db', {
   ...
   deletionProtection: false,
+  removalPolicy: RemovalPolicy.DESTROY,
 });
 ```
 </Fragment>
@@ -28,7 +41,24 @@ module "my_database" {
   source = "../../common/terraform/src/app/dbs/my-database"
   ...
   deletion_protection = false
+  skip_final_snapshot = true
 }
 ```
+
+`prevent_destroy`はリテラルでなければなりません — Terraformは変数を参照することを許可していません — そのため、`main.tf`からオフにすることはできません。また、`common/terraform/src/core/rdb/aurora/aurora.tf`のクラスターから`lifecycle`ブロックを削除してください：
+
+```hcl title="packages/common/terraform/src/core/rdb/aurora/aurora.tf" del={4-6}
+resource "aws_rds_cluster" "database" {
+  # ...
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+```
+
+:::caution
+このモジュールはワークスペース内のすべてのデータベースで共有されているため、ブロックを削除するとすべてのデータベースからそのガードが削除されます。
+:::
 </Fragment>
 </Infrastructure>

--- a/docs/src/content/docs/ko/snippets/dynamodb/deploying-table.mdx
+++ b/docs/src/content/docs/ko/snippets/dynamodb/deploying-table.mdx
@@ -46,7 +46,7 @@ module "my_table" {
 - 온디맨드 (`PAY_PER_REQUEST`) 과금
 - 자동 키 로테이션이 활성화된 고객 관리형 KMS 암호화
 - 특정 시점 복구 활성화
-- 삭제 보호 활성화
+- 삭제 보호 활성화 및 `prevent_destroy` 라이프사이클 가드
 - AWS AppConfig의 `dynamodb` 네임스페이스 아래 Runtime Config에 등록된 테이블 이름
 
 `core/runtime-config/appconfig` 모듈은 기본적으로 `dynamodb` 네임스페이스를 노출하므로, 추가 구성 없이 테이블 이름이 배포됩니다. 해당 모듈에 `namespaces`를 명시적으로 전달하는 경우, 목록에 `dynamodb`를 유지하세요. 그렇지 않으면 구성 프로필이 생성되지 않아 생성된 테이블 클라이언트가 테이블 이름을 확인할 수 없습니다.
@@ -55,20 +55,33 @@ module "my_table" {
 
 ### 삭제 보호
 
-실수로 테이블이 삭제되는 것을 방지하기 위해 삭제 보호가 기본적으로 활성화되어 있습니다.
+테이블은 두 개의 독립적인 가드로 보호되므로, 둘 중 하나만 끄는 것으로는 데이터를 삭제할 수 없습니다:
 
-#### 삭제 보호 비활성화
+<Infrastructure>
+<Fragment slot="cdk">
+- `deletionProtection`, DynamoDB에 의해 적용됩니다.
+- `RemovalPolicy.RETAIN`, CloudFormation에 의해 적용되며, 스택에서 제거될 때 테이블을 그대로 유지합니다.
+</Fragment>
+<Fragment slot="terraform">
+- `deletion_protection_enabled`, DynamoDB에 의해 적용됩니다.
+- `common/terraform/src/core/dynamodb/dynamodb.tf`의 테이블에 있는 `lifecycle { prevent_destroy = true }`, Terraform에 의해 적용되며, 테이블을 삭제하려는 모든 플랜을 실패시킵니다.
+</Fragment>
+</Infrastructure>
 
-단기 개발 또는 프리뷰 스택과 같이 테이블 삭제가 예상되는 환경에서는 비활성화하세요.
+#### 테이블 삭제하기
+
+단기 개발 또는 프리뷰 스택과 같이 테이블 삭제가 예상되는 환경에서는 보호를 비활성화하세요.
 
 <Infrastructure>
 <Fragment slot="cdk">
 
 ```ts title="packages/infra/src/stacks/application-stack.ts"
+import { RemovalPolicy } from 'aws-cdk-lib';
 import { MyTable } from '@my-scope/common-constructs';
 
 const table = new MyTable(this, 'Table', {
   deletionProtection: false,
+  removalPolicy: RemovalPolicy.DESTROY,
 });
 ```
 </Fragment>
@@ -80,6 +93,22 @@ module "my_table" {
   deletion_protection_enabled = false
 }
 ```
+
+`prevent_destroy`는 리터럴이어야 합니다 — Terraform은 변수를 참조하는 것을 허용하지 않습니다 — 따라서 `main.tf`에서 끌 수 없습니다. 또한 `common/terraform/src/core/dynamodb/dynamodb.tf`의 테이블에서 `lifecycle` 블록을 제거하세요:
+
+```hcl title="packages/common/terraform/src/core/dynamodb/dynamodb.tf" del={4-6}
+resource "aws_dynamodb_table" "table" {
+  # ...
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+```
+
+:::caution
+이 모듈은 워크스페이스의 모든 테이블에서 공유되므로, 블록을 제거하면 모든 테이블에 대한 가드가 제거됩니다.
+:::
 </Fragment>
 </Infrastructure>
 
@@ -145,4 +174,3 @@ module "my_table" {
 테이블은 기본적으로 고객 관리형 KMS 키로 암호화되며, 자동으로 생성됩니다. 암호화를 다르게 관리하는 경우 AWS 관리형 키, AWS 소유 키로 전환하거나 자체 KMS 키를 가져올 수 있습니다.
 
 <Snippet name="dynamodb/encryption-options" parentHeading="암호화" />
-

--- a/docs/src/content/docs/ko/snippets/rdb/deletion-protection.mdx
+++ b/docs/src/content/docs/ko/snippets/rdb/deletion-protection.mdx
@@ -3,21 +3,34 @@ title: 삭제 보호
 ---
 import Infrastructure from '@components/infrastructure.astro';
 
-삭제 보호는 기본적으로 활성화되어 있으며(CDK에서 `deletionProtection: true`, Terraform에서 `deletion_protection = true`) Aurora 클러스터를 실수로 삭제하는 것을 방지합니다.
+Aurora 클러스터는 두 개의 독립적인 보호 장치로 보호되므로, 둘 중 하나만 끄는 것으로는 데이터를 삭제할 수 없습니다:
 
-#### 삭제 보호 비활성화
+<Infrastructure>
+<Fragment slot="cdk">
+- `deletionProtection`, RDS에 의해 적용됩니다.
+- `RemovalPolicy.RETAIN`, CloudFormation에 의해 적용되며, 스택에서 제거될 때 클러스터를 그대로 유지합니다.
+</Fragment>
+<Fragment slot="terraform">
+- `deletion_protection`, RDS에 의해 적용됩니다.
+- `common/terraform/src/core/rdb/aurora/aurora.tf`의 클러스터에 있는 `lifecycle { prevent_destroy = true }`, Terraform에 의해 적용되며, 클러스터를 삭제하려는 모든 계획을 실패시킵니다.
+</Fragment>
+</Infrastructure>
 
-단기 개발 또는 프리뷰 스택과 같이 데이터베이스 삭제가 예상되는 환경에서는 삭제 보호를 비활성화할 수 있습니다.
+#### 데이터베이스 삭제
+
+단기 개발 또는 프리뷰 스택과 같이 데이터베이스 삭제가 예상되는 환경에서는 보호를 비활성화할 수 있습니다.
 
 <Infrastructure>
 <Fragment slot="cdk">
 
 ```ts title="packages/infra/src/stacks/application-stack.ts"
+import { RemovalPolicy } from 'aws-cdk-lib';
 import { MyDatabase } from '@my-scope/common-constructs';
 
 const db = new MyDatabase(this, 'Db', {
   ...
   deletionProtection: false,
+  removalPolicy: RemovalPolicy.DESTROY,
 });
 ```
 </Fragment>
@@ -28,7 +41,24 @@ module "my_database" {
   source = "../../common/terraform/src/app/dbs/my-database"
   ...
   deletion_protection = false
+  skip_final_snapshot = true
 }
 ```
+
+`prevent_destroy`는 리터럴이어야 합니다 — Terraform은 변수를 참조하는 것을 허용하지 않습니다 — 따라서 `main.tf`에서 끌 수 없습니다. 또한 `common/terraform/src/core/rdb/aurora/aurora.tf`의 클러스터에서 `lifecycle` 블록을 제거하세요:
+
+```hcl title="packages/common/terraform/src/core/rdb/aurora/aurora.tf" del={4-6}
+resource "aws_rds_cluster" "database" {
+  # ...
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+```
+
+:::caution
+이 모듈은 워크스페이스의 모든 데이터베이스에서 공유되므로, 블록을 제거하면 모든 데이터베이스에 대한 보호 장치가 제거됩니다.
+:::
 </Fragment>
 </Infrastructure>

--- a/docs/src/content/docs/pt/snippets/dynamodb/deploying-table.mdx
+++ b/docs/src/content/docs/pt/snippets/dynamodb/deploying-table.mdx
@@ -46,7 +46,7 @@ Isso provisiona uma tabela DynamoDB com:
 - Cobrança sob demanda (`PAY_PER_REQUEST`)
 - Criptografia KMS gerenciada pelo cliente com rotação automática de chave
 - Recuperação point-in-time habilitada
-- Proteção contra exclusão habilitada
+- Proteção contra exclusão habilitada, além de uma proteção de ciclo de vida `prevent_destroy`
 - Nome da tabela registrado no Runtime Config sob o namespace `dynamodb` no AWS AppConfig
 
 O módulo `core/runtime-config/appconfig` expõe o namespace `dynamodb` por padrão, então o nome da tabela é implantado sem configuração adicional. Se você passar `namespaces` para esse módulo explicitamente, mantenha `dynamodb` na lista — caso contrário, nenhum perfil de configuração é criado para ele e o cliente de tabela gerado não consegue resolver o nome da tabela.
@@ -55,20 +55,33 @@ O módulo `core/runtime-config/appconfig` expõe o namespace `dynamodb` por padr
 
 ### Proteção contra Exclusão
 
-A proteção contra exclusão está habilitada por padrão para prevenir a exclusão acidental da tabela.
+A tabela é protegida por duas proteções independentes, de modo que desativar apenas uma delas não pode excluir seus dados:
 
-#### Desabilitar Proteção contra Exclusão
+<Infrastructure>
+<Fragment slot="cdk">
+- `deletionProtection`, aplicada pelo DynamoDB.
+- `RemovalPolicy.RETAIN`, aplicada pelo CloudFormation, que deixa a tabela no lugar quando ela é removida da stack.
+</Fragment>
+<Fragment slot="terraform">
+- `deletion_protection_enabled`, aplicada pelo DynamoDB.
+- `lifecycle { prevent_destroy = true }` na tabela em `common/terraform/src/core/dynamodb/dynamodb.tf`, aplicada pelo Terraform, que falha qualquer plano que destruiria a tabela.
+</Fragment>
+</Infrastructure>
 
-Desabilite-a para ambientes onde a exclusão da tabela é esperada, como stacks de desenvolvimento ou preview de curta duração.
+#### Excluindo a Tabela
+
+Desabilite a proteção para ambientes onde a exclusão da tabela é esperada, como stacks de desenvolvimento ou preview de curta duração.
 
 <Infrastructure>
 <Fragment slot="cdk">
 
 ```ts title="packages/infra/src/stacks/application-stack.ts"
+import { RemovalPolicy } from 'aws-cdk-lib';
 import { MyTable } from '@my-scope/common-constructs';
 
 const table = new MyTable(this, 'Table', {
   deletionProtection: false,
+  removalPolicy: RemovalPolicy.DESTROY,
 });
 ```
 </Fragment>
@@ -80,6 +93,22 @@ module "my_table" {
   deletion_protection_enabled = false
 }
 ```
+
+`prevent_destroy` deve ser um literal — o Terraform não permite que ele referencie uma variável — então não pode ser desativado a partir de `main.tf`. Remova também o bloco `lifecycle` da tabela em `common/terraform/src/core/dynamodb/dynamodb.tf`:
+
+```hcl title="packages/common/terraform/src/core/dynamodb/dynamodb.tf" del={4-6}
+resource "aws_dynamodb_table" "table" {
+  # ...
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+```
+
+:::caution
+Este módulo é compartilhado por todas as tabelas no seu workspace, então remover o bloco remove essa proteção para todas elas.
+:::
 </Fragment>
 </Infrastructure>
 
@@ -145,4 +174,3 @@ module "my_table" {
 A tabela é criptografada com uma chave KMS gerenciada pelo cliente por padrão, criada automaticamente para você. Mude para uma chave gerenciada pela AWS, a chave de propriedade da AWS, ou traga sua própria chave KMS, se você gerencia a criptografia de forma diferente.
 
 <Snippet name="dynamodb/encryption-options" parentHeading="Criptografia" />
-

--- a/docs/src/content/docs/pt/snippets/rdb/deletion-protection.mdx
+++ b/docs/src/content/docs/pt/snippets/rdb/deletion-protection.mdx
@@ -3,21 +3,34 @@ title: Proteção contra Exclusão
 ---
 import Infrastructure from '@components/infrastructure.astro';
 
-A proteção contra exclusão está habilitada por padrão (`deletionProtection: true` no CDK, `deletion_protection = true` no Terraform) para proteger o cluster Aurora contra exclusão acidental.
+O cluster Aurora é protegido por duas proteções independentes, de modo que desativar apenas uma delas não pode excluir seus dados:
 
-#### Desabilitar Proteção contra Exclusão
+<Infrastructure>
+<Fragment slot="cdk">
+- `deletionProtection`, aplicado pelo RDS.
+- `RemovalPolicy.RETAIN`, aplicado pelo CloudFormation, que deixa o cluster no lugar quando ele é removido da stack.
+</Fragment>
+<Fragment slot="terraform">
+- `deletion_protection`, aplicado pelo RDS.
+- `lifecycle { prevent_destroy = true }` no cluster em `common/terraform/src/core/rdb/aurora/aurora.tf`, aplicado pelo Terraform, que falha qualquer plano que destruiria o cluster.
+</Fragment>
+</Infrastructure>
 
-Você pode desabilitar a proteção contra exclusão para ambientes onde a exclusão do banco de dados é esperada, como stacks de desenvolvimento ou preview de curta duração.
+#### Excluir o Banco de Dados
+
+Você pode desabilitar a proteção para ambientes onde a exclusão do banco de dados é esperada, como stacks de desenvolvimento ou preview de curta duração.
 
 <Infrastructure>
 <Fragment slot="cdk">
 
 ```ts title="packages/infra/src/stacks/application-stack.ts"
+import { RemovalPolicy } from 'aws-cdk-lib';
 import { MyDatabase } from '@my-scope/common-constructs';
 
 const db = new MyDatabase(this, 'Db', {
   ...
   deletionProtection: false,
+  removalPolicy: RemovalPolicy.DESTROY,
 });
 ```
 </Fragment>
@@ -28,7 +41,24 @@ module "my_database" {
   source = "../../common/terraform/src/app/dbs/my-database"
   ...
   deletion_protection = false
+  skip_final_snapshot = true
 }
 ```
+
+`prevent_destroy` deve ser um literal — o Terraform não permite que ele referencie uma variável — então não pode ser desativado a partir de `main.tf`. Remova também o bloco `lifecycle` do cluster em `common/terraform/src/core/rdb/aurora/aurora.tf`:
+
+```hcl title="packages/common/terraform/src/core/rdb/aurora/aurora.tf" del={4-6}
+resource "aws_rds_cluster" "database" {
+  # ...
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+```
+
+:::caution
+Este módulo é compartilhado por todos os bancos de dados no seu workspace, então remover o bloco remove essa proteção para todos eles.
+:::
 </Fragment>
 </Infrastructure>

--- a/docs/src/content/docs/vi/snippets/dynamodb/deploying-table.mdx
+++ b/docs/src/content/docs/vi/snippets/dynamodb/deploying-table.mdx
@@ -46,7 +46,7 @@ module "my_table" {
 - Thanh toán theo yêu cầu (`PAY_PER_REQUEST`)
 - Mã hóa KMS do khách hàng quản lý với tự động xoay vòng khóa
 - Khôi phục theo thời điểm được bật
-- Bảo vệ xóa được bật
+- Bảo vệ xóa được bật, cùng với bảo vệ vòng đời `prevent_destroy`
 - Tên bảng được đăng ký trong Runtime Config dưới namespace `dynamodb` trong AWS AppConfig
 
 Module `core/runtime-config/appconfig` hiển thị namespace `dynamodb` theo mặc định, vì vậy tên bảng được triển khai mà không cần cấu hình thêm. Nếu bạn truyền `namespaces` vào module đó một cách rõ ràng, hãy giữ `dynamodb` trong danh sách — nếu không, không có configuration profile nào được tạo cho nó và table client được tạo ra không thể phân giải tên bảng.
@@ -55,20 +55,33 @@ Module `core/runtime-config/appconfig` hiển thị namespace `dynamodb` theo m�
 
 ### Bảo vệ Xóa
 
-Bảo vệ xóa được bật mặc định để ngăn chặn việc xóa bảng một cách vô tình.
+Bảng được bảo vệ bởi hai biện pháp bảo vệ độc lập, do đó việc tắt một trong hai không thể xóa dữ liệu của bạn:
 
-#### Vô hiệu hóa Bảo vệ Xóa
+<Infrastructure>
+<Fragment slot="cdk">
+- `deletionProtection`, được thực thi bởi DynamoDB.
+- `RemovalPolicy.RETAIN`, được thực thi bởi CloudFormation, giữ bảng tại chỗ khi nó bị xóa khỏi stack.
+</Fragment>
+<Fragment slot="terraform">
+- `deletion_protection_enabled`, được thực thi bởi DynamoDB.
+- `lifecycle { prevent_destroy = true }` trên bảng trong `common/terraform/src/core/dynamodb/dynamodb.tf`, được thực thi bởi Terraform, làm thất bại bất kỳ kế hoạch nào sẽ phá hủy bảng.
+</Fragment>
+</Infrastructure>
 
-Vô hiệu hóa nó cho các môi trường mà việc xóa bảng được mong đợi, chẳng hạn như các stack phát triển hoặc xem trước có thời gian tồn tại ngắn.
+#### Xóa Bảng
+
+Vô hiệu hóa bảo vệ cho các môi trường mà việc xóa bảng được mong đợi, chẳng hạn như các stack phát triển hoặc xem trước có thời gian tồn tại ngắn.
 
 <Infrastructure>
 <Fragment slot="cdk">
 
 ```ts title="packages/infra/src/stacks/application-stack.ts"
+import { RemovalPolicy } from 'aws-cdk-lib';
 import { MyTable } from '@my-scope/common-constructs';
 
 const table = new MyTable(this, 'Table', {
   deletionProtection: false,
+  removalPolicy: RemovalPolicy.DESTROY,
 });
 ```
 </Fragment>
@@ -80,6 +93,22 @@ module "my_table" {
   deletion_protection_enabled = false
 }
 ```
+
+`prevent_destroy` phải là một giá trị cố định — Terraform không cho phép nó tham chiếu đến một biến — vì vậy nó không thể được tắt từ `main.tf`. Cũng xóa khối `lifecycle` khỏi bảng trong `common/terraform/src/core/dynamodb/dynamodb.tf`:
+
+```hcl title="packages/common/terraform/src/core/dynamodb/dynamodb.tf" del={4-6}
+resource "aws_dynamodb_table" "table" {
+  # ...
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+```
+
+:::caution
+Module này được chia sẻ bởi mọi bảng trong workspace của bạn, vì vậy việc xóa khối này sẽ xóa biện pháp bảo vệ đó cho tất cả chúng.
+:::
 </Fragment>
 </Infrastructure>
 

--- a/docs/src/content/docs/vi/snippets/rdb/deletion-protection.mdx
+++ b/docs/src/content/docs/vi/snippets/rdb/deletion-protection.mdx
@@ -3,21 +3,34 @@ title: Bảo Vệ Xóa
 ---
 import Infrastructure from '@components/infrastructure.astro';
 
-Bảo vệ xóa được bật theo mặc định (`deletionProtection: true` trong CDK, `deletion_protection = true` trong Terraform) để bảo vệ cụm Aurora khỏi bị xóa do nhầm lẫn.
+Cụm Aurora được bảo vệ bởi hai lớp bảo vệ độc lập, do đó việc tắt một trong hai không thể xóa dữ liệu của bạn:
 
-#### Tắt Bảo Vệ Xóa
+<Infrastructure>
+<Fragment slot="cdk">
+- `deletionProtection`, được thực thi bởi RDS.
+- `RemovalPolicy.RETAIN`, được thực thi bởi CloudFormation, giữ cụm tại chỗ khi nó bị xóa khỏi stack.
+</Fragment>
+<Fragment slot="terraform">
+- `deletion_protection`, được thực thi bởi RDS.
+- `lifecycle { prevent_destroy = true }` trên cụm trong `common/terraform/src/core/rdb/aurora/aurora.tf`, được thực thi bởi Terraform, làm thất bại bất kỳ kế hoạch nào có thể phá hủy cụm.
+</Fragment>
+</Infrastructure>
 
-Bạn có thể tắt bảo vệ xóa cho các môi trường mà việc xóa cơ sở dữ liệu được mong đợi, chẳng hạn như các stack phát triển hoặc xem trước có thời gian tồn tại ngắn.
+#### Xóa Cơ Sở Dữ Liệu
+
+Bạn có thể tắt bảo vệ cho các môi trường mà việc xóa cơ sở dữ liệu được mong đợi, chẳng hạn như các stack phát triển hoặc xem trước có thời gian tồn tại ngắn.
 
 <Infrastructure>
 <Fragment slot="cdk">
 
 ```ts title="packages/infra/src/stacks/application-stack.ts"
+import { RemovalPolicy } from 'aws-cdk-lib';
 import { MyDatabase } from '@my-scope/common-constructs';
 
 const db = new MyDatabase(this, 'Db', {
   ...
   deletionProtection: false,
+  removalPolicy: RemovalPolicy.DESTROY,
 });
 ```
 </Fragment>
@@ -28,7 +41,24 @@ module "my_database" {
   source = "../../common/terraform/src/app/dbs/my-database"
   ...
   deletion_protection = false
+  skip_final_snapshot = true
 }
 ```
+
+`prevent_destroy` phải là một giá trị cố định — Terraform không cho phép nó tham chiếu đến một biến — do đó nó không thể được tắt từ `main.tf`. Đồng thời xóa khối `lifecycle` khỏi cụm trong `common/terraform/src/core/rdb/aurora/aurora.tf`:
+
+```hcl title="packages/common/terraform/src/core/rdb/aurora/aurora.tf" del={4-6}
+resource "aws_rds_cluster" "database" {
+  # ...
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+```
+
+:::caution
+Module này được chia sẻ bởi mọi cơ sở dữ liệu trong workspace của bạn, do đó việc xóa khối này sẽ xóa lớp bảo vệ đó cho tất cả chúng.
+:::
 </Fragment>
 </Infrastructure>

--- a/docs/src/content/docs/zh/snippets/dynamodb/deploying-table.mdx
+++ b/docs/src/content/docs/zh/snippets/dynamodb/deploying-table.mdx
@@ -46,7 +46,7 @@ module "my_table" {
 - 按需（`PAY_PER_REQUEST`）计费
 - 具有自动密钥轮换的客户托管 KMS 加密
 - 启用时间点恢复
-- 启用删除保护
+- 启用删除保护，以及 `prevent_destroy` 生命周期保护
 - 表名在 AWS AppConfig 的 `dynamodb` 命名空间下注册到 Runtime Config
 
 `core/runtime-config/appconfig` 模块默认公开 `dynamodb` 命名空间，因此表名无需进一步配置即可部署。如果您显式地向该模块传递 `namespaces`，请在列表中保留 `dynamodb` —— 否则不会为其创建配置文件，生成的表客户端将无法解析表名。
@@ -55,20 +55,33 @@ module "my_table" {
 
 ### 删除保护
 
-默认启用删除保护以防止意外删除表。
+表由两个独立的保护机制保护，因此单独关闭其中任何一个都无法删除您的数据：
 
-#### 禁用删除保护
+<Infrastructure>
+<Fragment slot="cdk">
+- `deletionProtection`，由 DynamoDB 强制执行。
+- `RemovalPolicy.RETAIN`，由 CloudFormation 强制执行，当表从堆栈中移除时会将其保留在原处。
+</Fragment>
+<Fragment slot="terraform">
+- `deletion_protection_enabled`，由 DynamoDB 强制执行。
+- `lifecycle { prevent_destroy = true }` 在 `common/terraform/src/core/dynamodb/dynamodb.tf` 中的表上，由 Terraform 强制执行，会使任何试图销毁表的计划失败。
+</Fragment>
+</Infrastructure>
 
-对于预期会删除表的环境（例如短期开发或预览堆栈），可以禁用它。
+#### 删除表
+
+对于预期会删除表的环境（例如短期开发或预览堆栈），可以禁用保护。
 
 <Infrastructure>
 <Fragment slot="cdk">
 
 ```ts title="packages/infra/src/stacks/application-stack.ts"
+import { RemovalPolicy } from 'aws-cdk-lib';
 import { MyTable } from '@my-scope/common-constructs';
 
 const table = new MyTable(this, 'Table', {
   deletionProtection: false,
+  removalPolicy: RemovalPolicy.DESTROY,
 });
 ```
 </Fragment>
@@ -80,6 +93,22 @@ module "my_table" {
   deletion_protection_enabled = false
 }
 ```
+
+`prevent_destroy` 必须是字面量 —— Terraform 不允许它引用变量 —— 因此无法从 `main.tf` 中关闭它。还需要从 `common/terraform/src/core/dynamodb/dynamodb.tf` 中的表中删除 `lifecycle` 块：
+
+```hcl title="packages/common/terraform/src/core/dynamodb/dynamodb.tf" del={4-6}
+resource "aws_dynamodb_table" "table" {
+  # ...
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+```
+
+:::caution
+此模块由工作区中的每个表共享，因此删除该块会移除所有表的保护。
+:::
 </Fragment>
 </Infrastructure>
 

--- a/docs/src/content/docs/zh/snippets/rdb/deletion-protection.mdx
+++ b/docs/src/content/docs/zh/snippets/rdb/deletion-protection.mdx
@@ -3,21 +3,34 @@ title: 删除保护
 ---
 import Infrastructure from '@components/infrastructure.astro';
 
-默认情况下启用删除保护（CDK 中为 `deletionProtection: true`，Terraform 中为 `deletion_protection = true`），以保护 Aurora 集群免遭意外删除。
+Aurora 集群受到两个独立保护措施的保护，因此单独关闭其中任何一个都无法删除您的数据：
 
-#### 禁用删除保护
+<Infrastructure>
+<Fragment slot="cdk">
+- `deletionProtection`，由 RDS 强制执行。
+- `RemovalPolicy.RETAIN`，由 CloudFormation 强制执行，当集群从堆栈中移除时，它会将集群保留在原位。
+</Fragment>
+<Fragment slot="terraform">
+- `deletion_protection`，由 RDS 强制执行。
+- `lifecycle { prevent_destroy = true }` 在 `common/terraform/src/core/rdb/aurora/aurora.tf` 中的集群上，由 Terraform 强制执行，它会使任何试图销毁集群的计划失败。
+</Fragment>
+</Infrastructure>
 
-您可以为预期会删除数据库的环境禁用删除保护，例如短期开发或预览堆栈。
+#### 删除数据库
+
+您可以为预期会删除数据库的环境禁用保护，例如短期开发或预览堆栈。
 
 <Infrastructure>
 <Fragment slot="cdk">
 
 ```ts title="packages/infra/src/stacks/application-stack.ts"
+import { RemovalPolicy } from 'aws-cdk-lib';
 import { MyDatabase } from '@my-scope/common-constructs';
 
 const db = new MyDatabase(this, 'Db', {
   ...
   deletionProtection: false,
+  removalPolicy: RemovalPolicy.DESTROY,
 });
 ```
 </Fragment>
@@ -28,7 +41,24 @@ module "my_database" {
   source = "../../common/terraform/src/app/dbs/my-database"
   ...
   deletion_protection = false
+  skip_final_snapshot = true
 }
 ```
+
+`prevent_destroy` 必须是字面量 — Terraform 不允许它引用变量 — 因此无法从 `main.tf` 中关闭它。还需要从 `common/terraform/src/core/rdb/aurora/aurora.tf` 中的集群中移除 `lifecycle` 块：
+
+```hcl title="packages/common/terraform/src/core/rdb/aurora/aurora.tf" del={4-6}
+resource "aws_rds_cluster" "database" {
+  # ...
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+```
+
+:::caution
+此模块由工作区中的每个数据库共享，因此移除该块会移除所有数据库的保护措施。
+:::
 </Fragment>
 </Infrastructure>

--- a/e2e/src/smoke-tests/terraform-deploy.spec.ts
+++ b/e2e/src/smoke-tests/terraform-deploy.spec.ts
@@ -170,6 +170,27 @@ const runTerraformDeployVariant = (config: TerraformDeployVariant) => {
         );
       }
 
+      // The data-bearing modules guard themselves with
+      // `lifecycle { prevent_destroy = true }`, which cannot be driven by a
+      // variable. Flip the literal to false so `terraform destroy` can tear the
+      // test stack down; the server-side deletion_protection flags are already
+      // disabled by the main.tf wiring templates.
+      for (const relativeTfPath of [
+        'core/dynamodb/dynamodb.tf',
+        'core/rdb/aurora/aurora.tf',
+      ]) {
+        const tfPath = `${opts.cwd}/packages/common/terraform/src/${relativeTfPath}`;
+        if (existsSync(tfPath)) {
+          writeFileSync(
+            tfPath,
+            readFileSync(tfPath, 'utf-8').replace(
+              /prevent_destroy\s*=\s*true/g,
+              'prevent_destroy = false',
+            ),
+          );
+        }
+      }
+
       if (config.requiresRdsServiceLinkedRole) {
         ensureRdsServiceLinkedRole();
       }

--- a/packages/nx-plugin/src/migrations/latest/terraform-data-resource-destroy-protection/__snapshots__/migration.spec.ts.snap
+++ b/packages/nx-plugin/src/migrations/latest/terraform-data-resource-destroy-protection/__snapshots__/migration.spec.ts.snap
@@ -1,0 +1,75 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`terraform-data-resource-destroy-protection migration > should protect the aurora cluster and pin its key window 1`] = `
+"resource "aws_kms_key" "database" {
+  description         = "KMS key for Aurora cluster \${var.name}"
+  enable_key_rotation = var.enable_key_rotation
+
+  deletion_window_in_days = 30
+
+  tags = merge(var.tags, {
+    Name = "\${var.name}-aurora"
+  })
+}
+
+resource "aws_rds_cluster" "database" {
+  cluster_identifier  = local.cluster_name
+  engine              = var.engine
+  storage_encrypted   = true
+  kms_key_id          = aws_kms_key.database.arn
+  deletion_protection = var.deletion_protection
+  skip_final_snapshot = var.skip_final_snapshot
+
+  serverlessv2_scaling_configuration {
+    min_capacity = var.serverless_min_capacity
+    max_capacity = var.serverless_max_capacity
+  }
+
+  tags = merge(var.tags, {
+    Name = "\${var.name}-aurora"
+  })
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+"
+`;
+
+exports[`terraform-data-resource-destroy-protection migration > should protect the dynamodb table and pin its key window 1`] = `
+"resource "aws_kms_key" "table" {
+  count = local.create_table_key ? 1 : 0
+
+  description         = "KMS key for DynamoDB table \${var.name}"
+  enable_key_rotation = var.enable_key_rotation
+
+  deletion_window_in_days = 30
+}
+
+resource "aws_dynamodb_table" "table" {
+  name                        = var.name
+  billing_mode                = var.billing_mode
+  hash_key                    = "pk"
+  range_key                   = "sk"
+  deletion_protection_enabled = var.deletion_protection_enabled
+
+  attribute {
+    name = "pk"
+    type = "S"
+  }
+
+  point_in_time_recovery {
+    enabled = var.point_in_time_recovery_enabled
+  }
+
+  server_side_encryption {
+    enabled     = var.encryption != "DEFAULT"
+    kms_key_arn = local.table_kms_key_arn
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+"
+`;

--- a/packages/nx-plugin/src/migrations/latest/terraform-data-resource-destroy-protection/metadata.json
+++ b/packages/nx-plugin/src/migrations/latest/terraform-data-resource-destroy-protection/metadata.json
@@ -1,0 +1,3 @@
+{
+  "description": "Add prevent_destroy and a 30 day KMS deletion window to the vended Terraform DynamoDB table and Aurora cluster modules"
+}

--- a/packages/nx-plugin/src/migrations/latest/terraform-data-resource-destroy-protection/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/latest/terraform-data-resource-destroy-protection/migration.spec.ts
@@ -1,0 +1,175 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import type { Tree } from '@nx/devkit';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test.js';
+import migration from './migration.js';
+
+const DYNAMODB_FILE = 'packages/common/terraform/src/core/dynamodb/dynamodb.tf';
+const AURORA_FILE = 'packages/common/terraform/src/core/rdb/aurora/aurora.tf';
+
+/**
+ * The pre-change shape of the vended DynamoDB core module: a KMS key with no
+ * pending window, and a table guarded only by the service-side flag.
+ */
+const DYNAMODB_BEFORE = `resource "aws_kms_key" "table" {
+  count = local.create_table_key ? 1 : 0
+
+  description         = "KMS key for DynamoDB table \${var.name}"
+  enable_key_rotation = var.enable_key_rotation
+}
+
+resource "aws_dynamodb_table" "table" {
+  name                        = var.name
+  billing_mode                = var.billing_mode
+  hash_key                    = "pk"
+  range_key                   = "sk"
+  deletion_protection_enabled = var.deletion_protection_enabled
+
+  attribute {
+    name = "pk"
+    type = "S"
+  }
+
+  point_in_time_recovery {
+    enabled = var.point_in_time_recovery_enabled
+  }
+
+  server_side_encryption {
+    enabled     = var.encryption != "DEFAULT"
+    kms_key_arn = local.table_kms_key_arn
+  }
+}
+`;
+
+/** The pre-change shape of the vended Aurora core module. */
+const AURORA_BEFORE = `resource "aws_kms_key" "database" {
+  description         = "KMS key for Aurora cluster \${var.name}"
+  enable_key_rotation = var.enable_key_rotation
+
+  tags = merge(var.tags, {
+    Name = "\${var.name}-aurora"
+  })
+}
+
+resource "aws_rds_cluster" "database" {
+  cluster_identifier  = local.cluster_name
+  engine              = var.engine
+  storage_encrypted   = true
+  kms_key_id          = aws_kms_key.database.arn
+  deletion_protection = var.deletion_protection
+  skip_final_snapshot = var.skip_final_snapshot
+
+  serverlessv2_scaling_configuration {
+    min_capacity = var.serverless_min_capacity
+    max_capacity = var.serverless_max_capacity
+  }
+
+  tags = merge(var.tags, {
+    Name = "\${var.name}-aurora"
+  })
+}
+`;
+
+describe('terraform-data-resource-destroy-protection migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeUsingTsSolutionSetup();
+  });
+
+  it('should protect the dynamodb table and pin its key window', async () => {
+    tree.write(DYNAMODB_FILE, DYNAMODB_BEFORE);
+
+    const result = await migration(tree);
+
+    const content = tree.read(DYNAMODB_FILE, 'utf-8');
+    expect(content).toContain('prevent_destroy = true');
+    expect(content).toContain('deletion_window_in_days = 30');
+    // The service-side flag stays configurable - the lifecycle block is an
+    // additional layer, not a replacement.
+    expect(content).toContain(
+      'deletion_protection_enabled = var.deletion_protection_enabled',
+    );
+    expect(result.nextSteps).toEqual([]);
+    expect(content).toMatchSnapshot();
+  });
+
+  it('should protect the aurora cluster and pin its key window', async () => {
+    tree.write(AURORA_FILE, AURORA_BEFORE);
+
+    const result = await migration(tree);
+
+    const content = tree.read(AURORA_FILE, 'utf-8');
+    expect(content).toContain('prevent_destroy = true');
+    expect(content).toContain('deletion_window_in_days = 30');
+    expect(content).toContain('deletion_protection = var.deletion_protection');
+    expect(result.nextSteps).toEqual([]);
+    expect(content).toMatchSnapshot();
+  });
+
+  it('should do nothing when the workspace has no terraform modules', async () => {
+    const result = await migration(tree);
+
+    expect(result.nextSteps).toEqual([]);
+    expect(tree.exists(DYNAMODB_FILE)).toBe(false);
+    expect(tree.exists(AURORA_FILE)).toBe(false);
+  });
+
+  it('should skip and report a customised file', async () => {
+    const customised = `resource "aws_dynamodb_table" "my_own_table" {
+  name = "custom"
+}
+`;
+    tree.write(DYNAMODB_FILE, customised);
+
+    const result = await migration(tree);
+
+    expect(tree.read(DYNAMODB_FILE, 'utf-8')).toBe(customised);
+    expect(result.nextSteps).toHaveLength(1);
+    expect(result.nextSteps[0]).toContain(DYNAMODB_FILE);
+    expect(result.nextSteps[0]).toContain('prevent_destroy');
+  });
+
+  it('should preserve an existing prevent_destroy setting', async () => {
+    // A user who has deliberately turned the guard off keeps that choice.
+    tree.write(
+      DYNAMODB_FILE,
+      DYNAMODB_BEFORE.replace(
+        '  server_side_encryption {',
+        '  lifecycle {\n    prevent_destroy = false\n  }\n\n  server_side_encryption {',
+      ),
+    );
+
+    const result = await migration(tree);
+
+    const content = tree.read(DYNAMODB_FILE, 'utf-8');
+    expect(content).toContain('prevent_destroy = false');
+    expect(content).not.toContain('prevent_destroy = true');
+    expect(result.nextSteps).toEqual([]);
+  });
+
+  it('should be idempotent', async () => {
+    tree.write(DYNAMODB_FILE, DYNAMODB_BEFORE);
+    tree.write(AURORA_FILE, AURORA_BEFORE);
+
+    await migration(tree);
+    const afterFirst = {
+      dynamodb: tree.read(DYNAMODB_FILE, 'utf-8'),
+      aurora: tree.read(AURORA_FILE, 'utf-8'),
+    };
+
+    const result = await migration(tree);
+
+    expect(tree.read(DYNAMODB_FILE, 'utf-8')).toBe(afterFirst.dynamodb);
+    expect(tree.read(AURORA_FILE, 'utf-8')).toBe(afterFirst.aurora);
+    expect(result.nextSteps).toEqual([]);
+
+    // Exactly one guard and one window per file, not a second appended copy.
+    for (const content of Object.values(afterFirst)) {
+      expect(content?.match(/prevent_destroy/g)).toHaveLength(1);
+      expect(content?.match(/deletion_window_in_days/g)).toHaveLength(1);
+    }
+  });
+});

--- a/packages/nx-plugin/src/migrations/latest/terraform-data-resource-destroy-protection/migration.ts
+++ b/packages/nx-plugin/src/migrations/latest/terraform-data-resource-destroy-protection/migration.ts
@@ -1,0 +1,162 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import type { MigrationReturnObject, Tree } from '@nx/devkit';
+import { applyGritQL, matchGritQL } from '../../../utils/ast.js';
+import { formatFilesInSubtree } from '../../../utils/format.js';
+import {
+  PACKAGES_DIR,
+  SHARED_TERRAFORM_DIR,
+} from '../../../utils/shared-constructs-constants.js';
+
+/**
+ * Bring existing workspaces up to the destroy protection the generators now
+ * vend on the data-bearing Terraform resources:
+ *
+ * - The DynamoDB table and the Aurora cluster gain
+ *   `lifecycle { prevent_destroy = true }`. This is a second, independent layer
+ *   on top of the service-side `deletion_protection_enabled` /
+ *   `deletion_protection` flags, matching the two guards the CDK constructs
+ *   already have (`deletionProtection` plus `RemovalPolicy.RETAIN`). Without it,
+ *   clearing the service-side flag destroys the data in the same apply.
+ *   `prevent_destroy` cannot reference a variable, so it is vended as a literal
+ *   and removed to tear down.
+ * - Their KMS keys pin `deletion_window_in_days = 30`, the provider maximum and
+ *   the CDK default. Restoring either resource from a point-in-time backup or
+ *   snapshot requires its key, so the window in which a scheduled key deletion
+ *   can still be cancelled matters as much as the backup itself.
+ *
+ * These files are generated with `KeepExisting`, so without this an upgraded
+ * workspace keeps the weaker single-layer protection. Diverged files are left
+ * untouched and reported via `nextSteps`.
+ */
+
+const TERRAFORM_DYNAMODB_FILE = `${PACKAGES_DIR}/${SHARED_TERRAFORM_DIR}/src/core/dynamodb/dynamodb.tf`;
+const TERRAFORM_AURORA_FILE = `${PACKAGES_DIR}/${SHARED_TERRAFORM_DIR}/src/core/rdb/aurora/aurora.tf`;
+
+const hcl = (pattern: string) => `language hcl\n${pattern}`;
+
+const divergedMessage = (filePath: string, resource: string) =>
+  `${filePath}: has diverged from the generated shape - left untouched. To protect the ${resource} from being destroyed when the service-side deletion protection flag is cleared, add \`lifecycle { prevent_destroy = true }\` to it, and set \`deletion_window_in_days = 30\` on its KMS key.`;
+
+/**
+ * Add the maximum KMS pending window to a key that omits it, so a scheduled
+ * deletion stays cancellable for as long as the provider allows.
+ */
+const migrateKmsKey = async (
+  tree: Tree,
+  filePath: string,
+  keyLabel: string,
+): Promise<void> => {
+  const keyBlock = hcl(`\`resource "aws_kms_key" "${keyLabel}" { $props }\``);
+
+  // Already pinned - nothing to do.
+  if (
+    await matchGritQL(
+      tree,
+      filePath,
+      hcl(
+        `\`resource "aws_kms_key" "${keyLabel}" { $props }\` where { $props <: contains \`deletion_window_in_days = $_\` }`,
+      ),
+    )
+  ) {
+    return;
+  }
+
+  if (!(await matchGritQL(tree, filePath, keyBlock))) {
+    return; // Reported by the caller, which matches the data resource too.
+  }
+
+  await applyGritQL(
+    tree,
+    filePath,
+    hcl(
+      `\`resource "aws_kms_key" "${keyLabel}" { $props }\` where { $props <: contains \`enable_key_rotation = $rotation\` => \`enable_key_rotation = $rotation\n\n  deletion_window_in_days = 30\` }`,
+    ),
+  );
+};
+
+/**
+ * Add `lifecycle { prevent_destroy = true }` to a data-bearing resource.
+ */
+const migrateDataResource = async (
+  tree: Tree,
+  filePath: string,
+  resourceType: string,
+  resourceLabel: string,
+  nextSteps: string[],
+  description: string,
+): Promise<boolean> => {
+  const resourceBlock = hcl(
+    `\`resource "${resourceType}" "${resourceLabel}" { $props }\``,
+  );
+
+  if (!(await matchGritQL(tree, filePath, resourceBlock))) {
+    nextSteps.push(divergedMessage(filePath, description));
+    return false;
+  }
+
+  // Already guarded - keep the user's block, whatever it is set to.
+  if (
+    await matchGritQL(
+      tree,
+      filePath,
+      hcl(
+        `\`resource "${resourceType}" "${resourceLabel}" { $props }\` where { $props <: contains \`prevent_destroy = $_\` }`,
+      ),
+    )
+  ) {
+    return true;
+  }
+
+  await applyGritQL(
+    tree,
+    filePath,
+    hcl(
+      `\`resource "${resourceType}" "${resourceLabel}" { $props }\` => \`resource "${resourceType}" "${resourceLabel}" {\n  $props\n\n  lifecycle {\n    prevent_destroy = true\n  }\n}\``,
+    ),
+  );
+
+  return true;
+};
+
+export default async function migration(
+  tree: Tree,
+): Promise<MigrationReturnObject> {
+  const nextSteps: string[] = [];
+
+  if (tree.exists(TERRAFORM_DYNAMODB_FILE)) {
+    if (
+      await migrateDataResource(
+        tree,
+        TERRAFORM_DYNAMODB_FILE,
+        'aws_dynamodb_table',
+        'table',
+        nextSteps,
+        'DynamoDB table',
+      )
+    ) {
+      await migrateKmsKey(tree, TERRAFORM_DYNAMODB_FILE, 'table');
+    }
+  }
+
+  if (tree.exists(TERRAFORM_AURORA_FILE)) {
+    if (
+      await migrateDataResource(
+        tree,
+        TERRAFORM_AURORA_FILE,
+        'aws_rds_cluster',
+        'database',
+        nextSteps,
+        'Aurora cluster',
+      )
+    ) {
+      await migrateKmsKey(tree, TERRAFORM_AURORA_FILE, 'database');
+    }
+  }
+
+  await formatFilesInSubtree(tree);
+
+  return { nextSteps };
+}

--- a/packages/nx-plugin/src/py/dynamodb/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/dynamodb/__snapshots__/generator.spec.ts.snap
@@ -126,6 +126,10 @@ resource "aws_kms_key" "table" {
   description         = "KMS key for DynamoDB table \${var.name}"
   enable_key_rotation = var.enable_key_rotation
 
+  # A point-in-time restore of a CMK-encrypted table requires this key, so keep
+  # the maximum window in which a scheduled deletion can still be cancelled.
+  deletion_window_in_days = 30
+
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
@@ -201,6 +205,13 @@ resource "aws_dynamodb_table" "table" {
   server_side_encryption {
     enabled     = var.encryption != "DEFAULT"
     kms_key_arn = local.table_kms_key_arn
+  }
+
+  # Second, independent layer of protection: \`deletion_protection_enabled\` is
+  # enforced by DynamoDB, this is enforced by Terraform, so clearing the
+  # variable alone cannot destroy the table. Remove this block to tear down.
+  lifecycle {
+    prevent_destroy = true
   }
 }
 

--- a/packages/nx-plugin/src/py/dynamodb/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/dynamodb/__snapshots__/generator.spec.ts.snap
@@ -126,8 +126,6 @@ resource "aws_kms_key" "table" {
   description         = "KMS key for DynamoDB table \${var.name}"
   enable_key_rotation = var.enable_key_rotation
 
-  # A point-in-time restore of a CMK-encrypted table requires this key, so keep
-  # the maximum window in which a scheduled deletion can still be cancelled.
   deletion_window_in_days = 30
 
   policy = jsonencode({
@@ -207,9 +205,6 @@ resource "aws_dynamodb_table" "table" {
     kms_key_arn = local.table_kms_key_arn
   }
 
-  # Second, independent layer of protection: \`deletion_protection_enabled\` is
-  # enforced by DynamoDB, this is enforced by Terraform, so clearing the
-  # variable alone cannot destroy the table. Remove this block to tear down.
   lifecycle {
     prevent_destroy = true
   }

--- a/packages/nx-plugin/src/ts/dynamodb/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/dynamodb/__snapshots__/generator.spec.ts.snap
@@ -126,6 +126,10 @@ resource "aws_kms_key" "table" {
   description         = "KMS key for DynamoDB table \${var.name}"
   enable_key_rotation = var.enable_key_rotation
 
+  # A point-in-time restore of a CMK-encrypted table requires this key, so keep
+  # the maximum window in which a scheduled deletion can still be cancelled.
+  deletion_window_in_days = 30
+
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
@@ -201,6 +205,13 @@ resource "aws_dynamodb_table" "table" {
   server_side_encryption {
     enabled     = var.encryption != "DEFAULT"
     kms_key_arn = local.table_kms_key_arn
+  }
+
+  # Second, independent layer of protection: \`deletion_protection_enabled\` is
+  # enforced by DynamoDB, this is enforced by Terraform, so clearing the
+  # variable alone cannot destroy the table. Remove this block to tear down.
+  lifecycle {
+    prevent_destroy = true
   }
 }
 

--- a/packages/nx-plugin/src/ts/dynamodb/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/dynamodb/__snapshots__/generator.spec.ts.snap
@@ -126,8 +126,6 @@ resource "aws_kms_key" "table" {
   description         = "KMS key for DynamoDB table \${var.name}"
   enable_key_rotation = var.enable_key_rotation
 
-  # A point-in-time restore of a CMK-encrypted table requires this key, so keep
-  # the maximum window in which a scheduled deletion can still be cancelled.
   deletion_window_in_days = 30
 
   policy = jsonencode({
@@ -207,9 +205,6 @@ resource "aws_dynamodb_table" "table" {
     kms_key_arn = local.table_kms_key_arn
   }
 
-  # Second, independent layer of protection: \`deletion_protection_enabled\` is
-  # enforced by DynamoDB, this is enforced by Terraform, so clearing the
-  # variable alone cannot destroy the table. Remove this block to tear down.
   lifecycle {
     prevent_destroy = true
   }

--- a/packages/nx-plugin/src/ts/dynamodb/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/dynamodb/generator.spec.ts
@@ -159,6 +159,29 @@ describe('ts#dynamodb generator', () => {
     );
   });
 
+  it('should protect the table and its key from destruction in terraform', async () => {
+    await tsDynamoDBGenerator(tree, {
+      ...defaultOptions,
+      iac: 'terraform',
+    });
+
+    const dynamodb = tree.read(
+      'packages/common/terraform/src/core/dynamodb/dynamodb.tf',
+      'utf-8',
+    );
+
+    // Terraform-side guard, independent of the DynamoDB-side
+    // deletion_protection_enabled flag, so clearing that variable alone cannot
+    // destroy the table. It must be a literal — prevent_destroy cannot
+    // reference a variable.
+    expect(dynamodb).toContain('prevent_destroy = true');
+
+    // The maximum KMS pending window, matching the CDK default, so a
+    // point-in-time restore of the table stays possible for as long as
+    // possible.
+    expect(dynamodb).toContain('deletion_window_in_days = 30');
+  });
+
   it('should keep an existing dynamodb app construct', async () => {
     await sharedConstructsGenerator(
       tree,

--- a/packages/nx-plugin/src/ts/rdb/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/rdb/__snapshots__/generator.spec.ts.snap
@@ -1008,8 +1008,6 @@ resource "aws_kms_key" "database" {
   description         = "KMS key for Aurora cluster \${var.name}"
   enable_key_rotation = var.enable_key_rotation
 
-  # Restoring a snapshot of an encrypted cluster requires this key, so keep the
-  # maximum window in which a scheduled deletion can still be cancelled.
   deletion_window_in_days = 30
 
   policy = jsonencode({
@@ -1155,9 +1153,6 @@ resource "aws_rds_cluster" "database" {
     Name = "\${var.name}-aurora"
   })
 
-  # Second, independent layer of protection: \`deletion_protection\` is enforced
-  # by RDS, this is enforced by Terraform, so clearing the variable alone cannot
-  # destroy the cluster. Remove this block to tear down.
   lifecycle {
     prevent_destroy = true
   }
@@ -2505,8 +2500,6 @@ resource "aws_kms_key" "database" {
   description         = "KMS key for Aurora cluster \${var.name}"
   enable_key_rotation = var.enable_key_rotation
 
-  # Restoring a snapshot of an encrypted cluster requires this key, so keep the
-  # maximum window in which a scheduled deletion can still be cancelled.
   deletion_window_in_days = 30
 
   policy = jsonencode({
@@ -2652,9 +2645,6 @@ resource "aws_rds_cluster" "database" {
     Name = "\${var.name}-aurora"
   })
 
-  # Second, independent layer of protection: \`deletion_protection\` is enforced
-  # by RDS, this is enforced by Terraform, so clearing the variable alone cannot
-  # destroy the cluster. Remove this block to tear down.
   lifecycle {
     prevent_destroy = true
   }

--- a/packages/nx-plugin/src/ts/rdb/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/rdb/__snapshots__/generator.spec.ts.snap
@@ -1008,6 +1008,10 @@ resource "aws_kms_key" "database" {
   description         = "KMS key for Aurora cluster \${var.name}"
   enable_key_rotation = var.enable_key_rotation
 
+  # Restoring a snapshot of an encrypted cluster requires this key, so keep the
+  # maximum window in which a scheduled deletion can still be cancelled.
+  deletion_window_in_days = 30
+
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
@@ -1150,6 +1154,13 @@ resource "aws_rds_cluster" "database" {
   tags = merge(var.tags, {
     Name = "\${var.name}-aurora"
   })
+
+  # Second, independent layer of protection: \`deletion_protection\` is enforced
+  # by RDS, this is enforced by Terraform, so clearing the variable alone cannot
+  # destroy the cluster. Remove this block to tear down.
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 resource "aws_rds_cluster_instance" "database" {
@@ -2494,6 +2505,10 @@ resource "aws_kms_key" "database" {
   description         = "KMS key for Aurora cluster \${var.name}"
   enable_key_rotation = var.enable_key_rotation
 
+  # Restoring a snapshot of an encrypted cluster requires this key, so keep the
+  # maximum window in which a scheduled deletion can still be cancelled.
+  deletion_window_in_days = 30
+
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
@@ -2636,6 +2651,13 @@ resource "aws_rds_cluster" "database" {
   tags = merge(var.tags, {
     Name = "\${var.name}-aurora"
   })
+
+  # Second, independent layer of protection: \`deletion_protection\` is enforced
+  # by RDS, this is enforced by Terraform, so clearing the variable alone cannot
+  # destroy the cluster. Remove this block to tear down.
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 resource "aws_rds_cluster_instance" "database" {

--- a/packages/nx-plugin/src/ts/rdb/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/rdb/generator.spec.ts
@@ -320,6 +320,27 @@ describe('ts#rdb generator', () => {
     );
   });
 
+  it('should protect the aurora cluster and its key from destruction in terraform', async () => {
+    await tsRdbGenerator(tree, {
+      ...defaultOptions,
+      iac: 'terraform',
+    });
+
+    const aurora = tree.read(
+      'packages/common/terraform/src/core/rdb/aurora/aurora.tf',
+      'utf-8',
+    );
+
+    // Terraform-side guard, independent of the RDS-side deletion_protection
+    // flag, so clearing that variable alone cannot destroy the cluster. It must
+    // be a literal — prevent_destroy cannot reference a variable.
+    expect(aurora).toContain('prevent_destroy = true');
+
+    // The maximum KMS pending window, matching the CDK default, so a snapshot
+    // of an encrypted cluster stays restorable for as long as possible.
+    expect(aurora).toContain('deletion_window_in_days = 30');
+  });
+
   it('should keep an existing aurora shared construct', async () => {
     await sharedConstructsGenerator(
       tree,

--- a/packages/nx-plugin/src/utils/dynamodb-constructs/files/terraform/core/dynamodb/dynamodb.tf.template
+++ b/packages/nx-plugin/src/utils/dynamodb-constructs/files/terraform/core/dynamodb/dynamodb.tf.template
@@ -95,8 +95,6 @@ resource "aws_kms_key" "table" {
   description         = "KMS key for DynamoDB table ${var.name}"
   enable_key_rotation = var.enable_key_rotation
 
-  # A point-in-time restore of a CMK-encrypted table requires this key, so keep
-  # the maximum window in which a scheduled deletion can still be cancelled.
   deletion_window_in_days = 30
 
   policy = jsonencode({
@@ -176,9 +174,6 @@ resource "aws_dynamodb_table" "table" {
     kms_key_arn = local.table_kms_key_arn
   }
 
-  # Second, independent layer of protection: `deletion_protection_enabled` is
-  # enforced by DynamoDB, this is enforced by Terraform, so clearing the
-  # variable alone cannot destroy the table. Remove this block to tear down.
   lifecycle {
     prevent_destroy = true
   }

--- a/packages/nx-plugin/src/utils/dynamodb-constructs/files/terraform/core/dynamodb/dynamodb.tf.template
+++ b/packages/nx-plugin/src/utils/dynamodb-constructs/files/terraform/core/dynamodb/dynamodb.tf.template
@@ -95,6 +95,10 @@ resource "aws_kms_key" "table" {
   description         = "KMS key for DynamoDB table ${var.name}"
   enable_key_rotation = var.enable_key_rotation
 
+  # A point-in-time restore of a CMK-encrypted table requires this key, so keep
+  # the maximum window in which a scheduled deletion can still be cancelled.
+  deletion_window_in_days = 30
+
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
@@ -170,6 +174,13 @@ resource "aws_dynamodb_table" "table" {
   server_side_encryption {
     enabled     = var.encryption != "DEFAULT"
     kms_key_arn = local.table_kms_key_arn
+  }
+
+  # Second, independent layer of protection: `deletion_protection_enabled` is
+  # enforced by DynamoDB, this is enforced by Terraform, so clearing the
+  # variable alone cannot destroy the table. Remove this block to tear down.
+  lifecycle {
+    prevent_destroy = true
   }
 }
 

--- a/packages/nx-plugin/src/utils/rdb-constructs/files/terraform/core/rdb/aurora/aurora.tf.template
+++ b/packages/nx-plugin/src/utils/rdb-constructs/files/terraform/core/rdb/aurora/aurora.tf.template
@@ -215,6 +215,10 @@ resource "aws_kms_key" "database" {
   description         = "KMS key for Aurora cluster ${var.name}"
   enable_key_rotation = var.enable_key_rotation
 
+  # Restoring a snapshot of an encrypted cluster requires this key, so keep the
+  # maximum window in which a scheduled deletion can still be cancelled.
+  deletion_window_in_days = 30
+
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
@@ -357,6 +361,13 @@ resource "aws_rds_cluster" "database" {
   tags = merge(var.tags, {
     Name = "${var.name}-aurora"
   })
+
+  # Second, independent layer of protection: `deletion_protection` is enforced
+  # by RDS, this is enforced by Terraform, so clearing the variable alone cannot
+  # destroy the cluster. Remove this block to tear down.
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 resource "aws_rds_cluster_instance" "database" {

--- a/packages/nx-plugin/src/utils/rdb-constructs/files/terraform/core/rdb/aurora/aurora.tf.template
+++ b/packages/nx-plugin/src/utils/rdb-constructs/files/terraform/core/rdb/aurora/aurora.tf.template
@@ -215,8 +215,6 @@ resource "aws_kms_key" "database" {
   description         = "KMS key for Aurora cluster ${var.name}"
   enable_key_rotation = var.enable_key_rotation
 
-  # Restoring a snapshot of an encrypted cluster requires this key, so keep the
-  # maximum window in which a scheduled deletion can still be cancelled.
   deletion_window_in_days = 30
 
   policy = jsonencode({
@@ -362,9 +360,6 @@ resource "aws_rds_cluster" "database" {
     Name = "${var.name}-aurora"
   })
 
-  # Second, independent layer of protection: `deletion_protection` is enforced
-  # by RDS, this is enforced by Terraform, so clearing the variable alone cannot
-  # destroy the cluster. Remove this block to tear down.
   lifecycle {
     prevent_destroy = true
   }


### PR DESCRIPTION
### Reason for this change

The CDK and Terraform paths had materially different data-loss protection, and Terraform's was weaker by one whole layer.

CDK guards data-bearing resources with **two independent** guards:

| | CDK | Terraform (before) |
|---|---|---|
| DynamoDB table | `deletionProtection = true` **+** `RemovalPolicy.RETAIN` | `deletion_protection_enabled = true` only |
| Aurora cluster | `deletionProtection = true` **+** `RemovalPolicy.RETAIN` | `deletion_protection = true` only |

`grep -rn "prevent_destroy" packages/nx-plugin/src/` returned zero matches. The service-side defaults were correctly at `true` and matched CDK — that part was fine. The gap was that a user who flips that flag to `false` — a one-line, plan-visible, entirely ordinary change ("disable deletion protection so I can rename the table") — destroys the data **in the same apply**. On CDK they would still have to defeat `DeletionPolicy: Retain` separately, in a different place.

### Description of changes

**1. A second, independent guard on the two data-bearing resources.**

`lifecycle { prevent_destroy = true }` on `aws_dynamodb_table.table` and `aws_rds_cluster.database`. The service-side flag is enforced by DynamoDB/RDS; this is enforced by Terraform, so clearing the variable alone can no longer destroy the data — mirroring the CDK posture.

**Design decision — why `prevent_destroy`, and why it is a literal.** `prevent_destroy` **cannot be driven by a variable**; Terraform requires a literal. That constraint shaped the design:

- Scoped to the **two resources that actually hold data**, not all 23 KMS keys or every resource in the modules. A blanket application would make routine key rotation and instance replacement fail plans for no data-safety benefit.
- Vended as a literal with a comment naming the teardown action, and documented in both generator guides. This follows the precedent already in the repo for an "edit this to tear down" flow (the e2e string-patches Cognito `deletion_protection`).
- The alternative — docs/KMS alignment only, no `prevent_destroy` — was rejected because it leaves the actual exposure open: the whole point is that one variable flip should not be sufficient to delete data.

**2. `deletion_window_in_days = 30` on both data resources' KMS keys.**

This is the correction of a premise worth flagging explicitly, because it runs **opposite** to "make the table's CMK consistent with its 22 siblings":

- CDK's `Key` default `pendingWindow` is **30 days** (`aws-cdk-lib` typing: `@default - 30 days`).
- The AWS provider's `aws_kms_key.deletion_window_in_days` default is also **30**: *"If you do not specify a value, it defaults to `30`."*

So the DynamoDB and Aurora keys, which omitted the attribute, were already the **safest** keys and already at CDK parity. The 5 siblings pinning `= 7` are the ones diverging from CDK. Setting the table's key to `7` "for consistency" would have **shrunk** the recovery window 30→7 and moved it *further* from CDK — the opposite of the stated goal. A PITR restore of a CMK-encrypted table requires the original key, so the window matters as much as the backup. I therefore pinned `30` **explicitly** on the two data keys, which is a no-op in behaviour but makes the intent load-bearing and immune to a future provider default change. The 22 unrelated `= 7` keys (buckets, logs, APIs) are left alone as out of scope.

**3. A migration**, per CONTRIBUTING ("assume a migration is needed"), since these files are vended `KeepExisting` and an upgraded workspace would otherwise keep the weaker protection. Deterministic, GritQL-based, pattern-matches the vended shape before writing, reports diverged files via `nextSteps`, preserves a user's own `prevent_destroy = false`, and is idempotent.

**4. Docs** (English only) for both guides: the two-layer model, and the full teardown path including the `prevent_destroy`-is-a-literal caveat and a caution that the core module is shared by every table/database in the workspace.

### Description of how you validated changes

**Teardown still works — the critical constraint.** `terraform-deploy` and `terraform-deploy-rdb` both destroy these exact resources, so leaking CI resources would be worse than the bug. `e2e/src/smoke-tests/terraform-deploy.spec.ts` now flips the literal to `false`, alongside the existing Cognito patch and immediately before `bootstrap`/`apply`:

```ts
for (const relativeTfPath of ['core/dynamodb/dynamodb.tf', 'core/rdb/aurora/aurora.tf']) {
  // ... .replace(/prevent_destroy\s*=\s*true/g, 'prevent_destroy = false')
}
```

Why this is sufficient:
- The server-side flags are **already** disabled by the wiring templates (`deletion_protection_enabled = false` in `main.tf.template`; `deletion_protection = false` + `skip_final_snapshot = true` in `main-rdb.tf.template`), so the lifecycle literal was the only remaining blocker.
- `prevent_destroy = false` is a valid literal, so no block removal or HCL surgery is needed.
- Run against the **real generated workspace**, the patch matched both files exactly — `remaining true=0, false=1` in each — and the patched config still plans clean.
- **`bootstrap-destroy` is unaffected**: `infra/bootstrap/main.tf` defines only its own `aws_s3_bucket.terraform_state` (+ versioning/encryption/policy) and never consumes the vended data modules. `grep -rn prevent_destroy infra/bootstrap/` → no matches.

**Proof the guard actually works.** Real `terraform apply` then `terraform destroy`:

```
Plan: 0 to add, 0 to change, 1 to destroy.
Error: Instance cannot be destroyed
Resource null_resource.table has lifecycle.prevent_destroy set, but the plan
calls for this resource to be destroyed.
```

`0 destroyed`. After applying the e2e's exact substitution: `Destroy complete! Resources: 1 destroyed.` Both directions verified.

**Real generated workspace + credential-free plan.** Compiled the plugin, generated a Terraform workspace with `ts#dynamodb` (electrodb) and `ts#rdb` (Aurora postgres), and ran `terraform init -backend=false` plus `terraform test` with the mocked-provider pattern from `e2e/src/smoke-tests/terraform-plan-test.ts`:

```
Success! 1 passed, 0 failed.
```

Generated HCL:

```hcl
resource "aws_kms_key" "table" {
  count = local.create_table_key ? 1 : 0

  description         = "KMS key for DynamoDB table ${var.name}"
  enable_key_rotation = var.enable_key_rotation

  # A point-in-time restore of a CMK-encrypted table requires this key, so keep
  # the maximum window in which a scheduled deletion can still be cancelled.
  deletion_window_in_days = 30
```

```hcl
resource "aws_dynamodb_table" "table" {
  # ...
  # Second, independent layer of protection: `deletion_protection_enabled` is
  # enforced by DynamoDB, this is enforced by Terraform, so clearing the
  # variable alone cannot destroy the table. Remove this block to tear down.
  lifecycle {
    prevent_destroy = true
  }
}
```

```hcl
resource "aws_rds_cluster" "database" {
  # ...
  # Second, independent layer of protection: `deletion_protection` is enforced
  # by RDS, this is enforced by Terraform, so clearing the variable alone cannot
  # destroy the cluster. Remove this block to tear down.
  lifecycle {
    prevent_destroy = true
  }
}
```

**Tests.** Added generator unit tests asserting both guards appear in the generated `.tf` (`ts#dynamodb`, `ts#rdb`), and 6 migration tests (applies to each vended shape, no-op on a workspace without the modules, skips + reports a customised file, preserves an existing `prevent_destroy = false`, idempotent with exactly one guard per file).

- `pnpm nx run @aws/nx-plugin:test` — **198 files / 3709 tests pass**. The only snapshot changes were the 4 additive diffs for these templates; each was inspected before updating.
- `pnpm nx run-many --target build --all` — pass.
- `pnpm nx run-many --target lint --all --configuration=fix` — pass, no changes to any file in this PR.

### Issue #

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
