### PR TITLE
fix(ts#dynamodb,ts#rdb): depend on pull-image from the dev target

### DIFF
--- a/packages/nx-plugin/src/migrations/latest/dev-target-depends-on-pull-image/metadata.json
+++ b/packages/nx-plugin/src/migrations/latest/dev-target-depends-on-pull-image/metadata.json
@@ -1,0 +1,3 @@
+{
+  "description": "Add dependsOn pull-image to the dev target of ts#dynamodb and ts#rdb projects"
+}

--- a/packages/nx-plugin/src/migrations/latest/dev-target-depends-on-pull-image/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/latest/dev-target-depends-on-pull-image/migration.spec.ts
@@ -7,12 +7,22 @@ import {
   type ProjectConfiguration,
   readProjectConfiguration,
   type Tree,
+  updateProjectConfiguration,
 } from '@nx/devkit';
 import { PY_DYNAMODB_GENERATOR_INFO } from '../../../py/dynamodb/generator.js';
-import { TS_DYNAMODB_GENERATOR_INFO } from '../../../ts/dynamodb/generator.js';
+import {
+  TS_DYNAMODB_GENERATOR_INFO,
+  tsDynamoDBGenerator,
+} from '../../../ts/dynamodb/generator.js';
 import { TS_RDB_GENERATOR_INFO } from '../../../ts/rdb/generator.js';
+import { resolveContainers } from '../../../utils/containers.js';
+import { readProjectConfigurationUnqualified } from '../../../utils/nx.js';
 import { createTreeUsingTsSolutionSetup } from '../../../utils/test.js';
 import migration from './migration.js';
+
+vi.mock('../../../utils/containers', () => ({
+  resolveContainers: vi.fn(),
+}));
 
 const pullImageTarget = (scriptsDir: string) => ({
   executor: 'nx:run-commands',
@@ -126,7 +136,60 @@ describe('dev-target-depends-on-pull-image migration', () => {
 
     expect(
       readProjectConfiguration(tree, 'my-table').targets.dev.dependsOn,
-    ).toEqual(['pull-image', '^build']);
+    ).toEqual(['^build', 'pull-image']);
+  });
+
+  it('should treat the object form of the pull-image dependency as already migrated', async () => {
+    const project = dynamoDbProject();
+    project.targets.dev.dependsOn = [{ target: 'pull-image' }];
+    addProjectConfiguration(tree, 'my-table', project);
+
+    const { nextSteps } = await migration(tree);
+
+    expect(nextSteps).toHaveLength(0);
+    expect(
+      readProjectConfiguration(tree, 'my-table').targets.dev.dependsOn,
+    ).toEqual([{ target: 'pull-image' }]);
+  });
+
+  it('should add pull-image alongside an unrelated object form dependency', async () => {
+    const project = dynamoDbProject();
+    project.targets.dev.dependsOn = [{ target: 'build', projects: ['other'] }];
+    addProjectConfiguration(tree, 'my-table', project);
+
+    await migration(tree);
+
+    expect(
+      readProjectConfiguration(tree, 'my-table').targets.dev.dependsOn,
+    ).toEqual([{ target: 'build', projects: ['other'] }, 'pull-image']);
+  });
+
+  it('should add pull-image when the object form targets another project', async () => {
+    const project = dynamoDbProject();
+    project.targets.dev.dependsOn = [
+      { target: 'pull-image', projects: ['other'] },
+    ];
+    addProjectConfiguration(tree, 'my-table', project);
+
+    await migration(tree);
+
+    expect(
+      readProjectConfiguration(tree, 'my-table').targets.dev.dependsOn,
+    ).toEqual([{ target: 'pull-image', projects: ['other'] }, 'pull-image']);
+  });
+
+  it('should report a dependsOn that is not an array rather than rewriting it', async () => {
+    const project = dynamoDbProject();
+    (project.targets.dev as any).dependsOn = '^build';
+    addProjectConfiguration(tree, 'my-table', project);
+
+    const { nextSteps } = await migration(tree);
+
+    expect(nextSteps).toHaveLength(1);
+    expect(nextSteps[0]).toContain('my-table');
+    expect(
+      readProjectConfiguration(tree, 'my-table').targets.dev.dependsOn,
+    ).toEqual('^build');
   });
 
   it('should skip and report a customised dev target', async () => {
@@ -170,6 +233,31 @@ describe('dev-target-depends-on-pull-image migration', () => {
     expect(
       readProjectConfiguration(tree, 'my-table').targets.dev.dependsOn,
     ).toBeUndefined();
+  });
+
+  it('should converge a generated project stripped of the dependency on what the generator vends', async () => {
+    vi.mocked(resolveContainers).mockResolvedValue('docker');
+    await tsDynamoDBGenerator(tree, {
+      name: 'MyTable',
+      directory: 'packages',
+      framework: 'electrodb',
+      infra: 'none',
+      iac: 'cdk',
+    } as any);
+
+    const generated = readProjectConfigurationUnqualified(tree, 'my-table');
+    const vended = structuredClone(generated.targets.dev);
+    expect(vended.dependsOn).toEqual(['pull-image']);
+
+    delete generated.targets.dev.dependsOn;
+    updateProjectConfiguration(tree, generated.name, generated);
+
+    const { nextSteps } = await migration(tree);
+
+    expect(nextSteps).toHaveLength(0);
+    expect(
+      readProjectConfigurationUnqualified(tree, 'my-table').targets.dev,
+    ).toEqual(vended);
   });
 
   it('should be idempotent', async () => {

--- a/packages/nx-plugin/src/migrations/latest/dev-target-depends-on-pull-image/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/latest/dev-target-depends-on-pull-image/migration.spec.ts
@@ -1,0 +1,192 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import {
+  addProjectConfiguration,
+  type ProjectConfiguration,
+  readProjectConfiguration,
+  type Tree,
+} from '@nx/devkit';
+import { PY_DYNAMODB_GENERATOR_INFO } from '../../../py/dynamodb/generator.js';
+import { TS_DYNAMODB_GENERATOR_INFO } from '../../../ts/dynamodb/generator.js';
+import { TS_RDB_GENERATOR_INFO } from '../../../ts/rdb/generator.js';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test.js';
+import migration from './migration.js';
+
+const pullImageTarget = (scriptsDir: string) => ({
+  executor: 'nx:run-commands',
+  options: {
+    command: `tsx ${scriptsDir}/pull-image.ts`,
+    cwd: '{projectRoot}',
+  },
+});
+
+const dynamoDbProject = (): ProjectConfiguration => ({
+  name: 'my-table',
+  root: 'packages/my-table',
+  metadata: { generator: TS_DYNAMODB_GENERATOR_INFO.id } as any,
+  targets: {
+    'pull-image': pullImageTarget('../common/scripts/src/dynamodb'),
+    dev: {
+      executor: 'nx:run-commands',
+      continuous: true,
+      options: {
+        commands: [
+          'tsx ../common/scripts/src/dynamodb/start-container.ts',
+          'tsx ../common/scripts/src/dynamodb/create-local-table.ts',
+        ],
+        parallel: true,
+        cwd: '{projectRoot}',
+      },
+    },
+  },
+});
+
+const rdbProject = (): ProjectConfiguration => ({
+  name: 'my-db',
+  root: 'packages/my-db',
+  metadata: { generator: TS_RDB_GENERATOR_INFO.id } as any,
+  targets: {
+    'pull-image': pullImageTarget('../common/scripts/src/rdb'),
+    dev: {
+      executor: 'nx:run-commands',
+      options: {
+        command: 'tsx ../common/scripts/src/rdb/start-container.ts',
+        cwd: '{projectRoot}',
+      },
+      continuous: true,
+    },
+    'wait-for-db': {
+      executor: 'nx:run-commands',
+      dependsOn: ['dev'],
+      options: {
+        command: 'tsx ../common/scripts/src/rdb/wait-for-postgres-db.ts',
+        cwd: '{projectRoot}',
+      },
+    },
+  },
+});
+
+describe('dev-target-depends-on-pull-image migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeUsingTsSolutionSetup();
+  });
+
+  it('should add pull-image to a ts#dynamodb dev target', async () => {
+    addProjectConfiguration(tree, 'my-table', dynamoDbProject());
+
+    const { nextSteps } = await migration(tree);
+
+    expect(nextSteps).toHaveLength(0);
+    expect(readProjectConfiguration(tree, 'my-table').targets.dev).toEqual({
+      executor: 'nx:run-commands',
+      dependsOn: ['pull-image'],
+      continuous: true,
+      options: {
+        commands: [
+          'tsx ../common/scripts/src/dynamodb/start-container.ts',
+          'tsx ../common/scripts/src/dynamodb/create-local-table.ts',
+        ],
+        parallel: true,
+        cwd: '{projectRoot}',
+      },
+    });
+  });
+
+  it('should add pull-image to a ts#rdb dev target and leave its dependents alone', async () => {
+    addProjectConfiguration(tree, 'my-db', rdbProject());
+
+    const { nextSteps } = await migration(tree);
+
+    expect(nextSteps).toHaveLength(0);
+    const { targets } = readProjectConfiguration(tree, 'my-db');
+    expect(targets.dev.dependsOn).toEqual(['pull-image']);
+    expect(targets['wait-for-db'].dependsOn).toEqual(['dev']);
+  });
+
+  it('should order dev target keys the way nx serializes them', async () => {
+    addProjectConfiguration(tree, 'my-table', dynamoDbProject());
+
+    await migration(tree);
+
+    expect(
+      Object.keys(readProjectConfiguration(tree, 'my-table').targets.dev),
+    ).toEqual(['executor', 'dependsOn', 'continuous', 'options']);
+  });
+
+  it('should preserve existing dependsOn entries', async () => {
+    const project = dynamoDbProject();
+    project.targets.dev.dependsOn = ['^build'];
+    addProjectConfiguration(tree, 'my-table', project);
+
+    await migration(tree);
+
+    expect(
+      readProjectConfiguration(tree, 'my-table').targets.dev.dependsOn,
+    ).toEqual(['pull-image', '^build']);
+  });
+
+  it('should skip and report a customised dev target', async () => {
+    const project = dynamoDbProject();
+    project.targets.dev.options = {
+      commands: ['docker compose up'],
+      cwd: '{projectRoot}',
+    };
+    addProjectConfiguration(tree, 'my-table', project);
+
+    const { nextSteps } = await migration(tree);
+
+    expect(nextSteps).toHaveLength(1);
+    expect(nextSteps[0]).toContain('my-table');
+    expect(
+      readProjectConfiguration(tree, 'my-table').targets.dev.dependsOn,
+    ).toBeUndefined();
+  });
+
+  it('should leave projects from other generators alone', async () => {
+    const project = dynamoDbProject();
+    project.metadata = { generator: PY_DYNAMODB_GENERATOR_INFO.id } as any;
+    addProjectConfiguration(tree, 'my-table', project);
+
+    const { nextSteps } = await migration(tree);
+
+    expect(nextSteps).toHaveLength(0);
+    expect(
+      readProjectConfiguration(tree, 'my-table').targets.dev.dependsOn,
+    ).toBeUndefined();
+  });
+
+  it('should skip a project without a pull-image target', async () => {
+    const project = dynamoDbProject();
+    delete project.targets['pull-image'];
+    addProjectConfiguration(tree, 'my-table', project);
+
+    const { nextSteps } = await migration(tree);
+
+    expect(nextSteps).toHaveLength(0);
+    expect(
+      readProjectConfiguration(tree, 'my-table').targets.dev.dependsOn,
+    ).toBeUndefined();
+  });
+
+  it('should be idempotent', async () => {
+    addProjectConfiguration(tree, 'my-table', dynamoDbProject());
+    addProjectConfiguration(tree, 'my-db', rdbProject());
+
+    await migration(tree);
+    const afterFirst = tree.read('packages/my-table/project.json', 'utf-8');
+
+    const { nextSteps } = await migration(tree);
+
+    expect(nextSteps).toHaveLength(0);
+    expect(tree.read('packages/my-table/project.json', 'utf-8')).toEqual(
+      afterFirst,
+    );
+    expect(
+      readProjectConfiguration(tree, 'my-table').targets.dev.dependsOn,
+    ).toEqual(['pull-image']);
+  });
+});

--- a/packages/nx-plugin/src/migrations/latest/dev-target-depends-on-pull-image/migration.ts
+++ b/packages/nx-plugin/src/migrations/latest/dev-target-depends-on-pull-image/migration.ts
@@ -1,0 +1,78 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import {
+  getProjects,
+  type MigrationReturnObject,
+  type ProjectConfiguration,
+  type Tree,
+  updateProjectConfiguration,
+} from '@nx/devkit';
+import { TS_DYNAMODB_GENERATOR_INFO } from '../../../ts/dynamodb/generator.js';
+import { TS_RDB_GENERATOR_INFO } from '../../../ts/rdb/generator.js';
+import { formatFilesInSubtree } from '../../../utils/format.js';
+import { normalizeTargetKeyOrder } from '../../../utils/nx.js';
+
+/**
+ * Make the dev target of ts#dynamodb and ts#rdb projects depend on pull-image
+ *
+ * Without it, `nx dev` starts the container (and, for DynamoDB, creates the
+ * local table) while the image is still being fetched, so a first run on a
+ * machine without the image races the pull.
+ */
+
+const GENERATOR_IDS = [TS_DYNAMODB_GENERATOR_INFO.id, TS_RDB_GENERATOR_INFO.id];
+
+const PULL_IMAGE_TARGET = 'pull-image';
+
+const startsGeneratedContainer = (project: ProjectConfiguration): boolean => {
+  const { command, commands } = project.targets?.dev?.options ?? {};
+  return [...(commands ?? []), ...(command ? [command] : [])].some(
+    (c: string) => typeof c === 'string' && c.includes('start-container.ts'),
+  );
+};
+
+const divergedNextStep = (projectName: string): string =>
+  `${projectName}: its dev target has been customised, so it was left as it is. Add "${PULL_IMAGE_TARGET}" to the target's dependsOn so the container image is fetched before the container starts.`;
+
+export default async function migration(
+  tree: Tree,
+): Promise<MigrationReturnObject> {
+  const nextSteps: string[] = [];
+  let migrated = false;
+
+  for (const [name, project] of getProjects(tree)) {
+    if (!GENERATOR_IDS.includes((project.metadata as any)?.generator)) {
+      continue;
+    }
+
+    const dev = project.targets?.dev;
+    if (!dev || !project.targets?.[PULL_IMAGE_TARGET]) {
+      continue;
+    }
+
+    const dependsOn = dev.dependsOn ?? [];
+    if (dependsOn.includes(PULL_IMAGE_TARGET)) {
+      continue;
+    }
+
+    if (!startsGeneratedContainer(project)) {
+      nextSteps.push(divergedNextStep(name));
+      continue;
+    }
+
+    project.targets.dev = normalizeTargetKeyOrder({
+      ...dev,
+      dependsOn: [PULL_IMAGE_TARGET, ...dependsOn],
+    });
+    updateProjectConfiguration(tree, name, project);
+    migrated = true;
+  }
+
+  if (migrated) {
+    await formatFilesInSubtree(tree);
+  }
+
+  return { nextSteps };
+}

--- a/packages/nx-plugin/src/migrations/latest/dev-target-depends-on-pull-image/migration.ts
+++ b/packages/nx-plugin/src/migrations/latest/dev-target-depends-on-pull-image/migration.ts
@@ -12,7 +12,7 @@ import {
 import { TS_DYNAMODB_GENERATOR_INFO } from '../../../ts/dynamodb/generator.js';
 import { TS_RDB_GENERATOR_INFO } from '../../../ts/rdb/generator.js';
 import { formatFilesInSubtree } from '../../../utils/format.js';
-import { normalizeTargetKeyOrder } from '../../../utils/nx.js';
+import { addDependencyToTargetIfNotPresent } from '../../../utils/nx.js';
 
 /**
  * Make the dev target of ts#dynamodb and ts#rdb projects depend on pull-image
@@ -52,8 +52,22 @@ export default async function migration(
       continue;
     }
 
-    const dependsOn = dev.dependsOn ?? [];
-    if (dependsOn.includes(PULL_IMAGE_TARGET)) {
+    // Nx requires an array here. Anything else is hand-written and is reported
+    // rather than rewritten, so a malformed value is never spread or clobbered.
+    if (dev.dependsOn !== undefined && !Array.isArray(dev.dependsOn)) {
+      nextSteps.push(divergedNextStep(name));
+      continue;
+    }
+
+    const alreadyDependsOnPullImage = (dev.dependsOn ?? []).some(
+      (dependency) =>
+        dependency === PULL_IMAGE_TARGET ||
+        (typeof dependency === 'object' &&
+          dependency !== null &&
+          dependency.target === PULL_IMAGE_TARGET &&
+          dependency.projects === undefined),
+    );
+    if (alreadyDependsOnPullImage) {
       continue;
     }
 
@@ -62,10 +76,7 @@ export default async function migration(
       continue;
     }
 
-    project.targets.dev = normalizeTargetKeyOrder({
-      ...dev,
-      dependsOn: [PULL_IMAGE_TARGET, ...dependsOn],
-    });
+    addDependencyToTargetIfNotPresent(project, 'dev', PULL_IMAGE_TARGET);
     updateProjectConfiguration(tree, name, project);
     migrated = true;
   }

--- a/packages/nx-plugin/src/py/dynamodb/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/dynamodb/__snapshots__/generator.spec.ts.snap
@@ -591,26 +591,11 @@ const isRunning = (): boolean => {
   return result.status === 0 && result.stdout.trim() === 'true';
 };
 
-// Ensure the image is available locally before starting the container.
-const ensureImage = (): void => {
-  const inspect = spawnSync(containerEngine, ['image', 'inspect', image], {
-    stdio: 'ignore',
-  });
-  if (inspect.status !== 0) {
-    const pull = spawnSync(containerEngine, ['pull', image], {
-      stdio: 'inherit',
-    });
-    if (pull.status !== 0) process.exit(pull.status ?? 1);
-  }
-};
-
 // Multiple dynamo table packages run dev in parallel sharing the same
 // container. All processes stream logs, but only the one that created the
 // container stops it on exit — others just detach.
 let created = false;
 let runRetries = 0;
-
-ensureImage();
 
 for (;;) {
   if (containerExists()) {
@@ -1327,26 +1312,11 @@ const isRunning = (): boolean => {
   return result.status === 0 && result.stdout.trim() === 'true';
 };
 
-// Ensure the image is available locally before starting the container.
-const ensureImage = (): void => {
-  const inspect = spawnSync(containerEngine, ['image', 'inspect', image], {
-    stdio: 'ignore',
-  });
-  if (inspect.status !== 0) {
-    const pull = spawnSync(containerEngine, ['pull', image], {
-      stdio: 'inherit',
-    });
-    if (pull.status !== 0) process.exit(pull.status ?? 1);
-  }
-};
-
 // Multiple dynamo table packages run dev in parallel sharing the same
 // container. All processes stream logs, but only the one that created the
 // container stops it on exit — others just detach.
 let created = false;
 let runRetries = 0;
-
-ensureImage();
 
 for (;;) {
   if (containerExists()) {

--- a/packages/nx-plugin/src/ts/dynamodb/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/dynamodb/__snapshots__/generator.spec.ts.snap
@@ -591,26 +591,11 @@ const isRunning = (): boolean => {
   return result.status === 0 && result.stdout.trim() === 'true';
 };
 
-// Ensure the image is available locally before starting the container.
-const ensureImage = (): void => {
-  const inspect = spawnSync(containerEngine, ['image', 'inspect', image], {
-    stdio: 'ignore',
-  });
-  if (inspect.status !== 0) {
-    const pull = spawnSync(containerEngine, ['pull', image], {
-      stdio: 'inherit',
-    });
-    if (pull.status !== 0) process.exit(pull.status ?? 1);
-  }
-};
-
 // Multiple dynamo table packages run dev in parallel sharing the same
 // container. All processes stream logs, but only the one that created the
 // container stops it on exit — others just detach.
 let created = false;
 let runRetries = 0;
-
-ensureImage();
 
 for (;;) {
   if (containerExists()) {
@@ -1259,26 +1244,11 @@ const isRunning = (): boolean => {
   return result.status === 0 && result.stdout.trim() === 'true';
 };
 
-// Ensure the image is available locally before starting the container.
-const ensureImage = (): void => {
-  const inspect = spawnSync(containerEngine, ['image', 'inspect', image], {
-    stdio: 'ignore',
-  });
-  if (inspect.status !== 0) {
-    const pull = spawnSync(containerEngine, ['pull', image], {
-      stdio: 'inherit',
-    });
-    if (pull.status !== 0) process.exit(pull.status ?? 1);
-  }
-};
-
 // Multiple dynamo table packages run dev in parallel sharing the same
 // container. All processes stream logs, but only the one that created the
 // container stops it on exit — others just detach.
 let created = false;
 let runRetries = 0;
-
-ensureImage();
 
 for (;;) {
   if (containerExists()) {

--- a/packages/nx-plugin/src/ts/dynamodb/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/dynamodb/generator.spec.ts
@@ -82,6 +82,7 @@ describe('ts#dynamodb generator', () => {
     });
     expect(projectConfig.targets['dev']).toEqual({
       executor: 'nx:run-commands',
+      dependsOn: ['pull-image'],
       continuous: true,
       options: {
         commands: [

--- a/packages/nx-plugin/src/ts/dynamodb/generator.ts
+++ b/packages/nx-plugin/src/ts/dynamodb/generator.ts
@@ -141,6 +141,7 @@ export const tsDynamoDBGenerator = async (
   };
   projectConfig.targets['dev'] = {
     executor: 'nx:run-commands',
+    dependsOn: ['pull-image'],
     continuous: true,
     options: {
       commands: [

--- a/packages/nx-plugin/src/ts/rdb/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/rdb/generator.spec.ts
@@ -139,6 +139,7 @@ describe('ts#rdb generator', () => {
     });
     expect(projectConfig.targets['dev']).toEqual({
       executor: 'nx:run-commands',
+      dependsOn: ['pull-image'],
       options: {
         command: 'tsx ../common/scripts/src/rdb/start-container.ts',
         cwd: '{projectRoot}',
@@ -251,6 +252,7 @@ describe('ts#rdb generator', () => {
     });
     expect(mysqlProjectConfig.targets['dev']).toEqual({
       executor: 'nx:run-commands',
+      dependsOn: ['pull-image'],
       options: {
         command: 'tsx ../common/scripts/src/rdb/start-container.ts',
         cwd: '{projectRoot}',

--- a/packages/nx-plugin/src/ts/rdb/generator.ts
+++ b/packages/nx-plugin/src/ts/rdb/generator.ts
@@ -306,6 +306,7 @@ export const tsRdbGenerator = async (
   };
   projectConfig.targets['dev'] = {
     executor: 'nx:run-commands',
+    dependsOn: ['pull-image'],
     options: {
       command: `tsx ${scriptsDir}/start-container.ts`,
       cwd: '{projectRoot}',

--- a/packages/nx-plugin/src/utils/files/common/scripts/src/dynamodb/start-container.ts.template
+++ b/packages/nx-plugin/src/utils/files/common/scripts/src/dynamodb/start-container.ts.template
@@ -18,26 +18,11 @@ const isRunning = (): boolean => {
   return result.status === 0 && result.stdout.trim() === 'true';
 };
 
-// Ensure the image is available locally before starting the container.
-const ensureImage = (): void => {
-  const inspect = spawnSync(containerEngine, ['image', 'inspect', image], {
-    stdio: 'ignore',
-  });
-  if (inspect.status !== 0) {
-    const pull = spawnSync(containerEngine, ['pull', image], {
-      stdio: 'inherit',
-    });
-    if (pull.status !== 0) process.exit(pull.status ?? 1);
-  }
-};
-
 // Multiple dynamo table packages run dev in parallel sharing the same
 // container. All processes stream logs, but only the one that created the
 // container stops it on exit — others just detach.
 let created = false;
 let runRetries = 0;
-
-ensureImage();
 
 for (;;) {
   if (containerExists()) {

--- a/packages/nx-plugin/src/utils/files/common/scripts/src/rdb/shared/start-container.ts.template
+++ b/packages/nx-plugin/src/utils/files/common/scripts/src/rdb/shared/start-container.ts.template
@@ -26,21 +26,6 @@ const isRunning = (): boolean => {
   return result.status === 0 && result.stdout.trim() === "true";
 };
 
-// Ensure the image is available locally before starting the container.
-const ensureImage = (): void => {
-  const inspect = spawnSync(containerEngine, ["image", "inspect", image], {
-    stdio: "ignore",
-  });
-  if (inspect.status !== 0) {
-    const pull = spawnSync(containerEngine, ["pull", image], {
-      stdio: "inherit",
-    });
-    if (pull.status !== 0) process.exit(pull.status ?? 1);
-  }
-};
-
-ensureImage();
-
 if (containerExists()) {
   if (!isRunning()) {
     const start = spawnSync(containerEngine, ["start", containerName], {


### PR DESCRIPTION
### Reason for this change

The `dev` target of `ts#dynamodb` and `ts#rdb` starts the local container but does not declare `dependsOn: ['pull-image']`, unlike its `py#dynamodb` and `py#rdb` counterparts, which do.

This is a regression rather than a deliberate difference. Both TS generators authored the dependency when they were first added (#745 for `ts#dynamodb`, #552 for `ts#rdb`, where it was spelled `docker-pull` and later renamed to `pull-image` by #763); it was dropped when `serve-local` was renamed to `dev` in #806, which kept it for the Python generators:

```
-  projectConfig.targets['serve-local'] = {
+  projectConfig.targets['dev'] = {
-    dependsOn: ['pull-image'],
```

The impact is not merely cosmetic. For `ts#dynamodb`, `dev` runs `start-container` and `create-local-table` **in parallel**, so on a machine without the image the table script races the pull: `create-local-table` starts connecting immediately and exhausts its 30-attempt retry budget before DynamoDB Local is listening, then exits with `ECONNRESET`. The container comes up but the table is never created — and because `dev` is a continuous target, `nx dev` still prints `Successfully ran target dev`, so the failure is silent.

`ts#rdb` runs a single command, so an inline image check in `start-container` was previously masking the missing dependency there; for that generator this change is a consistency/observability fix (the pull is reported as its own task rather than happening mid-`dev`).

With `pull-image` now gating `dev`, the inline `ensureImage()` in the vended `start-container.ts` was doing work that had already happened, so it is removed — fetching the image is expressed in exactly one place and 15 lines leave every user's workspace. Thanks to @AlexTo for [pointing this out](https://github.com/awslabs/nx-plugin-for-aws/pull/1159#issuecomment-5468721814). The two shared templates cover the TypeScript and Python DynamoDB and relational database generators alike. A standalone `start-container.ts` still works — the container engine pulls an absent image implicitly on `run` (verified below), so no replacement guard is needed.

**No migration for the script change.** `start-container.ts` is vended `KeepExisting` into `packages/common/scripts/`, so it is user-owned and may carry local edits. The leftover `ensureImage()` in an existing workspace is redundant but harmless — it inspects an image that `pull-image` has already fetched — so rewriting a user's script to delete it would risk clobbering their changes for no functional gain. Existing workspaces keep their copy; new ones get the simpler script. The `dependsOn` change *is* migrated, since that lives in generator-owned `project.json`.

### Description of changes

- `ts#dynamodb` and `ts#rdb` now author `dependsOn: ['pull-image']` on `dev`, matching the Python generators.
- New `dev-target-depends-on-pull-image` migration backfills existing workspaces. It only touches projects whose `metadata.generator` is `ts#dynamodb`/`ts#rdb` and whose `dev` target still runs the generated `start-container.ts`; a customised `dev` target is left alone and reported via `nextSteps`. It preserves any existing `dependsOn` entries, normalises target key order, and is a no-op on re-run.

The migration dedupes with `addDependencyToTargetIfNotPresent`, so a hand-written `dependsOn: [{ target: 'pull-image' }]` (a shape the Nx project schema permits) is recognised rather than duplicated, and a `dependsOn` that is not an array is reported via `nextSteps` rather than rewritten.

I also swept the rest of the generators for the same class of bug — a `dev`/`serve` target needing a container or downloaded artefact without depending on the target that fetches it. These four were the only affected cases: no other dev/serve target starts a container, and the remaining artefact-producing targets (`docker`, `copy-ssdk`) are already wired to their consumers.

Docs needed no change — `snippets/dynamodb/local-dev-start.mdx` already documents `dev` as pulling the image first, which was only true for Python before this change.

### Description of how you validated changes

Unit tests: updated the `ts#dynamodb`/`ts#rdb` generator specs (including the MySQL `dev` assertion) and added 13 migration tests covering both generators, key order, preserved `dependsOn`, the customised-target `nextSteps` path, other generators being left alone, a project with no `pull-image` target, and idempotency. One fixture is derived from `ts#dynamodb` itself — it runs the generator, strips `dependsOn` from the result, and asserts the migration converges on exactly what the generator vends, so the fixture cannot drift from the generated shape. Full suite green: 3961 tests / 221 files. Lint clean.

End-to-end, in a generated workspace using the locally built plugin with the image absent:

| | image absent, before | image absent, after |
|---|---|---|
| task order | `dev` only | `pull-image` then `dev` |
| `Created table` / `Created GSI` | 0 | 3 |
| `ECONNRESET` / `TimeoutError` | yes, `create-local-table` crashed | none |
| `nx dev` reported | `Successfully ran target dev` | `Successfully ran target dev` |

After removing `ensureImage()`, re-verified in a fresh workspace built from this branch with a timestamped probe in all three vended scripts:

- **Cold (`docker rmi` first):** `PULL_START 0ms -> PULL_END 6820ms`, then `start-container` at `+255ms` and `create-local-table` at `+386ms` after `PULL_END`. Both parallel commands are gated behind the pull, table and 2 GSIs created, zero `ECONNRESET`/`TimeoutError`.
- **Image already present:** `pull-image` completes in 18ms with zero registry traffic, and the full `dev` run creates the table with no pull attempts — so `nx dev` still works with no network.
- **Standalone `tsx start-container.ts`, image absent:** still succeeds. `docker run` pulls the image implicitly and DynamoDB Local starts, so removing the inline pull does not strand this path and no error-message guard is warranted.

Migration verified end-to-end on a pre-change workspace via `nx migrate --run-migrations=migrations.json`: it updated both `project.json` files, produced `dependsOn: ["pull-image"]` in Nx's key order, and a second run reported `No changes were made`.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*