### PR TITLE
fix(ts#api,py#api): cache HTTP API custom authorizer results on Terraform

### DIFF
--- a/docs/src/content/docs/en/guides/fastapi.mdx
+++ b/docs/src/content/docs/en/guides/fastapi.mdx
@@ -491,6 +491,8 @@ The `UserIdentity` construct can be generated using the <Link path="/guides/reac
 <OptionFilter when={{ auth: 'custom' }} description="Custom Lambda Authorizer CDK usage">
 :::caution[Custom Lambda Authorizer]
 When using `Custom` auth, the construct creates a Lambda Authorizer internally from the generated `authorizer.py` file, which **denies all requests by default**. You must implement your authorization logic in that file before your API will accept any traffic.
+
+Authorizer results are cached for 5 minutes, keyed on the `Authorization` header, so a revoked token may be accepted until its cached result expires. Reduce the cache duration in the generated infrastructure if you need faster revocation.
 :::
 </OptionFilter>
 </Fragment>
@@ -604,6 +606,8 @@ module "my_api" {
 <OptionFilter when={{ auth: 'custom' }} description="Custom Lambda Authorizer usage with Terraform">
 :::caution[Custom Lambda Authorizer]
 When using `Custom` auth, your API is protected by a Lambda Authorizer that **denies all requests by default**. You must implement your authorization logic in the generated `authorizer.py` file before your API will accept any traffic.
+
+Authorizer results are cached for 5 minutes, keyed on the `Authorization` header, so a revoked token may be accepted until its cached result expires. Reduce the cache duration in the generated infrastructure if you need faster revocation.
 :::
 </OptionFilter>
 </Fragment>

--- a/docs/src/content/docs/en/guides/trpc.mdx
+++ b/docs/src/content/docs/en/guides/trpc.mdx
@@ -573,6 +573,8 @@ export class ExampleStack extends Stack {
 
 :::caution[Custom Lambda Authorizer]
 When using `Custom` auth, the construct creates a Lambda Authorizer internally from the generated `src/authorizer.ts` file, which **denies all requests by default**. You must implement your authorization logic in that file before your API will accept any traffic.
+
+Authorizer results are cached for 5 minutes, keyed on the `Authorization` header, so a revoked token may be accepted until its cached result expires. Reduce the cache duration in the generated infrastructure if you need faster revocation.
 :::
 </OptionFilter>
 
@@ -718,6 +720,8 @@ module "my_api" {
 <OptionFilter when={{ auth: 'custom' }} description="Custom Lambda Authorizer usage with Terraform">
 :::caution[Custom Lambda Authorizer]
 When using `Custom` auth, your API is protected by a Lambda Authorizer that **denies all requests by default**. You must implement your authorization logic in the generated `src/authorizer.ts` file before your API will accept any traffic.
+
+Authorizer results are cached for 5 minutes, keyed on the `Authorization` header, so a revoked token may be accepted until its cached result expires. Reduce the cache duration in the generated infrastructure if you need faster revocation.
 :::
 </OptionFilter>
 </Fragment>

--- a/docs/src/content/docs/en/guides/ts-smithy-api.mdx
+++ b/docs/src/content/docs/en/guides/ts-smithy-api.mdx
@@ -697,6 +697,8 @@ The `UserIdentity` construct can be generated using the <Link path="/guides/reac
 <OptionFilter when={{ auth: 'custom' }} description="Custom Lambda Authorizer CDK usage">
 :::caution[Custom Lambda Authorizer]
 When using `Custom` auth, the construct creates a Lambda Authorizer internally from the generated `src/authorizer.ts` file, which **denies all requests by default**. You must implement your authorization logic in that file before your API will accept any traffic.
+
+Authorizer results are cached for 5 minutes, keyed on the `Authorization` header, so a revoked token may be accepted until its cached result expires. Reduce the cache duration in the generated infrastructure if you need faster revocation.
 :::
 </OptionFilter>
 </Fragment>
@@ -768,6 +770,8 @@ module "my_api" {
 <OptionFilter when={{ auth: 'custom' }} description="Custom Lambda Authorizer usage with Terraform">
 :::caution[Custom Lambda Authorizer]
 When using `Custom` auth, your API is protected by a Lambda Authorizer that **denies all requests by default**. You must implement your authorization logic in the generated `src/authorizer.ts` file before your API will accept any traffic.
+
+Authorizer results are cached for 5 minutes, keyed on the `Authorization` header, so a revoked token may be accepted until its cached result expires. Reduce the cache duration in the generated infrastructure if you need faster revocation.
 :::
 </OptionFilter>
 

--- a/docs/src/content/docs/es/guides/fastapi.mdx
+++ b/docs/src/content/docs/es/guides/fastapi.mdx
@@ -491,6 +491,8 @@ El constructo `UserIdentity` se puede generar usando el <Link path="/guides/reac
 <OptionFilter when={{ auth: 'custom' }} description="Uso de CDK con Lambda Authorizer personalizado">
 :::caution[Lambda Authorizer Personalizado]
 Cuando se usa autenticación `Custom`, el constructo crea un Lambda Authorizer internamente desde el archivo `authorizer.py` generado, que **deniega todas las solicitudes por defecto**. Debes implementar tu lógica de autorización en ese archivo antes de que tu API acepte cualquier tráfico.
+
+Los resultados del autorizador se almacenan en caché durante 5 minutos, con clave en el encabezado `Authorization`, por lo que un token revocado puede ser aceptado hasta que expire su resultado en caché. Reduce la duración del caché en la infraestructura generada si necesitas una revocación más rápida.
 :::
 </OptionFilter>
 </Fragment>
@@ -604,6 +606,8 @@ module "my_api" {
 <OptionFilter when={{ auth: 'custom' }} description="Uso de Lambda Authorizer personalizado con Terraform">
 :::caution[Lambda Authorizer Personalizado]
 Cuando se usa autenticación `Custom`, tu API está protegida por un Lambda Authorizer que **deniega todas las solicitudes por defecto**. Debes implementar tu lógica de autorización en el archivo `authorizer.py` generado antes de que tu API acepte cualquier tráfico.
+
+Los resultados del autorizador se almacenan en caché durante 5 minutos, con clave en el encabezado `Authorization`, por lo que un token revocado puede ser aceptado hasta que expire su resultado en caché. Reduce la duración del caché en la infraestructura generada si necesitas una revocación más rápida.
 :::
 </OptionFilter>
 </Fragment>

--- a/docs/src/content/docs/es/guides/trpc.mdx
+++ b/docs/src/content/docs/es/guides/trpc.mdx
@@ -573,6 +573,8 @@ export class ExampleStack extends Stack {
 
 :::caution[Custom Lambda Authorizer]
 Cuando usas autenticación `Custom`, el constructo crea un Lambda Authorizer internamente desde el archivo generado `src/authorizer.ts`, que **deniega todas las solicitudes por defecto**. Debes implementar tu lógica de autorización en ese archivo antes de que tu API acepte cualquier tráfico.
+
+Los resultados del autorizador se almacenan en caché durante 5 minutos, con clave en el encabezado `Authorization`, por lo que un token revocado puede ser aceptado hasta que expire su resultado en caché. Reduce la duración del caché en la infraestructura generada si necesitas una revocación más rápida.
 :::
 </OptionFilter>
 

--- a/docs/src/content/docs/es/guides/trpc.mdx
+++ b/docs/src/content/docs/es/guides/trpc.mdx
@@ -718,6 +718,8 @@ module "my_api" {
 <OptionFilter when={{ auth: 'custom' }} description="Custom Lambda Authorizer usage with Terraform">
 :::caution[Custom Lambda Authorizer]
 Cuando usas autenticación `Custom`, tu API está protegida por un Lambda Authorizer que **deniega todas las solicitudes por defecto**. Debes implementar tu lógica de autorización en el archivo generado `src/authorizer.ts` antes de que tu API acepte cualquier tráfico.
+
+Los resultados del autorizador se almacenan en caché durante 5 minutos, con clave en el encabezado `Authorization`, por lo que un token revocado puede ser aceptado hasta que expire su resultado en caché. Reduce la duración del caché en la infraestructura generada si necesitas una revocación más rápida.
 :::
 </OptionFilter>
 </Fragment>

--- a/docs/src/content/docs/es/guides/ts-smithy-api.mdx
+++ b/docs/src/content/docs/es/guides/ts-smithy-api.mdx
@@ -697,6 +697,8 @@ El constructo `UserIdentity` puede generarse usando el <Link path="/es/guides/re
 <OptionFilter when={{ auth: 'custom' }} description="Uso del Autorizador Lambda Personalizado con CDK">
 :::caution[Autorizador Lambda Personalizado]
 Al usar autenticación `Custom`, el constructo crea un Lambda Authorizer internamente desde el archivo `src/authorizer.ts` generado, que **deniega todas las solicitudes por defecto**. Debes implementar tu lógica de autorización en ese archivo antes de que tu API acepte cualquier tráfico.
+
+Los resultados del autorizador se almacenan en caché durante 5 minutos, con clave en el encabezado `Authorization`, por lo que un token revocado puede ser aceptado hasta que expire su resultado en caché. Reduce la duración del caché en la infraestructura generada si necesitas una revocación más rápida.
 :::
 </OptionFilter>
 </Fragment>

--- a/docs/src/content/docs/es/guides/ts-smithy-api.mdx
+++ b/docs/src/content/docs/es/guides/ts-smithy-api.mdx
@@ -768,6 +768,8 @@ module "my_api" {
 <OptionFilter when={{ auth: 'custom' }} description="Uso del Autorizador Lambda Personalizado con Terraform">
 :::caution[Autorizador Lambda Personalizado]
 Al usar autenticación `Custom`, tu API está protegida por un Lambda Authorizer que **deniega todas las solicitudes por defecto**. Debes implementar tu lógica de autorización en el archivo `src/authorizer.ts` generado antes de que tu API acepte cualquier tráfico.
+
+Los resultados del autorizador se almacenan en caché durante 5 minutos, con clave en el encabezado `Authorization`, por lo que un token revocado puede ser aceptado hasta que expire su resultado en caché. Reduce la duración del caché en la infraestructura generada si necesitas una revocación más rápida.
 :::
 </OptionFilter>
 

--- a/docs/src/content/docs/fr/guides/fastapi.mdx
+++ b/docs/src/content/docs/fr/guides/fastapi.mdx
@@ -604,6 +604,8 @@ module "my_api" {
 <OptionFilter when={{ auth: 'custom' }} description="Utilisation de l'autorisateur Lambda personnalisé avec Terraform">
 :::caution[Autorisateur Lambda personnalisé]
 Lors de l'utilisation de l'authentification `Custom`, votre API est protégée par un autorisateur Lambda qui **refuse toutes les requêtes par défaut**. Vous devez implémenter votre logique d'autorisation dans le fichier `authorizer.py` généré avant que votre API n'accepte du trafic.
+
+Les résultats de l'autorisateur sont mis en cache pendant 5 minutes, indexés sur l'en-tête `Authorization`, donc un jeton révoqué peut être accepté jusqu'à l'expiration de son résultat en cache. Réduisez la durée du cache dans l'infrastructure générée si vous avez besoin d'une révocation plus rapide.
 :::
 </OptionFilter>
 </Fragment>

--- a/docs/src/content/docs/fr/guides/fastapi.mdx
+++ b/docs/src/content/docs/fr/guides/fastapi.mdx
@@ -491,6 +491,8 @@ Le construct `UserIdentity` peut être généré en utilisant le <Link path="/gu
 <OptionFilter when={{ auth: 'custom' }} description="Utilisation de l'autorisateur Lambda personnalisé CDK">
 :::caution[Autorisateur Lambda personnalisé]
 Lors de l'utilisation de l'authentification `Custom`, le construct crée un autorisateur Lambda en interne à partir du fichier `authorizer.py` généré, qui **refuse toutes les requêtes par défaut**. Vous devez implémenter votre logique d'autorisation dans ce fichier avant que votre API n'accepte du trafic.
+
+Les résultats de l'autorisateur sont mis en cache pendant 5 minutes, indexés sur l'en-tête `Authorization`, donc un jeton révoqué peut être accepté jusqu'à l'expiration de son résultat en cache. Réduisez la durée du cache dans l'infrastructure générée si vous avez besoin d'une révocation plus rapide.
 :::
 </OptionFilter>
 </Fragment>

--- a/docs/src/content/docs/fr/guides/trpc.mdx
+++ b/docs/src/content/docs/fr/guides/trpc.mdx
@@ -718,6 +718,8 @@ module "my_api" {
 <OptionFilter when={{ auth: 'custom' }} description="Custom Lambda Authorizer usage with Terraform">
 :::caution[Custom Lambda Authorizer]
 Lors de l'utilisation de l'authentification `Custom`, votre API est protégée par un Lambda Authorizer qui **refuse toutes les requêtes par défaut**. Vous devez implémenter votre logique d'autorisation dans le fichier généré `src/authorizer.ts` avant que votre API n'accepte du trafic.
+
+Les résultats de l'autorisateur sont mis en cache pendant 5 minutes, indexés sur l'en-tête `Authorization`, donc un jeton révoqué peut être accepté jusqu'à ce que son résultat en cache expire. Réduisez la durée du cache dans l'infrastructure générée si vous avez besoin d'une révocation plus rapide.
 :::
 </OptionFilter>
 </Fragment>

--- a/docs/src/content/docs/fr/guides/trpc.mdx
+++ b/docs/src/content/docs/fr/guides/trpc.mdx
@@ -573,6 +573,8 @@ export class ExampleStack extends Stack {
 
 :::caution[Custom Lambda Authorizer]
 Lors de l'utilisation de l'authentification `Custom`, le construct crée un Lambda Authorizer en interne à partir du fichier généré `src/authorizer.ts`, qui **refuse toutes les requêtes par défaut**. Vous devez implémenter votre logique d'autorisation dans ce fichier avant que votre API n'accepte du trafic.
+
+Les résultats de l'autorisateur sont mis en cache pendant 5 minutes, indexés sur l'en-tête `Authorization`, donc un jeton révoqué peut être accepté jusqu'à ce que son résultat en cache expire. Réduisez la durée du cache dans l'infrastructure générée si vous avez besoin d'une révocation plus rapide.
 :::
 </OptionFilter>
 

--- a/docs/src/content/docs/fr/guides/ts-smithy-api.mdx
+++ b/docs/src/content/docs/fr/guides/ts-smithy-api.mdx
@@ -768,6 +768,8 @@ module "my_api" {
 <OptionFilter when={{ auth: 'custom' }} description="Utilisation de l'autorisateur Lambda personnalisé avec Terraform">
 :::caution[Autorisateur Lambda personnalisé]
 Lors de l'utilisation de l'authentification `Custom`, votre API est protégée par un Lambda Authorizer qui **refuse toutes les requêtes par défaut**. Vous devez implémenter votre logique d'autorisation dans le fichier `src/authorizer.ts` généré avant que votre API n'accepte du trafic.
+
+Les résultats de l'autorisateur sont mis en cache pendant 5 minutes, indexés sur l'en-tête `Authorization`, donc un jeton révoqué peut être accepté jusqu'à ce que son résultat en cache expire. Réduisez la durée du cache dans l'infrastructure générée si vous avez besoin d'une révocation plus rapide.
 :::
 </OptionFilter>
 

--- a/docs/src/content/docs/fr/guides/ts-smithy-api.mdx
+++ b/docs/src/content/docs/fr/guides/ts-smithy-api.mdx
@@ -698,6 +698,8 @@ Le construct `UserIdentity` peut être généré avec le générateur <Link path
 <OptionFilter when={{ auth: 'custom' }} description="Utilisation CDK de l'autorisateur Lambda personnalisé">
 :::caution[Autorisateur Lambda personnalisé]
 Lors de l'utilisation de l'authentification `Custom`, le construct crée un Lambda Authorizer en interne à partir du fichier `src/authorizer.ts` généré, qui **refuse toutes les requêtes par défaut**. Vous devez implémenter votre logique d'autorisation dans ce fichier avant que votre API n'accepte du trafic.
+
+Les résultats de l'autorisateur sont mis en cache pendant 5 minutes, indexés sur l'en-tête `Authorization`, donc un jeton révoqué peut être accepté jusqu'à ce que son résultat en cache expire. Réduisez la durée du cache dans l'infrastructure générée si vous avez besoin d'une révocation plus rapide.
 :::
 </OptionFilter>
 <Fragment slot="terraform">

--- a/docs/src/content/docs/it/guides/fastapi.mdx
+++ b/docs/src/content/docs/it/guides/fastapi.mdx
@@ -606,6 +606,8 @@ module "my_api" {
 <OptionFilter when={{ auth: 'custom' }} description="Utilizzo dell'autorizzatore Lambda personalizzato con Terraform">
 :::caution[Autorizzatore Lambda personalizzato]
 Quando si utilizza l'autenticazione `Custom`, la tua API è protetta da un Lambda Authorizer che **nega tutte le richieste per impostazione predefinita**. Devi implementare la tua logica di autorizzazione nel file `authorizer.py` generato prima che la tua API accetti qualsiasi traffico.
+
+I risultati dell'autorizzatore vengono memorizzati nella cache per 5 minuti, indicizzati sull'header `Authorization`, quindi un token revocato potrebbe essere accettato fino alla scadenza del risultato memorizzato nella cache. Riduci la durata della cache nell'infrastruttura generata se hai bisogno di una revoca più rapida.
 :::
 </OptionFilter>
 </Fragment>

--- a/docs/src/content/docs/it/guides/fastapi.mdx
+++ b/docs/src/content/docs/it/guides/fastapi.mdx
@@ -491,6 +491,8 @@ Il costrutto `UserIdentity` può essere generato utilizzando il <Link path="/gui
 <OptionFilter when={{ auth: 'custom' }} description="Utilizzo CDK dell'autorizzatore Lambda personalizzato">
 :::caution[Autorizzatore Lambda personalizzato]
 Quando si utilizza l'autenticazione `Custom`, il costrutto crea internamente un Lambda Authorizer dal file `authorizer.py` generato, che **nega tutte le richieste per impostazione predefinita**. Devi implementare la tua logica di autorizzazione in quel file prima che la tua API accetti qualsiasi traffico.
+
+I risultati dell'autorizzatore vengono memorizzati nella cache per 5 minuti, indicizzati sull'header `Authorization`, quindi un token revocato potrebbe essere accettato fino alla scadenza del risultato memorizzato nella cache. Riduci la durata della cache nell'infrastruttura generata se hai bisogno di una revoca più rapida.
 :::
 </OptionFilter>
 </Fragment>

--- a/docs/src/content/docs/it/guides/trpc.mdx
+++ b/docs/src/content/docs/it/guides/trpc.mdx
@@ -718,6 +718,8 @@ module "my_api" {
 <OptionFilter when={{ auth: 'custom' }} description="Custom Lambda Authorizer usage with Terraform">
 :::caution[Custom Lambda Authorizer]
 Quando si utilizza l'autenticazione `Custom`, la tua API è protetta da un Lambda Authorizer che **nega tutte le richieste per impostazione predefinita**. Devi implementare la tua logica di autorizzazione nel file generato `src/authorizer.ts` prima che la tua API accetti qualsiasi traffico.
+
+I risultati dell'autorizzatore vengono memorizzati nella cache per 5 minuti, indicizzati sull'header `Authorization`, quindi un token revocato potrebbe essere accettato fino alla scadenza del risultato memorizzato nella cache. Riduci la durata della cache nell'infrastruttura generata se hai bisogno di una revoca più rapida.
 :::
 </OptionFilter>
 </Fragment>

--- a/docs/src/content/docs/it/guides/trpc.mdx
+++ b/docs/src/content/docs/it/guides/trpc.mdx
@@ -573,6 +573,8 @@ export class ExampleStack extends Stack {
 
 :::caution[Custom Lambda Authorizer]
 Quando si utilizza l'autenticazione `Custom`, il costrutto crea internamente un Lambda Authorizer dal file generato `src/authorizer.ts`, che **nega tutte le richieste per impostazione predefinita**. Devi implementare la tua logica di autorizzazione in quel file prima che la tua API accetti qualsiasi traffico.
+
+I risultati dell'autorizzatore vengono memorizzati nella cache per 5 minuti, indicizzati sull'header `Authorization`, quindi un token revocato potrebbe essere accettato fino alla scadenza del risultato memorizzato nella cache. Riduci la durata della cache nell'infrastruttura generata se hai bisogno di una revoca più rapida.
 :::
 </OptionFilter>
 

--- a/docs/src/content/docs/it/guides/ts-smithy-api.mdx
+++ b/docs/src/content/docs/it/guides/ts-smithy-api.mdx
@@ -768,6 +768,8 @@ module "my_api" {
 <OptionFilter when={{ auth: 'custom' }} description="Custom Lambda Authorizer usage with Terraform">
 :::caution[Lambda Authorizer Personalizzato]
 Quando si utilizza l'autenticazione `Custom`, la tua API è protetta da un Lambda Authorizer che **nega tutte le richieste per impostazione predefinita**. Devi implementare la tua logica di autorizzazione nel file generato `src/authorizer.ts` prima che la tua API accetti qualsiasi traffico.
+
+I risultati dell'authorizer vengono memorizzati nella cache per 5 minuti, con chiave sull'header `Authorization`, quindi un token revocato potrebbe essere accettato fino alla scadenza del risultato memorizzato nella cache. Riduci la durata della cache nell'infrastruttura generata se hai bisogno di una revoca più rapida.
 :::
 </OptionFilter>
 

--- a/docs/src/content/docs/it/guides/ts-smithy-api.mdx
+++ b/docs/src/content/docs/it/guides/ts-smithy-api.mdx
@@ -697,6 +697,8 @@ Il costrutto `UserIdentity` può essere generato utilizzando il <Link path="/it/
 <OptionFilter when={{ auth: 'custom' }} description="Custom Lambda Authorizer CDK usage">
 :::caution[Lambda Authorizer Personalizzato]
 Quando si utilizza l'autenticazione `Custom`, il costrutto crea internamente un Lambda Authorizer dal file generato `src/authorizer.ts`, che **nega tutte le richieste per impostazione predefinita**. Devi implementare la tua logica di autorizzazione in quel file prima che la tua API accetti qualsiasi traffico.
+
+I risultati dell'authorizer vengono memorizzati nella cache per 5 minuti, con chiave sull'header `Authorization`, quindi un token revocato potrebbe essere accettato fino alla scadenza del risultato memorizzato nella cache. Riduci la durata della cache nell'infrastruttura generata se hai bisogno di una revoca più rapida.
 :::
 </OptionFilter>
 </Fragment>

--- a/docs/src/content/docs/jp/guides/fastapi.mdx
+++ b/docs/src/content/docs/jp/guides/fastapi.mdx
@@ -491,6 +491,8 @@ export class ExampleStack extends Stack {
 <OptionFilter when={{ auth: 'custom' }} description="カスタムLambdaオーソライザーのCDK使用">
 :::caution[カスタムLambdaオーソライザー]
 `Custom`認証を使用する場合、コンストラクトは生成された`authorizer.py`ファイルから内部的にLambdaオーソライザーを作成しますが、**デフォルトですべてのリクエストを拒否します**。APIがトラフィックを受け入れる前に、そのファイルに認可ロジックを実装する必要があります。
+
+オーソライザーの結果は5分間キャッシュされ、`Authorization`ヘッダーをキーとしているため、キャッシュされた結果が期限切れになるまで、取り消されたトークンが受け入れられる可能性があります。より迅速な取り消しが必要な場合は、生成されたインフラストラクチャでキャッシュ期間を短縮してください。
 :::
 </OptionFilter>
 </Fragment>

--- a/docs/src/content/docs/jp/guides/fastapi.mdx
+++ b/docs/src/content/docs/jp/guides/fastapi.mdx
@@ -606,6 +606,8 @@ module "my_api" {
 <OptionFilter when={{ auth: 'custom' }} description="TerraformでのカスタムLambdaオーソライザーの使用">
 :::caution[カスタムLambdaオーソライザー]
 `Custom`認証を使用する場合、APIは**デフォルトですべてのリクエストを拒否する**Lambdaオーソライザーによって保護されます。APIがトラフィックを受け入れる前に、生成された`authorizer.py`ファイルに認可ロジックを実装する必要があります。
+
+オーソライザーの結果は5分間キャッシュされ、`Authorization`ヘッダーをキーとしているため、キャッシュされた結果が期限切れになるまで、取り消されたトークンが受け入れられる可能性があります。より迅速な取り消しが必要な場合は、生成されたインフラストラクチャでキャッシュ期間を短縮してください。
 :::
 </OptionFilter>
 </Fragment>

--- a/docs/src/content/docs/jp/guides/trpc.mdx
+++ b/docs/src/content/docs/jp/guides/trpc.mdx
@@ -573,6 +573,8 @@ export class ExampleStack extends Stack {
 
 :::caution[Custom Lambda Authorizer]
 `Custom`認証を使用する場合、コンストラクトは生成された`src/authorizer.ts`ファイルから内部的にLambda Authorizerを作成しますが、**デフォルトですべてのリクエストを拒否します**。APIがトラフィックを受け入れる前に、そのファイルに認可ロジックを実装する必要があります。
+
+オーソライザーの結果は5分間キャッシュされ、`Authorization`ヘッダーをキーとしているため、失効したトークンがキャッシュされた結果の有効期限が切れるまで受け入れられる可能性があります。より迅速な失効が必要な場合は、生成されたインフラストラクチャでキャッシュ期間を短縮してください。
 :::
 </OptionFilter>
 
@@ -718,6 +720,8 @@ module "my_api" {
 <OptionFilter when={{ auth: 'custom' }} description="Custom Lambda Authorizer usage with Terraform">
 :::caution[Custom Lambda Authorizer]
 `Custom`認証を使用する場合、APIは**デフォルトですべてのリクエストを拒否する**Lambda Authorizerによって保護されます。APIがトラフィックを受け入れる前に、生成された`src/authorizer.ts`ファイルに認可ロジックを実装する必要があります。
+
+オーソライザーの結果は5分間キャッシュされ、`Authorization`ヘッダーをキーとしているため、失効したトークンがキャッシュされた結果の有効期限が切れるまで受け入れられる可能性があります。より迅速な失効が必要な場合は、生成されたインフラストラクチャでキャッシュ期間を短縮してください。
 :::
 </OptionFilter>
 </Fragment>

--- a/docs/src/content/docs/jp/guides/ts-smithy-api.mdx
+++ b/docs/src/content/docs/jp/guides/ts-smithy-api.mdx
@@ -768,6 +768,8 @@ module "my_api" {
 <OptionFilter when={{ auth: 'custom' }} description="Terraform でのカスタム Lambda オーソライザーの使用">
 :::caution[カスタム Lambda オーソライザー]
 `Custom` 認証を使用する場合、API は**デフォルトですべてのリクエストを拒否する** Lambda オーソライザーによって保護されます。API がトラフィックを受け入れる前に、生成された `src/authorizer.ts` ファイルに認可ロジックを実装する必要があります。
+
+オーソライザーの結果は 5 分間キャッシュされ、`Authorization` ヘッダーをキーとするため、失効したトークンはキャッシュされた結果が期限切れになるまで受け入れられる可能性があります。より迅速な失効が必要な場合は、生成されたインフラストラクチャでキャッシュ期間を短縮してください。
 :::
 </OptionFilter>
 

--- a/docs/src/content/docs/jp/guides/ts-smithy-api.mdx
+++ b/docs/src/content/docs/jp/guides/ts-smithy-api.mdx
@@ -697,6 +697,8 @@ export class ExampleStack extends Stack {
 <OptionFilter when={{ auth: 'custom' }} description="カスタム Lambda オーソライザー CDK の使用">
 :::caution[カスタム Lambda オーソライザー]
 `Custom` 認証を使用する場合、コンストラクトは生成された `src/authorizer.ts` ファイルから内部的に Lambda オーソライザーを作成しますが、これは**デフォルトですべてのリクエストを拒否します**。API がトラフィックを受け入れる前に、そのファイルに認可ロジックを実装する必要があります。
+
+オーソライザーの結果は 5 分間キャッシュされ、`Authorization` ヘッダーをキーとするため、失効したトークンはキャッシュされた結果が期限切れになるまで受け入れられる可能性があります。より迅速な失効が必要な場合は、生成されたインフラストラクチャでキャッシュ期間を短縮してください。
 :::
 </OptionFilter>
 </Fragment>

--- a/docs/src/content/docs/ko/guides/fastapi.mdx
+++ b/docs/src/content/docs/ko/guides/fastapi.mdx
@@ -491,6 +491,8 @@ export class ExampleStack extends Stack {
 <OptionFilter when={{ auth: 'custom' }} description="사용자 정의 Lambda 권한 부여자 CDK 사용">
 :::caution[사용자 정의 Lambda 권한 부여자]
 `Custom` 인증을 사용할 때, 구성은 생성된 `authorizer.py` 파일에서 내부적으로 Lambda 권한 부여자를 생성하며, **기본적으로 모든 요청을 거부합니다**. API가 트래픽을 수락하기 전에 해당 파일에 권한 부여 로직을 구현해야 합니다.
+
+권한 부여자 결과는 `Authorization` 헤더를 키로 하여 5분 동안 캐시되므로, 취소된 토큰이 캐시된 결과가 만료될 때까지 수락될 수 있습니다. 더 빠른 취소가 필요한 경우 생성된 인프라에서 캐시 기간을 줄이세요.
 :::
 </OptionFilter>
 </Fragment>
@@ -604,6 +606,8 @@ module "my_api" {
 <OptionFilter when={{ auth: 'custom' }} description="Terraform을 사용한 사용자 정의 Lambda 권한 부여자 사용">
 :::caution[사용자 정의 Lambda 권한 부여자]
 `Custom` 인증을 사용할 때, API는 **기본적으로 모든 요청을 거부하는** Lambda 권한 부여자로 보호됩니다. API가 트래픽을 수락하기 전에 생성된 `authorizer.py` 파일에 권한 부여 로직을 구현해야 합니다.
+
+권한 부여자 결과는 `Authorization` 헤더를 키로 하여 5분 동안 캐시되므로, 취소된 토큰이 캐시된 결과가 만료될 때까지 수락될 수 있습니다. 더 빠른 취소가 필요한 경우 생성된 인프라에서 캐시 기간을 줄이세요.
 :::
 </OptionFilter>
 </Fragment>

--- a/docs/src/content/docs/ko/guides/trpc.mdx
+++ b/docs/src/content/docs/ko/guides/trpc.mdx
@@ -573,6 +573,8 @@ export class ExampleStack extends Stack {
 
 :::caution[Custom Lambda Authorizer]
 `Custom` 인증을 사용하는 경우 구성은 생성된 `src/authorizer.ts` 파일에서 내부적으로 Lambda Authorizer를 생성하며, 이는 **기본적으로 모든 요청을 거부합니다**. API가 트래픽을 수락하기 전에 해당 파일에서 권한 부여 로직을 구현해야 합니다.
+
+권한 부여자 결과는 `Authorization` 헤더를 키로 하여 5분 동안 캐시되므로 취소된 토큰이 캐시된 결과가 만료될 때까지 수락될 수 있습니다. 더 빠른 취소가 필요한 경우 생성된 인프라에서 캐시 기간을 줄이세요.
 :::
 </OptionFilter>
 
@@ -718,6 +720,8 @@ module "my_api" {
 <OptionFilter when={{ auth: 'custom' }} description="Custom Lambda Authorizer usage with Terraform">
 :::caution[Custom Lambda Authorizer]
 `Custom` 인증을 사용하는 경우 API는 **기본적으로 모든 요청을 거부하는** Lambda Authorizer로 보호됩니다. API가 트래픽을 수락하기 전에 생성된 `src/authorizer.ts` 파일에서 권한 부여 로직을 구현해야 합니다.
+
+권한 부여자 결과는 `Authorization` 헤더를 키로 하여 5분 동안 캐시되므로 취소된 토큰이 캐시된 결과가 만료될 때까지 수락될 수 있습니다. 더 빠른 취소가 필요한 경우 생성된 인프라에서 캐시 기간을 줄이세요.
 :::
 </OptionFilter>
 </Fragment>

--- a/docs/src/content/docs/ko/guides/ts-smithy-api.mdx
+++ b/docs/src/content/docs/ko/guides/ts-smithy-api.mdx
@@ -697,6 +697,8 @@ export class ExampleStack extends Stack {
 <OptionFilter when={{ auth: 'custom' }} description="사용자 정의 Lambda 권한 부여자 CDK 사용">
 :::caution[사용자 정의 Lambda 권한 부여자]
 `Custom` 인증을 사용할 때 구성 요소는 생성된 `src/authorizer.ts` 파일에서 내부적으로 Lambda 권한 부여자를 생성하며, 이는 **기본적으로 모든 요청을 거부합니다**. API가 트래픽을 수락하기 전에 해당 파일에서 권한 부여 로직을 구현해야 합니다.
+
+권한 부여자 결과는 `Authorization` 헤더를 키로 하여 5분 동안 캐시되므로, 취소된 토큰이 캐시된 결과가 만료될 때까지 수락될 수 있습니다. 더 빠른 취소가 필요한 경우 생성된 인프라에서 캐시 기간을 줄이세요.
 :::
 </OptionFilter>
 </Fragment>

--- a/docs/src/content/docs/ko/guides/ts-smithy-api.mdx
+++ b/docs/src/content/docs/ko/guides/ts-smithy-api.mdx
@@ -770,6 +770,8 @@ module "my_api" {
 <OptionFilter when={{ auth: 'custom' }} description="Terraform과 함께 사용자 정의 Lambda 권한 부여자 사용">
 :::caution[사용자 정의 Lambda 권한 부여자]
 `Custom` 인증을 사용할 때 API는 **기본적으로 모든 요청을 거부하는** Lambda 권한 부여자로 보호됩니다. API가 트래픽을 수락하기 전에 생성된 `src/authorizer.ts` 파일에서 권한 부여 로직을 구현해야 합니다.
+
+권한 부여자 결과는 `Authorization` 헤더를 키로 하여 5분 동안 캐시되므로, 취소된 토큰이 캐시된 결과가 만료될 때까지 수락될 수 있습니다. 더 빠른 취소가 필요한 경우 생성된 인프라에서 캐시 기간을 줄이세요.
 :::
 </OptionFilter>
 

--- a/docs/src/content/docs/pt/guides/fastapi.mdx
+++ b/docs/src/content/docs/pt/guides/fastapi.mdx
@@ -491,6 +491,8 @@ O construto `UserIdentity` pode ser gerado usando o <Link path="/guides/react-we
 <OptionFilter when={{ auth: 'custom' }} description="Uso do Autorizador Lambda Personalizado no CDK">
 :::caution[Autorizador Lambda Personalizado]
 Ao usar autenticação `Custom`, o construto cria um Lambda Authorizer internamente a partir do arquivo `authorizer.py` gerado, que **nega todas as solicitações por padrão**. Você deve implementar sua lógica de autorização nesse arquivo antes que sua API aceite qualquer tráfego.
+
+Os resultados do autorizador são armazenados em cache por 5 minutos, com chave no cabeçalho `Authorization`, portanto, um token revogado pode ser aceito até que seu resultado em cache expire. Reduza a duração do cache na infraestrutura gerada se você precisar de revogação mais rápida.
 :::
 </OptionFilter>
 </Fragment>
@@ -604,6 +606,8 @@ module "my_api" {
 <OptionFilter when={{ auth: 'custom' }} description="Uso do Autorizador Lambda Personalizado com Terraform">
 :::caution[Autorizador Lambda Personalizado]
 Ao usar autenticação `Custom`, sua API é protegida por um Lambda Authorizer que **nega todas as solicitações por padrão**. Você deve implementar sua lógica de autorização no arquivo `authorizer.py` gerado antes que sua API aceite qualquer tráfego.
+
+Os resultados do autorizador são armazenados em cache por 5 minutos, com chave no cabeçalho `Authorization`, portanto, um token revogado pode ser aceito até que seu resultado em cache expire. Reduza a duração do cache na infraestrutura gerada se você precisar de revogação mais rápida.
 :::
 </OptionFilter>
 </Fragment>

--- a/docs/src/content/docs/pt/guides/trpc.mdx
+++ b/docs/src/content/docs/pt/guides/trpc.mdx
@@ -573,6 +573,8 @@ export class ExampleStack extends Stack {
 
 :::caution[Custom Lambda Authorizer]
 Ao usar autenticação `Custom`, o construto cria um Lambda Authorizer internamente a partir do arquivo `src/authorizer.ts` gerado, que **nega todas as solicitações por padrão**. Você deve implementar sua lógica de autorização nesse arquivo antes que sua API aceite qualquer tráfego.
+
+Os resultados do autorizador são armazenados em cache por 5 minutos, com chave no cabeçalho `Authorization`, portanto, um token revogado pode ser aceito até que seu resultado em cache expire. Reduza a duração do cache na infraestrutura gerada se você precisar de revogação mais rápida.
 :::
 </OptionFilter>
 
@@ -718,6 +720,8 @@ module "my_api" {
 <OptionFilter when={{ auth: 'custom' }} description="Custom Lambda Authorizer usage with Terraform">
 :::caution[Custom Lambda Authorizer]
 Ao usar autenticação `Custom`, sua API é protegida por um Lambda Authorizer que **nega todas as solicitações por padrão**. Você deve implementar sua lógica de autorização no arquivo `src/authorizer.ts` gerado antes que sua API aceite qualquer tráfego.
+
+Os resultados do autorizador são armazenados em cache por 5 minutos, com chave no cabeçalho `Authorization`, portanto, um token revogado pode ser aceito até que seu resultado em cache expire. Reduza a duração do cache na infraestrutura gerada se você precisar de revogação mais rápida.
 :::
 </OptionFilter>
 </Fragment>

--- a/docs/src/content/docs/pt/guides/ts-smithy-api.mdx
+++ b/docs/src/content/docs/pt/guides/ts-smithy-api.mdx
@@ -697,6 +697,8 @@ O construct `UserIdentity` pode ser gerado usando o <Link path="/pt/guides/react
 <OptionFilter when={{ auth: 'custom' }} description="Uso do Lambda Authorizer personalizado com CDK">
 :::caution[Lambda Authorizer Personalizado]
 Ao usar autenticação `Custom`, o construct cria um Lambda Authorizer internamente a partir do arquivo `src/authorizer.ts` gerado, que **nega todas as requisições por padrão**. Você deve implementar sua lógica de autorização nesse arquivo antes que sua API aceite qualquer tráfego.
+
+Os resultados do autorizador são armazenados em cache por 5 minutos, com chave no cabeçalho `Authorization`, então um token revogado pode ser aceito até que seu resultado em cache expire. Reduza a duração do cache na infraestrutura gerada se você precisar de revogação mais rápida.
 :::
 </OptionFilter>
 </Fragment>
@@ -768,6 +770,8 @@ module "my_api" {
 <OptionFilter when={{ auth: 'custom' }} description="Uso do Lambda Authorizer personalizado com Terraform">
 :::caution[Lambda Authorizer Personalizado]
 Ao usar autenticação `Custom`, sua API é protegida por um Lambda Authorizer que **nega todas as requisições por padrão**. Você deve implementar sua lógica de autorização no arquivo `src/authorizer.ts` gerado antes que sua API aceite qualquer tráfego.
+
+Os resultados do autorizador são armazenados em cache por 5 minutos, com chave no cabeçalho `Authorization`, então um token revogado pode ser aceito até que seu resultado em cache expire. Reduza a duração do cache na infraestrutura gerada se você precisar de revogação mais rápida.
 :::
 </OptionFilter>
 

--- a/docs/src/content/docs/vi/guides/fastapi.mdx
+++ b/docs/src/content/docs/vi/guides/fastapi.mdx
@@ -491,6 +491,8 @@ Construct `UserIdentity` có thể được tạo bằng cách sử dụng <Link
 <OptionFilter when={{ auth: 'custom' }} description="Custom Lambda Authorizer CDK usage">
 :::caution[Custom Lambda Authorizer]
 Khi sử dụng auth `Custom`, construct tạo một Lambda Authorizer nội bộ từ file `authorizer.py` được tạo, **từ chối tất cả các request theo mặc định**. Bạn phải triển khai logic authorization của mình trong file đó trước khi API của bạn chấp nhận bất kỳ traffic nào.
+
+Kết quả của Authorizer được cache trong 5 phút, được khóa trên header `Authorization`, vì vậy một token đã bị thu hồi có thể được chấp nhận cho đến khi kết quả được cache của nó hết hạn. Giảm thời gian cache trong cơ sở hạ tầng được tạo nếu bạn cần thu hồi nhanh hơn.
 :::
 </OptionFilter>
 </Fragment>
@@ -604,6 +606,8 @@ module "my_api" {
 <OptionFilter when={{ auth: 'custom' }} description="Custom Lambda Authorizer usage with Terraform">
 :::caution[Custom Lambda Authorizer]
 Khi sử dụng auth `Custom`, API của bạn được bảo vệ bởi một Lambda Authorizer **từ chối tất cả các request theo mặc định**. Bạn phải triển khai logic authorization của mình trong file `authorizer.py` được tạo trước khi API của bạn chấp nhận bất kỳ traffic nào.
+
+Kết quả của Authorizer được cache trong 5 phút, được khóa trên header `Authorization`, vì vậy một token đã bị thu hồi có thể được chấp nhận cho đến khi kết quả được cache của nó hết hạn. Giảm thời gian cache trong cơ sở hạ tầng được tạo nếu bạn cần thu hồi nhanh hơn.
 :::
 </OptionFilter>
 </Fragment>

--- a/docs/src/content/docs/vi/guides/trpc.mdx
+++ b/docs/src/content/docs/vi/guides/trpc.mdx
@@ -573,6 +573,8 @@ export class ExampleStack extends Stack {
 
 :::caution[Custom Lambda Authorizer]
 Khi sử dụng xác thực `Custom`, construct tạo một Lambda Authorizer nội bộ từ file `src/authorizer.ts` được tạo, **từ chối tất cả các request theo mặc định**. Bạn phải triển khai logic ủy quyền của mình trong file đó trước khi API của bạn chấp nhận bất kỳ traffic nào.
+
+Kết quả của Authorizer được cache trong 5 phút, dựa trên header `Authorization`, vì vậy một token đã bị thu hồi có thể vẫn được chấp nhận cho đến khi kết quả cache của nó hết hạn. Giảm thời gian cache trong cơ sở hạ tầng được tạo nếu bạn cần thu hồi nhanh hơn.
 :::
 </OptionFilter>
 
@@ -718,6 +720,8 @@ module "my_api" {
 <OptionFilter when={{ auth: 'custom' }} description="Custom Lambda Authorizer usage with Terraform">
 :::caution[Custom Lambda Authorizer]
 Khi sử dụng xác thực `Custom`, API của bạn được bảo vệ bởi một Lambda Authorizer **từ chối tất cả các request theo mặc định**. Bạn phải triển khai logic ủy quyền của mình trong file `src/authorizer.ts` được tạo trước khi API của bạn chấp nhận bất kỳ traffic nào.
+
+Kết quả của Authorizer được cache trong 5 phút, dựa trên header `Authorization`, vì vậy một token đã bị thu hồi có thể vẫn được chấp nhận cho đến khi kết quả cache của nó hết hạn. Giảm thời gian cache trong cơ sở hạ tầng được tạo nếu bạn cần thu hồi nhanh hơn.
 :::
 </OptionFilter>
 </Fragment>

--- a/docs/src/content/docs/vi/guides/ts-smithy-api.mdx
+++ b/docs/src/content/docs/vi/guides/ts-smithy-api.mdx
@@ -697,6 +697,8 @@ Construct `UserIdentity` có thể được tạo bằng trình tạo <Link path
 <OptionFilter when={{ auth: 'custom' }} description="Sử dụng Custom Lambda Authorizer với CDK">
 :::caution[Custom Lambda Authorizer]
 Khi sử dụng xác thực `Custom`, construct tạo một Lambda Authorizer nội bộ từ tệp `src/authorizer.ts` được tạo, **từ chối tất cả các yêu cầu theo mặc định**. Bạn phải triển khai logic ủy quyền của mình trong tệp đó trước khi API của bạn chấp nhận bất kỳ lưu lượng nào.
+
+Kết quả của Authorizer được lưu vào bộ nhớ cache trong 5 phút, được khóa trên header `Authorization`, vì vậy một token đã bị thu hồi có thể được chấp nhận cho đến khi kết quả được lưu trong bộ nhớ cache hết hạn. Giảm thời gian cache trong cơ sở hạ tầng được tạo nếu bạn cần thu hồi nhanh hơn.
 :::
 </OptionFilter>
 </Fragment>

--- a/docs/src/content/docs/vi/guides/ts-smithy-api.mdx
+++ b/docs/src/content/docs/vi/guides/ts-smithy-api.mdx
@@ -768,6 +768,8 @@ module "my_api" {
 <OptionFilter when={{ auth: 'custom' }} description="Sử dụng Custom Lambda Authorizer với Terraform">
 :::caution[Custom Lambda Authorizer]
 Khi sử dụng xác thực `Custom`, API của bạn được bảo vệ bởi một Lambda Authorizer **từ chối tất cả các yêu cầu theo mặc định**. Bạn phải triển khai logic ủy quyền của mình trong tệp `src/authorizer.ts` được tạo trước khi API của bạn chấp nhận bất kỳ lưu lượng nào.
+
+Kết quả của Authorizer được lưu vào bộ nhớ cache trong 5 phút, được khóa trên header `Authorization`, vì vậy một token đã bị thu hồi có thể được chấp nhận cho đến khi kết quả được lưu trong bộ nhớ cache hết hạn. Giảm thời gian cache trong cơ sở hạ tầng được tạo nếu bạn cần thu hồi nhanh hơn.
 :::
 </OptionFilter>
 

--- a/docs/src/content/docs/zh/guides/fastapi.mdx
+++ b/docs/src/content/docs/zh/guides/fastapi.mdx
@@ -491,6 +491,8 @@ export class ExampleStack extends Stack {
 <OptionFilter when={{ auth: 'custom' }} description="自定义 Lambda 授权器 CDK 用法">
 :::caution[自定义 Lambda 授权器]
 使用 `Custom` 身份验证时，构造从生成的 `authorizer.py` 文件内部创建一个 Lambda 授权器，**默认拒绝所有请求**。您必须在该文件中实现授权逻辑，然后您的 API 才能接受任何流量。
+
+授权器结果会缓存 5 分钟，以 `Authorization` 标头为键，因此被撤销的令牌可能会被接受，直到其缓存结果过期。如果您需要更快的撤销，请减少生成的基础设施中的缓存持续时间。
 :::
 </OptionFilter>
 </Fragment>
@@ -604,6 +606,8 @@ module "my_api" {
 <OptionFilter when={{ auth: 'custom' }} description="使用 Terraform 的自定义 Lambda 授权器用法">
 :::caution[自定义 Lambda 授权器]
 使用 `Custom` 身份验证时，您的 API 受 Lambda 授权器保护，**默认拒绝所有请求**。您必须在生成的 `authorizer.py` 文件中实现授权逻辑，然后您的 API 才能接受任何流量。
+
+授权器结果会缓存 5 分钟，以 `Authorization` 标头为键，因此被撤销的令牌可能会被接受，直到其缓存结果过期。如果您需要更快的撤销，请减少生成的基础设施中的缓存持续时间。
 :::
 </OptionFilter>
 </Fragment>

--- a/docs/src/content/docs/zh/guides/trpc.mdx
+++ b/docs/src/content/docs/zh/guides/trpc.mdx
@@ -720,6 +720,8 @@ module "my_api" {
 <OptionFilter when={{ auth: 'custom' }} description="使用 Terraform 的自定义 Lambda 授权器用法">
 :::caution[自定义 Lambda 授权器]
 使用 `Custom` 身份验证时,您的 API 受 Lambda 授权器保护,该授权器**默认拒绝所有请求**。您必须在生成的 `src/authorizer.ts` 文件中实现授权逻辑,然后您的 API 才会接受任何流量。
+
+授权器结果会缓存 5 分钟,以 `Authorization` 标头为键,因此被撤销的令牌可能会被接受,直到其缓存结果过期。如果您需要更快的撤销,请减少生成的基础设施中的缓存持续时间。
 :::
 </OptionFilter>
 </Fragment>

--- a/docs/src/content/docs/zh/guides/trpc.mdx
+++ b/docs/src/content/docs/zh/guides/trpc.mdx
@@ -573,6 +573,8 @@ export class ExampleStack extends Stack {
 
 :::caution[自定义 Lambda 授权器]
 使用 `Custom` 身份验证时,构造会从生成的 `src/authorizer.ts` 文件内部创建一个 Lambda 授权器,该授权器**默认拒绝所有请求**。您必须在该文件中实现授权逻辑,然后您的 API 才会接受任何流量。
+
+授权器结果会缓存 5 分钟,以 `Authorization` 标头为键,因此被撤销的令牌可能会被接受,直到其缓存结果过期。如果您需要更快的撤销,请减少生成的基础设施中的缓存持续时间。
 :::
 </OptionFilter>
 

--- a/docs/src/content/docs/zh/guides/ts-smithy-api.mdx
+++ b/docs/src/content/docs/zh/guides/ts-smithy-api.mdx
@@ -697,6 +697,8 @@ export class ExampleStack extends Stack {
 <OptionFilter when={{ auth: 'custom' }} description="自定义 Lambda 授权器 CDK 用法">
 :::caution[自定义 Lambda 授权器]
 使用 `Custom` 身份验证时，构造从生成的 `src/authorizer.ts` 文件内部创建 Lambda 授权器，该文件**默认拒绝所有请求**。在您的 API 接受任何流量之前，您必须在该文件中实现您的授权逻辑。
+
+授权器结果会缓存 5 分钟，以 `Authorization` 标头为键，因此已撤销的令牌可能会被接受，直到其缓存结果过期。如果您需要更快的撤销，请减少生成的基础设施中的缓存持续时间。
 :::
 </OptionFilter>
 </Fragment>

--- a/docs/src/content/docs/zh/guides/ts-smithy-api.mdx
+++ b/docs/src/content/docs/zh/guides/ts-smithy-api.mdx
@@ -768,6 +768,8 @@ module "my_api" {
 <OptionFilter when={{ auth: 'custom' }} description="使用 Terraform 的自定义 Lambda 授权器用法">
 :::caution[自定义 Lambda 授权器]
 使用 `Custom` 身份验证时，您的 API 受 Lambda 授权器保护，该授权器**默认拒绝所有请求**。在您的 API 接受任何流量之前，您必须在生成的 `src/authorizer.ts` 文件中实现您的授权逻辑。
+
+授权器结果会缓存 5 分钟，以 `Authorization` 标头为键，因此已撤销的令牌可能会被接受，直到其缓存结果过期。如果您需要更快的撤销，请减少生成的基础设施中的缓存持续时间。
 :::
 </OptionFilter>
 

--- a/packages/nx-plugin/src/py/fast-api/__snapshots__/generator.terraform.spec.ts.snap
+++ b/packages/nx-plugin/src/py/fast-api/__snapshots__/generator.terraform.spec.ts.snap
@@ -1425,7 +1425,8 @@ resource "aws_apigatewayv2_authorizer" "custom_authorizer" {
   authorizer_type                   = "REQUEST"
   authorizer_uri                    = aws_lambda_function.authorizer_lambda.invoke_arn
   authorizer_payload_format_version = "2.0"
-  authorizer_result_ttl_in_seconds  = 0
+  authorizer_result_ttl_in_seconds  = 300
+  identity_sources                  = ["$request.header.Authorization"]
   enable_simple_responses           = true
   name                              = "TestApiAuthorizer-\${random_string.suffix.result}"
 }

--- a/packages/nx-plugin/src/trpc/backend/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/trpc/backend/__snapshots__/generator.spec.ts.snap
@@ -4554,7 +4554,8 @@ resource "aws_apigatewayv2_authorizer" "custom_authorizer" {
   authorizer_type                   = "REQUEST"
   authorizer_uri                    = aws_lambda_function.authorizer_lambda.invoke_arn
   authorizer_payload_format_version = "2.0"
-  authorizer_result_ttl_in_seconds  = 0
+  authorizer_result_ttl_in_seconds  = 300
+  identity_sources                  = ["$request.header.Authorization"]
   enable_simple_responses           = true
   name                              = "TestApiAuthorizer-\${random_string.suffix.result}"
 }

--- a/packages/nx-plugin/src/trpc/backend/generator.spec.ts
+++ b/packages/nx-plugin/src/trpc/backend/generator.spec.ts
@@ -493,6 +493,80 @@ describe('trpc backend generator', () => {
     expect(tree.exists('apps/test-api/src/authorizer.ts')).toBe(true);
   });
 
+  // The authorizer result cache TTL must stay aligned across CDK and Terraform,
+  // and across HTTP and REST, so the same workspace behaves the same whichever
+  // it is generated with. Caching is keyed on the identity source, so the TTL is
+  // only meaningful alongside one.
+  describe('custom authorizer result cache TTL', () => {
+    it.each(['http-lambda', 'rest-lambda'] as const)(
+      'should leave the 300s aws-cdk-lib default in place for %s on CDK',
+      async (infra) => {
+        await tsTrpcApiGenerator(tree, {
+          name: 'TestApi',
+          directory: 'apps',
+          infra,
+          auth: 'custom',
+          integrationPattern: 'isolated',
+          iac: 'cdk',
+        });
+
+        const construct = tree.read(
+          'packages/common/constructs/src/app/apis/test-api.ts',
+          'utf-8',
+        );
+
+        // Both HttpLambdaAuthorizer and TokenAuthorizer default resultsCacheTtl
+        // to Duration.minutes(5), which is the value we want, so the construct
+        // must not override it.
+        expect(construct).not.toContain('resultsCacheTtl');
+      },
+    );
+
+    it('should pin 300s alongside an identity source for HTTP on Terraform', async () => {
+      await tsTrpcApiGenerator(tree, {
+        name: 'TestApi',
+        directory: 'apps',
+        infra: 'http-lambda',
+        auth: 'custom',
+        iac: 'terraform',
+      });
+
+      const module = tree.read(
+        'packages/common/terraform/src/app/apis/test-api/test-api.tf',
+        'utf-8',
+      );
+
+      expect(module).toMatch(/authorizer_result_ttl_in_seconds\s+=\s+300/);
+      // API Gateway keys the cache on the identity sources, and requires at
+      // least one for caching to be enabled at all.
+      expect(module).toMatch(
+        /identity_sources\s+=\s+\["\$request\.header\.Authorization"\]/,
+      );
+    });
+
+    it('should leave the 300s provider default in place for REST on Terraform', async () => {
+      await tsTrpcApiGenerator(tree, {
+        name: 'TestApi',
+        directory: 'apps',
+        infra: 'rest-lambda',
+        auth: 'custom',
+        iac: 'terraform',
+      });
+
+      const module = tree.read(
+        'packages/common/terraform/src/app/apis/test-api/test-api.tf',
+        'utf-8',
+      );
+
+      // aws_api_gateway_authorizer defaults authorizer_result_ttl_in_seconds to
+      // 300, so the module must not override it.
+      expect(module).not.toContain('authorizer_result_ttl_in_seconds');
+      expect(module).toMatch(
+        /identity_source\s+=\s+"method\.request\.header\.Authorization"/,
+      );
+    });
+  });
+
   it('should generate a single router lambda for REST APIs when using the shared integration pattern', async () => {
     await tsTrpcApiGenerator(tree, {
       name: 'TestApi',

--- a/packages/nx-plugin/src/utils/api-constructs/files/terraform/app/apis/http/__apiNameKebabCase__/__apiNameKebabCase__.tf.template
+++ b/packages/nx-plugin/src/utils/api-constructs/files/terraform/app/apis/http/__apiNameKebabCase__/__apiNameKebabCase__.tf.template
@@ -455,7 +455,8 @@ resource "aws_apigatewayv2_authorizer" "custom_authorizer" {
   authorizer_type                   = "REQUEST"
   authorizer_uri                    = aws_lambda_function.authorizer_lambda.invoke_arn
   authorizer_payload_format_version = "2.0"
-  authorizer_result_ttl_in_seconds  = 0
+  authorizer_result_ttl_in_seconds  = 300
+  identity_sources                  = ["$request.header.Authorization"]
   enable_simple_responses           = true
   name                              = "<%- apiNameClassName %>Authorizer-${random_string.suffix.result}"
 }


### PR DESCRIPTION
### Reason for this change

For `--auth=custom` HTTP APIs, the Terraform module pinned `authorizer_result_ttl_in_seconds = 0`, disabling authorizer result caching entirely, so **every single request** invoked the authorizer Lambda. CDK's `HttpLambdaAuthorizer` defaults `resultsCacheTtl` to `Duration.minutes(5)`, and both providers' REST authorizers sit on the same 300s default (the Terraform REST template omits the attribute, so the provider default of 300 applies). HTTP-on-Terraform was the lone outlier, which made the divergence look unintentional rather than chosen.

There was a second, related bug in the same block: the Terraform HTTP custom authorizer set **no `identity_sources` at all**. API Gateway uses the identity sources as the cache key and [requires at least one for caching to be enabled](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-lambda-authorizer.html#http-api-lambda-authorizer.caching), so raising the TTL alone would have been inert. (The `identity_sources` already present in that template belongs to the *Cognito* authorizer, a separate resource.) CDK defaults `identitySource` to `["$request.header.Authorization"]`, so the two are set together to match.

### Description of changes

`packages/nx-plugin/src/utils/api-constructs/files/terraform/app/apis/http/.../*.tf.template` — on the `custom_authorizer` resource:

```diff
-  authorizer_result_ttl_in_seconds  = 0
+  authorizer_result_ttl_in_seconds  = 300
+  identity_sources                  = ["$request.header.Authorization"]
```

**Why 300 and not 0 — the security/cost trade-off.** This is a real trade-off, not just a consistency argument, so to state the choice plainly: **300s means a revoked token can keep working for up to 5 minutes.** TTL 0 buys instant revocation, at the cost of a Lambda invocation on every request. I have gone with 300 because:

- **It is what users already get on the other three of four paths.** CDK/HTTP, CDK/REST and Terraform/REST are all 300 today. Someone reasoning about their revocation window from the REST docs, or from the CDK construct, is already reasoning about 5 minutes; leaving one provider silently at 0 means the same generator flags produce a materially different security posture depending on `--iac`, which is the more dangerous failure mode. Divergence is the bug here, in either direction.
- **The vended authorizer denies by default and is a TODO.** The generated `authorizer.ts` returns `isAuthorized: false` until the user writes their logic, so we are picking the default for a *type* of authorizer, not for a known token scheme. 300s is upstream's default for exactly that situation.
- **Cost/latency is not marginal.** At TTL 0 a chatty client pays an authorizer invocation per request — proven below at 8 invocations for 8 requests, versus 1 for 10 once cached.

Anyone who needs instant revocation sets the TTL to 0 in the vended module — it is their file to edit.

**Should it be a module variable?** No — deliberately, to match CDK. `HttpLambdaAuthorizer` exposes `resultsCacheTtl` as a construct prop, but the vended CDK construct does not thread it out to a `TestApiProps` field; users edit the construct. Adding a Terraform `variable` would make Terraform *more* configurable than CDK for this one attribute, re-introducing an asymmetry in the opposite direction. A literal on both sides keeps the two readable side by side. Worth a follow-up to expose it on both providers together if there's appetite.

**No migration.** The generated files are vended `KeepExisting`, and this deliberately ships without a migration: **existing workspaces keep `authorizer_result_ttl_in_seconds = 0` and only newly generated ones get the cached authorizer.** That is the intended trade-off, not an oversight — raising the TTL under an existing deployment silently lengthens its token revocation window, which is a change of security posture better left to an explicit, opt-in edit than applied automatically by `nx migrate`. Users who want it can make the two-line change in their own module.

Documentation: the 5-minute window is user-facing behaviour that wasn't documented, so the existing `:::caution[Custom Lambda Authorizer]` block in the tRPC, FastAPI and Smithy guides now notes it (both the CDK and Terraform variants). English only; the 24 translated files are the `Translate Documentation` workflow's own output.

### Description of how you validated changes

`pnpm nx run @aws/nx-plugin:test` — **208 files / 3785 tests green** (baseline `main` is 3781, so exactly +4: the four regression cases below). `build --all` and `lint --all --configuration=fix` both pass. Rebased on latest `main` (#1125, #1126, #1127, #1136, #1137 merged since branching); #1127 touched this same HTTP template to add `required_providers`, in a different region of the file, and rebased without conflict. Two Terraform snapshots updated (tRPC + FastAPI), each showing only the two intended lines.

Regression tests pinning the TTL across **both** providers and **both** protocols (`trpc/backend/generator.spec.ts`):

- Terraform/HTTP — pins `300` *and* asserts `identity_sources` is present. The pairing is the point: a TTL without an identity source silently does nothing.
- Terraform/REST — asserts the attribute stays *absent*, so the provider's own 300 default applies.
- CDK, HTTP and REST — asserts the construct does not override `resultsCacheTtl`, since `aws-cdk-lib`'s default is the value we want.

In fairness these overlap substantially with the existing snapshots, which do already capture both the TTL and `identity_sources` on contiguous lines. What the tests add beyond them is the *negative* assertions — that CDK never sets `resultsCacheTtl` and Terraform/REST never sets `authorizer_result_ttl_in_seconds`, so the four paths cannot silently drift apart again by someone adding an override. Happy to drop them if the snapshots are considered sufficient.

#### Deployed to AWS and proven from CloudWatch logs

A synth/plan diff can't demonstrate caching, so both providers were **deployed** using the locally compiled plugin (`pnpm link`), with the vended authorizer instrumented to log `AUTHORIZER_INVOKED` on entry. Requests were sent with an identical `Authorization` header.

**Live authorizer config — identical on both providers:**

| | Terraform (`8ot4lanrgk`) | CDK (`k2it3v0mf5`) |
|---|---|---|
| `AuthorizerResultTtlInSeconds` | `300` | `300` |
| `IdentitySource` | `["$request.header.Authorization"]` | `["$request.header.Authorization"]` |
| `EnableSimpleResponses` | `true` | `true` |
| `AuthorizerPayloadFormatVersion` | `2.0` | `2.0` |

**Terraform, fixed — 10 requests, 1 invocation:**

```
$ ./cachetest.sh https://8ot4lanrgk.execute-api.us-east-1.amazonaws.com "Bearer cache-probe-tf-1" 10
req 1..10 -> 403   (all ten)

$ aws logs filter-log-events --log-group-name /aws/lambda/TestApiAuthorizer-too4qoni \
    --filter-pattern AUTHORIZER_INVOKED --query 'length(events)'
1
```

```json
{"level":"INFO","message":"AUTHORIZER_INVOKED","timestamp":"2026-08-26T14:12:45.795Z",
 "function_name":"TestApiAuthorizer-too4qoni",
 "function_request_id":"61669d1d-4732-447d-853f-1bd97aab92de",
 "token":"Bearer cache-probe-tf-1"}
```

**Same live API with the TTL forced back to 0 (the pre-fix state) — 8 requests, 8 invocations.** This is the contrast that shows the attribute is what's doing the work; it is the *only* thing changed between the two runs:

```
2026-08-26T14:14:29.322Z  Bearer cache-probe-ttl0  946342a5
2026-08-26T14:14:31.042Z  Bearer cache-probe-ttl0  9a793ee5
2026-08-26T14:14:32.742Z  Bearer cache-probe-ttl0  97092eb9
2026-08-26T14:14:34.444Z  Bearer cache-probe-ttl0  b581c287
2026-08-26T14:14:36.185Z  Bearer cache-probe-ttl0  301fd525
2026-08-26T14:14:38.069Z  Bearer cache-probe-ttl0  a42c4583
2026-08-26T14:14:39.752Z  Bearer cache-probe-ttl0  548dad6f
2026-08-26T14:14:41.423Z  Bearer cache-probe-ttl0  43b491a6
```

Eight distinct `function_request_id`s for eight requests bearing the same token.

**CDK, for comparison — 10 requests, 1 invocation:**

```json
{"level":"INFO","message":"AUTHORIZER_INVOKED","timestamp":"2026-08-26T14:21:49.467Z",
 "function_name":"cdkws-infra-sandbox-Appli-TestApiAuthorizerFunctio-HPXKpuebqHHW",
 "function_request_id":"98bcbe77-3b8e-4f39-a10b-5ba9d7ee0e3a",
 "token":"Bearer cache-probe-cdk-1"}
```

**Caching really is keyed on the identity source**, rather than blanket-allowing everything for 5 minutes: a second, different token in the same window produced its own separate invocation (`cache-probe-tf-2`, request id `6e776c0b`). Authorization itself was confirmed working first — `Bearer let-me-in` passed through to tRPC, `Bearer nope` returned 403.

#### Teardown

All deployed infrastructure destroyed and verified: `terraform destroy` completed (`terraform state list` now empty), `cdk destroy` completed (stack `does not exist`), and the CDK-retained authorizer log group deleted by hand. `get-apis` returns `[]` and no `TestApi*`/`cdkws*` Lambdas or log groups remain.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
