### PR TITLE
fix(ts#rdb,py#rdb): align the Aurora Serverless v2 scaling ceiling across CDK and Terraform

### DIFF
--- a/docs/src/content/docs/en/snippets/rdb/serverless-capacity.mdx
+++ b/docs/src/content/docs/en/snippets/rdb/serverless-capacity.mdx
@@ -3,7 +3,7 @@ title: Serverless Capacity
 ---
 import Infrastructure from '@components/infrastructure.astro';
 
-Control Aurora Serverless v2 scaling limits to match your workload.
+Control Aurora Serverless v2 scaling limits to match your workload. Both providers default to a minimum of 0.5 ACUs and a maximum of 4.
 
 <Infrastructure>
 <Fragment slot="cdk">

--- a/docs/src/content/docs/es/snippets/rdb/serverless-capacity.mdx
+++ b/docs/src/content/docs/es/snippets/rdb/serverless-capacity.mdx
@@ -3,7 +3,7 @@ title: Capacidad Serverless
 ---
 import Infrastructure from '@components/infrastructure.astro';
 
-Controla los límites de escalado de Aurora Serverless v2 para que coincidan con tu carga de trabajo.
+Controla los límites de escalado de Aurora Serverless v2 para que coincidan con tu carga de trabajo. Ambos proveedores tienen por defecto un mínimo de 0.5 ACUs y un máximo de 4.
 
 <Infrastructure>
 <Fragment slot="cdk">

--- a/docs/src/content/docs/fr/snippets/rdb/serverless-capacity.mdx
+++ b/docs/src/content/docs/fr/snippets/rdb/serverless-capacity.mdx
@@ -3,7 +3,7 @@ title: Capacité Serverless
 ---
 import Infrastructure from '@components/infrastructure.astro';
 
-Contrôlez les limites de mise à l'échelle d'Aurora Serverless v2 pour correspondre à votre charge de travail.
+Contrôlez les limites de mise à l'échelle d'Aurora Serverless v2 pour correspondre à votre charge de travail. Les deux fournisseurs utilisent par défaut un minimum de 0,5 ACU et un maximum de 4.
 
 <Infrastructure>
 <Fragment slot="cdk">

--- a/docs/src/content/docs/it/snippets/rdb/serverless-capacity.mdx
+++ b/docs/src/content/docs/it/snippets/rdb/serverless-capacity.mdx
@@ -3,7 +3,7 @@ title: Capacità Serverless
 ---
 import Infrastructure from '@components/infrastructure.astro';
 
-Controlla i limiti di scalabilità di Aurora Serverless v2 per adattarli al tuo carico di lavoro.
+Controlla i limiti di scalabilità di Aurora Serverless v2 per adattarli al tuo carico di lavoro. Entrambi i provider utilizzano per impostazione predefinita un minimo di 0,5 ACU e un massimo di 4.
 
 <Infrastructure>
 <Fragment slot="cdk">

--- a/docs/src/content/docs/jp/snippets/rdb/serverless-capacity.mdx
+++ b/docs/src/content/docs/jp/snippets/rdb/serverless-capacity.mdx
@@ -3,7 +3,7 @@ title: サーバーレスキャパシティ
 ---
 import Infrastructure from '@components/infrastructure.astro';
 
-ワークロードに合わせて Aurora Serverless v2 のスケーリング制限を制御します。
+ワークロードに合わせて Aurora Serverless v2 のスケーリング制限を制御します。両方のプロバイダーは、デフォルトで最小 0.5 ACU、最大 4 ACU に設定されています。
 
 <Infrastructure>
 <Fragment slot="cdk">

--- a/docs/src/content/docs/ko/snippets/rdb/serverless-capacity.mdx
+++ b/docs/src/content/docs/ko/snippets/rdb/serverless-capacity.mdx
@@ -3,7 +3,7 @@ title: Serverless 용량
 ---
 import Infrastructure from '@components/infrastructure.astro';
 
-워크로드에 맞게 Aurora Serverless v2 스케일링 제한을 제어합니다.
+워크로드에 맞게 Aurora Serverless v2 스케일링 제한을 제어합니다. 두 프로바이더 모두 기본적으로 최소 0.5 ACU, 최대 4로 설정됩니다.
 
 <Infrastructure>
 <Fragment slot="cdk">

--- a/docs/src/content/docs/pt/snippets/rdb/serverless-capacity.mdx
+++ b/docs/src/content/docs/pt/snippets/rdb/serverless-capacity.mdx
@@ -3,7 +3,7 @@ title: Capacidade Serverless
 ---
 import Infrastructure from '@components/infrastructure.astro';
 
-Controle os limites de escalabilidade do Aurora Serverless v2 para corresponder à sua carga de trabalho.
+Controle os limites de escalabilidade do Aurora Serverless v2 para corresponder à sua carga de trabalho. Ambos os provedores usam como padrão um mínimo de 0,5 ACUs e um máximo de 4.
 
 <Infrastructure>
 <Fragment slot="cdk">

--- a/docs/src/content/docs/vi/snippets/rdb/serverless-capacity.mdx
+++ b/docs/src/content/docs/vi/snippets/rdb/serverless-capacity.mdx
@@ -3,7 +3,7 @@ title: Dung lượng Serverless
 ---
 import Infrastructure from '@components/infrastructure.astro';
 
-Kiểm soát giới hạn mở rộng của Aurora Serverless v2 để phù hợp với khối lượng công việc của bạn.
+Kiểm soát giới hạn mở rộng của Aurora Serverless v2 để phù hợp với khối lượng công việc của bạn. Cả hai nhà cung cấp đều mặc định tối thiểu là 0.5 ACU và tối đa là 4.
 
 <Infrastructure>
 <Fragment slot="cdk">

--- a/docs/src/content/docs/zh/snippets/rdb/serverless-capacity.mdx
+++ b/docs/src/content/docs/zh/snippets/rdb/serverless-capacity.mdx
@@ -3,7 +3,7 @@ title: Serverless 容量
 ---
 import Infrastructure from '@components/infrastructure.astro';
 
-控制 Aurora Serverless v2 扩展限制以匹配您的工作负载。
+控制 Aurora Serverless v2 扩展限制以匹配您的工作负载。两个提供商默认最小值为 0.5 ACU，最大值为 4。
 
 <Infrastructure>
 <Fragment slot="cdk">

--- a/packages/nx-plugin/src/py/rdb/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/rdb/__snapshots__/generator.spec.ts.snap
@@ -1853,6 +1853,20 @@ export interface AuroraDatabaseProps extends _AuroraDatabaseProps {
    * @default true
    */
   readonly enablePerformanceInsights?: boolean;
+
+  /**
+   * Minimum Aurora Serverless v2 ACUs.
+   *
+   * @default 0.5
+   */
+  readonly serverlessV2MinCapacity?: number;
+
+  /**
+   * Maximum Aurora Serverless v2 ACUs.
+   *
+   * @default 4
+   */
+  readonly serverlessV2MaxCapacity?: number;
 }
 
 /**
@@ -1882,6 +1896,8 @@ export abstract class AuroraDatabase extends Construct {
       enableKeyRotation = true,
       enableCloudwatchLogs = true,
       enablePerformanceInsights = true,
+      serverlessV2MinCapacity = 0.5,
+      serverlessV2MaxCapacity = 4,
       engine,
       engineVersion,
       ...clusterProps
@@ -1897,6 +1913,8 @@ export abstract class AuroraDatabase extends Construct {
       vpc,
       vpcSubnets,
       engine: engine.clusterEngine(engineVersion ?? engine.defaultVersion),
+      serverlessV2MinCapacity,
+      serverlessV2MaxCapacity,
       writer:
         writer ??
         ClusterInstance.serverlessV2('writer', {

--- a/packages/nx-plugin/src/ts/rdb/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/rdb/__snapshots__/generator.spec.ts.snap
@@ -539,6 +539,20 @@ export interface AuroraDatabaseProps extends _AuroraDatabaseProps {
    * @default true
    */
   readonly enablePerformanceInsights?: boolean;
+
+  /**
+   * Minimum Aurora Serverless v2 ACUs.
+   *
+   * @default 0.5
+   */
+  readonly serverlessV2MinCapacity?: number;
+
+  /**
+   * Maximum Aurora Serverless v2 ACUs.
+   *
+   * @default 4
+   */
+  readonly serverlessV2MaxCapacity?: number;
 }
 
 /**
@@ -568,6 +582,8 @@ export abstract class AuroraDatabase extends Construct {
       enableKeyRotation = true,
       enableCloudwatchLogs = true,
       enablePerformanceInsights = true,
+      serverlessV2MinCapacity = 0.5,
+      serverlessV2MaxCapacity = 4,
       engine,
       engineVersion,
       ...clusterProps
@@ -583,6 +599,8 @@ export abstract class AuroraDatabase extends Construct {
       vpc,
       vpcSubnets,
       engine: engine.clusterEngine(engineVersion ?? engine.defaultVersion),
+      serverlessV2MinCapacity,
+      serverlessV2MaxCapacity,
       writer:
         writer ??
         ClusterInstance.serverlessV2('writer', {
@@ -4358,6 +4376,20 @@ export interface AuroraDatabaseProps extends _AuroraDatabaseProps {
    * @default true
    */
   readonly enablePerformanceInsights?: boolean;
+
+  /**
+   * Minimum Aurora Serverless v2 ACUs.
+   *
+   * @default 0.5
+   */
+  readonly serverlessV2MinCapacity?: number;
+
+  /**
+   * Maximum Aurora Serverless v2 ACUs.
+   *
+   * @default 4
+   */
+  readonly serverlessV2MaxCapacity?: number;
 }
 
 /**
@@ -4387,6 +4419,8 @@ export abstract class AuroraDatabase extends Construct {
       enableKeyRotation = true,
       enableCloudwatchLogs = true,
       enablePerformanceInsights = true,
+      serverlessV2MinCapacity = 0.5,
+      serverlessV2MaxCapacity = 4,
       engine,
       engineVersion,
       ...clusterProps
@@ -4402,6 +4436,8 @@ export abstract class AuroraDatabase extends Construct {
       vpc,
       vpcSubnets,
       engine: engine.clusterEngine(engineVersion ?? engine.defaultVersion),
+      serverlessV2MinCapacity,
+      serverlessV2MaxCapacity,
       writer:
         writer ??
         ClusterInstance.serverlessV2('writer', {

--- a/packages/nx-plugin/src/utils/rdb-constructs/files/cdk/core/rdb/aurora.ts.template
+++ b/packages/nx-plugin/src/utils/rdb-constructs/files/cdk/core/rdb/aurora.ts.template
@@ -180,6 +180,20 @@ export interface AuroraDatabaseProps extends _AuroraDatabaseProps {
    * @default true
    */
   readonly enablePerformanceInsights?: boolean;
+
+  /**
+   * Minimum Aurora Serverless v2 ACUs.
+   *
+   * @default <%= serverlessMinCapacity %>
+   */
+  readonly serverlessV2MinCapacity?: number;
+
+  /**
+   * Maximum Aurora Serverless v2 ACUs.
+   *
+   * @default <%= serverlessMaxCapacity %>
+   */
+  readonly serverlessV2MaxCapacity?: number;
 }
 
 /**
@@ -209,6 +223,8 @@ export abstract class AuroraDatabase extends Construct {
       enableKeyRotation = true,
       enableCloudwatchLogs = true,
       enablePerformanceInsights = true,
+      serverlessV2MinCapacity = <%= serverlessMinCapacity %>,
+      serverlessV2MaxCapacity = <%= serverlessMaxCapacity %>,
       engine,
       engineVersion,
       ...clusterProps
@@ -224,6 +240,8 @@ export abstract class AuroraDatabase extends Construct {
       vpc,
       vpcSubnets,
       engine: engine.clusterEngine(engineVersion ?? engine.defaultVersion),
+      serverlessV2MinCapacity,
+      serverlessV2MaxCapacity,
       writer:
         writer ??
         ClusterInstance.serverlessV2("writer", {

--- a/packages/nx-plugin/src/utils/rdb-constructs/files/terraform/app/dbs/__nameKebabCase__/__nameKebabCase__.tf.template
+++ b/packages/nx-plugin/src/utils/rdb-constructs/files/terraform/app/dbs/__nameKebabCase__/__nameKebabCase__.tf.template
@@ -51,13 +51,13 @@ variable "port" {
 variable "serverless_min_capacity" {
   description = "Minimum Aurora Serverless v2 ACUs."
   type        = number
-  default     = 0.5
+  default     = <%= serverlessMinCapacity %>
 }
 
 variable "serverless_max_capacity" {
   description = "Maximum Aurora Serverless v2 ACUs."
   type        = number
-  default     = 4
+  default     = <%= serverlessMaxCapacity %>
 }
 
 variable "instance_count" {

--- a/packages/nx-plugin/src/utils/rdb-constructs/files/terraform/core/rdb/aurora/aurora.tf.template
+++ b/packages/nx-plugin/src/utils/rdb-constructs/files/terraform/core/rdb/aurora/aurora.tf.template
@@ -84,13 +84,13 @@ variable "port" {
 variable "serverless_min_capacity" {
   description = "Minimum Aurora Serverless v2 ACUs."
   type        = number
-  default     = 0.5
+  default     = <%= serverlessMinCapacity %>
 }
 
 variable "serverless_max_capacity" {
   description = "Maximum Aurora Serverless v2 ACUs."
   type        = number
-  default     = 4
+  default     = <%= serverlessMaxCapacity %>
 }
 
 variable "instance_count" {

--- a/packages/nx-plugin/src/utils/rdb-constructs/rdb-constructs.ts
+++ b/packages/nx-plugin/src/utils/rdb-constructs/rdb-constructs.ts
@@ -20,7 +20,10 @@ import {
   SHARED_CONSTRUCTS_DIR,
   SHARED_TERRAFORM_DIR,
 } from '../shared-constructs-constants.js';
-import { terraformProviderVersions } from '../versions.js';
+import {
+  auroraServerlessV2Capacity,
+  terraformProviderVersions,
+} from '../versions.js';
 
 export interface AddRdbConstructOptions {
   projectName: string;
@@ -91,7 +94,7 @@ export const addRdbCdkConstructs = async (
       'core',
       'rdb',
     ),
-    { ...options, ...esmVars(tree) },
+    { ...options, ...esmVars(tree), ...auroraServerlessV2Capacity() },
     {
       overwriteStrategy: OverwriteStrategy.KeepExisting,
     },
@@ -151,7 +154,7 @@ export const addRdbTerraformModules = (
     tree,
     joinPathFragments(import.meta.dirname, 'files', 'terraform', 'core', 'rdb'),
     joinPathFragments(PACKAGES_DIR, SHARED_TERRAFORM_DIR, 'src', 'core', 'rdb'),
-    { ...terraformProviderVersions() },
+    { ...terraformProviderVersions(), ...auroraServerlessV2Capacity() },
     {
       overwriteStrategy: OverwriteStrategy.KeepExisting,
     },
@@ -161,7 +164,11 @@ export const addRdbTerraformModules = (
     tree,
     joinPathFragments(import.meta.dirname, 'files', 'terraform', 'app', 'dbs'),
     joinPathFragments(PACKAGES_DIR, SHARED_TERRAFORM_DIR, 'src', 'app', 'dbs'),
-    { ...options, ...terraformProviderVersions() },
+    {
+      ...options,
+      ...terraformProviderVersions(),
+      ...auroraServerlessV2Capacity(),
+    },
     {
       overwriteStrategy: OverwriteStrategy.KeepExisting,
     },

--- a/packages/nx-plugin/src/utils/rdb-constructs/rdb-constructs.ts
+++ b/packages/nx-plugin/src/utils/rdb-constructs/rdb-constructs.ts
@@ -20,10 +20,29 @@ import {
   SHARED_CONSTRUCTS_DIR,
   SHARED_TERRAFORM_DIR,
 } from '../shared-constructs-constants.js';
-import {
-  auroraServerlessV2Capacity,
-  terraformProviderVersions,
-} from '../versions.js';
+import { terraformProviderVersions } from '../versions.js';
+
+/**
+ * Aurora Serverless v2 scaling bounds, in ACUs, that both IaC providers derive
+ * from so the same generator options vend the same ceiling regardless of `--iac`.
+ *
+ * Set explicitly on CDK rather than inheriting `DatabaseClusterProps`, whose
+ * default moves with `aws-cdk-lib`. Serverless v2 bills on ACUs consumed, not on
+ * the ceiling, so the maximum is headroom rather than a cost commitment.
+ */
+export const AURORA_SERVERLESS_V2_CAPACITY = {
+  min: 0.5,
+  max: 4,
+} as const;
+
+/**
+ * Substitution variables exposing the Aurora Serverless v2 scaling bounds to
+ * generated CDK and Terraform templates.
+ */
+const auroraServerlessV2Capacity = () => ({
+  serverlessMinCapacity: AURORA_SERVERLESS_V2_CAPACITY.min,
+  serverlessMaxCapacity: AURORA_SERVERLESS_V2_CAPACITY.max,
+});
 
 export interface AddRdbConstructOptions {
   projectName: string;

--- a/packages/nx-plugin/src/utils/versions.ts
+++ b/packages/nx-plugin/src/utils/versions.ts
@@ -347,28 +347,6 @@ export const containerImage = (tool: keyof typeof CONTAINER_VERSIONS): string =>
   `${CONTAINER_REPOSITORIES[tool]}:${CONTAINER_VERSIONS[tool]}`;
 
 /**
- * Aurora Serverless v2 scaling bounds, in ACUs, that both IaC providers derive
- * from so the same generator options vend the same ceiling regardless of `--iac`.
- *
- * Set explicitly on CDK rather than inheriting `DatabaseClusterProps`, whose
- * default moves with `aws-cdk-lib`. Serverless v2 bills on ACUs consumed, not on
- * the ceiling, so the maximum is headroom rather than a cost commitment.
- */
-export const AURORA_SERVERLESS_V2_CAPACITY = {
-  min: 0.5,
-  max: 4,
-} as const;
-
-/**
- * Substitution variables exposing the Aurora Serverless v2 scaling bounds to
- * generated CDK and Terraform templates.
- */
-export const auroraServerlessV2Capacity = () => ({
-  serverlessMinCapacity: AURORA_SERVERLESS_V2_CAPACITY.min,
-  serverlessMaxCapacity: AURORA_SERVERLESS_V2_CAPACITY.max,
-});
-
-/**
  * Exact versions for Terraform providers used by generated `.tf` modules.
  * Pinned exactly (no range operator) so generated infrastructure is reproducible.
  */

--- a/packages/nx-plugin/src/utils/versions.ts
+++ b/packages/nx-plugin/src/utils/versions.ts
@@ -347,6 +347,28 @@ export const containerImage = (tool: keyof typeof CONTAINER_VERSIONS): string =>
   `${CONTAINER_REPOSITORIES[tool]}:${CONTAINER_VERSIONS[tool]}`;
 
 /**
+ * Aurora Serverless v2 scaling bounds, in ACUs, that both IaC providers derive
+ * from so the same generator options vend the same ceiling regardless of `--iac`.
+ *
+ * Set explicitly on CDK rather than inheriting `DatabaseClusterProps`, whose
+ * default moves with `aws-cdk-lib`. Serverless v2 bills on ACUs consumed, not on
+ * the ceiling, so the maximum is headroom rather than a cost commitment.
+ */
+export const AURORA_SERVERLESS_V2_CAPACITY = {
+  min: 0.5,
+  max: 4,
+} as const;
+
+/**
+ * Substitution variables exposing the Aurora Serverless v2 scaling bounds to
+ * generated CDK and Terraform templates.
+ */
+export const auroraServerlessV2Capacity = () => ({
+  serverlessMinCapacity: AURORA_SERVERLESS_V2_CAPACITY.min,
+  serverlessMaxCapacity: AURORA_SERVERLESS_V2_CAPACITY.max,
+});
+
+/**
  * Exact versions for Terraform providers used by generated `.tf` modules.
  * Pinned exactly (no range operator) so generated infrastructure is reproducible.
  */


### PR DESCRIPTION
### Reason for this change

Identical `ts#rdb`/`py#rdb` generator options produced a different Aurora Serverless v2 scaling ceiling depending on `--iac`, so the worst-case compute bill differed by 2x for the same requested infrastructure:

| Provider | Before | After |
| --- | --- | --- |
| CDK (`cdk synth`) | `{"MinCapacity": 0.5, "MaxCapacity": 2}` | `{"MinCapacity": 0.5, "MaxCapacity": 4}` |
| Terraform (`terraform plan`) | `min_capacity = 0.5`, `max_capacity = 4` | `min_capacity = 0.5`, `max_capacity = 4` |

Terraform set `serverless_max_capacity` explicitly, while CDK set neither bound and inherited `DatabaseClusterProps`, whose `serverlessV2MaxCapacity` default is 2.

The docs snippet showed `8` for both providers, which matched neither and so hid the divergence rather than documenting it.

### Description of changes

**Chose 4 ACUs, keeping Terraform's value and raising CDK to match.** The reasoning, rather than defaulting to the lower value or matching CDK reflexively:

- CDK's 2 was never a decision this repo made — it is whatever `aws-cdk-lib` happens to default to, so "match CDK" carries little weight as an argument. Terraform's 4 is the only one of the two that was ever chosen deliberately.
- **Serverless v2 bills on ACU-seconds actually consumed, not on the ceiling.** Raising the maximum does not raise the steady-state bill at all; both values idle at the same 0.5 ACU floor. The ceiling only raises the *worst case*, and only while a workload is genuinely demanding that capacity.
- The failure modes are asymmetric. Exceeding the ceiling does not fail loudly — Aurora simply stops scaling and the database degrades under load, which is a slow, hard-to-diagnose problem for the vended default to have. 2 ACUs is a small instance that a modest workload can saturate, so 4 buys meaningful headroom against a cost that is only incurred if it is actually needed.

**Made CDK set both bounds explicitly.** An inherited library default silently moves on the next `aws-cdk-lib` bump, which is precisely how this drift appeared; pinning it means a future change to the ceiling is a deliberate, reviewable edit. Both providers now derive from a single `AURORA_SERVERLESS_V2_CAPACITY` in `packages/nx-plugin/src/utils/rdb-constructs/rdb-constructs.ts` — alongside the rest of the RDB generator logic that owns it — so the two cannot drift apart again.

**Kept the knob equivalent across providers.** CDK gains documented `serverlessV2MinCapacity`/`serverlessV2MaxCapacity` props; Terraform keeps `serverless_min_capacity`/`serverless_max_capacity`. Both are tunable and both now document the same default.

**No migration.** The vended files are `KeepExisting`, so an existing workspace keeps its current values and is unaffected. Only Terraform users would see a change, and for them the vended default already *was* 4 — there is nothing to migrate. Worth noting for anyone considering one later: changing max capacity is an in-place `ModifyDBCluster` (it flips `ParameterApplyStatus` to `pending-reboot`), **not** a cluster replacement — but silently retuning the capacity of a live database on upgrade is not something an upgrade should do unasked.

Docs now state the real default instead of the fictional `8`.

### Description of how you validated changes

`pnpm nx run @aws/nx-plugin:test` — 3763 tests / 206 files pass. The existing `ts#rdb` and `py#rdb` snapshots already pin the Terraform defaults and now also pin the CDK literals (`serverlessV2MaxCapacity = 4`), so a future divergence — including an `aws-cdk-lib` bump moving the inherited default — fails a snapshot instead of shipping silently. No new spec file was needed.

`pnpm nx run-many --target build --all` and `pnpm nx run-many --target lint --all --configuration=fix` are both clean.

End-to-end, with the locally compiled plugin linked into two fresh workspaces (`ts#rdb` with `--iac=cdk` and `--iac=terraform`):

- **CDK: real `cdk synth`.** The synthesised `AWS::RDS::DBCluster` reports `{"MaxCapacity": 4, "MinCapacity": 0.5}`. I also captured the before figure from the same workspace by reverting just the vended construct to the inherited-default shape and re-synthing, which gave `{"MaxCapacity": 2, "MinCapacity": 0.5}` — the 2x gap, measured rather than inferred.
- **Terraform: real `terraform plan`** against the vended `core/rdb/aurora` module (aws provider 6.61.0, real VPC/subnet IDs). Planned `serverlessv2_scaling_configuration { max_capacity = 4, min_capacity = 0.5 }`, 24 to add.

I did **not** deploy. This is a defaults change with no runtime behaviour to exercise, and both providers' capacity configuration is fully determined at synth/plan time, so the synth-vs-plan comparison establishes the alignment directly. The plan ran against a local backend in a scratch directory and created no resources, so no teardown was required and no shared Terraform state was touched.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
