### PR TITLE
fix(ts#agent,py#agent): narrow session storage IAM to the actions the session code issues

### DIFF
--- a/docs/src/content/docs/en/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/en/get_started/tutorials/dungeon-game/1.mdx
@@ -847,7 +847,25 @@ export class StoryAgent extends Construct implements IGrantable, IConnectable {
       }),
     );
 
-    sessionBucket.grantReadWrite(this.agentCoreRuntime);
+    // Actions the session manager issues against the bucket.
+    this.agentCoreRuntime.addToRolePolicy(
+      new PolicyStatement({
+        actions: ['s3:GetObject', 's3:PutObject', 's3:DeleteObject'],
+        resources: [sessionBucket.arnForObjects('*')],
+      }),
+    );
+    this.agentCoreRuntime.addToRolePolicy(
+      new PolicyStatement({
+        actions: ['s3:ListBucket'],
+        resources: [sessionBucket.bucketArn],
+      }),
+    );
+    this.agentCoreRuntime.addToRolePolicy(
+      new PolicyStatement({
+        actions: ['kms:Decrypt', 'kms:GenerateDataKey*'],
+        resources: [sessionKey.keyArn],
+      }),
+    );
 
     rc.grantReadAppConfig(this.agentCoreRuntime);
 

--- a/docs/src/content/docs/es/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/es/get_started/tutorials/dungeon-game/1.mdx
@@ -847,7 +847,25 @@ export class StoryAgent extends Construct implements IGrantable, IConnectable {
       }),
     );
 
-    sessionBucket.grantReadWrite(this.agentCoreRuntime);
+    // Actions the session manager issues against the bucket.
+    this.agentCoreRuntime.addToRolePolicy(
+      new PolicyStatement({
+        actions: ['s3:GetObject', 's3:PutObject', 's3:DeleteObject'],
+        resources: [sessionBucket.arnForObjects('*')],
+      }),
+    );
+    this.agentCoreRuntime.addToRolePolicy(
+      new PolicyStatement({
+        actions: ['s3:ListBucket'],
+        resources: [sessionBucket.bucketArn],
+      }),
+    );
+    this.agentCoreRuntime.addToRolePolicy(
+      new PolicyStatement({
+        actions: ['kms:Decrypt', 'kms:GenerateDataKey*'],
+        resources: [sessionKey.keyArn],
+      }),
+    );
 
     rc.grantReadAppConfig(this.agentCoreRuntime);
 

--- a/docs/src/content/docs/fr/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/fr/get_started/tutorials/dungeon-game/1.mdx
@@ -847,7 +847,25 @@ export class StoryAgent extends Construct implements IGrantable, IConnectable {
       }),
     );
 
-    sessionBucket.grantReadWrite(this.agentCoreRuntime);
+    // Actions the session manager issues against the bucket.
+    this.agentCoreRuntime.addToRolePolicy(
+      new PolicyStatement({
+        actions: ['s3:GetObject', 's3:PutObject', 's3:DeleteObject'],
+        resources: [sessionBucket.arnForObjects('*')],
+      }),
+    );
+    this.agentCoreRuntime.addToRolePolicy(
+      new PolicyStatement({
+        actions: ['s3:ListBucket'],
+        resources: [sessionBucket.bucketArn],
+      }),
+    );
+    this.agentCoreRuntime.addToRolePolicy(
+      new PolicyStatement({
+        actions: ['kms:Decrypt', 'kms:GenerateDataKey*'],
+        resources: [sessionKey.keyArn],
+      }),
+    );
 
     rc.grantReadAppConfig(this.agentCoreRuntime);
 

--- a/docs/src/content/docs/it/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/it/get_started/tutorials/dungeon-game/1.mdx
@@ -847,7 +847,25 @@ export class StoryAgent extends Construct implements IGrantable, IConnectable {
       }),
     );
 
-    sessionBucket.grantReadWrite(this.agentCoreRuntime);
+    // Actions the session manager issues against the bucket.
+    this.agentCoreRuntime.addToRolePolicy(
+      new PolicyStatement({
+        actions: ['s3:GetObject', 's3:PutObject', 's3:DeleteObject'],
+        resources: [sessionBucket.arnForObjects('*')],
+      }),
+    );
+    this.agentCoreRuntime.addToRolePolicy(
+      new PolicyStatement({
+        actions: ['s3:ListBucket'],
+        resources: [sessionBucket.bucketArn],
+      }),
+    );
+    this.agentCoreRuntime.addToRolePolicy(
+      new PolicyStatement({
+        actions: ['kms:Decrypt', 'kms:GenerateDataKey*'],
+        resources: [sessionKey.keyArn],
+      }),
+    );
 
     rc.grantReadAppConfig(this.agentCoreRuntime);
 

--- a/docs/src/content/docs/jp/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/jp/get_started/tutorials/dungeon-game/1.mdx
@@ -847,7 +847,25 @@ export class StoryAgent extends Construct implements IGrantable, IConnectable {
       }),
     );
 
-    sessionBucket.grantReadWrite(this.agentCoreRuntime);
+    // Actions the session manager issues against the bucket.
+    this.agentCoreRuntime.addToRolePolicy(
+      new PolicyStatement({
+        actions: ['s3:GetObject', 's3:PutObject', 's3:DeleteObject'],
+        resources: [sessionBucket.arnForObjects('*')],
+      }),
+    );
+    this.agentCoreRuntime.addToRolePolicy(
+      new PolicyStatement({
+        actions: ['s3:ListBucket'],
+        resources: [sessionBucket.bucketArn],
+      }),
+    );
+    this.agentCoreRuntime.addToRolePolicy(
+      new PolicyStatement({
+        actions: ['kms:Decrypt', 'kms:GenerateDataKey*'],
+        resources: [sessionKey.keyArn],
+      }),
+    );
 
     rc.grantReadAppConfig(this.agentCoreRuntime);
 

--- a/docs/src/content/docs/ko/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/ko/get_started/tutorials/dungeon-game/1.mdx
@@ -847,7 +847,25 @@ export class StoryAgent extends Construct implements IGrantable, IConnectable {
       }),
     );
 
-    sessionBucket.grantReadWrite(this.agentCoreRuntime);
+    // Actions the session manager issues against the bucket.
+    this.agentCoreRuntime.addToRolePolicy(
+      new PolicyStatement({
+        actions: ['s3:GetObject', 's3:PutObject', 's3:DeleteObject'],
+        resources: [sessionBucket.arnForObjects('*')],
+      }),
+    );
+    this.agentCoreRuntime.addToRolePolicy(
+      new PolicyStatement({
+        actions: ['s3:ListBucket'],
+        resources: [sessionBucket.bucketArn],
+      }),
+    );
+    this.agentCoreRuntime.addToRolePolicy(
+      new PolicyStatement({
+        actions: ['kms:Decrypt', 'kms:GenerateDataKey*'],
+        resources: [sessionKey.keyArn],
+      }),
+    );
 
     rc.grantReadAppConfig(this.agentCoreRuntime);
 

--- a/docs/src/content/docs/pt/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/pt/get_started/tutorials/dungeon-game/1.mdx
@@ -847,7 +847,25 @@ export class StoryAgent extends Construct implements IGrantable, IConnectable {
       }),
     );
 
-    sessionBucket.grantReadWrite(this.agentCoreRuntime);
+    // Actions the session manager issues against the bucket.
+    this.agentCoreRuntime.addToRolePolicy(
+      new PolicyStatement({
+        actions: ['s3:GetObject', 's3:PutObject', 's3:DeleteObject'],
+        resources: [sessionBucket.arnForObjects('*')],
+      }),
+    );
+    this.agentCoreRuntime.addToRolePolicy(
+      new PolicyStatement({
+        actions: ['s3:ListBucket'],
+        resources: [sessionBucket.bucketArn],
+      }),
+    );
+    this.agentCoreRuntime.addToRolePolicy(
+      new PolicyStatement({
+        actions: ['kms:Decrypt', 'kms:GenerateDataKey*'],
+        resources: [sessionKey.keyArn],
+      }),
+    );
 
     rc.grantReadAppConfig(this.agentCoreRuntime);
 

--- a/docs/src/content/docs/vi/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/vi/get_started/tutorials/dungeon-game/1.mdx
@@ -847,7 +847,25 @@ export class StoryAgent extends Construct implements IGrantable, IConnectable {
       }),
     );
 
-    sessionBucket.grantReadWrite(this.agentCoreRuntime);
+    // Actions the session manager issues against the bucket.
+    this.agentCoreRuntime.addToRolePolicy(
+      new PolicyStatement({
+        actions: ['s3:GetObject', 's3:PutObject', 's3:DeleteObject'],
+        resources: [sessionBucket.arnForObjects('*')],
+      }),
+    );
+    this.agentCoreRuntime.addToRolePolicy(
+      new PolicyStatement({
+        actions: ['s3:ListBucket'],
+        resources: [sessionBucket.bucketArn],
+      }),
+    );
+    this.agentCoreRuntime.addToRolePolicy(
+      new PolicyStatement({
+        actions: ['kms:Decrypt', 'kms:GenerateDataKey*'],
+        resources: [sessionKey.keyArn],
+      }),
+    );
 
     rc.grantReadAppConfig(this.agentCoreRuntime);
 

--- a/docs/src/content/docs/zh/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/zh/get_started/tutorials/dungeon-game/1.mdx
@@ -847,7 +847,25 @@ export class StoryAgent extends Construct implements IGrantable, IConnectable {
       }),
     );
 
-    sessionBucket.grantReadWrite(this.agentCoreRuntime);
+    // Actions the session manager issues against the bucket.
+    this.agentCoreRuntime.addToRolePolicy(
+      new PolicyStatement({
+        actions: ['s3:GetObject', 's3:PutObject', 's3:DeleteObject'],
+        resources: [sessionBucket.arnForObjects('*')],
+      }),
+    );
+    this.agentCoreRuntime.addToRolePolicy(
+      new PolicyStatement({
+        actions: ['s3:ListBucket'],
+        resources: [sessionBucket.bucketArn],
+      }),
+    );
+    this.agentCoreRuntime.addToRolePolicy(
+      new PolicyStatement({
+        actions: ['kms:Decrypt', 'kms:GenerateDataKey*'],
+        resources: [sessionKey.keyArn],
+      }),
+    );
 
     rc.grantReadAppConfig(this.agentCoreRuntime);
 

--- a/e2e/src/files/dungeon-adventure/2/agents/story-agent.ts.old.template
+++ b/e2e/src/files/dungeon-adventure/2/agents/story-agent.ts.old.template
@@ -230,7 +230,25 @@ export class StoryAgent extends Construct implements IGrantable, IConnectable {
       }),
     );
 
-    sessionBucket.grantReadWrite(this.agentCoreRuntime);
+    // Actions the session manager issues against the bucket.
+    this.agentCoreRuntime.addToRolePolicy(
+      new PolicyStatement({
+        actions: ['s3:GetObject', 's3:PutObject', 's3:DeleteObject'],
+        resources: [sessionBucket.arnForObjects('*')],
+      }),
+    );
+    this.agentCoreRuntime.addToRolePolicy(
+      new PolicyStatement({
+        actions: ['s3:ListBucket'],
+        resources: [sessionBucket.bucketArn],
+      }),
+    );
+    this.agentCoreRuntime.addToRolePolicy(
+      new PolicyStatement({
+        actions: ['kms:Decrypt', 'kms:GenerateDataKey*'],
+        resources: [sessionKey.keyArn],
+      }),
+    );
 
     rc.grantReadAppConfig(this.agentCoreRuntime);
 

--- a/e2e/src/files/dungeon-adventure/2/agents/story-agent.ts.template
+++ b/e2e/src/files/dungeon-adventure/2/agents/story-agent.ts.template
@@ -234,7 +234,25 @@ export class StoryAgent extends Construct implements IGrantable, IConnectable {
       }),
     );
 
-    sessionBucket.grantReadWrite(this.agentCoreRuntime);
+    // Actions the session manager issues against the bucket.
+    this.agentCoreRuntime.addToRolePolicy(
+      new PolicyStatement({
+        actions: ['s3:GetObject', 's3:PutObject', 's3:DeleteObject'],
+        resources: [sessionBucket.arnForObjects('*')],
+      }),
+    );
+    this.agentCoreRuntime.addToRolePolicy(
+      new PolicyStatement({
+        actions: ['s3:ListBucket'],
+        resources: [sessionBucket.bucketArn],
+      }),
+    );
+    this.agentCoreRuntime.addToRolePolicy(
+      new PolicyStatement({
+        actions: ['kms:Decrypt', 'kms:GenerateDataKey*'],
+        resources: [sessionKey.keyArn],
+      }),
+    );
 
     rc.grantReadAppConfig(this.agentCoreRuntime);
 

--- a/packages/nx-plugin/src/migrations/latest/agent-session-least-privilege-iam/metadata.json
+++ b/packages/nx-plugin/src/migrations/latest/agent-session-least-privilege-iam/metadata.json
@@ -1,0 +1,3 @@
+{
+  "description": "Narrow the vended agent session storage IAM grants to the actions the session code issues"
+}

--- a/packages/nx-plugin/src/migrations/latest/agent-session-least-privilege-iam/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/latest/agent-session-least-privilege-iam/migration.spec.ts
@@ -1,0 +1,216 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import type { Tree } from '@nx/devkit';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test.js';
+import migration from './migration.js';
+
+const CDK_FILE =
+  'packages/common/constructs/src/app/agents/my-agent/my-agent.ts';
+const TF_FILE = 'packages/common/terraform/src/app/agents/my-agent/my-agent.tf';
+
+/** The pre-change CDK shape: coarse grant helpers for both stores. */
+const cdkBefore = (session: 's3' | 'dynamodb-s3') => `import {
+  PolicyStatement,
+  Effect,
+  ServicePrincipal,
+  IGrantable,
+  IPrincipal,
+} from 'aws-cdk-lib/aws-iam';
+
+export class MyAgent extends Construct {
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+
+    const sessionKey = new Key(this, 'SessionKey', { enableKeyRotation: true });
+    const sessionBucket = new Bucket(this, 'SessionBucket', {});
+${
+  session === 'dynamodb-s3'
+    ? `    const sessionTable = new Table(this, 'SessionTable', {});\n`
+    : ''
+}
+${session === 'dynamodb-s3' ? '    sessionTable.grantReadWriteData(this.agentCoreRuntime);\n' : ''}    sessionBucket.grantReadWrite(this.agentCoreRuntime);
+
+    rc.grantReadAppConfig(this.agentCoreRuntime);
+  }
+}
+`;
+
+/** The pre-change Terraform shape: one statement covering bucket and objects. */
+const TF_BEFORE = `resource "aws_s3_bucket" "session" {
+  bucket = "my-agent-sessions"
+}
+
+module "agent_core_runtime" {
+  source = "../../../core/agent-core"
+
+  additional_iam_policy_statements = concat([
+    {
+      Effect = "Allow"
+      Action = [
+        "s3:GetObject",
+        "s3:PutObject",
+        "s3:DeleteObject",
+        "s3:ListBucket"
+      ]
+      Resource = [
+        aws_s3_bucket.session.arn,
+        "\${aws_s3_bucket.session.arn}/*"
+      ]
+    },
+    {
+      Effect = "Allow"
+      Action = [
+        "kms:Decrypt",
+        "kms:GenerateDataKey*"
+      ]
+      Resource = [aws_kms_key.session.arn]
+    }
+  ], var.additional_iam_policy_statements)
+}
+`;
+
+describe('agent-session-least-privilege-iam migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeUsingTsSolutionSetup();
+  });
+
+  it('should replace the CDK bucket grant with explicit statements', async () => {
+    tree.write(CDK_FILE, cdkBefore('s3'));
+
+    const result = await migration(tree);
+    const content = tree.read(CDK_FILE, 'utf-8')!;
+
+    expect(content).not.toContain('sessionBucket.grantReadWrite');
+    expect(content).toContain(
+      "'s3:GetObject', 's3:PutObject', 's3:DeleteObject'",
+    );
+    expect(content).toContain("sessionBucket.arnForObjects('*')");
+    expect(content).toContain("actions: ['s3:ListBucket']");
+    expect(content).toContain('resources: [sessionBucket.bucketArn]');
+    expect(content).toContain("'kms:Decrypt', 'kms:GenerateDataKey*'");
+    expect(content).toContain('resources: [sessionKey.keyArn]');
+
+    // The wide actions the grant helper used to add must be gone.
+    expect(content).not.toContain('s3:Abort');
+    expect(content).not.toContain('kms:Encrypt');
+
+    expect(result.nextSteps).toEqual([]);
+  });
+
+  it('should replace the CDK table grant with explicit statements', async () => {
+    tree.write(CDK_FILE, cdkBefore('dynamodb-s3'));
+
+    const result = await migration(tree);
+    const content = tree.read(CDK_FILE, 'utf-8')!;
+
+    expect(content).not.toContain('sessionTable.grantReadWriteData');
+    expect(content).toContain("'dynamodb:GetItem'");
+    expect(content).toContain("'dynamodb:BatchWriteItem'");
+    expect(content).toContain('resources: [sessionTable.tableArn]');
+
+    // Actions the checkpointer never issues must not be granted.
+    for (const action of [
+      'dynamodb:UpdateItem',
+      'dynamodb:DeleteItem',
+      'dynamodb:Scan',
+      'dynamodb:ConditionCheckItem',
+      'dynamodb:DescribeTable',
+    ]) {
+      expect(content).not.toContain(action);
+    }
+
+    expect(result.nextSteps).toEqual([]);
+  });
+
+  it('should add the PolicyStatement import when absent', async () => {
+    tree.write(CDK_FILE, cdkBefore('s3').replace('  PolicyStatement,\n', ''));
+
+    await migration(tree);
+    const content = tree.read(CDK_FILE, 'utf-8')!;
+
+    expect(content).toContain('PolicyStatement');
+    expect(
+      content.match(/PolicyStatement,/g)?.length ?? 0,
+    ).toBeGreaterThanOrEqual(1);
+    // Only one aws-iam import statement.
+    expect(content.match(/from 'aws-cdk-lib\/aws-iam'/g)).toHaveLength(1);
+  });
+
+  it('should split the Terraform bucket statement by resource', async () => {
+    tree.write(TF_FILE, TF_BEFORE);
+
+    const result = await migration(tree);
+    const content = tree.read(TF_FILE, 'utf-8')!;
+
+    expect(content).toContain('Resource = ["${aws_s3_bucket.session.arn}/*"]');
+    expect(content).toContain('Action   = ["s3:ListBucket"]');
+    expect(content).toContain('Resource = [aws_s3_bucket.session.arn]');
+    expect(result.nextSteps).toEqual([]);
+  });
+
+  it('should leave a diverged CDK file untouched and report it', async () => {
+    const diverged = cdkBefore('dynamodb-s3').replace(
+      '    sessionBucket.grantReadWrite(this.agentCoreRuntime);\n',
+      '    sessionBucket.grantReadWrite(someOtherPrincipal);\n',
+    );
+    tree.write(CDK_FILE, diverged);
+
+    const result = await migration(tree);
+
+    expect(tree.read(CDK_FILE, 'utf-8')).toEqual(diverged);
+    expect(result.nextSteps).toHaveLength(1);
+    expect(result.nextSteps?.[0]).toContain(CDK_FILE);
+  });
+
+  it('should leave a diverged Terraform statement untouched and report it', async () => {
+    const diverged = TF_BEFORE.replace('"s3:DeleteObject",\n        ', '');
+    tree.write(TF_FILE, diverged);
+
+    const result = await migration(tree);
+
+    expect(tree.read(TF_FILE, 'utf-8')).toEqual(diverged);
+    expect(result.nextSteps).toHaveLength(1);
+    expect(result.nextSteps?.[0]).toContain(TF_FILE);
+  });
+
+  it('should ignore files without session storage', async () => {
+    const unrelated = `resource "aws_s3_bucket" "website" {
+  bucket = "my-website"
+}
+`;
+    tree.write(
+      'packages/common/terraform/src/app/website/website.tf',
+      unrelated,
+    );
+
+    const result = await migration(tree);
+
+    expect(
+      tree.read(
+        'packages/common/terraform/src/app/website/website.tf',
+        'utf-8',
+      ),
+    ).toEqual(unrelated);
+    expect(result.nextSteps).toEqual([]);
+  });
+
+  it('should be idempotent', async () => {
+    tree.write(CDK_FILE, cdkBefore('dynamodb-s3'));
+    tree.write(TF_FILE, TF_BEFORE);
+
+    const first = await migration(tree);
+    const cdkAfterFirst = tree.read(CDK_FILE, 'utf-8')!;
+    const tfAfterFirst = tree.read(TF_FILE, 'utf-8')!;
+
+    const second = await migration(tree);
+
+    expect(tree.read(CDK_FILE, 'utf-8')).toEqual(cdkAfterFirst);
+    expect(tree.read(TF_FILE, 'utf-8')).toEqual(tfAfterFirst);
+    expect(second.nextSteps).toEqual(first.nextSteps);
+    expect(second.nextSteps).toEqual([]);
+  });
+});

--- a/packages/nx-plugin/src/migrations/latest/agent-session-least-privilege-iam/migration.ts
+++ b/packages/nx-plugin/src/migrations/latest/agent-session-least-privilege-iam/migration.ts
@@ -1,0 +1,196 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import {
+  type MigrationReturnObject,
+  type Tree,
+  visitNotIgnoredFiles,
+} from '@nx/devkit';
+import { applyGritQL, matchGritQL } from '../../../utils/ast.js';
+import { formatFilesInSubtree } from '../../../utils/format.js';
+
+/**
+ * Narrow the agent session storage grants to the actions the session code
+ * issues.
+ *
+ * The CDK constructs granted access with `sessionBucket.grantReadWrite` and
+ * `sessionTable.grantReadWriteData`, whose action sets are far wider than the
+ * session managers use: object legal-hold/retention/tagging and multipart abort
+ * on the bucket, `UpdateItem`/`DeleteItem`/`Scan`/`ConditionCheckItem` and
+ * stream reads on the table, plus `kms:Encrypt`/`kms:ReEncrypt*` on the key.
+ * Both are replaced with explicit statements, and the Terraform bucket
+ * statement is split so the object actions no longer target the bucket ARN
+ * itself.
+ *
+ * These files are generated with `KeepExisting`, so without this an upgraded
+ * workspace keeps the wider grants. Diverged files are left untouched and
+ * reported via `nextSteps`.
+ */
+
+const hcl = (pattern: string) => `language hcl\n${pattern}`;
+
+/** The vended CDK table grant, and the explicit statement replacing it. */
+const CDK_TABLE_GRANT = `\`sessionTable.grantReadWriteData(this.agentCoreRuntime);\` => raw\`// Actions the checkpointer issues against the table.
+    this.agentCoreRuntime.addToRolePolicy(
+      new PolicyStatement({
+        actions: [
+          'dynamodb:GetItem',
+          'dynamodb:PutItem',
+          'dynamodb:Query',
+          'dynamodb:BatchGetItem',
+          'dynamodb:BatchWriteItem',
+        ],
+        resources: [sessionTable.tableArn],
+      }),
+    );\``;
+
+/** The vended CDK bucket grant, and the explicit statements replacing it. */
+const CDK_BUCKET_GRANT = `\`sessionBucket.grantReadWrite(this.agentCoreRuntime);\` => raw\`// Actions the session manager issues against the bucket.
+    this.agentCoreRuntime.addToRolePolicy(
+      new PolicyStatement({
+        actions: ['s3:GetObject', 's3:PutObject', 's3:DeleteObject'],
+        resources: [sessionBucket.arnForObjects('*')],
+      }),
+    );
+    this.agentCoreRuntime.addToRolePolicy(
+      new PolicyStatement({
+        actions: ['s3:ListBucket'],
+        resources: [sessionBucket.bucketArn],
+      }),
+    );
+    this.agentCoreRuntime.addToRolePolicy(
+      new PolicyStatement({
+        actions: ['kms:Decrypt', 'kms:GenerateDataKey*'],
+        resources: [sessionKey.keyArn],
+      }),
+    );\``;
+
+/** `PolicyStatement` is already imported by every agent that grants bedrock. */
+const CDK_POLICY_STATEMENT_IMPORT = `\`import { $imports } from 'aws-cdk-lib/aws-iam';\` where { $imports <: contains \`PolicyStatement\` }`;
+
+const CDK_ADD_POLICY_STATEMENT_IMPORT = `\`import { $imports } from 'aws-cdk-lib/aws-iam';\` => \`import { PolicyStatement, $imports } from 'aws-cdk-lib/aws-iam';\``;
+
+/**
+ * The Terraform bucket statement, split so the object actions target only
+ * `<bucket>/*` and `s3:ListBucket` only the bucket itself.
+ */
+const TF_BUCKET_STATEMENT = hcl(`\`{
+      Effect = "Allow"
+      Action = [
+        "s3:GetObject",
+        "s3:PutObject",
+        "s3:DeleteObject",
+        "s3:ListBucket"
+      ]
+      Resource = [
+        aws_s3_bucket.session.arn,
+        "\${aws_s3_bucket.session.arn}/*"
+      ]
+    }\` => \`{
+      Effect = "Allow"
+      Action = [
+        "s3:GetObject",
+        "s3:PutObject",
+        "s3:DeleteObject"
+      ]
+      Resource = ["\${aws_s3_bucket.session.arn}/*"]
+    },
+    {
+      Effect   = "Allow"
+      Action   = ["s3:ListBucket"]
+      Resource = [aws_s3_bucket.session.arn]
+    }\``);
+
+const cdkDivergedMessage = (filePath: string) =>
+  `${filePath}: the session storage IAM grants have diverged from the generated shape - left untouched. Replace \`sessionBucket.grantReadWrite\` / \`sessionTable.grantReadWriteData\` with explicit \`addToRolePolicy\` statements granting only s3:GetObject/PutObject/DeleteObject on \`sessionBucket.arnForObjects('*')\`, s3:ListBucket on the bucket ARN, kms:Decrypt/GenerateDataKey* on the session key, and (for dynamodb-s3) dynamodb:GetItem/PutItem/Query/BatchGetItem/BatchWriteItem on the table ARN.`;
+
+const tfDivergedMessage = (filePath: string) =>
+  `${filePath}: the session bucket IAM statement has diverged from the generated shape - left untouched. Split it so s3:GetObject/PutObject/DeleteObject target only "\${aws_s3_bucket.session.arn}/*" and s3:ListBucket targets only aws_s3_bucket.session.arn.`;
+
+/** Narrow the grants in one vended CDK agent construct. */
+const migrateCdkAgent = async (
+  tree: Tree,
+  filePath: string,
+  nextSteps: string[],
+): Promise<void> => {
+  const hasTableGrant = await matchGritQL(
+    tree,
+    filePath,
+    '`sessionTable.grantReadWriteData(this.agentCoreRuntime);`',
+  );
+  const hasBucketGrant = await matchGritQL(
+    tree,
+    filePath,
+    '`sessionBucket.grantReadWrite(this.agentCoreRuntime);`',
+  );
+
+  if (!hasTableGrant && !hasBucketGrant) {
+    return;
+  }
+
+  // The bucket grant carries the KMS permissions, so an agent with a session
+  // table but no recognisable bucket grant is a shape we don't know.
+  if (hasTableGrant && !hasBucketGrant) {
+    nextSteps.push(cdkDivergedMessage(filePath));
+    return;
+  }
+
+  if (hasTableGrant) {
+    await applyGritQL(tree, filePath, CDK_TABLE_GRANT);
+  }
+  await applyGritQL(tree, filePath, CDK_BUCKET_GRANT);
+
+  // MCP runtimes don't grant bedrock, so they may not import PolicyStatement.
+  if (!(await matchGritQL(tree, filePath, CDK_POLICY_STATEMENT_IMPORT))) {
+    await applyGritQL(tree, filePath, CDK_ADD_POLICY_STATEMENT_IMPORT);
+  }
+};
+
+export default async function migration(
+  tree: Tree,
+): Promise<MigrationReturnObject> {
+  const nextSteps: string[] = [];
+
+  const cdkFiles: string[] = [];
+  const tfFiles: string[] = [];
+  visitNotIgnoredFiles(tree, '', (filePath) => {
+    if (filePath.endsWith('.ts') && !filePath.endsWith('.d.ts')) {
+      cdkFiles.push(filePath);
+    } else if (filePath.endsWith('.tf')) {
+      tfFiles.push(filePath);
+    }
+  });
+
+  for (const filePath of cdkFiles) {
+    await migrateCdkAgent(tree, filePath, nextSteps);
+  }
+
+  for (const filePath of tfFiles) {
+    // Only the agent-core app modules define an `aws_s3_bucket.session`.
+    if (
+      !(await matchGritQL(
+        tree,
+        filePath,
+        hcl('`resource "aws_s3_bucket" "session" { $_ }`'),
+      ))
+    ) {
+      continue;
+    }
+
+    // Already split by a previous run.
+    if (
+      await matchGritQL(tree, filePath, hcl('`Action   = ["s3:ListBucket"]`'))
+    ) {
+      continue;
+    }
+
+    if (!(await applyGritQL(tree, filePath, TF_BUCKET_STATEMENT))) {
+      nextSteps.push(tfDivergedMessage(filePath));
+    }
+  }
+
+  await formatFilesInSubtree(tree);
+
+  return { nextSteps };
+}

--- a/packages/nx-plugin/src/py/agent/__snapshots__/generator.constructs.spec.ts.snap
+++ b/packages/nx-plugin/src/py/agent/__snapshots__/generator.constructs.spec.ts.snap
@@ -255,8 +255,38 @@ export class DynamodbAgent
       }),
     );
 
-    sessionTable.grantReadWriteData(this.agentCoreRuntime);
-    sessionBucket.grantReadWrite(this.agentCoreRuntime);
+    // Actions the checkpointer issues against the table.
+    this.agentCoreRuntime.addToRolePolicy(
+      new PolicyStatement({
+        actions: [
+          'dynamodb:GetItem',
+          'dynamodb:PutItem',
+          'dynamodb:Query',
+          'dynamodb:BatchGetItem',
+          'dynamodb:BatchWriteItem',
+        ],
+        resources: [sessionTable.tableArn],
+      }),
+    );
+    // Actions the session manager issues against the bucket.
+    this.agentCoreRuntime.addToRolePolicy(
+      new PolicyStatement({
+        actions: ['s3:GetObject', 's3:PutObject', 's3:DeleteObject'],
+        resources: [sessionBucket.arnForObjects('*')],
+      }),
+    );
+    this.agentCoreRuntime.addToRolePolicy(
+      new PolicyStatement({
+        actions: ['s3:ListBucket'],
+        resources: [sessionBucket.bucketArn],
+      }),
+    );
+    this.agentCoreRuntime.addToRolePolicy(
+      new PolicyStatement({
+        actions: ['kms:Decrypt', 'kms:GenerateDataKey*'],
+        resources: [sessionKey.keyArn],
+      }),
+    );
 
     rc.grantReadAppConfig(this.agentCoreRuntime);
 
@@ -573,7 +603,25 @@ export class SnapshotBedrockAgent
       }),
     );
 
-    sessionBucket.grantReadWrite(this.agentCoreRuntime);
+    // Actions the session manager issues against the bucket.
+    this.agentCoreRuntime.addToRolePolicy(
+      new PolicyStatement({
+        actions: ['s3:GetObject', 's3:PutObject', 's3:DeleteObject'],
+        resources: [sessionBucket.arnForObjects('*')],
+      }),
+    );
+    this.agentCoreRuntime.addToRolePolicy(
+      new PolicyStatement({
+        actions: ['s3:ListBucket'],
+        resources: [sessionBucket.bucketArn],
+      }),
+    );
+    this.agentCoreRuntime.addToRolePolicy(
+      new PolicyStatement({
+        actions: ['kms:Decrypt', 'kms:GenerateDataKey*'],
+        resources: [sessionKey.keyArn],
+      }),
+    );
 
     rc.grantReadAppConfig(this.agentCoreRuntime);
 

--- a/packages/nx-plugin/src/py/agent/__snapshots__/generator.protocols.spec.ts.snap
+++ b/packages/nx-plugin/src/py/agent/__snapshots__/generator.protocols.spec.ts.snap
@@ -289,13 +289,14 @@ module "agent_core_runtime" {
       Action = [
         "s3:GetObject",
         "s3:PutObject",
-        "s3:DeleteObject",
-        "s3:ListBucket"
+        "s3:DeleteObject"
       ]
-      Resource = [
-        aws_s3_bucket.session.arn,
-        "\${aws_s3_bucket.session.arn}/*"
-      ]
+      Resource = ["\${aws_s3_bucket.session.arn}/*"]
+    },
+    {
+      Effect   = "Allow"
+      Action   = ["s3:ListBucket"]
+      Resource = [aws_s3_bucket.session.arn]
     },
     # Grant access for the agent to use the session bucket's KMS key
     {
@@ -606,13 +607,14 @@ module "agent_core_runtime" {
       Action = [
         "s3:GetObject",
         "s3:PutObject",
-        "s3:DeleteObject",
-        "s3:ListBucket"
+        "s3:DeleteObject"
       ]
-      Resource = [
-        aws_s3_bucket.session.arn,
-        "\${aws_s3_bucket.session.arn}/*"
-      ]
+      Resource = ["\${aws_s3_bucket.session.arn}/*"]
+    },
+    {
+      Effect   = "Allow"
+      Action   = ["s3:ListBucket"]
+      Resource = [aws_s3_bucket.session.arn]
     },
     # Grant access for the agent to use the session bucket's KMS key
     {

--- a/packages/nx-plugin/src/ts/agent/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/agent/__snapshots__/generator.spec.ts.snap
@@ -894,7 +894,25 @@ export class SnapshotBedrockAgent
       }),
     );
 
-    sessionBucket.grantReadWrite(this.agentCoreRuntime);
+    // Actions the session manager issues against the bucket.
+    this.agentCoreRuntime.addToRolePolicy(
+      new PolicyStatement({
+        actions: ['s3:GetObject', 's3:PutObject', 's3:DeleteObject'],
+        resources: [sessionBucket.arnForObjects('*')],
+      }),
+    );
+    this.agentCoreRuntime.addToRolePolicy(
+      new PolicyStatement({
+        actions: ['s3:ListBucket'],
+        resources: [sessionBucket.bucketArn],
+      }),
+    );
+    this.agentCoreRuntime.addToRolePolicy(
+      new PolicyStatement({
+        actions: ['kms:Decrypt', 'kms:GenerateDataKey*'],
+        resources: [sessionKey.keyArn],
+      }),
+    );
 
     rc.grantReadAppConfig(this.agentCoreRuntime);
 
@@ -1225,13 +1243,14 @@ module "agent_core_runtime" {
       Action = [
         "s3:GetObject",
         "s3:PutObject",
-        "s3:DeleteObject",
-        "s3:ListBucket"
+        "s3:DeleteObject"
       ]
-      Resource = [
-        aws_s3_bucket.session.arn,
-        "\${aws_s3_bucket.session.arn}/*"
-      ]
+      Resource = ["\${aws_s3_bucket.session.arn}/*"]
+    },
+    {
+      Effect   = "Allow"
+      Action   = ["s3:ListBucket"]
+      Resource = [aws_s3_bucket.session.arn]
     },
     # Grant access for the agent to use the session bucket's KMS key
     {

--- a/packages/nx-plugin/src/utils/agent-core-constructs/files/cdk/app/agent-core/__nameKebabCase__/__nameKebabCase__.ts.template
+++ b/packages/nx-plugin/src/utils/agent-core-constructs/files/cdk/app/agent-core/__nameKebabCase__/__nameKebabCase__.ts.template
@@ -33,7 +33,7 @@ import {
   RuntimeAuthorizerConfiguration,
 <%_ } _%>
 } from 'aws-cdk-lib/aws-bedrockagentcore';
-import { <%_ if (serverProtocol !== 'mcp') { _%>PolicyStatement, <%_ } _%><%_ if (hasSessionBucket) { _%>Effect, ServicePrincipal, <%_ } _%>IGrantable, IPrincipal<%_ if (auth === 'iam') { _%>, Grant<%_ } _%> } from 'aws-cdk-lib/aws-iam';
+import { <%_ if (serverProtocol !== 'mcp' || hasSessionBucket) { _%>PolicyStatement, <%_ } _%><%_ if (hasSessionBucket) { _%>Effect, ServicePrincipal, <%_ } _%>IGrantable, IPrincipal<%_ if (auth === 'iam') { _%>, Grant<%_ } _%> } from 'aws-cdk-lib/aws-iam';
 <%_ if (auth === 'cognito') { _%>
 import { IUserPool, IUserPoolClient } from 'aws-cdk-lib/aws-cognito';
 <%_ } _%>
@@ -336,10 +336,40 @@ export class <%- nameClassName %> extends Construct implements IGrantable, IConn
 
 <%_ } _%>
 <%_ if (session === 'dynamodb-s3') { _%>
-    sessionTable.grantReadWriteData(this.agentCoreRuntime);
+    // Actions the checkpointer issues against the table.
+    this.agentCoreRuntime.addToRolePolicy(
+      new PolicyStatement({
+        actions: [
+          'dynamodb:GetItem',
+          'dynamodb:PutItem',
+          'dynamodb:Query',
+          'dynamodb:BatchGetItem',
+          'dynamodb:BatchWriteItem',
+        ],
+        resources: [sessionTable.tableArn],
+      }),
+    );
 <%_ } _%>
 <%_ if (hasSessionBucket) { _%>
-    sessionBucket.grantReadWrite(this.agentCoreRuntime);
+    // Actions the session manager issues against the bucket.
+    this.agentCoreRuntime.addToRolePolicy(
+      new PolicyStatement({
+        actions: ['s3:GetObject', 's3:PutObject', 's3:DeleteObject'],
+        resources: [sessionBucket.arnForObjects('*')],
+      }),
+    );
+    this.agentCoreRuntime.addToRolePolicy(
+      new PolicyStatement({
+        actions: ['s3:ListBucket'],
+        resources: [sessionBucket.bucketArn],
+      }),
+    );
+    this.agentCoreRuntime.addToRolePolicy(
+      new PolicyStatement({
+        actions: ['kms:Decrypt', 'kms:GenerateDataKey*'],
+        resources: [sessionKey.keyArn],
+      }),
+    );
 <%_ } _%>
 
     rc.grantReadAppConfig(this.agentCoreRuntime);

--- a/packages/nx-plugin/src/utils/agent-core-constructs/files/terraform/app/agent-core/__nameKebabCase__/__nameKebabCase__.tf.template
+++ b/packages/nx-plugin/src/utils/agent-core-constructs/files/terraform/app/agent-core/__nameKebabCase__/__nameKebabCase__.tf.template
@@ -327,13 +327,14 @@ module "agent_core_runtime" {
       Action = [
         "s3:GetObject",
         "s3:PutObject",
-        "s3:DeleteObject",
-        "s3:ListBucket"
+        "s3:DeleteObject"
       ]
-      Resource = [
-        aws_s3_bucket.session.arn,
-        "${aws_s3_bucket.session.arn}/*"
-      ]
+      Resource = ["${aws_s3_bucket.session.arn}/*"]
+    },
+    {
+      Effect   = "Allow"
+      Action   = ["s3:ListBucket"]
+      Resource = [aws_s3_bucket.session.arn]
     },
     # Grant access for the agent to use the session bucket's KMS key
     {


### PR DESCRIPTION
### Reason for this change

Agent session storage IAM differed between the two IaC providers: CDK granted access with `sessionBucket.grantReadWrite` / `sessionTable.grantReadWriteData`, while Terraform hand-listed a narrower set. That looked like a Terraform gap — reported as missing `s3:Abort*`, `kms:Encrypt`, and `dynamodb:UpdateItem`/`DeleteItem`/`Scan`/`ConditionCheckItem`.

The open question was whether the vended session code needs those actions. It does not — the narrower Terraform set is provably sufficient, so **CDK was the over-broad side**, not Terraform the broken one. Establishing that from the package sources:

**TS agent, `session: 's3'` — `@strands-agents/sdk` 1.14.0.** The `S3Storage` the template imports from `@strands-agents/sdk/storage` (`dist/src/storage/s3-storage.js`) issues only `PutObjectCommand`, `GetObjectCommand`, `DeleteObjectCommand` and `ListObjectsV2Command`. There is no multipart upload anywhere, so `s3:AbortMultipartUpload` is unreachable.

**Python Strands agent, `session: 's3'` — `strands-agents` 1.53.0.** `S3SessionManager` uses `get_object`, `put_object`, `head_object`, `list_objects_v2` and `delete_objects`. `head_object` is authorized by `s3:GetObject`; again no multipart.

**Python LangChain agent, `session: 'dynamodb-s3'` — `langgraph-checkpoint-aws` 1.2.2.** Exhaustively enumerating every client call in `checkpoint/dynamodb/{saver,unified_repository,storage_strategy}.py`:

- DynamoDB: `batch_get_item`, `batch_write_item`, `get_item`, `put_item`, `query`
- S3: `put_object`, `get_object`, `delete_objects`, plus `get_bucket_lifecycle_configuration` / `put_bucket_lifecycle_configuration`

No `update_item`, no `delete_item`, no `scan`, no `ConditionCheckItem`, no `transact*` — the `ScanIndexForward` occurrences are *Query* parameters, not the Scan API. The two lifecycle calls and object `Tagging` are gated on `ttl_seconds` (`storage_strategy.py:64-65,400,506`), and the vended `session.py` constructs `DynamoDBSaver(table_name=..., region_name=..., s3_offload_config={...})` without it, so they are never reached.

For reference, what CDK's helpers actually expand to (`aws-cdk-lib` 2.266.0, the pinned version) — everything beyond the sets above is unused:

- `aws-s3/lib/perms.js`: `s3:GetObject*`, `s3:GetBucket*`, `s3:List*`, `s3:PutObject`, `s3:PutObjectLegalHold`, `s3:PutObjectRetention`, `s3:PutObjectTagging`, `s3:PutObjectVersionTagging`, `s3:Abort*`, `s3:DeleteObject*`, and on the key `kms:Decrypt`, `kms:DescribeKey`, `kms:Encrypt`, `kms:ReEncrypt*`, `kms:GenerateDataKey*`
- `aws-dynamodb/lib/perms.js`: `BatchGetItem`, `Query`, `GetItem`, `Scan`, `ConditionCheckItem`, `BatchWriteItem`, `PutItem`, `UpdateItem`, `DeleteItem`, `DescribeTable`, `GetRecords`, `GetShardIterator`

### Description of changes

Both providers now grant the same explicit, least-privilege set:

- S3 objects: `s3:GetObject`, `s3:PutObject`, `s3:DeleteObject`
- Bucket: `s3:ListBucket`
- Key: `kms:Decrypt`, `kms:GenerateDataKey*`
- Table (`dynamodb-s3` only): `dynamodb:GetItem`, `PutItem`, `Query`, `BatchGetItem`, `BatchWriteItem`

The CDK construct replaces the two grant helpers with explicit `addToRolePolicy` statements. The Terraform bucket statement is split by resource, so the object actions target `<bucket>/*` and `s3:ListBucket` targets the bucket ARN — previously both actions were granted against both ARNs.

The vended files are `KeepExisting`, so a deterministic migration (`agent-session-least-privilege-iam`) carries existing workspaces across, using GritQL to match the exact vended shapes and reporting anything diverged via `nextSteps` rather than rewriting it.

### Description of how you validated changes

`pnpm nx run @aws/nx-plugin:test` (206 files, 3762 tests), `build --all` and `lint --all --configuration=fix` all pass. The migration has 8 unit tests covering both providers, the added-import case, diverged-file reporting, and idempotency.

**Isolated IAM proof.** Before changing anything, I stood up a real KMS CMK, an SSE-KMS bucket and a PK/SK+`ttl` table encrypted with that key, plus an IAM role whose only policy was the action set above, then drove the real pinned packages under that assumed role:

- `langgraph-checkpoint-aws` 1.2.2, 3 turns: each `put` / `put_writes` / `get_tuple` / `list` succeeded (1, 2, 3 checkpoints); a 500 KB payload round-tripped through the S3 offload; `delete_thread` succeeded.
- `strands-agents` 1.53.0 `S3SessionManager`, 3 turns: appended user+assistant messages per turn (`list_messages` → 2, 4, 6), `read_message` → `q1`, `update_message` → `edited`, `delete_session` OK.
- `@strands-agents/sdk` 1.14.0 `SessionManager` + `S3Storage`, 3 turns with genuine continuity: turn 2 restored 2 messages, turn 3 restored 4; a 2 MB message saved and restored; `deleteSession` OK.
- **Control:** `s3:PutBucketTagging` (not granted) returned `AccessDenied` under the same role, confirming the harness would surface a real gap.

**Deployed both providers and invoked over multiple turns.** Terraform workspace with a TypeScript agent (`session: 's3'`) and a Python LangChain agent (`session: 'dynamodb-s3'`), plus a CDK workspace of the same shape. The live role policies matched the intended sets exactly on both providers.

Multi-turn conversation against each deployed agent (same session id across turns, so state had to round-trip through storage):

```
=== TURN 1 ===  > Remember this fact: my favourite colour is chartreuse. Reply with just OK.
                < OK
=== TURN 2 ===  > What is my favourite colour? Answer with the single word only.
                < Chartreuse
=== TURN 3 ===  > Repeat my favourite colour one more time, single word only.
                < Chartreuse
```

All four agents (Terraform TS + Python, CDK TS + Python) reproduced that continuity. Storage was confirmed written — a session snapshot object in the TS agent's bucket, and 36 items in the Python agent's checkpoint table. Every runtime's CloudWatch log group returned **0 matches** for `AccessDenied`, `AccessDeniedException`, `NotAuthorized`, `UnauthorizedOperation` and `not authorized`.

Both deployments were then torn down (`terraform destroy`: 60 resources destroyed, state file left with 0 resources; CDK stack deleted) and the teardown verified — no session buckets, checkpoint tables or agent roles remaining, and the harness resources removed.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
