### PR TITLE
fix(ts#rdb,py#rdb): default Terraform Aurora CloudWatch log export on, matching CDK

### DIFF
--- a/docs/src/content/docs/en/snippets/rdb/performance-insights.mdx
+++ b/docs/src/content/docs/en/snippets/rdb/performance-insights.mdx
@@ -5,6 +5,8 @@ import Infrastructure from '@components/infrastructure.astro';
 
 Performance Insights is enabled on the Aurora writer instance by default (encrypted with the cluster's KMS key). Aurora engine logs are also exported to [CloudWatch Logs](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/USER_LogAccess.html) by default, configured to surface schema-level activity without leaking row data.
 
+Exported log volume — and so [CloudWatch Logs ingestion cost](https://aws.amazon.com/cloudwatch/pricing/) — scales with schema changes and connections rather than query traffic, since the log types that carry full statement text are excluded. On Aurora MySQL the `CONNECT` audit event is emitted per connection, so workloads that open a connection per request produce more than ones that pool.
+
 Disable log export per database if not required:
 
 <Infrastructure>

--- a/docs/src/content/docs/es/snippets/rdb/performance-insights.mdx
+++ b/docs/src/content/docs/es/snippets/rdb/performance-insights.mdx
@@ -5,6 +5,8 @@ import Infrastructure from '@components/infrastructure.astro';
 
 Performance Insights está habilitado en la instancia de escritura de Aurora de forma predeterminada (cifrado con la clave KMS del clúster). Los registros del motor de Aurora también se exportan a [CloudWatch Logs](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/USER_LogAccess.html) de forma predeterminada, configurados para mostrar actividad a nivel de esquema sin filtrar datos de filas.
 
+El volumen de registros exportados — y por lo tanto el [costo de ingesta de CloudWatch Logs](https://aws.amazon.com/cloudwatch/pricing/) — escala con los cambios de esquema y las conexiones en lugar del tráfico de consultas, ya que se excluyen los tipos de registro que contienen el texto completo de las declaraciones. En Aurora MySQL, el evento de auditoría `CONNECT` se emite por conexión, por lo que las cargas de trabajo que abren una conexión por solicitud producen más que las que utilizan un pool.
+
 Deshabilite la exportación de registros por base de datos si no es necesario:
 
 <Infrastructure>

--- a/docs/src/content/docs/fr/snippets/rdb/performance-insights.mdx
+++ b/docs/src/content/docs/fr/snippets/rdb/performance-insights.mdx
@@ -5,6 +5,8 @@ import Infrastructure from '@components/infrastructure.astro';
 
 Performance Insights est activé par défaut sur l'instance writer Aurora (chiffré avec la clé KMS du cluster). Les journaux du moteur Aurora sont également exportés vers [CloudWatch Logs](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/USER_LogAccess.html) par défaut, configurés pour exposer l'activité au niveau du schéma sans divulguer les données de ligne.
 
+Le volume de journaux exportés — et donc le [coût d'ingestion CloudWatch Logs](https://aws.amazon.com/cloudwatch/pricing/) — évolue en fonction des modifications de schéma et des connexions plutôt que du trafic de requêtes, car les types de journaux qui contiennent le texte complet des instructions sont exclus. Sur Aurora MySQL, l'événement d'audit `CONNECT` est émis par connexion, de sorte que les charges de travail qui ouvrent une connexion par requête en produisent plus que celles qui utilisent un pool.
+
 Désactivez l'export des journaux par base de données si ce n'est pas nécessaire :
 
 <Infrastructure>

--- a/docs/src/content/docs/it/snippets/rdb/performance-insights.mdx
+++ b/docs/src/content/docs/it/snippets/rdb/performance-insights.mdx
@@ -5,6 +5,8 @@ import Infrastructure from '@components/infrastructure.astro';
 
 Performance Insights è abilitato per impostazione predefinita sull'istanza writer di Aurora (crittografato con la chiave KMS del cluster). Anche i log del motore Aurora vengono esportati in [CloudWatch Logs](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/USER_LogAccess.html) per impostazione predefinita, configurati per mostrare l'attività a livello di schema senza esporre i dati delle righe.
 
+Il volume dei log esportati — e quindi il [costo di ingestione di CloudWatch Logs](https://aws.amazon.com/cloudwatch/pricing/) — scala con le modifiche allo schema e le connessioni piuttosto che con il traffico delle query, poiché i tipi di log che contengono il testo completo delle istruzioni sono esclusi. Su Aurora MySQL l'evento di audit `CONNECT` viene emesso per ogni connessione, quindi i carichi di lavoro che aprono una connessione per richiesta ne producono di più rispetto a quelli che utilizzano il pooling.
+
 Disabilita l'esportazione dei log per database se non necessaria:
 
 <Infrastructure>

--- a/docs/src/content/docs/jp/snippets/rdb/performance-insights.mdx
+++ b/docs/src/content/docs/jp/snippets/rdb/performance-insights.mdx
@@ -5,6 +5,8 @@ import Infrastructure from '@components/infrastructure.astro';
 
 Performance Insights は、デフォルトで Aurora ライターインスタンスで有効になっています（クラスターの KMS キーで暗号化されます）。Aurora エンジンログもデフォルトで [CloudWatch Logs](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/USER_LogAccess.html) にエクスポートされ、行データを漏洩させることなくスキーマレベルのアクティビティを表示するように設定されています。
 
+エクスポートされるログ量、つまり [CloudWatch Logs の取り込みコスト](https://aws.amazon.com/cloudwatch/pricing/) は、クエリトラフィックではなくスキーマ変更と接続数に応じてスケールします。これは、完全なステートメントテキストを含むログタイプが除外されているためです。Aurora MySQL では、`CONNECT` 監査イベントが接続ごとに発行されるため、リクエストごとに接続を開くワークロードは、プールを使用するワークロードよりも多くのログを生成します。
+
 必要ない場合は、データベースごとにログエクスポートを無効にします：
 
 <Infrastructure>

--- a/docs/src/content/docs/ko/snippets/rdb/performance-insights.mdx
+++ b/docs/src/content/docs/ko/snippets/rdb/performance-insights.mdx
@@ -5,6 +5,8 @@ import Infrastructure from '@components/infrastructure.astro';
 
 Performance Insights는 기본적으로 Aurora 라이터 인스턴스에서 활성화됩니다(클러스터의 KMS 키로 암호화됨). Aurora 엔진 로그도 기본적으로 [CloudWatch Logs](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/USER_LogAccess.html)로 내보내지며, 행 데이터를 노출하지 않고 스키마 수준의 활동을 표시하도록 구성됩니다.
 
+내보낸 로그 볼륨 — 따라서 [CloudWatch Logs 수집 비용](https://aws.amazon.com/cloudwatch/pricing/) — 은 전체 문장 텍스트를 포함하는 로그 유형이 제외되므로 쿼리 트래픽보다는 스키마 변경 및 연결에 따라 확장됩니다. Aurora MySQL에서는 `CONNECT` 감사 이벤트가 연결당 발생하므로, 요청당 연결을 여는 워크로드는 풀링하는 워크로드보다 더 많은 로그를 생성합니다.
+
 필요하지 않은 경우 데이터베이스별로 로그 내보내기를 비활성화하세요:
 
 <Infrastructure>

--- a/docs/src/content/docs/pt/snippets/rdb/performance-insights.mdx
+++ b/docs/src/content/docs/pt/snippets/rdb/performance-insights.mdx
@@ -5,6 +5,8 @@ import Infrastructure from '@components/infrastructure.astro';
 
 O Performance Insights está habilitado na instância de gravação do Aurora por padrão (criptografado com a chave KMS do cluster). Os logs do mecanismo Aurora também são exportados para o [CloudWatch Logs](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/USER_LogAccess.html) por padrão, configurados para exibir atividade no nível de esquema sem vazar dados de linha.
 
+O volume de logs exportados — e, portanto, o [custo de ingestão do CloudWatch Logs](https://aws.amazon.com/cloudwatch/pricing/) — escala com mudanças de esquema e conexões, em vez de tráfego de consultas, já que os tipos de log que carregam texto completo de instruções são excluídos. No Aurora MySQL, o evento de auditoria `CONNECT` é emitido por conexão, então cargas de trabalho que abrem uma conexão por solicitação produzem mais do que aquelas que usam pool.
+
 Desabilite a exportação de logs por banco de dados se não for necessário:
 
 <Infrastructure>

--- a/docs/src/content/docs/vi/snippets/rdb/performance-insights.mdx
+++ b/docs/src/content/docs/vi/snippets/rdb/performance-insights.mdx
@@ -5,6 +5,8 @@ import Infrastructure from '@components/infrastructure.astro';
 
 Performance Insights được bật trên Aurora writer instance theo mặc định (được mã hóa bằng KMS key của cluster). Aurora engine logs cũng được xuất sang [CloudWatch Logs](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/USER_LogAccess.html) theo mặc định, được cấu hình để hiển thị hoạt động ở cấp độ schema mà không làm rò rỉ dữ liệu hàng.
 
+Khối lượng log được xuất — và do đó [chi phí ingestion CloudWatch Logs](https://aws.amazon.com/cloudwatch/pricing/) — tăng theo các thay đổi schema và kết nối thay vì lưu lượng truy vấn, vì các loại log chứa toàn bộ văn bản câu lệnh đã bị loại trừ. Trên Aurora MySQL, sự kiện audit `CONNECT` được phát ra cho mỗi kết nối, do đó các workload mở một kết nối cho mỗi request sẽ tạo ra nhiều hơn so với các workload sử dụng pool.
+
 Tắt xuất log cho từng database nếu không cần thiết:
 
 <Infrastructure>

--- a/docs/src/content/docs/zh/snippets/rdb/performance-insights.mdx
+++ b/docs/src/content/docs/zh/snippets/rdb/performance-insights.mdx
@@ -5,6 +5,8 @@ import Infrastructure from '@components/infrastructure.astro';
 
 Performance Insights 默认在 Aurora 写入器实例上启用（使用集群的 KMS 密钥加密）。Aurora 引擎日志也默认导出到 [CloudWatch Logs](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/USER_LogAccess.html)，配置为显示架构级活动而不泄露行数据。
 
+导出的日志量——以及 [CloudWatch Logs 摄取成本](https://aws.amazon.com/cloudwatch/pricing/)——随架构更改和连接数量而扩展，而不是查询流量，因为携带完整语句文本的日志类型被排除在外。在 Aurora MySQL 上，`CONNECT` 审计事件按每个连接发出，因此每个请求打开一个连接的工作负载比使用连接池的工作负载产生更多日志。
+
 如果不需要，可以按数据库禁用日志导出：
 
 <Infrastructure>

--- a/packages/nx-plugin/src/migrations/latest/rdb-terraform-aurora-app-module-defaults/__snapshots__/migration.spec.ts.snap
+++ b/packages/nx-plugin/src/migrations/latest/rdb-terraform-aurora-app-module-defaults/__snapshots__/migration.spec.ts.snap
@@ -1,0 +1,54 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`rdb-terraform-aurora-app-module-defaults migration > should align the app module defaults with the core module 1`] = `
+"variable "enable_credential_rotation" {
+  description = "Whether to enable automatic credential rotation for the admin secret."
+  type        = bool
+  default     = true
+}
+
+variable "enable_cloudwatch_logs" {
+  description = "Whether to export Aurora engine logs to CloudWatch. PostgreSQL logs DDL statements only (log_statement=ddl); MySQL enables Advanced Auditing scoped to connections and DDL (server_audit_events=CONNECT,QUERY_DDL). Neither logs statement parameter values, to avoid leaking PII into log data."
+  type        = bool
+  default = true
+}
+
+variable "enable_performance_insights" {
+  description = "Whether to enable Performance Insights on Aurora cluster instances."
+  type        = bool
+  default     = true
+}
+
+variable "enable_backup" {
+  description = "Whether to provision an AWS Backup plan for the Aurora cluster."
+  type        = bool
+  default     = false
+}
+
+variable "enable_key_rotation" {
+  description = "Whether to enable automatic key rotation on the KMS key used to encrypt the Aurora cluster and its credentials secret."
+  type        = bool
+  default     = true
+}
+
+variable "tags" {
+  description = "Tags to apply to all resources."
+  type        = map(string)
+  default     = {}
+}
+
+module "aurora" {
+  source = "../../../core/rdb/aurora"
+
+  name                        = "my-db"
+  engine                      = "aurora-postgresql"
+  enable_credential_rotation  = var.enable_credential_rotation
+  enable_cloudwatch_logs      = var.enable_cloudwatch_logs
+  enable_performance_insights = var.enable_performance_insights
+  enable_backup               = var.enable_backup
+  tags                        = var.tags
+
+  enable_key_rotation = var.enable_key_rotation
+}
+"
+`;

--- a/packages/nx-plugin/src/migrations/latest/rdb-terraform-aurora-app-module-defaults/metadata.json
+++ b/packages/nx-plugin/src/migrations/latest/rdb-terraform-aurora-app-module-defaults/metadata.json
@@ -1,0 +1,3 @@
+{
+  "description": "Align the vended Terraform Aurora app module variable defaults with the core module, enabling CloudWatch engine log export and exposing enable_key_rotation"
+}

--- a/packages/nx-plugin/src/migrations/latest/rdb-terraform-aurora-app-module-defaults/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/latest/rdb-terraform-aurora-app-module-defaults/migration.spec.ts
@@ -1,0 +1,186 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import type { Tree } from '@nx/devkit';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test.js';
+import migration from './migration.js';
+
+const DB_FILE = 'packages/common/terraform/src/app/dbs/my-db/my-db.tf';
+
+/** The pre-change shape of the vended per-database Terraform app module. */
+const BEFORE = `variable "enable_credential_rotation" {
+  description = "Whether to enable automatic credential rotation for the admin secret."
+  type        = bool
+  default     = true
+}
+
+variable "enable_cloudwatch_logs" {
+  description = "Whether to export Aurora engine logs to CloudWatch. PostgreSQL also enables verbose statement logging."
+  type        = bool
+  default     = false
+}
+
+variable "enable_performance_insights" {
+  description = "Whether to enable Performance Insights on Aurora cluster instances."
+  type        = bool
+  default     = true
+}
+
+variable "enable_backup" {
+  description = "Whether to provision an AWS Backup plan for the Aurora cluster."
+  type        = bool
+  default     = false
+}
+
+variable "tags" {
+  description = "Tags to apply to all resources."
+  type        = map(string)
+  default     = {}
+}
+
+module "aurora" {
+  source = "../../../core/rdb/aurora"
+
+  name                        = "my-db"
+  engine                      = "aurora-postgresql"
+  enable_credential_rotation  = var.enable_credential_rotation
+  enable_cloudwatch_logs      = var.enable_cloudwatch_logs
+  enable_performance_insights = var.enable_performance_insights
+  enable_backup               = var.enable_backup
+  tags                        = var.tags
+}
+`;
+
+describe('rdb-terraform-aurora-app-module-defaults migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeUsingTsSolutionSetup();
+  });
+
+  it('should align the app module defaults with the core module', async () => {
+    tree.write(DB_FILE, BEFORE);
+
+    const result = await migration(tree);
+
+    const content = tree.read(DB_FILE, 'utf-8');
+
+    // Matches the core module and the CDK construct, so engine logs are
+    // exported and the cluster parameter group that configures them is created.
+    expect(content).toMatch(
+      /variable "enable_cloudwatch_logs"[\s\S]*?default\s+= true/,
+    );
+    expect(content).not.toContain(
+      'PostgreSQL also enables verbose statement logging',
+    );
+    expect(content).toContain('log_statement=ddl');
+
+    // The core module's key rotation variable becomes reachable from a root
+    // configuration.
+    expect(content).toMatch(
+      /variable "enable_key_rotation"[\s\S]*?default\s+= true/,
+    );
+    expect(content).toContain('enable_key_rotation = var.enable_key_rotation');
+
+    // Everything else is left as the user had it.
+    expect(content).toContain(
+      'enable_backup               = var.enable_backup',
+    );
+    expect(content).toMatch(
+      /variable "enable_backup"[\s\S]*?default\s+= false/,
+    );
+    expect(result.nextSteps).toEqual([]);
+    expect(content).toMatchSnapshot();
+  });
+
+  it('should migrate every database module in the workspace', async () => {
+    tree.write(DB_FILE, BEFORE);
+    tree.write(
+      'packages/common/terraform/src/app/dbs/other-db/other-db.tf',
+      BEFORE.replace(/my-db/g, 'other-db'),
+    );
+
+    const result = await migration(tree);
+
+    for (const path of [
+      DB_FILE,
+      'packages/common/terraform/src/app/dbs/other-db/other-db.tf',
+    ]) {
+      expect(tree.read(path, 'utf-8')).toContain(
+        'enable_key_rotation = var.enable_key_rotation',
+      );
+    }
+    expect(result.nextSteps).toEqual([]);
+  });
+
+  it('should do nothing when the workspace has no terraform database modules', async () => {
+    const result = await migration(tree);
+
+    expect(result.nextSteps).toEqual([]);
+    expect(tree.exists(DB_FILE)).toBe(false);
+  });
+
+  it('should skip and report a customised file', async () => {
+    const customised = `module "my_own_aurora" {
+  source = "../../../core/rdb/aurora"
+  name   = "custom"
+}
+`;
+    tree.write(DB_FILE, customised);
+
+    const result = await migration(tree);
+
+    expect(tree.read(DB_FILE, 'utf-8')).toBe(customised);
+    expect(result.nextSteps).toHaveLength(1);
+    expect(result.nextSteps[0]).toContain(DB_FILE);
+    expect(result.nextSteps[0]).toContain('enable_cloudwatch_logs');
+  });
+
+  it('should preserve a deliberately disabled log export', async () => {
+    // A user who turned log export off keeps that choice; only the missing
+    // variable is added.
+    tree.write(
+      DB_FILE,
+      BEFORE.replace(
+        `variable "enable_cloudwatch_logs" {
+  description = "Whether to export Aurora engine logs to CloudWatch. PostgreSQL also enables verbose statement logging."
+  type        = bool
+  default     = false
+}`,
+        `variable "enable_cloudwatch_logs" {
+  description = "Logging is handled by our central platform account."
+  type        = bool
+  default     = false
+}`,
+      ),
+    );
+
+    const result = await migration(tree);
+
+    const content = tree.read(DB_FILE, 'utf-8');
+    expect(content).toContain(
+      'Logging is handled by our central platform account.',
+    );
+    expect(content).toContain('enable_key_rotation = var.enable_key_rotation');
+    expect(result.nextSteps).toEqual([]);
+  });
+
+  it('should be idempotent', async () => {
+    tree.write(DB_FILE, BEFORE);
+
+    await migration(tree);
+    const afterFirst = tree.read(DB_FILE, 'utf-8');
+
+    const result = await migration(tree);
+
+    expect(tree.read(DB_FILE, 'utf-8')).toBe(afterFirst);
+    expect(result.nextSteps).toEqual([]);
+
+    // Exactly one declaration and one forwarded value, not a second copy.
+    expect(afterFirst.match(/variable "enable_key_rotation"/g)).toHaveLength(1);
+    expect(
+      afterFirst.match(/enable_key_rotation = var\.enable_key_rotation/g),
+    ).toHaveLength(1);
+  });
+});

--- a/packages/nx-plugin/src/migrations/latest/rdb-terraform-aurora-app-module-defaults/migration.ts
+++ b/packages/nx-plugin/src/migrations/latest/rdb-terraform-aurora-app-module-defaults/migration.ts
@@ -1,0 +1,172 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import {
+  joinPathFragments,
+  type MigrationReturnObject,
+  type Tree,
+} from '@nx/devkit';
+import {
+  applyGritQL,
+  GRIT_INSERT_PLACEHOLDER,
+  insertViaGritQL,
+  matchGritQL,
+} from '../../../utils/ast.js';
+import { formatFilesInSubtree } from '../../../utils/format.js';
+import {
+  PACKAGES_DIR,
+  SHARED_TERRAFORM_DIR,
+} from '../../../utils/shared-constructs-constants.js';
+
+/**
+ * Align each vended per-database Terraform app module
+ * (`app/dbs/<name>/<name>.tf`) with the core Aurora module it wraps.
+ *
+ * The app module is what a root configuration instantiates and it forwards its
+ * own value down, so its default is the one that takes effect:
+ *
+ * - `enable_cloudwatch_logs` defaulted to `false` against the core module's
+ *   `true`, so Aurora exported no engine logs and the cluster parameter group
+ *   that configures them (`log_statement=ddl` on PostgreSQL,
+ *   `server_audit_events=CONNECT,QUERY_DDL` on MySQL) was never created —
+ *   the CDK construct enabled both.
+ * - `enable_key_rotation` was never declared, leaving the core module's
+ *   variable unreachable from a root configuration.
+ *
+ * These files are generated with `KeepExisting`, so an upgraded workspace keeps
+ * the diverged defaults until this runs. Diverged files are left untouched and
+ * reported via `nextSteps`.
+ */
+
+const TERRAFORM_DBS_APP_DIR = `${PACKAGES_DIR}/${SHARED_TERRAFORM_DIR}/src/app/dbs`;
+
+const hcl = (pattern: string) => `language hcl\n${pattern}`;
+
+const KEY_ROTATION_VARIABLE = [
+  'variable "enable_key_rotation" {',
+  '  description = "Whether to enable automatic key rotation on the KMS key used to encrypt the Aurora cluster and its credentials secret."',
+  '  type        = bool',
+  '  default     = true',
+  '}',
+].join('\n');
+
+const divergedMessage = (filePath: string) =>
+  `${filePath}: has diverged from the generated shape - left untouched. To export Aurora engine logs to CloudWatch as the CDK construct and the core Terraform module do, default \`enable_cloudwatch_logs\` to true here, and declare an \`enable_key_rotation\` variable (bool, default true) forwarded to the aurora module (see the ts#rdb generator's dbs app template).`;
+
+const OLD_LOGS_DESCRIPTION =
+  'Whether to export Aurora engine logs to CloudWatch. PostgreSQL also enables verbose statement logging.';
+const NEW_LOGS_DESCRIPTION =
+  'Whether to export Aurora engine logs to CloudWatch. PostgreSQL logs DDL statements only (log_statement=ddl); MySQL enables Advanced Auditing scoped to connections and DDL (server_audit_events=CONNECT,QUERY_DDL). Neither logs statement parameter values, to avoid leaking PII into log data.';
+
+/**
+ * Flip the app module's `enable_cloudwatch_logs` default to match the core
+ * module, and replace the description that documented the old behaviour.
+ *
+ * Keyed on that description, which is the only thing distinguishing the vended
+ * `default = false` from a user who deliberately turned log export off.
+ */
+const migrateCloudwatchLogsDefault = (tree: Tree, filePath: string) =>
+  applyGritQL(
+    tree,
+    filePath,
+    hcl(
+      `\`variable "enable_cloudwatch_logs" { $props }\` where {` +
+        ` $props <: contains \`description = "${OLD_LOGS_DESCRIPTION}"\` => \`description = "${NEW_LOGS_DESCRIPTION}"\`,` +
+        ` $props <: contains \`default = false\` => \`default = true\`` +
+        ` }`,
+    ),
+  );
+
+/**
+ * Declare `enable_key_rotation` and forward it to the core aurora module, so a
+ * root configuration can reach the variable the core module already exposes.
+ */
+const migrateKeyRotationVariable = async (
+  tree: Tree,
+  filePath: string,
+): Promise<void> => {
+  if (
+    await matchGritQL(
+      tree,
+      filePath,
+      hcl('`variable "enable_key_rotation" { $_ }`'),
+    )
+  ) {
+    return; // Already declared.
+  }
+
+  const declared = await insertViaGritQL(
+    tree,
+    filePath,
+    hcl(
+      `\`variable "enable_backup" { $props }\` => \`variable "enable_backup" {\n  $props\n}\n\n${GRIT_INSERT_PLACEHOLDER}\``,
+    ),
+    KEY_ROTATION_VARIABLE,
+  );
+  if (!declared) return;
+
+  // Appended after the existing arguments so their alignment is preserved;
+  // `terraform fmt` re-aligns the block.
+  await applyGritQL(
+    tree,
+    filePath,
+    hcl(
+      `\`module "aurora" { $props }\` => \`module "aurora" {\n  $props\n\n  enable_key_rotation = var.enable_key_rotation\n}\``,
+    ),
+  );
+};
+
+export default async function migration(
+  tree: Tree,
+): Promise<MigrationReturnObject> {
+  const nextSteps: string[] = [];
+
+  if (!tree.exists(TERRAFORM_DBS_APP_DIR)) {
+    return { nextSteps }; // This workspace has no Terraform database modules.
+  }
+
+  for (const dirName of tree.children(TERRAFORM_DBS_APP_DIR)) {
+    const filePath = joinPathFragments(
+      TERRAFORM_DBS_APP_DIR,
+      dirName,
+      `${dirName}.tf`,
+    );
+    if (!tree.exists(filePath)) {
+      continue; // Not a database app module directory.
+    }
+
+    // Both edits hang off the shape the generator produces: the two variables
+    // and the module call that forwards them.
+    const recognised =
+      (await matchGritQL(
+        tree,
+        filePath,
+        hcl('`variable "enable_cloudwatch_logs" { $_ }`'),
+      )) &&
+      (await matchGritQL(
+        tree,
+        filePath,
+        hcl('`variable "enable_backup" { $_ }`'),
+      )) &&
+      (await matchGritQL(
+        tree,
+        filePath,
+        hcl(
+          '`module "aurora" { $props }` where { $props <: contains `enable_cloudwatch_logs = var.enable_cloudwatch_logs` }',
+        ),
+      ));
+
+    if (!recognised) {
+      nextSteps.push(divergedMessage(filePath));
+      continue;
+    }
+
+    await migrateCloudwatchLogsDefault(tree, filePath);
+    await migrateKeyRotationVariable(tree, filePath);
+  }
+
+  await formatFilesInSubtree(tree);
+
+  return { nextSteps };
+}

--- a/packages/nx-plugin/src/py/rdb/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/rdb/__snapshots__/generator.spec.ts.snap
@@ -297,9 +297,9 @@ variable "enable_credential_rotation" {
 }
 
 variable "enable_cloudwatch_logs" {
-  description = "Whether to export Aurora engine logs to CloudWatch. PostgreSQL also enables verbose statement logging."
+  description = "Whether to export Aurora engine logs to CloudWatch. PostgreSQL logs DDL statements only (log_statement=ddl); MySQL enables Advanced Auditing scoped to connections and DDL (server_audit_events=CONNECT,QUERY_DDL). Neither logs statement parameter values, to avoid leaking PII into log data."
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "enable_performance_insights" {
@@ -318,6 +318,12 @@ variable "enable_backup" {
   description = "Whether to provision an AWS Backup plan for the Aurora cluster."
   type        = bool
   default     = false
+}
+
+variable "enable_key_rotation" {
+  description = "Whether to enable automatic key rotation on the KMS key used to encrypt the Aurora cluster and its credentials secret."
+  type        = bool
+  default     = true
 }
 
 variable "tags" {
@@ -379,6 +385,7 @@ module "aurora" {
   enable_performance_insights           = var.enable_performance_insights
   performance_insights_retention_period = var.performance_insights_retention_period
   enable_backup                         = var.enable_backup
+  enable_key_rotation                   = var.enable_key_rotation
   tags                                  = var.tags
 }
 

--- a/packages/nx-plugin/src/ts/rdb/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/rdb/__snapshots__/generator.spec.ts.snap
@@ -1643,9 +1643,9 @@ variable "enable_credential_rotation" {
 }
 
 variable "enable_cloudwatch_logs" {
-  description = "Whether to export Aurora engine logs to CloudWatch. PostgreSQL also enables verbose statement logging."
+  description = "Whether to export Aurora engine logs to CloudWatch. PostgreSQL logs DDL statements only (log_statement=ddl); MySQL enables Advanced Auditing scoped to connections and DDL (server_audit_events=CONNECT,QUERY_DDL). Neither logs statement parameter values, to avoid leaking PII into log data."
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "enable_performance_insights" {
@@ -1664,6 +1664,12 @@ variable "enable_backup" {
   description = "Whether to provision an AWS Backup plan for the Aurora cluster."
   type        = bool
   default     = false
+}
+
+variable "enable_key_rotation" {
+  description = "Whether to enable automatic key rotation on the KMS key used to encrypt the Aurora cluster and its credentials secret."
+  type        = bool
+  default     = true
 }
 
 variable "tags" {
@@ -1725,6 +1731,7 @@ module "aurora" {
   enable_performance_insights           = var.enable_performance_insights
   performance_insights_retention_period = var.performance_insights_retention_period
   enable_backup                         = var.enable_backup
+  enable_key_rotation                   = var.enable_key_rotation
   tags                                  = var.tags
 }
 
@@ -3135,9 +3142,9 @@ variable "enable_credential_rotation" {
 }
 
 variable "enable_cloudwatch_logs" {
-  description = "Whether to export Aurora engine logs to CloudWatch. PostgreSQL also enables verbose statement logging."
+  description = "Whether to export Aurora engine logs to CloudWatch. PostgreSQL logs DDL statements only (log_statement=ddl); MySQL enables Advanced Auditing scoped to connections and DDL (server_audit_events=CONNECT,QUERY_DDL). Neither logs statement parameter values, to avoid leaking PII into log data."
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "enable_performance_insights" {
@@ -3156,6 +3163,12 @@ variable "enable_backup" {
   description = "Whether to provision an AWS Backup plan for the Aurora cluster."
   type        = bool
   default     = false
+}
+
+variable "enable_key_rotation" {
+  description = "Whether to enable automatic key rotation on the KMS key used to encrypt the Aurora cluster and its credentials secret."
+  type        = bool
+  default     = true
 }
 
 variable "tags" {
@@ -3217,6 +3230,7 @@ module "aurora" {
   enable_performance_insights           = var.enable_performance_insights
   performance_insights_retention_period = var.performance_insights_retention_period
   enable_backup                         = var.enable_backup
+  enable_key_rotation                   = var.enable_key_rotation
   tags                                  = var.tags
 }
 

--- a/packages/nx-plugin/src/ts/rdb/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/rdb/generator.spec.ts
@@ -23,6 +23,35 @@ const sharedConstructsDeclaration = declareDependencies()({
   ts: [...SHARED_CONSTRUCTS_DEPENDENCIES],
 });
 
+const TERRAFORM_AURORA_CORE =
+  'packages/common/terraform/src/core/rdb/aurora/aurora.tf';
+const TERRAFORM_AURORA_APP = 'packages/common/terraform/src/app/dbs/db/db.tf';
+
+/** Declared name to default value for every optional variable in a module. */
+const readTerraformVariableDefaults = (
+  tree: Tree,
+  filePath: string,
+): Record<string, string> =>
+  Object.fromEntries(
+    [
+      // Nested blocks are indented, so an unindented `}` closes the variable.
+      ...tree
+        .read(filePath, 'utf-8')
+        .matchAll(/variable "(?<name>\w+)" \{\n(?<body>.*?)\n\}/gs),
+    ]
+      .map(({ groups }) => [
+        groups.name,
+        /^\s*default\s*=\s*(?<value>.+)$/m.exec(groups.body)?.groups.value,
+      ])
+      .filter(([, value]) => value !== undefined),
+  );
+
+/** The app module's call into the core module, with alignment padding collapsed. */
+const readTerraformAuroraModuleCall = (tree: Tree): string =>
+  /module "aurora" \{\n.*?\n\}/s
+    .exec(tree.read(TERRAFORM_AURORA_APP, 'utf-8'))[0]
+    .replace(/ +/g, ' ');
+
 describe('ts#rdb generator', () => {
   let tree: Tree;
   beforeEach(() => {
@@ -340,6 +369,60 @@ describe('ts#rdb generator', () => {
     // of an encrypted cluster stays restorable for as long as possible.
     expect(aurora).toContain('deletion_window_in_days = 30');
   });
+
+  it('should agree on every aurora variable default between the terraform app and core modules', async () => {
+    await tsRdbGenerator(tree, { ...defaultOptions, iac: 'terraform' });
+
+    const core = readTerraformVariableDefaults(tree, TERRAFORM_AURORA_CORE);
+    const app = readTerraformVariableDefaults(tree, TERRAFORM_AURORA_APP);
+
+    // A root configuration instantiates the app module, which forwards its own
+    // value down, so a differing default there silently overrides the core one.
+    const shared = Object.keys(core).filter((name) => name in app);
+    expect(Object.fromEntries(shared.map((n) => [n, app[n]]))).toEqual(
+      Object.fromEntries(shared.map((n) => [n, core[n]])),
+    );
+
+    // Every re-declared variable must forward its own value down, so the app
+    // module's default is the one that takes effect.
+    const moduleCall = readTerraformAuroraModuleCall(tree);
+    for (const name of shared) {
+      expect(moduleCall).toContain(`${name} = var.${name}`);
+    }
+
+    // Any optional core variable the app module does not re-declare is
+    // unreachable from a root configuration. `engine` is the one exception —
+    // the generator fixes it from the chosen engine.
+    expect(Object.keys(core).filter((name) => !(name in app))).toEqual([
+      'engine',
+    ]);
+  });
+
+  it.each([
+    ['postgres', '["postgresql"]', 'log_statement'],
+    ['mysql', '["audit", "error"]', 'server_audit_events'],
+  ] as const)(
+    'should export %s engine logs and create the cluster parameter group by default in terraform',
+    async (engine, exports, parameter) => {
+      await tsRdbGenerator(tree, {
+        ...defaultOptions,
+        iac: 'terraform',
+        engine,
+      });
+
+      expect(
+        readTerraformVariableDefaults(tree, TERRAFORM_AURORA_APP)
+          .enable_cloudwatch_logs,
+      ).toBe('true');
+
+      // The same variable count-gates the cluster parameter group, which is what
+      // configures the engine to emit the logs it exports.
+      const core = tree.read(TERRAFORM_AURORA_CORE, 'utf-8');
+      expect(core).toContain('count = var.enable_cloudwatch_logs ? 1 : 0');
+      expect(core).toContain(exports);
+      expect(core).toContain(parameter);
+    },
+  );
 
   it('should keep an existing aurora shared construct', async () => {
     await sharedConstructsGenerator(

--- a/packages/nx-plugin/src/utils/rdb-constructs/files/terraform/app/dbs/__nameKebabCase__/__nameKebabCase__.tf.template
+++ b/packages/nx-plugin/src/utils/rdb-constructs/files/terraform/app/dbs/__nameKebabCase__/__nameKebabCase__.tf.template
@@ -91,9 +91,9 @@ variable "enable_credential_rotation" {
 }
 
 variable "enable_cloudwatch_logs" {
-  description = "Whether to export Aurora engine logs to CloudWatch. PostgreSQL also enables verbose statement logging."
+  description = "Whether to export Aurora engine logs to CloudWatch. PostgreSQL logs DDL statements only (log_statement=ddl); MySQL enables Advanced Auditing scoped to connections and DDL (server_audit_events=CONNECT,QUERY_DDL). Neither logs statement parameter values, to avoid leaking PII into log data."
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "enable_performance_insights" {
@@ -112,6 +112,12 @@ variable "enable_backup" {
   description = "Whether to provision an AWS Backup plan for the Aurora cluster."
   type        = bool
   default     = false
+}
+
+variable "enable_key_rotation" {
+  description = "Whether to enable automatic key rotation on the KMS key used to encrypt the Aurora cluster and its credentials secret."
+  type        = bool
+  default     = true
 }
 
 variable "tags" {
@@ -184,6 +190,7 @@ module "aurora" {
   enable_performance_insights           = var.enable_performance_insights
   performance_insights_retention_period = var.performance_insights_retention_period
   enable_backup                         = var.enable_backup
+  enable_key_rotation                   = var.enable_key_rotation
   tags                                  = var.tags
 }
 


### PR DESCRIPTION
### Reason for this change

Aurora engine-log export to CloudWatch was **on in CDK and off in Terraform**.

The core Terraform module defaults `enable_cloudwatch_logs` to `true`, matching the CDK construct. But the **app** module — `app/dbs/<name>/<name>.tf`, which is what a root configuration actually instantiates — defaulted the same variable to `false` and forwarded its own value down, so the app module's default was the one that took effect.

The same variable `count`-gates `aws_rds_cluster_parameter_group.database`, so with it `false` the group was never created and `db_cluster_parameter_group_name` resolved to `null`. That meant `log_statement=ddl` (PostgreSQL) and `server_audit_logging=1` / `server_audit_events=CONNECT,QUERY_DDL` (MySQL) were **also** silently not configured — the very parameters that make the exported logs PII-safe.

Two things in the tree already asserted the fixed behaviour, and were true for CDK but false for Terraform:

- the core module's own `#checkov:skip=CKV2_AWS_27` reason: *"Query logging is enabled by default via enable_cloudwatch_logs"*
- the docs: *"Aurora engine logs are also exported to CloudWatch Logs by default"*

**This was an oversight, not a deliberate opt-out.** #961 ("feat(rdb): enable PII-safe database logging by default") set out to default log export on for *"both ts#rdb and py#rdb, in CDK and Terraform"* — and its diff touched only `cdk/core/rdb/aurora.ts.template` and `terraform/core/rdb/aurora/aurora.tf.template`. The Terraform **app** module was simply missed, which is why it still carried the pre-#961 default *and* the pre-#961 description (`"PostgreSQL also enables verbose statement logging"`, describing the `log_statement=all` behaviour that #961 removed).

On cost: the CDK default is the right one to converge on. The log types that carry full statement text are deliberately excluded (`general`/`slowquery` on MySQL; `log_statement=ddl` not `all` on PostgreSQL), so exported volume scales with schema changes and connections, not query traffic. That is a small, bounded ingestion cost for an audit trail of every schema change — and the option to turn it off is one line. Noted in the docs so the profile is explicit.

### Description of changes

`packages/nx-plugin/src/utils/rdb-constructs/files/terraform/app/dbs/__nameKebabCase__/__nameKebabCase__.tf.template`:

- `enable_cloudwatch_logs` defaults to `true`, matching the core module and CDK.
- Its stale description is replaced with the core module's, which describes what the variable actually configures now.

**Other app-vs-core default drift found.** I diffed every variable the app module re-declares against the core module's default and CDK's. `enable_cloudwatch_logs` was the only differing *default*, but the audit surfaced a second defect of the same class: **`enable_key_rotation` was missing from the app module entirely** — the core module exposes it, but the app module neither declared nor forwarded it, leaving it unreachable from a root configuration. The docs tell Terraform users to set it there (`snippets/rdb/encryption-key-rotation.mdx`), so that snippet errored with *"An argument named enable_key_rotation is not expected here"*. Fixed by declaring it (bool, default `true`, matching core and CDK) and forwarding it.

Everything else agreed. `engine` is the one core variable the app module deliberately does not re-declare — the generator fixes it from the chosen engine — which the regression test encodes explicitly.

**Migration** (`latest/rdb-terraform-aurora-app-module-defaults`). These files are vended `KeepExisting`, so an upgraded workspace keeps the old default. Deterministic, GritQL over HCL. The default flip is keyed on the **previously vended description**, which is the only thing distinguishing the vended `default = false` from a user who deliberately turned log export off — so a user's own choice is preserved (covered by a test). Files that don't match the generated shape are left untouched and reported via `nextSteps`.

### Description of how you validated changes

**Unit tests.** Two regression tests in `ts/rdb/generator.spec.ts`, plus six for the migration:

- every variable the app module re-declares has the same default as the core module, and forwards its own value down (`engine` asserted as the sole intentional exception, so a future omission fails rather than passing silently);
- per engine, `enable_cloudwatch_logs` defaults to `true` **and** the parameter group is `count`-gated on it with the expected exports/parameters.

`pnpm nx run @aws/nx-plugin:test` → **3763 passed / 3763**. Build → all 5 projects pass. Lint → pass.

**Deployed to AWS and verified against real infrastructure** (account `597088032894`, `us-east-1`). Fresh Terraform workspace on the locally compiled plugin, `ts#rdb` Postgres + MySQL Aurora, `nx run infra:apply` → `Apply complete! Resources: 105 added`.

Log export is on and the parameter group is attached — before this change these were `[]` and `default.aurora-*`:

```
$ aws rds describe-db-clusters --query 'DBClusters[].[DBClusterIdentifier,EnabledCloudwatchLogsExports,DBClusterParameterGroup]'
[["mysql-db-aurora-ienh0wqw",    ["audit","error"], "mysql-db-519fae596fb9f48828534eda58"],
 ["postgres-db-aurora-mfx3osv7", ["postgresql"],    "postgres-db-06f71ee426d7492198b9ce5937"]]
```

The parameter groups carry the PII-safe parameters (`--source user`):

```
postgres-db-06f71ee426d7492198b9ce5937   log_statement          ddl                 dynamic
mysql-db-519fae596fb9f48828534eda58      server_audit_events    CONNECT,QUERY_DDL   dynamic
                                         server_audit_logging   1                   dynamic
```

Both `count`-gated groups are in Terraform state, so the group is genuinely created rather than defaulted:

```
module.postgres_db.module.aurora.aws_rds_cluster_parameter_group.database[0]
module.mysql_db.module.aurora.aws_rds_cluster_parameter_group.database[0]
```

**Log groups exist and receive events.** All three appeared on their own (Aurora creates them only when the export is enabled), with real event timestamps:

```
/aws/rds/cluster/postgres-db-aurora-mfx3osv7/postgresql
/aws/rds/cluster/mysql-db-aurora-ienh0wqw/audit
/aws/rds/cluster/mysql-db-aurora-ienh0wqw/error
```

PostgreSQL confirms the parameter reached the engine:

```
2026-08-26 14:21:40 UTC::@:[679]:LOG:  parameter "log_statement" changed to "ddl"
2026-08-26 14:22:19 UTC::@:[679]:LOG:  database system is ready to accept connections
```

MySQL Advanced Auditing emits exactly the scoped events — connections, no statement text:

```
1787754405157300,mysql-db-aurora-ienh0wqw-1,rdsadmin,localhost,52,0,CONNECT,,,0
1787754405160370,mysql-db-aurora-ienh0wqw-1,rdsadmin,localhost,52,0,DISCONNECT,,,0
```

**CDK comparison.** Same two databases in a CDK workspace, `cdk synth`. Terraform now matches CDK exactly:

| | CDK synth | Terraform (deployed) |
|---|---|---|
| Postgres exports | `['postgresql']` | `['postgresql']` |
| Postgres parameters | `{log_statement: ddl}` | `log_statement=ddl` |
| MySQL exports | `['audit','error']` | `['audit','error']` |
| MySQL parameters | `{server_audit_logging: 1, server_audit_events: CONNECT,QUERY_DDL}` | same |
| Parameter groups | 2 created (1 per cluster) | 2 created (1 per cluster) |

**Teardown.** `nx run infra:destroy -- -auto-approve`; `describe-db-clusters` returns empty. A sibling change added `lifecycle { prevent_destroy = true }` to the Aurora cluster, so as `e2e/src/smoke-tests/terraform-deploy.spec.ts` does, the literal was flipped to `false` in the workspace copy before deploying.

One deviation worth stating plainly: the container's Docker daemon is remote and would not retain a qemu binfmt registration, so the migration/create-db-user Lambdas were built and deployed as `x86_64` rather than the vended `arm64`. Lambda architecture has no bearing on the Aurora cluster configuration under test, and every assertion above is read back from the deployed cluster.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
