### PR TITLE
fix(ci): treat perf and revert commits as a patch bump

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -108,7 +108,11 @@
       }
     },
     "conventionalCommits": {
-      "useCommitScope": false
+      "useCommitScope": false,
+      "types": {
+        "perf": { "semverBump": "patch" },
+        "revert": { "semverBump": "patch" }
+      }
     }
   }
 }


### PR DESCRIPTION
### Reason for this change

The release on `main` failed for [perf(init): raise default Nx task parallelism to 8 (#1152)](https://github.com/awslabs/nx-plugin-for-aws/actions/runs/33276806342) with an empty `npm dist-tag add error:`, and would fail again on any similar push. Two lists disagreed:

- The release gate in `ci.yml` releases when a commit since the last tag matches `feat|fix|revert|perf`.
- nx's `DEFAULT_CONVENTIONAL_COMMITS_CONFIG` maps **`perf` and `revert` to `semverBump: 'none'`** (only `feat` → minor and `fix` → patch bump).

Since `v1.0.0-rc.88` the only commits were `perf`, `docs` and `test` — all `none` to nx. So the gate opened the door on a commit nx then refused to version:

```
@aws/nx-plugin 🚫 No changes were detected using git history and the conventional commits standard
NX  No files changed as a result of running versioning
```

Because versioning was a no-op, `dist/packages/*/package.json` kept its placeholder `0.0.0`, and the publish step went on to use it. `nx release publish` run standalone passes no `nxReleaseVersionData`, so the executor's *"Skipped, because no new version was resolved"* guard never fired. It read `0.0.0` off disk, saw `latest` (`1.0.0-rc.88`) didn't match, saw `0.0.0` **is** a real published version, and ran `npm dist-tag add @aws/nx-plugin@0.0.0 latest`. That got an E401 (OIDC trusted publishing issues no token for `dist-tag add`), printing a bare error because nx parses only `err.stdout` while npm wrote to stderr. The retries were futile — the failure is deterministic, not transient.

Worth recording: the E401 was *protecting* us. Reproduced locally against Verdaccio with auth, the command succeeds and repoints `latest` to `0.0.0` — which would break every `npm install @aws/nx-plugin` and `create @aws/nx-workspace`. The visible failure was the lucky outcome.

### Description of changes

Map `perf` and `revert` to a patch bump in `nx.json`, so nx versions what CI has already decided to release. `perf` work and reverts are user-facing changes to the vended code, so shipping them as a patch is the intent the gate already encodes.

```json
"conventionalCommits": {
  "useCommitScope": false,
  "types": {
    "perf": { "semverBump": "patch" },
    "revert": { "semverBump": "patch" }
  }
}
```

The gate regex in `ci.yml` is unchanged — it already lists exactly `feat|fix|revert|perf`, which now matches nx's config precisely.

One intentional side effect: nx's `normalizeConventionalCommitsConfig` forces `hidden: false` for any type explicitly configured, so `revert` commits will now appear in the changelog (`⏪ Revert`) where they were previously hidden. `perf` was already visible. A revert that ships a release should be listed, so this is the behaviour we want. Default changelog titles are preserved for both, and no other commit type changes.

### Description of how you validated changes

Verified against the exact commit that broke the release (`6c8d4df8`, where the only commits since `v1.0.0-rc.88` are `perf`, `docs`, `test`):

**Effective config** resolved through nx's own `createNxReleaseConfig` — `perf`/`revert` now patch, defaults preserved, other types untouched:

```
feat     bump=minor  hidden=false title=🚀 Features
fix      bump=patch  hidden=false title=🩹 Fixes
perf     bump=patch  hidden=false title=🔥 Performance
revert   bump=patch  hidden=false title=⏪ Revert
docs     bump=none   hidden=true  title=📖 Documentation
chore    bump=none   hidden=true  title=🏡 Chore
test     bump=none   hidden=true  title=✅ Tests
```

**Before** — `nx release version --preid rc --dry-run`:

```
@aws/nx-plugin 🚫 No changes were detected using git history and the conventional commits standard
```

**After** — resolves the bump and writes it to all three dist manifests, replacing the `0.0.0` placeholder that caused the failure:

```
UPDATE dist/packages/nx-plugin/package.json [dry-run]
-   "version": "0.0.0",
+   "version": "1.0.0-rc.89",
```

Also reproduced the original failure end to end against a local Verdaccio seeded to mirror npm's real state (`0.0.0` present, `latest` → `1.0.0-rc.88`): confirmed nx's `npm view` step returns `0.0.0 in versions? True` so the skip is bypassed, the no-auth `dist-tag add` fails with E401 matching CI's empty error, and the with-auth run repoints `latest` to `0.0.0`. Registry state was restored and the test environment torn down.

`prettier --check nx.json` passes and `nx show projects` confirms nx accepts the config. No source files or tests reference the release config, so this is config-only.

### Follow-up (not in this PR)

This fixes the trigger, but `scripts/release.ts` can still publish a `0.0.0` manifest and clobber `latest` for any *other* reason versioning no-ops. Worth having it compare `distVersion()` against `currentTag()` after the version step and exit early when unchanged, so the guard doesn't depend on a regex in the workflow staying in sync with nx's rules. Happy to raise that separately.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*