### PR TITLE
feat(agentcore-harness): bring the Terraform module to parity on VPC, execution role and native fields, and fix the managed-memory grant

### DIFF
--- a/docs/src/content/docs/en/guides/agentcore-harness.mdx
+++ b/docs/src/content/docs/en/guides/agentcore-harness.mdx
@@ -112,16 +112,21 @@ module "my_harness" {
 }
 ```
 
-The module exposes four variables:
+The module exposes the following variables:
 
 - `model_id` — the Bedrock model or inference profile the Harness uses by default.
 - `allowed_tools` — the tools the Harness may use. Defaults to none, see <a href="#configuring-tools">Configuring tools</a>.
-- `model_resource_arns` — the Bedrock model and inference-profile ARNs the execution role may invoke, replacing the default list.
-- `additional_execution_role_policy_statements` — a list of IAM statement objects (`Effect`, `Action`, `Resource`, optional `Sid` and `Condition`) appended to the execution role policy.
+- `memory` — the Harness memory configuration, see <a href="#configuring-memory">Configuring memory</a>.
+- `environment_variables`, `max_iterations`, `timeout_seconds` — the corresponding native Harness fields.
+- `execution_role_arn` — an existing IAM role to use instead of the generated role. A supplied role is used as-is: neither the role nor its baseline policy is created, so `model_resource_arns` and `additional_execution_role_policy_statements` cannot be combined with it.
+- `model_resource_arns` — the Bedrock model and inference-profile ARNs the generated execution role may invoke, replacing the default list.
+- `additional_execution_role_policy_statements` — a list of IAM statement objects (`Effect`, `Action`, `Resource`, optional `Sid` and `Condition`) appended to the generated execution role policy.
+- `enable_vpc`, `vpc_id`, `subnet_ids` — run the Harness in a VPC so it can reach private resources, see <a href="#running-in-a-vpc">Running in a VPC</a>.
+- `tags` — tags applied to the resources the module creates.
 
-Everything else is configured on the generated `aws_bedrockagentcore_harness` resource in the module itself.
+Other provider-native fields are configured by editing the generated `aws_bedrockagentcore_harness` resource in the module itself, see <a href="#customizing-your-harness">Customizing your Harness</a>.
 
-The module outputs `harness_id`, `harness_arn`, and `execution_role_arn`.
+The module outputs `harness_id`, `harness_arn`, `execution_role_arn` and `security_group_id`.
 
 Deploy with your Terraform project's plan/apply workflow as usual — see the <Link path="guides/terraform-project">Terraform project guide</Link>.
   </Fragment>
@@ -197,7 +202,7 @@ With neither set, the script fails with an error naming both options.
 Every native Harness property of the pinned `aws-cdk-lib/aws-bedrockagentcore` module is available through the construct's props — alternate model providers, tool definitions, memory, skills, environment configuration, truncation, custom JWT authorization, and execution limits — and explicit props take precedence over the generated defaults. Alternatively, edit the generated construct in `packages/common/constructs/src/app/harnesses/<name>/<name>.ts`.
   </Fragment>
   <Fragment slot="terraform">
-The generated module keeps the native `aws_bedrockagentcore_harness` resource directly editable, so provider-native fields — alternate model providers (`gemini_model_config`, `openai_model_config`), `tool` blocks, `memory`, `skill` blocks, environments (`environment`, `environment_variables`, `environment_artifact`), `truncation`, and `authorizer_configuration` with a `custom_jwt_authorizer` — are configured by editing `packages/common/terraform/src/app/harnesses/<name>/<name>.tf`.
+The module's variables cover the fields most deployments configure — `model_id`, `allowed_tools`, `memory`, `environment_variables`, `max_iterations`, `timeout_seconds` — plus the execution role and VPC placement. Terraform has no equivalent of the CDK construct's prop spread, so the remaining provider-native fields are configured by editing the `aws_bedrockagentcore_harness` resource in `packages/common/terraform/src/app/harnesses/<name>/<name>.tf`: alternate model providers (`gemini_model_config`, `openai_model_config`), `tool` blocks, `skill` blocks, `environment_artifact`, filesystem and lifecycle configuration under `environment`, `truncation`, and `authorizer_configuration` with a `custom_jwt_authorizer`.
   </Fragment>
 </Infrastructure>
 
@@ -216,8 +221,7 @@ new MyHarness(this, 'Harness', { allowedTools: ['@builtin'] });
   <Fragment slot="terraform">
 ```hcl title="packages/infra/src/main.tf"
 module "my_harness" {
-  source = "../../common/terraform/src/app/harnesses/my-harness"
-
+  source        = "../../common/terraform/src/app/harnesses/my-harness"
   allowed_tools = ["@builtin"]
 }
 ```
@@ -225,6 +229,36 @@ module "my_harness" {
 </Infrastructure>
 
 Narrow `@builtin` to specific patterns such as `@builtin/file_operations` to restrict what the agent loop can do. See [Harness tools](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/harness-tools.html) for the built-in tools you can add.
+
+### Configuring memory
+
+The service provisions managed memory for the Harness by default, and the generated execution role is granted access to it — scoped to the memory ARN the service assigns, and only granted while the Harness uses managed memory the infrastructure created. Configure memory explicitly to tune that managed memory, point the Harness at a memory resource you own, or turn memory off:
+
+<Infrastructure>
+  <Fragment slot="cdk">
+```ts
+new MyHarness(this, 'MyHarness', {
+  memory: { managedMemoryConfiguration: { strategies: ['SUMMARIZATION'] } },
+});
+```
+
+Supplying `memory` at all replaces the default managed memory, so the construct leaves the memory grant off the execution role: add whatever the configuration needs with `addToRolePolicy`.
+  </Fragment>
+  <Fragment slot="terraform">
+```hcl
+module "my_harness" {
+  source = "../../common/terraform/src/app/harnesses/my-harness"
+  memory = {
+    managed_memory_configuration = {
+      strategies = ["SUMMARIZATION"]
+    }
+  }
+}
+```
+
+Set exactly one of `managed_memory_configuration` (tune the service's managed memory), `agentcore_memory_configuration` (use a memory resource you own, by ARN) or `disabled` (no memory). Choosing `agentcore_memory_configuration` or `disabled` drops the managed-memory grant from the execution role; for your own memory resource, grant access through `additional_execution_role_policy_statements`.
+  </Fragment>
+</Infrastructure>
 
 ### Running in a VPC
 
@@ -241,28 +275,31 @@ database.connections.allowDefaultPortFrom(harness, 'Harness to database');
 The Harness is placed in the VPC's private subnets with egress, in a security group created for it. Override either with `vpcSubnets` and `securityGroups`. Both require `vpc`, and `connections` is only available when the Harness runs in a VPC.
   </Fragment>
   <Fragment slot="terraform">
-Add a `network_configuration` block to the generated `aws_bedrockagentcore_harness` resource's `environment.agent_core_runtime_environment`, then reference the security group you place it in from your other resources' rules:
+Set `enable_vpc` alongside `vpc_id` and `subnet_ids` to run the Harness inside a VPC, so it can reach private resources such as a database:
 
-```hcl title="packages/common/terraform/src/app/harnesses/my-harness/my-harness.tf"
-resource "aws_security_group" "harness" {
-  vpc_id = var.vpc_id
-}
-
-resource "aws_bedrockagentcore_harness" "this" {
-  # ...
-  environment {
-    agent_core_runtime_environment {
-      network_configuration {
-        network_mode = "VPC"
-        network_mode_config {
-          security_groups = [aws_security_group.harness.id]
-          subnets         = var.subnet_ids
-        }
-      }
-    }
-  }
+```hcl
+module "my_harness" {
+  source     = "../../common/terraform/src/app/harnesses/my-harness"
+  enable_vpc = true
+  vpc_id     = var.vpc_id
+  subnet_ids = var.private_subnet_ids
 }
 ```
+
+The module creates a security group for the Harness, allowing outbound HTTPS only. Its `security_group_id` output is what resources the Harness must reach reference in their own ingress rules:
+
+```hcl
+resource "aws_vpc_security_group_ingress_rule" "harness_to_database" {
+  security_group_id            = aws_security_group.database.id
+  referenced_security_group_id = module.my_harness.security_group_id
+  from_port                    = 5432
+  to_port                      = 5432
+  ip_protocol                  = "tcp"
+  description                  = "Harness to database"
+}
+```
+
+`security_group_id` is null unless `enable_vpc` is true, and `vpc_id` and `subnet_ids` are both required when it is.
   </Fragment>
 </Infrastructure>
 

--- a/docs/src/content/docs/es/guides/agentcore-harness.mdx
+++ b/docs/src/content/docs/es/guides/agentcore-harness.mdx
@@ -112,16 +112,21 @@ module "my_harness" {
 }
 ```
 
-El módulo expone cuatro variables:
+El módulo expone las siguientes variables:
 
 - `model_id` — el modelo de Bedrock o perfil de inferencia que el Harness usa de forma predeterminada.
 - `allowed_tools` — las herramientas que el Harness puede usar. Por defecto ninguna, consulta <a href="#configurar-herramientas">Configurar herramientas</a>.
-- `model_resource_arns` — los ARN del modelo de Bedrock y del perfil de inferencia que el rol de ejecución puede invocar, reemplazando la lista predeterminada.
-- `additional_execution_role_policy_statements` — una lista de objetos de declaración IAM (`Effect`, `Action`, `Resource`, `Sid` y `Condition` opcionales) agregados a la política del rol de ejecución.
+- `memory` — la configuración de memoria del Harness, consulta <a href="#configurar-memoria">Configurar memoria</a>.
+- `environment_variables`, `max_iterations`, `timeout_seconds` — los campos nativos correspondientes del Harness.
+- `execution_role_arn` — un rol IAM existente para usar en lugar del rol generado. Un rol proporcionado se usa tal cual: ni el rol ni su política básica se crean, por lo que `model_resource_arns` y `additional_execution_role_policy_statements` no se pueden combinar con él.
+- `model_resource_arns` — los ARN del modelo de Bedrock y del perfil de inferencia que el rol de ejecución generado puede invocar, reemplazando la lista predeterminada.
+- `additional_execution_role_policy_statements` — una lista de objetos de declaración IAM (`Effect`, `Action`, `Resource`, `Sid` y `Condition` opcionales) agregados a la política del rol de ejecución generado.
+- `enable_vpc`, `vpc_id`, `subnet_ids` — ejecuta el Harness en una VPC para que pueda alcanzar recursos privados, consulta <a href="#ejecutar-en-una-vpc">Ejecutar en una VPC</a>.
+- `tags` — etiquetas aplicadas a los recursos que el módulo crea.
 
-Todo lo demás se configura en el recurso `aws_bedrockagentcore_harness` generado en el módulo mismo.
+Otros campos nativos del proveedor se configuran editando el recurso `aws_bedrockagentcore_harness` generado en el módulo mismo, consulta <a href="#personalizar-tu-harness">Personalizar tu Harness</a>.
 
-El módulo genera `harness_id`, `harness_arn`, y `execution_role_arn`.
+El módulo genera `harness_id`, `harness_arn`, `execution_role_arn` y `security_group_id`.
 
 Implementa con el flujo de trabajo plan/apply de tu proyecto Terraform como de costumbre — consulta la <Link path="guides/terraform-project">guía de proyecto Terraform</Link>.
   </Fragment>
@@ -197,7 +202,7 @@ Sin ninguno establecido, el script falla con un error nombrando ambas opciones.
 Cada propiedad nativa de Harness del módulo `aws-cdk-lib/aws-bedrockagentcore` fijado está disponible a través de las props del constructo — proveedores de modelos alternativos, definiciones de herramientas, memoria, habilidades, configuración de entorno, truncamiento, autorización JWT personalizada y límites de ejecución — y las props explícitas tienen precedencia sobre los valores predeterminados generados. Alternativamente, edita el constructo generado en `packages/common/constructs/src/app/harnesses/<name>/<name>.ts`.
   </Fragment>
   <Fragment slot="terraform">
-El módulo generado mantiene el recurso nativo `aws_bedrockagentcore_harness` directamente editable, por lo que los campos nativos del proveedor — proveedores de modelos alternativos (`gemini_model_config`, `openai_model_config`), bloques `tool`, `memory`, bloques `skill`, entornos (`environment`, `environment_variables`, `environment_artifact`), `truncation`, y `authorizer_configuration` con un `custom_jwt_authorizer` — se configuran editando `packages/common/terraform/src/app/harnesses/<name>/<name>.tf`.
+Las variables del módulo cubren los campos que la mayoría de las implementaciones configuran — `model_id`, `allowed_tools`, `memory`, `environment_variables`, `max_iterations`, `timeout_seconds` — más el rol de ejecución y la ubicación de VPC. Terraform no tiene un equivalente de la propagación de props del constructo CDK, por lo que los campos nativos del proveedor restantes se configuran editando el recurso `aws_bedrockagentcore_harness` en `packages/common/terraform/src/app/harnesses/<name>/<name>.tf`: proveedores de modelos alternativos (`gemini_model_config`, `openai_model_config`), bloques `tool`, bloques `skill`, `environment_artifact`, configuración de sistema de archivos y ciclo de vida bajo `environment`, `truncation`, y `authorizer_configuration` con un `custom_jwt_authorizer`.
   </Fragment>
 </Infrastructure>
 
@@ -216,8 +221,7 @@ new MyHarness(this, 'Harness', { allowedTools: ['@builtin'] });
   <Fragment slot="terraform">
 ```hcl title="packages/infra/src/main.tf"
 module "my_harness" {
-  source = "../../common/terraform/src/app/harnesses/my-harness"
-
+  source        = "../../common/terraform/src/app/harnesses/my-harness"
   allowed_tools = ["@builtin"]
 }
 ```
@@ -225,6 +229,36 @@ module "my_harness" {
 </Infrastructure>
 
 Reduce `@builtin` a patrones específicos como `@builtin/file_operations` para restringir lo que el bucle de agente puede hacer. Consulta [Herramientas de Harness](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/harness-tools.html) para las herramientas integradas que puedes agregar.
+
+### Configurar memoria
+
+El servicio aprovisiona memoria administrada para el Harness de forma predeterminada, y al rol de ejecución generado se le otorga acceso a ella — limitado al ARN de memoria que el servicio asigna, y solo otorgado mientras el Harness usa la memoria administrada que la infraestructura creó. Configura la memoria explícitamente para ajustar esa memoria administrada, apuntar el Harness a un recurso de memoria que posees, o desactivar la memoria:
+
+<Infrastructure>
+  <Fragment slot="cdk">
+```ts
+new MyHarness(this, 'MyHarness', {
+  memory: { managedMemoryConfiguration: { strategies: ['SUMMARIZATION'] } },
+});
+```
+
+Proporcionar `memory` en absoluto reemplaza la memoria administrada predeterminada, por lo que el constructo deja el permiso de memoria fuera del rol de ejecución: agrega lo que la configuración necesite con `addToRolePolicy`.
+  </Fragment>
+  <Fragment slot="terraform">
+```hcl
+module "my_harness" {
+  source = "../../common/terraform/src/app/harnesses/my-harness"
+  memory = {
+    managed_memory_configuration = {
+      strategies = ["SUMMARIZATION"]
+    }
+  }
+}
+```
+
+Establece exactamente uno de `managed_memory_configuration` (ajustar la memoria administrada del servicio), `agentcore_memory_configuration` (usar un recurso de memoria que posees, por ARN) o `disabled` (sin memoria). Elegir `agentcore_memory_configuration` o `disabled` elimina el permiso de memoria administrada del rol de ejecución; para tu propio recurso de memoria, otorga acceso a través de `additional_execution_role_policy_statements`.
+  </Fragment>
+</Infrastructure>
 
 ### Ejecutar en una VPC
 
@@ -241,28 +275,31 @@ database.connections.allowDefaultPortFrom(harness, 'Harness to database');
 El Harness se coloca en las subredes privadas de la VPC con salida, en un grupo de seguridad creado para él. Anula cualquiera de los dos con `vpcSubnets` y `securityGroups`. Ambos requieren `vpc`, y `connections` solo está disponible cuando el Harness se ejecuta en una VPC.
   </Fragment>
   <Fragment slot="terraform">
-Agrega un bloque `network_configuration` al `environment.agent_core_runtime_environment` del recurso `aws_bedrockagentcore_harness` generado, luego referencia el grupo de seguridad en el que lo colocas desde las reglas de tus otros recursos:
+Establece `enable_vpc` junto con `vpc_id` y `subnet_ids` para ejecutar el Harness dentro de una VPC, de modo que pueda alcanzar recursos privados como una base de datos:
 
-```hcl title="packages/common/terraform/src/app/harnesses/my-harness/my-harness.tf"
-resource "aws_security_group" "harness" {
-  vpc_id = var.vpc_id
-}
-
-resource "aws_bedrockagentcore_harness" "this" {
-  # ...
-  environment {
-    agent_core_runtime_environment {
-      network_configuration {
-        network_mode = "VPC"
-        network_mode_config {
-          security_groups = [aws_security_group.harness.id]
-          subnets         = var.subnet_ids
-        }
-      }
-    }
-  }
+```hcl
+module "my_harness" {
+  source     = "../../common/terraform/src/app/harnesses/my-harness"
+  enable_vpc = true
+  vpc_id     = var.vpc_id
+  subnet_ids = var.private_subnet_ids
 }
 ```
+
+El módulo crea un grupo de seguridad para el Harness, permitiendo solo HTTPS saliente. Su salida `security_group_id` es lo que los recursos que el Harness debe alcanzar referencian en sus propias reglas de entrada:
+
+```hcl
+resource "aws_vpc_security_group_ingress_rule" "harness_to_database" {
+  security_group_id            = aws_security_group.database.id
+  referenced_security_group_id = module.my_harness.security_group_id
+  from_port                    = 5432
+  to_port                      = 5432
+  ip_protocol                  = "tcp"
+  description                  = "Harness to database"
+}
+```
+
+`security_group_id` es nulo a menos que `enable_vpc` sea verdadero, y `vpc_id` y `subnet_ids` son ambos requeridos cuando lo es.
   </Fragment>
 </Infrastructure>
 

--- a/docs/src/content/docs/fr/guides/agentcore-harness.mdx
+++ b/docs/src/content/docs/fr/guides/agentcore-harness.mdx
@@ -112,16 +112,21 @@ module "my_harness" {
 }
 ```
 
-Le module expose quatre variables :
+Le module expose les variables suivantes :
 
 - `model_id` — le modèle Bedrock ou le profil d'inférence que le Harness utilise par défaut.
 - `allowed_tools` — les outils que le Harness peut utiliser. Par défaut aucun, voir <a href="#configuring-tools">Configuration des outils</a>.
-- `model_resource_arns` — les ARN de modèle Bedrock et de profil d'inférence que le rôle d'exécution peut invoquer, remplaçant la liste par défaut.
-- `additional_execution_role_policy_statements` — une liste d'objets d'instruction IAM (`Effect`, `Action`, `Resource`, `Sid` et `Condition` optionnels) ajoutés à la politique du rôle d'exécution.
+- `memory` — la configuration de mémoire du Harness, voir <a href="#configuring-memory">Configuration de la mémoire</a>.
+- `environment_variables`, `max_iterations`, `timeout_seconds` — les champs Harness natifs correspondants.
+- `execution_role_arn` — un rôle IAM existant à utiliser au lieu du rôle généré. Un rôle fourni est utilisé tel quel : ni le rôle ni sa politique de base ne sont créés, donc `model_resource_arns` et `additional_execution_role_policy_statements` ne peuvent pas être combinés avec lui.
+- `model_resource_arns` — les ARN de modèle Bedrock et de profil d'inférence que le rôle d'exécution généré peut invoquer, remplaçant la liste par défaut.
+- `additional_execution_role_policy_statements` — une liste d'objets d'instruction IAM (`Effect`, `Action`, `Resource`, `Sid` et `Condition` optionnels) ajoutés à la politique du rôle d'exécution généré.
+- `enable_vpc`, `vpc_id`, `subnet_ids` — exécutez le Harness dans un VPC afin qu'il puisse atteindre des ressources privées, voir <a href="#running-in-a-vpc">Exécution dans un VPC</a>.
+- `tags` — balises appliquées aux ressources que le module crée.
 
-Tout le reste est configuré sur la ressource `aws_bedrockagentcore_harness` générée dans le module lui-même.
+Les autres champs natifs du fournisseur sont configurés en modifiant la ressource `aws_bedrockagentcore_harness` générée dans le module lui-même, voir <a href="#customizing-your-harness">Personnaliser votre Harness</a>.
 
-Le module produit `harness_id`, `harness_arn` et `execution_role_arn`.
+Le module produit `harness_id`, `harness_arn`, `execution_role_arn` et `security_group_id`.
 
 Déployez avec le flux de travail plan/apply de votre projet Terraform comme d'habitude — voir le <Link path="guides/terraform-project">guide de projet Terraform</Link>.
   </Fragment>
@@ -197,7 +202,7 @@ Si aucun n'est défini, le script échoue avec une erreur nommant les deux optio
 Chaque propriété Harness native du module `aws-cdk-lib/aws-bedrockagentcore` épinglé est disponible via les props du construct — fournisseurs de modèles alternatifs, définitions d'outils, mémoire, compétences, configuration d'environnement, troncature, autorisation JWT personnalisée et limites d'exécution — et les props explicites ont la priorité sur les valeurs par défaut générées. Alternativement, modifiez le construct généré dans `packages/common/constructs/src/app/harnesses/<name>/<name>.ts`.
   </Fragment>
   <Fragment slot="terraform">
-Le module généré garde la ressource native `aws_bedrockagentcore_harness` directement modifiable, donc les champs natifs du fournisseur — fournisseurs de modèles alternatifs (`gemini_model_config`, `openai_model_config`), blocs `tool`, `memory`, blocs `skill`, environnements (`environment`, `environment_variables`, `environment_artifact`), `truncation` et `authorizer_configuration` avec un `custom_jwt_authorizer` — sont configurés en modifiant `packages/common/terraform/src/app/harnesses/<name>/<name>.tf`.
+Les variables du module couvrent les champs que la plupart des déploiements configurent — `model_id`, `allowed_tools`, `memory`, `environment_variables`, `max_iterations`, `timeout_seconds` — plus le rôle d'exécution et le placement VPC. Terraform n'a pas d'équivalent à la propagation de props du construct CDK, donc les champs natifs du fournisseur restants sont configurés en modifiant la ressource `aws_bedrockagentcore_harness` dans `packages/common/terraform/src/app/harnesses/<name>/<name>.tf` : fournisseurs de modèles alternatifs (`gemini_model_config`, `openai_model_config`), blocs `tool`, blocs `skill`, `environment_artifact`, configuration du système de fichiers et du cycle de vie sous `environment`, `truncation`, et `authorizer_configuration` avec un `custom_jwt_authorizer`.
   </Fragment>
 </Infrastructure>
 
@@ -216,8 +221,7 @@ new MyHarness(this, 'Harness', { allowedTools: ['@builtin'] });
   <Fragment slot="terraform">
 ```hcl title="packages/infra/src/main.tf"
 module "my_harness" {
-  source = "../../common/terraform/src/app/harnesses/my-harness"
-
+  source        = "../../common/terraform/src/app/harnesses/my-harness"
   allowed_tools = ["@builtin"]
 }
 ```
@@ -225,6 +229,36 @@ module "my_harness" {
 </Infrastructure>
 
 Restreignez `@builtin` à des modèles spécifiques tels que `@builtin/file_operations` pour limiter ce que la boucle d'agent peut faire. Voir [Outils Harness](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/harness-tools.html) pour les outils intégrés que vous pouvez ajouter.
+
+### Configuration de la mémoire
+
+Le service provisionne une mémoire gérée pour le Harness par défaut, et le rôle d'exécution généré se voit accorder l'accès à celle-ci — limité à l'ARN de mémoire que le service attribue, et accordé uniquement tant que le Harness utilise la mémoire gérée que l'infrastructure a créée. Configurez la mémoire explicitement pour ajuster cette mémoire gérée, pointer le Harness vers une ressource de mémoire que vous possédez, ou désactiver la mémoire :
+
+<Infrastructure>
+  <Fragment slot="cdk">
+```ts
+new MyHarness(this, 'MyHarness', {
+  memory: { managedMemoryConfiguration: { strategies: ['SUMMARIZATION'] } },
+});
+```
+
+Fournir `memory` remplace la mémoire gérée par défaut, donc le construct n'ajoute pas l'autorisation de mémoire au rôle d'exécution : ajoutez ce dont la configuration a besoin avec `addToRolePolicy`.
+  </Fragment>
+  <Fragment slot="terraform">
+```hcl
+module "my_harness" {
+  source = "../../common/terraform/src/app/harnesses/my-harness"
+  memory = {
+    managed_memory_configuration = {
+      strategies = ["SUMMARIZATION"]
+    }
+  }
+}
+```
+
+Définissez exactement l'un de `managed_memory_configuration` (ajuster la mémoire gérée du service), `agentcore_memory_configuration` (utiliser une ressource de mémoire que vous possédez, par ARN) ou `disabled` (pas de mémoire). Choisir `agentcore_memory_configuration` ou `disabled` supprime l'autorisation de mémoire gérée du rôle d'exécution ; pour votre propre ressource de mémoire, accordez l'accès via `additional_execution_role_policy_statements`.
+  </Fragment>
+</Infrastructure>
 
 ### Exécution dans un VPC
 
@@ -241,28 +275,31 @@ database.connections.allowDefaultPortFrom(harness, 'Harness to database');
 Le Harness est placé dans les sous-réseaux privés du VPC avec sortie, dans un groupe de sécurité créé pour lui. Remplacez l'un ou l'autre avec `vpcSubnets` et `securityGroups`. Les deux nécessitent `vpc`, et `connections` n'est disponible que lorsque le Harness s'exécute dans un VPC.
   </Fragment>
   <Fragment slot="terraform">
-Ajoutez un bloc `network_configuration` à l'`environment.agent_core_runtime_environment` de la ressource `aws_bedrockagentcore_harness` générée, puis référencez le groupe de sécurité dans lequel vous le placez depuis les règles de vos autres ressources :
+Définissez `enable_vpc` avec `vpc_id` et `subnet_ids` pour exécuter le Harness dans un VPC, afin qu'il puisse atteindre des ressources privées telles qu'une base de données :
 
-```hcl title="packages/common/terraform/src/app/harnesses/my-harness/my-harness.tf"
-resource "aws_security_group" "harness" {
-  vpc_id = var.vpc_id
-}
-
-resource "aws_bedrockagentcore_harness" "this" {
-  # ...
-  environment {
-    agent_core_runtime_environment {
-      network_configuration {
-        network_mode = "VPC"
-        network_mode_config {
-          security_groups = [aws_security_group.harness.id]
-          subnets         = var.subnet_ids
-        }
-      }
-    }
-  }
+```hcl
+module "my_harness" {
+  source     = "../../common/terraform/src/app/harnesses/my-harness"
+  enable_vpc = true
+  vpc_id     = var.vpc_id
+  subnet_ids = var.private_subnet_ids
 }
 ```
+
+Le module crée un groupe de sécurité pour le Harness, autorisant uniquement le HTTPS sortant. Sa sortie `security_group_id` est ce que les ressources que le Harness doit atteindre référencent dans leurs propres règles d'entrée :
+
+```hcl
+resource "aws_vpc_security_group_ingress_rule" "harness_to_database" {
+  security_group_id            = aws_security_group.database.id
+  referenced_security_group_id = module.my_harness.security_group_id
+  from_port                    = 5432
+  to_port                      = 5432
+  ip_protocol                  = "tcp"
+  description                  = "Harness to database"
+}
+```
+
+`security_group_id` est null sauf si `enable_vpc` est true, et `vpc_id` et `subnet_ids` sont tous deux requis lorsqu'il l'est.
   </Fragment>
 </Infrastructure>
 

--- a/docs/src/content/docs/it/guides/agentcore-harness.mdx
+++ b/docs/src/content/docs/it/guides/agentcore-harness.mdx
@@ -112,16 +112,21 @@ module "my_harness" {
 }
 ```
 
-Il modulo espone quattro variabili:
+Il modulo espone le seguenti variabili:
 
 - `model_id` — il modello Bedrock o il profilo di inferenza che l'Harness utilizza per impostazione predefinita.
 - `allowed_tools` — gli strumenti che l'Harness può utilizzare. Il valore predefinito è nessuno, vedi <a href="#configuring-tools">Configurazione degli strumenti</a>.
-- `model_resource_arns` — gli ARN del modello Bedrock e del profilo di inferenza che il ruolo di esecuzione può invocare, sostituendo l'elenco predefinito.
-- `additional_execution_role_policy_statements` — un elenco di oggetti di istruzione IAM (`Effect`, `Action`, `Resource`, `Sid` e `Condition` opzionali) aggiunti alla policy del ruolo di esecuzione.
+- `memory` — la configurazione della memoria dell'Harness, vedi <a href="#configuring-memory">Configurazione della memoria</a>.
+- `environment_variables`, `max_iterations`, `timeout_seconds` — i corrispondenti campi nativi dell'Harness.
+- `execution_role_arn` — un ruolo IAM esistente da utilizzare al posto del ruolo generato. Un ruolo fornito viene utilizzato così com'è: né il ruolo né la sua policy di base vengono creati, quindi `model_resource_arns` e `additional_execution_role_policy_statements` non possono essere combinati con esso.
+- `model_resource_arns` — gli ARN del modello Bedrock e del profilo di inferenza che il ruolo di esecuzione generato può invocare, sostituendo l'elenco predefinito.
+- `additional_execution_role_policy_statements` — un elenco di oggetti di istruzione IAM (`Effect`, `Action`, `Resource`, `Sid` e `Condition` opzionali) aggiunti alla policy del ruolo di esecuzione generato.
+- `enable_vpc`, `vpc_id`, `subnet_ids` — esegui l'Harness in un VPC in modo che possa raggiungere risorse private, vedi <a href="#running-in-a-vpc">Esecuzione in un VPC</a>.
+- `tags` — tag applicati alle risorse create dal modulo.
 
-Tutto il resto è configurato sulla risorsa `aws_bedrockagentcore_harness` generata nel modulo stesso.
+Gli altri campi nativi del provider sono configurati modificando la risorsa `aws_bedrockagentcore_harness` generata nel modulo stesso, vedi <a href="#customizing-your-harness">Personalizzazione del tuo Harness</a>.
 
-Il modulo restituisce `harness_id`, `harness_arn` e `execution_role_arn`.
+Il modulo restituisce `harness_id`, `harness_arn`, `execution_role_arn` e `security_group_id`.
 
 Distribuisci con il consueto flusso di lavoro plan/apply del tuo progetto Terraform — vedi la <Link path="guides/terraform-project">guida al progetto Terraform</Link>.
   </Fragment>
@@ -197,7 +202,7 @@ Se nessuno dei due è impostato, lo script fallisce con un errore che nomina ent
 Ogni proprietà nativa dell'Harness del modulo `aws-cdk-lib/aws-bedrockagentcore` bloccato è disponibile attraverso le props del costrutto — provider di modelli alternativi, definizioni di strumenti, memoria, competenze, configurazione dell'ambiente, troncamento, autorizzazione JWT personalizzata e limiti di esecuzione — e le props esplicite hanno la precedenza sui valori predefiniti generati. In alternativa, modifica il costrutto generato in `packages/common/constructs/src/app/harnesses/<name>/<name>.ts`.
   </Fragment>
   <Fragment slot="terraform">
-Il modulo generato mantiene la risorsa nativa `aws_bedrockagentcore_harness` direttamente modificabile, quindi i campi nativi del provider — provider di modelli alternativi (`gemini_model_config`, `openai_model_config`), blocchi `tool`, `memory`, blocchi `skill`, ambienti (`environment`, `environment_variables`, `environment_artifact`), `truncation` e `authorizer_configuration` con un `custom_jwt_authorizer` — sono configurati modificando `packages/common/terraform/src/app/harnesses/<name>/<name>.tf`.
+Le variabili del modulo coprono i campi che la maggior parte delle distribuzioni configura — `model_id`, `allowed_tools`, `memory`, `environment_variables`, `max_iterations`, `timeout_seconds` — più il ruolo di esecuzione e il posizionamento VPC. Terraform non ha un equivalente dello spread delle props del costrutto CDK, quindi i restanti campi nativi del provider sono configurati modificando la risorsa `aws_bedrockagentcore_harness` in `packages/common/terraform/src/app/harnesses/<name>/<name>.tf`: provider di modelli alternativi (`gemini_model_config`, `openai_model_config`), blocchi `tool`, blocchi `skill`, `environment_artifact`, configurazione del filesystem e del ciclo di vita sotto `environment`, `truncation` e `authorizer_configuration` con un `custom_jwt_authorizer`.
   </Fragment>
 </Infrastructure>
 
@@ -216,8 +221,7 @@ new MyHarness(this, 'Harness', { allowedTools: ['@builtin'] });
   <Fragment slot="terraform">
 ```hcl title="packages/infra/src/main.tf"
 module "my_harness" {
-  source = "../../common/terraform/src/app/harnesses/my-harness"
-
+  source        = "../../common/terraform/src/app/harnesses/my-harness"
   allowed_tools = ["@builtin"]
 }
 ```
@@ -225,6 +229,36 @@ module "my_harness" {
 </Infrastructure>
 
 Restringi `@builtin` a pattern specifici come `@builtin/file_operations` per limitare ciò che il ciclo dell'agente può fare. Vedi [Strumenti Harness](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/harness-tools.html) per gli strumenti integrati che puoi aggiungere.
+
+### Configurazione della memoria
+
+Il servizio fornisce memoria gestita per l'Harness per impostazione predefinita, e al ruolo di esecuzione generato viene concesso l'accesso ad essa — limitato all'ARN della memoria che il servizio assegna, e concesso solo mentre l'Harness utilizza la memoria gestita creata dall'infrastruttura. Configura la memoria esplicitamente per ottimizzare quella memoria gestita, puntare l'Harness a una risorsa di memoria che possiedi o disattivare la memoria:
+
+<Infrastructure>
+  <Fragment slot="cdk">
+```ts
+new MyHarness(this, 'MyHarness', {
+  memory: { managedMemoryConfiguration: { strategies: ['SUMMARIZATION'] } },
+});
+```
+
+Fornire `memory` sostituisce completamente la memoria gestita predefinita, quindi il costrutto non include la concessione di memoria nel ruolo di esecuzione: aggiungi ciò di cui la configurazione ha bisogno con `addToRolePolicy`.
+  </Fragment>
+  <Fragment slot="terraform">
+```hcl
+module "my_harness" {
+  source = "../../common/terraform/src/app/harnesses/my-harness"
+  memory = {
+    managed_memory_configuration = {
+      strategies = ["SUMMARIZATION"]
+    }
+  }
+}
+```
+
+Imposta esattamente uno tra `managed_memory_configuration` (ottimizza la memoria gestita del servizio), `agentcore_memory_configuration` (usa una risorsa di memoria che possiedi, tramite ARN) o `disabled` (nessuna memoria). Scegliere `agentcore_memory_configuration` o `disabled` rimuove la concessione di memoria gestita dal ruolo di esecuzione; per la tua risorsa di memoria, concedi l'accesso tramite `additional_execution_role_policy_statements`.
+  </Fragment>
+</Infrastructure>
 
 ### Esecuzione in un VPC
 
@@ -241,28 +275,31 @@ database.connections.allowDefaultPortFrom(harness, 'Harness to database');
 L'Harness viene posizionato nelle subnet private del VPC con egress, in un gruppo di sicurezza creato per esso. Sovrascrivi uno dei due con `vpcSubnets` e `securityGroups`. Entrambi richiedono `vpc`, e `connections` è disponibile solo quando l'Harness viene eseguito in un VPC.
   </Fragment>
   <Fragment slot="terraform">
-Aggiungi un blocco `network_configuration` all'`environment.agent_core_runtime_environment` della risorsa `aws_bedrockagentcore_harness` generata, quindi fai riferimento al gruppo di sicurezza in cui lo posizioni dalle regole delle tue altre risorse:
+Imposta `enable_vpc` insieme a `vpc_id` e `subnet_ids` per eseguire l'Harness all'interno di un VPC, in modo che possa raggiungere risorse private come un database:
 
-```hcl title="packages/common/terraform/src/app/harnesses/my-harness/my-harness.tf"
-resource "aws_security_group" "harness" {
-  vpc_id = var.vpc_id
-}
-
-resource "aws_bedrockagentcore_harness" "this" {
-  # ...
-  environment {
-    agent_core_runtime_environment {
-      network_configuration {
-        network_mode = "VPC"
-        network_mode_config {
-          security_groups = [aws_security_group.harness.id]
-          subnets         = var.subnet_ids
-        }
-      }
-    }
-  }
+```hcl
+module "my_harness" {
+  source     = "../../common/terraform/src/app/harnesses/my-harness"
+  enable_vpc = true
+  vpc_id     = var.vpc_id
+  subnet_ids = var.private_subnet_ids
 }
 ```
+
+Il modulo crea un gruppo di sicurezza per l'Harness, consentendo solo HTTPS in uscita. Il suo output `security_group_id` è ciò a cui le risorse che l'Harness deve raggiungere fanno riferimento nelle proprie regole di ingresso:
+
+```hcl
+resource "aws_vpc_security_group_ingress_rule" "harness_to_database" {
+  security_group_id            = aws_security_group.database.id
+  referenced_security_group_id = module.my_harness.security_group_id
+  from_port                    = 5432
+  to_port                      = 5432
+  ip_protocol                  = "tcp"
+  description                  = "Harness to database"
+}
+```
+
+`security_group_id` è null a meno che `enable_vpc` non sia true, e `vpc_id` e `subnet_ids` sono entrambi richiesti quando lo è.
   </Fragment>
 </Infrastructure>
 

--- a/docs/src/content/docs/jp/guides/agentcore-harness.mdx
+++ b/docs/src/content/docs/jp/guides/agentcore-harness.mdx
@@ -112,16 +112,21 @@ module "my_harness" {
 }
 ```
 
-モジュールは4つの変数を公開します。
+モジュールは以下の変数を公開します。
 
 - `model_id` — Harnessがデフォルトで使用するBedrockモデルまたは推論プロファイル。
 - `allowed_tools` — Harnessが使用できるツール。デフォルトではなし。<a href="#configuring-tools">ツールの構成</a>を参照してください。
-- `model_resource_arns` — 実行ロールが呼び出せるBedrockモデルおよび推論プロファイルARN。デフォルトリストを置き換えます。
-- `additional_execution_role_policy_statements` — 実行ロールポリシーに追加されるIAMステートメントオブジェクト（`Effect`、`Action`、`Resource`、オプションの`Sid`と`Condition`）のリスト。
+- `memory` — Harnessメモリ構成。<a href="#configuring-memory">メモリの構成</a>を参照してください。
+- `environment_variables`、`max_iterations`、`timeout_seconds` — 対応するネイティブHarnessフィールド。
+- `execution_role_arn` — 生成されたロールの代わりに使用する既存のIAMロール。指定されたロールはそのまま使用されます。ロールもそのベースラインポリシーも作成されないため、`model_resource_arns`と`additional_execution_role_policy_statements`を組み合わせることはできません。
+- `model_resource_arns` — 生成された実行ロールが呼び出せるBedrockモデルおよび推論プロファイルARN。デフォルトリストを置き換えます。
+- `additional_execution_role_policy_statements` — 生成された実行ロールポリシーに追加されるIAMステートメントオブジェクト（`Effect`、`Action`、`Resource`、オプションの`Sid`と`Condition`）のリスト。
+- `enable_vpc`、`vpc_id`、`subnet_ids` — HarnessをVPC内で実行し、プライベートリソースに到達できるようにします。<a href="#running-in-a-vpc">VPCでの実行</a>を参照してください。
+- `tags` — モジュールが作成するリソースに適用されるタグ。
 
-その他すべては、モジュール自体の生成された`aws_bedrockagentcore_harness`リソースで構成されます。
+その他のプロバイダーネイティブフィールドは、モジュール自体の生成された`aws_bedrockagentcore_harness`リソースを編集することで構成されます。<a href="#customizing-your-harness">Harnessのカスタマイズ</a>を参照してください。
 
-モジュールは`harness_id`、`harness_arn`、`execution_role_arn`を出力します。
+モジュールは`harness_id`、`harness_arn`、`execution_role_arn`、`security_group_id`を出力します。
 
 通常どおりTerraformプロジェクトのplan/applyワークフローでデプロイします。<Link path="guides/terraform-project">Terraformプロジェクトガイド</Link>を参照してください。
   </Fragment>
@@ -197,7 +202,7 @@ Harness ARNは次の順序で解決されます。
 固定された`aws-cdk-lib/aws-bedrockagentcore`モジュールのすべてのネイティブHarnessプロパティは、コンストラクトのpropsを通じて利用可能です。代替モデルプロバイダー、ツール定義、メモリ、スキル、環境構成、トランケーション、カスタムJWT認証、実行制限などがあり、明示的なpropsは生成されたデフォルトよりも優先されます。または、`packages/common/constructs/src/app/harnesses/<name>/<name>.ts`で生成されたコンストラクトを編集します。
   </Fragment>
   <Fragment slot="terraform">
-生成されたモジュールは、ネイティブ`aws_bedrockagentcore_harness`リソースを直接編集可能に保つため、プロバイダーネイティブフィールド（代替モデルプロバイダー（`gemini_model_config`、`openai_model_config`）、`tool`ブロック、`memory`、`skill`ブロック、環境（`environment`、`environment_variables`、`environment_artifact`）、`truncation`、`custom_jwt_authorizer`を持つ`authorizer_configuration`）は、`packages/common/terraform/src/app/harnesses/<name>/<name>.tf`を編集することで構成されます。
+モジュールの変数は、ほとんどのデプロイメントが構成するフィールド（`model_id`、`allowed_tools`、`memory`、`environment_variables`、`max_iterations`、`timeout_seconds`）と、実行ロールおよびVPC配置をカバーしています。TerraformにはCDKコンストラクトのpropスプレッドに相当するものがないため、残りのプロバイダーネイティブフィールドは、`packages/common/terraform/src/app/harnesses/<name>/<name>.tf`の`aws_bedrockagentcore_harness`リソースを編集することで構成されます。代替モデルプロバイダー（`gemini_model_config`、`openai_model_config`）、`tool`ブロック、`skill`ブロック、`environment_artifact`、`environment`下のファイルシステムとライフサイクル構成、`truncation`、`custom_jwt_authorizer`を持つ`authorizer_configuration`などです。
   </Fragment>
 </Infrastructure>
 
@@ -216,8 +221,7 @@ new MyHarness(this, 'Harness', { allowedTools: ['@builtin'] });
   <Fragment slot="terraform">
 ```hcl title="packages/infra/src/main.tf"
 module "my_harness" {
-  source = "../../common/terraform/src/app/harnesses/my-harness"
-
+  source        = "../../common/terraform/src/app/harnesses/my-harness"
   allowed_tools = ["@builtin"]
 }
 ```
@@ -225,6 +229,36 @@ module "my_harness" {
 </Infrastructure>
 
 `@builtin`を`@builtin/file_operations`などの特定のパターンに絞り込んで、エージェントループができることを制限します。追加できる組み込みツールについては、[Harnessツール](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/harness-tools.html)を参照してください。
+
+### メモリの構成
+
+サービスはデフォルトでHarness用のマネージドメモリをプロビジョニングし、生成された実行ロールにはそれへのアクセスが許可されます。サービスが割り当てるメモリARNにスコープされ、インフラストラクチャが作成したマネージドメモリをHarnessが使用している間のみ許可されます。メモリを明示的に構成して、そのマネージドメモリを調整したり、所有するメモリリソースにHarnessを向けたり、メモリをオフにしたりできます。
+
+<Infrastructure>
+  <Fragment slot="cdk">
+```ts
+new MyHarness(this, 'MyHarness', {
+  memory: { managedMemoryConfiguration: { strategies: ['SUMMARIZATION'] } },
+});
+```
+
+`memory`を指定すると、デフォルトのマネージドメモリが置き換えられるため、コンストラクトは実行ロールからメモリ許可を除外します。構成に必要なものを`addToRolePolicy`で追加してください。
+  </Fragment>
+  <Fragment slot="terraform">
+```hcl
+module "my_harness" {
+  source = "../../common/terraform/src/app/harnesses/my-harness"
+  memory = {
+    managed_memory_configuration = {
+      strategies = ["SUMMARIZATION"]
+    }
+  }
+}
+```
+
+`managed_memory_configuration`（サービスのマネージドメモリを調整）、`agentcore_memory_configuration`（所有するメモリリソースをARNで使用）、`disabled`（メモリなし）のいずれか1つを正確に設定します。`agentcore_memory_configuration`または`disabled`を選択すると、実行ロールからマネージドメモリ許可が削除されます。独自のメモリリソースの場合は、`additional_execution_role_policy_statements`を通じてアクセスを許可します。
+  </Fragment>
+</Infrastructure>
 
 ### VPCでの実行
 
@@ -241,28 +275,31 @@ database.connections.allowDefaultPortFrom(harness, 'Harness to database');
 Harnessは、VPCのプライベートサブネット（エグレス付き）に配置され、専用のセキュリティグループに入れられます。`vpcSubnets`と`securityGroups`でいずれかをオーバーライドできます。両方とも`vpc`が必要で、`connections`はHarnessがVPC内で実行されている場合にのみ利用可能です。
   </Fragment>
   <Fragment slot="terraform">
-生成された`aws_bedrockagentcore_harness`リソースの`environment.agent_core_runtime_environment`に`network_configuration`ブロックを追加し、配置したセキュリティグループを他のリソースのルールから参照します。
+`enable_vpc`を`vpc_id`および`subnet_ids`と一緒に設定して、HarnessをVPC内で実行し、データベースなどのプライベートリソースに到達できるようにします。
 
-```hcl title="packages/common/terraform/src/app/harnesses/my-harness/my-harness.tf"
-resource "aws_security_group" "harness" {
-  vpc_id = var.vpc_id
-}
-
-resource "aws_bedrockagentcore_harness" "this" {
-  # ...
-  environment {
-    agent_core_runtime_environment {
-      network_configuration {
-        network_mode = "VPC"
-        network_mode_config {
-          security_groups = [aws_security_group.harness.id]
-          subnets         = var.subnet_ids
-        }
-      }
-    }
-  }
+```hcl
+module "my_harness" {
+  source     = "../../common/terraform/src/app/harnesses/my-harness"
+  enable_vpc = true
+  vpc_id     = var.vpc_id
+  subnet_ids = var.private_subnet_ids
 }
 ```
+
+モジュールはHarness用のセキュリティグループを作成し、アウトバウンドHTTPSのみを許可します。その`security_group_id`出力は、Harnessが到達する必要があるリソースが独自のイングレスルールで参照するものです。
+
+```hcl
+resource "aws_vpc_security_group_ingress_rule" "harness_to_database" {
+  security_group_id            = aws_security_group.database.id
+  referenced_security_group_id = module.my_harness.security_group_id
+  from_port                    = 5432
+  to_port                      = 5432
+  ip_protocol                  = "tcp"
+  description                  = "Harness to database"
+}
+```
+
+`security_group_id`は、`enable_vpc`がtrueでない限りnullであり、`vpc_id`と`subnet_ids`はtrueの場合に両方とも必要です。
   </Fragment>
 </Infrastructure>
 

--- a/docs/src/content/docs/ko/guides/agentcore-harness.mdx
+++ b/docs/src/content/docs/ko/guides/agentcore-harness.mdx
@@ -112,16 +112,21 @@ module "my_harness" {
 }
 ```
 
-모듈은 네 가지 변수를 노출합니다:
+모듈은 다음 변수를 노출합니다:
 
 - `model_id` — Harness가 기본적으로 사용하는 Bedrock 모델 또는 추론 프로필.
 - `allowed_tools` — Harness가 사용할 수 있는 도구. 기본값은 없음입니다. <a href="#configuring-tools">도구 구성</a>을 참조하세요.
-- `model_resource_arns` — 실행 역할이 호출할 수 있는 Bedrock 모델 및 추론 프로필 ARN으로, 기본 목록을 대체합니다.
-- `additional_execution_role_policy_statements` — 실행 역할 정책에 추가되는 IAM 문 객체 목록(`Effect`, `Action`, `Resource`, 선택적 `Sid` 및 `Condition`).
+- `memory` — Harness 메모리 구성. <a href="#configuring-memory">메모리 구성</a>을 참조하세요.
+- `environment_variables`, `max_iterations`, `timeout_seconds` — 해당하는 네이티브 Harness 필드.
+- `execution_role_arn` — 생성된 역할 대신 사용할 기존 IAM 역할. 제공된 역할은 있는 그대로 사용됩니다: 역할과 기본 정책 모두 생성되지 않으므로 `model_resource_arns` 및 `additional_execution_role_policy_statements`와 함께 사용할 수 없습니다.
+- `model_resource_arns` — 생성된 실행 역할이 호출할 수 있는 Bedrock 모델 및 추론 프로필 ARN으로, 기본 목록을 대체합니다.
+- `additional_execution_role_policy_statements` — 생성된 실행 역할 정책에 추가되는 IAM 문 객체 목록(`Effect`, `Action`, `Resource`, 선택적 `Sid` 및 `Condition`).
+- `enable_vpc`, `vpc_id`, `subnet_ids` — VPC에서 Harness를 실행하여 프라이빗 리소스에 도달할 수 있도록 합니다. <a href="#running-in-a-vpc">VPC에서 실행</a>을 참조하세요.
+- `tags` — 모듈이 생성하는 리소스에 적용되는 태그.
 
-그 외의 모든 것은 모듈 자체의 생성된 `aws_bedrockagentcore_harness` 리소스에서 구성됩니다.
+다른 공급자 네이티브 필드는 모듈 자체의 생성된 `aws_bedrockagentcore_harness` 리소스를 편집하여 구성됩니다. <a href="#customizing-your-harness">Harness 사용자 정의</a>를 참조하세요.
 
-모듈은 `harness_id`, `harness_arn`, `execution_role_arn`을 출력합니다.
+모듈은 `harness_id`, `harness_arn`, `execution_role_arn` 및 `security_group_id`를 출력합니다.
 
 평소와 같이 Terraform 프로젝트의 plan/apply 워크플로로 배포하세요 — <Link path="guides/terraform-project">Terraform 프로젝트 가이드</Link>를 참조하세요.
   </Fragment>
@@ -197,7 +202,7 @@ Harness ARN은 다음 순서로 확인됩니다:
 고정된 `aws-cdk-lib/aws-bedrockagentcore` 모듈의 모든 네이티브 Harness 속성은 구성의 props를 통해 사용할 수 있습니다 — 대체 모델 공급자, 도구 정의, 메모리, 스킬, 환경 구성, 잘림, 사용자 정의 JWT 권한 부여 및 실행 제한 — 명시적 props는 생성된 기본값보다 우선합니다. 또는 `packages/common/constructs/src/app/harnesses/<name>/<name>.ts`에서 생성된 구성을 편집하세요.
   </Fragment>
   <Fragment slot="terraform">
-생성된 모듈은 네이티브 `aws_bedrockagentcore_harness` 리소스를 직접 편집 가능하게 유지하므로 공급자 네이티브 필드 — 대체 모델 공급자(`gemini_model_config`, `openai_model_config`), `tool` 블록, `memory`, `skill` 블록, 환경(`environment`, `environment_variables`, `environment_artifact`), `truncation`, `custom_jwt_authorizer`가 있는 `authorizer_configuration` — 은 `packages/common/terraform/src/app/harnesses/<name>/<name>.tf`를 편집하여 구성됩니다.
+모듈의 변수는 대부분의 배포가 구성하는 필드를 다룹니다 — `model_id`, `allowed_tools`, `memory`, `environment_variables`, `max_iterations`, `timeout_seconds` — 그리고 실행 역할 및 VPC 배치. Terraform에는 CDK 구성의 prop spread와 동등한 것이 없으므로 나머지 공급자 네이티브 필드는 `packages/common/terraform/src/app/harnesses/<name>/<name>.tf`의 `aws_bedrockagentcore_harness` 리소스를 편집하여 구성됩니다: 대체 모델 공급자(`gemini_model_config`, `openai_model_config`), `tool` 블록, `skill` 블록, `environment_artifact`, `environment` 아래의 파일 시스템 및 수명 주기 구성, `truncation`, `custom_jwt_authorizer`가 있는 `authorizer_configuration`.
   </Fragment>
 </Infrastructure>
 
@@ -216,8 +221,7 @@ new MyHarness(this, 'Harness', { allowedTools: ['@builtin'] });
   <Fragment slot="terraform">
 ```hcl title="packages/infra/src/main.tf"
 module "my_harness" {
-  source = "../../common/terraform/src/app/harnesses/my-harness"
-
+  source        = "../../common/terraform/src/app/harnesses/my-harness"
   allowed_tools = ["@builtin"]
 }
 ```
@@ -225,6 +229,36 @@ module "my_harness" {
 </Infrastructure>
 
 `@builtin`을 `@builtin/file_operations`와 같은 특정 패턴으로 좁혀 에이전트 루프가 수행할 수 있는 작업을 제한하세요. 추가할 수 있는 내장 도구는 [Harness tools](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/harness-tools.html)를 참조하세요.
+
+### 메모리 구성
+
+서비스는 기본적으로 Harness를 위한 관리형 메모리를 프로비저닝하며, 생성된 실행 역할에는 이에 대한 액세스 권한이 부여됩니다 — 서비스가 할당하는 메모리 ARN으로 범위가 지정되며, Harness가 인프라가 생성한 관리형 메모리를 사용하는 동안에만 부여됩니다. 관리형 메모리를 조정하거나, Harness를 소유한 메모리 리소스로 지정하거나, 메모리를 끄려면 메모리를 명시적으로 구성하세요:
+
+<Infrastructure>
+  <Fragment slot="cdk">
+```ts
+new MyHarness(this, 'MyHarness', {
+  memory: { managedMemoryConfiguration: { strategies: ['SUMMARIZATION'] } },
+});
+```
+
+`memory`를 제공하면 기본 관리형 메모리가 대체되므로 구성은 실행 역할에서 메모리 권한을 제외합니다: 구성에 필요한 것을 `addToRolePolicy`로 추가하세요.
+  </Fragment>
+  <Fragment slot="terraform">
+```hcl
+module "my_harness" {
+  source = "../../common/terraform/src/app/harnesses/my-harness"
+  memory = {
+    managed_memory_configuration = {
+      strategies = ["SUMMARIZATION"]
+    }
+  }
+}
+```
+
+`managed_memory_configuration`(서비스의 관리형 메모리 조정), `agentcore_memory_configuration`(ARN으로 소유한 메모리 리소스 사용) 또는 `disabled`(메모리 없음) 중 정확히 하나를 설정하세요. `agentcore_memory_configuration` 또는 `disabled`를 선택하면 실행 역할에서 관리형 메모리 권한이 제거됩니다. 자체 메모리 리소스의 경우 `additional_execution_role_policy_statements`를 통해 액세스 권한을 부여하세요.
+  </Fragment>
+</Infrastructure>
 
 ### VPC에서 실행
 
@@ -241,28 +275,31 @@ database.connections.allowDefaultPortFrom(harness, 'Harness to database');
 Harness는 VPC의 프라이빗 서브넷에 배치되며, 이를 위해 생성된 보안 그룹에 배치됩니다. `vpcSubnets` 및 `securityGroups`로 둘 중 하나를 재정의할 수 있습니다. 둘 다 `vpc`가 필요하며, `connections`는 Harness가 VPC에서 실행될 때만 사용할 수 있습니다.
   </Fragment>
   <Fragment slot="terraform">
-생성된 `aws_bedrockagentcore_harness` 리소스의 `environment.agent_core_runtime_environment`에 `network_configuration` 블록을 추가한 다음, 다른 리소스의 규칙에서 배치한 보안 그룹을 참조하세요:
+`enable_vpc`를 `vpc_id` 및 `subnet_ids`와 함께 설정하여 VPC 내에서 Harness를 실행하면 데이터베이스와 같은 프라이빗 리소스에 도달할 수 있습니다:
 
-```hcl title="packages/common/terraform/src/app/harnesses/my-harness/my-harness.tf"
-resource "aws_security_group" "harness" {
-  vpc_id = var.vpc_id
-}
-
-resource "aws_bedrockagentcore_harness" "this" {
-  # ...
-  environment {
-    agent_core_runtime_environment {
-      network_configuration {
-        network_mode = "VPC"
-        network_mode_config {
-          security_groups = [aws_security_group.harness.id]
-          subnets         = var.subnet_ids
-        }
-      }
-    }
-  }
+```hcl
+module "my_harness" {
+  source     = "../../common/terraform/src/app/harnesses/my-harness"
+  enable_vpc = true
+  vpc_id     = var.vpc_id
+  subnet_ids = var.private_subnet_ids
 }
 ```
+
+모듈은 Harness를 위한 보안 그룹을 생성하여 아웃바운드 HTTPS만 허용합니다. `security_group_id` 출력은 Harness가 도달해야 하는 리소스가 자체 인그레스 규칙에서 참조하는 것입니다:
+
+```hcl
+resource "aws_vpc_security_group_ingress_rule" "harness_to_database" {
+  security_group_id            = aws_security_group.database.id
+  referenced_security_group_id = module.my_harness.security_group_id
+  from_port                    = 5432
+  to_port                      = 5432
+  ip_protocol                  = "tcp"
+  description                  = "Harness to database"
+}
+```
+
+`security_group_id`는 `enable_vpc`가 true가 아니면 null이며, `vpc_id`와 `subnet_ids`는 true일 때 모두 필요합니다.
   </Fragment>
 </Infrastructure>
 

--- a/docs/src/content/docs/pt/guides/agentcore-harness.mdx
+++ b/docs/src/content/docs/pt/guides/agentcore-harness.mdx
@@ -112,16 +112,21 @@ module "my_harness" {
 }
 ```
 
-O módulo expõe quatro variáveis:
+O módulo expõe as seguintes variáveis:
 
 - `model_id` — o modelo Bedrock ou perfil de inferência que o Harness usa por padrão.
 - `allowed_tools` — as ferramentas que o Harness pode usar. O padrão é nenhuma, veja <a href="#configuring-tools">Configurando ferramentas</a>.
-- `model_resource_arns` — os ARNs de modelo e perfil de inferência do Bedrock que a função de execução pode invocar, substituindo a lista padrão.
-- `additional_execution_role_policy_statements` — uma lista de objetos de declaração IAM (`Effect`, `Action`, `Resource`, `Sid` e `Condition` opcionais) anexados à política da função de execução.
+- `memory` — a configuração de memória do Harness, veja <a href="#configuring-memory">Configurando memória</a>.
+- `environment_variables`, `max_iterations`, `timeout_seconds` — os campos nativos correspondentes do Harness.
+- `execution_role_arn` — uma função IAM existente para usar em vez da função gerada. Uma função fornecida é usada como está: nem a função nem sua política básica são criadas, então `model_resource_arns` e `additional_execution_role_policy_statements` não podem ser combinados com ela.
+- `model_resource_arns` — os ARNs de modelo e perfil de inferência do Bedrock que a função de execução gerada pode invocar, substituindo a lista padrão.
+- `additional_execution_role_policy_statements` — uma lista de objetos de declaração IAM (`Effect`, `Action`, `Resource`, `Sid` e `Condition` opcionais) anexados à política da função de execução gerada.
+- `enable_vpc`, `vpc_id`, `subnet_ids` — execute o Harness em uma VPC para que ele possa alcançar recursos privados, veja <a href="#running-in-a-vpc">Executando em uma VPC</a>.
+- `tags` — tags aplicadas aos recursos que o módulo cria.
 
-Todo o resto é configurado no recurso `aws_bedrockagentcore_harness` gerado no próprio módulo.
+Outros campos nativos do provedor são configurados editando o recurso `aws_bedrockagentcore_harness` gerado no próprio módulo, veja <a href="#customizing-your-harness">Customizando seu Harness</a>.
 
-O módulo produz `harness_id`, `harness_arn`, e `execution_role_arn`.
+O módulo produz `harness_id`, `harness_arn`, `execution_role_arn` e `security_group_id`.
 
 Implante com o fluxo de trabalho plan/apply do seu projeto Terraform como de costume — veja o <Link path="guides/terraform-project">guia de projeto Terraform</Link>.
   </Fragment>
@@ -197,7 +202,7 @@ Com nenhum definido, o script falha com um erro nomeando ambas as opções.
 Toda propriedade nativa do Harness do módulo fixado `aws-cdk-lib/aws-bedrockagentcore` está disponível através das props do construto — provedores de modelo alternativos, definições de ferramentas, memória, habilidades, configuração de ambiente, truncamento, autorização JWT personalizada e limites de execução — e props explícitas têm precedência sobre os padrões gerados. Alternativamente, edite o construto gerado em `packages/common/constructs/src/app/harnesses/<name>/<name>.ts`.
   </Fragment>
   <Fragment slot="terraform">
-O módulo gerado mantém o recurso nativo `aws_bedrockagentcore_harness` diretamente editável, então campos nativos do provedor — provedores de modelo alternativos (`gemini_model_config`, `openai_model_config`), blocos `tool`, `memory`, blocos `skill`, ambientes (`environment`, `environment_variables`, `environment_artifact`), `truncation`, e `authorizer_configuration` com um `custom_jwt_authorizer` — são configurados editando `packages/common/terraform/src/app/harnesses/<name>/<name>.tf`.
+As variáveis do módulo cobrem os campos que a maioria das implantações configura — `model_id`, `allowed_tools`, `memory`, `environment_variables`, `max_iterations`, `timeout_seconds` — além da função de execução e posicionamento VPC. O Terraform não tem equivalente ao spread de props do construto CDK, então os campos nativos do provedor restantes são configurados editando o recurso `aws_bedrockagentcore_harness` em `packages/common/terraform/src/app/harnesses/<name>/<name>.tf`: provedores de modelo alternativos (`gemini_model_config`, `openai_model_config`), blocos `tool`, blocos `skill`, `environment_artifact`, configuração de sistema de arquivos e ciclo de vida em `environment`, `truncation`, e `authorizer_configuration` com um `custom_jwt_authorizer`.
   </Fragment>
 </Infrastructure>
 
@@ -216,8 +221,7 @@ new MyHarness(this, 'Harness', { allowedTools: ['@builtin'] });
   <Fragment slot="terraform">
 ```hcl title="packages/infra/src/main.tf"
 module "my_harness" {
-  source = "../../common/terraform/src/app/harnesses/my-harness"
-
+  source        = "../../common/terraform/src/app/harnesses/my-harness"
   allowed_tools = ["@builtin"]
 }
 ```
@@ -225,6 +229,36 @@ module "my_harness" {
 </Infrastructure>
 
 Restrinja `@builtin` a padrões específicos como `@builtin/file_operations` para restringir o que o loop do agente pode fazer. Veja [Harness tools](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/harness-tools.html) para as ferramentas integradas que você pode adicionar.
+
+### Configurando memória
+
+O serviço provisiona memória gerenciada para o Harness por padrão, e a função de execução gerada recebe acesso a ela — com escopo para o ARN de memória que o serviço atribui, e concedido apenas enquanto o Harness usa memória gerenciada que a infraestrutura criou. Configure a memória explicitamente para ajustar essa memória gerenciada, apontar o Harness para um recurso de memória que você possui, ou desativar a memória:
+
+<Infrastructure>
+  <Fragment slot="cdk">
+```ts
+new MyHarness(this, 'MyHarness', {
+  memory: { managedMemoryConfiguration: { strategies: ['SUMMARIZATION'] } },
+});
+```
+
+Fornecer `memory` substitui a memória gerenciada padrão, então o construto deixa a concessão de memória fora da função de execução: adicione o que a configuração precisa com `addToRolePolicy`.
+  </Fragment>
+  <Fragment slot="terraform">
+```hcl
+module "my_harness" {
+  source = "../../common/terraform/src/app/harnesses/my-harness"
+  memory = {
+    managed_memory_configuration = {
+      strategies = ["SUMMARIZATION"]
+    }
+  }
+}
+```
+
+Defina exatamente um de `managed_memory_configuration` (ajustar a memória gerenciada do serviço), `agentcore_memory_configuration` (usar um recurso de memória que você possui, por ARN) ou `disabled` (sem memória). Escolher `agentcore_memory_configuration` ou `disabled` remove a concessão de memória gerenciada da função de execução; para seu próprio recurso de memória, conceda acesso através de `additional_execution_role_policy_statements`.
+  </Fragment>
+</Infrastructure>
 
 ### Executando em uma VPC
 
@@ -241,28 +275,31 @@ database.connections.allowDefaultPortFrom(harness, 'Harness to database');
 O Harness é colocado nas sub-redes privadas da VPC com saída, em um grupo de segurança criado para ele. Substitua qualquer um com `vpcSubnets` e `securityGroups`. Ambos requerem `vpc`, e `connections` está disponível apenas quando o Harness é executado em uma VPC.
   </Fragment>
   <Fragment slot="terraform">
-Adicione um bloco `network_configuration` ao `environment.agent_core_runtime_environment` do recurso `aws_bedrockagentcore_harness` gerado, então referencie o grupo de segurança no qual você o coloca a partir das regras de seus outros recursos:
+Defina `enable_vpc` junto com `vpc_id` e `subnet_ids` para executar o Harness dentro de uma VPC, para que ele possa alcançar recursos privados como um banco de dados:
 
-```hcl title="packages/common/terraform/src/app/harnesses/my-harness/my-harness.tf"
-resource "aws_security_group" "harness" {
-  vpc_id = var.vpc_id
-}
-
-resource "aws_bedrockagentcore_harness" "this" {
-  # ...
-  environment {
-    agent_core_runtime_environment {
-      network_configuration {
-        network_mode = "VPC"
-        network_mode_config {
-          security_groups = [aws_security_group.harness.id]
-          subnets         = var.subnet_ids
-        }
-      }
-    }
-  }
+```hcl
+module "my_harness" {
+  source     = "../../common/terraform/src/app/harnesses/my-harness"
+  enable_vpc = true
+  vpc_id     = var.vpc_id
+  subnet_ids = var.private_subnet_ids
 }
 ```
+
+O módulo cria um grupo de segurança para o Harness, permitindo apenas HTTPS de saída. Sua saída `security_group_id` é o que os recursos que o Harness deve alcançar referenciam em suas próprias regras de entrada:
+
+```hcl
+resource "aws_vpc_security_group_ingress_rule" "harness_to_database" {
+  security_group_id            = aws_security_group.database.id
+  referenced_security_group_id = module.my_harness.security_group_id
+  from_port                    = 5432
+  to_port                      = 5432
+  ip_protocol                  = "tcp"
+  description                  = "Harness to database"
+}
+```
+
+`security_group_id` é null a menos que `enable_vpc` seja true, e `vpc_id` e `subnet_ids` são ambos obrigatórios quando for.
   </Fragment>
 </Infrastructure>
 

--- a/docs/src/content/docs/vi/guides/agentcore-harness.mdx
+++ b/docs/src/content/docs/vi/guides/agentcore-harness.mdx
@@ -112,16 +112,21 @@ module "my_harness" {
 }
 ```
 
-Module hiển thị bốn biến:
+Module hiển thị các biến sau:
 
 - `model_id` — Bedrock model hoặc inference profile mà Harness sử dụng theo mặc định.
 - `allowed_tools` — các công cụ mà Harness có thể sử dụng. Mặc định là không có, xem <a href="#configuring-tools">Configuring tools</a>.
-- `model_resource_arns` — các ARN của Bedrock model và inference-profile mà execution role có thể gọi, thay thế danh sách mặc định.
-- `additional_execution_role_policy_statements` — một danh sách các đối tượng IAM statement (`Effect`, `Action`, `Resource`, `Sid` và `Condition` tùy chọn) được thêm vào execution role policy.
+- `memory` — cấu hình memory của Harness, xem <a href="#configuring-memory">Configuring memory</a>.
+- `environment_variables`, `max_iterations`, `timeout_seconds` — các trường Harness gốc tương ứng.
+- `execution_role_arn` — một IAM role hiện có để sử dụng thay vì role được tạo. Một role được cung cấp được sử dụng nguyên trạng: cả role và baseline policy của nó đều không được tạo, vì vậy `model_resource_arns` và `additional_execution_role_policy_statements` không thể kết hợp với nó.
+- `model_resource_arns` — các ARN của Bedrock model và inference-profile mà execution role được tạo có thể gọi, thay thế danh sách mặc định.
+- `additional_execution_role_policy_statements` — một danh sách các đối tượng IAM statement (`Effect`, `Action`, `Resource`, `Sid` và `Condition` tùy chọn) được thêm vào execution role policy được tạo.
+- `enable_vpc`, `vpc_id`, `subnet_ids` — chạy Harness trong một VPC để nó có thể tiếp cận các tài nguyên riêng tư, xem <a href="#running-in-a-vpc">Running in a VPC</a>.
+- `tags` — các tag được áp dụng cho các tài nguyên mà module tạo ra.
 
-Mọi thứ khác được cấu hình trên tài nguyên `aws_bedrockagentcore_harness` được tạo trong chính module.
+Các trường gốc khác của nhà cung cấp được cấu hình bằng cách chỉnh sửa tài nguyên `aws_bedrockagentcore_harness` được tạo trong chính module, xem <a href="#customizing-your-harness">Customizing your Harness</a>.
 
-Module xuất ra `harness_id`, `harness_arn`, và `execution_role_arn`.
+Module xuất ra `harness_id`, `harness_arn`, `execution_role_arn` và `security_group_id`.
 
 Triển khai với quy trình plan/apply của dự án Terraform của bạn như thường lệ — xem <Link path="guides/terraform-project">hướng dẫn dự án Terraform</Link>.
   </Fragment>
@@ -197,7 +202,7 @@ Nếu không đặt cả hai, script sẽ thất bại với lỗi nêu tên c�
 Mọi thuộc tính Harness gốc của module `aws-cdk-lib/aws-bedrockagentcore` được ghim đều có sẵn thông qua props của construct — các nhà cung cấp model thay thế, định nghĩa công cụ, memory, skills, cấu hình environment, truncation, custom JWT authorization và execution limits — và các props rõ ràng được ưu tiên hơn các giá trị mặc định được tạo. Ngoài ra, chỉnh sửa construct được tạo trong `packages/common/constructs/src/app/harnesses/<name>/<name>.ts`.
   </Fragment>
   <Fragment slot="terraform">
-Module được tạo giữ tài nguyên `aws_bedrockagentcore_harness` gốc có thể chỉnh sửa trực tiếp, vì vậy các trường gốc của nhà cung cấp — các nhà cung cấp model thay thế (`gemini_model_config`, `openai_model_config`), các khối `tool`, `memory`, các khối `skill`, environments (`environment`, `environment_variables`, `environment_artifact`), `truncation`, và `authorizer_configuration` với `custom_jwt_authorizer` — được cấu hình bằng cách chỉnh sửa `packages/common/terraform/src/app/harnesses/<name>/<name>.tf`.
+Các biến của module bao gồm các trường mà hầu hết các triển khai cấu hình — `model_id`, `allowed_tools`, `memory`, `environment_variables`, `max_iterations`, `timeout_seconds` — cộng với execution role và vị trí VPC. Terraform không có tương đương với prop spread của CDK construct, vì vậy các trường gốc còn lại của nhà cung cấp được cấu hình bằng cách chỉnh sửa tài nguyên `aws_bedrockagentcore_harness` trong `packages/common/terraform/src/app/harnesses/<name>/<name>.tf`: các nhà cung cấp model thay thế (`gemini_model_config`, `openai_model_config`), các khối `tool`, các khối `skill`, `environment_artifact`, cấu hình filesystem và lifecycle trong `environment`, `truncation`, và `authorizer_configuration` với `custom_jwt_authorizer`.
   </Fragment>
 </Infrastructure>
 
@@ -216,8 +221,7 @@ new MyHarness(this, 'Harness', { allowedTools: ['@builtin'] });
   <Fragment slot="terraform">
 ```hcl title="packages/infra/src/main.tf"
 module "my_harness" {
-  source = "../../common/terraform/src/app/harnesses/my-harness"
-
+  source        = "../../common/terraform/src/app/harnesses/my-harness"
   allowed_tools = ["@builtin"]
 }
 ```
@@ -225,6 +229,36 @@ module "my_harness" {
 </Infrastructure>
 
 Thu hẹp `@builtin` thành các mẫu cụ thể như `@builtin/file_operations` để hạn chế những gì vòng lặp agent có thể làm. Xem [Harness tools](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/harness-tools.html) cho các công cụ tích hợp sẵn mà bạn có thể thêm.
+
+### Cấu hình memory
+
+Dịch vụ cung cấp managed memory cho Harness theo mặc định, và execution role được tạo được cấp quyền truy cập vào nó — giới hạn trong memory ARN mà dịch vụ chỉ định, và chỉ được cấp trong khi Harness sử dụng managed memory mà hạ tầng đã tạo. Cấu hình memory một cách rõ ràng để điều chỉnh managed memory đó, trỏ Harness đến một tài nguyên memory bạn sở hữu, hoặc tắt memory:
+
+<Infrastructure>
+  <Fragment slot="cdk">
+```ts
+new MyHarness(this, 'MyHarness', {
+  memory: { managedMemoryConfiguration: { strategies: ['SUMMARIZATION'] } },
+});
+```
+
+Cung cấp `memory` sẽ thay thế managed memory mặc định, vì vậy construct bỏ qua memory grant khỏi execution role: thêm bất cứ thứ gì mà cấu hình cần với `addToRolePolicy`.
+  </Fragment>
+  <Fragment slot="terraform">
+```hcl
+module "my_harness" {
+  source = "../../common/terraform/src/app/harnesses/my-harness"
+  memory = {
+    managed_memory_configuration = {
+      strategies = ["SUMMARIZATION"]
+    }
+  }
+}
+```
+
+Đặt chính xác một trong `managed_memory_configuration` (điều chỉnh managed memory của dịch vụ), `agentcore_memory_configuration` (sử dụng tài nguyên memory bạn sở hữu, theo ARN) hoặc `disabled` (không có memory). Chọn `agentcore_memory_configuration` hoặc `disabled` sẽ loại bỏ managed-memory grant khỏi execution role; đối với tài nguyên memory của riêng bạn, cấp quyền truy cập thông qua `additional_execution_role_policy_statements`.
+  </Fragment>
+</Infrastructure>
 
 ### Chạy trong một VPC
 
@@ -241,28 +275,31 @@ database.connections.allowDefaultPortFrom(harness, 'Harness to database');
 Harness được đặt trong các subnet riêng tư của VPC với egress, trong một security group được tạo cho nó. Ghi đè một trong hai với `vpcSubnets` và `securityGroups`. Cả hai đều yêu cầu `vpc`, và `connections` chỉ khả dụng khi Harness chạy trong một VPC.
   </Fragment>
   <Fragment slot="terraform">
-Thêm một khối `network_configuration` vào `environment.agent_core_runtime_environment` của tài nguyên `aws_bedrockagentcore_harness` được tạo, sau đó tham chiếu security group mà bạn đặt nó vào từ các quy tắc của các tài nguyên khác của bạn:
+Đặt `enable_vpc` cùng với `vpc_id` và `subnet_ids` để chạy Harness bên trong một VPC, để nó có thể tiếp cận các tài nguyên riêng tư như cơ sở dữ liệu:
 
-```hcl title="packages/common/terraform/src/app/harnesses/my-harness/my-harness.tf"
-resource "aws_security_group" "harness" {
-  vpc_id = var.vpc_id
-}
-
-resource "aws_bedrockagentcore_harness" "this" {
-  # ...
-  environment {
-    agent_core_runtime_environment {
-      network_configuration {
-        network_mode = "VPC"
-        network_mode_config {
-          security_groups = [aws_security_group.harness.id]
-          subnets         = var.subnet_ids
-        }
-      }
-    }
-  }
+```hcl
+module "my_harness" {
+  source     = "../../common/terraform/src/app/harnesses/my-harness"
+  enable_vpc = true
+  vpc_id     = var.vpc_id
+  subnet_ids = var.private_subnet_ids
 }
 ```
+
+Module tạo một security group cho Harness, chỉ cho phép outbound HTTPS. Đầu ra `security_group_id` của nó là những gì các tài nguyên mà Harness phải tiếp cận tham chiếu trong các quy tắc ingress của riêng chúng:
+
+```hcl
+resource "aws_vpc_security_group_ingress_rule" "harness_to_database" {
+  security_group_id            = aws_security_group.database.id
+  referenced_security_group_id = module.my_harness.security_group_id
+  from_port                    = 5432
+  to_port                      = 5432
+  ip_protocol                  = "tcp"
+  description                  = "Harness to database"
+}
+```
+
+`security_group_id` là null trừ khi `enable_vpc` là true, và `vpc_id` và `subnet_ids` đều được yêu cầu khi nó là true.
   </Fragment>
 </Infrastructure>
 

--- a/docs/src/content/docs/zh/guides/agentcore-harness.mdx
+++ b/docs/src/content/docs/zh/guides/agentcore-harness.mdx
@@ -112,16 +112,21 @@ module "my_harness" {
 }
 ```
 
-该模块公开四个变量：
+该模块公开以下变量：
 
 - `model_id` — Harness 默认使用的 Bedrock 模型或推理配置文件。
 - `allowed_tools` — Harness 可以使用的工具。默认为无，请参阅<a href="#configuring-tools">配置工具</a>。
-- `model_resource_arns` — 执行角色可以调用的 Bedrock 模型和推理配置文件 ARN，替换默认列表。
-- `additional_execution_role_policy_statements` — 附加到执行角色策略的 IAM 语句对象列表（`Effect`、`Action`、`Resource`、可选的 `Sid` 和 `Condition`）。
+- `memory` — Harness 内存配置，请参阅<a href="#configuring-memory">配置内存</a>。
+- `environment_variables`、`max_iterations`、`timeout_seconds` — 相应的原生 Harness 字段。
+- `execution_role_arn` — 要使用的现有 IAM 角色，而不是生成的角色。提供的角色按原样使用：既不创建角色也不创建其基线策略，因此 `model_resource_arns` 和 `additional_execution_role_policy_statements` 不能与其组合使用。
+- `model_resource_arns` — 生成的执行角色可以调用的 Bedrock 模型和推理配置文件 ARN，替换默认列表。
+- `additional_execution_role_policy_statements` — 附加到生成的执行角色策略的 IAM 语句对象列表（`Effect`、`Action`、`Resource`、可选的 `Sid` 和 `Condition`）。
+- `enable_vpc`、`vpc_id`、`subnet_ids` — 在 VPC 中运行 Harness，以便它可以访问私有资源，请参阅<a href="#running-in-a-vpc">在 VPC 中运行</a>。
+- `tags` — 应用于模块创建的资源的标签。
 
-其他所有内容都在模块本身生成的 `aws_bedrockagentcore_harness` 资源上配置。
+其他提供程序原生字段通过编辑模块本身生成的 `aws_bedrockagentcore_harness` 资源进行配置，请参阅<a href="#customizing-your-harness">自定义您的 Harness</a>。
 
-该模块输出 `harness_id`、`harness_arn` 和 `execution_role_arn`。
+该模块输出 `harness_id`、`harness_arn`、`execution_role_arn` 和 `security_group_id`。
 
 像往常一样使用 Terraform 项目的 plan/apply 工作流进行部署 — 请参阅 <Link path="guides/terraform-project">Terraform 项目指南</Link>。
   </Fragment>
@@ -197,7 +202,7 @@ Harness ARN 按以下顺序解析：
 固定的 `aws-cdk-lib/aws-bedrockagentcore` 模块的每个原生 Harness 属性都可以通过构造的 props 使用 — 备用模型提供程序、工具定义、内存、技能、环境配置、截断、自定义 JWT 授权和执行限制 — 显式 props 优先于生成的默认值。或者，编辑 `packages/common/constructs/src/app/harnesses/<name>/<name>.ts` 中生成的构造。
   </Fragment>
   <Fragment slot="terraform">
-生成的模块保持原生 `aws_bedrockagentcore_harness` 资源直接可编辑，因此提供程序原生字段 — 备用模型提供程序（`gemini_model_config`、`openai_model_config`）、`tool` 块、`memory`、`skill` 块、环境（`environment`、`environment_variables`、`environment_artifact`）、`truncation` 和带有 `custom_jwt_authorizer` 的 `authorizer_configuration` — 通过编辑 `packages/common/terraform/src/app/harnesses/<name>/<name>.tf` 进行配置。
+该模块的变量涵盖了大多数部署配置的字段 — `model_id`、`allowed_tools`、`memory`、`environment_variables`、`max_iterations`、`timeout_seconds` — 以及执行角色和 VPC 放置。Terraform 没有与 CDK 构造的 prop 展开等效的功能，因此其余提供程序原生字段通过编辑 `packages/common/terraform/src/app/harnesses/<name>/<name>.tf` 中的 `aws_bedrockagentcore_harness` 资源进行配置：备用模型提供程序（`gemini_model_config`、`openai_model_config`）、`tool` 块、`skill` 块、`environment_artifact`、`environment` 下的文件系统和生命周期配置、`truncation` 以及带有 `custom_jwt_authorizer` 的 `authorizer_configuration`。
   </Fragment>
 </Infrastructure>
 
@@ -216,8 +221,7 @@ new MyHarness(this, 'Harness', { allowedTools: ['@builtin'] });
   <Fragment slot="terraform">
 ```hcl title="packages/infra/src/main.tf"
 module "my_harness" {
-  source = "../../common/terraform/src/app/harnesses/my-harness"
-
+  source        = "../../common/terraform/src/app/harnesses/my-harness"
   allowed_tools = ["@builtin"]
 }
 ```
@@ -225,6 +229,36 @@ module "my_harness" {
 </Infrastructure>
 
 将 `@builtin` 缩小到特定模式（如 `@builtin/file_operations`）以限制代理循环可以执行的操作。有关可以添加的内置工具，请参阅 [Harness 工具](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/harness-tools.html)。
+
+### 配置内存
+
+默认情况下，该服务为 Harness 提供托管内存，并且生成的执行角色被授予访问权限 — 范围限定为服务分配的内存 ARN，并且仅在 Harness 使用基础设施创建的托管内存时授予。显式配置内存以调整该托管内存、将 Harness 指向您拥有的内存资源或关闭内存：
+
+<Infrastructure>
+  <Fragment slot="cdk">
+```ts
+new MyHarness(this, 'MyHarness', {
+  memory: { managedMemoryConfiguration: { strategies: ['SUMMARIZATION'] } },
+});
+```
+
+提供 `memory` 会完全替换默认的托管内存，因此构造会从执行角色中省略内存授权：使用 `addToRolePolicy` 添加配置所需的任何内容。
+  </Fragment>
+  <Fragment slot="terraform">
+```hcl
+module "my_harness" {
+  source = "../../common/terraform/src/app/harnesses/my-harness"
+  memory = {
+    managed_memory_configuration = {
+      strategies = ["SUMMARIZATION"]
+    }
+  }
+}
+```
+
+设置 `managed_memory_configuration`（调整服务的托管内存）、`agentcore_memory_configuration`（使用您拥有的内存资源，通过 ARN）或 `disabled`（无内存）中的一个。选择 `agentcore_memory_configuration` 或 `disabled` 会从执行角色中删除托管内存授权；对于您自己的内存资源，通过 `additional_execution_role_policy_statements` 授予访问权限。
+  </Fragment>
+</Infrastructure>
 
 ### 在 VPC 中运行
 
@@ -241,28 +275,31 @@ database.connections.allowDefaultPortFrom(harness, 'Harness to database');
 Harness 被放置在 VPC 的具有出口的私有子网中，位于为其创建的安全组中。使用 `vpcSubnets` 和 `securityGroups` 覆盖任一项。两者都需要 `vpc`，并且 `connections` 仅在 Harness 在 VPC 中运行时可用。
   </Fragment>
   <Fragment slot="terraform">
-将 `network_configuration` 块添加到生成的 `aws_bedrockagentcore_harness` 资源的 `environment.agent_core_runtime_environment`，然后从其他资源的规则中引用您放置它的安全组：
+将 `enable_vpc` 与 `vpc_id` 和 `subnet_ids` 一起设置，以在 VPC 内运行 Harness，以便它可以访问私有资源（如数据库）：
 
-```hcl title="packages/common/terraform/src/app/harnesses/my-harness/my-harness.tf"
-resource "aws_security_group" "harness" {
-  vpc_id = var.vpc_id
-}
-
-resource "aws_bedrockagentcore_harness" "this" {
-  # ...
-  environment {
-    agent_core_runtime_environment {
-      network_configuration {
-        network_mode = "VPC"
-        network_mode_config {
-          security_groups = [aws_security_group.harness.id]
-          subnets         = var.subnet_ids
-        }
-      }
-    }
-  }
+```hcl
+module "my_harness" {
+  source     = "../../common/terraform/src/app/harnesses/my-harness"
+  enable_vpc = true
+  vpc_id     = var.vpc_id
+  subnet_ids = var.private_subnet_ids
 }
 ```
+
+该模块为 Harness 创建一个安全组，仅允许出站 HTTPS。其 `security_group_id` 输出是 Harness 必须访问的资源在其自己的入站规则中引用的内容：
+
+```hcl
+resource "aws_vpc_security_group_ingress_rule" "harness_to_database" {
+  security_group_id            = aws_security_group.database.id
+  referenced_security_group_id = module.my_harness.security_group_id
+  from_port                    = 5432
+  to_port                      = 5432
+  ip_protocol                  = "tcp"
+  description                  = "Harness to database"
+}
+```
+
+除非 `enable_vpc` 为 true，否则 `security_group_id` 为 null，并且当它为 true 时，`vpc_id` 和 `subnet_ids` 都是必需的。
   </Fragment>
 </Infrastructure>
 

--- a/packages/nx-plugin/src/agentcore-harness/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/agentcore-harness/__snapshots__/generator.spec.ts.snap
@@ -62,12 +62,13 @@ construct's \`grantInvokeAccess\` grants exactly those two actions.
 ## Customizing your Harness
 
 Edit \`src/PROMPT.md\` for the system prompt. Everything else is configured
-where you instantiate the infrastructure — including tools, which the
-Harness deploys without:
+where you instantiate the infrastructure — including tools, which default
+to none:
 
 - CDK construct props, for example
   \`new MyHarness(this, 'MyHarness', { allowedTools: ['@builtin'] })\`
-- Terraform module variables, for example \`allowed_tools = ["@builtin"]\`
+- Terraform, by setting the module's \`allowed_tools\` variable, for example
+  \`allowed_tools = ["@builtin"]\`
 
 The generated infrastructure is also yours to edit directly:
 

--- a/packages/nx-plugin/src/agentcore-harness/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/agentcore-harness/__snapshots__/generator.spec.ts.snap
@@ -62,13 +62,12 @@ construct's \`grantInvokeAccess\` grants exactly those two actions.
 ## Customizing your Harness
 
 Edit \`src/PROMPT.md\` for the system prompt. Everything else is configured
-where you instantiate the infrastructure — including tools, which default
-to none:
+where you instantiate the infrastructure — including tools, which the
+Harness deploys without:
 
 - CDK construct props, for example
   \`new MyHarness(this, 'MyHarness', { allowedTools: ['@builtin'] })\`
-- Terraform, by setting the module's \`allowed_tools\` variable, for example
-  \`allowed_tools = ["@builtin"]\`
+- Terraform module variables, for example \`allowed_tools = ["@builtin"]\`
 
 The generated infrastructure is also yours to edit directly:
 

--- a/packages/nx-plugin/src/agentcore-harness/generator.spec.ts
+++ b/packages/nx-plugin/src/agentcore-harness/generator.spec.ts
@@ -91,6 +91,7 @@ const SCHEMA_INTERFACE_OPTIONS: Record<
  */
 const TF_CHECKOV_SKIPS = [
   'CKV2_AWS_5:Attached to the Harness via its network configuration; Checkov cannot resolve this reference',
+  'CKV_AWS_355:EcrManagedImageToken requires a wildcard resource; ecr:GetAuthorizationToken has no resource-level permission',
   'CKV_AWS_355:EcrPublicTokenAccess requires a wildcard resource; ecr-public:GetAuthorizationToken has no resource-level permission',
   'CKV_AWS_355:StsForEcrPublicPull requires a wildcard resource; sts:GetServiceBearerToken has no resource-level permission',
   'CKV_AWS_355:XRayTracingAccess requires a wildcard resource; the X-Ray segment and sampling APIs have no resource-level permission',
@@ -587,6 +588,21 @@ describe('agentcore-harness generator', () => {
         'value       = var.enable_vpc ? aws_security_group.harness[0].id : null',
       );
 >>>>>>> 92fe76cf (docs(agentcore-harness): document the Terraform module's variables, VPC support and memory grant)
+    });
+
+    it('grants the private ECR pull VPC mode needs, and only then', () => {
+      // In VPC mode the harness pulls its managed container from a private ECR
+      // repository rather than ECR Public, so the role needs pull permissions
+      // on it or sessions fail to start.
+      expect(tf).toContain('var.enable_vpc ? [');
+      expect(tf).toContain('Sid    = "EcrManagedImagePull"');
+      expect(tf).toContain(
+        'Resource = ["arn:${local.partition}:ecr:${local.region}:*:repository/harness-*"]',
+      );
+      expect(tf).toContain('Sid      = "EcrManagedImageToken"');
+
+      // ECR Public remains the non-VPC path, so both stay.
+      expect(tf).toContain('Sid      = "EcrPublicTokenAccess"');
     });
 
     it('justifies every wildcard IAM statement inline', () => {

--- a/packages/nx-plugin/src/agentcore-harness/generator.spec.ts
+++ b/packages/nx-plugin/src/agentcore-harness/generator.spec.ts
@@ -383,7 +383,23 @@ describe('agentcore-harness generator', () => {
       expect(construct).toContain('systemPrompt: [{ text: systemPrompt }],');
     });
 
-    it('suppresses the three unscopeable IAM statements on the role policy', () => {
+    it('grants the private ECR pull a VPC Harness needs, and only then', () => {
+      // In a VPC the Harness pulls its managed container from a private ECR
+      // repository rather than ECR Public, so the role needs pull permissions
+      // on it or sessions fail to start.
+      expect(construct).toContain("sid: 'EcrManagedImagePull',");
+      expect(construct).toContain(
+        '`arn:${stack.partition}:ecr:${stack.region}:*:repository/harness-*`',
+      );
+      expect(construct).toContain("sid: 'EcrManagedImageToken',");
+      // Conditional on the VPC prop, spread into the baseline statements.
+      expect(construct).toContain('...(vpc\n');
+
+      // ECR Public remains the non-VPC path, so both stay.
+      expect(construct).toContain("sid: 'EcrPublicTokenAccess',");
+    });
+
+    it('suppresses the four unscopeable IAM statements on the role policy', () => {
       // App-level specifier: the construct sits three directories below core/.
       expect(construct).toContain(
         "import { suppressRules } from '../../../core/checkov.js';",
@@ -396,7 +412,7 @@ describe('agentcore-harness generator', () => {
       expect(construct).toContain(
         'const isPolicy = (c: IConstruct) => c instanceof iam.Policy;',
       );
-      expect(construct.match(/suppressRules\(\n/g)).toHaveLength(3);
+      expect(construct.match(/suppressRules\(\n/g)).toHaveLength(4);
       for (const reason of [
         'EcrPublicTokenAccess: ecr-public:GetAuthorizationToken has no resource-level permission.',
         'StsForEcrPublicPull: sts:GetServiceBearerToken has no resource-level permission.',
@@ -404,6 +420,11 @@ describe('agentcore-harness generator', () => {
       ]) {
         expect(construct, reason).toContain(`        '${reason}',`);
       }
+      // The VPC-only grant is suppressed inside the matching conditional, so it
+      // is indented one level further.
+      expect(construct).toContain(
+        "          'EcrManagedImageToken: ecr:GetAuthorizationToken has no resource-level permission.',",
+      );
     });
 
     it('configures no tools on the resource but exposes allowedTools as props', () => {

--- a/packages/nx-plugin/src/agentcore-harness/generator.spec.ts
+++ b/packages/nx-plugin/src/agentcore-harness/generator.spec.ts
@@ -502,6 +502,7 @@ describe('agentcore-harness generator', () => {
         'environment_variables',
         'max_iterations',
         'timeout_seconds',
+        'create_execution_role',
         'execution_role_arn',
         'model_resource_arns',
         'additional_execution_role_policy_statements',
@@ -529,7 +530,10 @@ describe('agentcore-harness generator', () => {
         'error_message = "vpc_id and subnet_ids must be set when enable_vpc is true."',
       );
       expect(tf).toContain(
-        'error_message = "model_resource_arns and additional_execution_role_policy_statements configure the generated execution role, which is not created when execution_role_arn is supplied. Grant those permissions on the supplied role instead."',
+        'error_message = "execution_role_arn must be set when create_execution_role is false."',
+      );
+      expect(tf).toContain(
+        'error_message = "model_resource_arns and additional_execution_role_policy_statements configure the generated execution role, which is not created when create_execution_role is false. Grant those permissions on the supplied role instead."',
       );
       expect(tf).toContain(
         'error_message = "Set exactly one of memory.managed_memory_configuration, memory.agentcore_memory_configuration or memory.disabled."',
@@ -537,20 +541,20 @@ describe('agentcore-harness generator', () => {
     });
 
     it('creates the role and its baseline policy only when none is supplied', () => {
+      // Counted off a plain input, not a computed value: a count derived from a
+      // supplied ARN is unknown at plan time whenever that ARN is itself a
+      // resource attribute, which fails the plan outright.
       for (const resource of [
         'resource "aws_iam_role" "execution_role"',
         'resource "aws_iam_role_policy" "execution_role"',
       ]) {
         expect(tf, resource).toContain(
-          `${resource} {\n  count = local.create_execution_role ? 1 : 0`,
+          `${resource} {\n  count = var.create_execution_role ? 1 : 0`,
         );
       }
-      expect(tf).toContain(
-        'create_execution_role = var.execution_role_arn == null',
-      );
       // The harness and the output both follow whichever role is in use.
       expect(tf).toContain(
-        'execution_role_arn    = local.create_execution_role ? aws_iam_role.execution_role[0].arn : var.execution_role_arn',
+        'execution_role_arn = var.create_execution_role ? aws_iam_role.execution_role[0].arn : var.execution_role_arn',
       );
       expect(tf).toContain('execution_role_arn = local.execution_role_arn');
     });
@@ -648,7 +652,7 @@ describe('agentcore-harness generator', () => {
       // policy, which the harness itself depends on.
       expect(tf).toContain('resource "aws_iam_role_policy" "managed_memory"');
       expect(tf).toContain(
-        'count = local.create_execution_role && local.has_managed_memory ? 1 : 0',
+        'count = var.create_execution_role && local.has_managed_memory ? 1 : 0',
       );
     });
 

--- a/packages/nx-plugin/src/agentcore-harness/generator.spec.ts
+++ b/packages/nx-plugin/src/agentcore-harness/generator.spec.ts
@@ -83,11 +83,14 @@ const SCHEMA_INTERFACE_OPTIONS: Record<
 };
 
 /**
- * Every wildcard-resource IAM statement in the Terraform module, justified
- * inline. The rule ids differ from the CDK template's because checkov ships
- * separate rule sets for HCL and CloudFormation.
+ * Every checkov finding the Terraform module suppresses, justified inline —
+ * the wildcard-resource IAM statements, plus the security group whose
+ * attachment checkov cannot resolve. The rule ids differ from the CDK
+ * template's because checkov ships separate rule sets for HCL and
+ * CloudFormation.
  */
 const TF_CHECKOV_SKIPS = [
+  'CKV2_AWS_5:Attached to the Harness via its network configuration; Checkov cannot resolve this reference',
   'CKV_AWS_355:EcrPublicTokenAccess requires a wildcard resource; ecr-public:GetAuthorizationToken has no resource-level permission',
   'CKV_AWS_355:StsForEcrPublicPull requires a wildcard resource; sts:GetServiceBearerToken has no resource-level permission',
   'CKV_AWS_355:XRayTracingAccess requires a wildcard resource; the X-Ray segment and sampling APIs have no resource-level permission',
@@ -487,20 +490,26 @@ describe('agentcore-harness generator', () => {
       expect(tree.exists(CDK_HARNESSES_INDEX_PATH)).toBe(false);
     });
 
-    it('declares only the four retained input variables', () => {
-      // Set equality, so a reintroduced system_prompt, max_iterations,
-      // max_tokens or timeout_seconds variable fails.
+    it('declares exactly the retained input variables', () => {
+      // Set equality, so a variable added or removed here is deliberate. The
+      // system prompt stays a file read rather than a variable.
       expect(
         [...tf.matchAll(/^variable "([a-z_]+)"/gm)].map(([, name]) => name),
       ).toEqual([
         'model_id',
         'allowed_tools',
+        'memory',
+        'environment_variables',
+        'max_iterations',
+        'timeout_seconds',
+        'execution_role_arn',
         'model_resource_arns',
         'additional_execution_role_policy_statements',
+        'enable_vpc',
+        'vpc_id',
+        'subnet_ids',
+        'tags',
       ]);
-      // No validation block survives, and nothing references the removed
-      // variables.
-      expect(tf).not.toContain('validation {');
       expect(tf).not.toContain('var.system_prompt');
     });
 
@@ -510,7 +519,70 @@ describe('agentcore-harness generator', () => {
       expect(tf).toMatch(
         /variable "allowed_tools" \{[^}]*type {8}= list\(string\)\n {2}default {5}= \[\]/,
       );
-      expect(tf).toContain('allowed_tools      = var.allowed_tools');
+      expect(tf).toContain('allowed_tools         = var.allowed_tools');
+    });
+
+    it('cross-validates the variables that cannot be combined', () => {
+      // enable_vpc needs both network inputs; a supplied role cannot be shaped
+      // by the generated role's variables; memory takes exactly one form.
+      expect(tf).toContain(
+        'error_message = "vpc_id and subnet_ids must be set when enable_vpc is true."',
+      );
+      expect(tf).toContain(
+        'error_message = "model_resource_arns and additional_execution_role_policy_statements configure the generated execution role, which is not created when execution_role_arn is supplied. Grant those permissions on the supplied role instead."',
+      );
+      expect(tf).toContain(
+        'error_message = "Set exactly one of memory.managed_memory_configuration, memory.agentcore_memory_configuration or memory.disabled."',
+      );
+    });
+
+    it('creates the role and its baseline policy only when none is supplied', () => {
+      for (const resource of [
+        'resource "aws_iam_role" "execution_role"',
+        'resource "aws_iam_role_policy" "execution_role"',
+      ]) {
+        expect(tf, resource).toContain(
+          `${resource} {\n  count = local.create_execution_role ? 1 : 0`,
+        );
+      }
+      expect(tf).toContain(
+        'create_execution_role = var.execution_role_arn == null',
+      );
+      // The harness and the output both follow whichever role is in use.
+      expect(tf).toContain(
+        'execution_role_arn    = local.create_execution_role ? aws_iam_role.execution_role[0].arn : var.execution_role_arn',
+      );
+      expect(tf).toContain('execution_role_arn = local.execution_role_arn');
+    });
+
+    it('places the harness in a VPC only when enable_vpc is set', () => {
+      // The security group and its egress rule are counted off enable_vpc, as
+      // is the network configuration block.
+      for (const resource of [
+        'resource "aws_security_group" "harness"',
+        'resource "aws_vpc_security_group_egress_rule" "harness_https"',
+      ]) {
+        expect(tf, resource).toContain(
+          `${resource} {\n  count = var.enable_vpc ? 1 : 0`,
+        );
+      }
+      // Egress is HTTPS only, to AWS service endpoints.
+      expect(tf).toContain('from_port         = 443');
+      expect(tf).toContain('to_port           = 443');
+
+      expect(tf).toContain(
+        'dynamic "environment" {\n    for_each = var.enable_vpc ? [1] : []',
+      );
+      expect(tf).toContain('network_mode = "VPC"');
+      expect(tf).toContain(
+        'security_groups = [aws_security_group.harness[0].id]',
+      );
+
+      // Exposed so resources the harness reaches can reference it.
+      expect(tf).toContain(
+        'value       = var.enable_vpc ? aws_security_group.harness[0].id : null',
+      );
+>>>>>>> 92fe76cf (docs(agentcore-harness): document the Terraform module's variables, VPC support and memory grant)
     });
 
     it('justifies every wildcard IAM statement inline', () => {
@@ -564,14 +636,35 @@ describe('agentcore-harness generator', () => {
       expect(tf).not.toContain('regexall(');
     });
 
-    it('scopes the managed memory statement to the name the service assigns', () => {
-      // The service names the managed memory `<harness_name>-<10 chars>`, so it
-      // carries neither the runtime's `harness_` prefix nor an `_` separator.
-      // The provider exposes no memory ARN attribute, hence the wildcard.
+    it('scopes the managed memory grant to the ARN the service assigns', () => {
+      // The provider exposes the assigned ARN via memory_actual, so the grant
+      // names the exact resource rather than guessing at its name.
       expect(tf).toContain(
-        'Resource = [\n          "arn:${local.partition}:bedrock-agentcore:${local.region}:${local.account_id}:memory/${local.harness_name}-*",',
+        'Resource = [\n        aws_bedrockagentcore_harness.this.memory_actual[0].managed_memory_configuration[0].arn,',
       );
-      expect(tf).not.toContain(':memory/harness_');
+      expect(tf).not.toContain(':memory/');
+
+      // Reading a deployed attribute means it cannot live in the baseline
+      // policy, which the harness itself depends on.
+      expect(tf).toContain('resource "aws_iam_role_policy" "managed_memory"');
+      expect(tf).toContain(
+        'count = local.create_execution_role && local.has_managed_memory ? 1 : 0',
+      );
+    });
+
+    it('grants managed memory access only where it applies', () => {
+      // Granted while the service provisions the memory; not for a memory
+      // resource the user owns, nor when memory is off.
+      expect(tf).toContain(
+        'has_managed_memory = var.memory == null || var.memory.managed_memory_configuration != null',
+      );
+
+      // The baseline policy carries no memory statement of its own.
+      const baseline = tf.slice(
+        tf.indexOf('resource "aws_iam_role_policy" "execution_role"'),
+        tf.indexOf('# Security group for the Harness'),
+      );
+      expect(baseline).not.toContain('AgentCoreManagedMemory');
     });
   });
 

--- a/packages/nx-plugin/src/agentcore-harness/generator.spec.ts
+++ b/packages/nx-plugin/src/agentcore-harness/generator.spec.ts
@@ -608,7 +608,6 @@ describe('agentcore-harness generator', () => {
       expect(tf).toContain(
         'value       = var.enable_vpc ? aws_security_group.harness[0].id : null',
       );
->>>>>>> 92fe76cf (docs(agentcore-harness): document the Terraform module's variables, VPC support and memory grant)
     });
 
     it('grants the private ECR pull VPC mode needs, and only then', () => {

--- a/packages/nx-plugin/src/migrations/latest/terraform-harness-vpc-role-and-memory-grant/__snapshots__/migration.spec.ts.snap
+++ b/packages/nx-plugin/src/migrations/latest/terraform-harness-vpc-role-and-memory-grant/__snapshots__/migration.spec.ts.snap
@@ -1,0 +1,487 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`terraform-harness-vpc-role-and-memory-grant migration > snapshots the migrated module 1`] = `
+"terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "6.61.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "3.6.3"
+    }
+  }
+}
+
+variable "model_id" {
+  description = "Amazon Bedrock model or inference profile used by default."
+  type        = string
+  default     = "global.anthropic.claude-sonnet-4-6"
+}
+
+variable "allowed_tools" {
+  description = "Tools the Harness may use, e.g. [\\"@builtin\\"] or narrower patterns such as [\\"@builtin/file_operations\\"]. Deploys with no tools when null."
+  type        = list(string)
+  default     = null
+}
+
+variable "memory" {
+  description = "Memory configuration for the Harness. Null leaves the service to provision managed memory with default strategies. Set exactly one field: managed_memory_configuration to tune that managed memory, agentcore_memory_configuration to use a memory resource you own, or disabled to turn memory off."
+  type = object({
+    managed_memory_configuration = optional(object({
+      strategies            = optional(set(string))
+      event_expiry_duration = optional(number)
+      encryption_key_arn    = optional(string)
+    }))
+    agentcore_memory_configuration = optional(object({
+      arn            = string
+      actor_id       = optional(string)
+      messages_count = optional(number)
+    }))
+    disabled = optional(bool, false)
+  })
+  default = null
+
+  validation {
+    condition = var.memory == null || length([
+      for configured in [
+        var.memory.managed_memory_configuration != null,
+        var.memory.agentcore_memory_configuration != null,
+        var.memory.disabled,
+      ] : configured if configured
+    ]) == 1
+    error_message = "Set exactly one of memory.managed_memory_configuration, memory.agentcore_memory_configuration or memory.disabled."
+  }
+}
+
+variable "environment_variables" {
+  description = "Environment variables available to the Harness."
+  type        = map(string)
+  default     = null
+  sensitive   = true
+}
+
+variable "max_iterations" {
+  description = "Maximum agent loop iterations per invocation. Uses the service default when null."
+  type        = number
+  default     = null
+}
+
+variable "timeout_seconds" {
+  description = "Maximum seconds an invocation may run. Uses the service default when null."
+  type        = number
+  default     = null
+}
+
+variable "execution_role_arn" {
+  description = "ARN of an existing IAM role for the Harness to assume. Used as-is: no role is created and none of the baseline permissions below are granted. Creates the baseline role when null."
+  type        = string
+  default     = null
+
+  validation {
+    condition = var.execution_role_arn == null || (
+      var.model_resource_arns == null && length(var.additional_execution_role_policy_statements) == 0
+    )
+    error_message = "model_resource_arns and additional_execution_role_policy_statements configure the generated execution role, which is not created when execution_role_arn is supplied. Grant those permissions on the supplied role instead."
+  }
+}
+
+variable "model_resource_arns" {
+  description = "Bedrock model and inference-profile ARNs the execution role may invoke. Defaults to every foundation model plus this account's Bedrock resources in the deployment region; replace with narrower ARNs to restrict baseline model access."
+  type        = set(string)
+  default     = null
+}
+
+variable "additional_execution_role_policy_statements" {
+  description = "Additional least-privilege IAM policy statements required by configured optional capabilities (e.g. customer-owned Gateways, memory, custom browsers or code interpreters, skills, secrets). Sid and Condition are optional; null fields are omitted from the rendered policy."
+  type = list(object({
+    Sid       = optional(string)
+    Effect    = string
+    Action    = list(string)
+    Resource  = list(string)
+    Condition = optional(any)
+  }))
+  default = []
+}
+
+# VPC Configuration (optional)
+variable "enable_vpc" {
+  description = "Run the Harness inside a VPC so it can reach private resources. Set alongside vpc_id/subnet_ids."
+  type        = bool
+  default     = false
+}
+
+variable "vpc_id" {
+  description = "VPC ID to run the Harness in. Required when enable_vpc is true."
+  type        = string
+  default     = null
+
+  validation {
+    condition     = !var.enable_vpc || (var.vpc_id != null && var.subnet_ids != null)
+    error_message = "vpc_id and subnet_ids must be set when enable_vpc is true."
+  }
+}
+
+variable "subnet_ids" {
+  description = "Subnet IDs to run the Harness in. Required when enable_vpc is true."
+  type        = list(string)
+  default     = null
+}
+
+variable "tags" {
+  description = "Tags to apply to resources"
+  type        = map(string)
+  default     = {}
+}
+
+data "aws_caller_identity" "current" {}
+data "aws_partition" "current" {}
+data "aws_region" "current" {}
+
+resource "random_id" "unique_suffix" {
+  byte_length = 4
+}
+
+locals {
+  account_id = data.aws_caller_identity.current.account_id
+  partition  = data.aws_partition.current.partition
+  region     = data.aws_region.current.region
+
+  # Capped at 31 characters so the suffix keeps the deployed Harness name
+  # within its 40-character limit.
+  harness_name_prefix = "MyHarness"
+  harness_name        = "\${local.harness_name_prefix}_\${random_id.unique_suffix.hex}"
+
+  # Set var.model_resource_arns to narrow the default model access.
+  model_resource_arns = var.model_resource_arns != null ? var.model_resource_arns : [
+    "arn:\${local.partition}:bedrock:*::foundation-model/*",
+    "arn:\${local.partition}:bedrock:\${local.region}:\${local.account_id}:*",
+  ]
+
+  create_execution_role = var.execution_role_arn == null
+  execution_role_arn    = local.create_execution_role ? aws_iam_role.execution_role[0].arn : var.execution_role_arn
+
+  # The service provisions managed memory unless var.memory redirects it
+  # elsewhere or turns it off.
+  has_managed_memory = var.memory == null || var.memory.managed_memory_configuration != null
+}
+
+resource "aws_iam_role" "execution_role" {
+  count = local.create_execution_role ? 1 : 0
+
+  name = "\${local.harness_name_prefix}-HarnessRole-\${random_id.unique_suffix.hex}"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Principal = {
+        Service = "bedrock-agentcore.amazonaws.com"
+      }
+      Action = "sts:AssumeRole"
+      Condition = {
+        StringEquals = {
+          "aws:SourceAccount" = local.account_id
+        }
+        ArnLike = {
+          "aws:SourceArn" = "arn:\${local.partition}:bedrock-agentcore:\${local.region}:\${local.account_id}:*"
+        }
+      }
+    }]
+  })
+
+  tags = var.tags
+}
+
+# Baseline permissions per the AgentCore Harness security guidance; extend for
+# customer-owned resources via var.additional_execution_role_policy_statements.
+# https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/harness-security.html
+resource "aws_iam_role_policy" "execution_role" {
+  count = local.create_execution_role ? 1 : 0
+
+  name = "\${local.harness_name_prefix}-HarnessPolicy"
+  role = aws_iam_role.execution_role[0].id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = concat([
+      {
+        Sid    = "BedrockModelInvocation"
+        Effect = "Allow"
+        Action = [
+          "bedrock:InvokeModel",
+          "bedrock:InvokeModelWithResponseStream",
+        ]
+        Resource = local.model_resource_arns
+      },
+      {
+        #checkov:skip=CKV_AWS_355:EcrPublicTokenAccess requires a wildcard resource; ecr-public:GetAuthorizationToken has no resource-level permission
+        Sid      = "EcrPublicTokenAccess"
+        Effect   = "Allow"
+        Action   = ["ecr-public:GetAuthorizationToken"]
+        Resource = ["*"]
+      },
+      {
+        #checkov:skip=CKV_AWS_355:StsForEcrPublicPull requires a wildcard resource; sts:GetServiceBearerToken has no resource-level permission
+        Sid      = "StsForEcrPublicPull"
+        Effect   = "Allow"
+        Action   = ["sts:GetServiceBearerToken"]
+        Resource = ["*"]
+      },
+      {
+        #checkov:skip=CKV_AWS_355:XRayTracingAccess requires a wildcard resource; the X-Ray segment and sampling APIs have no resource-level permission
+        #checkov:skip=CKV_AWS_290:XRayTracingAccess requires a wildcard resource; the X-Ray segment and sampling APIs have no resource-level permission
+        Sid    = "XRayTracingAccess"
+        Effect = "Allow"
+        Action = [
+          "xray:PutTraceSegments",
+          "xray:PutTelemetryRecords",
+          "xray:GetSamplingRules",
+          "xray:GetSamplingTargets",
+        ]
+        Resource = ["*"]
+      },
+      {
+        Sid    = "CloudWatchLogsGroup"
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:DescribeLogStreams",
+        ]
+        Resource = [
+          "arn:\${local.partition}:logs:\${local.region}:\${local.account_id}:log-group:/aws/bedrock-agentcore/runtimes/*",
+        ]
+      },
+      {
+        Sid      = "CloudWatchLogsDescribeGroups"
+        Effect   = "Allow"
+        Action   = ["logs:DescribeLogGroups"]
+        Resource = ["arn:\${local.partition}:logs:\${local.region}:\${local.account_id}:log-group:*"]
+      },
+      {
+        Sid    = "CloudWatchLogsStream"
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogStream",
+          "logs:PutLogEvents",
+        ]
+        Resource = [
+          "arn:\${local.partition}:logs:\${local.region}:\${local.account_id}:log-group:/aws/bedrock-agentcore/runtimes/*:log-stream:*",
+        ]
+      },
+      {
+        #checkov:skip=CKV_AWS_355:CloudWatchMetricsPublish requires a wildcard resource; cloudwatch:PutMetricData is scoped by the namespace condition instead
+        #checkov:skip=CKV_AWS_290:CloudWatchMetricsPublish requires a wildcard resource; cloudwatch:PutMetricData is scoped by the namespace condition instead
+        Sid      = "CloudWatchMetricsPublish"
+        Effect   = "Allow"
+        Action   = ["cloudwatch:PutMetricData"]
+        Resource = ["*"]
+        Condition = {
+          StringEquals = {
+            "cloudwatch:namespace" = "bedrock-agentcore"
+          }
+        }
+      },
+      {
+        Sid    = "AgentCoreWorkloadIdentity"
+        Effect = "Allow"
+        Action = [
+          "bedrock-agentcore:GetWorkloadAccessToken",
+          "bedrock-agentcore:GetWorkloadAccessTokenForJWT",
+        ]
+        Resource = [
+          "arn:\${local.partition}:bedrock-agentcore:\${local.region}:\${local.account_id}:workload-identity-directory/default",
+          "arn:\${local.partition}:bedrock-agentcore:\${local.region}:\${local.account_id}:workload-identity-directory/default/workload-identity/harness_\${local.harness_name}-*",
+        ]
+      },
+      {
+        Sid    = "AgentCoreBrowserDefault"
+        Effect = "Allow"
+        Action = [
+          "bedrock-agentcore:StartBrowserSession",
+          "bedrock-agentcore:StopBrowserSession",
+          "bedrock-agentcore:GetBrowserSession",
+          "bedrock-agentcore:ListBrowserSessions",
+          "bedrock-agentcore:UpdateBrowserStream",
+          "bedrock-agentcore:ConnectBrowserAutomationStream",
+          "bedrock-agentcore:ConnectBrowserLiveViewStream",
+        ]
+        Resource = [
+          "arn:\${local.partition}:bedrock-agentcore:\${local.region}:aws:browser/*",
+        ]
+      },
+      {
+        Sid    = "AgentCoreCodeInterpreterDefault"
+        Effect = "Allow"
+        Action = [
+          "bedrock-agentcore:StartCodeInterpreterSession",
+          "bedrock-agentcore:StopCodeInterpreterSession",
+          "bedrock-agentcore:GetCodeInterpreterSession",
+          "bedrock-agentcore:ListCodeInterpreterSessions",
+          "bedrock-agentcore:InvokeCodeInterpreter",
+        ]
+        Resource = [
+          "arn:\${local.partition}:bedrock-agentcore:\${local.region}:aws:code-interpreter/*",
+        ]
+      },
+      ], [
+      # Null Sid/Condition fields are dropped from the rendered policy.
+      for statement in var.additional_execution_role_policy_statements :
+      { for key, value in statement : key => value if value != null }
+    ])
+  })
+}
+
+# Security group for the Harness, used when running inside a VPC
+resource "aws_security_group" "harness" {
+  count = var.enable_vpc ? 1 : 0
+
+  #checkov:skip=CKV2_AWS_5:Attached to the Harness via its network configuration; Checkov cannot resolve this reference
+  name_prefix = "\${local.harness_name_prefix}-harness-"
+  description = "Security group for the \${local.harness_name_prefix} Harness"
+  vpc_id      = var.vpc_id
+  tags        = var.tags
+}
+
+resource "aws_vpc_security_group_egress_rule" "harness_https" {
+  count = var.enable_vpc ? 1 : 0
+
+  security_group_id = aws_security_group.harness[0].id
+  cidr_ipv4         = "0.0.0.0/0"
+  from_port         = 443
+  to_port           = 443
+  ip_protocol       = "tcp"
+  description       = "Allow outbound HTTPS to AWS service endpoints"
+}
+
+# Omitting authorizer_configuration uses IAM inbound authorization; add a
+# custom_jwt_authorizer block to change that.
+resource "aws_bedrockagentcore_harness" "this" {
+  harness_name       = local.harness_name
+  execution_role_arn = local.execution_role_arn
+
+  allowed_tools         = var.allowed_tools
+  environment_variables = var.environment_variables
+  max_iterations        = var.max_iterations
+  timeout_seconds       = var.timeout_seconds
+
+  model {
+    bedrock_model_config {
+      model_id = var.model_id
+    }
+  }
+
+  # Read at plan time; the walk up from path.module reaches the workspace root.
+  system_prompt {
+    text = file("\${path.module}/../../../../../../../packages/my-harness/src/PROMPT.md")
+  }
+
+  dynamic "memory" {
+    for_each = var.memory != null ? [var.memory] : []
+    content {
+      dynamic "managed_memory_configuration" {
+        for_each = memory.value.managed_memory_configuration != null ? [memory.value.managed_memory_configuration] : []
+        content {
+          strategies            = managed_memory_configuration.value.strategies
+          event_expiry_duration = managed_memory_configuration.value.event_expiry_duration
+          encryption_key_arn    = managed_memory_configuration.value.encryption_key_arn
+        }
+      }
+
+      dynamic "agentcore_memory_configuration" {
+        for_each = memory.value.agentcore_memory_configuration != null ? [memory.value.agentcore_memory_configuration] : []
+        content {
+          arn            = agentcore_memory_configuration.value.arn
+          actor_id       = agentcore_memory_configuration.value.actor_id
+          messages_count = agentcore_memory_configuration.value.messages_count
+        }
+      }
+
+      dynamic "disabled" {
+        for_each = memory.value.disabled ? [1] : []
+        content {}
+      }
+    }
+  }
+
+  dynamic "environment" {
+    for_each = var.enable_vpc ? [1] : []
+    content {
+      agentcore_runtime_environment {
+        network_configuration {
+          network_mode = "VPC"
+          network_mode_config {
+            security_groups = [aws_security_group.harness[0].id]
+            subnets         = var.subnet_ids
+          }
+        }
+      }
+    }
+  }
+
+  tags = var.tags
+
+  depends_on = [aws_iam_role_policy.execution_role]
+}
+
+# Scoped to the memory ARN the service assigns, which is only readable after the
+# Harness exists, so this is a policy of its own rather than a baseline
+# statement. Skipped when the Harness uses a role or memory the module did not
+# create.
+resource "aws_iam_role_policy" "managed_memory" {
+  count = local.create_execution_role && local.has_managed_memory ? 1 : 0
+
+  name = "\${local.harness_name_prefix}-HarnessManagedMemoryPolicy"
+  role = aws_iam_role.execution_role[0].id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Sid    = "AgentCoreManagedMemory"
+      Effect = "Allow"
+      Action = [
+        "bedrock-agentcore:CreateEvent",
+        "bedrock-agentcore:DeleteEvent",
+        "bedrock-agentcore:GetEvent",
+        "bedrock-agentcore:ListEvents",
+        "bedrock-agentcore:RetrieveMemoryRecords",
+      ]
+      Resource = [
+        aws_bedrockagentcore_harness.this.memory_actual[0].managed_memory_configuration[0].arn,
+      ]
+    }]
+  })
+}
+
+module "add_harness_arn_to_runtime_config" {
+  source = "../../../core/runtime-config/entry"
+
+  namespace = "agentcore"
+  key       = "harnesses"
+  value     = { "MyHarness" = aws_bedrockagentcore_harness.this.arn }
+}
+
+output "harness_id" {
+  description = "ID of the Amazon Bedrock AgentCore Harness"
+  value       = aws_bedrockagentcore_harness.this.harness_id
+}
+
+output "harness_arn" {
+  description = "ARN of the Amazon Bedrock AgentCore Harness"
+  value       = aws_bedrockagentcore_harness.this.arn
+}
+
+output "execution_role_arn" {
+  description = "ARN of the IAM role assumed by the Harness, whether generated or supplied via var.execution_role_arn"
+  value       = local.execution_role_arn
+}
+
+output "security_group_id" {
+  description = "Security group ID of the Harness, for use in ingress rules on resources it must reach (e.g. a database). Null unless enable_vpc is true."
+  value       = var.enable_vpc ? aws_security_group.harness[0].id : null
+}
+"
+`;

--- a/packages/nx-plugin/src/migrations/latest/terraform-harness-vpc-role-and-memory-grant/__snapshots__/migration.spec.ts.snap
+++ b/packages/nx-plugin/src/migrations/latest/terraform-harness-vpc-role-and-memory-grant/__snapshots__/migration.spec.ts.snap
@@ -23,9 +23,9 @@ variable "model_id" {
 }
 
 variable "allowed_tools" {
-  description = "Tools the Harness may use, e.g. [\\"@builtin\\"] or narrower patterns such as [\\"@builtin/file_operations\\"]. Deploys with no tools when null."
+  description = "Tools the Harness may use. Defaults to none; set [\\"@builtin\\"] for every built-in tool, or name individual tools. Always sent explicitly, since the service treats an absent value as every tool."
   type        = list(string)
-  default     = null
+  default     = []
 }
 
 variable "memory" {

--- a/packages/nx-plugin/src/migrations/latest/terraform-harness-vpc-role-and-memory-grant/__snapshots__/migration.spec.ts.snap
+++ b/packages/nx-plugin/src/migrations/latest/terraform-harness-vpc-role-and-memory-grant/__snapshots__/migration.spec.ts.snap
@@ -337,10 +337,34 @@ resource "aws_iam_role_policy" "execution_role" {
           "arn:\${local.partition}:bedrock-agentcore:\${local.region}:aws:code-interpreter/*",
         ]
       },
-      ], [
-      # Null Sid/Condition fields are dropped from the rendered policy.
-      for statement in var.additional_execution_role_policy_statements :
-      { for key, value in statement : key => value if value != null }
+      ],
+      # In VPC mode the Harness pulls its managed container from a private ECR
+      # repository in the region rather than ECR Public, so it needs pull
+      # permissions on it. The repository is service-owned, hence the wildcard
+      # account.
+      var.enable_vpc ? [
+        {
+          Sid    = "EcrManagedImagePull"
+          Effect = "Allow"
+          Action = [
+            "ecr:BatchGetImage",
+            "ecr:GetDownloadUrlForLayer",
+            "ecr:BatchCheckLayerAvailability",
+          ]
+          Resource = ["arn:\${local.partition}:ecr:\${local.region}:*:repository/harness-*"]
+        },
+        {
+          #checkov:skip=CKV_AWS_355:EcrManagedImageToken requires a wildcard resource; ecr:GetAuthorizationToken has no resource-level permission
+          Sid      = "EcrManagedImageToken"
+          Effect   = "Allow"
+          Action   = ["ecr:GetAuthorizationToken"]
+          Resource = ["*"]
+        },
+      ] : [],
+      [
+        # Null Sid/Condition fields are dropped from the rendered policy.
+        for statement in var.additional_execution_role_policy_statements :
+        { for key, value in statement : key => value if value != null }
     ])
   })
 }

--- a/packages/nx-plugin/src/migrations/latest/terraform-harness-vpc-role-and-memory-grant/__snapshots__/migration.spec.ts.snap
+++ b/packages/nx-plugin/src/migrations/latest/terraform-harness-vpc-role-and-memory-grant/__snapshots__/migration.spec.ts.snap
@@ -76,17 +76,28 @@ variable "timeout_seconds" {
   default     = null
 }
 
-variable "execution_role_arn" {
-  description = "ARN of an existing IAM role for the Harness to assume. Used as-is: no role is created and none of the baseline permissions below are granted. Creates the baseline role when null."
-  type        = string
-  default     = null
+variable "create_execution_role" {
+  description = "Create the execution role with the baseline permissions below. Set false alongside execution_role_arn to use a role you already have, which is then used as-is."
+  type        = bool
+  default     = true
 
   validation {
-    condition = var.execution_role_arn == null || (
+    condition     = var.create_execution_role || var.execution_role_arn != null
+    error_message = "execution_role_arn must be set when create_execution_role is false."
+  }
+
+  validation {
+    condition = var.create_execution_role || (
       var.model_resource_arns == null && length(var.additional_execution_role_policy_statements) == 0
     )
-    error_message = "model_resource_arns and additional_execution_role_policy_statements configure the generated execution role, which is not created when execution_role_arn is supplied. Grant those permissions on the supplied role instead."
+    error_message = "model_resource_arns and additional_execution_role_policy_statements configure the generated execution role, which is not created when create_execution_role is false. Grant those permissions on the supplied role instead."
   }
+}
+
+variable "execution_role_arn" {
+  description = "ARN of an existing IAM role for the Harness to assume. Requires create_execution_role = false."
+  type        = string
+  default     = null
 }
 
 variable "model_resource_arns" {
@@ -161,8 +172,7 @@ locals {
     "arn:\${local.partition}:bedrock:\${local.region}:\${local.account_id}:*",
   ]
 
-  create_execution_role = var.execution_role_arn == null
-  execution_role_arn    = local.create_execution_role ? aws_iam_role.execution_role[0].arn : var.execution_role_arn
+  execution_role_arn = var.create_execution_role ? aws_iam_role.execution_role[0].arn : var.execution_role_arn
 
   # The service provisions managed memory unless var.memory redirects it
   # elsewhere or turns it off.
@@ -170,7 +180,7 @@ locals {
 }
 
 resource "aws_iam_role" "execution_role" {
-  count = local.create_execution_role ? 1 : 0
+  count = var.create_execution_role ? 1 : 0
 
   name = "\${local.harness_name_prefix}-HarnessRole-\${random_id.unique_suffix.hex}"
 
@@ -200,7 +210,7 @@ resource "aws_iam_role" "execution_role" {
 # customer-owned resources via var.additional_execution_role_policy_statements.
 # https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/harness-security.html
 resource "aws_iam_role_policy" "execution_role" {
-  count = local.create_execution_role ? 1 : 0
+  count = var.create_execution_role ? 1 : 0
 
   name = "\${local.harness_name_prefix}-HarnessPolicy"
   role = aws_iam_role.execution_role[0].id
@@ -432,7 +442,7 @@ resource "aws_bedrockagentcore_harness" "this" {
 # statement. Skipped when the Harness uses a role or memory the module did not
 # create.
 resource "aws_iam_role_policy" "managed_memory" {
-  count = local.create_execution_role && local.has_managed_memory ? 1 : 0
+  count = var.create_execution_role && local.has_managed_memory ? 1 : 0
 
   name = "\${local.harness_name_prefix}-HarnessManagedMemoryPolicy"
   role = aws_iam_role.execution_role[0].id

--- a/packages/nx-plugin/src/migrations/latest/terraform-harness-vpc-role-and-memory-grant/metadata.json
+++ b/packages/nx-plugin/src/migrations/latest/terraform-harness-vpc-role-and-memory-grant/metadata.json
@@ -1,0 +1,3 @@
+{
+  "description": "Add VPC, execution role and native field support to the vended Terraform AgentCore Harness module, and scope its managed-memory grant to the service-assigned ARN"
+}

--- a/packages/nx-plugin/src/migrations/latest/terraform-harness-vpc-role-and-memory-grant/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/latest/terraform-harness-vpc-role-and-memory-grant/migration.spec.ts
@@ -352,17 +352,18 @@ describe('terraform-harness-vpc-role-and-memory-grant migration', () => {
     await migration(tree);
     const contents = tree.read(APP_MODULE_FILE, 'utf-8')!;
 
+    expect(contents).toContain('variable "create_execution_role"');
     expect(contents).toContain('variable "execution_role_arn"');
     expect(contents).toContain(
-      'create_execution_role = var.execution_role_arn == null',
+      'execution_role_arn = var.create_execution_role ? aws_iam_role.execution_role[0].arn : var.execution_role_arn',
     );
 
     // Both the role and its baseline policy are skipped for a supplied role
     expect(contents).toMatch(
-      /resource "aws_iam_role" "execution_role" \{\s*\n\s*count = local\.create_execution_role \? 1 : 0/,
+      /resource "aws_iam_role" "execution_role" \{\s*\n\s*count = var\.create_execution_role \? 1 : 0/,
     );
     expect(contents).toMatch(
-      /resource "aws_iam_role_policy" "execution_role" \{\s*\n\s*count = local\.create_execution_role \? 1 : 0/,
+      /resource "aws_iam_role_policy" "execution_role" \{\s*\n\s*count = var\.create_execution_role \? 1 : 0/,
     );
     expect(contents).toContain('role = aws_iam_role.execution_role[0].id');
 
@@ -421,7 +422,7 @@ describe('terraform-harness-vpc-role-and-memory-grant migration', () => {
       'resource "aws_iam_role_policy" "managed_memory"',
     );
     expect(contents).toContain(
-      'count = local.create_execution_role && local.has_managed_memory ? 1 : 0',
+      'count = var.create_execution_role && local.has_managed_memory ? 1 : 0',
     );
     expect(contents).toContain(
       'has_managed_memory = var.memory == null || var.memory.managed_memory_configuration != null',

--- a/packages/nx-plugin/src/migrations/latest/terraform-harness-vpc-role-and-memory-grant/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/latest/terraform-harness-vpc-role-and-memory-grant/migration.spec.ts
@@ -16,8 +16,10 @@ const divergedMessage = (filePath: string) =>
   `${filePath}: has diverged from the generated shape - left untouched. To pick up VPC support, a supplied execution role, the allowed_tools/memory/environment_variables/max_iterations/timeout_seconds variables and the corrected managed-memory grant, compare it against the agentcore-harness generator's Terraform template and apply the parts you want.`;
 
 /**
- * The vended Terraform harness app module as it was before VPC support, a
- * supplied execution role and the native field variables.
+ * The vended Terraform harness app module as an upgrading workspace has it: the
+ * earlier no-tools-by-default migration has run, so `allowed_tools` is already
+ * declared and assigned, but VPC support, a supplied execution role and the
+ * remaining native fields are not there yet.
  */
 const oldAppModule = `terraform {
   required_version = ">= 1.0"
@@ -38,6 +40,12 @@ variable "model_id" {
   description = "Amazon Bedrock model or inference profile used by default."
   type        = string
   default     = "global.anthropic.claude-sonnet-4-6"
+}
+
+variable "allowed_tools" {
+  description = "Tools the Harness may use. Defaults to none; set [\\"@builtin\\"] for every built-in tool, or name individual tools. Always sent explicitly, since the service treats an absent value as every tool."
+  type        = list(string)
+  default     = []
 }
 
 variable "model_resource_arns" {
@@ -264,6 +272,7 @@ resource "aws_iam_role_policy" "execution_role" {
 resource "aws_bedrockagentcore_harness" "this" {
   harness_name       = local.harness_name
   execution_role_arn = aws_iam_role.execution_role.arn
+  allowed_tools      = var.allowed_tools
 
   model {
     bedrock_model_config {

--- a/packages/nx-plugin/src/migrations/latest/terraform-harness-vpc-role-and-memory-grant/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/latest/terraform-harness-vpc-role-and-memory-grant/migration.spec.ts
@@ -1,0 +1,563 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import type { Tree } from '@nx/devkit';
+import { agentcoreHarnessGenerator } from '../../../agentcore-harness/generator.js';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test.js';
+import migration from './migration.js';
+
+const APP_MODULE_FILE =
+  'packages/common/terraform/src/app/harnesses/my-harness/my-harness.tf';
+const APP_MODULE_FILE_2 =
+  'packages/common/terraform/src/app/harnesses/other-harness/other-harness.tf';
+
+const divergedMessage = (filePath: string) =>
+  `${filePath}: has diverged from the generated shape - left untouched. To pick up VPC support, a supplied execution role, the allowed_tools/memory/environment_variables/max_iterations/timeout_seconds variables and the corrected managed-memory grant, compare it against the agentcore-harness generator's Terraform template and apply the parts you want.`;
+
+/**
+ * The vended Terraform harness app module as it was before VPC support, a
+ * supplied execution role and the native field variables.
+ */
+const oldAppModule = `terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "6.61.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "3.6.3"
+    }
+  }
+}
+
+variable "model_id" {
+  description = "Amazon Bedrock model or inference profile used by default."
+  type        = string
+  default     = "global.anthropic.claude-sonnet-4-6"
+}
+
+variable "model_resource_arns" {
+  description = "Bedrock model and inference-profile ARNs the execution role may invoke. Defaults to every foundation model plus this account's Bedrock resources in the deployment region; replace with narrower ARNs to restrict baseline model access."
+  type        = set(string)
+  default     = null
+}
+
+variable "additional_execution_role_policy_statements" {
+  description = "Additional least-privilege IAM policy statements required by configured optional capabilities (e.g. customer-owned Gateways, memory, custom browsers or code interpreters, skills, secrets). Sid and Condition are optional; null fields are omitted from the rendered policy."
+  type = list(object({
+    Sid       = optional(string)
+    Effect    = string
+    Action    = list(string)
+    Resource  = list(string)
+    Condition = optional(any)
+  }))
+  default = []
+}
+
+data "aws_caller_identity" "current" {}
+data "aws_partition" "current" {}
+data "aws_region" "current" {}
+
+resource "random_id" "unique_suffix" {
+  byte_length = 4
+}
+
+locals {
+  account_id = data.aws_caller_identity.current.account_id
+  partition  = data.aws_partition.current.partition
+  region     = data.aws_region.current.region
+
+  # Capped at 31 characters so the suffix keeps the deployed Harness name
+  # within its 40-character limit.
+  harness_name_prefix = "MyHarness"
+  harness_name        = "\${local.harness_name_prefix}_\${random_id.unique_suffix.hex}"
+
+  # Set var.model_resource_arns to narrow the default model access.
+  model_resource_arns = var.model_resource_arns != null ? var.model_resource_arns : [
+    "arn:\${local.partition}:bedrock:*::foundation-model/*",
+    "arn:\${local.partition}:bedrock:\${local.region}:\${local.account_id}:*",
+  ]
+}
+
+resource "aws_iam_role" "execution_role" {
+  name = "\${local.harness_name_prefix}-HarnessRole-\${random_id.unique_suffix.hex}"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Principal = {
+        Service = "bedrock-agentcore.amazonaws.com"
+      }
+      Action = "sts:AssumeRole"
+      Condition = {
+        StringEquals = {
+          "aws:SourceAccount" = local.account_id
+        }
+        ArnLike = {
+          "aws:SourceArn" = "arn:\${local.partition}:bedrock-agentcore:\${local.region}:\${local.account_id}:*"
+        }
+      }
+    }]
+  })
+}
+
+# Baseline permissions per the AgentCore Harness security guidance; extend for
+# customer-owned resources via var.additional_execution_role_policy_statements.
+# https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/harness-security.html
+resource "aws_iam_role_policy" "execution_role" {
+  name = "\${local.harness_name_prefix}-HarnessPolicy"
+  role = aws_iam_role.execution_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = concat([
+      {
+        Sid    = "BedrockModelInvocation"
+        Effect = "Allow"
+        Action = [
+          "bedrock:InvokeModel",
+          "bedrock:InvokeModelWithResponseStream",
+        ]
+        Resource = local.model_resource_arns
+      },
+      {
+        #checkov:skip=CKV_AWS_355:EcrPublicTokenAccess requires a wildcard resource; ecr-public:GetAuthorizationToken has no resource-level permission
+        Sid      = "EcrPublicTokenAccess"
+        Effect   = "Allow"
+        Action   = ["ecr-public:GetAuthorizationToken"]
+        Resource = ["*"]
+      },
+      {
+        #checkov:skip=CKV_AWS_355:StsForEcrPublicPull requires a wildcard resource; sts:GetServiceBearerToken has no resource-level permission
+        Sid      = "StsForEcrPublicPull"
+        Effect   = "Allow"
+        Action   = ["sts:GetServiceBearerToken"]
+        Resource = ["*"]
+      },
+      {
+        #checkov:skip=CKV_AWS_355:XRayTracingAccess requires a wildcard resource; the X-Ray segment and sampling APIs have no resource-level permission
+        #checkov:skip=CKV_AWS_290:XRayTracingAccess requires a wildcard resource; the X-Ray segment and sampling APIs have no resource-level permission
+        Sid    = "XRayTracingAccess"
+        Effect = "Allow"
+        Action = [
+          "xray:PutTraceSegments",
+          "xray:PutTelemetryRecords",
+          "xray:GetSamplingRules",
+          "xray:GetSamplingTargets",
+        ]
+        Resource = ["*"]
+      },
+      {
+        Sid    = "CloudWatchLogsGroup"
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:DescribeLogStreams",
+        ]
+        Resource = [
+          "arn:\${local.partition}:logs:\${local.region}:\${local.account_id}:log-group:/aws/bedrock-agentcore/runtimes/*",
+        ]
+      },
+      {
+        Sid      = "CloudWatchLogsDescribeGroups"
+        Effect   = "Allow"
+        Action   = ["logs:DescribeLogGroups"]
+        Resource = ["arn:\${local.partition}:logs:\${local.region}:\${local.account_id}:log-group:*"]
+      },
+      {
+        Sid    = "CloudWatchLogsStream"
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogStream",
+          "logs:PutLogEvents",
+        ]
+        Resource = [
+          "arn:\${local.partition}:logs:\${local.region}:\${local.account_id}:log-group:/aws/bedrock-agentcore/runtimes/*:log-stream:*",
+        ]
+      },
+      {
+        #checkov:skip=CKV_AWS_355:CloudWatchMetricsPublish requires a wildcard resource; cloudwatch:PutMetricData is scoped by the namespace condition instead
+        #checkov:skip=CKV_AWS_290:CloudWatchMetricsPublish requires a wildcard resource; cloudwatch:PutMetricData is scoped by the namespace condition instead
+        Sid      = "CloudWatchMetricsPublish"
+        Effect   = "Allow"
+        Action   = ["cloudwatch:PutMetricData"]
+        Resource = ["*"]
+        Condition = {
+          StringEquals = {
+            "cloudwatch:namespace" = "bedrock-agentcore"
+          }
+        }
+      },
+      {
+        Sid    = "AgentCoreWorkloadIdentity"
+        Effect = "Allow"
+        Action = [
+          "bedrock-agentcore:GetWorkloadAccessToken",
+          "bedrock-agentcore:GetWorkloadAccessTokenForJWT",
+        ]
+        Resource = [
+          "arn:\${local.partition}:bedrock-agentcore:\${local.region}:\${local.account_id}:workload-identity-directory/default",
+          "arn:\${local.partition}:bedrock-agentcore:\${local.region}:\${local.account_id}:workload-identity-directory/default/workload-identity/harness_\${local.harness_name}-*",
+        ]
+      },
+      # The service names the managed memory from the harness name plus a
+      # generated suffix, so this scopes to that prefix.
+      {
+        Sid    = "AgentCoreManagedMemory"
+        Effect = "Allow"
+        Action = [
+          "bedrock-agentcore:CreateEvent",
+          "bedrock-agentcore:DeleteEvent",
+          "bedrock-agentcore:GetEvent",
+          "bedrock-agentcore:ListEvents",
+          "bedrock-agentcore:RetrieveMemoryRecords",
+        ]
+        Resource = [
+          "arn:\${local.partition}:bedrock-agentcore:\${local.region}:\${local.account_id}:memory/\${local.harness_name}-*",
+        ]
+      },
+      {
+        Sid    = "AgentCoreBrowserDefault"
+        Effect = "Allow"
+        Action = [
+          "bedrock-agentcore:StartBrowserSession",
+          "bedrock-agentcore:StopBrowserSession",
+          "bedrock-agentcore:GetBrowserSession",
+          "bedrock-agentcore:ListBrowserSessions",
+          "bedrock-agentcore:UpdateBrowserStream",
+          "bedrock-agentcore:ConnectBrowserAutomationStream",
+          "bedrock-agentcore:ConnectBrowserLiveViewStream",
+        ]
+        Resource = [
+          "arn:\${local.partition}:bedrock-agentcore:\${local.region}:aws:browser/*",
+        ]
+      },
+      {
+        Sid    = "AgentCoreCodeInterpreterDefault"
+        Effect = "Allow"
+        Action = [
+          "bedrock-agentcore:StartCodeInterpreterSession",
+          "bedrock-agentcore:StopCodeInterpreterSession",
+          "bedrock-agentcore:GetCodeInterpreterSession",
+          "bedrock-agentcore:ListCodeInterpreterSessions",
+          "bedrock-agentcore:InvokeCodeInterpreter",
+        ]
+        Resource = [
+          "arn:\${local.partition}:bedrock-agentcore:\${local.region}:aws:code-interpreter/*",
+        ]
+      },
+      ], [
+      # Null Sid/Condition fields are dropped from the rendered policy.
+      for statement in var.additional_execution_role_policy_statements :
+      { for key, value in statement : key => value if value != null }
+    ])
+  })
+}
+
+# Omitting authorizer_configuration uses IAM inbound authorization; add a
+# custom_jwt_authorizer block to change that.
+resource "aws_bedrockagentcore_harness" "this" {
+  harness_name       = local.harness_name
+  execution_role_arn = aws_iam_role.execution_role.arn
+
+  model {
+    bedrock_model_config {
+      model_id = var.model_id
+    }
+  }
+
+  # Read at plan time; the walk up from path.module reaches the workspace root.
+  system_prompt {
+    text = file("\${path.module}/../../../../../../../packages/my-harness/src/PROMPT.md")
+  }
+
+  depends_on = [aws_iam_role_policy.execution_role]
+}
+
+module "add_harness_arn_to_runtime_config" {
+  source = "../../../core/runtime-config/entry"
+
+  namespace = "agentcore"
+  key       = "harnesses"
+  value     = { "MyHarness" = aws_bedrockagentcore_harness.this.arn }
+}
+
+output "harness_id" {
+  description = "ID of the Amazon Bedrock AgentCore Harness"
+  value       = aws_bedrockagentcore_harness.this.harness_id
+}
+
+output "harness_arn" {
+  description = "ARN of the Amazon Bedrock AgentCore Harness"
+  value       = aws_bedrockagentcore_harness.this.arn
+}
+
+output "execution_role_arn" {
+  description = "ARN of the IAM role assumed by the Harness"
+  value       = aws_iam_role.execution_role.arn
+}
+`;
+
+describe('terraform-harness-vpc-role-and-memory-grant migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeUsingTsSolutionSetup();
+  });
+
+  it('does nothing when no vended harness modules exist', async () => {
+    const result = await migration(tree);
+    expect(result.nextSteps).toEqual([]);
+  });
+
+  it('adds the VPC variables, security group and network configuration', async () => {
+    tree.write(APP_MODULE_FILE, oldAppModule);
+
+    const result = await migration(tree);
+    const contents = tree.read(APP_MODULE_FILE, 'utf-8')!;
+
+    expect(contents).toContain('variable "enable_vpc"');
+    expect(contents).toContain('variable "vpc_id"');
+    expect(contents).toContain('variable "subnet_ids"');
+    expect(contents).toContain(
+      'error_message = "vpc_id and subnet_ids must be set when enable_vpc is true."',
+    );
+
+    // The security group and its 443-only egress rule
+    expect(contents).toContain('resource "aws_security_group" "harness"');
+    expect(contents).toContain(
+      'resource "aws_vpc_security_group_egress_rule" "harness_https"',
+    );
+    expect(contents).toContain('from_port         = 443');
+
+    // The network configuration is rendered only when enable_vpc is set
+    expect(contents).toContain('dynamic "environment"');
+    expect(contents).toContain('network_mode = "VPC"');
+    expect(contents).toContain(
+      'security_groups = [aws_security_group.harness[0].id]',
+    );
+
+    expect(contents).toContain('output "security_group_id"');
+    expect(result.nextSteps).toEqual([]);
+  });
+
+  it('makes the generated role conditional on none being supplied', async () => {
+    tree.write(APP_MODULE_FILE, oldAppModule);
+
+    await migration(tree);
+    const contents = tree.read(APP_MODULE_FILE, 'utf-8')!;
+
+    expect(contents).toContain('variable "execution_role_arn"');
+    expect(contents).toContain(
+      'create_execution_role = var.execution_role_arn == null',
+    );
+
+    // Both the role and its baseline policy are skipped for a supplied role
+    expect(contents).toMatch(
+      /resource "aws_iam_role" "execution_role" \{\s*\n\s*count = local\.create_execution_role \? 1 : 0/,
+    );
+    expect(contents).toMatch(
+      /resource "aws_iam_role_policy" "execution_role" \{\s*\n\s*count = local\.create_execution_role \? 1 : 0/,
+    );
+    expect(contents).toContain('role = aws_iam_role.execution_role[0].id');
+
+    // The harness and the output both follow whichever role is in use
+    expect(contents).toContain('execution_role_arn = local.execution_role_arn');
+    expect(contents).toContain('value       = local.execution_role_arn');
+  });
+
+  it('exposes the native fields as variables', async () => {
+    tree.write(APP_MODULE_FILE, oldAppModule);
+
+    await migration(tree);
+    const contents = tree.read(APP_MODULE_FILE, 'utf-8')!;
+
+    for (const name of [
+      'allowed_tools',
+      'memory',
+      'environment_variables',
+      'max_iterations',
+      'timeout_seconds',
+    ]) {
+      expect(contents).toContain(`variable "${name}"`);
+    }
+
+    expect(contents).toContain('allowed_tools         = var.allowed_tools');
+    expect(contents).toContain(
+      'environment_variables = var.environment_variables',
+    );
+    expect(contents).toContain('max_iterations        = var.max_iterations');
+    expect(contents).toContain('timeout_seconds       = var.timeout_seconds');
+
+    // memory is rendered as a dynamic block covering all three variants
+    expect(contents).toContain('dynamic "memory"');
+    expect(contents).toContain('dynamic "managed_memory_configuration"');
+    expect(contents).toContain('dynamic "agentcore_memory_configuration"');
+    expect(contents).toContain('dynamic "disabled"');
+  });
+
+  it('re-scopes the managed-memory grant to the service-assigned ARN', async () => {
+    tree.write(APP_MODULE_FILE, oldAppModule);
+
+    // The name-prefix guess is what the module granted before
+    expect(oldAppModule).toContain('memory/${local.harness_name}-*');
+
+    await migration(tree);
+    const contents = tree.read(APP_MODULE_FILE, 'utf-8')!;
+
+    // The guess is gone, replaced by the ARN the service assigns
+    expect(contents).not.toContain('memory/${local.harness_name}-*');
+    expect(contents).toContain(
+      'aws_bedrockagentcore_harness.this.memory_actual[0].managed_memory_configuration[0].arn',
+    );
+
+    // Granted only when the module created both the role and the memory
+    expect(contents).toContain(
+      'resource "aws_iam_role_policy" "managed_memory"',
+    );
+    expect(contents).toContain(
+      'count = local.create_execution_role && local.has_managed_memory ? 1 : 0',
+    );
+    expect(contents).toContain(
+      'has_managed_memory = var.memory == null || var.memory.managed_memory_configuration != null',
+    );
+
+    // The grant is no longer part of the baseline policy
+    const baselinePolicy = contents.slice(
+      contents.indexOf('resource "aws_iam_role_policy" "execution_role"'),
+      contents.indexOf('# Security group for the Harness'),
+    );
+    expect(baselinePolicy).not.toContain('AgentCoreManagedMemory');
+  });
+
+  it('leaves the other baseline statements untouched', async () => {
+    tree.write(APP_MODULE_FILE, oldAppModule);
+
+    await migration(tree);
+    const contents = tree.read(APP_MODULE_FILE, 'utf-8')!;
+
+    for (const sid of [
+      'BedrockModelInvocation',
+      'EcrPublicTokenAccess',
+      'StsForEcrPublicPull',
+      'XRayTracingAccess',
+      'CloudWatchLogsGroup',
+      'CloudWatchLogsDescribeGroups',
+      'CloudWatchLogsStream',
+      'CloudWatchMetricsPublish',
+      'AgentCoreWorkloadIdentity',
+      'AgentCoreBrowserDefault',
+      'AgentCoreCodeInterpreterDefault',
+    ]) {
+      expect(contents).toContain(`"${sid}"`);
+    }
+
+    // And the module's existing configuration survives
+    expect(contents).toContain('variable "model_id"');
+    expect(contents).toContain('module "add_harness_arn_to_runtime_config"');
+    expect(contents).toContain('output "harness_arn"');
+    expect(contents).toContain('output "harness_id"');
+  });
+
+  it('skips and reports a module whose baseline policy was edited', async () => {
+    // The baseline policy is replaced whole, so an added statement would be
+    // discarded. Such a module is left alone instead.
+    tree.write(
+      APP_MODULE_FILE,
+      oldAppModule.replace(
+        '      {\n        Sid    = "AgentCoreBrowserDefault"',
+        '      {\n        Sid      = "MyOwnStatement"\n        Effect   = "Allow"\n        Action   = ["s3:GetObject"]\n        Resource = ["arn:aws:s3:::my-bucket/*"]\n      },\n      {\n        Sid    = "AgentCoreBrowserDefault"',
+      ),
+    );
+
+    const result = await migration(tree);
+    const contents = tree.read(APP_MODULE_FILE, 'utf-8')!;
+
+    expect(contents).toContain('"MyOwnStatement"');
+    expect(contents).not.toContain('variable "enable_vpc"');
+    expect(result.nextSteps).toEqual([divergedMessage(APP_MODULE_FILE)]);
+  });
+
+  it('migrates every app module directory found', async () => {
+    tree.write(APP_MODULE_FILE, oldAppModule);
+    tree.write(APP_MODULE_FILE_2, oldAppModule);
+
+    await migration(tree);
+
+    for (const file of [APP_MODULE_FILE, APP_MODULE_FILE_2]) {
+      expect(tree.read(file, 'utf-8')!).toContain('variable "enable_vpc"');
+    }
+  });
+
+  it('is idempotent', async () => {
+    tree.write(APP_MODULE_FILE, oldAppModule);
+
+    await migration(tree);
+    const afterFirst = tree.read(APP_MODULE_FILE, 'utf-8');
+
+    await migration(tree);
+
+    expect(tree.read(APP_MODULE_FILE, 'utf-8')).toEqual(afterFirst);
+  });
+
+  it('leaves an already-migrated module untouched', async () => {
+    tree.write(APP_MODULE_FILE, oldAppModule);
+    await migration(tree);
+    const migrated = tree.read(APP_MODULE_FILE, 'utf-8')!;
+
+    tree.write(APP_MODULE_FILE, migrated);
+    const result = await migration(tree);
+
+    expect(tree.read(APP_MODULE_FILE, 'utf-8')).toEqual(migrated);
+    expect(result.nextSteps).toEqual([]);
+  });
+
+  it('skips and reports a diverged app module', async () => {
+    tree.write(
+      APP_MODULE_FILE,
+      'resource "aws_bedrockagentcore_harness" "mine" {\n  harness_name = "custom"\n}\n',
+    );
+
+    const result = await migration(tree);
+
+    expect(tree.read(APP_MODULE_FILE, 'utf-8')).not.toContain(
+      'variable "enable_vpc"',
+    );
+    expect(result.nextSteps).toEqual([divergedMessage(APP_MODULE_FILE)]);
+  });
+
+  it('converges on what the generator writes today', async () => {
+    // The migration's contract: an upgraded workspace ends up with the module a
+    // workspace generated today would have.
+    tree.write(APP_MODULE_FILE, oldAppModule);
+    await migration(tree);
+
+    const fresh = createTreeUsingTsSolutionSetup();
+    await agentcoreHarnessGenerator(fresh, {
+      name: 'my-harness',
+      iac: 'terraform',
+    });
+
+    // Provider version pins are the `sync-vended-versions` migration's job, so
+    // the fixture's are left as they were.
+    const withoutVersionPins = (contents: string) =>
+      contents.replace(/^(\s*version\s*=\s*)".*"$/gm, '$1"<pinned>"');
+
+    expect(withoutVersionPins(tree.read(APP_MODULE_FILE, 'utf-8')!)).toEqual(
+      withoutVersionPins(fresh.read(APP_MODULE_FILE, 'utf-8')!),
+    );
+  });
+
+  it('snapshots the migrated module', async () => {
+    tree.write(APP_MODULE_FILE, oldAppModule);
+
+    await migration(tree);
+
+    expect(tree.read(APP_MODULE_FILE, 'utf-8')).toMatchSnapshot();
+  });
+});

--- a/packages/nx-plugin/src/migrations/latest/terraform-harness-vpc-role-and-memory-grant/migration.ts
+++ b/packages/nx-plugin/src/migrations/latest/terraform-harness-vpc-role-and-memory-grant/migration.ts
@@ -26,8 +26,8 @@ import {
  *
  * - `enable_vpc` / `vpc_id` / `subnet_ids` with a security group and a 443-only
  *   egress rule, so the Harness can reach private resources.
- * - `execution_role_arn`, so an existing role can be supplied. The generated
- *   role and its baseline policy are then not created.
+ * - `create_execution_role` / `execution_role_arn`, so an existing role can be
+ *   supplied. The generated role and its baseline policy are then not created.
  * - `allowed_tools`, `memory`, `environment_variables`, `max_iterations` and
  *   `timeout_seconds` as variables rather than HCL edits.
  * - The managed-memory grant moved to its own policy, made conditional and
@@ -100,17 +100,28 @@ variable "timeout_seconds" {
   default     = null
 }
 
-variable "execution_role_arn" {
-  description = "ARN of an existing IAM role for the Harness to assume. Used as-is: no role is created and none of the baseline permissions below are granted. Creates the baseline role when null."
-  type        = string
-  default     = null
+variable "create_execution_role" {
+  description = "Create the execution role with the baseline permissions below. Set false alongside execution_role_arn to use a role you already have, which is then used as-is."
+  type        = bool
+  default     = true
 
   validation {
-    condition = var.execution_role_arn == null || (
+    condition     = var.create_execution_role || var.execution_role_arn != null
+    error_message = "execution_role_arn must be set when create_execution_role is false."
+  }
+
+  validation {
+    condition = var.create_execution_role || (
       var.model_resource_arns == null && length(var.additional_execution_role_policy_statements) == 0
     )
-    error_message = "model_resource_arns and additional_execution_role_policy_statements configure the generated execution role, which is not created when execution_role_arn is supplied. Grant those permissions on the supplied role instead."
+    error_message = "model_resource_arns and additional_execution_role_policy_statements configure the generated execution role, which is not created when create_execution_role is false. Grant those permissions on the supplied role instead."
   }
+}
+
+variable "execution_role_arn" {
+  description = "ARN of an existing IAM role for the Harness to assume. Requires create_execution_role = false."
+  type        = string
+  default     = null
 }`;
 
 /** VPC and tag variables added after `additional_execution_role_policy_statements`. */
@@ -145,8 +156,7 @@ variable "tags" {
 }`;
 
 /** Locals added to the module's existing `locals` block. */
-const NEW_LOCALS_TEXT = `  create_execution_role = var.execution_role_arn == null
-  execution_role_arn    = local.create_execution_role ? aws_iam_role.execution_role[0].arn : var.execution_role_arn
+const NEW_LOCALS_TEXT = `  execution_role_arn = var.create_execution_role ? aws_iam_role.execution_role[0].arn : var.execution_role_arn
 
   # The service provisions managed memory unless var.memory redirects it
   # elsewhere or turns it off.
@@ -232,7 +242,7 @@ const MANAGED_MEMORY_POLICY_TEXT = `# Scoped to the memory ARN the service assig
 # statement. Skipped when the Harness uses a role or memory the module did not
 # create.
 resource "aws_iam_role_policy" "managed_memory" {
-  count = local.create_execution_role && local.has_managed_memory ? 1 : 0
+  count = var.create_execution_role && local.has_managed_memory ? 1 : 0
 
   name = "\${local.harness_name_prefix}-HarnessManagedMemoryPolicy"
   role = aws_iam_role.execution_role[0].id
@@ -268,7 +278,7 @@ const SECURITY_GROUP_OUTPUT_TEXT = `output "security_group_id" {
  * statement being removed.
  */
 const BASELINE_POLICY_TEXT = `resource "aws_iam_role_policy" "execution_role" {
-  count = local.create_execution_role ? 1 : 0
+  count = var.create_execution_role ? 1 : 0
 
   name = "\${local.harness_name_prefix}-HarnessPolicy"
   role = aws_iam_role.execution_role[0].id
@@ -528,7 +538,7 @@ export default async function migration(
       tree,
       filePath,
       hcl(
-        '`resource "aws_iam_role" "execution_role" { $body }` => `resource "aws_iam_role" "execution_role" {\n  count = local.create_execution_role ? 1 : 0\n\n  $body\n\n  tags = var.tags\n}`',
+        '`resource "aws_iam_role" "execution_role" { $body }` => `resource "aws_iam_role" "execution_role" {\n  count = var.create_execution_role ? 1 : 0\n\n  $body\n\n  tags = var.tags\n}`',
       ),
     );
 

--- a/packages/nx-plugin/src/migrations/latest/terraform-harness-vpc-role-and-memory-grant/migration.ts
+++ b/packages/nx-plugin/src/migrations/latest/terraform-harness-vpc-role-and-memory-grant/migration.ts
@@ -1,0 +1,608 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import {
+  joinPathFragments,
+  type MigrationReturnObject,
+  type Tree,
+} from '@nx/devkit';
+import {
+  applyGritQL,
+  captureAllGritQL,
+  GRIT_INSERT_PLACEHOLDER,
+  insertViaGritQL,
+  matchGritQL,
+} from '../../../utils/ast.js';
+import { formatFilesInSubtree } from '../../../utils/format.js';
+import {
+  PACKAGES_DIR,
+  SHARED_TERRAFORM_DIR,
+} from '../../../utils/shared-constructs-constants.js';
+
+/**
+ * Bring each vended Terraform AgentCore Harness app module
+ * (`app/harnesses/<name>/<name>.tf`) up to the shape the generator now writes:
+ *
+ * - `enable_vpc` / `vpc_id` / `subnet_ids` with a security group and a 443-only
+ *   egress rule, so the Harness can reach private resources.
+ * - `execution_role_arn`, so an existing role can be supplied. The generated
+ *   role and its baseline policy are then not created.
+ * - `allowed_tools`, `memory`, `environment_variables`, `max_iterations` and
+ *   `timeout_seconds` as variables rather than HCL edits.
+ * - The managed-memory grant moved to its own policy, made conditional and
+ *   re-scoped from a name-prefix guess to the ARN the service assigns.
+ *
+ * These files are generated with `KeepExisting`, so an upgraded workspace keeps
+ * the older module until this runs. Modules that have diverged from the
+ * generated shape are left untouched and reported via `nextSteps`.
+ */
+
+const TERRAFORM_HARNESS_APP_DIR = `${PACKAGES_DIR}/${SHARED_TERRAFORM_DIR}/src/app/harnesses`;
+
+const hcl = (pattern: string) => `language hcl\n${pattern}`;
+
+const divergedMessage = (filePath: string) =>
+  `${filePath}: has diverged from the generated shape - left untouched. To pick up VPC support, a supplied execution role, the allowed_tools/memory/environment_variables/max_iterations/timeout_seconds variables and the corrected managed-memory grant, compare it against the agentcore-harness generator's Terraform template and apply the parts you want.`;
+
+/** Variables added ahead of the existing `model_resource_arns` variable. */
+const NEW_VARIABLES_TEXT = `variable "allowed_tools" {
+  description = "Tools the Harness may use, e.g. [\\"@builtin\\"] or narrower patterns such as [\\"@builtin/file_operations\\"]. Deploys with no tools when null."
+  type        = list(string)
+  default     = null
+}
+
+variable "memory" {
+  description = "Memory configuration for the Harness. Null leaves the service to provision managed memory with default strategies. Set exactly one field: managed_memory_configuration to tune that managed memory, agentcore_memory_configuration to use a memory resource you own, or disabled to turn memory off."
+  type = object({
+    managed_memory_configuration = optional(object({
+      strategies            = optional(set(string))
+      event_expiry_duration = optional(number)
+      encryption_key_arn    = optional(string)
+    }))
+    agentcore_memory_configuration = optional(object({
+      arn            = string
+      actor_id       = optional(string)
+      messages_count = optional(number)
+    }))
+    disabled = optional(bool, false)
+  })
+  default = null
+
+  validation {
+    condition = var.memory == null || length([
+      for configured in [
+        var.memory.managed_memory_configuration != null,
+        var.memory.agentcore_memory_configuration != null,
+        var.memory.disabled,
+      ] : configured if configured
+    ]) == 1
+    error_message = "Set exactly one of memory.managed_memory_configuration, memory.agentcore_memory_configuration or memory.disabled."
+  }
+}
+
+variable "environment_variables" {
+  description = "Environment variables available to the Harness."
+  type        = map(string)
+  default     = null
+  sensitive   = true
+}
+
+variable "max_iterations" {
+  description = "Maximum agent loop iterations per invocation. Uses the service default when null."
+  type        = number
+  default     = null
+}
+
+variable "timeout_seconds" {
+  description = "Maximum seconds an invocation may run. Uses the service default when null."
+  type        = number
+  default     = null
+}
+
+variable "execution_role_arn" {
+  description = "ARN of an existing IAM role for the Harness to assume. Used as-is: no role is created and none of the baseline permissions below are granted. Creates the baseline role when null."
+  type        = string
+  default     = null
+
+  validation {
+    condition = var.execution_role_arn == null || (
+      var.model_resource_arns == null && length(var.additional_execution_role_policy_statements) == 0
+    )
+    error_message = "model_resource_arns and additional_execution_role_policy_statements configure the generated execution role, which is not created when execution_role_arn is supplied. Grant those permissions on the supplied role instead."
+  }
+}`;
+
+/** VPC and tag variables added after `additional_execution_role_policy_statements`. */
+const VPC_VARIABLES_TEXT = `# VPC Configuration (optional)
+variable "enable_vpc" {
+  description = "Run the Harness inside a VPC so it can reach private resources. Set alongside vpc_id/subnet_ids."
+  type        = bool
+  default     = false
+}
+
+variable "vpc_id" {
+  description = "VPC ID to run the Harness in. Required when enable_vpc is true."
+  type        = string
+  default     = null
+
+  validation {
+    condition     = !var.enable_vpc || (var.vpc_id != null && var.subnet_ids != null)
+    error_message = "vpc_id and subnet_ids must be set when enable_vpc is true."
+  }
+}
+
+variable "subnet_ids" {
+  description = "Subnet IDs to run the Harness in. Required when enable_vpc is true."
+  type        = list(string)
+  default     = null
+}
+
+variable "tags" {
+  description = "Tags to apply to resources"
+  type        = map(string)
+  default     = {}
+}`;
+
+/** Locals added to the module's existing `locals` block. */
+const NEW_LOCALS_TEXT = `  create_execution_role = var.execution_role_arn == null
+  execution_role_arn    = local.create_execution_role ? aws_iam_role.execution_role[0].arn : var.execution_role_arn
+
+  # The service provisions managed memory unless var.memory redirects it
+  # elsewhere or turns it off.
+  has_managed_memory = var.memory == null || var.memory.managed_memory_configuration != null`;
+
+/** Security group and egress rule, added before the Harness resource. */
+const SECURITY_GROUP_TEXT = `# Security group for the Harness, used when running inside a VPC
+resource "aws_security_group" "harness" {
+  count = var.enable_vpc ? 1 : 0
+
+  #checkov:skip=CKV2_AWS_5:Attached to the Harness via its network configuration; Checkov cannot resolve this reference
+  name_prefix = "\${local.harness_name_prefix}-harness-"
+  description = "Security group for the \${local.harness_name_prefix} Harness"
+  vpc_id      = var.vpc_id
+  tags        = var.tags
+}
+
+resource "aws_vpc_security_group_egress_rule" "harness_https" {
+  count = var.enable_vpc ? 1 : 0
+
+  security_group_id = aws_security_group.harness[0].id
+  cidr_ipv4         = "0.0.0.0/0"
+  from_port         = 443
+  to_port           = 443
+  ip_protocol       = "tcp"
+  description       = "Allow outbound HTTPS to AWS service endpoints"
+}`;
+
+/** Native fields and the VPC network configuration, added to the Harness resource. */
+const HARNESS_FIELDS_TEXT = `  allowed_tools         = var.allowed_tools
+  environment_variables = var.environment_variables
+  max_iterations        = var.max_iterations
+  timeout_seconds       = var.timeout_seconds`;
+
+const HARNESS_BLOCKS_TEXT = `  dynamic "memory" {
+    for_each = var.memory != null ? [var.memory] : []
+    content {
+      dynamic "managed_memory_configuration" {
+        for_each = memory.value.managed_memory_configuration != null ? [memory.value.managed_memory_configuration] : []
+        content {
+          strategies            = managed_memory_configuration.value.strategies
+          event_expiry_duration = managed_memory_configuration.value.event_expiry_duration
+          encryption_key_arn    = managed_memory_configuration.value.encryption_key_arn
+        }
+      }
+
+      dynamic "agentcore_memory_configuration" {
+        for_each = memory.value.agentcore_memory_configuration != null ? [memory.value.agentcore_memory_configuration] : []
+        content {
+          arn            = agentcore_memory_configuration.value.arn
+          actor_id       = agentcore_memory_configuration.value.actor_id
+          messages_count = agentcore_memory_configuration.value.messages_count
+        }
+      }
+
+      dynamic "disabled" {
+        for_each = memory.value.disabled ? [1] : []
+        content {}
+      }
+    }
+  }
+
+  dynamic "environment" {
+    for_each = var.enable_vpc ? [1] : []
+    content {
+      agentcore_runtime_environment {
+        network_configuration {
+          network_mode = "VPC"
+          network_mode_config {
+            security_groups = [aws_security_group.harness[0].id]
+            subnets         = var.subnet_ids
+          }
+        }
+      }
+    }
+  }
+
+  tags = var.tags`;
+
+/** The managed-memory grant, as its own policy scoped to the assigned ARN. */
+const MANAGED_MEMORY_POLICY_TEXT = `# Scoped to the memory ARN the service assigns, which is only readable after the
+# Harness exists, so this is a policy of its own rather than a baseline
+# statement. Skipped when the Harness uses a role or memory the module did not
+# create.
+resource "aws_iam_role_policy" "managed_memory" {
+  count = local.create_execution_role && local.has_managed_memory ? 1 : 0
+
+  name = "\${local.harness_name_prefix}-HarnessManagedMemoryPolicy"
+  role = aws_iam_role.execution_role[0].id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Sid    = "AgentCoreManagedMemory"
+      Effect = "Allow"
+      Action = [
+        "bedrock-agentcore:CreateEvent",
+        "bedrock-agentcore:DeleteEvent",
+        "bedrock-agentcore:GetEvent",
+        "bedrock-agentcore:ListEvents",
+        "bedrock-agentcore:RetrieveMemoryRecords",
+      ]
+      Resource = [
+        aws_bedrockagentcore_harness.this.memory_actual[0].managed_memory_configuration[0].arn,
+      ]
+    }]
+  })
+}`;
+
+const SECURITY_GROUP_OUTPUT_TEXT = `output "security_group_id" {
+  description = "Security group ID of the Harness, for use in ingress rules on resources it must reach (e.g. a database). Null unless enable_vpc is true."
+  value       = var.enable_vpc ? aws_security_group.harness[0].id : null
+}`;
+
+/**
+ * The baseline policy, replaced whole: the managed-memory statement leaves it
+ * for a policy of its own, and the resource gains a `count`. Rewriting the
+ * statement list in place would strand the comment and comma around the
+ * statement being removed.
+ */
+const BASELINE_POLICY_TEXT = `resource "aws_iam_role_policy" "execution_role" {
+  count = local.create_execution_role ? 1 : 0
+
+  name = "\${local.harness_name_prefix}-HarnessPolicy"
+  role = aws_iam_role.execution_role[0].id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = concat([
+      {
+        Sid    = "BedrockModelInvocation"
+        Effect = "Allow"
+        Action = [
+          "bedrock:InvokeModel",
+          "bedrock:InvokeModelWithResponseStream",
+        ]
+        Resource = local.model_resource_arns
+      },
+      {
+        #checkov:skip=CKV_AWS_355:EcrPublicTokenAccess requires a wildcard resource; ecr-public:GetAuthorizationToken has no resource-level permission
+        Sid      = "EcrPublicTokenAccess"
+        Effect   = "Allow"
+        Action   = ["ecr-public:GetAuthorizationToken"]
+        Resource = ["*"]
+      },
+      {
+        #checkov:skip=CKV_AWS_355:StsForEcrPublicPull requires a wildcard resource; sts:GetServiceBearerToken has no resource-level permission
+        Sid      = "StsForEcrPublicPull"
+        Effect   = "Allow"
+        Action   = ["sts:GetServiceBearerToken"]
+        Resource = ["*"]
+      },
+      {
+        #checkov:skip=CKV_AWS_355:XRayTracingAccess requires a wildcard resource; the X-Ray segment and sampling APIs have no resource-level permission
+        #checkov:skip=CKV_AWS_290:XRayTracingAccess requires a wildcard resource; the X-Ray segment and sampling APIs have no resource-level permission
+        Sid    = "XRayTracingAccess"
+        Effect = "Allow"
+        Action = [
+          "xray:PutTraceSegments",
+          "xray:PutTelemetryRecords",
+          "xray:GetSamplingRules",
+          "xray:GetSamplingTargets",
+        ]
+        Resource = ["*"]
+      },
+      {
+        Sid    = "CloudWatchLogsGroup"
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:DescribeLogStreams",
+        ]
+        Resource = [
+          "arn:\${local.partition}:logs:\${local.region}:\${local.account_id}:log-group:/aws/bedrock-agentcore/runtimes/*",
+        ]
+      },
+      {
+        Sid      = "CloudWatchLogsDescribeGroups"
+        Effect   = "Allow"
+        Action   = ["logs:DescribeLogGroups"]
+        Resource = ["arn:\${local.partition}:logs:\${local.region}:\${local.account_id}:log-group:*"]
+      },
+      {
+        Sid    = "CloudWatchLogsStream"
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogStream",
+          "logs:PutLogEvents",
+        ]
+        Resource = [
+          "arn:\${local.partition}:logs:\${local.region}:\${local.account_id}:log-group:/aws/bedrock-agentcore/runtimes/*:log-stream:*",
+        ]
+      },
+      {
+        #checkov:skip=CKV_AWS_355:CloudWatchMetricsPublish requires a wildcard resource; cloudwatch:PutMetricData is scoped by the namespace condition instead
+        #checkov:skip=CKV_AWS_290:CloudWatchMetricsPublish requires a wildcard resource; cloudwatch:PutMetricData is scoped by the namespace condition instead
+        Sid      = "CloudWatchMetricsPublish"
+        Effect   = "Allow"
+        Action   = ["cloudwatch:PutMetricData"]
+        Resource = ["*"]
+        Condition = {
+          StringEquals = {
+            "cloudwatch:namespace" = "bedrock-agentcore"
+          }
+        }
+      },
+      {
+        Sid    = "AgentCoreWorkloadIdentity"
+        Effect = "Allow"
+        Action = [
+          "bedrock-agentcore:GetWorkloadAccessToken",
+          "bedrock-agentcore:GetWorkloadAccessTokenForJWT",
+        ]
+        Resource = [
+          "arn:\${local.partition}:bedrock-agentcore:\${local.region}:\${local.account_id}:workload-identity-directory/default",
+          "arn:\${local.partition}:bedrock-agentcore:\${local.region}:\${local.account_id}:workload-identity-directory/default/workload-identity/harness_\${local.harness_name}-*",
+        ]
+      },
+      {
+        Sid    = "AgentCoreBrowserDefault"
+        Effect = "Allow"
+        Action = [
+          "bedrock-agentcore:StartBrowserSession",
+          "bedrock-agentcore:StopBrowserSession",
+          "bedrock-agentcore:GetBrowserSession",
+          "bedrock-agentcore:ListBrowserSessions",
+          "bedrock-agentcore:UpdateBrowserStream",
+          "bedrock-agentcore:ConnectBrowserAutomationStream",
+          "bedrock-agentcore:ConnectBrowserLiveViewStream",
+        ]
+        Resource = [
+          "arn:\${local.partition}:bedrock-agentcore:\${local.region}:aws:browser/*",
+        ]
+      },
+      {
+        Sid    = "AgentCoreCodeInterpreterDefault"
+        Effect = "Allow"
+        Action = [
+          "bedrock-agentcore:StartCodeInterpreterSession",
+          "bedrock-agentcore:StopCodeInterpreterSession",
+          "bedrock-agentcore:GetCodeInterpreterSession",
+          "bedrock-agentcore:ListCodeInterpreterSessions",
+          "bedrock-agentcore:InvokeCodeInterpreter",
+        ]
+        Resource = [
+          "arn:\${local.partition}:bedrock-agentcore:\${local.region}:aws:code-interpreter/*",
+        ]
+      },
+      ], [
+      # Null Sid/Condition fields are dropped from the rendered policy.
+      for statement in var.additional_execution_role_policy_statements :
+      { for key, value in statement : key => value if value != null }
+    ])
+  })
+}`;
+
+/**
+ * Every shape the migration rewrites, so a module missing any of them is
+ * reported rather than half-migrated.
+ */
+const REQUIRED_SHAPES = [
+  '`variable "model_resource_arns" { $_ }`',
+  '`variable "additional_execution_role_policy_statements" { $_ }`',
+  '`locals { $_ }`',
+  '`resource "aws_iam_role" "execution_role" { $_ }`',
+  '`resource "aws_iam_role_policy" "execution_role" { $_ }`',
+  '`resource "aws_bedrockagentcore_harness" "this" { $_ }`',
+  '`output "execution_role_arn" { $_ }`',
+];
+
+/**
+ * The baseline policy is replaced whole, so it is only safe to touch when it
+ * still carries exactly the statements the generator wrote. Any addition,
+ * removal or reordering means the user has edited it, and the replacement would
+ * discard that.
+ */
+const BASELINE_SIDS = [
+  'BedrockModelInvocation',
+  'EcrPublicTokenAccess',
+  'StsForEcrPublicPull',
+  'XRayTracingAccess',
+  'CloudWatchLogsGroup',
+  'CloudWatchLogsDescribeGroups',
+  'CloudWatchLogsStream',
+  'CloudWatchMetricsPublish',
+  'AgentCoreWorkloadIdentity',
+  'AgentCoreManagedMemory',
+  'AgentCoreBrowserDefault',
+  'AgentCoreCodeInterpreterDefault',
+];
+
+/**
+ * Whether the module's baseline policy still carries exactly the generated
+ * statements, in order. Sids are read from the whole file: the only other `Sid`
+ * is the `optional(string)` field of the additional-statements variable, which
+ * carries no string literal and so is filtered out.
+ */
+const hasUneditedBaselinePolicy = async (
+  tree: Tree,
+  filePath: string,
+): Promise<boolean> => {
+  const sids = (await captureAllGritQL(tree, filePath, hcl('`Sid = $sid`')))
+    .map((text) => /=\s*"([^"]+)"/.exec(text)?.[1])
+    .filter((sid): sid is string => sid !== undefined);
+  return (
+    sids.length === BASELINE_SIDS.length &&
+    sids.every((sid, index) => sid === BASELINE_SIDS[index])
+  );
+};
+
+export default async function migration(
+  tree: Tree,
+): Promise<MigrationReturnObject> {
+  const nextSteps: string[] = [];
+
+  if (!tree.exists(TERRAFORM_HARNESS_APP_DIR)) {
+    return { nextSteps }; // This workspace has no Terraform harness modules.
+  }
+
+  for (const dirName of tree.children(TERRAFORM_HARNESS_APP_DIR)) {
+    const filePath = joinPathFragments(
+      TERRAFORM_HARNESS_APP_DIR,
+      dirName,
+      `${dirName}.tf`,
+    );
+    if (!tree.exists(filePath)) {
+      continue; // Not a harness app module directory.
+    }
+
+    if (
+      await matchGritQL(tree, filePath, hcl('`variable "enable_vpc" { $_ }`'))
+    ) {
+      continue; // Already migrated.
+    }
+
+    const shapeChecks = await Promise.all(
+      REQUIRED_SHAPES.map((shape) => matchGritQL(tree, filePath, hcl(shape))),
+    );
+    if (
+      shapeChecks.includes(false) ||
+      !(await hasUneditedBaselinePolicy(tree, filePath))
+    ) {
+      nextSteps.push(divergedMessage(filePath));
+      continue;
+    }
+
+    // Variables, ahead of the model/role variables they sit beside in the
+    // template.
+    await insertViaGritQL(
+      tree,
+      filePath,
+      hcl(
+        `\`variable "model_resource_arns" { $body }\` => \`${GRIT_INSERT_PLACEHOLDER}\n\nvariable "model_resource_arns" {\n  $body\n}\``,
+      ),
+      NEW_VARIABLES_TEXT,
+    );
+    await insertViaGritQL(
+      tree,
+      filePath,
+      hcl(
+        `\`variable "additional_execution_role_policy_statements" { $body }\` => \`variable "additional_execution_role_policy_statements" {\n  $body\n}\n\n${GRIT_INSERT_PLACEHOLDER}\``,
+      ),
+      VPC_VARIABLES_TEXT,
+    );
+
+    // Locals resolving the role ARN and whether managed memory applies.
+    await insertViaGritQL(
+      tree,
+      filePath,
+      hcl(
+        `\`locals { $body }\` => \`locals {\n  $body\n\n${GRIT_INSERT_PLACEHOLDER}\n}\``,
+      ),
+      NEW_LOCALS_TEXT,
+    );
+
+    // The role becomes conditional on none being supplied, so it is indexed
+    // wherever it is referenced, and gains the shared tags.
+    await applyGritQL(
+      tree,
+      filePath,
+      hcl(
+        '`resource "aws_iam_role" "execution_role" { $body }` => `resource "aws_iam_role" "execution_role" {\n  count = local.create_execution_role ? 1 : 0\n\n  $body\n\n  tags = var.tags\n}`',
+      ),
+    );
+
+    // The baseline policy is replaced whole, dropping the managed-memory
+    // statement, which becomes a policy of its own scoped to the assigned ARN.
+    await insertViaGritQL(
+      tree,
+      filePath,
+      hcl(
+        `\`resource "aws_iam_role_policy" "execution_role" { $_ }\` => \`${GRIT_INSERT_PLACEHOLDER}\``,
+      ),
+      BASELINE_POLICY_TEXT,
+    );
+
+    // Native fields and the VPC network configuration on the Harness resource.
+    await insertViaGritQL(
+      tree,
+      filePath,
+      hcl(
+        `\`execution_role_arn = aws_iam_role.execution_role.arn\` => \`execution_role_arn = local.execution_role_arn\n\n${GRIT_INSERT_PLACEHOLDER}\``,
+      ),
+      HARNESS_FIELDS_TEXT,
+    );
+    // Ahead of `depends_on`, which the resource ends with.
+    await insertViaGritQL(
+      tree,
+      filePath,
+      hcl(
+        `\`depends_on = [aws_iam_role_policy.execution_role]\` => \`${GRIT_INSERT_PLACEHOLDER}\n\n  depends_on = [aws_iam_role_policy.execution_role]\``,
+      ),
+      // The placeholder already sits at the block's indentation.
+      HARNESS_BLOCKS_TEXT.replace(/^ {2}/, ''),
+    );
+
+    // Security group ahead of the Harness resource, and the managed-memory
+    // policy after it, since it reads an attribute of the deployed Harness.
+    // Anchored on the comment introducing the resource so it stays attached.
+    await insertViaGritQL(
+      tree,
+      filePath,
+      hcl(
+        `\`# Omitting authorizer_configuration uses IAM inbound authorization; add a\` => \`${GRIT_INSERT_PLACEHOLDER}\n\n# Omitting authorizer_configuration uses IAM inbound authorization; add a\``,
+      ),
+      SECURITY_GROUP_TEXT,
+    );
+    await insertViaGritQL(
+      tree,
+      filePath,
+      hcl(
+        `\`resource "aws_bedrockagentcore_harness" "this" { $body }\` => \`resource "aws_bedrockagentcore_harness" "this" {\n  $body\n}\n\n${GRIT_INSERT_PLACEHOLDER}\``,
+      ),
+      MANAGED_MEMORY_POLICY_TEXT,
+    );
+
+    // The role ARN output follows whichever role is in use, and the security
+    // group is exposed for ingress rules on resources the Harness reaches.
+    await applyGritQL(
+      tree,
+      filePath,
+      hcl(
+        '`output "execution_role_arn" { $_ }` => `output "execution_role_arn" {\n  description = "ARN of the IAM role assumed by the Harness, whether generated or supplied via var.execution_role_arn"\n  value       = local.execution_role_arn\n}`',
+      ),
+    );
+    await insertViaGritQL(
+      tree,
+      filePath,
+      hcl(
+        `\`output "execution_role_arn" { $body }\` => \`output "execution_role_arn" {\n  $body\n}\n\n${GRIT_INSERT_PLACEHOLDER}\``,
+      ),
+      SECURITY_GROUP_OUTPUT_TEXT,
+    );
+  }
+
+  await formatFilesInSubtree(tree);
+
+  return { nextSteps };
+}

--- a/packages/nx-plugin/src/migrations/latest/terraform-harness-vpc-role-and-memory-grant/migration.ts
+++ b/packages/nx-plugin/src/migrations/latest/terraform-harness-vpc-role-and-memory-grant/migration.ts
@@ -405,10 +405,34 @@ const BASELINE_POLICY_TEXT = `resource "aws_iam_role_policy" "execution_role" {
           "arn:\${local.partition}:bedrock-agentcore:\${local.region}:aws:code-interpreter/*",
         ]
       },
-      ], [
-      # Null Sid/Condition fields are dropped from the rendered policy.
-      for statement in var.additional_execution_role_policy_statements :
-      { for key, value in statement : key => value if value != null }
+      ],
+      # In VPC mode the Harness pulls its managed container from a private ECR
+      # repository in the region rather than ECR Public, so it needs pull
+      # permissions on it. The repository is service-owned, hence the wildcard
+      # account.
+      var.enable_vpc ? [
+        {
+          Sid    = "EcrManagedImagePull"
+          Effect = "Allow"
+          Action = [
+            "ecr:BatchGetImage",
+            "ecr:GetDownloadUrlForLayer",
+            "ecr:BatchCheckLayerAvailability",
+          ]
+          Resource = ["arn:\${local.partition}:ecr:\${local.region}:*:repository/harness-*"]
+        },
+        {
+          #checkov:skip=CKV_AWS_355:EcrManagedImageToken requires a wildcard resource; ecr:GetAuthorizationToken has no resource-level permission
+          Sid      = "EcrManagedImageToken"
+          Effect   = "Allow"
+          Action   = ["ecr:GetAuthorizationToken"]
+          Resource = ["*"]
+        },
+      ] : [],
+      [
+        # Null Sid/Condition fields are dropped from the rendered policy.
+        for statement in var.additional_execution_role_policy_statements :
+        { for key, value in statement : key => value if value != null }
     ])
   })
 }`;

--- a/packages/nx-plugin/src/migrations/latest/terraform-harness-vpc-role-and-memory-grant/migration.ts
+++ b/packages/nx-plugin/src/migrations/latest/terraform-harness-vpc-role-and-memory-grant/migration.ts
@@ -45,14 +45,12 @@ const hcl = (pattern: string) => `language hcl\n${pattern}`;
 const divergedMessage = (filePath: string) =>
   `${filePath}: has diverged from the generated shape - left untouched. To pick up VPC support, a supplied execution role, the allowed_tools/memory/environment_variables/max_iterations/timeout_seconds variables and the corrected managed-memory grant, compare it against the agentcore-harness generator's Terraform template and apply the parts you want.`;
 
-/** Variables added ahead of the existing `model_resource_arns` variable. */
-const NEW_VARIABLES_TEXT = `variable "allowed_tools" {
-  description = "Tools the Harness may use, e.g. [\\"@builtin\\"] or narrower patterns such as [\\"@builtin/file_operations\\"]. Deploys with no tools when null."
-  type        = list(string)
-  default     = null
-}
-
-variable "memory" {
+/**
+ * Variables added ahead of the existing `model_resource_arns` variable.
+ * `allowed_tools` is not among them: the earlier `agentcore-harness-no-tools-by-default`
+ * migration already declares it, and runs first.
+ */
+const NEW_VARIABLES_TEXT = `variable "memory" {
   description = "Memory configuration for the Harness. Null leaves the service to provision managed memory with default strategies. Set exactly one field: managed_memory_configuration to tune that managed memory, agentcore_memory_configuration to use a memory resource you own, or disabled to turn memory off."
   type = object({
     managed_memory_configuration = optional(object({
@@ -185,7 +183,11 @@ resource "aws_vpc_security_group_egress_rule" "harness_https" {
   description       = "Allow outbound HTTPS to AWS service endpoints"
 }`;
 
-/** Native fields and the VPC network configuration, added to the Harness resource. */
+/**
+ * Native fields added to the Harness resource. `allowed_tools` is re-emitted
+ * here, aligned with the rest, replacing the line the earlier
+ * no-tools-by-default migration added.
+ */
 const HARNESS_FIELDS_TEXT = `  allowed_tools         = var.allowed_tools
   environment_variables = var.environment_variables
   max_iterations        = var.max_iterations
@@ -449,6 +451,9 @@ const REQUIRED_SHAPES = [
   '`resource "aws_iam_role_policy" "execution_role" { $_ }`',
   '`resource "aws_bedrockagentcore_harness" "this" { $_ }`',
   '`output "execution_role_arn" { $_ }`',
+  // The no-tools-by-default migration runs first, so its assignment is present
+  // and is what the native fields below are anchored on.
+  '`allowed_tools = var.allowed_tools`',
 ];
 
 /**
@@ -577,7 +582,14 @@ export default async function migration(
       BASELINE_POLICY_TEXT,
     );
 
-    // Native fields and the VPC network configuration on the Harness resource.
+    // The role ARN follows whichever role is in use, and the `allowed_tools`
+    // line the no-tools-by-default migration added is re-aligned with the
+    // native fields that now sit beside it.
+    await applyGritQL(
+      tree,
+      filePath,
+      hcl('`allowed_tools      = var.allowed_tools` => ``'),
+    );
     await insertViaGritQL(
       tree,
       filePath,

--- a/packages/nx-plugin/src/utils/agent-core-constructs/files/cdk/app/agentcore-harness/__nameKebabCase__/__nameKebabCase__.ts.template
+++ b/packages/nx-plugin/src/utils/agent-core-constructs/files/cdk/app/agentcore-harness/__nameKebabCase__/__nameKebabCase__.ts.template
@@ -143,6 +143,29 @@ export class <%- nameClassName %>
           actions: ['sts:GetServiceBearerToken'],
           resources: ['*'],
         }),
+        // In a VPC the Harness pulls its managed container from a private ECR
+        // repository in the region rather than ECR Public. The repository is
+        // service-owned, hence the wildcard account.
+        ...(vpc
+          ? [
+              new iam.PolicyStatement({
+                sid: 'EcrManagedImagePull',
+                actions: [
+                  'ecr:BatchGetImage',
+                  'ecr:GetDownloadUrlForLayer',
+                  'ecr:BatchCheckLayerAvailability',
+                ],
+                resources: [
+                  `arn:${stack.partition}:ecr:${stack.region}:*:repository/harness-*`,
+                ],
+              }),
+              new iam.PolicyStatement({
+                sid: 'EcrManagedImageToken',
+                actions: ['ecr:GetAuthorizationToken'],
+                resources: ['*'],
+              }),
+            ]
+          : []),
         new iam.PolicyStatement({
           sid: 'XRayTracingAccess',
           actions: [
@@ -245,6 +268,14 @@ export class <%- nameClassName %>
         'XRayTracingAccess: X-Ray segment and sampling APIs have no resource-level permission.',
         isPolicy,
       );
+      if (vpc) {
+        suppressRules(
+          this.executionRole,
+          WILDCARD_IAM_RULES,
+          'EcrManagedImageToken: ecr:GetAuthorizationToken has no resource-level permission.',
+          isPolicy,
+        );
+      }
     }
 
     // Rendered lazily so security groups added through `connections` after

--- a/packages/nx-plugin/src/utils/agent-core-constructs/files/terraform/app/agentcore-harness/__nameKebabCase__/__nameKebabCase__.tf.template
+++ b/packages/nx-plugin/src/utils/agent-core-constructs/files/terraform/app/agentcore-harness/__nameKebabCase__/__nameKebabCase__.tf.template
@@ -25,6 +25,67 @@ variable "allowed_tools" {
   default     = []
 }
 
+variable "memory" {
+  description = "Memory configuration for the Harness. Null leaves the service to provision managed memory with default strategies. Set exactly one field: managed_memory_configuration to tune that managed memory, agentcore_memory_configuration to use a memory resource you own, or disabled to turn memory off."
+  type = object({
+    managed_memory_configuration = optional(object({
+      strategies            = optional(set(string))
+      event_expiry_duration = optional(number)
+      encryption_key_arn    = optional(string)
+    }))
+    agentcore_memory_configuration = optional(object({
+      arn            = string
+      actor_id       = optional(string)
+      messages_count = optional(number)
+    }))
+    disabled = optional(bool, false)
+  })
+  default = null
+
+  validation {
+    condition = var.memory == null || length([
+      for configured in [
+        var.memory.managed_memory_configuration != null,
+        var.memory.agentcore_memory_configuration != null,
+        var.memory.disabled,
+      ] : configured if configured
+    ]) == 1
+    error_message = "Set exactly one of memory.managed_memory_configuration, memory.agentcore_memory_configuration or memory.disabled."
+  }
+}
+
+variable "environment_variables" {
+  description = "Environment variables available to the Harness."
+  type        = map(string)
+  default     = null
+  sensitive   = true
+}
+
+variable "max_iterations" {
+  description = "Maximum agent loop iterations per invocation. Uses the service default when null."
+  type        = number
+  default     = null
+}
+
+variable "timeout_seconds" {
+  description = "Maximum seconds an invocation may run. Uses the service default when null."
+  type        = number
+  default     = null
+}
+
+variable "execution_role_arn" {
+  description = "ARN of an existing IAM role for the Harness to assume. Used as-is: no role is created and none of the baseline permissions below are granted. Creates the baseline role when null."
+  type        = string
+  default     = null
+
+  validation {
+    condition = var.execution_role_arn == null || (
+      var.model_resource_arns == null && length(var.additional_execution_role_policy_statements) == 0
+    )
+    error_message = "model_resource_arns and additional_execution_role_policy_statements configure the generated execution role, which is not created when execution_role_arn is supplied. Grant those permissions on the supplied role instead."
+  }
+}
+
 variable "model_resource_arns" {
   description = "Bedrock model and inference-profile ARNs the execution role may invoke. Defaults to every foundation model plus this account's Bedrock resources in the deployment region; replace with narrower ARNs to restrict baseline model access."
   type        = set(string)
@@ -41,6 +102,36 @@ variable "additional_execution_role_policy_statements" {
     Condition = optional(any)
   }))
   default = []
+}
+
+# VPC Configuration (optional)
+variable "enable_vpc" {
+  description = "Run the Harness inside a VPC so it can reach private resources. Set alongside vpc_id/subnet_ids."
+  type        = bool
+  default     = false
+}
+
+variable "vpc_id" {
+  description = "VPC ID to run the Harness in. Required when enable_vpc is true."
+  type        = string
+  default     = null
+
+  validation {
+    condition     = !var.enable_vpc || (var.vpc_id != null && var.subnet_ids != null)
+    error_message = "vpc_id and subnet_ids must be set when enable_vpc is true."
+  }
+}
+
+variable "subnet_ids" {
+  description = "Subnet IDs to run the Harness in. Required when enable_vpc is true."
+  type        = list(string)
+  default     = null
+}
+
+variable "tags" {
+  description = "Tags to apply to resources"
+  type        = map(string)
+  default     = {}
 }
 
 data "aws_caller_identity" "current" {}
@@ -66,9 +157,18 @@ locals {
     "arn:${local.partition}:bedrock:*::foundation-model/*",
     "arn:${local.partition}:bedrock:${local.region}:${local.account_id}:*",
   ]
+
+  create_execution_role = var.execution_role_arn == null
+  execution_role_arn    = local.create_execution_role ? aws_iam_role.execution_role[0].arn : var.execution_role_arn
+
+  # The service provisions managed memory unless var.memory redirects it
+  # elsewhere or turns it off.
+  has_managed_memory = var.memory == null || var.memory.managed_memory_configuration != null
 }
 
 resource "aws_iam_role" "execution_role" {
+  count = local.create_execution_role ? 1 : 0
+
   name = "${local.harness_name_prefix}-HarnessRole-${random_id.unique_suffix.hex}"
 
   assume_role_policy = jsonencode({
@@ -89,14 +189,18 @@ resource "aws_iam_role" "execution_role" {
       }
     }]
   })
+
+  tags = var.tags
 }
 
 # Baseline permissions per the AgentCore Harness security guidance; extend for
 # customer-owned resources via var.additional_execution_role_policy_statements.
 # https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/harness-security.html
 resource "aws_iam_role_policy" "execution_role" {
+  count = local.create_execution_role ? 1 : 0
+
   name = "${local.harness_name_prefix}-HarnessPolicy"
-  role = aws_iam_role.execution_role.id
+  role = aws_iam_role.execution_role[0].id
 
   policy = jsonencode({
     Version = "2012-10-17"
@@ -190,22 +294,6 @@ resource "aws_iam_role_policy" "execution_role" {
           "arn:${local.partition}:bedrock-agentcore:${local.region}:${local.account_id}:workload-identity-directory/default/workload-identity/harness_${local.harness_name}-*",
         ]
       },
-      # The service names the managed memory from the harness name plus a
-      # generated suffix, so this scopes to that prefix.
-      {
-        Sid    = "AgentCoreManagedMemory"
-        Effect = "Allow"
-        Action = [
-          "bedrock-agentcore:CreateEvent",
-          "bedrock-agentcore:DeleteEvent",
-          "bedrock-agentcore:GetEvent",
-          "bedrock-agentcore:ListEvents",
-          "bedrock-agentcore:RetrieveMemoryRecords",
-        ]
-        Resource = [
-          "arn:${local.partition}:bedrock-agentcore:${local.region}:${local.account_id}:memory/${local.harness_name}-*",
-        ]
-      },
       {
         Sid    = "AgentCoreBrowserDefault"
         Effect = "Allow"
@@ -244,12 +332,38 @@ resource "aws_iam_role_policy" "execution_role" {
   })
 }
 
+# Security group for the Harness, used when running inside a VPC
+resource "aws_security_group" "harness" {
+  count = var.enable_vpc ? 1 : 0
+
+  #checkov:skip=CKV2_AWS_5:Attached to the Harness via its network configuration; Checkov cannot resolve this reference
+  name_prefix = "${local.harness_name_prefix}-harness-"
+  description = "Security group for the ${local.harness_name_prefix} Harness"
+  vpc_id      = var.vpc_id
+  tags        = var.tags
+}
+
+resource "aws_vpc_security_group_egress_rule" "harness_https" {
+  count = var.enable_vpc ? 1 : 0
+
+  security_group_id = aws_security_group.harness[0].id
+  cidr_ipv4         = "0.0.0.0/0"
+  from_port         = 443
+  to_port           = 443
+  ip_protocol       = "tcp"
+  description       = "Allow outbound HTTPS to AWS service endpoints"
+}
+
 # Omitting authorizer_configuration uses IAM inbound authorization; add a
 # custom_jwt_authorizer block to change that.
 resource "aws_bedrockagentcore_harness" "this" {
   harness_name       = local.harness_name
-  execution_role_arn = aws_iam_role.execution_role.arn
-  allowed_tools      = var.allowed_tools
+  execution_role_arn = local.execution_role_arn
+
+  allowed_tools         = var.allowed_tools
+  environment_variables = var.environment_variables
+  max_iterations        = var.max_iterations
+  timeout_seconds       = var.timeout_seconds
 
   model {
     bedrock_model_config {
@@ -262,7 +376,81 @@ resource "aws_bedrockagentcore_harness" "this" {
     text = file("${path.module}/../../../../../../../<%- promptPathFromTerraform %>")
   }
 
+  dynamic "memory" {
+    for_each = var.memory != null ? [var.memory] : []
+    content {
+      dynamic "managed_memory_configuration" {
+        for_each = memory.value.managed_memory_configuration != null ? [memory.value.managed_memory_configuration] : []
+        content {
+          strategies            = managed_memory_configuration.value.strategies
+          event_expiry_duration = managed_memory_configuration.value.event_expiry_duration
+          encryption_key_arn    = managed_memory_configuration.value.encryption_key_arn
+        }
+      }
+
+      dynamic "agentcore_memory_configuration" {
+        for_each = memory.value.agentcore_memory_configuration != null ? [memory.value.agentcore_memory_configuration] : []
+        content {
+          arn            = agentcore_memory_configuration.value.arn
+          actor_id       = agentcore_memory_configuration.value.actor_id
+          messages_count = agentcore_memory_configuration.value.messages_count
+        }
+      }
+
+      dynamic "disabled" {
+        for_each = memory.value.disabled ? [1] : []
+        content {}
+      }
+    }
+  }
+
+  dynamic "environment" {
+    for_each = var.enable_vpc ? [1] : []
+    content {
+      agentcore_runtime_environment {
+        network_configuration {
+          network_mode = "VPC"
+          network_mode_config {
+            security_groups = [aws_security_group.harness[0].id]
+            subnets         = var.subnet_ids
+          }
+        }
+      }
+    }
+  }
+
+  tags = var.tags
+
   depends_on = [aws_iam_role_policy.execution_role]
+}
+
+# Scoped to the memory ARN the service assigns, which is only readable after the
+# Harness exists, so this is a policy of its own rather than a baseline
+# statement. Skipped when the Harness uses a role or memory the module did not
+# create.
+resource "aws_iam_role_policy" "managed_memory" {
+  count = local.create_execution_role && local.has_managed_memory ? 1 : 0
+
+  name = "${local.harness_name_prefix}-HarnessManagedMemoryPolicy"
+  role = aws_iam_role.execution_role[0].id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Sid    = "AgentCoreManagedMemory"
+      Effect = "Allow"
+      Action = [
+        "bedrock-agentcore:CreateEvent",
+        "bedrock-agentcore:DeleteEvent",
+        "bedrock-agentcore:GetEvent",
+        "bedrock-agentcore:ListEvents",
+        "bedrock-agentcore:RetrieveMemoryRecords",
+      ]
+      Resource = [
+        aws_bedrockagentcore_harness.this.memory_actual[0].managed_memory_configuration[0].arn,
+      ]
+    }]
+  })
 }
 
 module "add_harness_arn_to_runtime_config" {
@@ -284,6 +472,11 @@ output "harness_arn" {
 }
 
 output "execution_role_arn" {
-  description = "ARN of the IAM role assumed by the Harness"
-  value       = aws_iam_role.execution_role.arn
+  description = "ARN of the IAM role assumed by the Harness, whether generated or supplied via var.execution_role_arn"
+  value       = local.execution_role_arn
+}
+
+output "security_group_id" {
+  description = "Security group ID of the Harness, for use in ingress rules on resources it must reach (e.g. a database). Null unless enable_vpc is true."
+  value       = var.enable_vpc ? aws_security_group.harness[0].id : null
 }

--- a/packages/nx-plugin/src/utils/agent-core-constructs/files/terraform/app/agentcore-harness/__nameKebabCase__/__nameKebabCase__.tf.template
+++ b/packages/nx-plugin/src/utils/agent-core-constructs/files/terraform/app/agentcore-harness/__nameKebabCase__/__nameKebabCase__.tf.template
@@ -73,17 +73,28 @@ variable "timeout_seconds" {
   default     = null
 }
 
-variable "execution_role_arn" {
-  description = "ARN of an existing IAM role for the Harness to assume. Used as-is: no role is created and none of the baseline permissions below are granted. Creates the baseline role when null."
-  type        = string
-  default     = null
+variable "create_execution_role" {
+  description = "Create the execution role with the baseline permissions below. Set false alongside execution_role_arn to use a role you already have, which is then used as-is."
+  type        = bool
+  default     = true
 
   validation {
-    condition = var.execution_role_arn == null || (
+    condition     = var.create_execution_role || var.execution_role_arn != null
+    error_message = "execution_role_arn must be set when create_execution_role is false."
+  }
+
+  validation {
+    condition = var.create_execution_role || (
       var.model_resource_arns == null && length(var.additional_execution_role_policy_statements) == 0
     )
-    error_message = "model_resource_arns and additional_execution_role_policy_statements configure the generated execution role, which is not created when execution_role_arn is supplied. Grant those permissions on the supplied role instead."
+    error_message = "model_resource_arns and additional_execution_role_policy_statements configure the generated execution role, which is not created when create_execution_role is false. Grant those permissions on the supplied role instead."
   }
+}
+
+variable "execution_role_arn" {
+  description = "ARN of an existing IAM role for the Harness to assume. Requires create_execution_role = false."
+  type        = string
+  default     = null
 }
 
 variable "model_resource_arns" {
@@ -158,8 +169,7 @@ locals {
     "arn:${local.partition}:bedrock:${local.region}:${local.account_id}:*",
   ]
 
-  create_execution_role = var.execution_role_arn == null
-  execution_role_arn    = local.create_execution_role ? aws_iam_role.execution_role[0].arn : var.execution_role_arn
+  execution_role_arn = var.create_execution_role ? aws_iam_role.execution_role[0].arn : var.execution_role_arn
 
   # The service provisions managed memory unless var.memory redirects it
   # elsewhere or turns it off.
@@ -167,7 +177,7 @@ locals {
 }
 
 resource "aws_iam_role" "execution_role" {
-  count = local.create_execution_role ? 1 : 0
+  count = var.create_execution_role ? 1 : 0
 
   name = "${local.harness_name_prefix}-HarnessRole-${random_id.unique_suffix.hex}"
 
@@ -197,7 +207,7 @@ resource "aws_iam_role" "execution_role" {
 # customer-owned resources via var.additional_execution_role_policy_statements.
 # https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/harness-security.html
 resource "aws_iam_role_policy" "execution_role" {
-  count = local.create_execution_role ? 1 : 0
+  count = var.create_execution_role ? 1 : 0
 
   name = "${local.harness_name_prefix}-HarnessPolicy"
   role = aws_iam_role.execution_role[0].id
@@ -429,7 +439,7 @@ resource "aws_bedrockagentcore_harness" "this" {
 # statement. Skipped when the Harness uses a role or memory the module did not
 # create.
 resource "aws_iam_role_policy" "managed_memory" {
-  count = local.create_execution_role && local.has_managed_memory ? 1 : 0
+  count = var.create_execution_role && local.has_managed_memory ? 1 : 0
 
   name = "${local.harness_name_prefix}-HarnessManagedMemoryPolicy"
   role = aws_iam_role.execution_role[0].id

--- a/packages/nx-plugin/src/utils/agent-core-constructs/files/terraform/app/agentcore-harness/__nameKebabCase__/__nameKebabCase__.tf.template
+++ b/packages/nx-plugin/src/utils/agent-core-constructs/files/terraform/app/agentcore-harness/__nameKebabCase__/__nameKebabCase__.tf.template
@@ -334,10 +334,34 @@ resource "aws_iam_role_policy" "execution_role" {
           "arn:${local.partition}:bedrock-agentcore:${local.region}:aws:code-interpreter/*",
         ]
       },
-      ], [
-      # Null Sid/Condition fields are dropped from the rendered policy.
-      for statement in var.additional_execution_role_policy_statements :
-      { for key, value in statement : key => value if value != null }
+      ],
+      # In VPC mode the Harness pulls its managed container from a private ECR
+      # repository in the region rather than ECR Public, so it needs pull
+      # permissions on it. The repository is service-owned, hence the wildcard
+      # account.
+      var.enable_vpc ? [
+        {
+          Sid    = "EcrManagedImagePull"
+          Effect = "Allow"
+          Action = [
+            "ecr:BatchGetImage",
+            "ecr:GetDownloadUrlForLayer",
+            "ecr:BatchCheckLayerAvailability",
+          ]
+          Resource = ["arn:${local.partition}:ecr:${local.region}:*:repository/harness-*"]
+        },
+        {
+          #checkov:skip=CKV_AWS_355:EcrManagedImageToken requires a wildcard resource; ecr:GetAuthorizationToken has no resource-level permission
+          Sid      = "EcrManagedImageToken"
+          Effect   = "Allow"
+          Action   = ["ecr:GetAuthorizationToken"]
+          Resource = ["*"]
+        },
+      ] : [],
+      [
+        # Null Sid/Condition fields are dropped from the rendered policy.
+        for statement in var.additional_execution_role_policy_statements :
+        { for key, value in statement : key => value if value != null }
     ])
   })
 }


### PR DESCRIPTION
### Reason for this change

The AgentCore **Harness** module was materially less capable on Terraform than on CDK, and its managed-memory IAM grant was wrong in two ways.

The CDK construct accepts `vpc` / `vpcSubnets` / `securityGroups`, implements `ec2.IConnectable`, accepts an existing `executionRole`, and spreads `Partial<Omit<CfnHarnessProps, …>>` so arbitrary native fields pass through. The Terraform module exposed only `model_id`, `model_resource_arns` and `additional_execution_role_policy_statements`: **no VPC support at all** — no variables, no network block, no security group — no way to supply an existing role, and the remaining native fields required editing the generated HCL.

The managed-memory grant differed in substance, not just shape. CDK grants it conditionally — only when the user has *not* supplied their own `memory` — and scopes it to `attrMemoryManagedMemoryConfigurationArn`, the ARN the service assigns. Terraform granted it **unconditionally** and scoped it to a **name-prefix guess** (`memory/${harness_name}-*`), so it was both over-permissive (granted even with custom memory configured) and brittle (dependent on the service's naming).

Deploying the result also surfaced a **pre-existing bug in the CDK construct**: VPC mode has never worked. In VPC mode the Harness pulls its managed container from a private ECR repository rather than ECR Public, and neither provider granted the required pull permissions, so every VPC session failed with an image-pull authorization error.

### Description of changes

**VPC support** follows the pattern the agent-core runtime Terraform module already established, rather than inventing one — consistency across the two modules matters more than novelty: `enable_vpc` / `vpc_id` / `subnet_ids` with cross-field validation, a security group with an explicit 443-only egress rule, and a `security_group_id` output so resources the Harness must reach can reference it in their own ingress rules.

**The execution role** can be supplied via `create_execution_role = false` + `execution_role_arn`; the generated role and its baseline policy are then not created, matching CDK. The toggle is a **plain bool rather than being derived from the ARN** because `count` cannot depend on a value unknown until apply — deriving it broke the plan outright whenever the supplied ARN was itself a resource attribute, which is the ordinary case. Validations keep the two inputs consistent and reject `model_resource_arns` / `additional_execution_role_policy_statements` alongside a supplied role, since those shape a role that no longer exists.

**Native fields.** Terraform has no equivalent of CDK's prop spread, so full parity is impractical. Exposed as variables: `memory`, `environment_variables`, `max_iterations`, `timeout_seconds`, plus `tags` — alongside `allowed_tools`, which #1137 added while this was open (see below). Left **HCL-edit-only** (and documented as such rather than implying parity): alternate model providers (`gemini_model_config`, `openai_model_config`), `tool` blocks, `skill` blocks, `environment_artifact`, filesystem/lifecycle configuration, `truncation`, and `authorizer_configuration`.

**The memory grant** is now conditional and correctly scoped. The service-assigned ARN *is* obtainable in Terraform — the provider exposes `memory_actual[0].managed_memory_configuration[0].arn` — so there is **no residual difference from CDK**. Because it reads an attribute of the deployed Harness it lives in its own `aws_iam_role_policy` rather than the baseline policy (which the Harness depends on), counted off `create_execution_role && has_managed_memory`, so it is skipped for a supplied role, a user-owned memory resource, or `disabled`.

**The private ECR grant** (`EcrManagedImagePull` / `EcrManagedImageToken`) is added to **both** providers, conditional on VPC mode, per the [AgentCore Harness security guidance](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/harness-security.html).

Baseline IAM is otherwise untouched — statement-for-statement identical across both providers (verified by diffing the sid lists).

The vended files are `KeepExisting`, so a **deterministic migration** carries existing workspaces across. The baseline policy is replaced whole (rewriting the statement list in place would strand the comment and comma around the removed statement), so it only applies when the policy still carries exactly the generated sids in order; an edited policy is left untouched and reported via `nextSteps`. A test asserts the migrated module is **byte-identical to what the generator writes today**, so the two cannot drift.

**Composing with #1137.** [#1137](https://github.com/awslabs/nx-plugin-for-aws/pull/1137) merged while this was open and added `allowed_tools` to both providers, defaulting to none and **always sent explicitly** because the service treats an absent value as every tool. This branch takes that version verbatim rather than its own: an earlier draft here defaulted `allowed_tools` to `null`, which would have reintroduced exactly the every-tool bug #1137 fixed. Since #1137's migration is the earlier commit it runs first, so this migration no longer declares or assigns `allowed_tools` — it would have duplicated the variable — and instead requires that assignment as a precondition and re-aligns the line alongside the native fields added beside it. The migration spec's fixture is now the output of #1137's migration, which is the state an upgrading workspace is actually in.

### Description of how you validated changes

Unit tests: `agentcore-harness` covers the variable set, the three cross-field validations, the conditional role/policy, VPC placement, the ECR grant on both providers, and the memory scoping, alongside #1137's tool-default assertions. The migration spec covers each concern, idempotency, an already-migrated module, a diverged module, an *edited baseline policy*, and convergence on fresh generator output.

Re-run in full after rebasing onto the merged #1137:

- `pnpm nx run @aws/nx-plugin:test` — **209 files / 3800 tests pass**
- `pnpm nx run-many --target build --all` — passes
- `pnpm nx run-many --target lint --all --configuration=fix` — passes, no changes to these files

**Deployed to AWS (us-west-2) and invoked, on both providers.** Terraform: three harnesses from one module — default (no VPC), VPC, and supplied-role — plus a CDK stack with default and VPC harnesses.

All five returned a real model response (`HARNESS OK`, 5 stream events, ~1s latency):

```
[default]       contains HARNESS OK: True     [vpc]      contains HARNESS OK: True
[supplied-role] contains HARNESS OK: True
[cdk-default]   contains HARNESS OK: True     [cdk-vpc]  contains HARNESS OK: True
```

The **VPC harness initially failed with a 502**, which is how the missing private-ECR grant was found — CloudWatch showed `failed to resolve image: pull access denied … no basic auth credentials`. After adding the grant (and the ECR/S3 VPC endpoints the docs require, in the test scaffolding) it ran.

VPC attachment confirmed from the service's own view of the deployed resource:

```
network_configuration = [{ network_mode = "VPC"
  network_mode_config = [{ security_groups = ["sg-0f2d43f19e727ee54"]
    subnets = ["subnet-0320a2c86af61e660", "subnet-0f61136b16e31118d"] }] }]
```

Those are exactly the security group the module created and the two subnets passed in; two `agentic_ai` ENIs were present, one per subnet. The non-VPC harness reported `network_mode = "PUBLIC"`.

Memory grant scoped to a concrete ARN, matching each harness's actual memory resource (not a wildcard):

```
HwAe697b-HarnessRole-351e0f75  -> …:memory/HwAe697b_351e0f75-H3Ki0XDXnk
HwAe697b-HarnessRole-42400190  -> …:memory/HwAe697b_42400190-MnAfkTHzdQ
```

ECR grant present only where needed — VPC role: `EcrPublicTokenAccess, EcrManagedImagePull, EcrManagedImageToken`; default role: `EcrPublicTokenAccess` only.

Supplied-role path: exactly **2 generated roles for 3 harnesses**, and the supplied role carried only my own policy — the module created no role and attached no memory policy.

Against CDK, the two providers agree statement-for-statement (14 sids on the VPC role, 12 on the default), and CDK's `Fn::GetAtt … Memory.ManagedMemoryConfiguration.Arn` resolved to a concrete memory ARN just as Terraform's `memory_actual` does.

All infrastructure was destroyed. Every harness, agent runtime, memory resource and IAM role is gone; the last few network resources are waiting on service-owned `ela-attach` ENIs, which AWS releases on its own schedule and does not permit detaching, with a retry loop finishing the delete once they drain.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
