### PR TITLE
fix(agentcore-harness): default the Harness to no tools

### DIFF
--- a/docs/src/content/docs/en/guides/agentcore-harness.mdx
+++ b/docs/src/content/docs/en/guides/agentcore-harness.mdx
@@ -94,7 +94,7 @@ const harness = new MyHarness(this, 'MyHarness', {
 
 The construct also accepts:
 
-- `allowedTools` — the tools the Harness may use. The Harness deploys with none unless you supply them, see <a href="#configuring-tools">Configuring tools</a>.
+- `allowedTools` — the tools the Harness may use. Defaults to none, see <a href="#configuring-tools">Configuring tools</a>.
 - `executionRole` — an existing IAM role to use instead of the generated role. A supplied role is used as-is: the baseline permissions are not added to it, and its ARN always feeds the Harness (the raw `executionRoleArn` string cannot be overridden).
 - `modelResourceArns` — the Bedrock model and inference-profile ARNs the generated execution role may invoke, replacing the default list.
 - `vpc`, `vpcSubnets` and `securityGroups` — run the Harness in a VPC so it can reach private resources, see <a href="#running-in-a-vpc">Running in a VPC</a>.
@@ -112,9 +112,10 @@ module "my_harness" {
 }
 ```
 
-The module exposes three variables:
+The module exposes four variables:
 
 - `model_id` — the Bedrock model or inference profile the Harness uses by default.
+- `allowed_tools` — the tools the Harness may use. Defaults to none, see <a href="#configuring-tools">Configuring tools</a>.
 - `model_resource_arns` — the Bedrock model and inference-profile ARNs the execution role may invoke, replacing the default list.
 - `additional_execution_role_policy_statements` — a list of IAM statement objects (`Effect`, `Action`, `Resource`, optional `Sid` and `Condition`) appended to the execution role policy.
 
@@ -213,14 +214,13 @@ new MyHarness(this, 'Harness', { allowedTools: ['@builtin'] });
 ```
   </Fragment>
   <Fragment slot="terraform">
-```hcl title="packages/common/terraform/src/app/harnesses/my-harness/my-harness.tf"
-resource "aws_bedrockagentcore_harness" "this" {
-  # ...
+```hcl title="packages/infra/src/main.tf"
+module "my_harness" {
+  source = "../../common/terraform/src/app/harnesses/my-harness"
+
   allowed_tools = ["@builtin"]
 }
 ```
-
-Add an `allowed_tools` variable to the module if you would rather set it as a module argument where you reference the module.
   </Fragment>
 </Infrastructure>
 

--- a/docs/src/content/docs/es/guides/agentcore-harness.mdx
+++ b/docs/src/content/docs/es/guides/agentcore-harness.mdx
@@ -94,7 +94,7 @@ const harness = new MyHarness(this, 'MyHarness', {
 
 El constructo también acepta:
 
-- `allowedTools` — las herramientas que el Harness puede usar. El Harness se implementa sin ninguna a menos que las proporciones, consulta <a href="#configurar-herramientas">Configurar herramientas</a>.
+- `allowedTools` — las herramientas que el Harness puede usar. Por defecto ninguna, consulta <a href="#configurar-herramientas">Configurar herramientas</a>.
 - `executionRole` — un rol IAM existente para usar en lugar del rol generado. Un rol proporcionado se usa tal cual: los permisos básicos no se le agregan, y su ARN siempre alimenta el Harness (la cadena `executionRoleArn` sin procesar no se puede anular).
 - `modelResourceArns` — los ARN del modelo de Bedrock y del perfil de inferencia que el rol de ejecución generado puede invocar, reemplazando la lista predeterminada.
 - `vpc`, `vpcSubnets` y `securityGroups` — ejecuta el Harness en una VPC para que pueda alcanzar recursos privados, consulta <a href="#ejecutar-en-una-vpc">Ejecutar en una VPC</a>.
@@ -112,9 +112,10 @@ module "my_harness" {
 }
 ```
 
-El módulo expone tres variables:
+El módulo expone cuatro variables:
 
 - `model_id` — el modelo de Bedrock o perfil de inferencia que el Harness usa de forma predeterminada.
+- `allowed_tools` — las herramientas que el Harness puede usar. Por defecto ninguna, consulta <a href="#configurar-herramientas">Configurar herramientas</a>.
 - `model_resource_arns` — los ARN del modelo de Bedrock y del perfil de inferencia que el rol de ejecución puede invocar, reemplazando la lista predeterminada.
 - `additional_execution_role_policy_statements` — una lista de objetos de declaración IAM (`Effect`, `Action`, `Resource`, `Sid` y `Condition` opcionales) agregados a la política del rol de ejecución.
 
@@ -213,14 +214,13 @@ new MyHarness(this, 'Harness', { allowedTools: ['@builtin'] });
 ```
   </Fragment>
   <Fragment slot="terraform">
-```hcl title="packages/common/terraform/src/app/harnesses/my-harness/my-harness.tf"
-resource "aws_bedrockagentcore_harness" "this" {
-  # ...
+```hcl title="packages/infra/src/main.tf"
+module "my_harness" {
+  source = "../../common/terraform/src/app/harnesses/my-harness"
+
   allowed_tools = ["@builtin"]
 }
 ```
-
-Agrega una variable `allowed_tools` al módulo si prefieres establecerla como un argumento del módulo donde referencias el módulo.
   </Fragment>
 </Infrastructure>
 

--- a/docs/src/content/docs/fr/guides/agentcore-harness.mdx
+++ b/docs/src/content/docs/fr/guides/agentcore-harness.mdx
@@ -94,7 +94,7 @@ const harness = new MyHarness(this, 'MyHarness', {
 
 Le construct accepte également :
 
-- `allowedTools` — les outils que le Harness peut utiliser. Le Harness se déploie sans aucun outil sauf si vous les fournissez, voir <a href="#configuring-tools">Configuration des outils</a>.
+- `allowedTools` — les outils que le Harness peut utiliser. Par défaut aucun, voir <a href="#configuring-tools">Configuration des outils</a>.
 - `executionRole` — un rôle IAM existant à utiliser au lieu du rôle généré. Un rôle fourni est utilisé tel quel : les permissions de base ne lui sont pas ajoutées, et son ARN alimente toujours le Harness (la chaîne brute `executionRoleArn` ne peut pas être remplacée).
 - `modelResourceArns` — les ARN de modèle Bedrock et de profil d'inférence que le rôle d'exécution généré peut invoquer, remplaçant la liste par défaut.
 - `vpc`, `vpcSubnets` et `securityGroups` — exécutez le Harness dans un VPC afin qu'il puisse atteindre des ressources privées, voir <a href="#running-in-a-vpc">Exécution dans un VPC</a>.
@@ -112,9 +112,10 @@ module "my_harness" {
 }
 ```
 
-Le module expose trois variables :
+Le module expose quatre variables :
 
 - `model_id` — le modèle Bedrock ou le profil d'inférence que le Harness utilise par défaut.
+- `allowed_tools` — les outils que le Harness peut utiliser. Par défaut aucun, voir <a href="#configuring-tools">Configuration des outils</a>.
 - `model_resource_arns` — les ARN de modèle Bedrock et de profil d'inférence que le rôle d'exécution peut invoquer, remplaçant la liste par défaut.
 - `additional_execution_role_policy_statements` — une liste d'objets d'instruction IAM (`Effect`, `Action`, `Resource`, `Sid` et `Condition` optionnels) ajoutés à la politique du rôle d'exécution.
 
@@ -213,14 +214,13 @@ new MyHarness(this, 'Harness', { allowedTools: ['@builtin'] });
 ```
   </Fragment>
   <Fragment slot="terraform">
-```hcl title="packages/common/terraform/src/app/harnesses/my-harness/my-harness.tf"
-resource "aws_bedrockagentcore_harness" "this" {
-  # ...
+```hcl title="packages/infra/src/main.tf"
+module "my_harness" {
+  source = "../../common/terraform/src/app/harnesses/my-harness"
+
   allowed_tools = ["@builtin"]
 }
 ```
-
-Ajoutez une variable `allowed_tools` au module si vous préférez la définir comme argument de module là où vous référencez le module.
   </Fragment>
 </Infrastructure>
 

--- a/docs/src/content/docs/it/guides/agentcore-harness.mdx
+++ b/docs/src/content/docs/it/guides/agentcore-harness.mdx
@@ -94,7 +94,7 @@ const harness = new MyHarness(this, 'MyHarness', {
 
 Il costrutto accetta anche:
 
-- `allowedTools` — gli strumenti che l'Harness può utilizzare. L'Harness viene distribuito senza strumenti a meno che tu non li fornisca, vedi <a href="#configuring-tools">Configurazione degli strumenti</a>.
+- `allowedTools` — gli strumenti che l'Harness può utilizzare. Il valore predefinito è nessuno, vedi <a href="#configuring-tools">Configurazione degli strumenti</a>.
 - `executionRole` — un ruolo IAM esistente da utilizzare al posto del ruolo generato. Un ruolo fornito viene utilizzato così com'è: le autorizzazioni di base non vengono aggiunte ad esso e il suo ARN alimenta sempre l'Harness (la stringa `executionRoleArn` grezza non può essere sovrascritta).
 - `modelResourceArns` — gli ARN del modello Bedrock e del profilo di inferenza che il ruolo di esecuzione generato può invocare, sostituendo l'elenco predefinito.
 - `vpc`, `vpcSubnets` e `securityGroups` — esegui l'Harness in un VPC in modo che possa raggiungere risorse private, vedi <a href="#running-in-a-vpc">Esecuzione in un VPC</a>.
@@ -112,9 +112,10 @@ module "my_harness" {
 }
 ```
 
-Il modulo espone tre variabili:
+Il modulo espone quattro variabili:
 
 - `model_id` — il modello Bedrock o il profilo di inferenza che l'Harness utilizza per impostazione predefinita.
+- `allowed_tools` — gli strumenti che l'Harness può utilizzare. Il valore predefinito è nessuno, vedi <a href="#configuring-tools">Configurazione degli strumenti</a>.
 - `model_resource_arns` — gli ARN del modello Bedrock e del profilo di inferenza che il ruolo di esecuzione può invocare, sostituendo l'elenco predefinito.
 - `additional_execution_role_policy_statements` — un elenco di oggetti di istruzione IAM (`Effect`, `Action`, `Resource`, `Sid` e `Condition` opzionali) aggiunti alla policy del ruolo di esecuzione.
 
@@ -213,14 +214,13 @@ new MyHarness(this, 'Harness', { allowedTools: ['@builtin'] });
 ```
   </Fragment>
   <Fragment slot="terraform">
-```hcl title="packages/common/terraform/src/app/harnesses/my-harness/my-harness.tf"
-resource "aws_bedrockagentcore_harness" "this" {
-  # ...
+```hcl title="packages/infra/src/main.tf"
+module "my_harness" {
+  source = "../../common/terraform/src/app/harnesses/my-harness"
+
   allowed_tools = ["@builtin"]
 }
 ```
-
-Aggiungi una variabile `allowed_tools` al modulo se preferisci impostarla come argomento del modulo dove fai riferimento al modulo.
   </Fragment>
 </Infrastructure>
 

--- a/docs/src/content/docs/jp/guides/agentcore-harness.mdx
+++ b/docs/src/content/docs/jp/guides/agentcore-harness.mdx
@@ -94,7 +94,7 @@ const harness = new MyHarness(this, 'MyHarness', {
 
 コンストラクトは以下も受け入れます。
 
-- `allowedTools` — Harnessが使用できるツール。指定しない限り、Harnessはツールなしでデプロイされます。<a href="#configuring-tools">ツールの構成</a>を参照してください。
+- `allowedTools` — Harnessが使用できるツール。デフォルトではなし。<a href="#configuring-tools">ツールの構成</a>を参照してください。
 - `executionRole` — 生成されたロールの代わりに使用する既存のIAMロール。指定されたロールはそのまま使用されます。ベースライン権限は追加されず、そのARNは常にHarnessに供給されます（生の`executionRoleArn`文字列はオーバーライドできません）。
 - `modelResourceArns` — 生成された実行ロールが呼び出せるBedrockモデルおよび推論プロファイルARN。デフォルトリストを置き換えます。
 - `vpc`、`vpcSubnets`、`securityGroups` — HarnessをVPC内で実行し、プライベートリソースに到達できるようにします。<a href="#running-in-a-vpc">VPCでの実行</a>を参照してください。
@@ -112,9 +112,10 @@ module "my_harness" {
 }
 ```
 
-モジュールは3つの変数を公開します。
+モジュールは4つの変数を公開します。
 
 - `model_id` — Harnessがデフォルトで使用するBedrockモデルまたは推論プロファイル。
+- `allowed_tools` — Harnessが使用できるツール。デフォルトではなし。<a href="#configuring-tools">ツールの構成</a>を参照してください。
 - `model_resource_arns` — 実行ロールが呼び出せるBedrockモデルおよび推論プロファイルARN。デフォルトリストを置き換えます。
 - `additional_execution_role_policy_statements` — 実行ロールポリシーに追加されるIAMステートメントオブジェクト（`Effect`、`Action`、`Resource`、オプションの`Sid`と`Condition`）のリスト。
 
@@ -213,14 +214,13 @@ new MyHarness(this, 'Harness', { allowedTools: ['@builtin'] });
 ```
   </Fragment>
   <Fragment slot="terraform">
-```hcl title="packages/common/terraform/src/app/harnesses/my-harness/my-harness.tf"
-resource "aws_bedrockagentcore_harness" "this" {
-  # ...
+```hcl title="packages/infra/src/main.tf"
+module "my_harness" {
+  source = "../../common/terraform/src/app/harnesses/my-harness"
+
   allowed_tools = ["@builtin"]
 }
 ```
-
-モジュールを参照する場所でモジュール引数として設定したい場合は、`allowed_tools`変数をモジュールに追加します。
   </Fragment>
 </Infrastructure>
 

--- a/docs/src/content/docs/ko/guides/agentcore-harness.mdx
+++ b/docs/src/content/docs/ko/guides/agentcore-harness.mdx
@@ -94,7 +94,7 @@ const harness = new MyHarness(this, 'MyHarness', {
 
 구성은 다음도 허용합니다:
 
-- `allowedTools` — Harness가 사용할 수 있는 도구. 제공하지 않으면 Harness는 도구 없이 배포됩니다. <a href="#configuring-tools">도구 구성</a>을 참조하세요.
+- `allowedTools` — Harness가 사용할 수 있는 도구. 기본값은 없음입니다. <a href="#configuring-tools">도구 구성</a>을 참조하세요.
 - `executionRole` — 생성된 역할 대신 사용할 기존 IAM 역할. 제공된 역할은 있는 그대로 사용됩니다: 기본 권한이 추가되지 않으며, 해당 ARN은 항상 Harness에 제공됩니다(원시 `executionRoleArn` 문자열은 재정의할 수 없음).
 - `modelResourceArns` — 생성된 실행 역할이 호출할 수 있는 Bedrock 모델 및 추론 프로필 ARN으로, 기본 목록을 대체합니다.
 - `vpc`, `vpcSubnets` 및 `securityGroups` — VPC에서 Harness를 실행하여 프라이빗 리소스에 도달할 수 있도록 합니다. <a href="#running-in-a-vpc">VPC에서 실행</a>을 참조하세요.
@@ -112,9 +112,10 @@ module "my_harness" {
 }
 ```
 
-모듈은 세 가지 변수를 노출합니다:
+모듈은 네 가지 변수를 노출합니다:
 
 - `model_id` — Harness가 기본적으로 사용하는 Bedrock 모델 또는 추론 프로필.
+- `allowed_tools` — Harness가 사용할 수 있는 도구. 기본값은 없음입니다. <a href="#configuring-tools">도구 구성</a>을 참조하세요.
 - `model_resource_arns` — 실행 역할이 호출할 수 있는 Bedrock 모델 및 추론 프로필 ARN으로, 기본 목록을 대체합니다.
 - `additional_execution_role_policy_statements` — 실행 역할 정책에 추가되는 IAM 문 객체 목록(`Effect`, `Action`, `Resource`, 선택적 `Sid` 및 `Condition`).
 
@@ -213,14 +214,13 @@ new MyHarness(this, 'Harness', { allowedTools: ['@builtin'] });
 ```
   </Fragment>
   <Fragment slot="terraform">
-```hcl title="packages/common/terraform/src/app/harnesses/my-harness/my-harness.tf"
-resource "aws_bedrockagentcore_harness" "this" {
-  # ...
+```hcl title="packages/infra/src/main.tf"
+module "my_harness" {
+  source = "../../common/terraform/src/app/harnesses/my-harness"
+
   allowed_tools = ["@builtin"]
 }
 ```
-
-모듈을 참조하는 곳에서 모듈 인수로 설정하려면 모듈에 `allowed_tools` 변수를 추가하세요.
   </Fragment>
 </Infrastructure>
 

--- a/docs/src/content/docs/pt/guides/agentcore-harness.mdx
+++ b/docs/src/content/docs/pt/guides/agentcore-harness.mdx
@@ -94,7 +94,7 @@ const harness = new MyHarness(this, 'MyHarness', {
 
 O construto também aceita:
 
-- `allowedTools` — as ferramentas que o Harness pode usar. O Harness é implantado sem nenhuma a menos que você as forneça, veja <a href="#configuring-tools">Configurando ferramentas</a>.
+- `allowedTools` — as ferramentas que o Harness pode usar. O padrão é nenhuma, veja <a href="#configuring-tools">Configurando ferramentas</a>.
 - `executionRole` — uma função IAM existente para usar em vez da função gerada. Uma função fornecida é usada como está: as permissões básicas não são adicionadas a ela, e seu ARN sempre alimenta o Harness (a string bruta `executionRoleArn` não pode ser substituída).
 - `modelResourceArns` — os ARNs de modelo e perfil de inferência do Bedrock que a função de execução gerada pode invocar, substituindo a lista padrão.
 - `vpc`, `vpcSubnets` e `securityGroups` — execute o Harness em uma VPC para que ele possa alcançar recursos privados, veja <a href="#running-in-a-vpc">Executando em uma VPC</a>.
@@ -112,9 +112,10 @@ module "my_harness" {
 }
 ```
 
-O módulo expõe três variáveis:
+O módulo expõe quatro variáveis:
 
 - `model_id` — o modelo Bedrock ou perfil de inferência que o Harness usa por padrão.
+- `allowed_tools` — as ferramentas que o Harness pode usar. O padrão é nenhuma, veja <a href="#configuring-tools">Configurando ferramentas</a>.
 - `model_resource_arns` — os ARNs de modelo e perfil de inferência do Bedrock que a função de execução pode invocar, substituindo a lista padrão.
 - `additional_execution_role_policy_statements` — uma lista de objetos de declaração IAM (`Effect`, `Action`, `Resource`, `Sid` e `Condition` opcionais) anexados à política da função de execução.
 
@@ -213,14 +214,13 @@ new MyHarness(this, 'Harness', { allowedTools: ['@builtin'] });
 ```
   </Fragment>
   <Fragment slot="terraform">
-```hcl title="packages/common/terraform/src/app/harnesses/my-harness/my-harness.tf"
-resource "aws_bedrockagentcore_harness" "this" {
-  # ...
+```hcl title="packages/infra/src/main.tf"
+module "my_harness" {
+  source = "../../common/terraform/src/app/harnesses/my-harness"
+
   allowed_tools = ["@builtin"]
 }
 ```
-
-Adicione uma variável `allowed_tools` ao módulo se você preferir defini-la como um argumento do módulo onde você referencia o módulo.
   </Fragment>
 </Infrastructure>
 

--- a/docs/src/content/docs/vi/guides/agentcore-harness.mdx
+++ b/docs/src/content/docs/vi/guides/agentcore-harness.mdx
@@ -94,7 +94,7 @@ const harness = new MyHarness(this, 'MyHarness', {
 
 Construct cũng chấp nhận:
 
-- `allowedTools` — các công cụ mà Harness có thể sử dụng. Harness triển khai mà không có công cụ nào trừ khi bạn cung cấp chúng, xem <a href="#configuring-tools">Configuring tools</a>.
+- `allowedTools` — các công cụ mà Harness có thể sử dụng. Mặc định là không có, xem <a href="#configuring-tools">Configuring tools</a>.
 - `executionRole` — một IAM role hiện có để sử dụng thay vì role được tạo. Một role được cung cấp được sử dụng nguyên trạng: các quyền cơ bản không được thêm vào nó, và ARN của nó luôn cung cấp cho Harness (chuỗi `executionRoleArn` thô không thể bị ghi đè).
 - `modelResourceArns` — các ARN của Bedrock model và inference-profile mà execution role được tạo có thể gọi, thay thế danh sách mặc định.
 - `vpc`, `vpcSubnets` và `securityGroups` — chạy Harness trong một VPC để nó có thể tiếp cận các tài nguyên riêng tư, xem <a href="#running-in-a-vpc">Running in a VPC</a>.
@@ -112,9 +112,10 @@ module "my_harness" {
 }
 ```
 
-Module hiển thị ba biến:
+Module hiển thị bốn biến:
 
 - `model_id` — Bedrock model hoặc inference profile mà Harness sử dụng theo mặc định.
+- `allowed_tools` — các công cụ mà Harness có thể sử dụng. Mặc định là không có, xem <a href="#configuring-tools">Configuring tools</a>.
 - `model_resource_arns` — các ARN của Bedrock model và inference-profile mà execution role có thể gọi, thay thế danh sách mặc định.
 - `additional_execution_role_policy_statements` — một danh sách các đối tượng IAM statement (`Effect`, `Action`, `Resource`, `Sid` và `Condition` tùy chọn) được thêm vào execution role policy.
 
@@ -213,14 +214,13 @@ new MyHarness(this, 'Harness', { allowedTools: ['@builtin'] });
 ```
   </Fragment>
   <Fragment slot="terraform">
-```hcl title="packages/common/terraform/src/app/harnesses/my-harness/my-harness.tf"
-resource "aws_bedrockagentcore_harness" "this" {
-  # ...
+```hcl title="packages/infra/src/main.tf"
+module "my_harness" {
+  source = "../../common/terraform/src/app/harnesses/my-harness"
+
   allowed_tools = ["@builtin"]
 }
 ```
-
-Thêm một biến `allowed_tools` vào module nếu bạn muốn đặt nó làm đối số module nơi bạn tham chiếu module.
   </Fragment>
 </Infrastructure>
 

--- a/docs/src/content/docs/zh/guides/agentcore-harness.mdx
+++ b/docs/src/content/docs/zh/guides/agentcore-harness.mdx
@@ -94,7 +94,7 @@ const harness = new MyHarness(this, 'MyHarness', {
 
 构造还接受：
 
-- `allowedTools` — Harness 可以使用的工具。除非您提供工具，否则 Harness 部署时不带任何工具，请参阅<a href="#configuring-tools">配置工具</a>。
+- `allowedTools` — Harness 可以使用的工具。默认为无，请参阅<a href="#configuring-tools">配置工具</a>。
 - `executionRole` — 要使用的现有 IAM 角色，而不是生成的角色。提供的角色按原样使用：不会向其添加基线权限，其 ARN 始终提供给 Harness（原始 `executionRoleArn` 字符串无法被覆盖）。
 - `modelResourceArns` — 生成的执行角色可以调用的 Bedrock 模型和推理配置文件 ARN，替换默认列表。
 - `vpc`、`vpcSubnets` 和 `securityGroups` — 在 VPC 中运行 Harness，以便它可以访问私有资源，请参阅<a href="#running-in-a-vpc">在 VPC 中运行</a>。
@@ -112,9 +112,10 @@ module "my_harness" {
 }
 ```
 
-该模块公开三个变量：
+该模块公开四个变量：
 
 - `model_id` — Harness 默认使用的 Bedrock 模型或推理配置文件。
+- `allowed_tools` — Harness 可以使用的工具。默认为无，请参阅<a href="#configuring-tools">配置工具</a>。
 - `model_resource_arns` — 执行角色可以调用的 Bedrock 模型和推理配置文件 ARN，替换默认列表。
 - `additional_execution_role_policy_statements` — 附加到执行角色策略的 IAM 语句对象列表（`Effect`、`Action`、`Resource`、可选的 `Sid` 和 `Condition`）。
 
@@ -213,14 +214,13 @@ new MyHarness(this, 'Harness', { allowedTools: ['@builtin'] });
 ```
   </Fragment>
   <Fragment slot="terraform">
-```hcl title="packages/common/terraform/src/app/harnesses/my-harness/my-harness.tf"
-resource "aws_bedrockagentcore_harness" "this" {
-  # ...
+```hcl title="packages/infra/src/main.tf"
+module "my_harness" {
+  source = "../../common/terraform/src/app/harnesses/my-harness"
+
   allowed_tools = ["@builtin"]
 }
 ```
-
-如果您希望在引用模块的位置将其设置为模块参数，请向模块添加 `allowed_tools` 变量。
   </Fragment>
 </Infrastructure>
 

--- a/packages/nx-plugin/src/agentcore-harness/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/agentcore-harness/__snapshots__/generator.spec.ts.snap
@@ -62,14 +62,13 @@ construct's \`grantInvokeAccess\` grants exactly those two actions.
 ## Customizing your Harness
 
 Edit \`src/PROMPT.md\` for the system prompt. Everything else is configured
-where you instantiate the infrastructure — including tools, which the
-Harness deploys without:
+where you instantiate the infrastructure — including tools, which default
+to none:
 
 - CDK construct props, for example
   \`new MyHarness(this, 'MyHarness', { allowedTools: ['@builtin'] })\`
-- Terraform, by setting \`allowed_tools = ["@builtin"]\` on the module's
-  \`aws_bedrockagentcore_harness\` resource, or by adding an \`allowed_tools\`
-  variable if you would rather set it as a module argument
+- Terraform, by setting the module's \`allowed_tools\` variable, for example
+  \`allowed_tools = ["@builtin"]\`
 
 The generated infrastructure is also yours to edit directly:
 

--- a/packages/nx-plugin/src/agentcore-harness/files/project/README.md.template
+++ b/packages/nx-plugin/src/agentcore-harness/files/project/README.md.template
@@ -59,14 +59,13 @@ construct's `grantInvokeAccess` grants exactly those two actions.
 ## Customizing your Harness
 
 Edit `src/PROMPT.md` for the system prompt. Everything else is configured
-where you instantiate the infrastructure — including tools, which the
-Harness deploys without:
+where you instantiate the infrastructure — including tools, which default
+to none:
 
 - CDK construct props, for example
   `new <%- nameClassName %>(this, '<%- nameClassName %>', { allowedTools: ['@builtin'] })`
-- Terraform, by setting `allowed_tools = ["@builtin"]` on the module's
-  `aws_bedrockagentcore_harness` resource, or by adding an `allowed_tools`
-  variable if you would rather set it as a module argument
+- Terraform, by setting the module's `allowed_tools` variable, for example
+  `allowed_tools = ["@builtin"]`
 
 The generated infrastructure is also yours to edit directly:
 

--- a/packages/nx-plugin/src/agentcore-harness/generator.spec.ts
+++ b/packages/nx-plugin/src/agentcore-harness/generator.spec.ts
@@ -403,11 +403,19 @@ describe('agentcore-harness generator', () => {
     });
 
     it('configures no tools on the resource but exposes allowedTools as props', () => {
-      // From the resource literal onwards, so an allowedTools assignment
-      // anywhere in the resource or after it fails.
+      // The service treats an absent allowedTools as every tool, so the
+      // construct defaults it to none and always passes it explicitly.
+      expect(construct).toContain('allowedTools = [],');
+
+      // Assigned after the harnessProps spread, so an undefined value from a
+      // caller cannot reinstate the service's every-tool default.
       const resourceStart = construct.indexOf('new agentcore.CfnHarness(');
       expect(resourceStart).toBeGreaterThan(0);
-      expect(construct.slice(resourceStart)).not.toContain('allowedTools');
+      const resource = construct.slice(resourceStart);
+      expect(resource).toContain('allowedTools,');
+      expect(resource.indexOf('...harnessProps,')).toBeLessThan(
+        resource.indexOf('allowedTools,'),
+      );
 
       // Omitted from the inherited native props, so the optional field below
       // is the only route by which a caller can supply tools.
@@ -479,21 +487,30 @@ describe('agentcore-harness generator', () => {
       expect(tree.exists(CDK_HARNESSES_INDEX_PATH)).toBe(false);
     });
 
-    it('declares only the three retained input variables', () => {
-      // Set equality, so a reintroduced system_prompt, allowed_tools,
-      // max_iterations, max_tokens or timeout_seconds variable fails.
+    it('declares only the four retained input variables', () => {
+      // Set equality, so a reintroduced system_prompt, max_iterations,
+      // max_tokens or timeout_seconds variable fails.
       expect(
         [...tf.matchAll(/^variable "([a-z_]+)"/gm)].map(([, name]) => name),
       ).toEqual([
         'model_id',
+        'allowed_tools',
         'model_resource_arns',
         'additional_execution_role_policy_statements',
       ]);
       // No validation block survives, and nothing references the removed
-      // variables or assigns tools to the resource.
+      // variables.
       expect(tf).not.toContain('validation {');
       expect(tf).not.toContain('var.system_prompt');
-      expect(tf).not.toContain('allowed_tools');
+    });
+
+    it('defaults allowed_tools to none and always sends it', () => {
+      // The service treats an absent allowed_tools as every tool, so the
+      // module defaults to none and assigns the variable unconditionally.
+      expect(tf).toMatch(
+        /variable "allowed_tools" \{[^}]*type {8}= list\(string\)\n {2}default {5}= \[\]/,
+      );
+      expect(tf).toContain('allowed_tools      = var.allowed_tools');
     });
 
     it('justifies every wildcard IAM statement inline', () => {

--- a/packages/nx-plugin/src/migrations/latest/agentcore-harness-no-tools-by-default/__snapshots__/migration.spec.ts.snap
+++ b/packages/nx-plugin/src/migrations/latest/agentcore-harness-no-tools-by-default/__snapshots__/migration.spec.ts.snap
@@ -1,0 +1,79 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`agentcore-harness-no-tools-by-default migration > cdk > defaults allowedTools to none and passes it explicitly 1`] = `
+"import * as agentcore from 'aws-cdk-lib/aws-bedrockagentcore';
+import { Construct } from 'constructs';
+
+export class MyHarness extends Construct {
+  public readonly harness: agentcore.CfnHarness;
+
+  constructor(scope: Construct, id: string, props?: MyHarnessProps) {
+    super(scope, id);
+
+    const stack = Stack.of(this);
+    const {
+      // The service treats an absent allowedTools as every tool, so this
+      // defaults to none and is always passed explicitly.
+      allowedTools = [],
+      executionRole,
+      modelResourceArns = [
+        \`arn:\${stack.partition}:bedrock:*::foundation-model/*\`,
+      ],
+      vpc,
+      vpcSubnets,
+      securityGroups,
+      ...harnessProps
+    } = props ?? {};
+
+    this.harness = new agentcore.CfnHarness(this, 'Harness', {
+      model: {
+        bedrockModelConfig: {
+          modelId: 'global.anthropic.claude-sonnet-4-6',
+        },
+      },
+      systemPrompt: [{ text: systemPrompt }],
+      ...harnessProps,
+      allowedTools,
+      // Set after harnessProps so the deployed name always matches the
+      // execution role's workload-identity resource pattern.
+      harnessName,
+      executionRoleArn: this.executionRole.roleArn,
+      environment,
+    });
+  }
+}
+"
+`;
+
+exports[`agentcore-harness-no-tools-by-default migration > terraform > declares allowed_tools defaulting to none and assigns it 1`] = `
+"variable "model_id" {
+  description = "Amazon Bedrock model or inference profile used by default."
+  type        = string
+  default     = "global.anthropic.claude-sonnet-4-6"
+}
+
+variable "allowed_tools" {
+  description = "Tools the Harness may use. Defaults to none; set [\\"@builtin\\"] for every built-in tool, or name individual tools. Always sent explicitly, since the service treats an absent value as every tool."
+  type        = list(string)
+  default     = []
+}
+
+variable "model_resource_arns" {
+  description = "Bedrock model and inference-profile ARNs the execution role may invoke."
+  type        = set(string)
+  default     = null
+}
+
+resource "aws_bedrockagentcore_harness" "this" {
+  harness_name       = local.harness_name
+  execution_role_arn = aws_iam_role.execution_role.arn
+  allowed_tools      = var.allowed_tools
+
+  model {
+    bedrock_model_config {
+      model_id = var.model_id
+    }
+  }
+}
+"
+`;

--- a/packages/nx-plugin/src/migrations/latest/agentcore-harness-no-tools-by-default/metadata.json
+++ b/packages/nx-plugin/src/migrations/latest/agentcore-harness-no-tools-by-default/metadata.json
@@ -1,0 +1,3 @@
+{
+  "description": "Pin the vended AgentCore Harness construct/module to no tools by default, since AgentCore treats an absent allowedTools as every tool"
+}

--- a/packages/nx-plugin/src/migrations/latest/agentcore-harness-no-tools-by-default/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/latest/agentcore-harness-no-tools-by-default/migration.spec.ts
@@ -1,0 +1,191 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import type { Tree } from '@nx/devkit';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test.js';
+import migration from './migration.js';
+
+const CDK_FILE =
+  'packages/common/constructs/src/app/harnesses/my-harness/my-harness.ts';
+const TF_FILE =
+  'packages/common/terraform/src/app/harnesses/my-harness/my-harness.tf';
+
+/** The pre-change shape of the vended CDK Harness construct. */
+const CDK_BEFORE = `import * as agentcore from 'aws-cdk-lib/aws-bedrockagentcore';
+import { Construct } from 'constructs';
+
+export class MyHarness extends Construct {
+  public readonly harness: agentcore.CfnHarness;
+
+  constructor(scope: Construct, id: string, props?: MyHarnessProps) {
+    super(scope, id);
+
+    const stack = Stack.of(this);
+    const {
+      executionRole,
+      modelResourceArns = [
+        \`arn:\${stack.partition}:bedrock:*::foundation-model/*\`,
+      ],
+      vpc,
+      vpcSubnets,
+      securityGroups,
+      ...harnessProps
+    } = props ?? {};
+
+    this.harness = new agentcore.CfnHarness(this, 'Harness', {
+      model: {
+        bedrockModelConfig: {
+          modelId: 'global.anthropic.claude-sonnet-4-6',
+        },
+      },
+      systemPrompt: [{ text: systemPrompt }],
+      ...harnessProps,
+      // Set after harnessProps so the deployed name always matches the
+      // execution role's workload-identity resource pattern.
+      harnessName,
+      executionRoleArn: this.executionRole.roleArn,
+      environment,
+    });
+  }
+}
+`;
+
+/** The pre-change shape of the vended Terraform Harness module. */
+const TF_BEFORE = `variable "model_id" {
+  description = "Amazon Bedrock model or inference profile used by default."
+  type        = string
+  default     = "global.anthropic.claude-sonnet-4-6"
+}
+
+variable "model_resource_arns" {
+  description = "Bedrock model and inference-profile ARNs the execution role may invoke."
+  type        = set(string)
+  default     = null
+}
+
+resource "aws_bedrockagentcore_harness" "this" {
+  harness_name       = local.harness_name
+  execution_role_arn = aws_iam_role.execution_role.arn
+
+  model {
+    bedrock_model_config {
+      model_id = var.model_id
+    }
+  }
+}
+`;
+
+describe('agentcore-harness-no-tools-by-default migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeUsingTsSolutionSetup();
+  });
+
+  it('does nothing in a workspace with no harnesses', async () => {
+    const { nextSteps } = await migration(tree);
+    expect(nextSteps).toEqual([]);
+  });
+
+  describe('cdk', () => {
+    beforeEach(() => {
+      tree.write(CDK_FILE, CDK_BEFORE);
+    });
+
+    it('defaults allowedTools to none and passes it explicitly', async () => {
+      const { nextSteps } = await migration(tree);
+      expect(nextSteps).toEqual([]);
+
+      const construct = tree.read(CDK_FILE, 'utf-8')!;
+      expect(construct).toContain('allowedTools = [],');
+
+      // After the spread, so an undefined caller value cannot reinstate the
+      // service's every-tool default.
+      const resource = construct.slice(
+        construct.indexOf('new agentcore.CfnHarness('),
+      );
+      expect(resource).toContain('allowedTools,');
+      expect(resource.indexOf('...harnessProps,')).toBeLessThan(
+        resource.indexOf('allowedTools,'),
+      );
+      expect(construct).toMatchSnapshot();
+    });
+
+    it('is idempotent', async () => {
+      await migration(tree);
+      const once = tree.read(CDK_FILE, 'utf-8')!;
+      await migration(tree);
+      expect(tree.read(CDK_FILE, 'utf-8')!).toBe(once);
+    });
+
+    it('leaves a harness that already sets tools untouched', async () => {
+      const pinned = CDK_BEFORE.replace(
+        '      vpc,',
+        '      allowedTools = [],\n      vpc,',
+      );
+      tree.write(CDK_FILE, pinned);
+
+      const { nextSteps } = await migration(tree);
+      expect(nextSteps).toEqual([]);
+      expect(tree.read(CDK_FILE, 'utf-8')!).toBe(pinned);
+    });
+
+    it('reports a diverged construct rather than editing it', async () => {
+      tree.write(CDK_FILE, 'export class MyHarness {}\n');
+
+      const { nextSteps } = await migration(tree);
+      expect(nextSteps).toHaveLength(1);
+      expect(nextSteps[0]).toContain(CDK_FILE);
+      expect(nextSteps[0]).toContain('has diverged');
+      expect(tree.read(CDK_FILE, 'utf-8')!).toBe('export class MyHarness {}\n');
+    });
+  });
+
+  describe('terraform', () => {
+    beforeEach(() => {
+      tree.write(TF_FILE, TF_BEFORE);
+    });
+
+    it('declares allowed_tools defaulting to none and assigns it', async () => {
+      const { nextSteps } = await migration(tree);
+      expect(nextSteps).toEqual([]);
+
+      const tf = tree.read(TF_FILE, 'utf-8')!;
+      expect(tf).toMatch(
+        /variable "allowed_tools" \{[\s\S]*?type {8}= list\(string\)\n {2}default {5}= \[\]/,
+      );
+      expect(tf).toContain('allowed_tools      = var.allowed_tools');
+      expect(tf).toMatchSnapshot();
+    });
+
+    it('is idempotent', async () => {
+      await migration(tree);
+      const once = tree.read(TF_FILE, 'utf-8')!;
+      await migration(tree);
+      expect(tree.read(TF_FILE, 'utf-8')!).toBe(once);
+    });
+
+    it('leaves a harness that already sets tools untouched', async () => {
+      const pinned = TF_BEFORE.replace(
+        '  execution_role_arn = aws_iam_role.execution_role.arn',
+        '  execution_role_arn = aws_iam_role.execution_role.arn\n  allowed_tools      = ["@builtin"]',
+      );
+      tree.write(TF_FILE, pinned);
+
+      const { nextSteps } = await migration(tree);
+      expect(nextSteps).toEqual([]);
+      expect(tree.read(TF_FILE, 'utf-8')!).toBe(pinned);
+    });
+
+    it('reports a diverged module rather than editing it', async () => {
+      tree.write(TF_FILE, 'locals {}\n');
+
+      const { nextSteps } = await migration(tree);
+      expect(nextSteps).toHaveLength(1);
+      expect(nextSteps[0]).toContain(TF_FILE);
+      expect(nextSteps[0]).toContain('has diverged');
+      expect(tree.read(TF_FILE, 'utf-8')!).toBe('locals {}\n');
+    });
+  });
+});

--- a/packages/nx-plugin/src/migrations/latest/agentcore-harness-no-tools-by-default/migration.ts
+++ b/packages/nx-plugin/src/migrations/latest/agentcore-harness-no-tools-by-default/migration.ts
@@ -1,0 +1,174 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import {
+  joinPathFragments,
+  type MigrationReturnObject,
+  type Tree,
+} from '@nx/devkit';
+import {
+  applyGritQL,
+  GRIT_INSERT_PLACEHOLDER,
+  insertViaGritQL,
+  matchGritQL,
+} from '../../../utils/ast.js';
+import { formatFilesInSubtree } from '../../../utils/format.js';
+import {
+  PACKAGES_DIR,
+  SHARED_CONSTRUCTS_DIR,
+  SHARED_TERRAFORM_DIR,
+} from '../../../utils/shared-constructs-constants.js';
+
+/**
+ * Pin each vended Harness to no tools by default.
+ *
+ * AgentCore treats an absent `allowedTools` as every tool, so a Harness that
+ * never set it deployed with `allowedTools: ["*"]` — shell execution and file
+ * read/write included. Both providers now send the field explicitly, defaulting
+ * to none.
+ *
+ * These files are generated with `KeepExisting`, so an upgraded workspace keeps
+ * the implicit every-tool default until this runs. Diverged files are left
+ * untouched and reported via `nextSteps`.
+ */
+
+const CDK_HARNESSES_DIR = `${PACKAGES_DIR}/${SHARED_CONSTRUCTS_DIR}/src/app/harnesses`;
+const TERRAFORM_HARNESSES_DIR = `${PACKAGES_DIR}/${SHARED_TERRAFORM_DIR}/src/app/harnesses`;
+
+const hcl = (pattern: string) => `language hcl\n${pattern}`;
+
+const ALLOWED_TOOLS_VARIABLE = [
+  'variable "allowed_tools" {',
+  '  description = "Tools the Harness may use. Defaults to none; set [\\"@builtin\\"] for every built-in tool, or name individual tools. Always sent explicitly, since the service treats an absent value as every tool."',
+  '  type        = list(string)',
+  '  default     = []',
+  '}',
+].join('\n');
+
+const divergedMessage = (filePath: string, remedy: string) =>
+  `${filePath}: has diverged from the generated shape - left untouched. AgentCore treats an absent allowedTools as every tool, so this Harness deploys with all built-in tools (including shell and file access). ${remedy}`;
+
+/**
+ * Default the construct's `allowedTools` to none and pass it to the resource
+ * after the props spread, so an undefined caller value cannot reinstate the
+ * service's every-tool default.
+ */
+const migrateCdkConstruct = async (
+  tree: Tree,
+  filePath: string,
+): Promise<boolean> => {
+  const destructured = await insertViaGritQL(
+    tree,
+    filePath,
+    `\`const { $fields } = props ?? {};\` => \`const {\n      ${GRIT_INSERT_PLACEHOLDER}\n      $fields\n    } = props ?? {};\``,
+    [
+      '// The service treats an absent allowedTools as every tool, so this',
+      '// defaults to none and is always passed explicitly.',
+      'allowedTools = [],',
+    ].join('\n      '),
+  );
+  if (!destructured) return false;
+
+  return await applyGritQL(
+    tree,
+    filePath,
+    '`new agentcore.CfnHarness($scope, $id, { $props })` where {' +
+      ' $props <: contains spread_element() as $spread,' +
+      ' $spread => `$spread,\n      allowedTools`' +
+      ' }',
+  );
+};
+
+/**
+ * Declare `allowed_tools` and assign it to the Harness resource, so the module
+ * always sends the field.
+ */
+const migrateTerraformModule = async (
+  tree: Tree,
+  filePath: string,
+): Promise<boolean> => {
+  const declared = await insertViaGritQL(
+    tree,
+    filePath,
+    hcl(
+      `\`variable "model_resource_arns" { $props }\` => \`${GRIT_INSERT_PLACEHOLDER}\n\nvariable "model_resource_arns" {\n  $props\n}\``,
+    ),
+    ALLOWED_TOOLS_VARIABLE,
+  );
+  if (!declared) return false;
+
+  // Appended after the existing arguments so their alignment is preserved;
+  // `terraform fmt` re-aligns the block.
+  return await applyGritQL(
+    tree,
+    filePath,
+    hcl(
+      '`execution_role_arn = aws_iam_role.execution_role.arn` => `execution_role_arn = aws_iam_role.execution_role.arn\n  allowed_tools      = var.allowed_tools`',
+    ),
+  );
+};
+
+export default async function migration(
+  tree: Tree,
+): Promise<MigrationReturnObject> {
+  const nextSteps: string[] = [];
+
+  for (const dirName of tree.exists(CDK_HARNESSES_DIR)
+    ? tree.children(CDK_HARNESSES_DIR)
+    : []) {
+    const filePath = joinPathFragments(
+      CDK_HARNESSES_DIR,
+      dirName,
+      `${dirName}.ts`,
+    );
+    if (!tree.exists(filePath)) {
+      continue; // Not a Harness construct directory.
+    }
+
+    // Already pinned, by this migration or by hand.
+    if (tree.read(filePath, 'utf-8')?.includes('allowedTools = [],')) {
+      continue;
+    }
+
+    if (!(await migrateCdkConstruct(tree, filePath))) {
+      nextSteps.push(
+        divergedMessage(
+          filePath,
+          'Default `allowedTools` to `[]` when destructuring props, and pass `allowedTools` to the CfnHarness after the `...harnessProps` spread.',
+        ),
+      );
+    }
+  }
+
+  for (const dirName of tree.exists(TERRAFORM_HARNESSES_DIR)
+    ? tree.children(TERRAFORM_HARNESSES_DIR)
+    : []) {
+    const filePath = joinPathFragments(
+      TERRAFORM_HARNESSES_DIR,
+      dirName,
+      `${dirName}.tf`,
+    );
+    if (!tree.exists(filePath)) {
+      continue; // Not a Harness module directory.
+    }
+
+    // Already assigned, by this migration or by hand.
+    if (await matchGritQL(tree, filePath, hcl('`allowed_tools = $_`'))) {
+      continue;
+    }
+
+    if (!(await migrateTerraformModule(tree, filePath))) {
+      nextSteps.push(
+        divergedMessage(
+          filePath,
+          'Declare an `allowed_tools` variable (list(string), default []) and assign `allowed_tools = var.allowed_tools` on the `aws_bedrockagentcore_harness` resource.',
+        ),
+      );
+    }
+  }
+
+  await formatFilesInSubtree(tree);
+
+  return { nextSteps };
+}

--- a/packages/nx-plugin/src/utils/agent-core-constructs/files/cdk/app/agentcore-harness/__nameKebabCase__/__nameKebabCase__.ts.template
+++ b/packages/nx-plugin/src/utils/agent-core-constructs/files/cdk/app/agentcore-harness/__nameKebabCase__/__nameKebabCase__.ts.template
@@ -35,7 +35,10 @@ export interface <%- nameClassName %>Props
   executionRole?: iam.IRole;
   /** Model resources the generated execution role may invoke. */
   modelResourceArns?: string[];
-  /** Tools the Harness may use. Deploys with none unless supplied here. */
+  /**
+   * Tools the Harness may use. Defaults to none; pass `['@builtin']` for every
+   * built-in tool, or name individual tools.
+   */
   allowedTools?: agentcore.CfnHarnessProps['allowedTools'];
   /**
    * Run the Harness in a VPC so it can reach private resources. Selects private
@@ -68,6 +71,9 @@ export class <%- nameClassName %>
         `arn:${stack.partition}:bedrock:*::foundation-model/*`,
         `arn:${stack.partition}:bedrock:${stack.region}:${stack.account}:*`,
       ],
+      // The service treats an absent allowedTools as every tool, so this
+      // defaults to none and is always passed explicitly.
+      allowedTools = [],
       vpc,
       vpcSubnets,
       securityGroups,
@@ -281,6 +287,7 @@ export class <%- nameClassName %>
       },
       systemPrompt: [{ text: systemPrompt }],
       ...harnessProps,
+      allowedTools,
       // Set after harnessProps so the deployed name always matches the
       // execution role's workload-identity resource pattern.
       harnessName,

--- a/packages/nx-plugin/src/utils/agent-core-constructs/files/terraform/app/agentcore-harness/__nameKebabCase__/__nameKebabCase__.tf.template
+++ b/packages/nx-plugin/src/utils/agent-core-constructs/files/terraform/app/agentcore-harness/__nameKebabCase__/__nameKebabCase__.tf.template
@@ -19,6 +19,12 @@ variable "model_id" {
   default     = "global.anthropic.claude-sonnet-4-6"
 }
 
+variable "allowed_tools" {
+  description = "Tools the Harness may use. Defaults to none; set [\"@builtin\"] for every built-in tool, or name individual tools. Always sent explicitly, since the service treats an absent value as every tool."
+  type        = list(string)
+  default     = []
+}
+
 variable "model_resource_arns" {
   description = "Bedrock model and inference-profile ARNs the execution role may invoke. Defaults to every foundation model plus this account's Bedrock resources in the deployment region; replace with narrower ARNs to restrict baseline model access."
   type        = set(string)
@@ -243,6 +249,7 @@ resource "aws_iam_role_policy" "execution_role" {
 resource "aws_bedrockagentcore_harness" "this" {
   harness_name       = local.harness_name
   execution_role_arn = aws_iam_role.execution_role.arn
+  allowed_tools      = var.allowed_tools
 
   model {
     bedrock_model_config {


### PR DESCRIPTION
### Reason for this change

The generated Harness deployed with **every** built-in tool enabled, not none.

Both the CDK construct and the Terraform module omitted `allowedTools` from the resource entirely, and AgentCore treats an **absent** `allowedTools` as `["*"]`. The construct's prop doc, the vended README and the guide all stated the Harness "deploys with none", so the vended default contradicted its own documentation — and a Harness shipped with shell execution and file read/write on by default.

Verified against the service in `us-east-1` before the fix. `GetHarness` reported `allowedTools: ["*"]` for both providers, and a runtime probe did not merely report tools, it executed one:

```
[TOOL_USE] {"toolUse":{"name":"shell",...}}
[TOOL_USE] {"toolResult":{"status":"success"}}
6 × 7 = 42
...tools available: 1. shell  2. file_operations
```

The distinction is *absent* vs *empty* — only an absent field triggers the service default, so the field has to be sent explicitly.

### Description of changes

**CDK construct** — `allowedTools` defaults to `[]` when destructuring props, and is assigned **after** the `...harnessProps` spread. The ordering matters: inside the spread an `undefined` value from a caller would overwrite the default and reinstate the service's every-tool behaviour.

**Terraform module** — adds an `allowed_tools` variable (`list(string)`, default `[]`) assigned unconditionally on `aws_bedrockagentcore_harness`. This also makes opt-in a module argument rather than an edit to the generated module body.

**Migration** — the harness infrastructure is vended with `KeepExisting`, so an upgraded workspace would keep the implicit every-tool default. `agentcore-harness-no-tools-by-default` pins both providers, skips harnesses that already set tools, and reports diverged files via `nextSteps` instead of editing them.

**Docs** — the guide and vended README no longer claim the Harness deploys without tools; the Terraform tools example now sets the module variable. The `@builtin` opt-in guidance is unchanged and still correct.

The generated execution role still grants browser and code-interpreter session permissions. Those are now unused at the default, but left in place so the documented `@builtin` opt-in works without also having to extend the role — worth a follow-up decision, not silently changed here.

### Description of how you validated changes

**Unit tests** — the two existing tests asserted the buggy shape (that `allowedTools` appears *nowhere* in the resource, and that the module declares no `allowed_tools`); both now assert the explicit default, including the spread-ordering constraint. Added 9 migration tests covering both providers, idempotency, already-pinned files and diverged files. Full suite green: **3773 tests, 207 files**. Build and lint pass.

**Migration against real pre-fix workspaces** — ran the compiled migration against the two workspaces generated by the *published* plugin (`1.0.0-rc.81`), i.e. the exact pre-fix shape. Both migrated with no `nextSteps`, and the output matches what the generator now vends byte-for-byte. The migrated CDK construct compiles and synthesizes.

**Deployed both providers to `us-east-1` and confirmed the fix on the live service:**

| | CDK | Terraform |
|---|---|---|
| Synth / plan | `AllowedTools: []` | `allowed_tools = []` |
| `GetHarness` after deploy | `allowedTools: []` | `allowedTools: []` |
| Runtime probe | *"The exact list of tools I have available here is: **none**"* | *"To be precise: I have **no tools** available here"* |

The agent could not run the requested `echo HELLO` in either case — before the fix the same probe executed it.

Opt-in still works and was checked separately: `{ allowedTools: ['@builtin'] }` synthesizes `AllowedTools: ["@builtin"]`, and `allowed_tools = ["@builtin"]` on the module plans the populated list.

All deployed resources were torn down (harnesses, stacks, IAM roles; the service reclaims its managed memory once the harness is gone).

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*