### PR TITLE
fix(ts#react-website): point terraform load-runtime-config at the aggregated config file

### DIFF
--- a/docs/src/content/docs/en/guides/react-website.mdx
+++ b/docs/src/content/docs/en/guides/react-website.mdx
@@ -602,7 +602,7 @@ If you change the prefix for your stage names in your infrastructure project's `
 Additionally it's worth noting that the `load-runtime-config` target assumes a single stage of your application is deployed to the environment you have AWS credentials for. You will need to adjust the command if you deploy multiple stages to the same account and region.
 </Fragment>
 <Fragment slot="terraform">
-For Terraform projects, the `load-runtime-config` target copies the `runtime-config.json` file that was created after your most recent local `terraform apply`.
+For Terraform projects, the `load-runtime-config` target copies the runtime config your most recent local `terraform apply` aggregated, from `dist/packages/common/terraform/runtime-config/connection.json`.
 </Fragment>
 </Infrastructure>
 :::

--- a/docs/src/content/docs/es/guides/react-website.mdx
+++ b/docs/src/content/docs/es/guides/react-website.mdx
@@ -602,7 +602,7 @@ Si cambias el prefijo para los nombres de tus etapas en el `src/main.ts` de tu p
 Además, vale la pena señalar que el objetivo `load-runtime-config` asume que una sola etapa de tu aplicación está desplegada en el entorno para el que tienes credenciales AWS. Necesitarás ajustar el comando si despliegas múltiples etapas en la misma cuenta y región.
 </Fragment>
 <Fragment slot="terraform">
-Para proyectos Terraform, el objetivo `load-runtime-config` copia el archivo `runtime-config.json` que se creó después de tu `terraform apply` local más reciente.
+Para proyectos Terraform, el objetivo `load-runtime-config` copia la configuración en tiempo de ejecución que tu `terraform apply` local más reciente agregó, desde `dist/packages/common/terraform/runtime-config/connection.json`.
 </Fragment>
 </Infrastructure>
 :::

--- a/docs/src/content/docs/fr/guides/react-website.mdx
+++ b/docs/src/content/docs/fr/guides/react-website.mdx
@@ -602,7 +602,7 @@ Si vous modifiez le préfixe de vos noms de stage dans le `src/main.ts` de votre
 De plus, il convient de noter que la cible `load-runtime-config` suppose qu'un seul stage de votre application est déployé dans l'environnement pour lequel vous avez des informations d'identification AWS. Vous devrez ajuster la commande si vous déployez plusieurs stages dans le même compte et la même région.
 </Fragment>
 <Fragment slot="terraform">
-Pour les projets Terraform, la cible `load-runtime-config` copie le fichier `runtime-config.json` qui a été créé après votre `terraform apply` local le plus récent.
+Pour les projets Terraform, la cible `load-runtime-config` copie la configuration d'exécution que votre `terraform apply` local le plus récent a agrégée, depuis `dist/packages/common/terraform/runtime-config/connection.json`.
 </Fragment>
 </Infrastructure>
 :::

--- a/docs/src/content/docs/it/guides/react-website.mdx
+++ b/docs/src/content/docs/it/guides/react-website.mdx
@@ -602,7 +602,7 @@ Se modifichi il prefisso per i nomi dei tuoi stage nel file `src/main.ts` del tu
 Inoltre, vale la pena notare che il target `load-runtime-config` presuppone che un singolo stage della tua applicazione sia distribuito nell'ambiente per cui hai credenziali AWS. Dovrai regolare il comando se distribuisci più stage nello stesso account e regione.
 </Fragment>
 <Fragment slot="terraform">
-Per i progetti Terraform, il target `load-runtime-config` copia il file `runtime-config.json` che è stato creato dopo il tuo più recente `terraform apply` locale.
+Per i progetti Terraform, il target `load-runtime-config` copia la configurazione runtime aggregata dal tuo più recente `terraform apply` locale, da `dist/packages/common/terraform/runtime-config/connection.json`.
 </Fragment>
 </Infrastructure>
 :::

--- a/docs/src/content/docs/jp/guides/react-website.mdx
+++ b/docs/src/content/docs/jp/guides/react-website.mdx
@@ -602,7 +602,7 @@ const MyComponent = () => {
 また、`load-runtime-config`ターゲットは、AWS認証情報を持つ環境にアプリケーションの単一のステージがデプロイされていることを前提としていることに注意してください。同じアカウントとリージョンに複数のステージをデプロイする場合は、コマンドを調整する必要があります。
 </Fragment>
 <Fragment slot="terraform">
-Terraformプロジェクトの場合、`load-runtime-config`ターゲットは、最新のローカル`terraform apply`後に作成された`runtime-config.json`ファイルをコピーします。
+Terraformプロジェクトの場合、`load-runtime-config`ターゲットは、最新のローカル`terraform apply`が集約したランタイム設定を`dist/packages/common/terraform/runtime-config/connection.json`からコピーします。
 </Fragment>
 </Infrastructure>
 :::

--- a/docs/src/content/docs/ko/guides/react-website.mdx
+++ b/docs/src/content/docs/ko/guides/react-website.mdx
@@ -602,7 +602,7 @@ const MyComponent = () => {
 또한 `load-runtime-config` 타겟은 AWS 자격 증명이 있는 환경에 애플리케이션의 단일 스테이지가 배포되어 있다고 가정합니다. 동일한 계정 및 리전에 여러 스테이지를 배포하는 경우 명령을 조정해야 합니다.
 </Fragment>
 <Fragment slot="terraform">
-Terraform 프로젝트의 경우 `load-runtime-config` 타겟은 가장 최근의 로컬 `terraform apply` 후에 생성된 `runtime-config.json` 파일을 복사합니다.
+Terraform 프로젝트의 경우 `load-runtime-config` 타겟은 가장 최근의 로컬 `terraform apply`가 집계한 런타임 구성을 `dist/packages/common/terraform/runtime-config/connection.json`에서 복사합니다.
 </Fragment>
 </Infrastructure>
 :::

--- a/docs/src/content/docs/pt/guides/react-website.mdx
+++ b/docs/src/content/docs/pt/guides/react-website.mdx
@@ -602,7 +602,7 @@ Se você alterar o prefixo para seus nomes de stage no `src/main.ts` do seu proj
 Além disso, vale notar que o target `load-runtime-config` assume que um único stage da sua aplicação está implantado no ambiente para o qual você tem credenciais AWS. Você precisará ajustar o comando se implantar múltiplos stages na mesma conta e região.
 </Fragment>
 <Fragment slot="terraform">
-Para projetos Terraform, o target `load-runtime-config` copia o arquivo `runtime-config.json` que foi criado após seu `terraform apply` local mais recente.
+Para projetos Terraform, o target `load-runtime-config` copia a configuração de runtime que seu `terraform apply` local mais recente agregou, de `dist/packages/common/terraform/runtime-config/connection.json`.
 </Fragment>
 </Infrastructure>
 :::

--- a/docs/src/content/docs/vi/guides/react-website.mdx
+++ b/docs/src/content/docs/vi/guides/react-website.mdx
@@ -602,7 +602,7 @@ Nếu bạn thay đổi tiền tố cho tên stage của bạn trong `src/main.t
 Ngoài ra, đáng chú ý là target `load-runtime-config` giả định một stage duy nhất của ứng dụng của bạn được triển khai vào môi trường mà bạn có AWS credentials. Bạn sẽ cần điều chỉnh lệnh nếu bạn triển khai nhiều stages vào cùng một account và region.
 </Fragment>
 <Fragment slot="terraform">
-Đối với các dự án Terraform, target `load-runtime-config` sao chép file `runtime-config.json` được tạo sau lần `terraform apply` local gần nhất của bạn.
+Đối với các dự án Terraform, target `load-runtime-config` sao chép runtime config mà lần `terraform apply` local gần nhất của bạn đã tổng hợp, từ `dist/packages/common/terraform/runtime-config/connection.json`.
 </Fragment>
 </Infrastructure>
 :::

--- a/docs/src/content/docs/zh/guides/react-website.mdx
+++ b/docs/src/content/docs/zh/guides/react-website.mdx
@@ -602,7 +602,7 @@ const MyComponent = () => {
 此外值得注意的是，`load-runtime-config` 目标假设您的应用程序的单个阶段已部署到您拥有 AWS 凭证的环境中。如果您将多个阶段部署到同一账户和区域，则需要调整命令。
 </Fragment>
 <Fragment slot="terraform">
-对于 Terraform 项目，`load-runtime-config` 目标会复制在最近一次本地 `terraform apply` 后创建的 `runtime-config.json` 文件。
+对于 Terraform 项目，`load-runtime-config` 目标会从 `dist/packages/common/terraform/runtime-config/connection.json` 复制您最近一次本地 `terraform apply` 聚合的运行时配置。
 </Fragment>
 </Infrastructure>
 :::

--- a/packages/nx-plugin/src/migrations/latest/terraform-load-runtime-config-src-path/metadata.json
+++ b/packages/nx-plugin/src/migrations/latest/terraform-load-runtime-config-src-path/metadata.json
@@ -1,0 +1,3 @@
+{
+  "description": "Point the react website's terraform load-runtime-config target at the runtime-config file the terraform aggregation actually writes"
+}

--- a/packages/nx-plugin/src/migrations/latest/terraform-load-runtime-config-src-path/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/latest/terraform-load-runtime-config-src-path/migration.spec.ts
@@ -1,0 +1,166 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import {
+  addProjectConfiguration,
+  readProjectConfiguration,
+  type Tree,
+} from '@nx/devkit';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test.js';
+import migration from './migration.js';
+
+const BROKEN_SRC_FILE = 'dist/packages/common/terraform/runtime-config.json';
+const FIXED_SRC_FILE =
+  'dist/packages/common/terraform/runtime-config/connection.json';
+
+const terraformTarget = (srcFile = BROKEN_SRC_FILE) => ({
+  executor: 'nx:run-commands',
+  metadata: {
+    description:
+      "Load runtime config from most recently applied terraform env for dev purposes. Copies the runtime config from the Terraform dist directory to the website's public directory.",
+  },
+  options: {
+    command:
+      'node -e "const fs=require(\'fs\');fs.mkdirSync(process.env.DEST_DIR,{recursive:true});fs.copyFileSync(process.env.SRC_FILE,process.env.DEST_FILE);"',
+    env: {
+      SRC_FILE: srcFile,
+      DEST_DIR: '{projectRoot}/public',
+      DEST_FILE: '{projectRoot}/public/runtime-config.json',
+    },
+  },
+});
+
+const cdkTarget = () => ({
+  executor: 'nx:run-commands',
+  options: {
+    command:
+      'aws s3 cp s3://`aws cloudformation describe-stacks`/runtime-config.json "{projectRoot}/public/runtime-config.json"',
+  },
+});
+
+describe('terraform-load-runtime-config-src-path migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeUsingTsSolutionSetup();
+  });
+
+  it('should point SRC_FILE at the aggregated namespace file', async () => {
+    addProjectConfiguration(tree, 'website', {
+      root: 'packages/website',
+      targets: { 'load-runtime-config': terraformTarget() },
+    });
+
+    await migration(tree);
+
+    const target = readProjectConfiguration(tree, 'website').targets?.[
+      'load-runtime-config'
+    ];
+    expect(target?.options?.env).toEqual({
+      SRC_FILE: FIXED_SRC_FILE,
+      DEST_DIR: '{projectRoot}/public',
+      DEST_FILE: '{projectRoot}/public/runtime-config.json',
+    });
+    // The command is untouched — only the path it reads was wrong.
+    expect(target?.options?.command).toBe(terraformTarget().options.command);
+  });
+
+  it('should also fix the load:runtime-config target left in place by the rename', async () => {
+    addProjectConfiguration(tree, 'website', {
+      root: 'packages/website',
+      targets: {
+        'load:runtime-config': terraformTarget(),
+        'load-runtime-config': terraformTarget(),
+      },
+    });
+
+    await migration(tree);
+
+    const targets = readProjectConfiguration(tree, 'website').targets;
+    expect(targets?.['load:runtime-config']?.options?.env?.SRC_FILE).toBe(
+      FIXED_SRC_FILE,
+    );
+    expect(targets?.['load-runtime-config']?.options?.env?.SRC_FILE).toBe(
+      FIXED_SRC_FILE,
+    );
+  });
+
+  it('should leave a customised SRC_FILE untouched', async () => {
+    const customised = terraformTarget('dist/my/own/config.json');
+    addProjectConfiguration(tree, 'website', {
+      root: 'packages/website',
+      targets: { 'load-runtime-config': customised },
+    });
+
+    await migration(tree);
+
+    expect(
+      readProjectConfiguration(tree, 'website').targets?.[
+        'load-runtime-config'
+      ],
+    ).toEqual(customised);
+  });
+
+  it('should leave CDK websites untouched', async () => {
+    addProjectConfiguration(tree, 'website', {
+      root: 'packages/website',
+      targets: { 'load-runtime-config': cdkTarget() },
+    });
+
+    await migration(tree);
+
+    expect(
+      readProjectConfiguration(tree, 'website').targets?.[
+        'load-runtime-config'
+      ],
+    ).toEqual(cdkTarget());
+  });
+
+  it('should do nothing when no project has the target', async () => {
+    addProjectConfiguration(tree, 'api', {
+      root: 'packages/api',
+      targets: { build: { executor: 'nx:run-commands' } },
+    });
+
+    await migration(tree);
+
+    expect(
+      readProjectConfiguration(tree, 'api').targets?.['load-runtime-config'],
+    ).toBeUndefined();
+  });
+
+  it('should handle multiple projects', async () => {
+    addProjectConfiguration(tree, 'website-a', {
+      root: 'packages/website-a',
+      targets: { 'load-runtime-config': terraformTarget() },
+    });
+    addProjectConfiguration(tree, 'website-b', {
+      root: 'packages/website-b',
+      targets: { 'load-runtime-config': terraformTarget() },
+    });
+
+    await migration(tree);
+
+    for (const project of ['website-a', 'website-b']) {
+      expect(
+        readProjectConfiguration(tree, project).targets?.['load-runtime-config']
+          ?.options?.env?.SRC_FILE,
+      ).toBe(FIXED_SRC_FILE);
+    }
+  });
+
+  it('should be idempotent', async () => {
+    addProjectConfiguration(tree, 'website', {
+      root: 'packages/website',
+      targets: { 'load-runtime-config': terraformTarget() },
+    });
+
+    await migration(tree);
+    const afterFirst = readProjectConfiguration(tree, 'website');
+
+    await migration(tree);
+
+    expect(readProjectConfiguration(tree, 'website')).toEqual(afterFirst);
+  });
+});

--- a/packages/nx-plugin/src/migrations/latest/terraform-load-runtime-config-src-path/migration.ts
+++ b/packages/nx-plugin/src/migrations/latest/terraform-load-runtime-config-src-path/migration.ts
@@ -1,0 +1,61 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import {
+  getProjects,
+  type MigrationReturnObject,
+  type Tree,
+  updateProjectConfiguration,
+} from '@nx/devkit';
+import { formatFilesInSubtree } from '../../../utils/format.js';
+import { TERRAFORM_WEBSITE_RUNTIME_CONFIG_FILE } from '../../../utils/shared-constructs-constants.js';
+
+/**
+ * The Terraform `load-runtime-config` target copied
+ * `dist/packages/common/terraform/runtime-config.json`, which nothing writes:
+ * the vended runtime-config modules aggregate per namespace into the
+ * `runtime-config` *directory*, so the website's config lands at
+ * `runtime-config/connection.json`. Copying the directory path always failed
+ * with ENOENT, so point it at the file the aggregation actually writes.
+ *
+ * Both target names are rewritten — `load-runtime-config` and the
+ * `load:runtime-config` it was cloned from, which is left in place for
+ * workspaces that still reference it.
+ *
+ * How to write a migration:
+ * - https://nx.dev/docs/kb/migration-generators
+ * - What `nextSteps` means: https://nx.dev/docs/reference/devkit/MigrationReturnObject
+ */
+
+const TARGETS = ['load-runtime-config', 'load:runtime-config'];
+
+/** The path the target used to name, which never existed on disk. */
+const BROKEN_SRC_FILE = 'dist/packages/common/terraform/runtime-config.json';
+
+export default async function migration(
+  tree: Tree,
+): Promise<MigrationReturnObject> {
+  for (const [projectName, project] of getProjects(tree)) {
+    let updated = false;
+
+    for (const targetName of TARGETS) {
+      const env = project.targets?.[targetName]?.options?.env;
+      // Only the broken path is rewritten, so a workspace that pointed the
+      // target somewhere of its own keeps it.
+      if (env?.SRC_FILE !== BROKEN_SRC_FILE) {
+        continue;
+      }
+      env.SRC_FILE = TERRAFORM_WEBSITE_RUNTIME_CONFIG_FILE;
+      updated = true;
+    }
+
+    if (updated) {
+      updateProjectConfiguration(tree, projectName, project);
+    }
+  }
+
+  await formatFilesInSubtree(tree);
+
+  return {};
+}

--- a/packages/nx-plugin/src/migrations/v1.0.0-rc.62/0001-rename-load-runtime-config-target/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/v1.0.0-rc.62/0001-rename-load-runtime-config-target/migration.spec.ts
@@ -25,6 +25,12 @@ const cdkTarget = () => ({
   },
 });
 
+/**
+ * The target as workspaces of this era carried it. `SRC_FILE` names a path
+ * nothing writes — the `terraform-load-runtime-config-src-path` migration
+ * corrects that separately. This migration clones the target verbatim, so the
+ * fixture stays as-generated-then.
+ */
 const terraformTarget = () => ({
   executor: 'nx:run-commands',
   metadata: {

--- a/packages/nx-plugin/src/ts/react-website/app/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/react-website/app/generator.spec.ts
@@ -2,12 +2,20 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
+import { execSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, posix } from 'node:path';
 import { readJson, type Tree } from '@nx/devkit';
 import {
   ensureAwsNxPluginConfig,
   updateAwsNxPluginConfig,
 } from '../../../utils/config/utils.js';
 import { expectHasMetricTags } from '../../../utils/metrics.spec.js';
+import {
+  PACKAGES_DIR,
+  SHARED_TERRAFORM_DIR,
+} from '../../../utils/shared-constructs-constants.js';
 import {
   createTreeUsingTsSolutionSetup,
   snapshotTreeDir,
@@ -644,7 +652,8 @@ describe('react-website generator', () => {
         'fs.copyFileSync',
       );
       expect(loadRuntimeConfigTarget.options.env).toEqual({
-        SRC_FILE: 'dist/packages/common/terraform/runtime-config.json',
+        SRC_FILE:
+          'dist/packages/common/terraform/runtime-config/connection.json',
         DEST_DIR: '{projectRoot}/public',
         DEST_FILE: '{projectRoot}/public/runtime-config.json',
       });
@@ -672,7 +681,7 @@ describe('react-website generator', () => {
 
       expect(loadRuntimeConfigTarget).toBeDefined();
       expect(loadRuntimeConfigTarget.options.env.SRC_FILE).toBe(
-        'dist/packages/common/terraform/runtime-config.json',
+        'dist/packages/common/terraform/runtime-config/connection.json',
       );
       expect(loadRuntimeConfigTarget.options.env.DEST_DIR).toBe(
         '{projectRoot}/public',
@@ -705,6 +714,94 @@ describe('react-website generator', () => {
       expect(loadRuntimeConfigTarget.options.command).toContain(
         'TestAppWebsiteBucketName',
       );
+    });
+
+    /**
+     * The Terraform target copies a file the vended `.tf` modules write at apply
+     * time, so `SRC_FILE` is derived from those modules rather than restated
+     * here — a change to either the aggregation's output directory or the
+     * namespace the website reads fails this rather than silently breaking the
+     * target.
+     */
+    const deriveAggregatedConfigFile = (tree: Tree): string => {
+      const readModuleDir = `${PACKAGES_DIR}/${SHARED_TERRAFORM_DIR}/src/core/runtime-config/read`;
+
+      // The `read` module resolves its aggregation directory relative to itself.
+      const readTf = tree.read(`${readModuleDir}/read.tf`, 'utf-8')!;
+      const configDir = /config_dir\s*=\s*"\$\{path\.module\}\/(.+?)"/.exec(
+        readTf,
+      )![1];
+
+      // It aggregates the namespace's entries into `<config_dir>/<namespace>.json`.
+      expect(readTf).toContain(
+        'namespace_path  = "${local.config_dir}/${var.namespace}.json"',
+      );
+
+      // The website reads one namespace from that directory.
+      const staticWebsiteTf = tree.read(
+        `${PACKAGES_DIR}/${SHARED_TERRAFORM_DIR}/src/core/static-website/static-website.tf`,
+        'utf-8',
+      )!;
+      const namespace =
+        /module "runtime_config_reader" \{[^}]*?namespace\s*=\s*"(.+?)"/s.exec(
+          staticWebsiteTf,
+        )![1];
+
+      return `${posix.join(readModuleDir, configDir)}/${namespace}.json`;
+    };
+
+    it('should point SRC_FILE at the file the terraform aggregation writes', async () => {
+      await tsReactWebsiteGenerator(tree, {
+        ...options,
+        iac: 'terraform',
+      });
+
+      const projectConfig = readJson(tree, 'test-app/project.json');
+      expect(
+        projectConfig.targets['load-runtime-config'].options.env.SRC_FILE,
+      ).toBe(deriveAggregatedConfigFile(tree));
+    });
+
+    it("should copy the aggregated config into the website's public directory", async () => {
+      await tsReactWebsiteGenerator(tree, {
+        ...options,
+        iac: 'terraform',
+      });
+
+      const { command, env } = readJson(tree, 'test-app/project.json').targets[
+        'load-runtime-config'
+      ].options;
+
+      // Stand the aggregation's output up on disk exactly where the vended
+      // Terraform writes it, then run the target's real command against it.
+      const workspaceRoot = mkdtempSync(join(tmpdir(), 'load-runtime-config-'));
+      const runtimeConfig = { apis: { MyApi: 'https://example.com' } };
+      const srcFile = join(workspaceRoot, env.SRC_FILE);
+      mkdirSync(dirname(srcFile), { recursive: true });
+      writeFileSync(srcFile, JSON.stringify(runtimeConfig));
+
+      // `{projectRoot}` is substituted by nx before the executor runs.
+      const resolveTokens = (value: string) =>
+        value.replace(/\{projectRoot\}/g, 'test-app');
+
+      execSync(command, {
+        cwd: workspaceRoot,
+        env: {
+          ...process.env,
+          DEST_DIR: resolveTokens(env.DEST_DIR),
+          DEST_FILE: resolveTokens(env.DEST_FILE),
+          SRC_FILE: env.SRC_FILE,
+        },
+      });
+
+      expect(
+        JSON.parse(
+          readFileSync(
+            join(workspaceRoot, 'test-app/public/runtime-config.json'),
+            'utf-8',
+          ),
+        ),
+      ).toEqual(runtimeConfig);
     });
   });
 

--- a/packages/nx-plugin/src/ts/react-website/app/generator.ts
+++ b/packages/nx-plugin/src/ts/react-website/app/generator.ts
@@ -48,6 +48,7 @@ import {
   type IacMetadata,
   PACKAGES_DIR,
   SHARED_SHADCN_DIR,
+  TERRAFORM_WEBSITE_RUNTIME_CONFIG_FILE,
 } from '../../../utils/shared-constructs-constants.js';
 import {
   SHADCN_DEPENDENCIES,
@@ -262,7 +263,7 @@ export async function tsReactWebsiteGenerator(
         command:
           'node -e "const fs=require(\'fs\');fs.mkdirSync(process.env.DEST_DIR,{recursive:true});fs.copyFileSync(process.env.SRC_FILE,process.env.DEST_FILE);"',
         env: {
-          SRC_FILE: 'dist/packages/common/terraform/runtime-config.json',
+          SRC_FILE: TERRAFORM_WEBSITE_RUNTIME_CONFIG_FILE,
           DEST_DIR: `{projectRoot}/public`,
           DEST_FILE: `{projectRoot}/public/runtime-config.json`,
         },

--- a/packages/nx-plugin/src/utils/shared-constructs-constants.ts
+++ b/packages/nx-plugin/src/utils/shared-constructs-constants.ts
@@ -20,6 +20,26 @@ export const SHARED_SCRIPTS_DIR = 'common/scripts';
 export const DYNAMODB_GENERATOR_IDS = ['ts#dynamodb', 'py#dynamodb'];
 
 /**
+ * Directory the vended Terraform runtime-config modules aggregate into at apply
+ * time, relative to the workspace root. The `entry` module writes leaf files
+ * under `entries/<namespace>/`, and the `read` / `appconfig-deployment` modules
+ * merge those into one `<namespace>.json` here.
+ */
+export const TERRAFORM_RUNTIME_CONFIG_DIR = `dist/${PACKAGES_DIR}/${SHARED_TERRAFORM_DIR}/runtime-config`;
+
+/**
+ * Runtime-config namespace the static website publishes to and reads back, as
+ * passed to the `read` module by the vended static-website Terraform module.
+ */
+export const WEBSITE_RUNTIME_CONFIG_NAMESPACE = 'connection';
+
+/**
+ * File the Terraform aggregation writes the website's runtime config to,
+ * relative to the workspace root.
+ */
+export const TERRAFORM_WEBSITE_RUNTIME_CONFIG_FILE = `${TERRAFORM_RUNTIME_CONFIG_DIR}/${WEBSITE_RUNTIME_CONFIG_NAMESPACE}.json`;
+
+/**
  * What a generator records about the infrastructure it generated.
  *
  * Every generator that creates infrastructure records the `iac` it used, so a


### PR DESCRIPTION
### Reason for this change

The `load-runtime-config` target the `ts#react-website` generator vends for `iac=terraform` read a path that can never exist, so it always failed with `ENOENT`. That breaks the documented workflow of running the website locally against a deployed stack.

**The mismatch is a directory being treated as a file.** The vended runtime-config Terraform modules aggregate *per namespace* into a directory:

- `core/runtime-config/entry` writes each contributor's leaf file to `<config_dir>/entries/<namespace>/<key>-<sha>.json`
- `core/runtime-config/read` (and `appconfig-deployment`, which does the same aggregation for AppConfig) merges those into `<config_dir>/<namespace>.json`

Both resolve `config_dir` with seven `../` from their module location (`packages/common/terraform/src/core/runtime-config/{read,entry}`), which lands on **`dist/packages/common/terraform/runtime-config`** — a directory. The vended static-website module reads namespace `connection`:

```hcl
module "runtime_config_reader" {
  source    = "../runtime-config/read"
  namespace = "connection"
}
```

so the file that actually gets written is **`dist/packages/common/terraform/runtime-config/connection.json`**.

The target's `SRC_FILE` named `dist/packages/common/terraform/runtime-config.json` — the directory path with `.json` glued on. Nothing in the Terraform path writes that filename; the only other `runtime-config.json` is the **S3 object key** in `static-website.tf`, which is a different artefact (what the browser fetches from CloudFront). `fs.copyFileSync` therefore always threw.

### Description of changes

**Point `SRC_FILE` at the file the aggregation writes**, via new constants in `utils/shared-constructs-constants.ts` composed from the existing `PACKAGES_DIR` / `SHARED_TERRAFORM_DIR`:

```ts
export const TERRAFORM_RUNTIME_CONFIG_DIR = `dist/${PACKAGES_DIR}/${SHARED_TERRAFORM_DIR}/runtime-config`;
export const WEBSITE_RUNTIME_CONFIG_NAMESPACE = 'connection';
export const TERRAFORM_WEBSITE_RUNTIME_CONFIG_FILE = `${TERRAFORM_RUNTIME_CONFIG_DIR}/${WEBSITE_RUNTIME_CONFIG_NAMESPACE}.json`;
```

**Why point the target at the aggregated file rather than have the aggregation also emit `runtime-config.json`?** Both were weighed:

- The naming-consistency argument for emitting a second file is real — the S3 object key is `runtime-config.json` and the browser fetches `/runtime-config.json` at runtime, and `DEST_FILE` already writes that name into `public/`. But that name belongs to the *serving* layer, not the aggregation layer, and it is already produced correctly at both ends.
- `runtime-config/<namespace>.json` is what the namespace-based aggregation genuinely produces, and it is what the rest of the system reads: `read`'s `data "local_file"` and `appconfig-deployment`'s `data "local_file"` both consume `${config_dir}/${namespace}.json`. Emitting an extra copy at `runtime-config.json` would add a second writer with no reader, another thing to keep in sync, and would sit *beside* the directory it duplicates from — inviting exactly this confusion again. It would also have to pick one namespace to privilege, when the aggregation is deliberately namespace-plural (`connection`, `agentcore`).

Pointing the one broken consumer at the existing file is the smaller, less surprising change, and leaves a single source of truth per namespace.

The rest of the target was sanity-checked and is correct as-is: `DEST_DIR`/`DEST_FILE` are `{projectRoot}/public` and `{projectRoot}/public/runtime-config.json` (nx resolves `{projectRoot}` inside `options.env` via `resolveNxTokensInOptions`, which recurses into nested objects), and the target is only created when `infra !== 'none'` — already covered by an existing test.

**Migration reasoning.** The broken string originated in the generator, so every Terraform website generated to date carries it — a fix to the generator alone leaves those workspaces broken, which is exactly what `CONTRIBUTING.md` says to ship a migration for. I added a **new** migration (`latest/terraform-load-runtime-config-src-path`) rather than editing the released `v1.0.0-rc.62/0001-rename-load-runtime-config-target`:

- That released migration's job is orthogonal — it *clones* `load:runtime-config` to `load-runtime-config` so the verb syntax works. It never authored `SRC_FILE`; it copied whatever it found. Editing it to also rewrite the path would silently change released behaviour for users who already ran it, and they would never see the correction because `nx migrate` gates on `installed < version` and would skip a migration they've already passed.
- A new unversioned migration in `latest/` runs for everyone upgrading, whether or not they took the rc.62 hop.

The new migration rewrites `env.SRC_FILE` **only when it exactly equals the broken value**, so a workspace that repointed the target keeps its own path. It handles both `load-runtime-config` and the `load:runtime-config` that rc.62 deliberately leaves in place, ignores CDK websites (no `env.SRC_FILE`), and is idempotent.

The rc.62 spec's fixture still carries the broken string, which is correct — it models a workspace of that era, which genuinely had it. I added a comment saying so and pointing at the new migration, rather than falsifying the fixture.

Docs: the Terraform fragment in `guides/react-website.mdx` now names the actual path (English only).

### Description of how you validated changes

**Unit tests.** Two new tests in `ts/react-website/app/generator.spec.ts`, plus the two existing ones updated off the broken value:

- `should point SRC_FILE at the file the terraform aggregation writes` — derives the expected path **from the vended `.tf` modules in the generated tree** rather than restating it: parses `config_dir` out of `read.tf` and resolves it against the read module's own location, asserts `namespace_path` is still `${config_dir}/${namespace}.json`, and parses the namespace out of the `runtime_config_reader` block in `static-website.tf`. So `SRC_FILE` can't silently drift from what the aggregation writes — changing either the output directory or the website's namespace fails this test. Verified it catches the original bug (stashed the fix; it failed with `Expected "…/runtime-config/connection.json" / Received "…/runtime-config.json"`).
- `should copy the aggregated config into the website's public directory` — stands the aggregated file up on disk at `env.SRC_FILE`, runs the target's real `command` with `{projectRoot}` resolved as nx resolves it, and asserts the contents land at `public/runtime-config.json`.

Seven tests for the new migration (applies, fixes both target names, leaves a customised `SRC_FILE` alone, leaves CDK alone, no-op without the target, multiple projects, idempotent).

**Full gate, all green:** `pnpm nx run @aws/nx-plugin:test` — **199 files / 3716 tests passed**, no snapshot updates needed. `pnpm nx run-many --target build --all` — exit 0. `pnpm nx run-many --target lint --all --configuration=fix` — exit 0, none of the 8 changed files modified.

**End to end against a real generated Terraform workspace.** Compiled the plugin, generated a website with `iac=terraform`, then replayed the vended `read` module's aggregation *exactly* — including resolving `ENTRIES_DIR`/`NAMESPACE_PATH` relative to the read module's own path and running its embedded Python merge over realistic `entry`-module leaf files. That confirms the directory-vs-file shape:

```
dist/packages/common/terraform/runtime-config
dist/packages/common/terraform/runtime-config/connection.json
dist/packages/common/terraform/runtime-config/entries/connection/apis-8c1f2a3b…json
dist/packages/common/terraform/runtime-config/entries/connection/cognitoProps-1a2b3c4d…json
```

Note there is no `runtime-config.json` — `runtime-config` is a directory.

Then ran the generated target through the **real `nx` CLI**. Before (`SRC_FILE` as previously vended):

```
> nx run @tfws/website:load-runtime-config
Error: ENOENT: no such file or directory, copyfile
  'dist/packages/common/terraform/runtime-config.json' -> 'website/public/runtime-config.json'
  code: 'ENOENT', syscall: 'copyfile',
  path: 'dist/packages/common/terraform/runtime-config.json',
  dest: 'website/public/runtime-config.json'

NX   Running target load-runtime-config for project @tfws/website failed
landed: NO
```

After (`SRC_FILE` as vended now):

```
> nx run @tfws/website:load-runtime-config
> node -e "const fs=require('fs');fs.mkdirSync(process.env.DEST_DIR,{recursive:true});fs.copyFileSync(process.env.SRC_FILE,process.env.DEST_FILE);"

NX   Successfully ran target load-runtime-config for project @tfws/website
landed: yes
```

`website/public/runtime-config.json`:

```json
{
  "apis": {
    "MyApi": "https://abc123.execute-api.us-east-1.amazonaws.com/"
  },
  "cognitoProps": {
    "userPoolId": "us-east-1_AbCdEfGhI",
    "userPoolWebClientId": "1h57kjmo9j2gk3sf4l5m6n7o8p",
    "identityPoolId": "us-east-1:11111111-2222-3333-4444-555555555555",
    "region": "us-east-1"
  }
}
```

**Migration against that same workspace.** Regressed its `project.json` to the released shape (broken `SRC_FILE` on both `load-runtime-config` and `load:runtime-config`) and ran the compiled migration:

```
BEFORE migration:
 load-runtime-config.SRC_FILE = dist/packages/common/terraform/runtime-config.json
 load:runtime-config.SRC_FILE = dist/packages/common/terraform/runtime-config.json
AFTER migration:
 load-runtime-config.SRC_FILE = dist/packages/common/terraform/runtime-config/connection.json
 load:runtime-config.SRC_FILE = dist/packages/common/terraform/runtime-config/connection.json
nextSteps: []
re-run project.json changes: 0
```

No `nextSteps` (the edit applied cleanly, so there is nothing left for the user to do) and the second run is a no-op.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
