### PR TITLE
chore(ts#api): publish a trailing slash on the Terraform REST API url

### DIFF
--- a/packages/nx-plugin/src/py/fast-api/__snapshots__/generator.terraform.spec.ts.snap
+++ b/packages/nx-plugin/src/py/fast-api/__snapshots__/generator.terraform.spec.ts.snap
@@ -3200,7 +3200,7 @@ module "add_url_to_runtime_config" {
 
   namespace = "connection"
   key       = "apis"
-  value     = { "TestApi" = aws_api_gateway_stage.api_stage.invoke_url }
+  value     = { "TestApi" = "\${aws_api_gateway_stage.api_stage.invoke_url}/" }
 
   depends_on = [aws_api_gateway_stage.api_stage]
 }
@@ -4195,7 +4195,7 @@ module "add_url_to_runtime_config" {
 
   namespace = "connection"
   key       = "apis"
-  value     = { "TestApi" = aws_api_gateway_stage.api_stage.invoke_url }
+  value     = { "TestApi" = "\${aws_api_gateway_stage.api_stage.invoke_url}/" }
 
   depends_on = [aws_api_gateway_stage.api_stage]
 }
@@ -5273,7 +5273,7 @@ module "add_url_to_runtime_config" {
 
   namespace = "connection"
   key       = "apis"
-  value     = { "TestApi" = aws_api_gateway_stage.api_stage.invoke_url }
+  value     = { "TestApi" = "\${aws_api_gateway_stage.api_stage.invoke_url}/" }
 
   depends_on = [aws_api_gateway_stage.api_stage]
 }

--- a/packages/nx-plugin/src/smithy/ts/api/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/smithy/ts/api/__snapshots__/generator.spec.ts.snap
@@ -1317,7 +1317,7 @@ module "add_url_to_runtime_config" {
 
   namespace = "connection"
   key       = "apis"
-  value     = { "TestApi" = aws_api_gateway_stage.api_stage.invoke_url }
+  value     = { "TestApi" = "\${aws_api_gateway_stage.api_stage.invoke_url}/" }
 
   depends_on = [aws_api_gateway_stage.api_stage]
 }
@@ -2733,7 +2733,7 @@ module "add_url_to_runtime_config" {
 
   namespace = "connection"
   key       = "apis"
-  value     = { "TestApi" = aws_api_gateway_stage.api_stage.invoke_url }
+  value     = { "TestApi" = "\${aws_api_gateway_stage.api_stage.invoke_url}/" }
 
   depends_on = [aws_api_gateway_stage.api_stage]
 }
@@ -3697,7 +3697,7 @@ module "add_url_to_runtime_config" {
 
   namespace = "connection"
   key       = "apis"
-  value     = { "TestApi" = aws_api_gateway_stage.api_stage.invoke_url }
+  value     = { "TestApi" = "\${aws_api_gateway_stage.api_stage.invoke_url}/" }
 
   depends_on = [aws_api_gateway_stage.api_stage]
 }
@@ -4484,7 +4484,7 @@ module "add_url_to_runtime_config" {
 
   namespace = "connection"
   key       = "apis"
-  value     = { "CustomApi" = aws_api_gateway_stage.api_stage.invoke_url }
+  value     = { "CustomApi" = "\${aws_api_gateway_stage.api_stage.invoke_url}/" }
 
   depends_on = [aws_api_gateway_stage.api_stage]
 }

--- a/packages/nx-plugin/src/trpc/backend/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/trpc/backend/__snapshots__/generator.spec.ts.snap
@@ -6280,7 +6280,7 @@ module "add_url_to_runtime_config" {
 
   namespace = "connection"
   key       = "apis"
-  value     = { "TestApi" = aws_api_gateway_stage.api_stage.invoke_url }
+  value     = { "TestApi" = "\${aws_api_gateway_stage.api_stage.invoke_url}/" }
 
   depends_on = [aws_api_gateway_stage.api_stage]
 }
@@ -7245,7 +7245,7 @@ module "add_url_to_runtime_config" {
 
   namespace = "connection"
   key       = "apis"
-  value     = { "TestApi" = aws_api_gateway_stage.api_stage.invoke_url }
+  value     = { "TestApi" = "\${aws_api_gateway_stage.api_stage.invoke_url}/" }
 
   depends_on = [aws_api_gateway_stage.api_stage]
 }
@@ -8293,7 +8293,7 @@ module "add_url_to_runtime_config" {
 
   namespace = "connection"
   key       = "apis"
-  value     = { "TestApi" = aws_api_gateway_stage.api_stage.invoke_url }
+  value     = { "TestApi" = "\${aws_api_gateway_stage.api_stage.invoke_url}/" }
 
   depends_on = [aws_api_gateway_stage.api_stage]
 }

--- a/packages/nx-plugin/src/utils/api-constructs/files/terraform/app/apis/rest/__apiNameKebabCase__/__apiNameKebabCase__.tf.template
+++ b/packages/nx-plugin/src/utils/api-constructs/files/terraform/app/apis/rest/__apiNameKebabCase__/__apiNameKebabCase__.tf.template
@@ -785,7 +785,7 @@ module "add_url_to_runtime_config" {
 
   namespace = "connection"
   key       = "apis"
-  value     = { "<%- apiNameClassName %>" = aws_api_gateway_stage.api_stage.invoke_url }
+  value     = { "<%- apiNameClassName %>" = "${aws_api_gateway_stage.api_stage.invoke_url}/" }
 
   depends_on = [aws_api_gateway_stage.api_stage]
 }


### PR DESCRIPTION
### Reason for this change

The API URL published to `connection.apis` differed between IaC providers by a trailing slash, so consumer code that appends a path resolved correctly on one provider and broke on the other.

I re-derived the shape for all four provider/protocol combinations from the provider sources rather than the docs:

| Provider | Protocol | Attribute | Shape | Trailing slash |
|---|---|---|---|---|
| CDK | REST | `RestApi.url` → `urlForPath('/')` | `https://<id>.execute-api.<region>.<suffix>/<stage>/` | yes |
| CDK | HTTP | `HttpStage.url` | `https://<host>/` (`$default` renders an empty path segment) | yes |
| Terraform | HTTP | `aws_apigatewayv2_stage.invoke_url` | `https://<host>/` | yes |
| Terraform | REST | `aws_api_gateway_stage.invoke_url` | `https://<host>/<stage>` | **no** |

Sources: `RestApiBase.url` returns `this.urlForPath()`, whose default argument is `'/'`; `HttpStage.url` builds `` `https://${apiId}.execute-api.${region}.${urlSuffix}/${urlPath}` `` with `urlPath = ''` for the `$default` stage. On the Terraform side `conns.APIGatewayInvokeURL` is `fmt.Sprintf("https://%s/%s", host, stageName)`, while `conns.APIGatewayV2InvokeURL` has an explicit `$default` branch returning `fmt.Sprintf("https://%s/", host)`.

So **only Terraform REST diverged** — HTTP already agreed on both providers. Confirmed against real deployments (see below):

```
# before, Terraform
http_api_raw_invoke_url = "https://2o25cubzc5.execute-api.us-east-1.amazonaws.com/"
rest_api_raw_invoke_url = "https://2pd28h9vbh.execute-api.us-east-1.amazonaws.com/prod"   # <- no slash
```

The user-visible symptom, with the *same* application code across providers:

```
`${apiUrl}echo`
  Terraform REST (before) : https://…/prodecho          <- broken
  Terraform REST (after)  : https://…/prod/echo
  HTTP / CDK              : https://…/echo
```

### Description of changes

Normalised **Terraform REST to add the slash**, so all four combinations end with one.

Rationale for the direction — the argument is that the alternative is not actually representable. Dropping the slash to normalise the other way is impossible for an HTTP API: its `$default` stage contributes an *empty* path segment, so the URL is `https://<host>/` where the trailing slash is the origin's own root path. `new URL('https://host').href === 'https://host/'`, so a slash-free form cannot survive a round trip through any URL parser. A trailing slash is the only shape all four combinations can share, which is what makes it the choice that leaves least room for future divergence. It also keeps CDK's already-deployed values untouched, so no existing workspace's published value changes.

- `utils/api-constructs/files/terraform/app/apis/rest/…tf.template` — append `/` to the `invoke_url` published to `connection.apis`. The module's own `stage_invoke_url` output is deliberately left as the raw attribute; only the runtime-config entry is normalised.

Consumers were audited: the OpenAPI client strips a trailing slash (`$config.url.endsWith('/') ? …slice(0, -1)`), tRPC's `getUrl` does `base.replace(/\/$/, '')`, and the local-dev override already used a trailing slash — so all existing call sites, including the ones passing the URL straight to `httpLink`/`httpSubscriptionLink`, tolerate it. The change makes the hand-rolled `` `${apiUrl}foo` `` case work uniformly.

### Description of how you validated changes

`pnpm nx run @aws/nx-plugin:test` (205 files / 3754 tests), `build --all` and `lint --all --configuration=fix` all pass. The three existing Terraform snapshots (`py/fast-api`, `smithy/ts/api`, `trpc/backend`) record the generated `.tf`, so they pin the trailing slash; the snapshot diff is confined to the REST runtime-config entry.

**Deployed both providers to AWS and invoked the deployed APIs through the generated clients.** Two fresh workspaces (linked to the locally compiled plugin), each with a tRPC REST API and an HTTP API.

Deployed `connection.apis`, read back from AppConfig:

```
# Terraform (87 resources)
{ "HttpApi": "https://2o25cubzc5.execute-api.us-east-1.amazonaws.com/",
  "RestApi": "https://2pd28h9vbh.execute-api.us-east-1.amazonaws.com/prod/" }

# CDK
{ "OrdersApi": "https://fycvigcd31.execute-api.us-east-1.amazonaws.com/prod/",
  "ItemsApi":  "https://sg25d5aaed.execute-api.us-east-1.amazonaws.com/" }
```

Invoked through the vended clients, which pass the runtime-config URL straight to `httpLink`, with `fetch` instrumented to capture the resolved URL:

```
Terraform REST : …/prod/echo?input=… -> {"message":"hello-REST"}   double slash? false
Terraform HTTP : …/echo?input=…      -> {"message":"hello-HTTP"}   double slash? false
CDK REST       : …/prod/echo?input=… -> {"message":"hello-REST"}   double slash? false
CDK HTTP       : …/echo?input=…      -> {"message":"hello-HTTP"}   double slash? false
```

All four resolve identically with no double slash. `terraform fmt` accepts the edited template unchanged.

Everything was torn down — `cdk destroy` completed and Terraform destroyed all 87 resources. Verified empty afterwards: `describe-stacks` reports the stack does not exist, and `get-rest-apis`, `apigatewayv2 get-apis` and `appconfig list-applications` all return `[]`.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

