### PR TITLE
fix(ts#rdb,py#rdb): grant the terraform rds proxy role rds-db:connect on mysql

### DIFF
--- a/packages/nx-plugin/src/migrations/latest/terraform-rdb-proxy-iam-connect-grant/__snapshots__/migration.spec.ts.snap
+++ b/packages/nx-plugin/src/migrations/latest/terraform-rdb-proxy-iam-connect-grant/__snapshots__/migration.spec.ts.snap
@@ -1,0 +1,23 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`terraform-rdb-proxy-iam-connect-grant migration > should replace the mysql admin secret grant with rds-db:connect 1`] = `
+"resource "aws_iam_role_policy" "proxy_db_user_connect" {
+  count = var.enable_rds_proxy ? 1 : 0
+
+  role = module.aurora.proxy_role_name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = ["rds-db:connect"]
+        Resource = [
+          "arn:aws:rds-db:\${data.aws_region.current.region}:\${data.aws_caller_identity.current.account_id}:dbuser:\${module.aurora.cluster_resource_id}/\${local.database_runtime_user}"
+        ]
+      }
+    ]
+  })
+}
+"
+`;

--- a/packages/nx-plugin/src/migrations/latest/terraform-rdb-proxy-iam-connect-grant/metadata.json
+++ b/packages/nx-plugin/src/migrations/latest/terraform-rdb-proxy-iam-connect-grant/metadata.json
@@ -1,0 +1,3 @@
+{
+  "description": "Replace the MySQL RDS Proxy role's admin secret access with the rds-db:connect grant it needs for end-to-end IAM auth"
+}

--- a/packages/nx-plugin/src/migrations/latest/terraform-rdb-proxy-iam-connect-grant/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/latest/terraform-rdb-proxy-iam-connect-grant/migration.spec.ts
@@ -1,0 +1,154 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import type { Tree } from '@nx/devkit';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test.js';
+import migration from './migration.js';
+
+const MYSQL_FILE =
+  'packages/common/terraform/src/app/dbs/my-sql-db/my-sql-db.tf';
+const POSTGRES_FILE =
+  'packages/common/terraform/src/app/dbs/postgres-db/postgres-db.tf';
+
+/** The pre-change shape of a vended MySQL database app module. */
+const MYSQL_BEFORE = `resource "aws_iam_role_policy" "proxy_db_user_connect" {
+  count = var.enable_rds_proxy ? 1 : 0
+
+  role = module.aurora.proxy_role_name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "secretsmanager:GetSecretValue"
+        ]
+        Resource = [module.aurora.secret_arn]
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "kms:Decrypt"
+        ]
+        Resource = [module.aurora.kms_key_arn]
+      }
+    ]
+  })
+}
+`;
+
+/** The vended Postgres shape, which already has the grant. */
+const POSTGRES_BEFORE = `resource "aws_iam_role_policy" "proxy_db_user_connect" {
+  count = var.enable_rds_proxy ? 1 : 0
+
+  role = module.aurora.proxy_role_name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = ["rds-db:connect"]
+        Resource = [
+          "arn:aws:rds-db:\${data.aws_region.current.region}:\${data.aws_caller_identity.current.account_id}:dbuser:\${module.aurora.cluster_resource_id}/\${local.database_runtime_user}"
+        ]
+      }
+    ]
+  })
+}
+`;
+
+describe('terraform-rdb-proxy-iam-connect-grant migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeUsingTsSolutionSetup();
+  });
+
+  it('should replace the mysql admin secret grant with rds-db:connect', async () => {
+    tree.write(MYSQL_FILE, MYSQL_BEFORE);
+
+    const result = await migration(tree);
+
+    const content = tree.read(MYSQL_FILE, 'utf-8');
+    expect(content).toContain('Action = ["rds-db:connect"]');
+    expect(content).toContain(
+      'dbuser:${module.aurora.cluster_resource_id}/${local.database_runtime_user}',
+    );
+    // The proxy authenticates with IAM, so it must no longer hold the admin
+    // credentials.
+    expect(content).not.toContain('secretsmanager:GetSecretValue');
+    expect(content).not.toContain('kms:Decrypt');
+    expect(result.nextSteps).toEqual([]);
+    expect(content).toMatchSnapshot();
+  });
+
+  it('should leave a module that already grants rds-db:connect alone', async () => {
+    tree.write(POSTGRES_FILE, POSTGRES_BEFORE);
+
+    const result = await migration(tree);
+
+    expect(tree.read(POSTGRES_FILE, 'utf-8')).toBe(POSTGRES_BEFORE);
+    expect(result.nextSteps).toEqual([]);
+  });
+
+  it('should do nothing when the workspace has no terraform database modules', async () => {
+    const result = await migration(tree);
+
+    expect(result.nextSteps).toEqual([]);
+    expect(tree.exists(MYSQL_FILE)).toBe(false);
+  });
+
+  it('should skip and report a customised policy', async () => {
+    const customised = MYSQL_BEFORE.replace(
+      '        Resource = [module.aurora.kms_key_arn]',
+      '        Resource = [module.aurora.kms_key_arn, var.my_other_key_arn]',
+    );
+    tree.write(MYSQL_FILE, customised);
+
+    const result = await migration(tree);
+
+    expect(tree.read(MYSQL_FILE, 'utf-8')).toBe(customised);
+    expect(result.nextSteps).toHaveLength(1);
+    expect(result.nextSteps[0]).toContain(MYSQL_FILE);
+    expect(result.nextSteps[0]).toContain('rds-db:connect');
+  });
+
+  it('should ignore a module with no proxy policy', async () => {
+    const noProxyPolicy = `module "aurora" {
+  source = "../../../core/rdb/aurora"
+  name   = "my-sql-db"
+}
+`;
+    tree.write(MYSQL_FILE, noProxyPolicy);
+
+    const result = await migration(tree);
+
+    expect(tree.read(MYSQL_FILE, 'utf-8')).toBe(noProxyPolicy);
+    expect(result.nextSteps).toEqual([]);
+  });
+
+  it('should be idempotent', async () => {
+    tree.write(MYSQL_FILE, MYSQL_BEFORE);
+    tree.write(POSTGRES_FILE, POSTGRES_BEFORE);
+
+    await migration(tree);
+    const afterFirst = {
+      mysql: tree.read(MYSQL_FILE, 'utf-8'),
+      postgres: tree.read(POSTGRES_FILE, 'utf-8'),
+    };
+
+    const result = await migration(tree);
+
+    expect(tree.read(MYSQL_FILE, 'utf-8')).toBe(afterFirst.mysql);
+    expect(tree.read(POSTGRES_FILE, 'utf-8')).toBe(afterFirst.postgres);
+    expect(result.nextSteps).toEqual([]);
+
+    // Exactly one statement per file, not a second appended copy.
+    for (const content of Object.values(afterFirst)) {
+      expect(content?.match(/rds-db:connect/g)).toHaveLength(1);
+    }
+  });
+});

--- a/packages/nx-plugin/src/migrations/latest/terraform-rdb-proxy-iam-connect-grant/migration.ts
+++ b/packages/nx-plugin/src/migrations/latest/terraform-rdb-proxy-iam-connect-grant/migration.ts
@@ -1,0 +1,133 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import {
+  joinPathFragments,
+  type MigrationReturnObject,
+  type Tree,
+} from '@nx/devkit';
+import { applyGritQL, matchGritQL } from '../../../utils/ast.js';
+import { formatFilesInSubtree } from '../../../utils/format.js';
+import {
+  PACKAGES_DIR,
+  SHARED_TERRAFORM_DIR,
+} from '../../../utils/shared-constructs-constants.js';
+
+/**
+ * Give the RDS Proxy role in every vended Terraform Aurora app module the
+ * `rds-db:connect` grant for the application database user.
+ *
+ * The proxy is created with `default_auth_scheme = "IAM_AUTH"` and no secrets
+ * registered, so `rds-db:connect` on the application user is the only
+ * permission it needs to reach the cluster. MySQL modules instead granted the
+ * role `secretsmanager:GetSecretValue` on the admin credentials secret plus
+ * `kms:Decrypt` — credentials the proxy never uses, and a far wider grant than
+ * connecting as the application user.
+ *
+ * These files are generated with `KeepExisting`, so an upgraded MySQL workspace
+ * keeps the admin secret grant until this runs. Diverged files are left
+ * untouched and reported via `nextSteps`.
+ */
+
+const TERRAFORM_DBS_DIR = `${PACKAGES_DIR}/${SHARED_TERRAFORM_DIR}/src/app/dbs`;
+
+const hcl = (pattern: string) => `language hcl\n${pattern}`;
+
+const CONNECT_STATEMENT_TEXT = [
+  '{',
+  '        Effect = "Allow"',
+  '        Action = ["rds-db:connect"]',
+  '        Resource = [',
+  '          "arn:aws:rds-db:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:dbuser:${module.aurora.cluster_resource_id}/${local.database_runtime_user}"',
+  '        ]',
+  '      }',
+].join('\n');
+
+const divergedMessage = (filePath: string) =>
+  `${filePath}: the aws_iam_role_policy.proxy_db_user_connect policy has diverged from the generated shape - left untouched. The RDS Proxy authenticates to the cluster with IAM, so replace any secretsmanager:GetSecretValue / kms:Decrypt statements on the proxy role with a single rds-db:connect statement for local.database_runtime_user (see the ts#rdb generator's database app template).`;
+
+const proxyPolicyBlock = (body: string) =>
+  hcl(`\`resource "aws_iam_role_policy" "proxy_db_user_connect" { ${body} }\``);
+
+const migrateModule = async (
+  tree: Tree,
+  filePath: string,
+  nextSteps: string[],
+): Promise<void> => {
+  if (!(await matchGritQL(tree, filePath, proxyPolicyBlock('$_')))) {
+    return; // No proxy policy in this module - nothing this migration owns.
+  }
+
+  if (
+    await matchGritQL(
+      tree,
+      filePath,
+      proxyPolicyBlock('$props') +
+        ' where { $props <: contains `"rds-db:connect"` }',
+    )
+  ) {
+    return; // Already granted.
+  }
+
+  // The whole statement list is replaced, so the policy must still hold exactly
+  // the two statements the generator vended and nothing the user has added.
+  const secretStatements = hcl(
+    [
+      '`Statement = [',
+      '      {',
+      '        Effect = "Allow"',
+      '        Action = [',
+      '          "secretsmanager:GetSecretValue"',
+      '        ]',
+      '        Resource = [module.aurora.secret_arn]',
+      '      },',
+      '      {',
+      '        Effect = "Allow"',
+      '        Action = [',
+      '          "kms:Decrypt"',
+      '        ]',
+      '        Resource = [module.aurora.kms_key_arn]',
+      '      }',
+      '    ]`',
+    ].join('\n'),
+  );
+
+  if (!(await matchGritQL(tree, filePath, secretStatements))) {
+    nextSteps.push(divergedMessage(filePath));
+    return;
+  }
+
+  await applyGritQL(
+    tree,
+    filePath,
+    `${secretStatements} => \`Statement = [\n      ${CONNECT_STATEMENT_TEXT}\n    ]\``,
+  );
+};
+
+export default async function migration(
+  tree: Tree,
+): Promise<MigrationReturnObject> {
+  const nextSteps: string[] = [];
+
+  if (!tree.exists(TERRAFORM_DBS_DIR)) {
+    return { nextSteps }; // This workspace has no Terraform database modules.
+  }
+
+  for (const dirName of tree.children(TERRAFORM_DBS_DIR)) {
+    const filePath = joinPathFragments(
+      TERRAFORM_DBS_DIR,
+      dirName,
+      `${dirName}.tf`,
+    );
+    if (!tree.exists(filePath)) {
+      continue; // Not a database app module directory.
+    }
+
+    await migrateModule(tree, filePath, nextSteps);
+  }
+
+  await formatFilesInSubtree(tree);
+
+  return { nextSteps };
+}

--- a/packages/nx-plugin/src/ts/rdb/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/rdb/__snapshots__/generator.spec.ts.snap
@@ -3113,17 +3113,10 @@ resource "aws_iam_role_policy" "proxy_db_user_connect" {
     Statement = [
       {
         Effect = "Allow"
-        Action = [
-          "secretsmanager:GetSecretValue"
+        Action = ["rds-db:connect"]
+        Resource = [
+          "arn:aws:rds-db:\${data.aws_region.current.region}:\${data.aws_caller_identity.current.account_id}:dbuser:\${module.aurora.cluster_resource_id}/\${local.database_runtime_user}"
         ]
-        Resource = [module.aurora.secret_arn]
-      },
-      {
-        Effect = "Allow"
-        Action = [
-          "kms:Decrypt"
-        ]
-        Resource = [module.aurora.kms_key_arn]
       }
     ]
   })

--- a/packages/nx-plugin/src/ts/rdb/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/rdb/generator.spec.ts
@@ -424,6 +424,31 @@ describe('ts#rdb generator', () => {
     },
   );
 
+  it.each(['postgres', 'mysql'] as const)(
+    'should grant the terraform rds proxy role only rds-db:connect for %s',
+    async (engine) => {
+      await tsRdbGenerator(tree, {
+        ...defaultOptions,
+        iac: 'terraform',
+        engine,
+      });
+
+      const db = tree.read(TERRAFORM_AURORA_APP, 'utf-8');
+
+      // The proxy is created with default_auth_scheme = IAM_AUTH and no secrets
+      // registered, so rds-db:connect for the application user is the only
+      // permission it needs to reach the cluster — on either engine.
+      expect(db).toContain('Action = ["rds-db:connect"]');
+
+      const proxyPolicy = db?.slice(
+        db.indexOf('resource "aws_iam_role_policy" "proxy_db_user_connect"'),
+        db.indexOf('module "add_rdb_to_runtime_config"'),
+      );
+      expect(proxyPolicy).not.toContain('secretsmanager:GetSecretValue');
+      expect(proxyPolicy).not.toContain('kms:Decrypt');
+    },
+  );
+
   it('should keep an existing aurora shared construct', async () => {
     await sharedConstructsGenerator(
       tree,

--- a/packages/nx-plugin/src/utils/rdb-constructs/files/cdk/app/dbs/__nameKebabCase__.ts.template
+++ b/packages/nx-plugin/src/utils/rdb-constructs/files/cdk/app/dbs/__nameKebabCase__.ts.template
@@ -4,14 +4,14 @@ import { readFileSync } from 'fs';
 import { Construct } from 'constructs';
 import { Platform } from 'aws-cdk-lib/aws-ecr-assets';
 import {
-<%_ if (framework !== 'sqlmodel') { _%>
+<%_ if (framework === 'prisma') { _%>
   Code,
 <%_ } _%>
   DockerImageCode,
   DockerImageFunction,
   Function,
   FunctionOptions,
-<%_ if (framework !== 'sqlmodel') { _%>
+<%_ if (framework === 'prisma') { _%>
   Runtime,
 <%_ } _%>
 } from 'aws-cdk-lib/aws-lambda';

--- a/packages/nx-plugin/src/utils/rdb-constructs/files/terraform/app/dbs/__nameKebabCase__/__nameKebabCase__.tf.template
+++ b/packages/nx-plugin/src/utils/rdb-constructs/files/terraform/app/dbs/__nameKebabCase__/__nameKebabCase__.tf.template
@@ -198,22 +198,6 @@ resource "aws_iam_role_policy" "proxy_db_user_connect" {
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
-<%_ if (engine === 'mysql' && framework !== 'sqlmodel') { _%>
-      {
-        Effect = "Allow"
-        Action = [
-          "secretsmanager:GetSecretValue"
-        ]
-        Resource = [module.aurora.secret_arn]
-      },
-      {
-        Effect = "Allow"
-        Action = [
-          "kms:Decrypt"
-        ]
-        Resource = [module.aurora.kms_key_arn]
-      }
-<%_ } else { _%>
       {
         Effect = "Allow"
         Action = ["rds-db:connect"]
@@ -221,7 +205,6 @@ resource "aws_iam_role_policy" "proxy_db_user_connect" {
           "arn:aws:rds-db:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:dbuser:${module.aurora.cluster_resource_id}/${local.database_runtime_user}"
         ]
       }
-<%_ } _%>
     ]
   })
 }

--- a/packages/nx-plugin/src/utils/rdb-constructs/files/terraform/app/dbs/__nameKebabCase__/__nameKebabCase__.tf.template
+++ b/packages/nx-plugin/src/utils/rdb-constructs/files/terraform/app/dbs/__nameKebabCase__/__nameKebabCase__.tf.template
@@ -138,7 +138,7 @@ variable "create_db_user_docker_image_tag" {
 }
 <%_ } _%>
 
-<%_ if (framework !== 'sqlmodel') { _%>
+<%_ if (framework === 'prisma') { _%>
 variable "asset_bucket_name" {
   description = "Name of the shared asset S3 bucket used to stage the Lambda deployment zip. Instantiate the `core/asset-bucket` module once per deployment and pass its `bucket_name` output here."
   type        = string
@@ -157,7 +157,7 @@ resource "random_string" "suffix" {
 locals {
   config                       = jsondecode(file("${path.module}/../../../../../../../<%= projectRoot %>/config.json"))
   runtime_config_key           = local.config.runtimeConfigKey
-<%_ if (framework !== 'sqlmodel') { _%>
+<%_ if (framework === 'prisma') { _%>
   create_db_user_bundle_path   = "${path.module}/../../../../../../../<%- createDbUserBundleDir %>"
 <%_ } _%>
   migration_function_name      = "<%= nameKebabCase %>-migration-${random_string.suffix.result}"
@@ -209,7 +209,7 @@ resource "aws_iam_role_policy" "proxy_db_user_connect" {
   })
 }
 
-<%_ if (framework !== 'sqlmodel') { _%>
+<%_ if (framework === 'prisma') { _%>
 data "archive_file" "create_db_user_zip" {
   type        = "zip"
   source_dir  = local.create_db_user_bundle_path


### PR DESCRIPTION
### Reason for this change

For MySQL Aurora on Terraform, the RDS Proxy's IAM role was handed the **admin database secret** instead of the `rds-db:connect` permission it actually needs.

The vended proxy role policy (`aws_iam_role_policy.proxy_db_user_connect`) had a MySQL carve-out:

```hcl
<%_ if (engine === 'mysql' && framework !== 'sqlmodel') { _%>
  { Action = ["secretsmanager:GetSecretValue"], Resource = [module.aurora.secret_arn] },
  { Action = ["kms:Decrypt"],                   Resource = [module.aurora.kms_key_arn] }
<%_ } else { _%>
  { Action = ["rds-db:connect"], Resource = [".../dbuser:.../${local.database_runtime_user}"] }
<%_ } _%>
```

So a MySQL workspace's proxy role got read access to the Aurora **admin** credentials and their KMS key, and **no `rds-db:connect` at all**. Postgres already got it right, and the CDK construct calls `this.cluster.grantConnect(proxyRole, this.dbUser)` unconditionally for every engine while never granting the proxy secret access.

The secret grant is **dead permission**, not a MySQL requirement. The vended proxy is created with `default_auth_scheme = "IAM_AUTH"` and **no `auth` block**, i.e. no Secrets Manager secret is registered with it, so there is no mechanism by which it could use those credentials. Confirmed on the deployed proxies:

```
$ aws rds describe-db-proxies --db-proxy-name my-db-proxy-8oyqawg6 \
    --query 'DBProxies[0].{Auth:Auth,Scheme:DefaultAuthScheme}'
{ "Auth": [], "Scheme": "IAM_AUTH" }
```

AWS's own [end-to-end IAM authentication docs](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/rds-proxy-iam-setup.html) say the same, engine-agnostically: "*this requires configuring your IAM role with `rds-db:connect` permissions*", and the Secrets Manager policy is documented as the alternative for *standard* IAM auth, which this is not.

**Origin of the bug**, confirmed by @AlexTo (who authored the branch) [in review](https://github.com/awslabs/nx-plugin-for-aws/pull/1129#discussion_r3876763801): it is a **leftover**. MySQL migrations genuinely *used* to connect through the proxy with the admin secret, because the Rust driver did not support the `mysql_clear_password` plugin that IAM auth requires — so at the time the grant was load-bearing, and `rds-db:connect` was deliberately not given. #892 moved migrations off that path (they now connect direct-to-cluster as admin on every engine) but missed this Terraform branch: its Terraform hunk rewrote `migration_handler_access`, the security-group rules and the handler's env, and never touched `proxy_db_user_connect`. So the secret grant outlived its reason, and because `rds-db:connect` sat on the `else`, the MySQL proxy was left with neither a working credential path nor the permission it now needs. #902 removed the corresponding `auth { auth_scheme = "SECRETS" }` block and the core module's `proxy_secret_access` policy, which is what made the remaining grant not just unnecessary but inert.

This mattered on two counts: the proxy could not authenticate as the app user, and it held admin credentials — a privilege escalation relative to CDK. So the grant is **replaced**, not supplemented.

**MySQL needs nothing Postgres doesn't here.** Both engines authenticate identically as far as the proxy role is concerned: the vended `create-db-user` handler provisions the app user for IAM auth per engine (`IDENTIFIED WITH AWSAuthenticationPlugin AS 'RDS'` for MySQL, `GRANT rds_iam` for Postgres), and the *client* — not the proxy — mints the auth token (`@aws-sdk/rds-signer` in `prisma.ts.template`, `generate_db_auth_token` in `connection.py.template`), on both engines. Migrations connect directly to the cluster as admin via `DATABASE_SECRET_ARN` on both engines since #892, so nothing in the proxy path wants the secret.

`enable_rds_proxy = false` is unaffected: the whole policy is `count = var.enable_rds_proxy ? 1 : 0`, so it isn't created at all, and clients then grant against `connect_resource_id`, which resolves to the cluster resource id.

### Description of changes

- **`utils/rdb-constructs/.../__nameKebabCase__.tf.template`** — deleted the MySQL carve-out so every engine gets the single `rds-db:connect` statement. `ts#rdb --engine=mysql` and `--engine=postgres` now vend a byte-identical proxy policy.
- **New migration `latest/terraform-rdb-proxy-iam-connect-grant`** — the database app modules are vended `KeepExisting`, so an upgraded MySQL workspace would otherwise keep the admin secret grant. Walks `common/terraform/src/app/dbs/*`, and via GritQL on HCL: skips modules already granting `rds-db:connect` (Postgres, and re-runs), skips modules with no proxy policy, and replaces the statement list only where it still matches the exact two-statement shape the generator vended. A customised policy is left untouched and reported via `nextSteps`.

The second, identically-shaped MySQL carve-out at ~line 713 — `<%_ if (engine !== 'mysql' && framework !== 'sqlmodel') { _%>` gating `db_user` in `null_resource.migration_trigger`'s trigger set — is **deliberate, and left alone**. It is not the same mistake. Since #892 migrations run as admin from the secret on every engine and never reference `dbUser`, so for MySQL the app user genuinely is not an input to the migration handler and re-running migrations when it changes would be spurious. It is only a trigger-invalidation hint, carries no IAM consequence, and the surrounding `depends_on` still orders `migration_trigger` after `create_db_user_trigger`. (Arguably the Postgres side is now the stale one — `env.py.template` still reads `cfg['dbUser']` for sqlmodel, which is why the `framework` clause is there — but that is a separate question from this security fix, so I have not touched it.)

**Second commit — @AlexTo's style point**, that these conditions should say `framework === 'prisma'` rather than `framework !== 'sqlmodel'`. Kept separate from the IAM fix so the security change stays legible next to the mechanical one. Five sites converted:

| File | Site |
|---|---|
| `terraform/app/dbs/…/__nameKebabCase__.tf.template` | `variable "asset_bucket_name"` |
| | `create_db_user_bundle_path` local |
| | `data "archive_file" "create_db_user_zip"` + its `aws_s3_object` |
| `cdk/app/dbs/__nameKebabCase__.ts.template` | the `Code` import |
| | the `Runtime` import |

Each guards the **zip-bundled create-db-user Lambda**, which exists precisely because Prisma needs a Node.js zip handler where SQLModel uses a container image — so `=== 'prisma'` is the honest statement of the requirement, not merely an equivalent spelling. Every one of them is the counterpart of an adjacent `=== 'sqlmodel'` block (or, in CDK, feeds the `else` of a `framework === 'sqlmodel'` split of `createDbUserHandler`), i.e. a strict either/or over the bundling strategy rather than "anything that isn't SQLModel".

**One site deliberately left as `!==`:** `null_resource.migration_trigger`'s `engine !== 'mysql' && framework !== 'sqlmodel'`. It fails that test — the value it guards, `db_user`, is consumed by SQLModel's Alembic `env.py` (`username=cfg['dbUser']`) and by nothing in the Prisma migration handler, so the condition is genuinely SQLModel-negative and rewriting it `=== 'prisma'` would assert something different from what is meant. (Only the framework half; `engine !== 'mysql'` was never in question.)

### Description of how you validated changes

**Unit tests** — a per-engine regression test in `ts/rdb/generator.spec.ts` (`it.each(['postgres','mysql'])`) asserting the proxy role's actions: `rds-db:connect` present, and `secretsmanager:GetSecretValue` / `kms:Decrypt` absent from the policy body. Plus 6 migration tests (applies, already-granted no-op, no proxy policy, diverged-and-reported, idempotent, empty workspace). Full suite green: **3762 passed**, with the only snapshot change being the MySQL Terraform policy. `build` and `lint --configuration=fix` both clean.

**Deployed to AWS on both engines, with the proxy enabled.** Note the existing `terraform-deploy-rdb` smoke test sets `enable_rds_proxy = false`, so this policy has never actually been exercised by CI — I deployed a workspace with `enable_rds_proxy = true` for both a MySQL and a Postgres Aurora RDB (generated by the locally compiled plugin), which is what makes the proxy role's grant live.

`apply` succeeded in 12m40s. The vended `create-db-user` and migration handlers both ran clean on MySQL (`StatusCode: 200`, no `FunctionError`, nothing in logs). The **deployed** proxy role policies are now identical across engines and hold nothing else:

```
# MySQL — role my-db-aurora-proxy-111bcce350129fea2766170230
{ "Action": ["rds-db:connect"], "Effect": "Allow",
  "Resource": ["arn:aws:rds-db:us-east-1:...:dbuser:cluster-MYFHR7ZQKITT6BQWBD5422JXYQ/db_hdflenq5"] }

# Postgres — role pg-db-aurora-proxy-5609b7ffaed67f519748789bbb
{ "Action": ["rds-db:connect"], "Effect": "Allow",
  "Resource": ["arn:aws:rds-db:us-east-1:...:dbuser:cluster-JROQCGIDMQTPIJDZJ5KOHWWF4U/db_34o7syih"] }
```

A plan diff can't show whether the proxy can still authenticate, so I also deployed a prober Lambda that connects **through each proxy endpoint** as the application db user with an IAM auth token and runs a real query:

```json
{
  "postgres": { "ok": true, "connectedVia": "pg-db-proxy-0ycin2yd.proxy-....rds.amazonaws.com",
    "currentUser": "db_34o7syih", "database": "pg_db",
    "serverVersion": "PostgreSQL 17.7 on aarch64-unknown-linux-gnu...",
    "realQuery": { "math": 2, "backend_ip": "10.0.1.203/32", "ts": "2026-08-26T18:01:25.622Z" } },
  "mysql":    { "ok": true, "connectedVia": "my-db-proxy-8oyqawg6.proxy-....rds.amazonaws.com",
    "currentUser": "db_hdflenq5@%", "database": "my_db", "serverVersion": "8.0.44",
    "realQuery": { "math": 2, "backend_host": "ip-172-16-5-93", "ts": "2026-08-26T18:01:25.000Z" } }
}
```

**MySQL still authenticates end-to-end with the corrected IAM** — proxy-to-cluster on `rds-db:connect` alone, with the admin secret grant removed. `backend_host` / `backend_ip` are the Aurora backend, so the proxy really did complete its own hop. An earlier prober revision additionally confirmed the app user is correctly scoped to CRUD: DDL was refused post-authentication (`CREATE command denied to user 'db_hdflenq5'@'...'`), which is the create-db-user handler's grant working as intended.

Matches CDK, which grants the proxy role only `rds-db:connect` for every engine and no secret access.

**The condition sweep is proven behaviour-neutral rather than argued to be.** `test -u` writes **zero snapshots** — the rendered output is byte-identical for both `ts#rdb` (prisma) and `py#rdb` (sqlmodel), which is the strongest available evidence given both generators snapshot their full Terraform and CDK output. I also generated fresh workspaces on the rebuilt plugin and exercised the SQLModel path explicitly, since my deployment testing only covered Prisma/MySQL:

- `terraform validate` — **Success** on both the prisma module (`ts#rdb`, postgres) and the sqlmodel module (`py#rdb`, mysql).
- Conditional rendering confirmed in both directions: the prisma module renders all 5 zip-staging references; the sqlmodel module renders **0**.
- CDK: prisma renders `Code` / `Runtime` and uses both (`Code.fromAsset`, `Runtime.NODEJS_LATEST`); sqlmodel omits both, so no unused import.

(While checking the CDK path I hit a pre-existing, unrelated bug: `cdk/app/dbs/__nameKebabCase__.ts.template` uses bare `import.meta.url` at two sites that aren't `esm`-guarded the way line 28 is, so `common-constructs` fails to compile in a CJS workspace with `TS1470`. Identical on `main` and untouched by this PR — flagging it rather than fixing it here.)

Everything was torn down (`destroy` exit 0, 24m50s — `prevent_destroy` flipped to `false` first, as `terraform-deploy.spec.ts` does) and teardown verified: zero Aurora clusters, zero proxies, no `rdbproxy-*` VPC, and no `my-db`/`pg-db` secrets remaining.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

