### PR TITLE
fix(update-versions): hold ruff to the release its wasm bindings are built from

### DIFF
--- a/scripts/update-versions.ts
+++ b/scripts/update-versions.ts
@@ -29,6 +29,7 @@ import {
   type UvPythonEntry,
   unresolvedRuntimeWarning,
 } from '../packages/nx-plugin/src/utils/lambda-runtime-resolution';
+import { RUFF_WASM_VERSION } from '../packages/nx-plugin/src/utils/ruff';
 import { isNxPackage } from '../packages/nx-plugin/src/utils/version-upgrade-migration/nx-package-updates';
 import { registerNxPackageUpdates } from '../packages/nx-plugin/src/utils/version-upgrade-migration/register';
 import {
@@ -178,6 +179,35 @@ const getUpdatedPythonVersions = (tmpDir: string): Record<string, string> => {
 
   console.log('Updated Python versions:', updatedVersions);
   return updatedVersions;
+};
+
+/**
+ * Holds the vended `ruff` on the release `@astral-sh/ruff-wasm-nodejs` is built
+ * from, which is what actually formats generated Python.
+ *
+ * The two move on different clocks: the wasm package is an npm dependency, so
+ * `npm-check-updates` only takes it once its `cooldown` has elapsed, while
+ * `pip-check-updates` has no such delay and takes the ruff released hours
+ * earlier. Left alone the pins land a release apart and generated files fail the
+ * vended `format --check`, which `ruff.spec.ts` asserts against.
+ *
+ * The wasm build leads because it is the one already installed and running here;
+ * the held-back ruff is taken next run, once the bindings catch up.
+ */
+const holdRuffToWasmBuild = (
+  updatedVersions: Record<string, string>,
+): ReportNote[] => {
+  const proposed = updatedVersions.ruff;
+  const wasmPin = `==${RUFF_WASM_VERSION}`;
+  if (!proposed || proposed === wasmPin) {
+    return [];
+  }
+  updatedVersions.ruff = wasmPin;
+  return [
+    {
+      note: `ruff held at ${wasmPin} (${proposed} available): @astral-sh/ruff-wasm-nodejs is still on ${RUFF_WASM_VERSION}, and the two must match`,
+    },
+  ];
 };
 
 /**
@@ -575,14 +605,18 @@ const main = async () => {
     // Get updated Python versions
     const updatedPyVersions = getUpdatedPythonVersions(tmpDir);
 
+    // Applied before the rewrite so the held version is never written
+    const ruffHold = holdRuffToWasmBuild(updatedPyVersions);
+
     // Apply updated Python versions to the versions file
-    const pyChanges = await applyUpdatedVersions(
+    const pyChanges: ReportChange[] = await applyUpdatedVersions(
       tree,
       PY_VERSIONS,
       updatedPyVersions,
       'packages/nx-plugin/src/utils/versions.ts',
       'PY_VERSIONS',
     );
+    pyChanges.push(...ruffHold);
 
     // Get updated Terraform provider versions
     const updatedTerraformVersions = await getUpdatedTerraformVersions();


### PR DESCRIPTION
### Reason for this change

The weekly Update Versions run ([33149664551](https://github.com/awslabs/nx-plugin-for-aws/actions/runs/33149664551)) failed before it could raise a PR:

```
FAIL src/utils/ruff.spec.ts > ruff wasm version > should match the ruff pinned for generated projects
AssertionError: expected '==0.16.4' to be '==0.16.5'
```

`ruff.spec.ts` requires `PY_VERSIONS.ruff` to match the ruff that `@astral-sh/ruff-wasm-nodejs` is built from. Generated Python is formatted at generation time by the wasm bindings, but checked by the vended `format` target running the `PY_VERSIONS` ruff, so a drift between the two makes generated files fail `ruff format --check` on any formatting change.

The two pins move on different clocks, so the weekly run could only align them by luck:

- `@astral-sh/ruff-wasm-nodejs` is an npm dependency, so `npm-check-updates` only takes it once `.ncurc.cjs`'s `cooldown: 1` has elapsed.
- `ruff` is a Python dependency, and `pip-check-updates` has no such delay.

ruff 0.16.5 published ~14 hours before the run started, so ruff moved to `==0.16.5` while the bindings stayed on 0.16.4. Every release lands in that window, so this recurs whenever ruff ships within a day of the Monday run.

### Description of changes

Clamp the proposed `ruff` to the release the installed wasm bindings report, applied before the rewrite so the mismatched version is never written to `versions.ts`.

The wasm build leads rather than the other way around because it is the copy already installed and running in the script — `RUFF_WASM_VERSION` is `Workspace.version()` from the module itself, so it cannot be moved by rewriting a pin mid-run. The held ruff is taken on a later run, once `npm-check-updates` brings the bindings forward and both move together.

The hold is reported in the PR body via the existing `ReportNote` channel, so a pin deliberately sitting a release behind is visible rather than looking up to date:

```
Python Dependencies
- ...
- ruff held at ==0.16.4 (==0.16.5 available): @astral-sh/ruff-wasm-nodejs is still on 0.16.4, and the two must match
```

### Description of how you validated changes

- Ran `pnpm exec tsx ./scripts/update-versions.ts --dry-run` against the exact versions that broke the run. `ruff` was held at `==0.16.4` with the note above, while the other Python bumps (`boto3`, `checkov`, `langchain`, `strands-agents`, `ty`, ...) were proposed as normal — the hold is scoped to `ruff`.
- Confirmed the dry run leaves `versions.ts` untouched (`git status` showed only the script change).
- Ran `src/utils/ruff.spec.ts` — 23 tests pass, including the guard this fixes.
- `pnpm lint` passes.

### Issue # (if applicable)

N/A — the failing workflow run is linked above.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*