### PR TITLE
feat(ts#infra): add destroy-sandbox target

### DIFF
--- a/docs/src/content/docs/en/get_started/tutorials/dungeon-game/wrap-up.mdx
+++ b/docs/src/content/docs/en/get_started/tutorials/dungeon-game/wrap-up.mdx
@@ -34,7 +34,7 @@ We recommend you try your hand at extending the codebase with the following capa
 
 1. To destroy the AWS resources that were created, run the following command:
 
-<NxCommands commands={['destroy infra "dungeon-adventure-infra-sandbox/*"']} />
+<NxCommands commands={['destroy-sandbox infra']} />
 
     This will prompt you for a list of stacks to delete which should comprise of the `dungeon-adventure-infra-sandbox/Application/GameUI/waf` and `dungeon-adventure-infra-sandbox/Application`.
 

--- a/docs/src/content/docs/en/guides/typescript-infrastructure.mdx
+++ b/docs/src/content/docs/en/guides/typescript-infrastructure.mdx
@@ -435,6 +435,10 @@ The `destroy-sandbox` target tears down the sandbox stage that `main.ts` declare
 
 <NxCommands commands={['destroy-sandbox <my-infra>']} />
 
+Destroying is irreversible, so CDK asks you to confirm the stacks it is about to delete. Pass `--force` to skip that confirmation, which is what you want when there is no terminal attached (in a script, say):
+
+<NxCommands commands={['destroy-sandbox <my-infra> --force']} />
+
 ### Tearing Down a Specific Stage
 
 The `destroy` target tears down whichever stage or stacks you name:

--- a/docs/src/content/docs/en/guides/typescript-infrastructure.mdx
+++ b/docs/src/content/docs/en/guides/typescript-infrastructure.mdx
@@ -102,7 +102,7 @@ new ApplicationStage(app, 'my-app-sandbox', {
 
 The `env` property tells CDK which AWS account and region to deploy to. `CDK_DEFAULT_ACCOUNT` and `CDK_DEFAULT_REGION` are resolved automatically by the CDK CLI from your active AWS credentials. See the [CDK environments documentation](https://docs.aws.amazon.com/cdk/v2/guide/environments.html) for more details.
 
-The sandbox stage is the one the <Link path="guides/typescript-infrastructure#deploying-your-sandbox-stage">`deploy-sandbox` target</Link> deploys.
+The sandbox stage is the one the <Link path="guides/typescript-infrastructure#deploying-your-sandbox-stage">`deploy-sandbox`</Link> and <Link path="guides/typescript-infrastructure#tearing-down-your-sandbox-stage">`destroy-sandbox`</Link> targets act on.
 
 If you generated with `stageConfig`, the `main.ts` reads account and region from a centralized config file instead, falling back to environment variables when no config is set:
 
@@ -421,9 +421,29 @@ This target differs slightly from the regular `deploy` target in that it deploys
 
 ## Tearing Down AWS Infrastructure
 
-Use the `destroy` target to tear down your resources:
+Your project has three destroy targets, mirroring the deploy ones:
+
+| Target            | Use it for                                                                |
+| ----------------- | ------------------------------------------------------------------------- |
+| `destroy-sandbox` | Tearing down your own sandbox stage. No stage argument needed.             |
+| `destroy`         | Tearing down any stage, by naming the stage or stacks you want.            |
+| `destroy-ci`      | Tearing down from a CI/CD pipeline, using a pre-synthesized cloud assembly. |
+
+### Tearing Down your Sandbox Stage
+
+The `destroy-sandbox` target tears down the sandbox stage that `main.ts` declares, so you don't need to remember its stage name:
+
+<NxCommands commands={['destroy-sandbox <my-infra>']} />
+
+### Tearing Down a Specific Stage
+
+The `destroy` target tears down whichever stage or stacks you name:
 
 <NxCommands commands={['destroy <my-infra> <my-infra>-sandbox/*']} />
+
+To tear down an individual stack, give the full stack name:
+
+<NxCommands commands={['destroy <my-infra> <my-infra>-sandbox/Application']} />
 
 ## More Information
 

--- a/docs/src/content/docs/es/get_started/tutorials/dungeon-game/wrap-up.mdx
+++ b/docs/src/content/docs/es/get_started/tutorials/dungeon-game/wrap-up.mdx
@@ -34,7 +34,7 @@ Te recomendamos que intentes extender la base de código con las siguientes capa
 
 1. Para destruir los recursos de AWS que fueron creados, ejecuta el siguiente comando:
 
-<NxCommands commands={['destroy infra "dungeon-adventure-infra-sandbox/*"']} />
+<NxCommands commands={['destroy-sandbox infra']} />
 
     Esto te solicitará una lista de pilas para eliminar, que debería comprender `dungeon-adventure-infra-sandbox/Application/GameUI/waf` y `dungeon-adventure-infra-sandbox/Application`.
 

--- a/docs/src/content/docs/es/guides/typescript-infrastructure.mdx
+++ b/docs/src/content/docs/es/guides/typescript-infrastructure.mdx
@@ -102,7 +102,7 @@ new ApplicationStage(app, 'my-app-sandbox', {
 
 La propiedad `env` le indica a CDK a qué cuenta y región de AWS desplegar. `CDK_DEFAULT_ACCOUNT` y `CDK_DEFAULT_REGION` son resueltos automáticamente por el CLI de CDK desde tus credenciales activas de AWS. Consulta la [documentación de entornos de CDK](https://docs.aws.amazon.com/cdk/v2/guide/environments.html) para obtener más detalles.
 
-El stage sandbox es el que despliega el <Link path="guides/typescript-infrastructure#desplegando-tu-stage-sandbox">target `deploy-sandbox`</Link>.
+El stage sandbox es el que los targets <Link path="guides/typescript-infrastructure#desplegando-tu-stage-sandbox">`deploy-sandbox`</Link> y <Link path="guides/typescript-infrastructure#desmantelando-tu-stage-sandbox">`destroy-sandbox`</Link> actúan sobre.
 
 Si generaste con `stageConfig`, el `main.ts` lee la cuenta y región desde un archivo de configuración centralizado, recurriendo a variables de entorno cuando no se establece ninguna configuración:
 
@@ -421,9 +421,29 @@ Este target difiere ligeramente del target `deploy` regular en que despliega un 
 
 ## Desmantelar Infraestructura de AWS
 
-Usa el target `destroy` para desmantelar tus recursos:
+Tu proyecto tiene tres targets de desmantelamiento, reflejando los de despliegue:
+
+| Target            | Úsalo para                                                                |
+| ----------------- | ------------------------------------------------------------------------- |
+| `destroy-sandbox` | Desmantelar tu propio stage sandbox. No se necesita argumento de stage.   |
+| `destroy`         | Desmantelar cualquier stage, nombrando el stage o stacks que deseas.      |
+| `destroy-ci`      | Desmantelar desde un pipeline de CI/CD, usando un ensamblaje en la nube pre-sintetizado. |
+
+### Desmantelando tu Stage Sandbox
+
+El target `destroy-sandbox` desmantela el stage sandbox que declara `main.ts`, por lo que no necesitas recordar su nombre de stage:
+
+<NxCommands commands={['destroy-sandbox <my-infra>']} />
+
+### Desmantelar un Stage Específico
+
+El target `destroy` desmantela el stage o stacks que nombres:
 
 <NxCommands commands={['destroy <my-infra> <my-infra>-sandbox/*']} />
+
+Para desmantelar un stack individual, proporciona el nombre completo del stack:
+
+<NxCommands commands={['destroy <my-infra> <my-infra>-sandbox/Application']} />
 
 ## Más Información
 

--- a/docs/src/content/docs/es/guides/typescript-infrastructure.mdx
+++ b/docs/src/content/docs/es/guides/typescript-infrastructure.mdx
@@ -435,6 +435,10 @@ El target `destroy-sandbox` desmantela el stage sandbox que declara `main.ts`, p
 
 <NxCommands commands={['destroy-sandbox <my-infra>']} />
 
+Desmantelar es irreversible, por lo que CDK te pide que confirmes los stacks que está a punto de eliminar. Pasa `--force` para omitir esa confirmación, que es lo que deseas cuando no hay una terminal adjunta (en un script, por ejemplo):
+
+<NxCommands commands={['destroy-sandbox <my-infra> --force']} />
+
 ### Desmantelar un Stage Específico
 
 El target `destroy` desmantela el stage o stacks que nombres:

--- a/docs/src/content/docs/fr/get_started/tutorials/dungeon-game/wrap-up.mdx
+++ b/docs/src/content/docs/fr/get_started/tutorials/dungeon-game/wrap-up.mdx
@@ -34,7 +34,7 @@ Nous vous recommandons d'essayer d'étendre la base de code avec les capacités 
 
 1. Pour détruire les ressources AWS qui ont été créées, exécutez la commande suivante :
 
-<NxCommands commands={['destroy infra "dungeon-adventure-infra-sandbox/*"']} />
+<NxCommands commands={['destroy-sandbox infra']} />
 
     Cela vous demandera une liste de piles à supprimer qui devrait comprendre `dungeon-adventure-infra-sandbox/Application/GameUI/waf` et `dungeon-adventure-infra-sandbox/Application`.
 

--- a/docs/src/content/docs/fr/guides/typescript-infrastructure.mdx
+++ b/docs/src/content/docs/fr/guides/typescript-infrastructure.mdx
@@ -435,6 +435,10 @@ La cible `destroy-sandbox` détruit le stage sandbox que `main.ts` déclare, vou
 
 <NxCommands commands={['destroy-sandbox <my-infra>']} />
 
+La destruction est irréversible, donc CDK vous demande de confirmer les stacks qu'il est sur le point de supprimer. Passez `--force` pour ignorer cette confirmation, ce que vous voulez lorsqu'il n'y a pas de terminal attaché (dans un script, par exemple) :
+
+<NxCommands commands={['destroy-sandbox <my-infra> --force']} />
+
 ### Détruire un stage spécifique
 
 La cible `destroy` détruit le stage ou les stacks que vous nommez :

--- a/docs/src/content/docs/fr/guides/typescript-infrastructure.mdx
+++ b/docs/src/content/docs/fr/guides/typescript-infrastructure.mdx
@@ -102,7 +102,7 @@ new ApplicationStage(app, 'my-app-sandbox', {
 
 La propriété `env` indique à CDK dans quel compte AWS et quelle région déployer. `CDK_DEFAULT_ACCOUNT` et `CDK_DEFAULT_REGION` sont résolus automatiquement par la CLI CDK à partir de vos identifiants AWS actifs. Consultez la [documentation sur les environnements CDK](https://docs.aws.amazon.com/cdk/v2/guide/environments.html) pour plus de détails.
 
-Le stage sandbox est celui que la <Link path="guides/typescript-infrastructure#deploying-your-sandbox-stage">cible `deploy-sandbox`</Link> déploie.
+Le stage sandbox est celui sur lequel agissent les cibles <Link path="fr/guides/typescript-infrastructure#déployer-votre-stage-sandbox">`deploy-sandbox`</Link> et <Link path="fr/guides/typescript-infrastructure#détruire-votre-stage-sandbox">`destroy-sandbox`</Link>.
 
 Si vous avez généré avec `stageConfig`, le fichier `main.ts` lit le compte et la région à partir d'un fichier de configuration centralisé, en se repliant sur les variables d'environnement lorsqu'aucune configuration n'est définie :
 
@@ -421,9 +421,29 @@ Cette cible diffère légèrement de la cible `deploy` normale en ce qu'elle dé
 
 ## Détruire l'infrastructure AWS
 
-Utilisez la cible `destroy` pour détruire vos ressources :
+Votre projet dispose de trois cibles de destruction, reflétant celles de déploiement :
+
+| Cible            | Utilisez-la pour                                                                |
+| ----------------- | ------------------------------------------------------------------------- |
+| `destroy-sandbox` | Détruire votre propre stage sandbox. Aucun argument de stage nécessaire.             |
+| `destroy`         | Détruire n'importe quel stage, en nommant le stage ou les stacks que vous voulez.            |
+| `destroy-ci`      | Détruire depuis un pipeline CI/CD, en utilisant un assemblage cloud pré-synthétisé. |
+
+### Détruire votre stage sandbox
+
+La cible `destroy-sandbox` détruit le stage sandbox que `main.ts` déclare, vous n'avez donc pas besoin de vous souvenir de son nom de stage :
+
+<NxCommands commands={['destroy-sandbox <my-infra>']} />
+
+### Détruire un stage spécifique
+
+La cible `destroy` détruit le stage ou les stacks que vous nommez :
 
 <NxCommands commands={['destroy <my-infra> <my-infra>-sandbox/*']} />
+
+Pour détruire une stack individuelle, donnez le nom complet de la stack :
+
+<NxCommands commands={['destroy <my-infra> <my-infra>-sandbox/Application']} />
 
 ## Plus d'informations
 

--- a/docs/src/content/docs/it/get_started/tutorials/dungeon-game/wrap-up.mdx
+++ b/docs/src/content/docs/it/get_started/tutorials/dungeon-game/wrap-up.mdx
@@ -34,7 +34,7 @@ Ti consigliamo di provare ad estendere il codebase con le seguenti funzionalità
 
 1. Per distruggere le risorse AWS che sono state create, esegui il seguente comando:
 
-<NxCommands commands={['destroy infra "dungeon-adventure-infra-sandbox/*"']} />
+<NxCommands commands={['destroy-sandbox infra']} />
 
     Questo ti chiederà una lista di stack da eliminare che dovrebbe comprendere `dungeon-adventure-infra-sandbox/Application/GameUI/waf` e `dungeon-adventure-infra-sandbox/Application`.
 

--- a/docs/src/content/docs/it/guides/typescript-infrastructure.mdx
+++ b/docs/src/content/docs/it/guides/typescript-infrastructure.mdx
@@ -102,7 +102,7 @@ new ApplicationStage(app, 'my-app-sandbox', {
 
 La proprietà `env` indica a CDK in quale account AWS e regione distribuire. `CDK_DEFAULT_ACCOUNT` e `CDK_DEFAULT_REGION` vengono risolti automaticamente dalla CLI CDK dalle tue credenziali AWS attive. Consulta la [documentazione sugli ambienti CDK](https://docs.aws.amazon.com/cdk/v2/guide/environments.html) per maggiori dettagli.
 
-Lo stage sandbox è quello che il <Link path="guides/typescript-infrastructure#distribuire-il-tuo-stage-sandbox">target `deploy-sandbox`</Link> distribuisce.
+Lo stage sandbox è quello su cui agiscono i target <Link path="guides/typescript-infrastructure#distribuire-il-tuo-stage-sandbox">`deploy-sandbox`</Link> e <Link path="guides/typescript-infrastructure#smantellare-il-tuo-stage-sandbox">`destroy-sandbox`</Link>.
 
 Se hai generato con `stageConfig`, il file `main.ts` legge l'account e la regione da un file di configurazione centralizzato, ricorrendo alle variabili d'ambiente quando non è impostata alcuna configurazione:
 
@@ -421,9 +421,29 @@ Questo target differisce leggermente dal target `deploy` normale in quanto distr
 
 ## Smantellare l'infrastruttura AWS
 
-Usa il target `destroy` per smantellare le tue risorse:
+Il tuo progetto ha tre target di distruzione, che rispecchiano quelli di distribuzione:
+
+| Target            | Usalo per                                                                |
+| ----------------- | ------------------------------------------------------------------------- |
+| `destroy-sandbox` | Smantellare il tuo stage sandbox personale. Non è necessario un argomento stage. |
+| `destroy`         | Smantellare qualsiasi stage, nominando lo stage o gli stack che desideri. |
+| `destroy-ci`      | Smantellare da una pipeline CI/CD, utilizzando un cloud assembly pre-sintetizzato. |
+
+### Smantellare il tuo stage sandbox
+
+Il target `destroy-sandbox` smantella lo stage sandbox che `main.ts` dichiara, quindi non devi ricordare il suo nome di stage:
+
+<NxCommands commands={['destroy-sandbox <my-infra>']} />
+
+### Smantellare uno stage specifico
+
+Il target `destroy` smantella qualsiasi stage o stack tu nomini:
 
 <NxCommands commands={['destroy <my-infra> <my-infra>-sandbox/*']} />
+
+Per smantellare un singolo stack, fornisci il nome completo dello stack:
+
+<NxCommands commands={['destroy <my-infra> <my-infra>-sandbox/Application']} />
 
 ## Ulteriori informazioni
 

--- a/docs/src/content/docs/it/guides/typescript-infrastructure.mdx
+++ b/docs/src/content/docs/it/guides/typescript-infrastructure.mdx
@@ -435,6 +435,10 @@ Il target `destroy-sandbox` smantella lo stage sandbox che `main.ts` dichiara, q
 
 <NxCommands commands={['destroy-sandbox <my-infra>']} />
 
+La distruzione è irreversibile, quindi CDK ti chiede di confermare gli stack che sta per eliminare. Passa `--force` per saltare quella conferma, che è ciò che desideri quando non c'è un terminale collegato (in uno script, ad esempio):
+
+<NxCommands commands={['destroy-sandbox <my-infra> --force']} />
+
 ### Smantellare uno stage specifico
 
 Il target `destroy` smantella qualsiasi stage o stack tu nomini:

--- a/docs/src/content/docs/jp/get_started/tutorials/dungeon-game/wrap-up.mdx
+++ b/docs/src/content/docs/jp/get_started/tutorials/dungeon-game/wrap-up.mdx
@@ -34,7 +34,7 @@ import gameConversationPng from '@assets/game-conversation.png'
 
 1. 作成された AWS リソースを破棄するには、次のコマンドを実行します：
 
-<NxCommands commands={['destroy infra "dungeon-adventure-infra-sandbox/*"']} />
+<NxCommands commands={['destroy-sandbox infra']} />
 
     これにより、削除するスタックのリストが表示されます。これには `dungeon-adventure-infra-sandbox/Application/GameUI/waf` と `dungeon-adventure-infra-sandbox/Application` が含まれているはずです。
 

--- a/docs/src/content/docs/jp/guides/typescript-infrastructure.mdx
+++ b/docs/src/content/docs/jp/guides/typescript-infrastructure.mdx
@@ -102,7 +102,7 @@ new ApplicationStage(app, 'my-app-sandbox', {
 
 `env`プロパティは、CDKにどのAWSアカウントとリージョンにデプロイするかを指示します。`CDK_DEFAULT_ACCOUNT`と`CDK_DEFAULT_REGION`は、アクティブなAWS認証情報からCDK CLIによって自動的に解決されます。詳細については、[CDK環境のドキュメント](https://docs.aws.amazon.com/cdk/v2/guide/environments.html)を参照してください。
 
-サンドボックスステージは、<Link path="guides/typescript-infrastructure#deploying-your-sandbox-stage">`deploy-sandbox`ターゲット</Link>がデプロイするステージです。
+サンドボックスステージは、<Link path="guides/typescript-infrastructure#deploying-your-sandbox-stage">`deploy-sandbox`</Link>と<Link path="guides/typescript-infrastructure#tearing-down-your-sandbox-stage">`destroy-sandbox`</Link>ターゲットが作用するステージです。
 
 `stageConfig`を使用して生成した場合、`main.ts`は環境変数にフォールバックする代わりに、集中管理された設定ファイルからアカウントとリージョンを読み取ります：
 
@@ -421,9 +421,29 @@ CI/CDパイプラインの一部としてAWSにデプロイする場合は、`de
 
 ## AWSインフラストラクチャの削除
 
-リソースを削除するには、`destroy`ターゲットを使用します：
+プロジェクトには3つの削除ターゲットがあり、デプロイターゲットと対応しています：
+
+| ターゲット            | 使用目的                                                                |
+| ----------------- | ------------------------------------------------------------------------- |
+| `destroy-sandbox` | 独自のサンドボックスステージを削除する。ステージ引数は不要。             |
+| `destroy`         | 任意のステージを削除する。削除したいステージまたはスタックを指定する。            |
+| `destroy-ci`      | CI/CDパイプラインから削除する。事前に合成されたクラウドアセンブリを使用する。 |
+
+### サンドボックスステージの削除
+
+`destroy-sandbox`ターゲットは、`main.ts`が宣言するサンドボックスステージを削除するため、ステージ名を覚えておく必要はありません：
+
+<NxCommands commands={['destroy-sandbox <my-infra>']} />
+
+### 特定のステージの削除
+
+`destroy`ターゲットは、指定したステージまたはスタックを削除します：
 
 <NxCommands commands={['destroy <my-infra> <my-infra>-sandbox/*']} />
+
+個別のスタックを削除するには、完全なスタック名を指定します：
+
+<NxCommands commands={['destroy <my-infra> <my-infra>-sandbox/Application']} />
 
 ## 詳細情報
 

--- a/docs/src/content/docs/jp/guides/typescript-infrastructure.mdx
+++ b/docs/src/content/docs/jp/guides/typescript-infrastructure.mdx
@@ -435,6 +435,10 @@ CI/CDパイプラインの一部としてAWSにデプロイする場合は、`de
 
 <NxCommands commands={['destroy-sandbox <my-infra>']} />
 
+削除は元に戻せないため、CDKは削除しようとしているスタックの確認を求めます。`--force`を渡すことでその確認をスキップできます。これは、ターミナルが接続されていない場合（例えばスクリプト内）に必要です：
+
+<NxCommands commands={['destroy-sandbox <my-infra> --force']} />
+
 ### 特定のステージの削除
 
 `destroy`ターゲットは、指定したステージまたはスタックを削除します：

--- a/docs/src/content/docs/ko/get_started/tutorials/dungeon-game/wrap-up.mdx
+++ b/docs/src/content/docs/ko/get_started/tutorials/dungeon-game/wrap-up.mdx
@@ -34,7 +34,7 @@ import gameConversationPng from '@assets/game-conversation.png'
 
 1. 생성된 AWS 리소스를 삭제하려면 다음 명령을 실행하세요:
 
-<NxCommands commands={['destroy infra "dungeon-adventure-infra-sandbox/*"']} />
+<NxCommands commands={['destroy-sandbox infra']} />
 
     이 명령은 삭제할 스택 목록을 표시하며, `dungeon-adventure-infra-sandbox/Application/GameUI/waf`와 `dungeon-adventure-infra-sandbox/Application`으로 구성되어야 합니다.
 

--- a/docs/src/content/docs/ko/guides/typescript-infrastructure.mdx
+++ b/docs/src/content/docs/ko/guides/typescript-infrastructure.mdx
@@ -435,6 +435,10 @@ CI/CD 파이프라인의 일부로 AWS에 배포하는 경우 `deploy-ci` 타겟
 
 <NxCommands commands={['destroy-sandbox <my-infra>']} />
 
+해체는 되돌릴 수 없으므로, CDK는 삭제하려는 스택을 확인하도록 요청합니다. `--force`를 전달하여 확인을 건너뛸 수 있으며, 이는 터미널이 연결되지 않은 경우(예: 스크립트에서) 원하는 동작입니다:
+
+<NxCommands commands={['destroy-sandbox <my-infra> --force']} />
+
 ### 특정 스테이지 해체
 
 `destroy` 타겟은 지정한 스테이지 또는 스택을 해체합니다:

--- a/docs/src/content/docs/ko/guides/typescript-infrastructure.mdx
+++ b/docs/src/content/docs/ko/guides/typescript-infrastructure.mdx
@@ -102,7 +102,7 @@ new ApplicationStage(app, 'my-app-sandbox', {
 
 `env` 속성은 CDK에게 어떤 AWS 계정과 리전에 배포할지 알려줍니다. `CDK_DEFAULT_ACCOUNT`와 `CDK_DEFAULT_REGION`은 활성 AWS 자격 증명에서 CDK CLI에 의해 자동으로 해석됩니다. 자세한 내용은 [CDK 환경 문서](https://docs.aws.amazon.com/cdk/v2/guide/environments.html)를 참조하세요.
 
-샌드박스 스테이지는 <Link path="guides/typescript-infrastructure#deploying-your-sandbox-stage">`deploy-sandbox` 타겟</Link>이 배포하는 스테이지입니다.
+샌드박스 스테이지는 <Link path="guides/typescript-infrastructure#deploying-your-sandbox-stage">`deploy-sandbox`</Link> 및 <Link path="guides/typescript-infrastructure#tearing-down-your-sandbox-stage">`destroy-sandbox`</Link> 타겟이 작동하는 스테이지입니다.
 
 `stageConfig`로 생성한 경우, `main.ts`는 중앙 집중식 구성 파일에서 계정과 리전을 읽으며, 구성이 설정되지 않은 경우 환경 변수로 폴백합니다:
 
@@ -421,9 +421,29 @@ CI/CD 파이프라인의 일부로 AWS에 배포하는 경우 `deploy-ci` 타겟
 
 ## AWS 인프라 해체
 
-리소스를 해체하려면 `destroy` 타겟을 사용하세요:
+프로젝트에는 배포 타겟을 반영하는 세 가지 해체 타겟이 있습니다:
+
+| 타겟              | 사용 용도                                                                        |
+| ----------------- | -------------------------------------------------------------------------------- |
+| `destroy-sandbox` | 자체 샌드박스 스테이지 해체. 스테이지 인수가 필요하지 않습니다.                  |
+| `destroy`         | 원하는 스테이지 또는 스택을 지정하여 모든 스테이지 해체.                         |
+| `destroy-ci`      | 사전 합성된 클라우드 어셈블리를 사용하여 CI/CD 파이프라인에서 해체.              |
+
+### 샌드박스 스테이지 해체
+
+`destroy-sandbox` 타겟은 `main.ts`가 선언하는 샌드박스 스테이지를 해체하므로, 스테이지 이름을 기억할 필요가 없습니다:
+
+<NxCommands commands={['destroy-sandbox <my-infra>']} />
+
+### 특정 스테이지 해체
+
+`destroy` 타겟은 지정한 스테이지 또는 스택을 해체합니다:
 
 <NxCommands commands={['destroy <my-infra> <my-infra>-sandbox/*']} />
+
+개별 스택을 해체하려면 전체 스택 이름을 제공하세요:
+
+<NxCommands commands={['destroy <my-infra> <my-infra>-sandbox/Application']} />
 
 ## 추가 정보
 

--- a/docs/src/content/docs/pt/get_started/tutorials/dungeon-game/wrap-up.mdx
+++ b/docs/src/content/docs/pt/get_started/tutorials/dungeon-game/wrap-up.mdx
@@ -34,7 +34,7 @@ Recomendamos que você tente estender a base de código com as seguintes capacid
 
 1. Para destruir os recursos da AWS que foram criados, execute o seguinte comando:
 
-<NxCommands commands={['destroy infra "dungeon-adventure-infra-sandbox/*"']} />
+<NxCommands commands={['destroy-sandbox infra']} />
 
     Isso solicitará uma lista de stacks para excluir, que deve incluir `dungeon-adventure-infra-sandbox/Application/GameUI/waf` e `dungeon-adventure-infra-sandbox/Application`.
 

--- a/docs/src/content/docs/pt/guides/typescript-infrastructure.mdx
+++ b/docs/src/content/docs/pt/guides/typescript-infrastructure.mdx
@@ -435,6 +435,10 @@ O target `destroy-sandbox` desmonta o stage sandbox que `main.ts` declara, entã
 
 <NxCommands commands={['destroy-sandbox <my-infra>']} />
 
+Desmontar é irreversível, então o CDK pede que você confirme os stacks que está prestes a excluir. Passe `--force` para pular essa confirmação, que é o que você deseja quando não há terminal conectado (em um script, por exemplo):
+
+<NxCommands commands={['destroy-sandbox <my-infra> --force']} />
+
 ### Desmontando um Stage Específico
 
 O target `destroy` desmonta qualquer stage ou stacks que você nomear:

--- a/docs/src/content/docs/pt/guides/typescript-infrastructure.mdx
+++ b/docs/src/content/docs/pt/guides/typescript-infrastructure.mdx
@@ -102,7 +102,7 @@ new ApplicationStage(app, 'my-app-sandbox', {
 
 A propriedade `env` informa ao CDK em qual conta AWS e região implantar. `CDK_DEFAULT_ACCOUNT` e `CDK_DEFAULT_REGION` são resolvidos automaticamente pela CLI do CDK a partir de suas credenciais AWS ativas. Consulte a [documentação de ambientes do CDK](https://docs.aws.amazon.com/cdk/v2/guide/environments.html) para mais detalhes.
 
-O stage sandbox é aquele que o <Link path="guides/typescript-infrastructure#implantando-seu-stage-sandbox">target `deploy-sandbox`</Link> implanta.
+O stage sandbox é aquele sobre o qual os targets <Link path="guides/typescript-infrastructure#implantando-seu-stage-sandbox">`deploy-sandbox`</Link> e <Link path="guides/typescript-infrastructure#desmontando-seu-stage-sandbox">`destroy-sandbox`</Link> atuam.
 
 Se você gerou com `stageConfig`, o `main.ts` lê a conta e região de um arquivo de configuração centralizado, recorrendo a variáveis de ambiente quando nenhuma configuração está definida:
 
@@ -421,9 +421,29 @@ Este target difere ligeiramente do target `deploy` regular, pois implanta um clo
 
 ## Desmontando Infraestrutura AWS
 
-Use o target `destroy` para desmontar seus recursos:
+Seu projeto tem três targets de desmontagem, espelhando os de implantação:
+
+| Target            | Use para                                                                |
+| ----------------- | ----------------------------------------------------------------------- |
+| `destroy-sandbox` | Desmontar seu próprio stage sandbox. Nenhum argumento de stage necessário. |
+| `destroy`         | Desmontar qualquer stage, nomeando o stage ou stacks que você deseja.  |
+| `destroy-ci`      | Desmontar a partir de um pipeline CI/CD, usando um cloud assembly pré-sintetizado. |
+
+### Desmontando seu Stage Sandbox
+
+O target `destroy-sandbox` desmonta o stage sandbox que `main.ts` declara, então você não precisa lembrar seu nome de stage:
+
+<NxCommands commands={['destroy-sandbox <my-infra>']} />
+
+### Desmontando um Stage Específico
+
+O target `destroy` desmonta qualquer stage ou stacks que você nomear:
 
 <NxCommands commands={['destroy <my-infra> <my-infra>-sandbox/*']} />
+
+Para desmontar um stack individual, forneça o nome completo do stack:
+
+<NxCommands commands={['destroy <my-infra> <my-infra>-sandbox/Application']} />
 
 ## Mais Informações
 

--- a/docs/src/content/docs/vi/get_started/tutorials/dungeon-game/wrap-up.mdx
+++ b/docs/src/content/docs/vi/get_started/tutorials/dungeon-game/wrap-up.mdx
@@ -34,7 +34,7 @@ Chúng tôi khuyên bạn nên thử mở rộng codebase với các khả năng
 
 1. Để hủy các tài nguyên AWS đã được tạo, chạy lệnh sau:
 
-<NxCommands commands={['destroy infra "dungeon-adventure-infra-sandbox/*"']} />
+<NxCommands commands={['destroy-sandbox infra']} />
 
     Lệnh này sẽ nhắc bạn danh sách các stack cần xóa, bao gồm `dungeon-adventure-infra-sandbox/Application/GameUI/waf` và `dungeon-adventure-infra-sandbox/Application`.
 

--- a/docs/src/content/docs/vi/guides/typescript-infrastructure.mdx
+++ b/docs/src/content/docs/vi/guides/typescript-infrastructure.mdx
@@ -102,7 +102,7 @@ new ApplicationStage(app, 'my-app-sandbox', {
 
 Thuộc tính `env` cho CDK biết tài khoản AWS và vùng nào để triển khai. `CDK_DEFAULT_ACCOUNT` và `CDK_DEFAULT_REGION` được CDK CLI tự động phân giải từ thông tin xác thực AWS đang hoạt động của bạn. Xem [tài liệu môi trường CDK](https://docs.aws.amazon.com/cdk/v2/guide/environments.html) để biết thêm chi tiết.
 
-Sandbox stage là stage mà <Link path="guides/typescript-infrastructure#deploying-your-sandbox-stage">target `deploy-sandbox`</Link> triển khai.
+Sandbox stage là stage mà các target <Link path="guides/typescript-infrastructure#deploying-your-sandbox-stage">`deploy-sandbox`</Link> và <Link path="guides/typescript-infrastructure#tearing-down-your-sandbox-stage">`destroy-sandbox`</Link> hoạt động trên.
 
 Nếu bạn tạo với `stageConfig`, `main.ts` đọc tài khoản và vùng từ file cấu hình tập trung thay vì, quay lại biến môi trường khi không có cấu hình nào được đặt:
 
@@ -421,9 +421,29 @@ Target này khác một chút so với target `deploy` thông thường ở ch�
 
 ## Phá bỏ Hạ tầng AWS
 
-Sử dụng target `destroy` để phá bỏ các tài nguyên của bạn:
+Dự án của bạn có ba target phá bỏ, phản ánh các target triển khai:
+
+| Target            | Sử dụng nó cho                                                                |
+| ----------------- | ----------------------------------------------------------------------------- |
+| `destroy-sandbox` | Phá bỏ sandbox stage của riêng bạn. Không cần đối số stage.                  |
+| `destroy`         | Phá bỏ bất kỳ stage nào, bằng cách đặt tên stage hoặc stack bạn muốn.        |
+| `destroy-ci`      | Phá bỏ từ một CI/CD pipeline, sử dụng một cloud assembly đã được synthesized trước. |
+
+### Phá bỏ Sandbox Stage của bạn
+
+Target `destroy-sandbox` phá bỏ sandbox stage mà `main.ts` khai báo, vì vậy bạn không cần nhớ tên stage của nó:
+
+<NxCommands commands={['destroy-sandbox <my-infra>']} />
+
+### Phá bỏ một Stage cụ thể
+
+Target `destroy` phá bỏ bất kỳ stage hoặc stack nào bạn đặt tên:
 
 <NxCommands commands={['destroy <my-infra> <my-infra>-sandbox/*']} />
+
+Để phá bỏ một stack riêng lẻ, cung cấp tên stack đầy đủ:
+
+<NxCommands commands={['destroy <my-infra> <my-infra>-sandbox/Application']} />
 
 ## Thông tin thêm
 

--- a/docs/src/content/docs/vi/guides/typescript-infrastructure.mdx
+++ b/docs/src/content/docs/vi/guides/typescript-infrastructure.mdx
@@ -435,6 +435,10 @@ Target `destroy-sandbox` phá bỏ sandbox stage mà `main.ts` khai báo, vì v�
 
 <NxCommands commands={['destroy-sandbox <my-infra>']} />
 
+Việc phá bỏ là không thể đảo ngược, vì vậy CDK yêu cầu bạn xác nhận các stack mà nó sắp xóa. Truyền `--force` để bỏ qua xác nhận đó, đây là điều bạn muốn khi không có terminal được gắn kết (ví dụ trong một script):
+
+<NxCommands commands={['destroy-sandbox <my-infra> --force']} />
+
 ### Phá bỏ một Stage cụ thể
 
 Target `destroy` phá bỏ bất kỳ stage hoặc stack nào bạn đặt tên:

--- a/docs/src/content/docs/zh/get_started/tutorials/dungeon-game/wrap-up.mdx
+++ b/docs/src/content/docs/zh/get_started/tutorials/dungeon-game/wrap-up.mdx
@@ -34,7 +34,7 @@ import gameConversationPng from '@assets/game-conversation.png'
 
 1. 要销毁已创建的 AWS 资源，请运行以下命令：
 
-<NxCommands commands={['destroy infra "dungeon-adventure-infra-sandbox/*"']} />
+<NxCommands commands={['destroy-sandbox infra']} />
 
     这将提示您选择要删除的堆栈列表，其中应包括 `dungeon-adventure-infra-sandbox/Application/GameUI/waf` 和 `dungeon-adventure-infra-sandbox/Application`。
 

--- a/docs/src/content/docs/zh/guides/typescript-infrastructure.mdx
+++ b/docs/src/content/docs/zh/guides/typescript-infrastructure.mdx
@@ -435,6 +435,10 @@ npx cdk bootstrap aws://<account-id>/<region>
 
 <NxCommands commands={['destroy-sandbox <my-infra>']} />
 
+销毁是不可逆的，因此 CDK 会要求您确认即将删除的堆栈。传递 `--force` 以跳过该确认，这在没有终端连接时（例如在脚本中）是您想要的：
+
+<NxCommands commands={['destroy-sandbox <my-infra> --force']} />
+
 ### 拆除特定阶段
 
 `destroy` 目标拆除您命名的任何阶段或堆栈：

--- a/docs/src/content/docs/zh/guides/typescript-infrastructure.mdx
+++ b/docs/src/content/docs/zh/guides/typescript-infrastructure.mdx
@@ -102,7 +102,7 @@ new ApplicationStage(app, 'my-app-sandbox', {
 
 `env` 属性告诉 CDK 要部署到哪个 AWS 账户和区域。`CDK_DEFAULT_ACCOUNT` 和 `CDK_DEFAULT_REGION` 由 CDK CLI 从您的活动 AWS 凭证自动解析。有关更多详细信息，请参阅 [CDK 环境文档](https://docs.aws.amazon.com/cdk/v2/guide/environments.html)。
 
-沙箱阶段是 <Link path="guides/typescript-infrastructure#deploying-your-sandbox-stage">`deploy-sandbox` 目标</Link> 部署的阶段。
+沙箱阶段是 <Link path="guides/typescript-infrastructure#deploying-your-sandbox-stage">`deploy-sandbox`</Link> 和 <Link path="guides/typescript-infrastructure#tearing-down-your-sandbox-stage">`destroy-sandbox`</Link> 目标操作的阶段。
 
 如果您使用 `stageConfig` 生成，`main.ts` 会从集中配置文件中读取账户和区域，当没有设置配置时回退到环境变量：
 
@@ -421,9 +421,29 @@ npx cdk bootstrap aws://<account-id>/<region>
 
 ## 拆除 AWS 基础设施
 
-使用 `destroy` 目标来拆除您的资源：
+您的项目有三个销毁目标，与部署目标相对应：
+
+| 目标            | 用途                                                                |
+| ----------------- | ------------------------------------------------------------------------- |
+| `destroy-sandbox` | 拆除您自己的沙箱阶段。不需要阶段参数。             |
+| `destroy`         | 通过命名您想要的阶段或堆栈来拆除任何阶段。            |
+| `destroy-ci`      | 从 CI/CD 管道拆除，使用预合成的云程序集。 |
+
+### 拆除您的沙箱阶段
+
+`destroy-sandbox` 目标拆除 `main.ts` 声明的沙箱阶段，因此您不需要记住其阶段名称：
+
+<NxCommands commands={['destroy-sandbox <my-infra>']} />
+
+### 拆除特定阶段
+
+`destroy` 目标拆除您命名的任何阶段或堆栈：
 
 <NxCommands commands={['destroy <my-infra> <my-infra>-sandbox/*']} />
+
+要拆除单个堆栈，请提供完整的堆栈名称：
+
+<NxCommands commands={['destroy <my-infra> <my-infra>-sandbox/Application']} />
 
 ## 更多信息
 

--- a/packages/nx-plugin/src/infra/app/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/infra/app/__snapshots__/generator.spec.ts.snap
@@ -98,7 +98,7 @@ exports[`infra generator > should configure project.json with correct targets > 
   ],
   "executor": "nx:run-commands",
   "options": {
-    "command": "cdk destroy --require-approval=never",
+    "command": "cdk destroy --force",
     "cwd": "{projectRoot}",
   },
 }
@@ -202,14 +202,25 @@ exports[`infra generator > should configure project.json with correct targets > 
       ],
       "executor": "nx:run-commands",
       "options": {
-        "command": "cdk destroy --require-approval=never",
+        "command": "cdk destroy --force",
         "cwd": "{projectRoot}",
       },
     },
     "destroy-ci": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "cdk destroy --require-approval=never --app ../../dist/{projectRoot}/cdk.out",
+        "command": "cdk destroy --force --app ../../dist/{projectRoot}/cdk.out",
+        "cwd": "{projectRoot}",
+      },
+    },
+    "destroy-sandbox": {
+      "dependsOn": [
+        "^build",
+        "compile",
+      ],
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "cdk destroy --force "proj-test-sandbox/*"",
         "cwd": "{projectRoot}",
       },
     },
@@ -797,14 +808,25 @@ exports[`infra generator > should handle custom project names correctly > custom
       ],
       "executor": "nx:run-commands",
       "options": {
-        "command": "cdk destroy --require-approval=never",
+        "command": "cdk destroy --force",
         "cwd": "{projectRoot}",
       },
     },
     "destroy-ci": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "cdk destroy --require-approval=never --app ../../dist/{projectRoot}/cdk.out",
+        "command": "cdk destroy --force --app ../../dist/{projectRoot}/cdk.out",
+        "cwd": "{projectRoot}",
+      },
+    },
+    "destroy-sandbox": {
+      "dependsOn": [
+        "^build",
+        "compile",
+      ],
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "cdk destroy --force "proj-custom-infra-sandbox/*"",
         "cwd": "{projectRoot}",
       },
     },
@@ -1046,9 +1068,10 @@ exports[`infra generator > with stageConfig > should snapshot generated scripts 
 "/**
  * Builds the CDK command as an array of arguments for spawnSync.
  *
- * Defaults to --require-approval=never (standard for local dev deploys).
- * If the user explicitly passes --require-approval with any value, we
- * respect their choice and don't add the default.
+ * Runs non-interactively by default, since these commands run under nx with no
+ * TTY attached: \`--require-approval=never\` for deploys, \`--force\` for destroys
+ * (\`cdk destroy\` has no \`--require-approval\`). If the user passes the relevant
+ * flag themselves, their choice is respected and no default is added.
  *
  * Pass --express to opt into CloudFormation express mode for faster
  * iteration; it is not enabled by default so deploys wait for full
@@ -1058,11 +1081,17 @@ export function buildCdkCommand(
   action: string,
   remainingArgs: string[],
 ): string[] {
-  const hasRequireApproval = remainingArgs.some(
-    (a) => a === '--require-approval' || a.startsWith('--require-approval='),
-  );
-  const defaults = hasRequireApproval ? [] : ['--require-approval=never'];
-  return ['cdk', action, ...defaults, ...remainingArgs];
+  const has = (flag: string) =>
+    remainingArgs.some((a) => a === flag || a.startsWith(\`\${flag}=\`));
+  const nonInteractive =
+    action === 'destroy'
+      ? has('--force') || has('-f')
+        ? []
+        : ['--force']
+      : has('--require-approval')
+        ? []
+        : ['--require-approval=never'];
+  return ['cdk', action, ...nonInteractive, ...remainingArgs];
 }
 "
 `;

--- a/packages/nx-plugin/src/infra/app/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/infra/app/__snapshots__/generator.spec.ts.snap
@@ -98,7 +98,7 @@ exports[`infra generator > should configure project.json with correct targets > 
   ],
   "executor": "nx:run-commands",
   "options": {
-    "command": "cdk destroy --force",
+    "command": "cdk destroy",
     "cwd": "{projectRoot}",
   },
 }
@@ -202,14 +202,14 @@ exports[`infra generator > should configure project.json with correct targets > 
       ],
       "executor": "nx:run-commands",
       "options": {
-        "command": "cdk destroy --force",
+        "command": "cdk destroy",
         "cwd": "{projectRoot}",
       },
     },
     "destroy-ci": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "cdk destroy --force --app ../../dist/{projectRoot}/cdk.out",
+        "command": "cdk destroy --app ../../dist/{projectRoot}/cdk.out",
         "cwd": "{projectRoot}",
       },
     },
@@ -220,7 +220,7 @@ exports[`infra generator > should configure project.json with correct targets > 
       ],
       "executor": "nx:run-commands",
       "options": {
-        "command": "cdk destroy --force "proj-test-sandbox/*"",
+        "command": "cdk destroy "proj-test-sandbox/*"",
         "cwd": "{projectRoot}",
       },
     },
@@ -808,14 +808,14 @@ exports[`infra generator > should handle custom project names correctly > custom
       ],
       "executor": "nx:run-commands",
       "options": {
-        "command": "cdk destroy --force",
+        "command": "cdk destroy",
         "cwd": "{projectRoot}",
       },
     },
     "destroy-ci": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "cdk destroy --force --app ../../dist/{projectRoot}/cdk.out",
+        "command": "cdk destroy --app ../../dist/{projectRoot}/cdk.out",
         "cwd": "{projectRoot}",
       },
     },
@@ -826,7 +826,7 @@ exports[`infra generator > should handle custom project names correctly > custom
       ],
       "executor": "nx:run-commands",
       "options": {
-        "command": "cdk destroy --force "proj-custom-infra-sandbox/*"",
+        "command": "cdk destroy "proj-custom-infra-sandbox/*"",
         "cwd": "{projectRoot}",
       },
     },
@@ -1068,10 +1068,10 @@ exports[`infra generator > with stageConfig > should snapshot generated scripts 
 "/**
  * Builds the CDK command as an array of arguments for spawnSync.
  *
- * Runs non-interactively by default, since these commands run under nx with no
- * TTY attached: \`--require-approval=never\` for deploys, \`--force\` for destroys
- * (\`cdk destroy\` has no \`--require-approval\`). If the user passes the relevant
- * flag themselves, their choice is respected and no default is added.
+ * Deploys default to --require-approval=never (standard for local dev deploys).
+ * If the user explicitly passes --require-approval with any value, we
+ * respect their choice and don't add the default. \`cdk destroy\` has no
+ * --require-approval option, so nothing is added for it.
  *
  * Pass --express to opt into CloudFormation express mode for faster
  * iteration; it is not enabled by default so deploys wait for full
@@ -1081,17 +1081,14 @@ export function buildCdkCommand(
   action: string,
   remainingArgs: string[],
 ): string[] {
-  const has = (flag: string) =>
-    remainingArgs.some((a) => a === flag || a.startsWith(\`\${flag}=\`));
-  const nonInteractive =
-    action === 'destroy'
-      ? has('--force') || has('-f')
-        ? []
-        : ['--force']
-      : has('--require-approval')
-        ? []
-        : ['--require-approval=never'];
-  return ['cdk', action, ...nonInteractive, ...remainingArgs];
+  const hasRequireApproval = remainingArgs.some(
+    (a) => a === '--require-approval' || a.startsWith('--require-approval='),
+  );
+  const defaults =
+    action === 'destroy' || hasRequireApproval
+      ? []
+      : ['--require-approval=never'];
+  return ['cdk', action, ...defaults, ...remainingArgs];
 }
 "
 `;

--- a/packages/nx-plugin/src/infra/app/files/app/README.md.template
+++ b/packages/nx-plugin/src/infra/app/files/app/README.md.template
@@ -50,6 +50,20 @@ Currently hot swapping supports Lambda functions, Step Functions state machines,
 
 Run `<%= pkgMgrCmd %> nx deploy-sandbox <%= fullyQualifiedName %> --hotswap`
 
+## Tear Down from AWS
+
+### Tear down your Sandbox Stage
+
+Run `<%= pkgMgrCmd %> nx destroy-sandbox <%= fullyQualifiedName %>`
+
+### Tear down all Stacks in a Stage
+
+Run `<%= pkgMgrCmd %> nx destroy <%= fullyQualifiedName %> "[stageName]/*"`
+
+### Tear down a single Stack
+
+Run `<%= pkgMgrCmd %> nx destroy <%= fullyQualifiedName %> [stageName]/[stackName]`
+
 ## Checkov Rule Suppressions
 
 There may be instances where you want to suppress certain rules on resources. You can do this in two ways:

--- a/packages/nx-plugin/src/infra/app/generator.spec.ts
+++ b/packages/nx-plugin/src/infra/app/generator.spec.ts
@@ -110,7 +110,15 @@ describe('infra generator', () => {
       executor: 'nx:run-commands',
       options: {
         cwd: '{projectRoot}',
-        command: 'cdk destroy --require-approval=never',
+        command: 'cdk destroy --force',
+      },
+      dependsOn: ['^build', 'compile'],
+    });
+    expect(config.targets['destroy-sandbox']).toMatchObject({
+      executor: 'nx:run-commands',
+      options: {
+        cwd: '{projectRoot}',
+        command: 'cdk destroy --force "proj-test-sandbox/*"',
       },
       dependsOn: ['^build', 'compile'],
     });
@@ -118,8 +126,7 @@ describe('infra generator', () => {
       executor: 'nx:run-commands',
       options: {
         cwd: '{projectRoot}',
-        command:
-          'cdk destroy --require-approval=never --app ../../dist/{projectRoot}/cdk.out',
+        command: 'cdk destroy --force --app ../../dist/{projectRoot}/cdk.out',
       },
     });
     expect(config.targets.cdk).toMatchObject({
@@ -305,9 +312,7 @@ describe('infra generator', () => {
       'cdk deploy --require-approval=never',
     );
     expect(config.targets.deploy.options.cwd).toBe('{projectRoot}');
-    expect(config.targets.destroy.options.command).toBe(
-      'cdk destroy --require-approval=never',
-    );
+    expect(config.targets.destroy.options.command).toBe('cdk destroy --force');
     expect(config.targets.destroy.options.cwd).toBe('{projectRoot}');
   });
 
@@ -337,9 +342,16 @@ describe('infra generator', () => {
     );
   });
 
-  describe('deploy-sandbox target', () => {
+  // `cdk destroy` has no --require-approval; --force is what makes it
+  // non-interactive.
+  describe.each([
+    { action: 'deploy', flag: '--require-approval=never' },
+    { action: 'destroy', flag: '--force' },
+  ])('$action-sandbox target', ({ action, flag }) => {
+    const target = `${action}-sandbox`;
+
     // The stage pattern must match the stage main.ts instantiates, otherwise
-    // cdk deploys nothing. Derived from the scope-prefixed project name.
+    // cdk acts on nothing. Derived from the scope-prefixed project name.
     it.each([
       { name: 'test', subDirectory: undefined, stage: 'proj-test-sandbox' },
       { name: 'infra', subDirectory: undefined, stage: 'proj-infra-sandbox' },
@@ -361,8 +373,8 @@ describe('infra generator', () => {
         const mainTs = tree.read(`${config.root}/src/main.ts`).toString();
 
         expect(mainTs).toContain(`new ApplicationStage(app, '${stage}'`);
-        expect(config.targets['deploy-sandbox'].options.command).toBe(
-          `cdk deploy --require-approval=never "${stage}/*"`,
+        expect(config.targets[target].options.command).toBe(
+          `cdk ${action} ${flag} "${stage}/*"`,
         );
       },
     );
@@ -370,18 +382,15 @@ describe('infra generator', () => {
     it('should quote the stage pattern so the shell does not glob it', async () => {
       await tsInfraGenerator(tree, options);
       const config = readProjectConfiguration(tree, '@proj/test');
-      expect(config.targets['deploy-sandbox'].options.command).toContain(
+      expect(config.targets[target].options.command).toContain(
         '"proj-test-sandbox/*"',
       );
     });
 
-    it('should build before deploying, like the deploy target', async () => {
+    it(`should build first, like the ${action} target`, async () => {
       await tsInfraGenerator(tree, options);
       const config = readProjectConfiguration(tree, '@proj/test');
-      expect(config.targets['deploy-sandbox'].dependsOn).toEqual([
-        '^build',
-        'compile',
-      ]);
+      expect(config.targets[target].dependsOn).toEqual(['^build', 'compile']);
     });
   });
 
@@ -411,19 +420,22 @@ describe('infra generator', () => {
       );
     });
 
-    it('should pass the sandbox stage to infra-deploy for deploy-sandbox', async () => {
-      await tsInfraGenerator(tree, stageConfigOptions);
-      const config = readProjectConfiguration(tree, '@proj/test');
-      // The stage is the first positional arg after the project path, which is
-      // where infra-deploy looks it up in stages.config.ts.
-      expect(config.targets['deploy-sandbox'].options.command).toBe(
-        'tsx packages/common/scripts/src/infra/infra-deploy.ts packages/test "proj-test-sandbox/*"',
-      );
-      expect(config.targets['deploy-sandbox'].dependsOn).toEqual([
-        '^build',
-        'compile',
-      ]);
-    });
+    it.each(['deploy', 'destroy'] as const)(
+      'should pass the sandbox stage to infra-%s for %s-sandbox',
+      async (action) => {
+        await tsInfraGenerator(tree, stageConfigOptions);
+        const config = readProjectConfiguration(tree, '@proj/test');
+        // The stage is the first positional arg after the project path, which is
+        // where the script looks it up in stages.config.ts.
+        expect(config.targets[`${action}-sandbox`].options.command).toBe(
+          `tsx packages/common/scripts/src/infra/infra-${action}.ts packages/test "proj-test-sandbox/*"`,
+        );
+        expect(config.targets[`${action}-sandbox`].dependsOn).toEqual([
+          '^build',
+          'compile',
+        ]);
+      },
+    );
 
     it('should generate infra-config package with stages types and config', async () => {
       await tsInfraGenerator(tree, stageConfigOptions);

--- a/packages/nx-plugin/src/infra/app/generator.spec.ts
+++ b/packages/nx-plugin/src/infra/app/generator.spec.ts
@@ -110,7 +110,7 @@ describe('infra generator', () => {
       executor: 'nx:run-commands',
       options: {
         cwd: '{projectRoot}',
-        command: 'cdk destroy --force',
+        command: 'cdk destroy',
       },
       dependsOn: ['^build', 'compile'],
     });
@@ -118,7 +118,7 @@ describe('infra generator', () => {
       executor: 'nx:run-commands',
       options: {
         cwd: '{projectRoot}',
-        command: 'cdk destroy --force "proj-test-sandbox/*"',
+        command: 'cdk destroy "proj-test-sandbox/*"',
       },
       dependsOn: ['^build', 'compile'],
     });
@@ -126,7 +126,7 @@ describe('infra generator', () => {
       executor: 'nx:run-commands',
       options: {
         cwd: '{projectRoot}',
-        command: 'cdk destroy --force --app ../../dist/{projectRoot}/cdk.out',
+        command: 'cdk destroy --app ../../dist/{projectRoot}/cdk.out',
       },
     });
     expect(config.targets.cdk).toMatchObject({
@@ -312,7 +312,7 @@ describe('infra generator', () => {
       'cdk deploy --require-approval=never',
     );
     expect(config.targets.deploy.options.cwd).toBe('{projectRoot}');
-    expect(config.targets.destroy.options.command).toBe('cdk destroy --force');
+    expect(config.targets.destroy.options.command).toBe('cdk destroy');
     expect(config.targets.destroy.options.cwd).toBe('{projectRoot}');
   });
 
@@ -342,12 +342,11 @@ describe('infra generator', () => {
     );
   });
 
-  // `cdk destroy` has no --require-approval; --force is what makes it
-  // non-interactive.
+  // `cdk destroy` has no --require-approval option, so only deploys carry it.
   describe.each([
-    { action: 'deploy', flag: '--require-approval=never' },
-    { action: 'destroy', flag: '--force' },
-  ])('$action-sandbox target', ({ action, flag }) => {
+    { action: 'deploy', cdkCommand: 'cdk deploy --require-approval=never' },
+    { action: 'destroy', cdkCommand: 'cdk destroy' },
+  ])('$action-sandbox target', ({ action, cdkCommand }) => {
     const target = `${action}-sandbox`;
 
     // The stage pattern must match the stage main.ts instantiates, otherwise
@@ -374,7 +373,7 @@ describe('infra generator', () => {
 
         expect(mainTs).toContain(`new ApplicationStage(app, '${stage}'`);
         expect(config.targets[target].options.command).toBe(
-          `cdk ${action} ${flag} "${stage}/*"`,
+          `${cdkCommand} "${stage}/*"`,
         );
       },
     );

--- a/packages/nx-plugin/src/infra/app/generator.ts
+++ b/packages/nx-plugin/src/infra/app/generator.ts
@@ -235,7 +235,7 @@ export async function tsInfraGenerator(
             })
           : withCdkEnv({
               cwd: '{projectRoot}',
-              command: 'cdk destroy --force',
+              command: 'cdk destroy',
             }),
       };
       config.targets['destroy-sandbox'] = {
@@ -247,14 +247,14 @@ export async function tsInfraGenerator(
             })
           : withCdkEnv({
               cwd: '{projectRoot}',
-              command: `cdk destroy --force ${sandboxStagePattern}`,
+              command: `cdk destroy ${sandboxStagePattern}`,
             }),
       };
       config.targets['destroy-ci'] = {
         executor: 'nx:run-commands',
         options: withCdkEnv({
           cwd: '{projectRoot}',
-          command: `cdk destroy --force --app ${distDirFromProjectRoot}`,
+          command: `cdk destroy --app ${distDirFromProjectRoot}`,
         }),
       };
       config.targets.cdk = {

--- a/packages/nx-plugin/src/infra/app/generator.ts
+++ b/packages/nx-plugin/src/infra/app/generator.ts
@@ -235,14 +235,26 @@ export async function tsInfraGenerator(
             })
           : withCdkEnv({
               cwd: '{projectRoot}',
-              command: 'cdk destroy --require-approval=never',
+              command: 'cdk destroy --force',
+            }),
+      };
+      config.targets['destroy-sandbox'] = {
+        executor: 'nx:run-commands',
+        dependsOn: ['^build', 'compile'],
+        options: stageConfig
+          ? withCdkEnv({
+              command: `tsx packages/common/scripts/src/infra/infra-destroy.ts ${libraryRoot} ${sandboxStagePattern}`,
+            })
+          : withCdkEnv({
+              cwd: '{projectRoot}',
+              command: `cdk destroy --force ${sandboxStagePattern}`,
             }),
       };
       config.targets['destroy-ci'] = {
         executor: 'nx:run-commands',
         options: withCdkEnv({
           cwd: '{projectRoot}',
-          command: `cdk destroy --require-approval=never --app ${distDirFromProjectRoot}`,
+          command: `cdk destroy --force --app ${distDirFromProjectRoot}`,
         }),
       };
       config.targets.cdk = {

--- a/packages/nx-plugin/src/mcp-server/tools/general-guidance.ts
+++ b/packages/nx-plugin/src/mcp-server/tools/general-guidance.ts
@@ -78,7 +78,7 @@ ${PACKAGE_MANAGERS.map((pm) => buildNxCommand('<options>', pm)).join(' - \n')}
 - Generate all projects into the \`packages/\` directory
 - After making changes to your projects, fix linting issues, then run a full build
 - When it's time to start testing a project, suggest to the user that infrastructure is deployed to AWS. For websites, if a runtime-config.json is needed, use the load-runtime-config target after a deployment to point a local website at a sandbox stack.
-- For CDK infrastructure projects, deploy the sandbox stage with the \`deploy-sandbox\` target (eg \`nx deploy-sandbox infra\`) rather than passing a stage pattern to \`deploy\` — it already targets the sandbox stage declared in \`main.ts\`.
+- For CDK infrastructure projects, deploy the sandbox stage with the \`deploy-sandbox\` target (eg \`nx deploy-sandbox infra\`) rather than passing a stage pattern to \`deploy\` — it already targets the sandbox stage declared in \`main.ts\`. Likewise \`destroy-sandbox\` tears that stage back down.
 
 ## Batching Generators
 

--- a/packages/nx-plugin/src/migrations/latest/add-destroy-sandbox-target/metadata.json
+++ b/packages/nx-plugin/src/migrations/latest/add-destroy-sandbox-target/metadata.json
@@ -1,3 +1,3 @@
 {
-  "description": "Add a destroy-sandbox target to CDK infrastructure projects which destroys the sandbox stage, and pass --force rather than --require-approval to cdk destroy so it does not prompt without a TTY"
+  "description": "Add a destroy-sandbox target to CDK infrastructure projects which destroys the sandbox stage, and drop the --require-approval flag from cdk destroy, which has no such option"
 }

--- a/packages/nx-plugin/src/migrations/latest/add-destroy-sandbox-target/metadata.json
+++ b/packages/nx-plugin/src/migrations/latest/add-destroy-sandbox-target/metadata.json
@@ -1,0 +1,3 @@
+{
+  "description": "Add a destroy-sandbox target to CDK infrastructure projects which destroys the sandbox stage, and pass --force rather than --require-approval to cdk destroy so it does not prompt without a TTY"
+}

--- a/packages/nx-plugin/src/migrations/latest/add-destroy-sandbox-target/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/latest/add-destroy-sandbox-target/migration.spec.ts
@@ -1,0 +1,361 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import {
+  addProjectConfiguration,
+  readProjectConfiguration,
+  type Tree,
+  updateProjectConfiguration,
+} from '@nx/devkit';
+import { INFRA_APP_GENERATOR_INFO } from '../../../infra/app/generator.js';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test.js';
+import migration from './migration.js';
+
+const TARGET = 'destroy-sandbox';
+
+const mainTs = (stages: string[]) =>
+  `import { ApplicationStage } from './stages/application-stage.js';
+import { App } from '@proj/common-constructs';
+
+const app = new App();
+
+${stages
+  .map(
+    (stage) => `new ApplicationStage(app, '${stage}', {
+  env: {
+    account: process.env.CDK_DEFAULT_ACCOUNT,
+    region: process.env.CDK_DEFAULT_REGION,
+  },
+});
+`,
+  )
+  .join('\n')}
+app.synth();
+`;
+
+/** The destroy target as the pre-fix generator vended it. */
+const cdkDestroyTarget = () => ({
+  executor: 'nx:run-commands',
+  dependsOn: ['^build', 'compile'],
+  options: {
+    cwd: '{projectRoot}',
+    command: 'cdk destroy --require-approval=never',
+  },
+});
+
+const CDK_COMMAND_PATH =
+  'packages/common/scripts/src/infra/stage-credentials/cdk-command.ts';
+
+/** The command builder as the pre-fix generator vended it. */
+const CDK_COMMAND_BEFORE = `export function buildCdkCommand(
+  action: string,
+  remainingArgs: string[],
+): string[] {
+  const hasRequireApproval = remainingArgs.some(
+    (a) => a === '--require-approval' || a.startsWith('--require-approval='),
+  );
+  const defaults = hasRequireApproval ? [] : ['--require-approval=never'];
+  return ['cdk', action, ...defaults, ...remainingArgs];
+}
+`;
+
+const stageConfigDestroyTarget = () => ({
+  executor: 'nx:run-commands',
+  dependsOn: ['^build', 'compile'],
+  options: {
+    command:
+      'tsx packages/common/scripts/src/infra/infra-destroy.ts packages/infra',
+  },
+});
+
+/**
+ * Seeds a CDK infrastructure project as the generator leaves it: `ts#infra`
+ * metadata, a `destroy` target and a `main.ts` declaring the given stages.
+ */
+const seedInfraProject = (
+  tree: Tree,
+  {
+    name = '@proj/infra',
+    root = 'packages/infra',
+    stages = ['proj-infra-sandbox'],
+    destroy = cdkDestroyTarget(),
+    main,
+  }: {
+    name?: string;
+    root?: string;
+    stages?: string[];
+    destroy?: unknown;
+    main?: string;
+  } = {},
+) => {
+  addProjectConfiguration(tree, name, {
+    root,
+    projectType: 'application',
+    metadata: { generator: INFRA_APP_GENERATOR_INFO.id } as never,
+    targets: {
+      build: { executor: 'nx:run-commands' },
+      destroy: destroy as never,
+      'destroy-ci': { executor: 'nx:run-commands' },
+    },
+  });
+  tree.write(`${root}/src/main.ts`, main ?? mainTs(stages));
+};
+
+const sandboxTargetOf = (tree: Tree, project = '@proj/infra') =>
+  readProjectConfiguration(tree, project).targets[TARGET];
+
+describe('add-destroy-sandbox-target migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeUsingTsSolutionSetup();
+  });
+
+  it('should add the target destroying the sandbox stage main.ts declares', async () => {
+    seedInfraProject(tree);
+
+    const result = await migration(tree);
+
+    expect(sandboxTargetOf(tree)).toEqual({
+      executor: 'nx:run-commands',
+      dependsOn: ['^build', 'compile'],
+      options: {
+        cwd: '{projectRoot}',
+        command: 'cdk destroy --force "proj-infra-sandbox/*"',
+      },
+    });
+    expect(result.nextSteps).toEqual([]);
+  });
+
+  it('should pass the stage to the credential script under stageConfig', async () => {
+    seedInfraProject(tree, { destroy: stageConfigDestroyTarget() });
+
+    await migration(tree);
+
+    expect(sandboxTargetOf(tree).options).toEqual({
+      command:
+        'tsx packages/common/scripts/src/infra/infra-destroy.ts packages/infra "proj-infra-sandbox/*"',
+    });
+  });
+
+  it('should pick the sandbox stage when other stages are declared', async () => {
+    seedInfraProject(tree, {
+      stages: ['proj-infra-beta', 'proj-infra-prod', 'proj-infra-sandbox'],
+    });
+
+    await migration(tree);
+
+    expect(sandboxTargetOf(tree).options.command).toBe(
+      'cdk destroy --force "proj-infra-sandbox/*"',
+    );
+  });
+
+  it('should use a renamed sandbox stage rather than the project name', async () => {
+    seedInfraProject(tree, { stages: ['my-own-sandbox'] });
+
+    await migration(tree);
+
+    expect(sandboxTargetOf(tree).options.command).toBe(
+      'cdk destroy --force "my-own-sandbox/*"',
+    );
+  });
+
+  it('should read a double-quoted stage id', async () => {
+    seedInfraProject(tree, {
+      main: `const app = new App();
+new ApplicationStage(app, "proj-infra-sandbox", { env: {} });
+app.synth();
+`,
+    });
+
+    await migration(tree);
+
+    expect(sandboxTargetOf(tree).options.command).toBe(
+      'cdk destroy --force "proj-infra-sandbox/*"',
+    );
+  });
+
+  it('should leave non-infrastructure projects alone', async () => {
+    addProjectConfiguration(tree, '@proj/website', {
+      root: 'packages/website',
+      targets: { destroy: cdkDestroyTarget() },
+    });
+
+    const result = await migration(tree);
+
+    expect(sandboxTargetOf(tree, '@proj/website')).toBeUndefined();
+    expect(result.nextSteps).toEqual([]);
+  });
+
+  it('should skip and report a project with no sandbox stage', async () => {
+    seedInfraProject(tree, { stages: ['proj-infra-beta'] });
+
+    const result = await migration(tree);
+
+    expect(sandboxTargetOf(tree)).toBeUndefined();
+    expect(result.nextSteps).toEqual([
+      expect.stringContaining('no sandbox stage was found'),
+    ]);
+  });
+
+  it('should skip and report a project whose destroy target has diverged', async () => {
+    seedInfraProject(tree, {
+      destroy: {
+        executor: '@my-org/deployer:destroy',
+        options: { stage: 'x' },
+      },
+    });
+
+    const result = await migration(tree);
+
+    expect(sandboxTargetOf(tree)).toBeUndefined();
+    expect(result.nextSteps).toEqual([
+      expect.stringContaining('no longer matches the shape'),
+    ]);
+  });
+
+  it('should not overwrite an existing destroy-sandbox target', async () => {
+    seedInfraProject(tree);
+    const project = readProjectConfiguration(tree, '@proj/infra');
+    const existing = { executor: 'nx:run-commands', options: { command: 'x' } };
+    project.targets[TARGET] = existing;
+    updateProjectConfiguration(tree, '@proj/infra', project);
+
+    await migration(tree);
+
+    expect(sandboxTargetOf(tree)).toEqual(existing);
+  });
+
+  it('should handle multiple infrastructure projects', async () => {
+    seedInfraProject(tree);
+    seedInfraProject(tree, {
+      name: '@proj/other-infra',
+      root: 'packages/other-infra',
+      stages: ['proj-other-infra-sandbox'],
+    });
+
+    await migration(tree);
+
+    expect(sandboxTargetOf(tree).options.command).toBe(
+      'cdk destroy --force "proj-infra-sandbox/*"',
+    );
+    expect(sandboxTargetOf(tree, '@proj/other-infra').options.command).toBe(
+      'cdk destroy --force "proj-other-infra-sandbox/*"',
+    );
+  });
+
+  describe('non-interactive destroy flag', () => {
+    // `cdk destroy` has no --require-approval, so it ignores the flag and then
+    // blocks on a confirmation prompt, which nx cannot answer.
+    it('should swap --require-approval for --force on the destroy targets', async () => {
+      seedInfraProject(tree);
+      const project = readProjectConfiguration(tree, '@proj/infra');
+      project.targets['destroy-ci'] = {
+        executor: 'nx:run-commands',
+        options: {
+          cwd: '{projectRoot}',
+          command:
+            'cdk destroy --require-approval=never --app ../../dist/{projectRoot}/cdk.out',
+        },
+      };
+      updateProjectConfiguration(tree, '@proj/infra', project);
+
+      const result = await migration(tree);
+      const targets = readProjectConfiguration(tree, '@proj/infra').targets;
+
+      expect(targets.destroy.options.command).toBe('cdk destroy --force');
+      expect(targets['destroy-ci'].options.command).toBe(
+        'cdk destroy --force --app ../../dist/{projectRoot}/cdk.out',
+      );
+      expect(result.nextSteps).toEqual([]);
+    });
+
+    it('should leave a destroy target that already passes --force alone', async () => {
+      seedInfraProject(tree, {
+        destroy: {
+          executor: 'nx:run-commands',
+          options: { cwd: '{projectRoot}', command: 'cdk destroy --force' },
+        },
+      });
+
+      await migration(tree);
+
+      expect(
+        readProjectConfiguration(tree, '@proj/infra').targets.destroy.options
+          .command,
+      ).toBe('cdk destroy --force');
+    });
+
+    it('should not add a second --force when the user already passes one', async () => {
+      seedInfraProject(tree, {
+        destroy: {
+          executor: 'nx:run-commands',
+          options: {
+            cwd: '{projectRoot}',
+            command: 'cdk destroy --require-approval=never --force',
+          },
+        },
+      });
+
+      await migration(tree);
+
+      expect(
+        readProjectConfiguration(tree, '@proj/infra').targets.destroy.options
+          .command,
+      ).toBe('cdk destroy --force');
+    });
+
+    it('should re-vend the command builder so destroy passes --force', async () => {
+      seedInfraProject(tree);
+      tree.write(CDK_COMMAND_PATH, CDK_COMMAND_BEFORE);
+
+      const result = await migration(tree);
+      const after = tree.read(CDK_COMMAND_PATH).toString();
+
+      expect(after).toContain("action === 'destroy'");
+      expect(after).toContain("['--force']");
+      expect(result.nextSteps).toEqual([]);
+    });
+
+    it('should skip and report a customised command builder', async () => {
+      seedInfraProject(tree);
+      tree.write(
+        CDK_COMMAND_PATH,
+        'export function buildCdkCommand() {\n  return myOwnThing();\n}\n',
+      );
+
+      const result = await migration(tree);
+
+      expect(tree.read(CDK_COMMAND_PATH).toString()).toContain('myOwnThing()');
+      expect(tree.read(CDK_COMMAND_PATH).toString()).not.toContain('--force');
+      expect(result.nextSteps).toEqual([
+        expect.stringContaining('has diverged from the generated shape'),
+      ]);
+    });
+
+    it('should leave workspaces with no shared scripts package alone', async () => {
+      seedInfraProject(tree);
+
+      await migration(tree);
+
+      expect(tree.exists(CDK_COMMAND_PATH)).toBeFalsy();
+    });
+  });
+
+  it('should be idempotent', async () => {
+    seedInfraProject(tree);
+    tree.write(CDK_COMMAND_PATH, CDK_COMMAND_BEFORE);
+
+    await migration(tree);
+    const afterFirst = readProjectConfiguration(tree, '@proj/infra');
+    const builderAfterFirst = tree.read(CDK_COMMAND_PATH).toString();
+
+    await migration(tree);
+    const afterSecond = readProjectConfiguration(tree, '@proj/infra');
+
+    expect(tree.read(CDK_COMMAND_PATH).toString()).toBe(builderAfterFirst);
+
+    expect(afterSecond).toEqual(afterFirst);
+  });
+});

--- a/packages/nx-plugin/src/migrations/latest/add-destroy-sandbox-target/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/latest/add-destroy-sandbox-target/migration.spec.ts
@@ -122,7 +122,7 @@ describe('add-destroy-sandbox-target migration', () => {
       dependsOn: ['^build', 'compile'],
       options: {
         cwd: '{projectRoot}',
-        command: 'cdk destroy --force "proj-infra-sandbox/*"',
+        command: 'cdk destroy "proj-infra-sandbox/*"',
       },
     });
     expect(result.nextSteps).toEqual([]);
@@ -147,7 +147,7 @@ describe('add-destroy-sandbox-target migration', () => {
     await migration(tree);
 
     expect(sandboxTargetOf(tree).options.command).toBe(
-      'cdk destroy --force "proj-infra-sandbox/*"',
+      'cdk destroy "proj-infra-sandbox/*"',
     );
   });
 
@@ -157,7 +157,7 @@ describe('add-destroy-sandbox-target migration', () => {
     await migration(tree);
 
     expect(sandboxTargetOf(tree).options.command).toBe(
-      'cdk destroy --force "my-own-sandbox/*"',
+      'cdk destroy "my-own-sandbox/*"',
     );
   });
 
@@ -172,7 +172,7 @@ app.synth();
     await migration(tree);
 
     expect(sandboxTargetOf(tree).options.command).toBe(
-      'cdk destroy --force "proj-infra-sandbox/*"',
+      'cdk destroy "proj-infra-sandbox/*"',
     );
   });
 
@@ -238,17 +238,17 @@ app.synth();
     await migration(tree);
 
     expect(sandboxTargetOf(tree).options.command).toBe(
-      'cdk destroy --force "proj-infra-sandbox/*"',
+      'cdk destroy "proj-infra-sandbox/*"',
     );
     expect(sandboxTargetOf(tree, '@proj/other-infra').options.command).toBe(
-      'cdk destroy --force "proj-other-infra-sandbox/*"',
+      'cdk destroy "proj-other-infra-sandbox/*"',
     );
   });
 
-  describe('non-interactive destroy flag', () => {
-    // `cdk destroy` has no --require-approval, so it ignores the flag and then
-    // blocks on a confirmation prompt, which nx cannot answer.
-    it('should swap --require-approval for --force on the destroy targets', async () => {
+  describe('ignored approval flag', () => {
+    // `cdk destroy` has no --require-approval option, so it only warns that the
+    // flag is being ignored.
+    it('should drop --require-approval from the destroy targets', async () => {
       seedInfraProject(tree);
       const project = readProjectConfiguration(tree, '@proj/infra');
       project.targets['destroy-ci'] = {
@@ -264,30 +264,14 @@ app.synth();
       const result = await migration(tree);
       const targets = readProjectConfiguration(tree, '@proj/infra').targets;
 
-      expect(targets.destroy.options.command).toBe('cdk destroy --force');
+      expect(targets.destroy.options.command).toBe('cdk destroy');
       expect(targets['destroy-ci'].options.command).toBe(
-        'cdk destroy --force --app ../../dist/{projectRoot}/cdk.out',
+        'cdk destroy --app ../../dist/{projectRoot}/cdk.out',
       );
       expect(result.nextSteps).toEqual([]);
     });
 
-    it('should leave a destroy target that already passes --force alone', async () => {
-      seedInfraProject(tree, {
-        destroy: {
-          executor: 'nx:run-commands',
-          options: { cwd: '{projectRoot}', command: 'cdk destroy --force' },
-        },
-      });
-
-      await migration(tree);
-
-      expect(
-        readProjectConfiguration(tree, '@proj/infra').targets.destroy.options
-          .command,
-      ).toBe('cdk destroy --force');
-    });
-
-    it('should not add a second --force when the user already passes one', async () => {
+    it('should keep flags the user passes themselves', async () => {
       seedInfraProject(tree, {
         destroy: {
           executor: 'nx:run-commands',
@@ -306,7 +290,7 @@ app.synth();
       ).toBe('cdk destroy --force');
     });
 
-    it('should re-vend the command builder so destroy passes --force', async () => {
+    it('should re-vend the command builder so destroy skips the flag', async () => {
       seedInfraProject(tree);
       tree.write(CDK_COMMAND_PATH, CDK_COMMAND_BEFORE);
 
@@ -314,7 +298,6 @@ app.synth();
       const after = tree.read(CDK_COMMAND_PATH).toString();
 
       expect(after).toContain("action === 'destroy'");
-      expect(after).toContain("['--force']");
       expect(result.nextSteps).toEqual([]);
     });
 
@@ -328,7 +311,9 @@ app.synth();
       const result = await migration(tree);
 
       expect(tree.read(CDK_COMMAND_PATH).toString()).toContain('myOwnThing()');
-      expect(tree.read(CDK_COMMAND_PATH).toString()).not.toContain('--force');
+      expect(tree.read(CDK_COMMAND_PATH).toString()).not.toContain(
+        'buildCdkCommand(\n',
+      );
       expect(result.nextSteps).toEqual([
         expect.stringContaining('has diverged from the generated shape'),
       ]);

--- a/packages/nx-plugin/src/migrations/latest/add-destroy-sandbox-target/migration.ts
+++ b/packages/nx-plugin/src/migrations/latest/add-destroy-sandbox-target/migration.ts
@@ -32,11 +32,10 @@ import {
  * name, so a project whose sandbox stage has been renamed gets a target that
  * destroys the stage it actually declares.
  *
- * The destroy targets also move from `--require-approval=never` to `--force`.
- * `cdk destroy` has no `--require-approval` option — it ignores the flag and
- * then blocks on a confirmation prompt, which fails outright under nx, where no
- * TTY is attached. The same fix lands in the vended `buildCdkCommand`, which
- * builds the command for `stageConfig` workspaces.
+ * The destroy targets also drop `--require-approval=never`. `cdk destroy` has no
+ * such option, so it only warns that the flag is being ignored. The same fix
+ * lands in the vended `buildCdkCommand`, which builds the command for
+ * `stageConfig` workspaces.
  *
  * How to write a migration:
  * - https://nx.dev/docs/kb/migration-generators
@@ -45,10 +44,10 @@ import {
 
 const TARGET = 'destroy-sandbox';
 
-/** The destroy targets whose non-interactive flag is corrected. */
+/** The destroy targets the ignored flag is stripped from. */
 const DESTROY_TARGETS = ['destroy', 'destroy-ci'] as const;
 
-/** `cdk destroy` silently ignores this, then prompts for confirmation. */
+/** `cdk destroy` has no such option, so it only warns and carries on. */
 const IGNORED_APPROVAL_FLAG = /\s*--require-approval(=\S*)?/;
 
 /**
@@ -79,27 +78,24 @@ const sandboxStageId = async (
 };
 
 /**
- * Swap `--require-approval` for `--force` in a `cdk destroy` command. Returns
- * undefined when the command isn't the shape the generator produced, or already
- * runs non-interactively.
+ * Strip the ignored `--require-approval` from a `cdk destroy` command. Returns
+ * undefined when the command isn't the shape the generator produced, or the flag
+ * is already gone.
  */
-const withForceFlag = (command: unknown): string | undefined => {
+const withoutApprovalFlag = (command: unknown): string | undefined => {
   if (typeof command !== 'string' || !command.includes('cdk destroy')) {
     return undefined;
   }
   if (!IGNORED_APPROVAL_FLAG.test(command)) return undefined;
-  const stripped = command.replace(IGNORED_APPROVAL_FLAG, '');
-  return /(^|\s)(--force|-f)(\s|$)/.test(stripped)
-    ? stripped
-    : stripped.replace('cdk destroy', 'cdk destroy --force');
+  return command.replace(IGNORED_APPROVAL_FLAG, '');
 };
 
-/** Corrects the non-interactive flag on the project's destroy targets. */
+/** Drops the ignored approval flag from the project's destroy targets. */
 const migrateDestroyFlags = (project: ProjectConfiguration): boolean => {
   let changed = false;
   for (const name of DESTROY_TARGETS) {
     const target = project.targets?.[name];
-    const command = withForceFlag(target?.options?.command);
+    const command = withoutApprovalFlag(target?.options?.command);
     if (command) {
       target.options = { ...target.options, command };
       changed = true;
@@ -125,10 +121,9 @@ const CDK_COMMAND_TEMPLATE = readFileSync(
 );
 
 /**
- * Re-vends the CDK command builder, which picks the non-interactive flag per
- * action rather than always passing `--require-approval`. Only the shape the
- * generator produced is replaced: a customised copy is the user's, so it is
- * reported instead.
+ * Re-vends the CDK command builder, which no longer adds `--require-approval`
+ * for the `destroy` action. Only the shape the generator produced is replaced: a
+ * customised copy is the user's, so it is reported instead.
  */
 const migrateCdkCommandBuilder = (tree: Tree, nextSteps: string[]): void => {
   if (!tree.exists(CDK_COMMAND_PATH)) return;
@@ -139,7 +134,7 @@ const migrateCdkCommandBuilder = (tree: Tree, nextSteps: string[]): void => {
 
   if (!current.includes('hasRequireApproval')) {
     nextSteps.push(
-      `${CDK_COMMAND_PATH}: has diverged from the generated shape — left untouched. Have it pass \`--force\` rather than \`--require-approval\` for the \`destroy\` action, otherwise 'destroy' blocks on a confirmation prompt when run without a TTY.`,
+      `${CDK_COMMAND_PATH}: has diverged from the generated shape — left untouched. Have it skip \`--require-approval\` for the \`destroy\` action, which has no such option.`,
     );
     return;
   }

--- a/packages/nx-plugin/src/migrations/latest/add-destroy-sandbox-target/migration.ts
+++ b/packages/nx-plugin/src/migrations/latest/add-destroy-sandbox-target/migration.ts
@@ -1,0 +1,220 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import {
+  getProjects,
+  joinPathFragments,
+  type MigrationReturnObject,
+  type ProjectConfiguration,
+  type Tree,
+  updateProjectConfiguration,
+} from '@nx/devkit';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { INFRA_APP_GENERATOR_INFO } from '../../../infra/app/generator.js';
+import { captureGritQLVariable } from '../../../utils/ast.js';
+import { formatFilesInSubtree } from '../../../utils/format.js';
+import { normalizeTargetKeyOrder } from '../../../utils/nx.js';
+import { sortObjectKeys } from '../../../utils/object.js';
+import {
+  PACKAGES_DIR,
+  SHARED_SCRIPTS_DIR,
+} from '../../../utils/shared-constructs-constants.js';
+
+/**
+ * CDK infrastructure projects gained a `destroy-sandbox` target, mirroring
+ * `deploy-sandbox`: it tears down the sandbox stage without the user having to
+ * spell out its stage pattern (`nx destroy-sandbox infra` rather than
+ * `nx destroy infra "my-app-infra-sandbox/*"`).
+ *
+ * The stage id is read from `main.ts` rather than recomputed from the project
+ * name, so a project whose sandbox stage has been renamed gets a target that
+ * destroys the stage it actually declares.
+ *
+ * The destroy targets also move from `--require-approval=never` to `--force`.
+ * `cdk destroy` has no `--require-approval` option — it ignores the flag and
+ * then blocks on a confirmation prompt, which fails outright under nx, where no
+ * TTY is attached. The same fix lands in the vended `buildCdkCommand`, which
+ * builds the command for `stageConfig` workspaces.
+ *
+ * How to write a migration:
+ * - https://nx.dev/docs/kb/migration-generators
+ * - What `nextSteps` means: https://nx.dev/docs/reference/devkit/MigrationReturnObject
+ */
+
+const TARGET = 'destroy-sandbox';
+
+/** The destroy targets whose non-interactive flag is corrected. */
+const DESTROY_TARGETS = ['destroy', 'destroy-ci'] as const;
+
+/** `cdk destroy` silently ignores this, then prompts for confirmation. */
+const IGNORED_APPROVAL_FLAG = /\s*--require-approval(=\S*)?/;
+
+/**
+ * Matches `new ApplicationStage(app, '<id>-sandbox', { ... })`, binding the
+ * quoted stage id. The regex spans the quotes because it is matched against the
+ * whole string literal node; both quote styles are accepted since the user's
+ * formatter may have rewritten them.
+ *
+ * `main.ts` can declare several stages (beta, prod), so the pattern selects the
+ * sandbox one rather than whichever comes first.
+ */
+const SANDBOX_STAGE_PATTERN =
+  '`new ApplicationStage($app, $id, $props)` where { $id <: r"[\'\\"].*-sandbox[\'\\"]" }';
+
+/** The id of the sandbox stage a project's `main.ts` instantiates. */
+const sandboxStageId = async (
+  tree: Tree,
+  projectRoot: string,
+): Promise<string | undefined> => {
+  const captured = await captureGritQLVariable(
+    tree,
+    joinPathFragments(projectRoot, 'src', 'main.ts'),
+    SANDBOX_STAGE_PATTERN,
+    'id',
+  );
+  // The binding keeps the quotes from the source.
+  return captured?.slice(1, -1);
+};
+
+/**
+ * Swap `--require-approval` for `--force` in a `cdk destroy` command. Returns
+ * undefined when the command isn't the shape the generator produced, or already
+ * runs non-interactively.
+ */
+const withForceFlag = (command: unknown): string | undefined => {
+  if (typeof command !== 'string' || !command.includes('cdk destroy')) {
+    return undefined;
+  }
+  if (!IGNORED_APPROVAL_FLAG.test(command)) return undefined;
+  const stripped = command.replace(IGNORED_APPROVAL_FLAG, '');
+  return /(^|\s)(--force|-f)(\s|$)/.test(stripped)
+    ? stripped
+    : stripped.replace('cdk destroy', 'cdk destroy --force');
+};
+
+/** Corrects the non-interactive flag on the project's destroy targets. */
+const migrateDestroyFlags = (project: ProjectConfiguration): boolean => {
+  let changed = false;
+  for (const name of DESTROY_TARGETS) {
+    const target = project.targets?.[name];
+    const command = withForceFlag(target?.options?.command);
+    if (command) {
+      target.options = { ...target.options, command };
+      changed = true;
+    }
+  }
+  return changed;
+};
+
+/** Path the shared scripts package vends the CDK command builder at. */
+const CDK_COMMAND_PATH = joinPathFragments(
+  PACKAGES_DIR,
+  SHARED_SCRIPTS_DIR,
+  'src/infra/stage-credentials/cdk-command.ts',
+);
+
+/** The builder as it stands today. The template carries no EJS variables. */
+const CDK_COMMAND_TEMPLATE = readFileSync(
+  join(
+    import.meta.dirname,
+    '../../../utils/files/common/scripts/src/infra/stage-credentials/cdk-command.ts.template',
+  ),
+  'utf-8',
+);
+
+/**
+ * Re-vends the CDK command builder, which picks the non-interactive flag per
+ * action rather than always passing `--require-approval`. Only the shape the
+ * generator produced is replaced: a customised copy is the user's, so it is
+ * reported instead.
+ */
+const migrateCdkCommandBuilder = (tree: Tree, nextSteps: string[]): void => {
+  if (!tree.exists(CDK_COMMAND_PATH)) return;
+
+  const current = tree.read(CDK_COMMAND_PATH)!.toString();
+  // Already migrated, so a re-run is a no-op.
+  if (current.includes("action === 'destroy'")) return;
+
+  if (!current.includes('hasRequireApproval')) {
+    nextSteps.push(
+      `${CDK_COMMAND_PATH}: has diverged from the generated shape — left untouched. Have it pass \`--force\` rather than \`--require-approval\` for the \`destroy\` action, otherwise 'destroy' blocks on a confirmation prompt when run without a TTY.`,
+    );
+    return;
+  }
+
+  tree.write(CDK_COMMAND_PATH, CDK_COMMAND_TEMPLATE);
+};
+
+/** Adds the `destroy-sandbox` target, mirroring the project's `destroy`. */
+const addSandboxTarget = async (
+  tree: Tree,
+  projectName: string,
+  project: ProjectConfiguration,
+  nextSteps: string[],
+): Promise<boolean> => {
+  // The new target mirrors `destroy`, so it inherits whatever that resolved to
+  // when the project was generated: the `tsx` credential-resolving script
+  // under `stageConfig`, plain `cdk destroy` otherwise.
+  const destroy = project.targets.destroy;
+  const command = destroy?.options?.command;
+  const mainPath = joinPathFragments(project.root, 'src/main.ts');
+  const stageId = await sandboxStageId(tree, project.root);
+
+  if (typeof command !== 'string') {
+    nextSteps.push(
+      `Add a '${TARGET}' target to ${projectName} by hand if necessary — its 'destroy' target no longer matches the shape the generator produced.`,
+    );
+    return false;
+  }
+  if (!stageId) {
+    nextSteps.push(
+      `Add a '${TARGET}' target to ${projectName} by hand if necessary — no sandbox stage was found in ${mainPath}.`,
+    );
+    return false;
+  }
+
+  project.targets[TARGET] = normalizeTargetKeyOrder({
+    executor: destroy.executor,
+    ...(destroy.dependsOn ? { dependsOn: [...destroy.dependsOn] } : {}),
+    // Quoted so the shell does not glob the `*`.
+    options: { ...destroy.options, command: `${command} "${stageId}/*"` },
+  });
+  return true;
+};
+
+export default async function migration(
+  tree: Tree,
+): Promise<MigrationReturnObject> {
+  const nextSteps: string[] = [];
+
+  for (const [projectName, project] of getProjects(tree)) {
+    const generator = (project.metadata as { generator?: string } | undefined)
+      ?.generator;
+    // Not a CDK infrastructure project.
+    if (generator !== INFRA_APP_GENERATOR_INFO.id) continue;
+
+    // Corrected first so the new target inherits the fixed command.
+    let changed = migrateDestroyFlags(project);
+
+    if (!project.targets?.[TARGET]) {
+      changed =
+        (await addSandboxTarget(tree, projectName, project, nextSteps)) ||
+        changed;
+    }
+
+    if (changed) {
+      updateProjectConfiguration(tree, projectName, {
+        ...project,
+        targets: sortObjectKeys(project.targets),
+      });
+    }
+  }
+
+  migrateCdkCommandBuilder(tree, nextSteps);
+
+  await formatFilesInSubtree(tree);
+
+  return { nextSteps };
+}

--- a/packages/nx-plugin/src/utils/files/common/scripts/src/infra/stage-credentials/cdk-command.ts.template
+++ b/packages/nx-plugin/src/utils/files/common/scripts/src/infra/stage-credentials/cdk-command.ts.template
@@ -1,10 +1,10 @@
 /**
  * Builds the CDK command as an array of arguments for spawnSync.
  *
- * Runs non-interactively by default, since these commands run under nx with no
- * TTY attached: `--require-approval=never` for deploys, `--force` for destroys
- * (`cdk destroy` has no `--require-approval`). If the user passes the relevant
- * flag themselves, their choice is respected and no default is added.
+ * Deploys default to --require-approval=never (standard for local dev deploys).
+ * If the user explicitly passes --require-approval with any value, we
+ * respect their choice and don't add the default. `cdk destroy` has no
+ * --require-approval option, so nothing is added for it.
  *
  * Pass --express to opt into CloudFormation express mode for faster
  * iteration; it is not enabled by default so deploys wait for full
@@ -14,15 +14,12 @@ export function buildCdkCommand(
   action: string,
   remainingArgs: string[],
 ): string[] {
-  const has = (flag: string) =>
-    remainingArgs.some((a) => a === flag || a.startsWith(`${flag}=`));
-  const nonInteractive =
-    action === 'destroy'
-      ? has('--force') || has('-f')
-        ? []
-        : ['--force']
-      : has('--require-approval')
-        ? []
-        : ['--require-approval=never'];
-  return ['cdk', action, ...nonInteractive, ...remainingArgs];
+  const hasRequireApproval = remainingArgs.some(
+    (a) => a === '--require-approval' || a.startsWith('--require-approval='),
+  );
+  const defaults =
+    action === 'destroy' || hasRequireApproval
+      ? []
+      : ['--require-approval=never'];
+  return ['cdk', action, ...defaults, ...remainingArgs];
 }

--- a/packages/nx-plugin/src/utils/files/common/scripts/src/infra/stage-credentials/cdk-command.ts.template
+++ b/packages/nx-plugin/src/utils/files/common/scripts/src/infra/stage-credentials/cdk-command.ts.template
@@ -1,9 +1,10 @@
 /**
  * Builds the CDK command as an array of arguments for spawnSync.
  *
- * Defaults to --require-approval=never (standard for local dev deploys).
- * If the user explicitly passes --require-approval with any value, we
- * respect their choice and don't add the default.
+ * Runs non-interactively by default, since these commands run under nx with no
+ * TTY attached: `--require-approval=never` for deploys, `--force` for destroys
+ * (`cdk destroy` has no `--require-approval`). If the user passes the relevant
+ * flag themselves, their choice is respected and no default is added.
  *
  * Pass --express to opt into CloudFormation express mode for faster
  * iteration; it is not enabled by default so deploys wait for full
@@ -13,9 +14,15 @@ export function buildCdkCommand(
   action: string,
   remainingArgs: string[],
 ): string[] {
-  const hasRequireApproval = remainingArgs.some(
-    (a) => a === '--require-approval' || a.startsWith('--require-approval='),
-  );
-  const defaults = hasRequireApproval ? [] : ['--require-approval=never'];
-  return ['cdk', action, ...defaults, ...remainingArgs];
+  const has = (flag: string) =>
+    remainingArgs.some((a) => a === flag || a.startsWith(`${flag}=`));
+  const nonInteractive =
+    action === 'destroy'
+      ? has('--force') || has('-f')
+        ? []
+        : ['--force']
+      : has('--require-approval')
+        ? []
+        : ['--require-approval=never'];
+  return ['cdk', action, ...nonInteractive, ...remainingArgs];
 }

--- a/packages/nx-plugin/src/utils/infra-scripts.spec.ts
+++ b/packages/nx-plugin/src/utils/infra-scripts.spec.ts
@@ -93,32 +93,21 @@ describe('CDK command construction', () => {
     ]);
   });
 
-  // `cdk destroy` has no --require-approval; without --force it blocks on a
-  // confirmation prompt, which fails outright when nx runs it without a TTY.
-  it('should build destroy command with default --force', () => {
+  // `cdk destroy` has no --require-approval option, so it is not added.
+  it('should build destroy command without --require-approval', () => {
     expect(buildCdkCommand('destroy', ['my-app-dev/*'])).toEqual([
       'cdk',
       'destroy',
-      '--force',
       'my-app-dev/*',
     ]);
   });
 
-  it('should not repeat --force the user passed for destroy', () => {
+  it('should pass through flags the user gives destroy', () => {
     expect(buildCdkCommand('destroy', ['my-app-dev/*', '--force'])).toEqual([
       'cdk',
       'destroy',
       'my-app-dev/*',
       '--force',
-    ]);
-  });
-
-  it('should recognise the -f alias for destroy', () => {
-    expect(buildCdkCommand('destroy', ['my-app-dev/*', '-f'])).toEqual([
-      'cdk',
-      'destroy',
-      'my-app-dev/*',
-      '-f',
     ]);
   });
 

--- a/packages/nx-plugin/src/utils/infra-scripts.spec.ts
+++ b/packages/nx-plugin/src/utils/infra-scripts.spec.ts
@@ -93,13 +93,32 @@ describe('CDK command construction', () => {
     ]);
   });
 
-  it('should build destroy command with default --require-approval', () => {
+  // `cdk destroy` has no --require-approval; without --force it blocks on a
+  // confirmation prompt, which fails outright when nx runs it without a TTY.
+  it('should build destroy command with default --force', () => {
+    expect(buildCdkCommand('destroy', ['my-app-dev/*'])).toEqual([
+      'cdk',
+      'destroy',
+      '--force',
+      'my-app-dev/*',
+    ]);
+  });
+
+  it('should not repeat --force the user passed for destroy', () => {
     expect(buildCdkCommand('destroy', ['my-app-dev/*', '--force'])).toEqual([
       'cdk',
       'destroy',
-      '--require-approval=never',
       'my-app-dev/*',
       '--force',
+    ]);
+  });
+
+  it('should recognise the -f alias for destroy', () => {
+    expect(buildCdkCommand('destroy', ['my-app-dev/*', '-f'])).toEqual([
+      'cdk',
+      'destroy',
+      'my-app-dev/*',
+      '-f',
     ]);
   });
 


### PR DESCRIPTION
### Reason for this change

CDK infrastructure projects have a `deploy-sandbox` target that deploys the sandbox stage `main.ts` declares, so users don't have to remember its stage pattern. Tearing that stage back down had no equivalent — it meant `nx destroy infra "my-app-infra-sandbox/*"`.

While testing the new target, it turned out the destroy targets were passing a flag `cdk destroy` does not have. It warns and carries on:

```
Unknown option(s): --require-approval, --requireApproval. These will be ignored.
```

`--require-approval` is a deploy-only option, so it was doing nothing on `destroy`, `destroy-ci` and the new `destroy-sandbox`.

### Description of changes

**`ts#infra` generator**

- Adds a `destroy-sandbox` target mirroring `deploy-sandbox`: same `dependsOn`, and the sandbox stage pattern appended to whatever `destroy` resolved to — the `tsx` credential-resolving script under `stageConfig`, plain `cdk destroy` otherwise.
- Drops `--require-approval=never` from the destroy targets (`destroy`, `destroy-sandbox`, `destroy-ci`). CDK's confirmation prompt on an irreversible action is intended behaviour; `--force` skips it and is passed by the caller when wanted.

**Vended `buildCdkCommand`** (used by the `stageConfig` deploy/destroy scripts)

- No longer adds `--require-approval=never` for the `destroy` action. Deploys are unchanged, including respecting a `--require-approval` the user passes themselves.

**Migration** (`latest/add-destroy-sandbox-target`)

Carries existing workspaces to the same state:

- Adds `destroy-sandbox`, reading the stage id from `main.ts` rather than recomputing it from the project name, so a renamed sandbox stage gets a target that destroys the stage it actually declares.
- Strips `--require-approval` from `destroy` and `destroy-ci`, leaving any other flags the user added, and re-vends the command builder.
- Skips and reports anything that has diverged from the generated shape, and is idempotent.

**Documentation**

- `typescript-infrastructure` guide: the teardown section now covers all three destroy targets, mirroring the deploy section's structure, and notes that `--force` skips the confirmation prompt when there's no terminal attached.
- Generated `README.md`: a tear-down section matching the deploy one.
- Dungeon adventure wrap-up: uses `destroy-sandbox infra`.
- MCP `general-guidance`: mentions `destroy-sandbox` alongside `deploy-sandbox`.

### Description of how you validated changes

**Unit tests** — `destroy-sandbox` coverage added by parameterizing the existing `deploy-sandbox` describe block over both actions (stage pattern derivation across project names and subdirectories, quoting, `dependsOn`, and the `stageConfig` script path). `buildCdkCommand` cases for the destroy action and flag passthrough. New migration spec covering both halves, divergence reporting and idempotency. Full suite green: 3868 tests, 213 files. Build and lint green.

**Real AWS deployment and teardown** — generated workspaces with the locally compiled plugin, added an S3 bucket to the application stack, and ran the targets against `us-east-1` on both the default (plain `cdk`) and `stageConfig` (vended `tsx` script) configurations:

- `nx deploy-sandbox infra` → the sandbox `Application` stack reached `CREATE_COMPLETE` with the bucket created.
- `nx destroy-sandbox infra --force` → stack destroyed. Confirmed afterwards that the stack no longer exists and no buckets were left behind.

**Migration against a published workspace** — created a workspace on the published `@aws/nx-plugin` with `ts#infra --stageConfig` (exercising both the `tsx` script path and the vended command builder), then ran the migration through the real `nx migrate --run-migrations` cycle. It produced exactly what today's generator produces, the workspace built green, and a second run reported "No changes were made".

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
