### PR TITLE
chore(ts#api,py#api): avoid empty IAM policies for isolated Terraform APIs

### DIFF
--- a/packages/nx-plugin/src/py/fast-api/__snapshots__/generator.terraform.spec.ts.snap
+++ b/packages/nx-plugin/src/py/fast-api/__snapshots__/generator.terraform.spec.ts.snap
@@ -601,7 +601,7 @@ resource "aws_iam_role_policy" "lambda_additional_policies" {
 
   policy = jsonencode({
     Version = "2012-10-17"
-    Statement = local.lambda_policy_statements
+    Statement = local.lambda_policy_document_statements
   })
 }
 
@@ -617,6 +617,15 @@ locals {
       Resource = ["\${var.appconfig_application_arn}/*"]
     }
   ] : [], var.additional_iam_policy_statements)
+
+  # IAM rejects an empty statement list, so fall back to a no-op deny
+  lambda_policy_document_statements = length(local.lambda_policy_statements) > 0 ? local.lambda_policy_statements : [
+    {
+      Effect   = "Deny"
+      Action   = ["appconfig:GetLatestConfiguration"]
+      Resource = ["arn:aws:appconfig:\${data.aws_region.current.region}:\${data.aws_caller_identity.current.account_id}:application/none"]
+    }
+  ]
 }
 
 # CloudWatch Log Group for Lambda
@@ -1417,7 +1426,7 @@ resource "aws_iam_role_policy" "lambda_additional_policies" {
 
   policy = jsonencode({
     Version = "2012-10-17"
-    Statement = local.lambda_policy_statements
+    Statement = local.lambda_policy_document_statements
   })
 }
 
@@ -1433,6 +1442,15 @@ locals {
       Resource = ["\${var.appconfig_application_arn}/*"]
     }
   ] : [], var.additional_iam_policy_statements)
+
+  # IAM rejects an empty statement list, so fall back to a no-op deny
+  lambda_policy_document_statements = length(local.lambda_policy_statements) > 0 ? local.lambda_policy_statements : [
+    {
+      Effect   = "Deny"
+      Action   = ["appconfig:GetLatestConfiguration"]
+      Resource = ["arn:aws:appconfig:\${data.aws_region.current.region}:\${data.aws_caller_identity.current.account_id}:application/none"]
+    }
+  ]
 }
 
 # CloudWatch Log Group for Lambda
@@ -2316,7 +2334,7 @@ resource "aws_iam_role_policy" "lambda_additional_policies" {
 
   policy = jsonencode({
     Version = "2012-10-17"
-    Statement = local.lambda_policy_statements
+    Statement = local.lambda_policy_document_statements
   })
 }
 
@@ -2332,6 +2350,15 @@ locals {
       Resource = ["\${var.appconfig_application_arn}/*"]
     }
   ] : [], var.additional_iam_policy_statements)
+
+  # IAM rejects an empty statement list, so fall back to a no-op deny
+  lambda_policy_document_statements = length(local.lambda_policy_statements) > 0 ? local.lambda_policy_statements : [
+    {
+      Effect   = "Deny"
+      Action   = ["appconfig:GetLatestConfiguration"]
+      Resource = ["arn:aws:appconfig:\${data.aws_region.current.region}:\${data.aws_caller_identity.current.account_id}:application/none"]
+    }
+  ]
 }
 
 # CloudWatch Log Group for Lambda
@@ -3387,7 +3414,7 @@ resource "aws_iam_role_policy" "lambda_additional_policies" {
 
   policy = jsonencode({
     Version = "2012-10-17"
-    Statement = local.lambda_policy_statements
+    Statement = local.lambda_policy_document_statements
   })
 }
 
@@ -3403,6 +3430,15 @@ locals {
       Resource = ["\${var.appconfig_application_arn}/*"]
     }
   ] : [], var.additional_iam_policy_statements)
+
+  # IAM rejects an empty statement list, so fall back to a no-op deny
+  lambda_policy_document_statements = length(local.lambda_policy_statements) > 0 ? local.lambda_policy_statements : [
+    {
+      Effect   = "Deny"
+      Action   = ["appconfig:GetLatestConfiguration"]
+      Resource = ["arn:aws:appconfig:\${data.aws_region.current.region}:\${data.aws_caller_identity.current.account_id}:application/none"]
+    }
+  ]
 }
 
 # CloudWatch Log Group for Lambda
@@ -4716,7 +4752,7 @@ resource "aws_iam_role_policy" "lambda_additional_policies" {
 
   policy = jsonencode({
     Version = "2012-10-17"
-    Statement = local.lambda_policy_statements
+    Statement = local.lambda_policy_document_statements
   })
 }
 
@@ -4732,6 +4768,15 @@ locals {
       Resource = ["\${var.appconfig_application_arn}/*"]
     }
   ] : [], var.additional_iam_policy_statements)
+
+  # IAM rejects an empty statement list, so fall back to a no-op deny
+  lambda_policy_document_statements = length(local.lambda_policy_statements) > 0 ? local.lambda_policy_statements : [
+    {
+      Effect   = "Deny"
+      Action   = ["appconfig:GetLatestConfiguration"]
+      Resource = ["arn:aws:appconfig:\${data.aws_region.current.region}:\${data.aws_caller_identity.current.account_id}:application/none"]
+    }
+  ]
 }
 
 # CloudWatch Log Group for Lambda
@@ -6044,7 +6089,7 @@ resource "aws_iam_role_policy" "lambda_additional_policies" {
 
   policy = jsonencode({
     Version = "2012-10-17"
-    Statement = local.lambda_policy_statements
+    Statement = local.lambda_policy_document_statements
   })
 }
 
@@ -6060,6 +6105,15 @@ locals {
       Resource = ["\${var.appconfig_application_arn}/*"]
     }
   ] : [], var.additional_iam_policy_statements)
+
+  # IAM rejects an empty statement list, so fall back to a no-op deny
+  lambda_policy_document_statements = length(local.lambda_policy_statements) > 0 ? local.lambda_policy_statements : [
+    {
+      Effect   = "Deny"
+      Action   = ["appconfig:GetLatestConfiguration"]
+      Resource = ["arn:aws:appconfig:\${data.aws_region.current.region}:\${data.aws_caller_identity.current.account_id}:application/none"]
+    }
+  ]
 }
 
 # CloudWatch Log Group for Lambda

--- a/packages/nx-plugin/src/smithy/ts/api/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/smithy/ts/api/__snapshots__/generator.spec.ts.snap
@@ -1245,7 +1245,7 @@ resource "aws_iam_role_policy" "lambda_additional_policies" {
 
   policy = jsonencode({
     Version = "2012-10-17"
-    Statement = local.lambda_policy_statements
+    Statement = local.lambda_policy_document_statements
   })
 }
 
@@ -1261,6 +1261,15 @@ locals {
       Resource = ["\${var.appconfig_application_arn}/*"]
     }
   ] : [], var.additional_iam_policy_statements)
+
+  # IAM rejects an empty statement list, so fall back to a no-op deny
+  lambda_policy_document_statements = length(local.lambda_policy_statements) > 0 ? local.lambda_policy_statements : [
+    {
+      Effect   = "Deny"
+      Action   = ["appconfig:GetLatestConfiguration"]
+      Resource = ["arn:aws:appconfig:\${data.aws_region.current.region}:\${data.aws_caller_identity.current.account_id}:application/none"]
+    }
+  ]
 }
 
 # CloudWatch Log Group for Lambda
@@ -3072,7 +3081,7 @@ resource "aws_iam_role_policy" "lambda_additional_policies" {
 
   policy = jsonencode({
     Version = "2012-10-17"
-    Statement = local.lambda_policy_statements
+    Statement = local.lambda_policy_document_statements
   })
 }
 
@@ -3088,6 +3097,15 @@ locals {
       Resource = ["\${var.appconfig_application_arn}/*"]
     }
   ] : [], var.additional_iam_policy_statements)
+
+  # IAM rejects an empty statement list, so fall back to a no-op deny
+  lambda_policy_document_statements = length(local.lambda_policy_statements) > 0 ? local.lambda_policy_statements : [
+    {
+      Effect   = "Deny"
+      Action   = ["appconfig:GetLatestConfiguration"]
+      Resource = ["arn:aws:appconfig:\${data.aws_region.current.region}:\${data.aws_caller_identity.current.account_id}:application/none"]
+    }
+  ]
 }
 
 # CloudWatch Log Group for Lambda
@@ -4366,7 +4384,7 @@ resource "aws_iam_role_policy" "lambda_additional_policies" {
 
   policy = jsonencode({
     Version = "2012-10-17"
-    Statement = local.lambda_policy_statements
+    Statement = local.lambda_policy_document_statements
   })
 }
 
@@ -4382,6 +4400,15 @@ locals {
       Resource = ["\${var.appconfig_application_arn}/*"]
     }
   ] : [], var.additional_iam_policy_statements)
+
+  # IAM rejects an empty statement list, so fall back to a no-op deny
+  lambda_policy_document_statements = length(local.lambda_policy_statements) > 0 ? local.lambda_policy_statements : [
+    {
+      Effect   = "Deny"
+      Action   = ["appconfig:GetLatestConfiguration"]
+      Resource = ["arn:aws:appconfig:\${data.aws_region.current.region}:\${data.aws_caller_identity.current.account_id}:application/none"]
+    }
+  ]
 }
 
 # CloudWatch Log Group for Lambda
@@ -5346,7 +5373,7 @@ resource "aws_iam_role_policy" "lambda_additional_policies" {
 
   policy = jsonencode({
     Version = "2012-10-17"
-    Statement = local.lambda_policy_statements
+    Statement = local.lambda_policy_document_statements
   })
 }
 
@@ -5362,6 +5389,15 @@ locals {
       Resource = ["\${var.appconfig_application_arn}/*"]
     }
   ] : [], var.additional_iam_policy_statements)
+
+  # IAM rejects an empty statement list, so fall back to a no-op deny
+  lambda_policy_document_statements = length(local.lambda_policy_statements) > 0 ? local.lambda_policy_statements : [
+    {
+      Effect   = "Deny"
+      Action   = ["appconfig:GetLatestConfiguration"]
+      Resource = ["arn:aws:appconfig:\${data.aws_region.current.region}:\${data.aws_caller_identity.current.account_id}:application/none"]
+    }
+  ]
 }
 
 # CloudWatch Log Group for Lambda

--- a/packages/nx-plugin/src/trpc/backend/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/trpc/backend/__snapshots__/generator.spec.ts.snap
@@ -3756,7 +3756,7 @@ resource "aws_iam_role_policy" "lambda_additional_policies" {
 
   policy = jsonencode({
     Version = "2012-10-17"
-    Statement = local.lambda_policy_statements
+    Statement = local.lambda_policy_document_statements
   })
 }
 
@@ -3772,6 +3772,15 @@ locals {
       Resource = ["\${var.appconfig_application_arn}/*"]
     }
   ] : [], var.additional_iam_policy_statements)
+
+  # IAM rejects an empty statement list, so fall back to a no-op deny
+  lambda_policy_document_statements = length(local.lambda_policy_statements) > 0 ? local.lambda_policy_statements : [
+    {
+      Effect   = "Deny"
+      Action   = ["appconfig:GetLatestConfiguration"]
+      Resource = ["arn:aws:appconfig:\${data.aws_region.current.region}:\${data.aws_caller_identity.current.account_id}:application/none"]
+    }
+  ]
 }
 
 # CloudWatch Log Group for Lambda
@@ -4552,7 +4561,7 @@ resource "aws_iam_role_policy" "lambda_additional_policies" {
 
   policy = jsonencode({
     Version = "2012-10-17"
-    Statement = local.lambda_policy_statements
+    Statement = local.lambda_policy_document_statements
   })
 }
 
@@ -4568,6 +4577,15 @@ locals {
       Resource = ["\${var.appconfig_application_arn}/*"]
     }
   ] : [], var.additional_iam_policy_statements)
+
+  # IAM rejects an empty statement list, so fall back to a no-op deny
+  lambda_policy_document_statements = length(local.lambda_policy_statements) > 0 ? local.lambda_policy_statements : [
+    {
+      Effect   = "Deny"
+      Action   = ["appconfig:GetLatestConfiguration"]
+      Resource = ["arn:aws:appconfig:\${data.aws_region.current.region}:\${data.aws_caller_identity.current.account_id}:application/none"]
+    }
+  ]
 }
 
 # CloudWatch Log Group for Lambda
@@ -5431,7 +5449,7 @@ resource "aws_iam_role_policy" "lambda_additional_policies" {
 
   policy = jsonencode({
     Version = "2012-10-17"
-    Statement = local.lambda_policy_statements
+    Statement = local.lambda_policy_document_statements
   })
 }
 
@@ -5447,6 +5465,15 @@ locals {
       Resource = ["\${var.appconfig_application_arn}/*"]
     }
   ] : [], var.additional_iam_policy_statements)
+
+  # IAM rejects an empty statement list, so fall back to a no-op deny
+  lambda_policy_document_statements = length(local.lambda_policy_statements) > 0 ? local.lambda_policy_statements : [
+    {
+      Effect   = "Deny"
+      Action   = ["appconfig:GetLatestConfiguration"]
+      Resource = ["arn:aws:appconfig:\${data.aws_region.current.region}:\${data.aws_caller_identity.current.account_id}:application/none"]
+    }
+  ]
 }
 
 # CloudWatch Log Group for Lambda
@@ -6482,7 +6509,7 @@ resource "aws_iam_role_policy" "lambda_additional_policies" {
 
   policy = jsonencode({
     Version = "2012-10-17"
-    Statement = local.lambda_policy_statements
+    Statement = local.lambda_policy_document_statements
   })
 }
 
@@ -6498,6 +6525,15 @@ locals {
       Resource = ["\${var.appconfig_application_arn}/*"]
     }
   ] : [], var.additional_iam_policy_statements)
+
+  # IAM rejects an empty statement list, so fall back to a no-op deny
+  lambda_policy_document_statements = length(local.lambda_policy_statements) > 0 ? local.lambda_policy_statements : [
+    {
+      Effect   = "Deny"
+      Action   = ["appconfig:GetLatestConfiguration"]
+      Resource = ["arn:aws:appconfig:\${data.aws_region.current.region}:\${data.aws_caller_identity.current.account_id}:application/none"]
+    }
+  ]
 }
 
 # CloudWatch Log Group for Lambda
@@ -7777,7 +7813,7 @@ resource "aws_iam_role_policy" "lambda_additional_policies" {
 
   policy = jsonencode({
     Version = "2012-10-17"
-    Statement = local.lambda_policy_statements
+    Statement = local.lambda_policy_document_statements
   })
 }
 
@@ -7793,6 +7829,15 @@ locals {
       Resource = ["\${var.appconfig_application_arn}/*"]
     }
   ] : [], var.additional_iam_policy_statements)
+
+  # IAM rejects an empty statement list, so fall back to a no-op deny
+  lambda_policy_document_statements = length(local.lambda_policy_statements) > 0 ? local.lambda_policy_statements : [
+    {
+      Effect   = "Deny"
+      Action   = ["appconfig:GetLatestConfiguration"]
+      Resource = ["arn:aws:appconfig:\${data.aws_region.current.region}:\${data.aws_caller_identity.current.account_id}:application/none"]
+    }
+  ]
 }
 
 # CloudWatch Log Group for Lambda
@@ -9071,7 +9116,7 @@ resource "aws_iam_role_policy" "lambda_additional_policies" {
 
   policy = jsonencode({
     Version = "2012-10-17"
-    Statement = local.lambda_policy_statements
+    Statement = local.lambda_policy_document_statements
   })
 }
 
@@ -9087,6 +9132,15 @@ locals {
       Resource = ["\${var.appconfig_application_arn}/*"]
     }
   ] : [], var.additional_iam_policy_statements)
+
+  # IAM rejects an empty statement list, so fall back to a no-op deny
+  lambda_policy_document_statements = length(local.lambda_policy_statements) > 0 ? local.lambda_policy_statements : [
+    {
+      Effect   = "Deny"
+      Action   = ["appconfig:GetLatestConfiguration"]
+      Resource = ["arn:aws:appconfig:\${data.aws_region.current.region}:\${data.aws_caller_identity.current.account_id}:application/none"]
+    }
+  ]
 }
 
 # CloudWatch Log Group for Lambda

--- a/packages/nx-plugin/src/utils/api-constructs/files/terraform/app/apis/http/__apiNameKebabCase__/__apiNameKebabCase__.tf.template
+++ b/packages/nx-plugin/src/utils/api-constructs/files/terraform/app/apis/http/__apiNameKebabCase__/__apiNameKebabCase__.tf.template
@@ -389,16 +389,21 @@ resource "aws_iam_role_policy" "lambda_additional_policies" {
 
   name = "${substr(local.function_name[each.key], 0, 55)}-policies"
   role = aws_iam_role.lambda_execution_role[each.key].id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = local.lambda_policy_document_statements
+  })
   <%_ } else { _%>
   count = length(local.lambda_policy_statements) > 0 ? 1 : 0
   name  = "<%- apiNameClassName %>Handler-additional-policies-${random_string.suffix.result}"
   role  = aws_iam_role.lambda_execution_role.id
-  <%_ } _%>
 
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = local.lambda_policy_statements
   })
+  <%_ } _%>
 }
 
 locals {
@@ -413,6 +418,17 @@ locals {
       Resource = ["${var.appconfig_application_arn}/*"]
     }
   ] : [], var.additional_iam_policy_statements)
+<%_ if (backend.integrationPattern === 'isolated') { _%>
+
+  # IAM rejects an empty statement list, so fall back to a no-op deny
+  lambda_policy_document_statements = length(local.lambda_policy_statements) > 0 ? local.lambda_policy_statements : [
+    {
+      Effect   = "Deny"
+      Action   = ["appconfig:GetLatestConfiguration"]
+      Resource = ["arn:aws:appconfig:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:application/none"]
+    }
+  ]
+<%_ } _%>
 }
 
 # CloudWatch Log Group for Lambda

--- a/packages/nx-plugin/src/utils/api-constructs/files/terraform/app/apis/rest/__apiNameKebabCase__/__apiNameKebabCase__.tf.template
+++ b/packages/nx-plugin/src/utils/api-constructs/files/terraform/app/apis/rest/__apiNameKebabCase__/__apiNameKebabCase__.tf.template
@@ -443,16 +443,21 @@ resource "aws_iam_role_policy" "lambda_additional_policies" {
 
   name = "${substr(local.function_name[each.key], 0, 55)}-policies"
   role = aws_iam_role.lambda_execution_role[each.key].id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = local.lambda_policy_document_statements
+  })
   <%_ } else { _%>
   count = length(local.lambda_policy_statements) > 0 ? 1 : 0
   name  = "<%- apiNameClassName %>Handler-additional-policies-${random_string.suffix.result}"
   role  = aws_iam_role.lambda_execution_role.id
-  <%_ } _%>
 
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = local.lambda_policy_statements
   })
+  <%_ } _%>
 }
 
 locals {
@@ -467,6 +472,17 @@ locals {
       Resource = ["${var.appconfig_application_arn}/*"]
     }
   ] : [], var.additional_iam_policy_statements)
+<%_ if (backend.integrationPattern === 'isolated') { _%>
+
+  # IAM rejects an empty statement list, so fall back to a no-op deny
+  lambda_policy_document_statements = length(local.lambda_policy_statements) > 0 ? local.lambda_policy_statements : [
+    {
+      Effect   = "Deny"
+      Action   = ["appconfig:GetLatestConfiguration"]
+      Resource = ["arn:aws:appconfig:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:application/none"]
+    }
+  ]
+<%_ } _%>
 }
 
 # CloudWatch Log Group for Lambda


### PR DESCRIPTION
### Reason for this change

The `terraform-deploy` smoke test has been failing on `main` since #1124 introduced the `isolated` integration pattern for Terraform APIs. Every isolated API module failed to apply:

```
Error: putting IAM Role (MyApi-echo-role-...) Policy (MyApi-echo-...-policies):
operation error IAM: PutRolePolicy, https response error StatusCode: 400,
MalformedPolicyDocument: Syntax errors in policy.

  with module.my_api.aws_iam_role_policy.lambda_additional_policies["echo"],
```

The `isolated` pattern declares one `aws_iam_role_policy` per operation with `for_each = local.operations`. When neither `appconfig_application_arn` nor `additional_iam_policy_statements` is wired, `local.lambda_policy_statements` is empty, so each policy rendered `Statement = []`, which IAM rejects.

This hit 9 API modules in the smoke test (`my_api`, `my_api_http`, `my_api_custom`, `my_api_custom_http`, `my_smithy_api`, `py_api`, `py_api_http`, `py_api_custom`, `py_api_custom_http`). The `shared` pattern was unaffected because it uses `count = length(local.lambda_policy_statements) > 0 ? 1 : 0`, which correctly skips the resource.

### Description of changes

Mirroring the `shared` guard onto `for_each` does **not** work. The AppConfig ARN is only known after apply, so gating the instance keys on the statement count makes them unknown at plan time and Terraform fails with:

```
Error: Invalid for_each argument
  │ local.lambda_policy_statements is a list of object, known only after apply
  The "for_each" map includes keys derived from resource attributes that
  cannot be determined until apply
```

Terraform permits unknown values in resource *attributes* but not in `for_each` *keys*. So the resource is still declared once per operation (keys stay static and plan-known), and the policy **document** falls back to a no-op deny when there are no statements:

```hcl
# IAM rejects an empty statement list, so fall back to a no-op deny
lambda_policy_document_statements = length(local.lambda_policy_statements) > 0 ? local.lambda_policy_statements : [
  {
    Effect   = "Deny"
    Action   = ["appconfig:GetLatestConfiguration"]
    Resource = ["arn:aws:appconfig:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:application/none"]
  }
]
```

This is applied to both the `rest` and `http` API templates. The `shared` branch is untouched and the new local is only emitted for `isolated`, so shared-pattern output is byte-identical.

### Description of how you validated changes

Unit tests: `pnpm nx run @aws/nx-plugin:test -u` — 3844 passed, 16 snapshots updated. Build and `lint --fix` are clean.

Validated against **real AWS** with a locally compiled + linked plugin, deploying a Terraform workspace with Terraform 1.15.7 (the version CI pins):

1. **Reproduced the CI failure first.** With the pre-fix template, `nx apply infra` failed with the identical `MalformedPolicyDocument` error on `lambda_additional_policies["echo"]`. Separately confirmed the root cause in isolation — `PutRolePolicy` with `{"Version":"2012-10-17","Statement":[]}` returns exactly `MalformedPolicyDocument: Syntax errors in policy`.
2. **Isolated, no appconfig** (the CI case): applies cleanly; role carries the fallback deny; `AWSLambdaBasicExecutionRole` + `AWSXRayDaemonWriteAccess` still attached; SigV4-signed `GET /echo` → `200 {"result":{"data":{"message":"test"}}}`.
3. **Isolated, appconfig wired** (regression check for the plan-time failure): applies cleanly; the inline policy contains the real `appconfig:StartConfigurationSession`/`GetLatestConfiguration` grant scoped to the application ARN — the deny fallback is correctly absent; `GET /echo` → `200`.
4. **All three generator paths deployed together** (76 resources): tRPC isolated, tRPC `shared`, and FastAPI isolated (exercising the `rest` template). All three returned `200`. Verified the shared-pattern role has **no** inline policy (still skipped via `count`) while the FastAPI isolated role carries the fallback.

All provisioned AWS resources were torn down afterwards.

### Issue # (if applicable)

N/A — fixing a failing build on `main`.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*