### PR TITLE
test(nx-plugin-e2e): run the standalone smoke tests on macos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,6 +214,40 @@ jobs:
         env:
           NX_E2E_SHARD: ${{ matrix.shard }}/6
         run: pnpm nx run @aws/nx-plugin-e2e:smoke-test --name=standalone
+  # Runs on GitHub's hosted macOS runners. NX_E2E_NO_DOCKER skips the cases whose
+  # build packages a container image, since those images ship no Docker daemon;
+  # they stay covered on the Linux standalone leg.
+  smoke_tests_macos_standalone:
+    name: macOS Smoke Tests - standalone (${{matrix.shard}}/6)
+    runs-on: macos-latest
+    needs: package
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4, 5, 6]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+      - name: Download build artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: build-artifact
+          path: dist
+      - uses: ./.github/actions/init-monorepo
+        with:
+          container-tools: 'false'
+          setup-bun: 'false'
+          uv-cache-suffix: ${{ matrix.shard }}
+      - name: macOS Smoke Test - standalone (shard ${{ matrix.shard }}/6)
+        env:
+          NX_E2E_SHARD: ${{ matrix.shard }}/6
+          NX_E2E_NO_DOCKER: 'true'
+          # The image ships a Homebrew CPython, which uv would use to satisfy an
+          # interpreter it cannot download. That masks a version a developer on a
+          # clean machine cannot install, so only uv-managed interpreters count.
+          UV_MANAGED_PYTHON: '1'
+        run: pnpm nx run @aws/nx-plugin-e2e:smoke-test --name=standalone
   smoke_tests_windows:
     name: Windows Smoke Tests - ${{matrix.smoke_test}}
     runs-on: windows-latest
@@ -299,6 +333,7 @@ jobs:
         smoke_tests,
         smoke_tests_migrate,
         smoke_tests_standalone,
+        smoke_tests_macos_standalone,
         smoke_tests_windows,
         smoke_tests_windows_standalone,
       ]

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -200,6 +200,40 @@ jobs:
         env:
           NX_E2E_SHARD: ${{ matrix.shard }}/6
         run: pnpm nx run @aws/nx-plugin-e2e:smoke-test --name=standalone
+  # Runs on GitHub's hosted macOS runners. NX_E2E_NO_DOCKER skips the cases whose
+  # build packages a container image, since those images ship no Docker daemon;
+  # they stay covered on the Linux standalone leg.
+  smoke_tests_macos_standalone:
+    name: macOS Smoke Tests - standalone (${{matrix.shard}}/6)
+    runs-on: macos-latest
+    needs: package
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4, 5, 6]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+      - name: Download build artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: build-artifact
+          path: dist
+      - uses: ./.github/actions/init-monorepo
+        with:
+          container-tools: 'false'
+          setup-bun: 'false'
+          uv-cache-suffix: ${{ matrix.shard }}
+      - name: macOS Smoke Test - standalone (shard ${{ matrix.shard }}/6)
+        env:
+          NX_E2E_SHARD: ${{ matrix.shard }}/6
+          NX_E2E_NO_DOCKER: 'true'
+          # The image ships a Homebrew CPython, which uv would use to satisfy an
+          # interpreter it cannot download. That masks a version a developer on a
+          # clean machine cannot install, so only uv-managed interpreters count.
+          UV_MANAGED_PYTHON: '1'
+        run: pnpm nx run @aws/nx-plugin-e2e:smoke-test --name=standalone
   smoke_tests_windows:
     name: Windows Smoke Tests - ${{matrix.smoke_test}}
     runs-on: windows-latest

--- a/e2e/src/smoke-tests/standalone.spec.ts
+++ b/e2e/src/smoke-tests/standalone.spec.ts
@@ -82,36 +82,35 @@ const categorizeGenerators = () => {
 
 const { standalone, components } = categorizeGenerators();
 
-// The CodeBuild Windows runner lacks Docker (agents, MCP servers and rdb build a
-// Docker image) and can't run checkov (ts#infra and terraform#project). These stay
-// covered on the Linux standalone leg and the windows-latest dungeon-adventure
-// test.
+// Generators whose build packages a Docker image, so a runner without a daemon
+// cannot exercise them. They stay covered on the Linux standalone leg.
 //
 // Smithy is not among them: it builds with the Smithy CLI rather than a container,
 // which the runner installs (see .github/actions/init-monorepo).
-const CODEBUILD_WINDOWS = process.env.NX_E2E_CODEBUILD_WINDOWS === 'true';
-
-const CODEBUILD_WINDOWS_UNSUPPORTED = new Set([
+const DOCKER_DEPENDENT = [
   'ts#agent',
   'py#agent',
   'ts#mcp-server',
   'py#mcp-server',
   'ts#rdb',
   'py#rdb',
-  'ts#infra',
-  'terraform#project',
-]);
+];
+
+// The CodeBuild Windows runner lacks Docker and additionally can't run checkov
+// (ts#infra and terraform#project). The GitHub macOS runner lacks only Docker.
+const CODEBUILD_WINDOWS = process.env.NX_E2E_CODEBUILD_WINDOWS === 'true';
+const NO_DOCKER = process.env.NX_E2E_NO_DOCKER === 'true';
+
+const UNSUPPORTED_GENERATORS = new Set(
+  CODEBUILD_WINDOWS
+    ? [...DOCKER_DEPENDENT, 'ts#infra', 'terraform#project']
+    : DOCKER_DEPENDENT,
+);
 
 // A connection is unsupported when either endpoint's project is. Matched exactly
-// against each side of the key.
-const CONNECTION_UNSUPPORTED_ENDPOINTS = new Set([
-  'ts#agent',
-  'py#agent',
-  'ts#mcp-server',
-  'py#mcp-server',
-  'ts#rdb',
-  'py#rdb',
-]);
+// against each side of the key. Only the Docker-dependent endpoints matter here —
+// checkov runs on an infrastructure project, which is not a connection endpoint.
+const CONNECTION_UNSUPPORTED_ENDPOINTS = new Set(DOCKER_DEPENDENT);
 
 // Connections whose factories build an unsupported project the key doesn't
 // name (the website -> gateway case attaches a ts#agent to the gateway).
@@ -129,11 +128,11 @@ const connectionUnsupported = (key: string): boolean =>
 const keepForRunner = <T extends { generator?: string; unsupported?: boolean }>(
   cases: T[],
 ): T[] =>
-  CODEBUILD_WINDOWS
+  CODEBUILD_WINDOWS || NO_DOCKER
     ? cases.filter(
         (c) =>
           !c.unsupported &&
-          !(c.generator && CODEBUILD_WINDOWS_UNSUPPORTED.has(c.generator)),
+          !(c.generator && UNSUPPORTED_GENERATORS.has(c.generator)),
       )
     : cases;
 


### PR DESCRIPTION
### Reason for this change

No CI leg ran on macOS, which is the platform users are most likely to develop on. Generated projects resolve platform-specific artefacts — CPython builds, wheels, prebuilt binaries — so a workspace that generates and builds cleanly on Linux can still fail there, and nothing caught it before a user did.

That is not hypothetical. The vended `.python-version` pinned an exact CPython patch (`3.14.7`), which failed on macOS while passing on every Linux and Windows leg:

```
$ uv sync
error: No interpreter found for Python 3.14.7 in managed installations or search path
$ uv python install 3.14.7
error: No download found for request: cpython-3.14.7-macos-aarch64-none
```

#1146 fixed the pin. This adds the coverage that would have caught it.

### Description of changes

Adds `smoke_tests_macos_standalone` to both `ci.yml` and `pr.yml`: the standalone smoke test sharded across six `macos-latest` runners, the same shape as the CodeBuild Windows leg. The standalone suite generates and builds every generator in isolation, so one sharded leg covers the whole surface.

**`NX_E2E_NO_DOCKER` reuses the exclusion the Windows runner already applies.** GitHub's macOS images ship no Docker daemon, and without this the leg failed 13 tasks, all `*-docker`, all `/bin/sh: docker: command not found`.

Applying the Windows set verbatim would have over-excluded, because it conflated two unrelated limitations. It is now split:

| Runner | Docker-dependent cases | `ts#infra` / `terraform#project` |
|---|---|---|
| Linux | run | run |
| **macOS** | **skipped** | **run** — checkov works here |
| CodeBuild Windows | skipped | skipped — no checkov |

`CONNECTION_UNSUPPORTED_ENDPOINTS` now derives from the same `DOCKER_DEPENDENT` list rather than repeating it. The two literals were already identical, so Windows behaviour is unchanged.

**`UV_MANAGED_PYTHON` restricts uv to interpreters it manages itself.** The macOS image ships a Homebrew CPython that uv will happily use to satisfy a version it cannot download — which would pass in CI while failing on a developer's clean machine. This is what keeps the leg honest about interpreter pins.

### Description of how you validated changes

**All 6 macOS shards pass**, and the run is green apart from an unrelated in-flight `rdb` leg (63/64 at the time of writing). The Docker exclusion resolved every previously failing task, and no interpreter error remains.

**`UV_MANAGED_PYTHON` was verified to do what it claims** rather than assumed. With `.python-version` naming a version present only as a system interpreter:

```
default:               Using CPython 3.11.2 at /usr/bin/python3.11    ← passes
UV_MANAGED_PYTHON=1:   error: No interpreter found for Python 3.11.2
                              in managed installations                 ← fails
```

And the guard fires on an unavailable version, so the leg is not vacuously green:

```
.python-version=3.14.99, UV_MANAGED_PYTHON=1, UV_PYTHON_DOWNLOADS=never
→ error: No interpreter found for Python 3.14.99 in managed installations
```

uv is also strict about patches — `3.14.99` errors even with `3.14.7` and `3.14.0` installed, so a pin is matched exactly with no fallback.

### The original failure is no longer reproducible, and the reason matters

This leg passes on the `3.14.7` pin today. That is not the exclusions hiding it — the cause was **a temporary per-platform lag in uv's interpreter index**, not a permanently missing macOS build:

| uv version | max `3.14.x` on `macos-aarch64` |
|---|---|
| 0.9.5 | 3.14.0 |
| 0.11.0 | 3.14.3 |
| **0.12.0** | **3.14.6** ← the failure above |
| 0.12.2 | 3.14.7 — lag closed |
| 0.12.7 (on the runner) | 3.14.7 |

uv 0.12.0 knew `3.14.7` on Linux but only `3.14.6` on macOS and Windows. That asymmetry is exactly what made an exact pin resolve on one platform and fail on another. As of 0.12.7 there is **zero lag across every minor from 3.8 to 3.14**, and CI pins `version: 'latest'`.

So this leg cannot demonstrate the historical bug — but the lag is recurring by nature, since each new CPython patch reaches Linux first. Pinning `major.minor` (#1146) means a workspace is never exposed to that window, and `UV_MANAGED_PYTHON` here means the next occurrence fails this leg while Linux stays green, instead of reaching a user first.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
