### PR TITLE
fix(ts#project): write vitest coverage outside the project directory

### DIFF
--- a/docs/src/content/docs/en/guides/typescript-project.mdx
+++ b/docs/src/content/docs/en/guides/typescript-project.mdx
@@ -385,7 +385,7 @@ Pass Vitest's `--coverage` flag after a `--` separator to collect coverage:
 
 <NxCommands commands={['test <project-name> -- --coverage']} />
 
-Reports are written to `dist/<project-root>/test-output/vitest/coverage`, with the HTML report at `index.html`. Coverage output lives under `dist` rather than inside your project so it is not linted, formatted or treated as an input to your project's tasks.
+Reports are written to `dist/<project-root>/test-output/vitest/coverage`, with the HTML report at `index.html`.
 
 ## Linting
 

--- a/docs/src/content/docs/en/guides/typescript-project.mdx
+++ b/docs/src/content/docs/en/guides/typescript-project.mdx
@@ -379,6 +379,14 @@ You can run an individual test or suite of tests using Vitest's `-t` flag. Pass 
 If you are a VSCode user, we recommend installing the [Vitest Runner for VSCode that actually works](https://marketplace.visualstudio.com/items?itemName=rluvaton.vscode-vitest) extension, which allows you to run, watch or debug tests from your IDE.
 :::
 
+### Test Coverage
+
+Pass Vitest's `--coverage` flag after a `--` separator to collect coverage:
+
+<NxCommands commands={['test <project-name> -- --coverage']} />
+
+Reports are written to `dist/<project-root>/test-output/vitest/coverage`, with the HTML report at `index.html`. Coverage output lives under `dist` rather than inside your project so it is not linted, formatted or treated as an input to your project's tasks.
+
 ## Linting
 
 TypeScript projects use [Biome](https://biomejs.dev/) for linting and formatting. Biome is configured in the workspace root `biome.json` file — changes to this apply to all TypeScript projects in your workspace and ensure consistency.

--- a/docs/src/content/docs/es/guides/typescript-project.mdx
+++ b/docs/src/content/docs/es/guides/typescript-project.mdx
@@ -379,6 +379,14 @@ Puedes ejecutar una prueba individual o un conjunto de pruebas usando la bandera
 Si eres usuario de VSCode, recomendamos instalar la extensión [Vitest Runner for VSCode that actually works](https://marketplace.visualstudio.com/items?itemName=rluvaton.vscode-vitest), que te permite ejecutar, observar o depurar pruebas desde tu IDE.
 :::
 
+### Cobertura de Pruebas
+
+Pasa la bandera `--coverage` de Vitest después de un separador `--` para recopilar cobertura:
+
+<NxCommands commands={['test <project-name> -- --coverage']} />
+
+Los informes se escriben en `dist/<project-root>/test-output/vitest/coverage`, con el informe HTML en `index.html`. La salida de cobertura se encuentra bajo `dist` en lugar de dentro de tu proyecto para que no se aplique lint, no se formatee ni se trate como una entrada para las tareas de tu proyecto.
+
 ## Linting
 
 Los proyectos TypeScript usan [Biome](https://biomejs.dev/) para linting y formateo. Biome está configurado en el archivo `biome.json` de la raíz del workspace — los cambios a este se aplican a todos los proyectos TypeScript en tu workspace y aseguran consistencia.

--- a/docs/src/content/docs/es/guides/typescript-project.mdx
+++ b/docs/src/content/docs/es/guides/typescript-project.mdx
@@ -385,7 +385,7 @@ Pasa la bandera `--coverage` de Vitest después de un separador `--` para recopi
 
 <NxCommands commands={['test <project-name> -- --coverage']} />
 
-Los informes se escriben en `dist/<project-root>/test-output/vitest/coverage`, con el informe HTML en `index.html`. La salida de cobertura se encuentra bajo `dist` en lugar de dentro de tu proyecto para que no se aplique lint, no se formatee ni se trate como una entrada para las tareas de tu proyecto.
+Los informes se escriben en `dist/<project-root>/test-output/vitest/coverage`, con el informe HTML en `index.html`.
 
 ## Linting
 

--- a/docs/src/content/docs/fr/guides/typescript-project.mdx
+++ b/docs/src/content/docs/fr/guides/typescript-project.mdx
@@ -379,6 +379,14 @@ Vous pouvez exécuter un test individuel ou une suite de tests en utilisant le f
 Si vous êtes un utilisateur de VSCode, nous recommandons d'installer l'extension [Vitest Runner for VSCode that actually works](https://marketplace.visualstudio.com/items?itemName=rluvaton.vscode-vitest), qui vous permet d'exécuter, surveiller ou déboguer des tests depuis votre IDE.
 :::
 
+### Couverture de tests
+
+Passez le flag `--coverage` de Vitest après un séparateur `--` pour collecter la couverture :
+
+<NxCommands commands={['test <project-name> -- --coverage']} />
+
+Les rapports sont écrits dans `dist/<project-root>/test-output/vitest/coverage`, avec le rapport HTML dans `index.html`. La sortie de couverture se trouve sous `dist` plutôt qu'à l'intérieur de votre projet afin qu'elle ne soit pas lintée, formatée ou traitée comme une entrée pour les tâches de votre projet.
+
 ## Linting
 
 Les projets TypeScript utilisent [Biome](https://biomejs.dev/) pour le linting et le formatage. Biome est configuré dans le fichier `biome.json` à la racine de l'espace de travail — les modifications apportées à celui-ci s'appliquent à tous les projets TypeScript de votre espace de travail et garantissent la cohérence.

--- a/docs/src/content/docs/fr/guides/typescript-project.mdx
+++ b/docs/src/content/docs/fr/guides/typescript-project.mdx
@@ -385,7 +385,7 @@ Passez le flag `--coverage` de Vitest après un séparateur `--` pour collecter 
 
 <NxCommands commands={['test <project-name> -- --coverage']} />
 
-Les rapports sont écrits dans `dist/<project-root>/test-output/vitest/coverage`, avec le rapport HTML dans `index.html`. La sortie de couverture se trouve sous `dist` plutôt qu'à l'intérieur de votre projet afin qu'elle ne soit pas lintée, formatée ou traitée comme une entrée pour les tâches de votre projet.
+Les rapports sont écrits dans `dist/<project-root>/test-output/vitest/coverage`, avec le rapport HTML dans `index.html`.
 
 ## Linting
 

--- a/docs/src/content/docs/it/guides/typescript-project.mdx
+++ b/docs/src/content/docs/it/guides/typescript-project.mdx
@@ -385,7 +385,7 @@ Passa il flag `--coverage` di Vitest dopo un separatore `--` per raccogliere la 
 
 <NxCommands commands={['test <project-name> -- --coverage']} />
 
-I report vengono scritti in `dist/<project-root>/test-output/vitest/coverage`, con il report HTML in `index.html`. L'output della copertura si trova sotto `dist` invece che all'interno del tuo progetto in modo che non venga sottoposto a lint, formattato o trattato come input per le attività del tuo progetto.
+I report vengono scritti in `dist/<project-root>/test-output/vitest/coverage`, con il report HTML in `index.html`.
 
 ## Linting
 

--- a/docs/src/content/docs/it/guides/typescript-project.mdx
+++ b/docs/src/content/docs/it/guides/typescript-project.mdx
@@ -379,6 +379,14 @@ Puoi eseguire un singolo test o una suite di test usando il flag `-t` di Vitest.
 Se sei un utente VSCode, raccomandiamo di installare l'estensione [Vitest Runner for VSCode that actually works](https://marketplace.visualstudio.com/items?itemName=rluvaton.vscode-vitest), che ti consente di eseguire, osservare o debuggare i test dal tuo IDE.
 :::
 
+### Copertura dei Test
+
+Passa il flag `--coverage` di Vitest dopo un separatore `--` per raccogliere la copertura:
+
+<NxCommands commands={['test <project-name> -- --coverage']} />
+
+I report vengono scritti in `dist/<project-root>/test-output/vitest/coverage`, con il report HTML in `index.html`. L'output della copertura si trova sotto `dist` invece che all'interno del tuo progetto in modo che non venga sottoposto a lint, formattato o trattato come input per le attività del tuo progetto.
+
 ## Linting
 
 I progetti TypeScript usano [Biome](https://biomejs.dev/) per il linting e la formattazione. Biome è configurato nel file `biome.json` della radice del workspace — le modifiche a questo si applicano a tutti i progetti TypeScript nel tuo workspace e garantiscono coerenza.

--- a/docs/src/content/docs/jp/guides/typescript-project.mdx
+++ b/docs/src/content/docs/jp/guides/typescript-project.mdx
@@ -385,7 +385,7 @@ Vitest の `--coverage` フラグを `--` セパレーターの後に渡して�
 
 <NxCommands commands={['test <project-name> -- --coverage']} />
 
-レポートは `dist/<project-root>/test-output/vitest/coverage` に書き込まれ、HTML レポートは `index.html` にあります。カバレッジ出力は、プロジェクト内ではなく `dist` の下に配置されるため、リント、フォーマット、またはプロジェクトのタスクへの入力として扱われません。
+レポートは `dist/<project-root>/test-output/vitest/coverage` に書き込まれ、HTML レポートは `index.html` にあります。
 
 ## リント
 

--- a/docs/src/content/docs/jp/guides/typescript-project.mdx
+++ b/docs/src/content/docs/jp/guides/typescript-project.mdx
@@ -379,6 +379,14 @@ Vitest の `-t` フラグを使用して、個々のテストまたはテスト�
 VSCode ユーザーの場合は、[Vitest Runner for VSCode that actually works](https://marketplace.visualstudio.com/items?itemName=rluvaton.vscode-vitest) 拡張機能をインストールすることをお勧めします。これにより、IDE からテストを実行、監視、デバッグできます。
 :::
 
+### テストカバレッジ
+
+Vitest の `--coverage` フラグを `--` セパレーターの後に渡してカバレッジを収集します：
+
+<NxCommands commands={['test <project-name> -- --coverage']} />
+
+レポートは `dist/<project-root>/test-output/vitest/coverage` に書き込まれ、HTML レポートは `index.html` にあります。カバレッジ出力は、プロジェクト内ではなく `dist` の下に配置されるため、リント、フォーマット、またはプロジェクトのタスクへの入力として扱われません。
+
 ## リント
 
 TypeScript プロジェクトは、リントとフォーマットに [Biome](https://biomejs.dev/) を使用します。Biome はワークスペースルートの `biome.json` ファイルで設定されます — これに対する変更は、ワークスペース内のすべての TypeScript プロジェクトに適用され、一貫性を確保します。

--- a/docs/src/content/docs/ko/guides/typescript-project.mdx
+++ b/docs/src/content/docs/ko/guides/typescript-project.mdx
@@ -379,6 +379,14 @@ Vitest의 `-t` 플래그를 사용하여 개별 테스트 또는 테스트 스�
 VSCode 사용자인 경우 [Vitest Runner for VSCode that actually works](https://marketplace.visualstudio.com/items?itemName=rluvaton.vscode-vitest) 확장 프로그램을 설치하는 것이 좋습니다. 이를 통해 IDE에서 테스트를 실행, 감시 또는 디버그할 수 있습니다.
 :::
 
+### 테스트 커버리지
+
+커버리지를 수집하려면 `--` 구분 기호 뒤에 Vitest의 `--coverage` 플래그를 전달하세요:
+
+<NxCommands commands={['test <project-name> -- --coverage']} />
+
+보고서는 `dist/<project-root>/test-output/vitest/coverage`에 작성되며, HTML 보고서는 `index.html`에 있습니다. 커버리지 출력은 프로젝트 내부가 아닌 `dist` 아래에 위치하므로 린트, 포맷 또는 프로젝트 작업의 입력으로 처리되지 않습니다.
+
 ## 린팅
 
 TypeScript 프로젝트는 린팅 및 포매팅을 위해 [Biome](https://biomejs.dev/)를 사용합니다. Biome는 워크스페이스 루트 `biome.json` 파일에 구성되어 있으며 — 이에 대한 변경 사항은 워크스페이스의 모든 TypeScript 프로젝트에 적용되고 일관성을 보장합니다.

--- a/docs/src/content/docs/ko/guides/typescript-project.mdx
+++ b/docs/src/content/docs/ko/guides/typescript-project.mdx
@@ -385,7 +385,7 @@ VSCode 사용자인 경우 [Vitest Runner for VSCode that actually works](https:
 
 <NxCommands commands={['test <project-name> -- --coverage']} />
 
-보고서는 `dist/<project-root>/test-output/vitest/coverage`에 작성되며, HTML 보고서는 `index.html`에 있습니다. 커버리지 출력은 프로젝트 내부가 아닌 `dist` 아래에 위치하므로 린트, 포맷 또는 프로젝트 작업의 입력으로 처리되지 않습니다.
+보고서는 `dist/<project-root>/test-output/vitest/coverage`에 작성되며, HTML 보고서는 `index.html`에 있습니다.
 
 ## 린팅
 

--- a/docs/src/content/docs/pt/guides/typescript-project.mdx
+++ b/docs/src/content/docs/pt/guides/typescript-project.mdx
@@ -379,6 +379,14 @@ Você pode executar um teste individual ou conjunto de testes usando a flag `-t`
 Se você é um usuário do VSCode, recomendamos instalar a extensão [Vitest Runner for VSCode that actually works](https://marketplace.visualstudio.com/items?itemName=rluvaton.vscode-vitest), que permite executar, observar ou depurar testes do seu IDE.
 :::
 
+### Cobertura de Testes
+
+Passe a flag `--coverage` do Vitest após um separador `--` para coletar cobertura:
+
+<NxCommands commands={['test <project-name> -- --coverage']} />
+
+Os relatórios são escritos em `dist/<project-root>/test-output/vitest/coverage`, com o relatório HTML em `index.html`. A saída de cobertura fica em `dist` em vez de dentro do seu projeto para que não seja lintada, formatada ou tratada como uma entrada para as tarefas do seu projeto.
+
 ## Linting
 
 Os projetos TypeScript usam [Biome](https://biomejs.dev/) para linting e formatação. O Biome é configurado no arquivo `biome.json` da raiz do workspace — alterações nele se aplicam a todos os projetos TypeScript no seu workspace e garantem consistência.

--- a/docs/src/content/docs/pt/guides/typescript-project.mdx
+++ b/docs/src/content/docs/pt/guides/typescript-project.mdx
@@ -385,7 +385,7 @@ Passe a flag `--coverage` do Vitest após um separador `--` para coletar cobertu
 
 <NxCommands commands={['test <project-name> -- --coverage']} />
 
-Os relatórios são escritos em `dist/<project-root>/test-output/vitest/coverage`, com o relatório HTML em `index.html`. A saída de cobertura fica em `dist` em vez de dentro do seu projeto para que não seja lintada, formatada ou tratada como uma entrada para as tarefas do seu projeto.
+Os relatórios são escritos em `dist/<project-root>/test-output/vitest/coverage`, com o relatório HTML em `index.html`.
 
 ## Linting
 

--- a/docs/src/content/docs/vi/guides/typescript-project.mdx
+++ b/docs/src/content/docs/vi/guides/typescript-project.mdx
@@ -379,6 +379,14 @@ Bạn có thể chạy một bài kiểm thử riêng lẻ hoặc một bộ ki�
 Nếu bạn là người dùng VSCode, chúng tôi khuyên bạn nên cài đặt extension [Vitest Runner for VSCode that actually works](https://marketplace.visualstudio.com/items?itemName=rluvaton.vscode-vitest), cho phép bạn chạy, theo dõi hoặc debug các bài kiểm thử từ IDE của mình.
 :::
 
+### Độ bao phủ kiểm thử
+
+Truyền cờ `--coverage` của Vitest sau dấu phân cách `--` để thu thập độ bao phủ:
+
+<NxCommands commands={['test <project-name> -- --coverage']} />
+
+Các báo cáo được ghi vào `dist/<project-root>/test-output/vitest/coverage`, với báo cáo HTML tại `index.html`. Kết quả độ bao phủ nằm dưới `dist` thay vì bên trong dự án của bạn để nó không bị lint, format hoặc được coi là đầu vào cho các tác vụ của dự án bạn.
+
 ## Linting
 
 Các dự án TypeScript sử dụng [Biome](https://biomejs.dev/) để lint và format. Biome được cấu hình trong tệp `biome.json` ở thư mục gốc workspace — các thay đổi đối với tệp này áp dụng cho tất cả các dự án TypeScript trong workspace của bạn và đảm bảo tính nhất quán.

--- a/docs/src/content/docs/vi/guides/typescript-project.mdx
+++ b/docs/src/content/docs/vi/guides/typescript-project.mdx
@@ -385,7 +385,7 @@ Truyền cờ `--coverage` của Vitest sau dấu phân cách `--` để thu th�
 
 <NxCommands commands={['test <project-name> -- --coverage']} />
 
-Các báo cáo được ghi vào `dist/<project-root>/test-output/vitest/coverage`, với báo cáo HTML tại `index.html`. Kết quả độ bao phủ nằm dưới `dist` thay vì bên trong dự án của bạn để nó không bị lint, format hoặc được coi là đầu vào cho các tác vụ của dự án bạn.
+Các báo cáo được ghi vào `dist/<project-root>/test-output/vitest/coverage`, với báo cáo HTML tại `index.html`.
 
 ## Linting
 

--- a/docs/src/content/docs/zh/guides/typescript-project.mdx
+++ b/docs/src/content/docs/zh/guides/typescript-project.mdx
@@ -303,7 +303,7 @@ export default defineConfig([
 :::
 
 :::tip[Lambda 函数]
-如果您正在构建 AWS Lambda 函数，请查看 <Link path="/guides/ts-lambda-function">`ts#lambda-function`</Link> 生成器，因为它会为您配置打包，并生成基础设施并添加可观测性和类型安全性。
+如果您正在构建 AWS Lambda 函数，请查看 <Link path="/zh/guides/ts-lambda-function">`ts#lambda-function`</Link> 生成器，因为它会为您配置打包，并生成基础设施并添加可观测性和类型安全性。
 :::
 
 ### 安装
@@ -378,6 +378,14 @@ describe('sayHello', () => {
 :::tip[VSCode 集成]
 如果您是 VSCode 用户，我们建议安装 [Vitest Runner for VSCode that actually works](https://marketplace.visualstudio.com/items?itemName=rluvaton.vscode-vitest) 扩展，它允许您从 IDE 运行、监视或调试测试。
 :::
+
+### 测试覆盖率
+
+在 `--` 分隔符之后传递 Vitest 的 `--coverage` 标志以收集覆盖率：
+
+<NxCommands commands={['test <project-name> -- --coverage']} />
+
+报告将写入 `dist/<project-root>/test-output/vitest/coverage`，HTML 报告位于 `index.html`。覆盖率输出位于 `dist` 下而不是项目内部，因此不会被检查、格式化或作为项目任务的输入。
 
 ## 代码检查
 

--- a/docs/src/content/docs/zh/guides/typescript-project.mdx
+++ b/docs/src/content/docs/zh/guides/typescript-project.mdx
@@ -385,7 +385,7 @@ describe('sayHello', () => {
 
 <NxCommands commands={['test <project-name> -- --coverage']} />
 
-报告将写入 `dist/<project-root>/test-output/vitest/coverage`，HTML 报告位于 `index.html`。覆盖率输出位于 `dist` 下而不是项目内部，因此不会被检查、格式化或作为项目任务的输入。
+报告将写入 `dist/<project-root>/test-output/vitest/coverage`，HTML 报告位于 `index.html`。
 
 ## 代码检查
 

--- a/packages/nx-plugin/src/migrations/latest/vitest-coverage-output-dir/metadata.json
+++ b/packages/nx-plugin/src/migrations/latest/vitest-coverage-output-dir/metadata.json
@@ -1,0 +1,3 @@
+{
+  "description": "Write vitest coverage reports to the project's dist directory rather than inside the project"
+}

--- a/packages/nx-plugin/src/migrations/latest/vitest-coverage-output-dir/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/latest/vitest-coverage-output-dir/migration.spec.ts
@@ -1,0 +1,221 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { addProjectConfiguration, readJson, type Tree } from '@nx/devkit';
+import { getDefaultBiomeConfig } from '../../../utils/format.js';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test.js';
+import migration from './migration.js';
+
+const LIB_CONFIG = 'packages/lib/vitest.config.mts';
+const WEBSITE_CONFIG = 'packages/website/vite.config.mts';
+
+/**
+ * A library's `vitest.config.mts` as an older release generated it. Hardcoded
+ * rather than produced by the generator: a migration has to keep applying to the
+ * shape that shipped, however far the generator's output moves afterwards.
+ */
+const OLD_LIB_CONFIG = `import { defineConfig } from 'vitest/config';
+
+export default defineConfig(() => ({
+  root: import.meta.dirname,
+  cacheDir: '../../node_modules/.vite/packages/lib',
+  test: {
+    passWithNoTests: true,
+    name: '@proj/lib',
+    watch: false,
+    globals: true,
+    environment: 'jsdom',
+    reporters: ['default'],
+    coverage: {
+      reportsDirectory: './test-output/vitest/coverage',
+      provider: 'v8' as const,
+    },
+  },
+}));
+`;
+
+const read = (tree: Tree, path: string): string =>
+  tree.read(path, 'utf-8') ?? '';
+
+/**
+ * Read a config with whitespace collapsed. Biome wraps the long
+ * `reportsDirectory` lines the migration writes, so assertions match on the
+ * value rather than on where the line happens to break.
+ */
+const readCollapsed = (tree: Tree, path: string): string =>
+  read(tree, path).replace(/\s+/g, ' ');
+
+/** Register a project and write the given vitest config into it. */
+const givenProject = (
+  tree: Tree,
+  name: string,
+  config: string,
+  configFile = 'vitest.config.mts',
+): void => {
+  const root = `packages/${name}`;
+  addProjectConfiguration(tree, `@proj/${name}`, {
+    root,
+    sourceRoot: `${root}/src`,
+  });
+  tree.write(`${root}/${configFile}`, config);
+};
+
+describe('vitest-coverage-output-dir migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeUsingTsSolutionSetup();
+    tree.write(
+      'biome.json',
+      JSON.stringify(getDefaultBiomeConfig(tree), null, 2),
+    );
+  });
+
+  it('should point the generated coverage directory at dist', async () => {
+    givenProject(tree, 'lib', OLD_LIB_CONFIG);
+
+    const result = await migration(tree);
+
+    expect(read(tree, LIB_CONFIG)).toContain(
+      `reportsDirectory: '../../dist/packages/lib/test-output/vitest/coverage'`,
+    );
+    expect(read(tree, LIB_CONFIG)).not.toContain(`'./test-output`);
+    expect(result.nextSteps).toEqual([]);
+  });
+
+  it('should resolve the depth of a nested project root', async () => {
+    const root = 'packages/nested/lib';
+    addProjectConfiguration(tree, '@proj/nested-lib', { root });
+    tree.write(`${root}/vitest.config.mts`, OLD_LIB_CONFIG);
+
+    await migration(tree);
+
+    expect(readCollapsed(tree, `${root}/vitest.config.mts`)).toContain(
+      `reportsDirectory: '../../../dist/packages/nested/lib/test-output/vitest/coverage'`,
+    );
+  });
+
+  it('should migrate a website vite.config.mts', async () => {
+    givenProject(tree, 'website', OLD_LIB_CONFIG, 'vite.config.mts');
+
+    await migration(tree);
+
+    expect(readCollapsed(tree, WEBSITE_CONFIG)).toContain(
+      `reportsDirectory: '../../dist/packages/website/test-output/vitest/coverage'`,
+    );
+  });
+
+  it('should exclude test-output from biome', async () => {
+    givenProject(tree, 'lib', OLD_LIB_CONFIG);
+
+    await migration(tree);
+
+    const includes = readJson(tree, 'biome.json').files.includes;
+    expect(includes).toContain('!**/test-output');
+    // Kept alongside the other build-output excludes.
+    expect(includes.indexOf('!**/test-output')).toBe(
+      includes.indexOf('!**/out-tsc') + 1,
+    );
+  });
+
+  it('should leave a coverage directory the user repointed alone', async () => {
+    givenProject(
+      tree,
+      'lib',
+      OLD_LIB_CONFIG.replace(
+        `'./test-output/vitest/coverage'`,
+        `'./my-coverage'`,
+      ),
+    );
+
+    const result = await migration(tree);
+
+    expect(read(tree, LIB_CONFIG)).toContain(
+      `reportsDirectory: './my-coverage'`,
+    );
+    expect(result.nextSteps).toHaveLength(1);
+    expect(result.nextSteps[0]).toContain(LIB_CONFIG);
+    expect(result.nextSteps[0]).toContain('@proj/lib');
+  });
+
+  it('should leave a reportsDirectory outside the config alone', async () => {
+    givenProject(
+      tree,
+      'lib',
+      `const other = { coverage: { reportsDirectory: './test-output/vitest/coverage' } };\n${OLD_LIB_CONFIG}`,
+    );
+
+    await migration(tree);
+
+    const config = readCollapsed(tree, LIB_CONFIG);
+    expect(config).toContain(
+      `const other = { coverage: { reportsDirectory: './test-output/vitest/coverage' }`,
+    );
+    expect(config).toContain(
+      `reportsDirectory: '../../dist/packages/lib/test-output/vitest/coverage'`,
+    );
+  });
+
+  it('should leave a config without a coverage block alone', async () => {
+    const withoutCoverage = `import { defineConfig } from 'vitest/config';
+
+export default defineConfig(() => ({
+  root: import.meta.dirname,
+  test: {
+    passWithNoTests: true,
+    name: '@proj/lib',
+  },
+}));
+`;
+    givenProject(tree, 'lib', withoutCoverage);
+
+    const result = await migration(tree);
+
+    expect(read(tree, LIB_CONFIG)).toBe(withoutCoverage);
+    expect(result.nextSteps).toEqual([]);
+  });
+
+  it('should leave a workspace with no projects alone', async () => {
+    const result = await migration(tree);
+
+    expect(result.nextSteps).toEqual([]);
+  });
+
+  it('should preserve a biome files.includes the workspace has rewritten', async () => {
+    givenProject(tree, 'lib', OLD_LIB_CONFIG);
+    tree.write('biome.json', JSON.stringify({ files: { includes: ['**'] } }));
+
+    await migration(tree);
+
+    expect(readJson(tree, 'biome.json').files.includes).toEqual(['**']);
+  });
+
+  it('should be idempotent', async () => {
+    givenProject(tree, 'lib', OLD_LIB_CONFIG);
+    givenProject(
+      tree,
+      'custom',
+      OLD_LIB_CONFIG.replace(
+        `'./test-output/vitest/coverage'`,
+        `'./my-coverage'`,
+      ),
+    );
+
+    const first = await migration(tree);
+    const afterFirst = [
+      read(tree, LIB_CONFIG),
+      read(tree, 'packages/custom/vitest.config.mts'),
+      read(tree, 'biome.json'),
+    ];
+
+    const second = await migration(tree);
+
+    expect([
+      read(tree, LIB_CONFIG),
+      read(tree, 'packages/custom/vitest.config.mts'),
+      read(tree, 'biome.json'),
+    ]).toEqual(afterFirst);
+    expect(second.nextSteps).toEqual(first.nextSteps);
+  });
+});

--- a/packages/nx-plugin/src/migrations/latest/vitest-coverage-output-dir/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/latest/vitest-coverage-output-dir/migration.spec.ts
@@ -119,6 +119,124 @@ describe('vitest-coverage-output-dir migration', () => {
     );
   });
 
+  it('should delete the coverage directory written inside the project', async () => {
+    givenProject(tree, 'lib', OLD_LIB_CONFIG);
+    const vendored = 'packages/lib/test-output/vitest/coverage/sorter.js';
+    tree.write(vendored, 'var addSorting = (function() {});');
+
+    await migration(tree);
+
+    // Left in place it stays git-visible, so it can be committed and
+    // `license#sync` would stamp a copyright header onto it.
+    expect(tree.exists(vendored)).toBe(false);
+  });
+
+  it('should ignore test-output so later coverage runs are not committed', async () => {
+    givenProject(tree, 'lib', OLD_LIB_CONFIG);
+
+    await migration(tree);
+
+    expect(read(tree, '.gitignore').split('\n')).toContain('test-output');
+  });
+
+  it('should not duplicate an existing test-output gitignore entry', async () => {
+    givenProject(tree, 'lib', OLD_LIB_CONFIG);
+    tree.write('.gitignore', 'dist\ntest-output\n');
+
+    await migration(tree);
+
+    expect(
+      read(tree, '.gitignore')
+        .split('\n')
+        .filter((line) => line === 'test-output'),
+    ).toHaveLength(1);
+  });
+
+  it('should keep files the user put beside the coverage directory', async () => {
+    givenProject(tree, 'lib', OLD_LIB_CONFIG);
+    tree.write('packages/lib/test-output/notes.md', 'mine');
+    tree.write(
+      'packages/lib/test-output/vitest/coverage/sorter.js',
+      'vendored',
+    );
+
+    await migration(tree);
+
+    expect(tree.exists('packages/lib/test-output/notes.md')).toBe(true);
+    expect(
+      tree.exists('packages/lib/test-output/vitest/coverage/sorter.js'),
+    ).toBe(false);
+  });
+
+  it('should migrate a config renamed to a different extension', async () => {
+    givenProject(tree, 'lib', OLD_LIB_CONFIG, 'vitest.config.ts');
+
+    await migration(tree);
+
+    expect(readCollapsed(tree, 'packages/lib/vitest.config.ts')).toContain(
+      `reportsDirectory: '../../dist/packages/lib/test-output/vitest/coverage'`,
+    );
+  });
+
+  it('should report a reportsDirectory set on a target', async () => {
+    const root = 'packages/lib';
+    addProjectConfiguration(tree, '@proj/lib', {
+      root,
+      targets: {
+        test: {
+          executor: '@nx/vitest:test',
+          options: { reportsDirectory: './test-output/vitest/coverage' },
+        },
+      },
+    });
+    tree.write(`${root}/vitest.config.mts`, OLD_LIB_CONFIG);
+
+    const result = await migration(tree);
+
+    // A target option overrides the config, so the rewrite alone leaves the
+    // project broken.
+    expect(result.nextSteps).toHaveLength(1);
+    expect(result.nextSteps[0]).toContain('`test` target');
+    expect(result.nextSteps[0]).toContain('@proj/lib');
+  });
+
+  it('should not report a target reportsDirectory already outside the project', async () => {
+    const root = 'packages/lib';
+    addProjectConfiguration(tree, '@proj/lib', {
+      root,
+      targets: {
+        test: {
+          executor: '@nx/vitest:test',
+          options: {
+            reportsDirectory: '../../dist/packages/lib/test-output',
+          },
+        },
+      },
+    });
+    tree.write(`${root}/vitest.config.mts`, OLD_LIB_CONFIG);
+
+    const result = await migration(tree);
+
+    expect(result.nextSteps).toEqual([]);
+  });
+
+  it('should report a biome files.includes it does not recognise', async () => {
+    givenProject(tree, 'lib', OLD_LIB_CONFIG);
+    // A pre-upgrade list (no `!**/test-output`) that has also dropped the
+    // exclude this migration anchors to.
+    const includes = getDefaultBiomeConfig(tree).files.includes.filter(
+      (include) => include !== '!**/out-tsc' && include !== '!**/test-output',
+    );
+    tree.write('biome.json', JSON.stringify({ files: { includes } }));
+
+    const result = await migration(tree);
+
+    expect(readJson(tree, 'biome.json').files.includes).toEqual(includes);
+    expect(result.nextSteps.some((step) => step.includes('biome.json'))).toBe(
+      true,
+    );
+  });
+
   it('should leave a coverage directory the user repointed alone', async () => {
     givenProject(
       tree,
@@ -186,9 +304,13 @@ export default defineConfig(() => ({
     givenProject(tree, 'lib', OLD_LIB_CONFIG);
     tree.write('biome.json', JSON.stringify({ files: { includes: ['**'] } }));
 
-    await migration(tree);
+    const result = await migration(tree);
 
     expect(readJson(tree, 'biome.json').files.includes).toEqual(['**']);
+    // Failing closed is only safe if the user is told.
+    expect(result.nextSteps.some((step) => step.includes('biome.json'))).toBe(
+      true,
+    );
   });
 
   it('should be idempotent', async () => {

--- a/packages/nx-plugin/src/migrations/latest/vitest-coverage-output-dir/migration.ts
+++ b/packages/nx-plugin/src/migrations/latest/vitest-coverage-output-dir/migration.ts
@@ -6,9 +6,11 @@ import {
   getProjects,
   joinPathFragments,
   type MigrationReturnObject,
+  type ProjectConfiguration,
   type Tree,
   updateJson,
 } from '@nx/devkit';
+import { isAbsolute } from 'path';
 import {
   GENERATED_REPORTS_DIRECTORY,
   getCoverageReportsDirectory,
@@ -18,6 +20,7 @@ import {
   BIOME_TEST_OUTPUT_EXCLUDE,
   formatFilesInSubtree,
 } from '../../../utils/format.js';
+import { updateGitIgnore } from '../../../utils/git.js';
 
 /**
  * Point each project's vitest coverage directory at the workspace's `dist`.
@@ -29,17 +32,37 @@ import {
  * target reformats them (failing every later build) and the `default` named input
  * counts them, so no task in the project can be cached again.
  *
+ * Alongside the rewrite, the coverage directory an older release already wrote
+ * into the project is deleted and `test-output` is added to the workspace
+ * `.gitignore`, so the reporter's vendored third-party scripts can neither be
+ * committed nor picked up by `license#sync`.
+ *
  * Guardrails:
  * - The pattern is anchored to the exact literal `@nx/vitest` generated, and
  *   scoped to the `coverage` block of the config's own `test` object, so a
  *   `reportsDirectory` elsewhere in the file is left alone.
  * - A project whose directory has been repointed keeps its value, and is reported
- *   via `nextSteps` instead.
+ *   via `nextSteps` instead — as is one whose directory is set on a target, or a
+ *   `biome.json` whose `files.includes` has diverged from the vended list.
  * - Idempotent: the pattern no longer matches once rewritten.
  */
 
-/** The config filenames a generated project may carry. */
-const CONFIG_FILES = ['vitest.config.mts', 'vite.config.mts'];
+/**
+ * The config filenames to check. Generated projects carry the `.mts` forms; the
+ * other extensions vitest supports are included so a project whose config was
+ * renamed is still migrated. Safe to widen, because the pattern matched inside is
+ * anchored to the exact literal `@nx/vitest` generated.
+ */
+const CONFIG_FILES = [
+  'vitest.config.mts',
+  'vitest.config.ts',
+  'vitest.config.mjs',
+  'vitest.config.js',
+  'vite.config.mts',
+  'vite.config.ts',
+  'vite.config.mjs',
+  'vite.config.js',
+];
 
 /**
  * The `coverage` block of the object the config factory returns, scoped so a
@@ -75,23 +98,32 @@ const migratedDirectoryPattern = (projectRoot: string): string =>
     `$cov <: some \`reportsDirectory: '${getCoverageReportsDirectory(projectRoot)}'\``,
   );
 
+/** The directory an older release wrote coverage into, relative to a project. */
+const OLD_COVERAGE_DIRECTORY = 'test-output';
+
 /**
  * Exclude test reports from Biome, so a coverage directory pointed anywhere
- * inside the workspace is still never formatted or linted. Only added alongside
- * the excludes we vend, so a workspace that has rewritten `files.includes`
- * wholesale keeps its own list.
+ * inside the workspace is still never formatted or linted. Anchored to the
+ * excludes we vend, so a workspace that has rewritten `files.includes` keeps its
+ * own list — and is told to add the exclude itself.
  */
-const excludeTestOutputFromBiome = (tree: Tree): void => {
+const excludeTestOutputFromBiome = (tree: Tree): string[] => {
   if (!tree.exists('biome.json')) {
-    return;
+    return [];
   }
+  let unrecognised = false;
   updateJson(tree, 'biome.json', (biome) => {
     const includes: unknown = biome?.files?.includes;
     if (
       !Array.isArray(includes) ||
-      includes.includes(BIOME_TEST_OUTPUT_EXCLUDE) ||
-      !includes.includes('!**/out-tsc')
+      includes.includes(BIOME_TEST_OUTPUT_EXCLUDE)
     ) {
+      return biome;
+    }
+    // Placed next to the other build-output excludes. Without that anchor the
+    // list has diverged from the one we vend, so leave it to the user.
+    if (!includes.includes('!**/out-tsc')) {
+      unrecognised = true;
       return biome;
     }
     return {
@@ -106,16 +138,84 @@ const excludeTestOutputFromBiome = (tree: Tree): void => {
       },
     };
   });
+  return unrecognised
+    ? [
+        `\`biome.json\`: add \`"${BIOME_TEST_OUTPUT_EXCLUDE}"\` to \`files.includes\` so test reports are never formatted or linted. Its \`files.includes\` has diverged from the vended list, so it was left as it is.`,
+      ]
+    : [];
+};
+
+/**
+ * Delete the coverage directory an older release wrote inside the project.
+ *
+ * Left in place it stays git-visible: the vended `.gitignore` covers `dist` but
+ * not `test-output`, so the HTML reporter's vendored third-party scripts can be
+ * committed, and `license#sync` — which builds its candidate set from
+ * git-visible files rather than from `biome.json` — would stamp an Apache-2.0
+ * header onto them. Only the reporter's own output is removed; anything else the
+ * user keeps there is left alone.
+ */
+const deleteOldCoverageDirectory = (tree: Tree, projectRoot: string): void => {
+  const oldDirectory = joinPathFragments(
+    projectRoot,
+    OLD_COVERAGE_DIRECTORY,
+    'vitest/coverage',
+  );
+  if (tree.exists(oldDirectory)) {
+    tree.delete(oldDirectory);
+  }
+};
+
+/**
+ * A `reportsDirectory` set on a target rather than in the vitest config, which
+ * takes precedence over the config value. `@nx/vitest` supports this shape, so
+ * report any that still resolves inside the project — rewriting a target option
+ * is the user's call, not this migration's.
+ */
+const targetReportsDirectories = (
+  project: ProjectConfiguration,
+): { target: string; reportsDirectory: string }[] => {
+  const found: { target: string; reportsDirectory: string }[] = [];
+  for (const [target, config] of Object.entries(project.targets ?? {})) {
+    for (const options of [
+      config.options,
+      ...Object.values(config.configurations ?? {}),
+    ]) {
+      const reportsDirectory: unknown = options?.reportsDirectory;
+      // A path escaping the project root is already outside it.
+      if (
+        typeof reportsDirectory === 'string' &&
+        !reportsDirectory.startsWith('..') &&
+        !isAbsolute(reportsDirectory)
+      ) {
+        found.push({ target, reportsDirectory });
+      }
+    }
+  }
+  return found;
 };
 
 export default async function migration(
   tree: Tree,
 ): Promise<MigrationReturnObject> {
-  const nextSteps: string[] = [];
+  const nextSteps: string[] = [...excludeTestOutputFromBiome(tree)];
 
-  excludeTestOutputFromBiome(tree);
+  // Test reports are build output, so ignore them wherever a project writes them.
+  updateGitIgnore(tree, '.', (patterns) =>
+    patterns.includes(OLD_COVERAGE_DIRECTORY)
+      ? patterns
+      : [...patterns, OLD_COVERAGE_DIRECTORY],
+  );
 
   for (const [name, project] of getProjects(tree)) {
+    for (const { target, reportsDirectory } of targetReportsDirectories(
+      project,
+    )) {
+      nextSteps.push(
+        `${name}: the \`${target}\` target sets \`reportsDirectory: '${reportsDirectory}'\`, which resolves inside the project and takes precedence over the vitest config. Point it outside the project (eg \`${getCoverageReportsDirectory(project.root)}\`).`,
+      );
+    }
+
     for (const configFile of CONFIG_FILES) {
       const configPath = joinPathFragments(project.root, configFile);
       if (!tree.exists(configPath)) {
@@ -128,6 +228,7 @@ export default async function migration(
           configPath,
           rewriteDirectoryPattern(project.root),
         );
+        deleteOldCoverageDirectory(tree, project.root);
         continue;
       }
 

--- a/packages/nx-plugin/src/migrations/latest/vitest-coverage-output-dir/migration.ts
+++ b/packages/nx-plugin/src/migrations/latest/vitest-coverage-output-dir/migration.ts
@@ -1,0 +1,156 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import {
+  getProjects,
+  joinPathFragments,
+  type MigrationReturnObject,
+  type Tree,
+  updateJson,
+} from '@nx/devkit';
+import {
+  GENERATED_REPORTS_DIRECTORY,
+  getCoverageReportsDirectory,
+} from '../../../ts/lib/vitest.js';
+import { applyGritQL, matchGritQL } from '../../../utils/ast.js';
+import {
+  BIOME_TEST_OUTPUT_EXCLUDE,
+  formatFilesInSubtree,
+} from '../../../utils/format.js';
+
+/**
+ * Point each project's vitest coverage directory at the workspace's `dist`.
+ *
+ * `@nx/vitest` writes `reportsDirectory: './test-output/vitest/coverage'`, which
+ * resolves inside the project. Coverage is off by default, so the directory stays
+ * dormant until someone runs `vitest --coverage` — at which point the HTML
+ * reporter's bundled third-party scripts land in the project, where the `format`
+ * target reformats them (failing every later build) and the `default` named input
+ * counts them, so no task in the project can be cached again.
+ *
+ * Guardrails:
+ * - The pattern is anchored to the exact literal `@nx/vitest` generated, and
+ *   scoped to the `coverage` block of the config's own `test` object, so a
+ *   `reportsDirectory` elsewhere in the file is left alone.
+ * - A project whose directory has been repointed keeps its value, and is reported
+ *   via `nextSteps` instead.
+ * - Idempotent: the pattern no longer matches once rewritten.
+ */
+
+/** The config filenames a generated project may carry. */
+const CONFIG_FILES = ['vitest.config.mts', 'vite.config.mts'];
+
+/**
+ * The `coverage` block of the object the config factory returns, scoped so a
+ * `coverage` option elsewhere in the file is not matched.
+ */
+const coveragePattern = (body: string): string =>
+  `\`test: { $props }\` where {
+  $props <: within \`defineConfig($_)\`,
+  $props <: some \`coverage: { $cov }\`,
+  ${body}
+}`;
+
+/** Matches a coverage block still carrying the directory `@nx/vitest` generated. */
+const GENERATED_DIRECTORY_PATTERN = coveragePattern(
+  `$cov <: some \`reportsDirectory: '${GENERATED_REPORTS_DIRECTORY}'\``,
+);
+
+/** Matches a coverage block that declares a `reportsDirectory` at all. */
+const ANY_DIRECTORY_PATTERN = coveragePattern(
+  '$cov <: some `reportsDirectory: $_`',
+);
+
+/** Rewrites the generated directory to the one under `dist` for a project root. */
+const rewriteDirectoryPattern = (projectRoot: string): string =>
+  coveragePattern(
+    `$cov <: some \`reportsDirectory: '${GENERATED_REPORTS_DIRECTORY}'\` as $reportsDirectory,
+  $reportsDirectory => \`reportsDirectory: '${getCoverageReportsDirectory(projectRoot)}'\``,
+  );
+
+/** Matches a coverage block already pointing at the directory under `dist`. */
+const migratedDirectoryPattern = (projectRoot: string): string =>
+  coveragePattern(
+    `$cov <: some \`reportsDirectory: '${getCoverageReportsDirectory(projectRoot)}'\``,
+  );
+
+/**
+ * Exclude test reports from Biome, so a coverage directory pointed anywhere
+ * inside the workspace is still never formatted or linted. Only added alongside
+ * the excludes we vend, so a workspace that has rewritten `files.includes`
+ * wholesale keeps its own list.
+ */
+const excludeTestOutputFromBiome = (tree: Tree): void => {
+  if (!tree.exists('biome.json')) {
+    return;
+  }
+  updateJson(tree, 'biome.json', (biome) => {
+    const includes: unknown = biome?.files?.includes;
+    if (
+      !Array.isArray(includes) ||
+      includes.includes(BIOME_TEST_OUTPUT_EXCLUDE) ||
+      !includes.includes('!**/out-tsc')
+    ) {
+      return biome;
+    }
+    return {
+      ...biome,
+      files: {
+        ...biome.files,
+        includes: includes.flatMap((include) =>
+          include === '!**/out-tsc'
+            ? [include, BIOME_TEST_OUTPUT_EXCLUDE]
+            : [include],
+        ),
+      },
+    };
+  });
+};
+
+export default async function migration(
+  tree: Tree,
+): Promise<MigrationReturnObject> {
+  const nextSteps: string[] = [];
+
+  excludeTestOutputFromBiome(tree);
+
+  for (const [name, project] of getProjects(tree)) {
+    for (const configFile of CONFIG_FILES) {
+      const configPath = joinPathFragments(project.root, configFile);
+      if (!tree.exists(configPath)) {
+        continue;
+      }
+
+      if (await matchGritQL(tree, configPath, GENERATED_DIRECTORY_PATTERN)) {
+        await applyGritQL(
+          tree,
+          configPath,
+          rewriteDirectoryPattern(project.root),
+        );
+        continue;
+      }
+
+      // A directory the user repointed is theirs to keep, but it may still sit
+      // inside the project, so report it rather than rewriting it. A config
+      // declaring no directory at all relies on vitest's default, which this
+      // migration has no generated shape to match.
+      if (
+        (await matchGritQL(tree, configPath, ANY_DIRECTORY_PATTERN)) &&
+        !(await matchGritQL(
+          tree,
+          configPath,
+          migratedDirectoryPattern(project.root),
+        ))
+      ) {
+        nextSteps.push(
+          `${name}: \`${configPath}\` sets its own \`test.coverage.reportsDirectory\`. Point it outside the project (eg \`${getCoverageReportsDirectory(project.root)}\`) so coverage output is not formatted, linted or treated as a task input.`,
+        );
+      }
+    }
+  }
+
+  await formatFilesInSubtree(tree);
+
+  return { nextSteps };
+}

--- a/packages/nx-plugin/src/preset/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/preset/__snapshots__/generator.spec.ts.snap
@@ -298,6 +298,7 @@ exports[`preset generator > should run successfully > biome.json 1`] = `
       "**",
       "!**/dist",
       "!**/out-tsc",
+      "!**/test-output",
       "!**/node_modules",
       "!**/.nx",
       "!**/.venv",

--- a/packages/nx-plugin/src/ts/lib/__snapshots__/vitest.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/lib/__snapshots__/vitest.spec.ts.snap
@@ -15,7 +15,7 @@ export default defineConfig(() => ({
     include: ['{src,tests}/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
     reporters: ['default'],
     coverage: {
-      reportsDirectory: './test-output/vitest/coverage',
+      reportsDirectory: '../dist/test/test-output/vitest/coverage',
       provider: 'v8' as const,
     },
   },

--- a/packages/nx-plugin/src/ts/lib/vitest.spec.ts
+++ b/packages/nx-plugin/src/ts/lib/vitest.spec.ts
@@ -62,6 +62,76 @@ describe('vitest utils', () => {
     expect(content).not.toContain('root: __dirname');
   });
 
+  it('should write coverage under the project dist directory', async () => {
+    await configureVitest(
+      tree,
+      {
+        dir: 'test',
+        fullyQualifiedName: 'test',
+      },
+      declaration,
+    );
+    const content = tree.read('test/vitest.config.mts', 'utf8');
+    // Coverage inside the project would be formatted by the `format` target and
+    // counted as an input to every task in the project.
+    expect(content).toContain(
+      `reportsDirectory: '../dist/test/test-output/vitest/coverage'`,
+    );
+    expect(content).not.toContain(`'./test-output`);
+  });
+
+  it('should resolve the coverage depth of a nested project', async () => {
+    tree.write(
+      'packages/nested/lib/vitest.config.mts',
+      wrapConfig(`test: {
+    coverage: {
+      reportsDirectory: './test-output/vitest/coverage',
+      provider: 'v8' as const,
+    },
+  },`),
+    );
+
+    await configureVitest(
+      tree,
+      {
+        dir: 'packages/nested/lib',
+        fullyQualifiedName: '@proj/lib',
+      },
+      declaration,
+    );
+
+    expect(
+      tree.read('packages/nested/lib/vitest.config.mts', 'utf8'),
+    ).toContain(
+      `reportsDirectory: '../../../dist/packages/nested/lib/test-output/vitest/coverage'`,
+    );
+  });
+
+  it('should leave a coverage directory the user repointed alone', async () => {
+    tree.write(
+      'test/vitest.config.mts',
+      wrapConfig(`test: {
+    coverage: {
+      reportsDirectory: './my-coverage',
+      provider: 'v8' as const,
+    },
+  },`),
+    );
+
+    await configureVitest(
+      tree,
+      {
+        dir: 'test',
+        fullyQualifiedName: 'test',
+      },
+      declaration,
+    );
+
+    expect(tree.read('test/vitest.config.mts', 'utf8')).toContain(
+      `reportsDirectory: './my-coverage'`,
+    );
+  });
+
   it('should generate a valid vitest.config.mts without a double comma', () => {
     const content = tree.read('test/vitest.config.mts', 'utf8');
     // Guards against the grit transform emitting `},,` when the matched

--- a/packages/nx-plugin/src/ts/lib/vitest.ts
+++ b/packages/nx-plugin/src/ts/lib/vitest.ts
@@ -2,9 +2,14 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import { readNxJson, type Tree, updateNxJson } from '@nx/devkit';
+import {
+  joinPathFragments,
+  readNxJson,
+  type Tree,
+  updateNxJson,
+} from '@nx/devkit';
 import { readFileSync } from 'fs';
-import { join } from 'path';
+import { join, relative } from 'path';
 import { applyGritQL } from '../../utils/ast.js';
 import {
   type DependencyDeclaration,
@@ -34,6 +39,47 @@ const ROOT_IMPORT_META_DIRNAME = `\`defineConfig(() => ({ $props }))\` where {
   $root => \`root: import.meta.dirname\`
 }`;
 
+/** The `reportsDirectory` `@nx/vitest` writes, resolved against the project root. */
+export const GENERATED_REPORTS_DIRECTORY = './test-output/vitest/coverage';
+
+/**
+ * The coverage directory for a project, as a path relative to the project root
+ * (vitest resolves `reportsDirectory` against the config's `root`).
+ *
+ * Coverage lands under the workspace's `dist` rather than inside the project, so
+ * the HTML reporter's vendored assets are neither formatted by the `format`
+ * target nor counted as an input to the project's own tasks.
+ */
+export const getCoverageReportsDirectory = (dir: string): string =>
+  joinPathFragments(
+    relative(join('/', dir), '/'),
+    'dist',
+    dir,
+    'test-output/vitest/coverage',
+  );
+
+/**
+ * Point coverage at the project's `dist` directory.
+ *
+ * `@nx/vitest` writes `reportsDirectory: './test-output/vitest/coverage'`, which
+ * resolves inside the project. Coverage is off by default, so the directory is
+ * dormant until someone runs `vitest --coverage` — at which point the HTML
+ * reporter's bundled third-party scripts land in the project, where the `format`
+ * target reformats them (failing the build from then on) and the `default` named
+ * input counts them, so no task in the project can ever be cached again.
+ *
+ * Anchored to the exact literal `@nx/vitest` generates, and scoped to the
+ * `coverage` block of the config's own `test` object, so a directory the user has
+ * repointed is left alone.
+ */
+const coverageReportsDirectoryPattern = (dir: string): string =>
+  `\`test: { $props }\` where {
+  $props <: within \`defineConfig($_)\`,
+  $props <: some \`coverage: { $cov }\`,
+  $cov <: some \`reportsDirectory: '${GENERATED_REPORTS_DIRECTORY}'\` as $reportsDirectory,
+  $reportsDirectory => \`reportsDirectory: '${getCoverageReportsDirectory(dir)}'\`
+}`;
+
 /** Dependencies a caller must declare to configure vitest. */
 export const VITEST_DEPENDENCIES = [
   { name: 'vite' },
@@ -60,6 +106,12 @@ export const configureVitest = async <const D extends DependencyDeclaration>(
     );
 
     await applyGritQL(tree, configPath, ROOT_IMPORT_META_DIRNAME);
+
+    await applyGritQL(
+      tree,
+      configPath,
+      coverageReportsDirectoryPattern(options.dir),
+    );
 
     const nxJson = readNxJson(tree);
     updateNxJson(tree, {

--- a/packages/nx-plugin/src/ts/react-website/app/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/react-website/app/__snapshots__/generator.spec.ts.snap
@@ -48,7 +48,7 @@ export default defineConfig(() => ({
     include: ['{src,tests}/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
     reporters: ['default'],
     coverage: {
-      reportsDirectory: './test-output/vitest/coverage',
+      reportsDirectory: '../dist/test-app/test-output/vitest/coverage',
       provider: 'v8' as const,
     },
   },
@@ -104,7 +104,7 @@ export default defineConfig(() => ({
     include: ['{src,tests}/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
     reporters: ['default'],
     coverage: {
-      reportsDirectory: './test-output/vitest/coverage',
+      reportsDirectory: '../dist/test-app/test-output/vitest/coverage',
       provider: 'v8' as const,
     },
   },
@@ -1108,6 +1108,7 @@ exports[`react-website generator > Tanstack router integration > should generate
       "**",
       "!**/dist",
       "!**/out-tsc",
+      "!**/test-output",
       "!**/node_modules",
       "!**/.nx",
       "!**/.venv",
@@ -2307,7 +2308,8 @@ export default defineConfig(() => ({
     include: ['{src,tests}/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
     reporters: ['default'],
     coverage: {
-      reportsDirectory: './test-output/vitest/coverage',
+      reportsDirectory:
+        '../../../dist/packages/common/constructs/test-output/vitest/coverage',
       provider: 'v8' as const,
     },
   },
@@ -2853,7 +2855,7 @@ export default defineConfig(() => ({
     include: ['{src,tests}/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
     reporters: ['default'],
     coverage: {
-      reportsDirectory: './test-output/vitest/coverage',
+      reportsDirectory: '../dist/test-app/test-output/vitest/coverage',
       provider: 'v8' as const,
     },
   },
@@ -2972,6 +2974,7 @@ exports[`react-website generator > Tanstack router integration > should generate
       "**",
       "!**/dist",
       "!**/out-tsc",
+      "!**/test-output",
       "!**/node_modules",
       "!**/.nx",
       "!**/.venv",
@@ -4175,7 +4178,8 @@ export default defineConfig(() => ({
     include: ['{src,tests}/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
     reporters: ['default'],
     coverage: {
-      reportsDirectory: './test-output/vitest/coverage',
+      reportsDirectory:
+        '../../../dist/packages/common/constructs/test-output/vitest/coverage',
       provider: 'v8' as const,
     },
   },
@@ -4920,7 +4924,7 @@ export default defineConfig(() => ({
     include: ['{src,tests}/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
     reporters: ['default'],
     coverage: {
-      reportsDirectory: './test-output/vitest/coverage',
+      reportsDirectory: '../dist/test-app/test-output/vitest/coverage',
       provider: 'v8' as const,
     },
   },
@@ -5049,7 +5053,7 @@ export default defineConfig(() => ({
     include: ['{src,tests}/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
     reporters: ['default'],
     coverage: {
-      reportsDirectory: './test-output/vitest/coverage',
+      reportsDirectory: '../dist/test-app/test-output/vitest/coverage',
       provider: 'v8' as const,
     },
   },

--- a/packages/nx-plugin/src/utils/format.ts
+++ b/packages/nx-plugin/src/utils/format.ts
@@ -11,6 +11,12 @@ import { tryReadToml } from './toml.js';
 import { TS_VERSIONS } from './versions.js';
 
 /**
+ * Excludes test reports — including the vendored scripts vitest's coverage HTML
+ * reporter writes — from formatting and linting.
+ */
+export const BIOME_TEST_OUTPUT_EXCLUDE = '!**/test-output';
+
+/**
  * The biome.json vended into a new workspace. The pnpm catalog resolver is only
  * included on pnpm workspaces, since `experimentalPnpmCatalogs` is Biome's only
  * catalog resolver and reads `pnpm-workspace.yaml` exclusively — it does nothing
@@ -66,6 +72,7 @@ export const getDefaultBiomeConfig = (tree: Tree) => ({
       '**',
       '!**/dist',
       '!**/out-tsc',
+      BIOME_TEST_OUTPUT_EXCLUDE,
       '!**/node_modules',
       '!**/.nx',
       '!**/.venv',


### PR DESCRIPTION
### Reason for this change

`@nx/vitest` writes `reportsDirectory: './test-output/vitest/coverage'` into every generated project's vitest config, which resolves **inside** `{projectRoot}`. Coverage is off by default, so the directory stays dormant — until someone runs tests with `--coverage`.

At that point the coverage HTML reporter writes Istanbul's bundled third-party scripts (`block-navigation.js`, `prettify.js`, `sorter.js`) into the project. The vended `biome.json` `files.includes` excludes `!**/dist`, `!**/out-tsc`, `!**/node_modules` and `!**/generated/**` — but not `test-output`. So the project's `format` target reformats vendored third-party JS and **fails permanently on every subsequent build**. The files also fall under the `default` named input, so no task in the project can ever be cached again.

#### Reproduction

```bash
pnpm create @aws/nx-workspace ws-cov-repro --no-interactive --iac=cdk --no-gitSecrets
cd ws-cov-repro
nx g @aws/nx-plugin:ts#project --no-interactive --name=lib
nx run-many --target build --all                              # passes
nx run @ws-cov-repro/lib:test --skip-nx-cache -- --coverage
nx run-many --target build --all                              # FAILS
```

Before this change:

```
packages/lib/test-output/vitest/coverage/block-navigation.js format ━━━━━
packages/lib/test-output/vitest/coverage/prettify.js         format ━━━━━
packages/lib/test-output/vitest/coverage/sorter.js           format ━━━━━
Found 3 errors.

NX   Running target build for project @ws-cov-repro/lib and 4 tasks it depends on failed
Failed tasks:
  - @ws-cov-repro/lib:format
```

The failure is permanent — a failing target is never cached, so it re-runs and re-fails forever. Coverage output also invalidated the `test` target's cache (100% hit → 0% hit after a coverage run).

### Description of changes

**Generator** (`packages/nx-plugin/src/ts/lib/vitest.ts`) — a new GritQL transform, applied alongside the existing `vitest-pass-with-no-tests` and `ROOT_IMPORT_META_DIRNAME` patterns, repoints coverage at `dist/<projectRoot>/test-output/vitest/coverage`:

```
reportsDirectory: '../../dist/packages/lib/test-output/vitest/coverage',
```

The relative depth is derived from the project root (vitest resolves `reportsDirectory` against the config's `root`, which is `import.meta.dirname`), so a nested root such as `packages/nested/lib` correctly gets `../../../dist/...`. The pattern is anchored to the exact literal `@nx/vitest` generates and scoped to the `coverage` block of the config's own `test` object, so a `reportsDirectory` the user has repointed — or one appearing elsewhere in the file — is left alone.

**No `outputs` change was needed.** `@nx/vitest`'s plugin derives the `test` target's `outputs` from the resolved config, normalising a `..`-prefixed path to `{workspaceRoot}/…`. Verified on a real workspace:

```
outputs: ["{workspaceRoot}/dist/packages/lib/test-output/vitest/coverage"]
```

So Nx still caches and restores coverage output correctly, now keyed outside the project.

**Biome exclude** — `!**/test-output` is added to the vended `biome.json`. I chose to include it: the generator fix only covers the directory *we* generate, and a user who points coverage somewhere else themselves (or any other tool writing test reports) would hit the identical failure. It is cheap, and it also rescues workspaces that already have stale coverage committed or on disk — validated below, where the migrated workspace built successfully **with the old `test-output/` directory still present**.

**Migration** (`latest-vitest-coverage-output-dir`) — brings existing workspaces across. It rewrites `reportsDirectory` only where it still matches the generated shape, reports a repointed directory via `nextSteps` instead of clobbering it, adds the Biome exclude only alongside the excludes we vend, and is idempotent.

It also **deletes the coverage directory an older release already wrote inside the project** and adds `test-output` to the workspace `.gitignore`. Without that, the stale directory stays git-visible — the vended `.gitignore` covers `dist` but not `test-output` — so the reporter's vendored third-party scripts can be committed, and `license#sync` (whose candidate set is built from git-visible files, not from `biome.json`) stamps an Apache-2.0 header onto them. Reproduced end to end: `nx sync` rewrote Istanbul's `sorter.js` to begin with an Amazon copyright header, clobbering its `/* eslint-disable */` line. Files a user keeps elsewhere under `test-output` are preserved.

Two cases that previously passed in silence now emit a `nextSteps` note: a `biome.json` whose `files.includes` has diverged from the vended list (so the exclude could not be placed), and a `reportsDirectory` set on a **target**, which overrides the vitest config and so leaves the project broken despite the rewrite. `CONFIG_FILES` also covers the other extensions vitest accepts, so a renamed config is migrated — safe to widen because the pattern applied inside is anchored to the literal `@nx/vitest` generates.

### Description of how you validated changes

**Unit tests** — `pnpm nx run @aws/nx-plugin:test`: **3969 passed** (221 files), up from the 3948 baseline. 10 snapshots updated; every diff is `reportsDirectory` moving to the `dist` path or `"!**/test-output"` appearing in `biome.json`, and nothing else.

Added 3 generator tests (dist path, nested-root depth, user-repointed directory preserved) and 18 migration tests, covering the generated shape, nested roots, `vite.config.mts`, the Biome exclude and its position, a repointed directory reported via `nextSteps`, a `reportsDirectory` outside the config left alone, a config with no coverage block, an empty workspace, a rewritten `files.includes` preserved, and idempotency (both file contents and `nextSteps`) — plus deletion of the stale coverage directory, preservation of unrelated files beside it, the gitignore entry and its non-duplication, a renamed config, a target-set `reportsDirectory` reported (and one already outside the project not reported), and the diverged-`biome.json` note.

`pnpm nx run-many --target lint --all --configuration=fix` clean; `pnpm nx run-many --target build --all` passes.

**End-to-end, fresh workspace with the locally built plugin:**

```
reportsDirectory: '../../dist/packages/lib/test-output/vitest/coverage'

$ nx run @ws-cov-after/lib:test --skip-nx-cache -- --coverage
$ find dist -path "*test-output*" -name "*.js"
dist/packages/lib/test-output/vitest/coverage/block-navigation.js
dist/packages/lib/test-output/vitest/coverage/prettify.js
dist/packages/lib/test-output/vitest/coverage/sorter.js
$ find packages/lib -path "*test-output*"      # nothing inside the project

$ nx run-many --target build --all             # passes
$ nx run-many --target build --all             # Cache: 5/5 hit (100%)
$ nx run-many --target build --all             # Cache: 5/5 hit (100%)
```

Build passes after a coverage run, and repeat builds are a **100% cache hit — 0 tasks re-run**.

**End-to-end migration**, on a workspace generated *before* the change (stale coverage output already written into `packages/lib`), via `nx migrate --run-migrations=migrations.json`. Two projects: `lib` with the generated shape, `custom` deliberately repointed to `./my-coverage`.

```
Changes:
  UPDATE biome.json
  UPDATE packages/lib/vitest.config.mts

Next steps
  - @ws-cov-before/custom: `packages/custom/vitest.config.mts` sets its own
    `test.coverage.reportsDirectory`. Point it outside the project (eg
    `../../dist/packages/custom/test-output/vitest/coverage`) …
```

`lib` rewritten, `custom` preserved at `./my-coverage` and reported, `!**/test-output` added after `!**/out-tsc`. A second run changed no files and emitted the same single note (byte-identical `diff`), confirming idempotency.

The previously-broken build then recovered — **with the stale `packages/lib/test-output/` still on disk** (this is the Biome exclude earning its place):

```
$ nx run-many --target build --all    # Successfully ran target build
$ nx run-many --target build --all    # Cache: 10/10 hit (100%)
```

**Docs** — the TypeScript project guide now documents how to collect coverage and where reports land, since the location was previously undocumented.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*