### PR TITLE
perf(ts#sync): read the cached project graph instead of rebuilding it

### DIFF
--- a/packages/nx-plugin/src/ts/sync/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/sync/generator.spec.ts
@@ -51,6 +51,7 @@ const setProjectGraph = (graph: ProjectGraph) => {
 };
 
 // Mirrors a cold workspace: no cache on disk, so only building the graph works.
+// Nx throws a plain Error here, which the generator handles type-agnostically.
 const setUncachedProjectGraph = (graph: ProjectGraph) => {
   projectGraphModule.readCachedProjectGraph = () => {
     throw new Error(
@@ -79,6 +80,7 @@ describe('ts-sync generator', () => {
     projectGraphModule.createProjectGraphAsync =
       originalCreateProjectGraphAsync;
     projectGraphModule.readCachedProjectGraph = originalReadCachedProjectGraph;
+    vi.unstubAllEnvs();
   });
 
   const writeJson = (path: string, value: unknown) =>
@@ -505,6 +507,41 @@ describe('ts-sync generator', () => {
           '@proj/lib-a'
         ],
       ).toBe('workspace:*');
+    });
+
+    // NX_CACHE_PROJECT_GRAPH=false suppresses cache writes but not reads, so a
+    // cache that is present but stale must not be trusted.
+    it('builds the graph when graph caching is disabled', async () => {
+      vi.stubEnv('NX_CACHE_PROJECT_GRAPH', 'false');
+      addProject('lib-a', '@proj/lib-a');
+      addProject('lib-b', '@proj/lib-b');
+      addDependency('lib-b', 'lib-a');
+      // The cache predates the import and would miss the dependency.
+      projectGraphModule.readCachedProjectGraph = () => emptyGraph();
+      projectGraphModule.createProjectGraphAsync = async () => graph;
+
+      const result = await tsSyncGeneratorGenerator(tree);
+
+      expect(result.outOfSyncMessage).toContain('@proj/lib-a: workspace:*');
+      expect(
+        readJson(tree, 'packages/lib-b/package.json').dependencies[
+          '@proj/lib-a'
+        ],
+      ).toBe('workspace:*');
+    });
+
+    it('does not read the cache when graph caching is disabled', async () => {
+      vi.stubEnv('NX_CACHE_PROJECT_GRAPH', 'false');
+      addProject('lib-a', '@proj/lib-a');
+      addProject('lib-b', '@proj/lib-b');
+      addDependency('lib-b', 'lib-a');
+      const readCached = vi.fn();
+      projectGraphModule.readCachedProjectGraph = readCached;
+      projectGraphModule.createProjectGraphAsync = async () => graph;
+
+      await tsSyncGeneratorGenerator(tree);
+
+      expect(readCached).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/nx-plugin/src/ts/sync/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/sync/generator.spec.ts
@@ -28,19 +28,35 @@ vi.mock('@nx/devkit', async (importOriginal) => {
     // the per-test patch of the underlying nx module — delegate at call time.
     createProjectGraphAsync: (...args: unknown[]) =>
       nxProjectGraph.createProjectGraphAsync(...args),
+    readCachedProjectGraph: (...args: unknown[]) =>
+      nxProjectGraph.readCachedProjectGraph(...args),
   };
 });
 
-// The generator derives local dependencies from the Nx project graph (via
-// createProjectGraphAsync). Building a real graph reads from disk, so patch the
-// underlying nx module (the same technique as utils/mock-project-graph.ts) and
-// set the graph per test.
+// The generator derives local dependencies from the Nx project graph, preferring
+// the cache Nx populates before running sync generators. Both accessors read
+// from disk, so patch the underlying nx module (the same technique as
+// utils/mock-project-graph.ts) and set the graph per test.
 const _require = createRequire(import.meta.url);
 const projectGraphModule = _require('nx/src/project-graph/project-graph');
 const originalCreateProjectGraphAsync =
   projectGraphModule.createProjectGraphAsync;
+const originalReadCachedProjectGraph =
+  projectGraphModule.readCachedProjectGraph;
 
+// Mirrors Nx: the cache is populated and `createProjectGraphAsync` is redundant.
 const setProjectGraph = (graph: ProjectGraph) => {
+  projectGraphModule.readCachedProjectGraph = () => graph;
+  projectGraphModule.createProjectGraphAsync = async () => graph;
+};
+
+// Mirrors a cold workspace: no cache on disk, so only building the graph works.
+const setUncachedProjectGraph = (graph: ProjectGraph) => {
+  projectGraphModule.readCachedProjectGraph = () => {
+    throw new Error(
+      '[readCachedProjectGraph] ERROR: No cached ProjectGraph is available.',
+    );
+  };
   projectGraphModule.createProjectGraphAsync = async () => graph;
 };
 
@@ -62,6 +78,7 @@ describe('ts-sync generator', () => {
   afterEach(() => {
     projectGraphModule.createProjectGraphAsync =
       originalCreateProjectGraphAsync;
+    projectGraphModule.readCachedProjectGraph = originalReadCachedProjectGraph;
   });
 
   const writeJson = (path: string, value: unknown) =>
@@ -454,6 +471,40 @@ describe('ts-sync generator', () => {
       expect(
         readJson(tree, 'packages/lib-b/package.json').dependencies ?? {},
       ).not.toHaveProperty('@proj/lib-a');
+    });
+
+    it('reads the cached graph without rebuilding it', async () => {
+      addProject('lib-a', '@proj/lib-a');
+      addProject('lib-b', '@proj/lib-b');
+      addDependency('lib-b', 'lib-a');
+      projectGraphModule.readCachedProjectGraph = () => graph;
+      const createProjectGraph = vi.fn();
+      projectGraphModule.createProjectGraphAsync = createProjectGraph;
+
+      await tsSyncGeneratorGenerator(tree);
+
+      expect(createProjectGraph).not.toHaveBeenCalled();
+      expect(
+        readJson(tree, 'packages/lib-b/package.json').dependencies[
+          '@proj/lib-a'
+        ],
+      ).toBe('workspace:*');
+    });
+
+    it('builds the graph when no cache is available', async () => {
+      addProject('lib-a', '@proj/lib-a');
+      addProject('lib-b', '@proj/lib-b');
+      addDependency('lib-b', 'lib-a');
+      setUncachedProjectGraph(graph);
+
+      const result = await tsSyncGeneratorGenerator(tree);
+
+      expect(result.outOfSyncMessage).toContain('@proj/lib-a: workspace:*');
+      expect(
+        readJson(tree, 'packages/lib-b/package.json').dependencies[
+          '@proj/lib-a'
+        ],
+      ).toBe('workspace:*');
     });
   });
 });

--- a/packages/nx-plugin/src/ts/sync/generator.ts
+++ b/packages/nx-plugin/src/ts/sync/generator.ts
@@ -8,6 +8,7 @@ import {
   getProjects,
   joinPathFragments,
   type ProjectGraph,
+  readCachedProjectGraph,
   readJson,
   type Tree,
   updateJson,
@@ -94,7 +95,7 @@ const syncLocalProjectDependencies = async (
   tree: Tree,
   localSpecifier: string,
 ): Promise<Record<string, string[]>> => {
-  const projectGraph = await createProjectGraphAsync();
+  const projectGraph = await readProjectGraph();
 
   const projectInfoByName = collectProjectInfo(tree, projectGraph);
 
@@ -137,6 +138,19 @@ const syncLocalProjectDependencies = async (
   }
 
   return addedByManifest;
+};
+
+/**
+ * Nx builds the project graph immediately before invoking sync generators, so
+ * the cache is fresh. Reading it avoids a rebuild, which is not memoized in
+ * process. Falls back to building when no cache is available.
+ */
+const readProjectGraph = async (): Promise<ProjectGraph> => {
+  try {
+    return readCachedProjectGraph();
+  } catch {
+    return await createProjectGraphAsync();
+  }
 };
 
 interface ProjectInfo {

--- a/packages/nx-plugin/src/ts/sync/generator.ts
+++ b/packages/nx-plugin/src/ts/sync/generator.ts
@@ -144,13 +144,19 @@ const syncLocalProjectDependencies = async (
  * Nx builds the project graph immediately before invoking sync generators, so
  * the cache is fresh. Reading it avoids a rebuild, which is not memoized in
  * process. Falls back to building when no cache is available.
+ *
+ * `NX_CACHE_PROJECT_GRAPH=false` suppresses cache writes but not reads, so the
+ * graph must be built to avoid consuming a stale cache.
  */
 const readProjectGraph = async (): Promise<ProjectGraph> => {
-  try {
-    return readCachedProjectGraph();
-  } catch {
-    return await createProjectGraphAsync();
+  if (process.env.NX_CACHE_PROJECT_GRAPH !== 'false') {
+    try {
+      return readCachedProjectGraph();
+    } catch {
+      // No cached graph available, build it below.
+    }
   }
+  return await createProjectGraphAsync();
 };
 
 interface ProjectInfo {

--- a/packages/nx-plugin/src/utils/mock-project-graph.ts
+++ b/packages/nx-plugin/src/utils/mock-project-graph.ts
@@ -4,7 +4,8 @@
  */
 
 /**
- * Mock createProjectGraphAsync to avoid expensive project graph building in tests.
+ * Mock the project graph accessors to avoid expensive project graph building in
+ * tests, and to keep tests from reading this repository's own on-disk graph.
  *
  * This is the vitest equivalent of Nx's own internal testing utility:
  * https://github.com/nrwl/nx/blob/master/packages/nx/src/internal-testing-utils/mock-project-graph.ts
@@ -19,7 +20,6 @@ import { createRequire } from 'module';
 
 const _require = createRequire(import.meta.url);
 const projectGraph = _require('nx/src/project-graph/project-graph');
-projectGraph.createProjectGraphAsync = async () => ({
-  nodes: {},
-  dependencies: {},
-});
+const emptyGraph = () => ({ nodes: {}, dependencies: {} });
+projectGraph.createProjectGraphAsync = async () => emptyGraph();
+projectGraph.readCachedProjectGraph = () => emptyGraph();


### PR DESCRIPTION
### Reason for this change

`ts#sync` rebuilt the Nx project graph on every invocation, even though Nx had just built it.

`syncLocalProjectDependencies` in `packages/nx-plugin/src/ts/sync/generator.ts` called `createProjectGraphAsync()`. But Nx's `runSyncGenerators` builds the graph and passes `projects` in immediately before invoking each sync generator (`nx/dist/src/utils/sync-generators.js`, Nx 23.1.2):

```js
async function runSyncGenerators(generators) {
    const tree = new FsTree(workspaceRoot, false, 'running sync generators');
    const projectGraph = await createProjectGraphAsync();
    const { projects } = readProjectsConfigurationFromProjectGraph(projectGraph);
    for (const generator of generators) { ... await runSyncGenerator(tree, generator, projects); }
}
```

`createProjectGraphAsync` has no in-process memoization on the daemon-off path, so `ts#sync` rebuilt a graph that had been constructed milliseconds earlier. Isolated cost of that one call on a 14-project workspace: **1297ms daemon-off**, 21ms daemon-on.

### Description of changes

`syncLocalProjectDependencies` now prefers `readCachedProjectGraph()` and falls back to `createProjectGraphAsync()`:

```ts
const readProjectGraph = async (): Promise<ProjectGraph> => {
  try {
    return readCachedProjectGraph();
  } catch {
    return await createProjectGraphAsync();
  }
};
```

Reading the cache is safe here precisely because Nx rebuilds the graph immediately before calling sync generators, so the cache is fresh by construction.

Two design notes:

- **The fallback is a `try`/`catch`, not a null check.** `readCachedProjectGraph` *throws* when no cache is available (`nx/dist/src/project-graph/project-graph.js`: `throw new Error("[readCachedProjectGraph] ERROR: No cached ProjectGraph is available...")`). A null check would break `nx sync` on a cold workspace.
- **`minimumComputedAt` is deliberately not passed.** It exists to assert the cache is newer than some timestamp, which would mean inventing a freshness bound this caller has no correct value for. Since Nx already guarantees the graph was built immediately beforehand, passing it would add no safety and would turn a benign staleness question into a hard `StaleProjectGraphCacheError` on clock skew or slow writes. The `catch` already covers the genuinely-missing-cache case.

  Omitting it also carries a safety bonus: when the cached graph carries `errors`, `readProjectGraphCache` returns null (`nx-deps-cache.js:75-83`), so the read throws and the generator falls back to a real build. **An errored cache is never consumed.**

**No Nx migration is needed** — this is plugin-internal behaviour, not generated workspace config, so there is nothing in a user's workspace to migrate.

### Description of how you validated changes

`ts#sync` exists so each project declares its local workspace deps and Biome's `noUndeclaredDependencies` passes, so a faster generator that misses a dependency edge would be a regression. Verified in a real generated 14-project workspace with the locally compiled plugin:

1. **Stripped deps are restored.** Removed all `@ws-cdk/*` workspace deps from `web` (`@ws-cdk/common-shadcn`, `@ws-cdk/ts-api`) and `infra` (`@ws-cdk/common-constructs`), ran `nx sync`, and both manifests came back **byte-identical** to the originals (`diff` clean).

2. **A brand-new edge the cache has never seen is still detected, in both daemon modes.** Warmed the cache (recording `ts-ddb` with `dependencies: []`), then added a new `import { tsLibGreeting } from '@ws-cdk/ts-lib'` to `ts-ddb`. With the on-disk cache still reporting no deps for `ts-ddb`, `nx sync` declared `@ws-cdk/ts-lib: workspace:*` under both `NX_DAEMON=true` and unset. Also confirmed a *second* consecutive new edge (`ts-api` -> `ts-lib`) is picked up on an already-warm daemon with no `nx reset` in between. This works because Nx rebuilds the graph before invoking sync generators, so the cache is refreshed in the same command.

3. **Cold workspace works (fallback path).** After `nx reset` (no `project-graph.json` on disk), `nx sync` correctly declared the missing dep, exercising the `catch`.

Also confirmed the cached and freshly-built graphs are equivalent (14 nodes each, identical).

#### Follow-up fixes from review (commit 2)

An independent review raised two low-severity findings. **I reproduced both before fixing**, and both are now fixed in `a83d3af5`.

**`NX_CACHE_PROJECT_GRAPH=false` produced a stale read.** This env var suppresses cache *writes* (`project-graph.js:110`) but **not** reads — `readProjectGraphCache` has zero references to it (`nx-deps-cache.js:65-90`). So a pre-existing `project-graph.json` was silently consumed instead of the fresh in-process graph.

An earlier revision of this description claimed I had "forced the fallback permanently with `NX_CACHE_PROJECT_GRAPH=false`, so the cache is never written and `readCachedProjectGraph` always throws". **That claim was wrong and I have removed it.** It only held because my setup had run `nx reset` first, leaving no cache to read. Probed directly with the var set *and* a cache present: `readCachedProjectGraph()` returned a 14-node graph rather than throwing.

Reproduced end-to-end as a real regression: warmed the cache with `ts-ddb` having no deps, added `import { tsLibGreeting } from '@ws-cdk/ts-lib'`, ran `nx sync` daemon-off with the var set. The pre-fix build declared **nothing**; `main` on the identical scenario declared `@ws-cdk/ts-lib: workspace:*`. So this was a genuine behavioural regression versus `main`, not just a documentation error — I fixed the code rather than only the wording:

```ts
if (process.env.NX_CACHE_PROJECT_GRAPH !== 'false') {
  try {
    return readCachedProjectGraph();
  } catch {
    // No cached graph available, build it below.
  }
}
return await createProjectGraphAsync();
```

Post-fix the same scenario declares `@ws-cdk/ts-lib` correctly, matching `main`. The perf win is unaffected — the guard does not fire in normal operation (the var is set nowhere in this repo, its generated workspaces, or CI): cache read 9ms vs build 5866ms with the var unset.

**The global vitest graph mock had a bypass hole.** `utils/mock-project-graph.ts` (a global `setupFiles` entry) stubbed only `createProjectGraphAsync`, so after this PR `ts#sync` was no longer covered by it. Reproduced: stubbing only `createProjectGraphAsync` and calling `readCachedProjectGraph()` returned **6 real project nodes from this repo**. Any future spec reaching `ts#sync` without a local patch would have asserted against the plugin's own monorepo, and on a machine with no `.nx/workspace-data` would have thrown, fallen back, and run a genuine multi-second graph build inside a unit test. Latent today (only this spec invokes it). Fixed by adding `readCachedProjectGraph` to the mock; verified it now returns 0 nodes.

**Tests added for the stale-cache case** (previously untested): `builds the graph when graph caching is disabled` and `does not read the cache when graph caching is disabled`. Suite now **3952 passed / 220 files, exit 0**, no snapshot changes, lint exit 0.

I also tried to pin the fallback to Nx's *real* throw rather than a stubbed one, but `readCachedProjectGraph`'s cache path derives from `workspaceRoot` at **module load** (`cache-directory.js:81`), so it cannot be redirected in-process; that test was misleading and I removed it. I verified the real shape out-of-process instead: a plain `Error` with `[readCachedProjectGraph] ERROR: No cached ProjectGraph is available.` — exactly what the stub mirrors, and the `catch` is type-agnostic.

**Known coverage limit, stated so the green tick is not over-read:** CI does not exercise the `catch` branch. Task sync generators are skipped in CI (`run-command.js:438`), and e2e reaches `ts#sync` via `nx sync`, which always builds the graph first. The fallback is covered by unit tests and by the manual cold-workspace check above, not by CI.

**Unit tests** — extended `generator.spec.ts` (16 tests pass), adding coverage for both paths:
- `reads the cached graph without rebuilding it` — asserts `createProjectGraphAsync` is **not called** when a cache exists.
- `builds the graph when no cache is available` — `readCachedProjectGraph` throws, asserting the fallback still declares deps.

**Full validation**
- `pnpm nx run @aws/nx-plugin:test -u` — **3950 passed / 220 files, exit 0** (baseline 3948; +2 are the new tests). No snapshot files changed.
- `pnpm nx run-many --target lint --all --configuration=fix` — exit 0, no fixes applied.
- `pnpm nx run @aws/nx-plugin:compile` — exit 0.

#### Measurements

This container is shared with other concurrent workloads (load average ~78/32 CPUs), and sequential before/after runs proved unreliable — an early attempt showed the fix as *slower* purely from load drift. Numbers below are therefore **interleaved A/B**: the two plugin builds are swapped and run alternately within the same window, so background load hits both arms equally. Exit codes were checked on every run (a lint/format failure looks exactly like a fast run).

`nx sync` wall time, 6 interleaved pairs:

| daemon | before (median) | after (median) | delta |
| --- | --- | --- | --- |
| **on** (`NX_DAEMON=true`) | 1022ms | 971ms | -51ms (-5.0%) |
| **off** (unset) | 5584ms | 4546ms | **-1038ms (-18.6%)** |

Run-by-run, `daemon=off`: before `5389, 5479, 7571, 5689, 5227, 6185` / after `4423, 4675, 5992, 4220, 4121, 4668` — the fix wins every pair.

Run-by-run, `daemon=on`: before `1531, 1031, 985, 955, 1022, 1022` / after `1018, 959, 983, 985, 940, 927`.

Isolated cost of the graph call itself (interleaved in one process, so load affects both equally):

| daemon | `createProjectGraphAsync` | `readCachedProjectGraph` |
| --- | --- | --- |
| off | 1297ms median (`5025, 1411, 1297, 1279, 1266`) | **6ms** (`6, 6, 4, 6, 4`) |
| on | 21ms median (`2159, 18, 21, 20, 64`) | **6ms** (`5, 6, 4, 7, 6`) |

The daemon-on gain is small for a specific reason: sync generators run **inside** the daemon process (`daemon/server/server.js:72` sets `global.NX_DAEMON`), so `createProjectGraphAsync` already short-circuits to the in-memory graph (`project-graph.js:236-247`) and never makes an IPC round trip. Hence 21ms->6ms rather than seconds. The substantial win is daemon-off.

Both modes are reported because the daemon is disabled inside Docker unless `NX_DAEMON=true` is set in the environment (`useDaemonProcess` in `nx.json` does not override it) — real users on macOS/Linux hosts get the daemon by default, while CI often does not.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
