### PR TITLE
perf(open-api#ts-client,open-api#ts-hooks): run codegen targets in-process

### DIFF
--- a/packages/nx-plugin/executors.json
+++ b/packages/nx-plugin/executors.json
@@ -4,6 +4,11 @@
       "implementation": "./src/license/dependency-check/executor",
       "schema": "./src/license/dependency-check/executor-schema.json",
       "description": "Check that all workspace dependencies conform to a license allowlist"
+    },
+    "open-api-codegen": {
+      "implementation": "./src/open-api/codegen/executor",
+      "schema": "./src/open-api/codegen/executor-schema.json",
+      "description": "Generate a client, hooks or operation metadata from an OpenAPI specification"
     }
   }
 }

--- a/packages/nx-plugin/src/migrations/latest/open-api-codegen-executor/metadata.json
+++ b/packages/nx-plugin/src/migrations/latest/open-api-codegen-executor/metadata.json
@@ -1,0 +1,3 @@
+{
+  "description": "Switch generated OpenAPI codegen targets to the in-process open-api-codegen executor"
+}

--- a/packages/nx-plugin/src/migrations/latest/open-api-codegen-executor/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/latest/open-api-codegen-executor/migration.spec.ts
@@ -137,6 +137,61 @@ describe('open-api-codegen-executor migration', () => {
     ).toEqual(watchTarget);
   });
 
+  // `nx watch` runs until interrupted, which a single executor invocation cannot
+  // express, so a continuous target is never reported — even where it invokes the
+  // generator directly and so would otherwise look diverged.
+  it.each([
+    ['watch-generate:my-api-client', '--includeDependencies -- '],
+    ['regen-loop', '-- '],
+  ])(
+    'should silently skip the continuous target %s that invokes the generator',
+    async (targetName, watchArgs) => {
+      const target = {
+        executor: 'nx:run-commands',
+        continuous: true,
+        options: {
+          commands: [
+            `nx watch --projects=my-api ${watchArgs}nx g @aws/nx-plugin:open-api#ts-hooks --openApiSpecPath="dist/a.json" --outputPath="out" --no-interactive`,
+          ],
+        },
+      };
+      addProjectConfiguration(tree, 'web', {
+        root: 'packages/web',
+        targets: { [targetName]: target },
+      });
+
+      const { nextSteps } = await migration(tree);
+
+      expect(nextSteps).toEqual([]);
+      expect(readProjectConfiguration(tree, 'web').targets[targetName]).toEqual(
+        target,
+      );
+    },
+  );
+
+  // `continuous` is the property that makes a target un-convertible, not its name.
+  it('should report a diverged target named watch- that is not continuous', async () => {
+    addProjectConfiguration(tree, 'web', {
+      root: 'packages/web',
+      targets: {
+        'watch-but-not-continuous': {
+          executor: 'nx:run-commands',
+          options: {
+            commands: [
+              'nx g @aws/nx-plugin:open-api#ts-hooks --openApiSpecPath="dist/a.json" --outputPath="out" --no-interactive --verbose',
+            ],
+          },
+        },
+      },
+    });
+
+    const { nextSteps } = await migration(tree);
+
+    expect(nextSteps).toEqual([
+      expect.stringContaining('web:watch-but-not-continuous'),
+    ]);
+  });
+
   it.each([
     [
       'an extra flag',

--- a/packages/nx-plugin/src/migrations/latest/open-api-codegen-executor/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/latest/open-api-codegen-executor/migration.spec.ts
@@ -1,0 +1,225 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import {
+  addProjectConfiguration,
+  readProjectConfiguration,
+  type TargetConfiguration,
+  type Tree,
+} from '@nx/devkit';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test.js';
+import migration from './migration.js';
+
+/** A codegen target as the pre-migration generators vended it. */
+const shelledOutTarget = (
+  generator: string,
+  specPath: string,
+  outputPath: string,
+): TargetConfiguration => ({
+  cache: true,
+  executor: 'nx:run-commands',
+  inputs: [{ dependentTasksOutputFiles: '**/*.json' }],
+  outputs: [`{workspaceRoot}/${outputPath}`],
+  options: {
+    commands: [
+      `nx g @aws/nx-plugin:${generator} --openApiSpecPath="${specPath}" --outputPath="${outputPath}" --no-interactive`,
+    ],
+  },
+  dependsOn: ['my-api:openapi'],
+});
+
+describe('open-api-codegen-executor migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeUsingTsSolutionSetup();
+  });
+
+  it.each([
+    ['open-api#ts-hooks', 'ts-hooks'],
+    ['open-api#ts-client', 'ts-client'],
+    ['open-api#ts-metadata', 'ts-metadata'],
+    ['open-api#json-metadata', 'json-metadata'],
+  ])('should migrate a %s target', async (generator, expected) => {
+    addProjectConfiguration(tree, 'web', {
+      root: 'packages/web',
+      targets: {
+        'generate:my-api-client': shelledOutTarget(
+          generator,
+          'dist/packages/api/openapi.json',
+          'packages/web/src/generated/my-api',
+        ),
+      },
+    });
+
+    const { nextSteps } = await migration(tree);
+
+    expect(nextSteps).toEqual([]);
+    expect(
+      readProjectConfiguration(tree, 'web').targets['generate:my-api-client'],
+    ).toEqual({
+      executor: '@aws/nx-plugin:open-api-codegen',
+      dependsOn: ['my-api:openapi'],
+      cache: true,
+      inputs: [{ dependentTasksOutputFiles: '**/*.json' }],
+      outputs: ['{workspaceRoot}/packages/web/src/generated/my-api'],
+      options: {
+        generator: expected,
+        openApiSpecPath: 'dist/packages/api/openapi.json',
+        outputPath: 'packages/web/src/generated/my-api',
+      },
+    });
+  });
+
+  it('should migrate every codegen target across projects', async () => {
+    addProjectConfiguration(tree, 'web', {
+      root: 'packages/web',
+      targets: {
+        'generate:a-client': shelledOutTarget(
+          'open-api#ts-hooks',
+          'dist/a.json',
+          'packages/web/src/generated/a',
+        ),
+        'generate:b-client': shelledOutTarget(
+          'open-api#ts-hooks',
+          'dist/b.json',
+          'packages/web/src/generated/b',
+        ),
+      },
+    });
+    addProjectConfiguration(tree, 'constructs', {
+      root: 'packages/common/constructs',
+      targets: {
+        'generate:a-metadata': shelledOutTarget(
+          'open-api#ts-metadata',
+          'dist/a.json',
+          'packages/common/constructs/src/generated/a',
+        ),
+      },
+    });
+
+    await migration(tree);
+
+    const executors = [
+      ...Object.values(readProjectConfiguration(tree, 'web').targets),
+      ...Object.values(readProjectConfiguration(tree, 'constructs').targets),
+    ].map((target) => target.executor);
+    expect(executors).toEqual([
+      '@aws/nx-plugin:open-api-codegen',
+      '@aws/nx-plugin:open-api-codegen',
+      '@aws/nx-plugin:open-api-codegen',
+    ]);
+  });
+
+  it('should leave the watch target untouched', async () => {
+    const watchTarget = {
+      executor: 'nx:run-commands',
+      options: {
+        commands: [
+          'nx watch --projects=my-api --includeDependencies -- nx run web:"generate:my-api-client"',
+        ],
+      },
+      continuous: true,
+    };
+    addProjectConfiguration(tree, 'web', {
+      root: 'packages/web',
+      targets: { 'watch-generate:my-api-client': watchTarget },
+    });
+
+    const { nextSteps } = await migration(tree);
+
+    expect(nextSteps).toEqual([]);
+    expect(
+      readProjectConfiguration(tree, 'web').targets[
+        'watch-generate:my-api-client'
+      ],
+    ).toEqual(watchTarget);
+  });
+
+  it.each([
+    [
+      'an extra flag',
+      [
+        'nx g @aws/nx-plugin:open-api#ts-hooks --openApiSpecPath="dist/a.json" --outputPath="out" --no-interactive --verbose',
+      ],
+      undefined,
+    ],
+    [
+      'a chained command',
+      [
+        'nx g @aws/nx-plugin:open-api#ts-hooks --openApiSpecPath="dist/a.json" --outputPath="out" --no-interactive',
+        'echo done',
+      ],
+      undefined,
+    ],
+    [
+      'an extra option',
+      [
+        'nx g @aws/nx-plugin:open-api#ts-hooks --openApiSpecPath="dist/a.json" --outputPath="out" --no-interactive',
+      ],
+      { cwd: '{projectRoot}' },
+    ],
+  ])(
+    'should report a target customised with %s rather than rewrite it',
+    async (_label, commands, extraOptions) => {
+      const target = {
+        cache: true,
+        executor: 'nx:run-commands',
+        options: { commands, ...extraOptions },
+      };
+      addProjectConfiguration(tree, 'web', {
+        root: 'packages/web',
+        targets: { 'generate:my-api-client': target },
+      });
+
+      const { nextSteps } = await migration(tree);
+
+      expect(nextSteps).toEqual([
+        expect.stringContaining('web:generate:my-api-client'),
+      ]);
+      expect(
+        readProjectConfiguration(tree, 'web').targets['generate:my-api-client'],
+      ).toEqual(target);
+    },
+  );
+
+  it('should leave unrelated targets untouched', async () => {
+    const build = {
+      executor: 'nx:run-commands',
+      options: { commands: ['tsc --build'] },
+    };
+    addProjectConfiguration(tree, 'web', {
+      root: 'packages/web',
+      targets: { build },
+    });
+
+    const { nextSteps } = await migration(tree);
+
+    expect(nextSteps).toEqual([]);
+    expect(readProjectConfiguration(tree, 'web').targets.build).toEqual(build);
+  });
+
+  it('should be idempotent', async () => {
+    addProjectConfiguration(tree, 'web', {
+      root: 'packages/web',
+      targets: {
+        'generate:my-api-client': shelledOutTarget(
+          'open-api#ts-hooks',
+          'dist/a.json',
+          'packages/web/src/generated/a',
+        ),
+      },
+    });
+
+    await migration(tree);
+    const afterFirstRun = tree.read('packages/web/project.json')!.toString();
+
+    const { nextSteps } = await migration(tree);
+
+    expect(nextSteps).toEqual([]);
+    expect(tree.read('packages/web/project.json')!.toString()).toBe(
+      afterFirstRun,
+    );
+  });
+});

--- a/packages/nx-plugin/src/migrations/latest/open-api-codegen-executor/migration.ts
+++ b/packages/nx-plugin/src/migrations/latest/open-api-codegen-executor/migration.ts
@@ -1,0 +1,129 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import {
+  getProjects,
+  type MigrationReturnObject,
+  type TargetConfiguration,
+  type Tree,
+  updateProjectConfiguration,
+} from '@nx/devkit';
+import type { OpenApiCodegenTarget } from '../../../open-api/codegen/executor-schema';
+import { formatFilesInSubtree } from '../../../utils/format.js';
+import { normalizeTargetKeyOrder } from '../../../utils/nx.js';
+import { OPEN_API_CODEGEN_EXECUTOR } from '../../../utils/open-api-codegen-target.js';
+
+/**
+ * Codegen targets ran `nx g @aws/nx-plugin:open-api#<generator>` through
+ * `nx:run-commands`, paying a second full Nx bootstrap — project graph, plugin
+ * resolution and schema validation — for every codegen step. They now use the
+ * `open-api-codegen` executor, which runs the same generator in the Nx process
+ * that is already running.
+ *
+ * Only the command shape the generators produced is rewritten. A target that has
+ * been customised — an extra flag, a chained command, options beyond `commands` —
+ * is the user's, so it is left as it is and reported.
+ *
+ * How to write a migration:
+ * - https://nx.dev/docs/kb/migration-generators
+ * - What `nextSteps` means: https://nx.dev/docs/reference/devkit/MigrationReturnObject
+ */
+
+/** The generators the executor can run, by the collection name they had. */
+const GENERATORS: Record<string, OpenApiCodegenTarget> = {
+  'open-api#ts-client': 'ts-client',
+  'open-api#ts-hooks': 'ts-hooks',
+  'open-api#ts-metadata': 'ts-metadata',
+  'open-api#json-metadata': 'json-metadata',
+};
+
+/**
+ * Matches a whole generated codegen command, binding the generator name and its
+ * two paths. Anchored, so a command carrying anything else does not match and is
+ * reported instead of rewritten.
+ */
+const CODEGEN_COMMAND =
+  /^nx g @aws\/nx-plugin:(?<generator>[\w#-]+) --openApiSpecPath="(?<specPath>[^"]+)" --outputPath="(?<outputPath>[^"]+)" --no-interactive$/;
+
+interface CodegenOptions {
+  readonly generator: OpenApiCodegenTarget;
+  readonly openApiSpecPath: string;
+  readonly outputPath: string;
+}
+
+/**
+ * The command a target runs, when it is a single-command `nx:run-commands` — the
+ * shape the generators produced. A target carrying several commands, or options
+ * beyond `commands`, has diverged.
+ */
+const singleCommand = (target: TargetConfiguration): string | undefined => {
+  if (target.executor !== 'nx:run-commands') return undefined;
+  const options = target.options as Record<string, unknown> | undefined;
+  if (!options || Object.keys(options).length !== 1) return undefined;
+  const commands = options.commands;
+  if (!Array.isArray(commands) || commands.length !== 1) return undefined;
+  return typeof commands[0] === 'string' ? commands[0] : undefined;
+};
+
+/** Parses a generated codegen command, or undefined if it is not one. */
+const parseCodegenCommand = (command: string): CodegenOptions | undefined => {
+  const groups = CODEGEN_COMMAND.exec(command)?.groups;
+  if (!groups) return undefined;
+  const generator = GENERATORS[groups.generator];
+  if (!generator) return undefined;
+  return {
+    generator,
+    openApiSpecPath: groups.specPath,
+    outputPath: groups.outputPath,
+  };
+};
+
+/**
+ * Whether a target invokes an OpenAPI generator without being the shape the
+ * generators produced, so it must be reported rather than rewritten. The `watch`
+ * targets that wrap `nx run <project>:<codegen target>` are excluded: they
+ * invoke the codegen target rather than the generator, so they stay as they are.
+ */
+const hasCustomisedCodegenCommand = (target: TargetConfiguration): boolean =>
+  target.executor === 'nx:run-commands' &&
+  JSON.stringify(target.options ?? {}).includes('@aws/nx-plugin:open-api#');
+
+export default async function migration(
+  tree: Tree,
+): Promise<MigrationReturnObject> {
+  const nextSteps: string[] = [];
+
+  for (const [projectName, project] of getProjects(tree)) {
+    let changed = false;
+
+    for (const [targetName, target] of Object.entries(project.targets ?? {})) {
+      const command = singleCommand(target);
+      const options = command ? parseCodegenCommand(command) : undefined;
+
+      if (!options) {
+        if (hasCustomisedCodegenCommand(target)) {
+          nextSteps.push(
+            `${projectName}:${targetName} has diverged from the generated shape — left untouched. Switch it to the '${OPEN_API_CODEGEN_EXECUTOR}' executor to avoid a nested Nx invocation.`,
+          );
+        }
+        continue;
+      }
+
+      project.targets[targetName] = normalizeTargetKeyOrder({
+        ...target,
+        executor: OPEN_API_CODEGEN_EXECUTOR,
+        options,
+      });
+      changed = true;
+    }
+
+    if (changed) {
+      updateProjectConfiguration(tree, projectName, project);
+    }
+  }
+
+  await formatFilesInSubtree(tree);
+
+  return { nextSteps };
+}

--- a/packages/nx-plugin/src/migrations/latest/open-api-codegen-executor/migration.ts
+++ b/packages/nx-plugin/src/migrations/latest/open-api-codegen-executor/migration.ts
@@ -81,12 +81,21 @@ const parseCodegenCommand = (command: string): CodegenOptions | undefined => {
 
 /**
  * Whether a target invokes an OpenAPI generator without being the shape the
- * generators produced, so it must be reported rather than rewritten. The `watch`
- * targets that wrap `nx run <project>:<codegen target>` are excluded: they
- * invoke the codegen target rather than the generator, so they stay as they are.
+ * generators produced, so it must be reported rather than rewritten.
+ *
+ * Continuous targets are excluded. The vended `watch-generate:<api>-client`
+ * wraps `nx watch -- nx run <project>:<codegen target>`, which references the
+ * codegen target rather than the generator, so it never matches here anyway. But
+ * a watch target rewritten to invoke the generator directly would, and telling
+ * its owner to switch to the executor would be wrong advice: `nx watch` runs
+ * until interrupted, which a single executor invocation cannot express.
+ *
+ * `continuous` is the property that makes that true, so it is what is checked —
+ * rather than the `watch-` name prefix, which is only a convention.
  */
 const hasCustomisedCodegenCommand = (target: TargetConfiguration): boolean =>
   target.executor === 'nx:run-commands' &&
+  !target.continuous &&
   JSON.stringify(target.options ?? {}).includes('@aws/nx-plugin:open-api#');
 
 export default async function migration(

--- a/packages/nx-plugin/src/open-api/codegen/executor-schema.d.ts
+++ b/packages/nx-plugin/src/open-api/codegen/executor-schema.d.ts
@@ -1,0 +1,18 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/** Which code the executor generates from an OpenAPI specification. */
+export type OpenApiCodegenTarget =
+  | 'ts-client'
+  | 'ts-hooks'
+  | 'ts-metadata'
+  | 'json-metadata';
+
+export interface OpenApiCodegenExecutorSchema {
+  generator: OpenApiCodegenTarget;
+  openApiSpecPath: string;
+  outputPath: string;
+  dryRun?: boolean;
+}

--- a/packages/nx-plugin/src/open-api/codegen/executor-schema.json
+++ b/packages/nx-plugin/src/open-api/codegen/executor-schema.json
@@ -28,5 +28,6 @@
       "alias": "d"
     }
   },
-  "required": ["generator", "openApiSpecPath", "outputPath"]
+  "required": ["generator", "openApiSpecPath", "outputPath"],
+  "additionalProperties": false
 }

--- a/packages/nx-plugin/src/open-api/codegen/executor-schema.json
+++ b/packages/nx-plugin/src/open-api/codegen/executor-schema.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://json-schema.org/schema",
+  "$id": "OpenApiCodegen",
+  "title": "OpenAPI Code Generation",
+  "description": "Generate code from an OpenAPI specification",
+  "type": "object",
+  "properties": {
+    "generator": {
+      "type": "string",
+      "description": "Which code to generate from the specification",
+      "enum": ["ts-client", "ts-hooks", "ts-metadata", "json-metadata"],
+      "x-priority": "important"
+    },
+    "openApiSpecPath": {
+      "type": "string",
+      "description": "Path to the OpenAPI specification relative to the monorepo root",
+      "x-priority": "important"
+    },
+    "outputPath": {
+      "type": "string",
+      "description": "Path to the directory to generate into, relative to the monorepo root",
+      "x-priority": "important"
+    },
+    "dryRun": {
+      "type": "boolean",
+      "description": "Print the files that would be generated without writing them",
+      "default": false,
+      "alias": "d"
+    }
+  },
+  "required": ["generator", "openApiSpecPath", "outputPath"]
+}

--- a/packages/nx-plugin/src/open-api/codegen/executor.spec.ts
+++ b/packages/nx-plugin/src/open-api/codegen/executor.spec.ts
@@ -116,19 +116,24 @@ describe('open-api-codegen executor', () => {
     expect(generatedFiles()).toEqual([]);
   });
 
-  it('should fail for an unknown generator', async () => {
-    const result = await executor(
-      {
-        generator: 'not-a-generator' as OpenApiCodegenTarget,
-        openApiSpecPath: SPEC_PATH,
-        outputPath: OUTPUT_PATH,
-      },
-      {} as ExecutorContext,
-    );
+  // `constructor` and friends are inherited keys, so a lookup on the generator
+  // map finds them even though they are not generators.
+  it.each(['not-a-generator', 'constructor', 'toString', '__proto__'])(
+    'should fail for the unknown generator %s',
+    async (generator) => {
+      const result = await executor(
+        {
+          generator: generator as OpenApiCodegenTarget,
+          openApiSpecPath: SPEC_PATH,
+          outputPath: OUTPUT_PATH,
+        },
+        {} as ExecutorContext,
+      );
 
-    expect(result).toEqual({ success: false });
-    expect(generatedFiles()).toEqual([]);
-  });
+      expect(result).toEqual({ success: false });
+      expect(generatedFiles()).toEqual([]);
+    },
+  );
 
   it('should be idempotent', async () => {
     await run('ts-hooks');

--- a/packages/nx-plugin/src/open-api/codegen/executor.spec.ts
+++ b/packages/nx-plugin/src/open-api/codegen/executor.spec.ts
@@ -1,0 +1,141 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import type { ExecutorContext } from '@nx/devkit';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { OpenApiCodegenTarget } from './executor-schema';
+
+let workspace: string;
+
+vi.mock('@nx/devkit', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@nx/devkit')>()),
+  get workspaceRoot() {
+    return workspace;
+  },
+}));
+
+const { default: executor } = await import('./executor.js');
+
+const SPEC = {
+  openapi: '3.0.0',
+  info: { title: 'Test API', version: '1.0.0' },
+  paths: {
+    '/items': {
+      get: {
+        operationId: 'listItems',
+        responses: {
+          '200': {
+            description: 'ok',
+            content: {
+              'application/json': {
+                schema: { type: 'array', items: { type: 'string' } },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
+const SPEC_PATH = 'dist/openapi.json';
+const OUTPUT_PATH = 'src/generated';
+
+const run = (generator: OpenApiCodegenTarget, options?: { dryRun?: boolean }) =>
+  executor(
+    {
+      generator,
+      openApiSpecPath: SPEC_PATH,
+      outputPath: OUTPUT_PATH,
+      ...options,
+    },
+    {} as ExecutorContext,
+  );
+
+const generatedFiles = (): string[] => {
+  const dir = join(workspace, OUTPUT_PATH);
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir).sort();
+};
+
+const generatedContents = (): string[] =>
+  generatedFiles().map((file) =>
+    readFileSync(join(workspace, OUTPUT_PATH, file), 'utf-8'),
+  );
+
+describe('open-api-codegen executor', () => {
+  beforeEach(() => {
+    workspace = mkdtempSync(join(tmpdir(), 'codegen-executor-'));
+    mkdirSync(join(workspace, 'dist'), { recursive: true });
+    writeFileSync(join(workspace, SPEC_PATH), JSON.stringify(SPEC));
+  });
+
+  afterEach(() => {
+    rmSync(workspace, { recursive: true, force: true });
+  });
+
+  it.each([
+    ['ts-client', ['client.gen.ts', 'types.gen.ts']],
+    ['ts-hooks', ['client.gen.ts', 'options-proxy.gen.ts', 'types.gen.ts']],
+    ['ts-metadata', ['metadata.gen.ts']],
+    ['json-metadata', ['operations.json']],
+  ] as const)('should generate %s to disk', async (generator, expected) => {
+    const result = await run(generator);
+
+    expect(result).toEqual({ success: true });
+    expect(generatedFiles()).toEqual(expected);
+  });
+
+  it('should format what it writes', async () => {
+    await run('ts-client');
+
+    const client = readFileSync(
+      join(workspace, OUTPUT_PATH, 'client.gen.ts'),
+      'utf-8',
+    );
+    expect(client).not.toContain('\t');
+    expect(client).not.toContain('"');
+  });
+
+  it('should write nothing when dryRun is set', async () => {
+    const result = await run('ts-client', { dryRun: true });
+
+    expect(result).toEqual({ success: true });
+    expect(generatedFiles()).toEqual([]);
+  });
+
+  it('should fail for an unknown generator', async () => {
+    const result = await executor(
+      {
+        generator: 'not-a-generator' as OpenApiCodegenTarget,
+        openApiSpecPath: SPEC_PATH,
+        outputPath: OUTPUT_PATH,
+      },
+      {} as ExecutorContext,
+    );
+
+    expect(result).toEqual({ success: false });
+    expect(generatedFiles()).toEqual([]);
+  });
+
+  it('should be idempotent', async () => {
+    await run('ts-hooks');
+    const first = generatedContents();
+
+    await run('ts-hooks');
+
+    expect(generatedContents()).toEqual(first);
+  });
+});

--- a/packages/nx-plugin/src/open-api/codegen/executor.ts
+++ b/packages/nx-plugin/src/open-api/codegen/executor.ts
@@ -1,0 +1,61 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { type ExecutorContext, logger, workspaceRoot } from '@nx/devkit';
+import { FsTree, flushChanges, printChanges } from 'nx/src/generators/tree.js';
+import type { OpenApiCodegenExecutorSchema } from './executor-schema';
+
+/**
+ * The generators this executor can run, loaded on demand so a run only pays for
+ * the code generation it asks for.
+ */
+const GENERATORS = {
+  'ts-client': () => import('../ts-client/generator.js'),
+  'ts-hooks': () => import('../ts-hooks/generator.js'),
+  'ts-metadata': () => import('../ts-metadata/generator.js'),
+  'json-metadata': () => import('../json-metadata/generator.js'),
+} as const;
+
+/**
+ * Runs an OpenAPI code generator against the workspace.
+ *
+ * Generated codegen targets use this rather than shelling out to `nx g`, which
+ * pays a second full Nx bootstrap — project graph, plugin resolution and
+ * schema validation — for work the running Nx process has already done. The
+ * generator is invoked directly against a tree rooted at the workspace, so the
+ * output is the same as `nx g` produces, including formatting.
+ */
+export default async function openApiCodegenExecutor(
+  options: OpenApiCodegenExecutorSchema,
+  _context: ExecutorContext,
+): Promise<{ success: boolean }> {
+  const loadGenerator = GENERATORS[options.generator];
+  if (!loadGenerator) {
+    logger.error(
+      `Unknown generator "${options.generator}". Expected one of ${Object.keys(GENERATORS).join(', ')}.`,
+    );
+    return { success: false };
+  }
+
+  const generator = (await loadGenerator()).default;
+
+  const tree = new FsTree(workspaceRoot, false);
+  await generator(tree, {
+    openApiSpecPath: options.openApiSpecPath,
+    outputPath: options.outputPath,
+  });
+
+  tree.lock();
+  const changes = tree.listChanges();
+  printChanges(changes);
+
+  if (options.dryRun) {
+    logger.warn('\nNOTE: The "dryRun" flag means no changes were made.');
+    return { success: true };
+  }
+
+  flushChanges(workspaceRoot, changes);
+
+  return { success: true };
+}

--- a/packages/nx-plugin/src/open-api/codegen/executor.ts
+++ b/packages/nx-plugin/src/open-api/codegen/executor.ts
@@ -3,6 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { type ExecutorContext, logger, workspaceRoot } from '@nx/devkit';
+// `@nx/devkit` re-exports FsTree only from its `internal` entry and does not
+// export flushChanges at all, so the tree is taken from nx directly, as the
+// `nx g` command itself does.
 import { FsTree, flushChanges, printChanges } from 'nx/src/generators/tree.js';
 import type { OpenApiCodegenExecutorSchema } from './executor-schema';
 
@@ -30,17 +33,21 @@ export default async function openApiCodegenExecutor(
   options: OpenApiCodegenExecutorSchema,
   _context: ExecutorContext,
 ): Promise<{ success: boolean }> {
-  const loadGenerator = GENERATORS[options.generator];
-  if (!loadGenerator) {
+  // `Object.hasOwn` so an inherited key (eg `constructor`) is not mistaken for a
+  // generator, which would fail with a TypeError rather than the message below.
+  if (!Object.hasOwn(GENERATORS, options.generator)) {
     logger.error(
       `Unknown generator "${options.generator}". Expected one of ${Object.keys(GENERATORS).join(', ')}.`,
     );
     return { success: false };
   }
 
-  const generator = (await loadGenerator()).default;
+  const generator = (await GENERATORS[options.generator]()).default;
 
-  const tree = new FsTree(workspaceRoot, false);
+  const tree = new FsTree(
+    workspaceRoot,
+    process.env.NX_VERBOSE_LOGGING === 'true',
+  );
   await generator(tree, {
     openApiSpecPath: options.openApiSpecPath,
     outputPath: options.outputPath,

--- a/packages/nx-plugin/src/py/agent/generator.frameworks.spec.ts
+++ b/packages/nx-plugin/src/py/agent/generator.frameworks.spec.ts
@@ -192,9 +192,12 @@ dev-dependencies = []
     ).toContain('scripts/agent_openapi.py');
 
     expect(projectConfig.targets['agent-generate-client']).toBeDefined();
+    expect(projectConfig.targets['agent-generate-client'].executor).toBe(
+      '@aws/nx-plugin:open-api-codegen',
+    );
     expect(
-      projectConfig.targets['agent-generate-client'].options.commands[0],
-    ).toContain('@aws/nx-plugin:open-api#ts-client');
+      projectConfig.targets['agent-generate-client'].options.generator,
+    ).toBe('ts-client');
     expect(projectConfig.targets['agent-generate-client'].dependsOn).toEqual([
       'agent-openapi',
     ]);

--- a/packages/nx-plugin/src/py/agent/generator.ts
+++ b/packages/nx-plugin/src/py/agent/generator.ts
@@ -54,6 +54,7 @@ import {
   readProjectConfigurationUnqualified,
 } from '../../utils/nx.js';
 import { sortObjectKeys } from '../../utils/object.js';
+import { openApiCodegenTarget } from '../../utils/open-api-codegen-target.js';
 import {
   getRelativePathToRootByDirectory,
   toProjectRelativePath,
@@ -547,22 +548,13 @@ export const pyAgentGenerator = async (
               ],
             },
           },
-          [clientGenTargetName]: {
-            cache: true,
-            executor: 'nx:run-commands',
-            dependsOn: [openApiTargetName],
-            inputs: [
-              {
-                dependentTasksOutputFiles: '**/*.json',
-              },
-            ],
+          [clientGenTargetName]: openApiCodegenTarget({
+            generator: 'ts-client',
+            openApiSpecPath: `dist/${project.root}/openapi/${agentNameSnakeCase}/openapi.json`,
+            outputPath: `${project.root}/scripts/${agentTargetPrefix}/generated`,
+            specBuildTargetName: openApiTargetName,
             outputs: [`{projectRoot}/scripts/${agentTargetPrefix}/generated`],
-            options: {
-              commands: [
-                `nx g @aws/nx-plugin:open-api#ts-client --openApiSpecPath="dist/${project.root}/openapi/${agentNameSnakeCase}/openapi.json" --outputPath="${project.root}/scripts/${agentTargetPrefix}/generated" --no-interactive`,
-              ],
-            },
-          },
+          }),
         }
       : {};
 

--- a/packages/nx-plugin/src/py/agent/react-connection/generator.spec.ts
+++ b/packages/nx-plugin/src/py/agent/react-connection/generator.spec.ts
@@ -150,7 +150,7 @@ export function Main() {
     // Verify client generation target was added
     expect(projectConfig.targets['generate:test-agent-client']).toBeDefined();
     expect(projectConfig.targets['generate:test-agent-client'].executor).toBe(
-      'nx:run-commands',
+      '@aws/nx-plugin:open-api-codegen',
     );
     expect(
       projectConfig.targets['generate:test-agent-client'].dependsOn,

--- a/packages/nx-plugin/src/py/fast-api/generator.terraform.spec.ts
+++ b/packages/nx-plugin/src/py/fast-api/generator.terraform.spec.ts
@@ -444,10 +444,9 @@ describe('fastapi project generator', () => {
       // The module reads the metadata with `file()`, so it must be generated
       // before the shared terraform project is planned
       expect(target).toBeDefined();
-      expect(target.options.commands[0]).toContain(
-        '@aws/nx-plugin:open-api#json-metadata',
-      );
-      expect(target.options.commands[0]).toContain(
+      expect(target.executor).toBe('@aws/nx-plugin:open-api-codegen');
+      expect(target.options.generator).toBe('json-metadata');
+      expect(target.options.outputPath).toBe(
         'packages/common/terraform/src/generated/test-api',
       );
       expect(terraformConfig.targets.build.dependsOn).toContain(

--- a/packages/nx-plugin/src/py/fast-api/react/generator.spec.ts
+++ b/packages/nx-plugin/src/py/fast-api/react/generator.spec.ts
@@ -120,14 +120,14 @@ export function Main() {
     // Verify client generation target was added
     expect(projectConfig.targets['generate:test-api-client']).toBeDefined();
     expect(projectConfig.targets['generate:test-api-client'].executor).toBe(
-      'nx:run-commands',
+      '@aws/nx-plugin:open-api-codegen',
     );
 
-    expect(
-      projectConfig.targets['generate:test-api-client'].options.commands,
-    ).toEqual([
-      'nx g @aws/nx-plugin:open-api#ts-hooks --openApiSpecPath="dist/apps/backend/openapi/openapi.json" --outputPath="apps/frontend/src/generated/test-api" --no-interactive',
-    ]);
+    expect(projectConfig.targets['generate:test-api-client'].options).toEqual({
+      generator: 'ts-hooks',
+      openApiSpecPath: 'dist/apps/backend/openapi/openapi.json',
+      outputPath: 'apps/frontend/src/generated/test-api',
+    });
 
     expect(
       projectConfig.targets['generate:test-api-client'].dependsOn,

--- a/packages/nx-plugin/src/smithy/react-connection/generator.spec.ts
+++ b/packages/nx-plugin/src/smithy/react-connection/generator.spec.ts
@@ -127,13 +127,15 @@ export function Main() {
       // Verify client generation target was added
       expect(projectConfig.targets['generate:test-api-client']).toBeDefined();
       expect(projectConfig.targets['generate:test-api-client'].executor).toBe(
-        'nx:run-commands',
+        '@aws/nx-plugin:open-api-codegen',
       );
-      expect(
-        projectConfig.targets['generate:test-api-client'].options.commands,
-      ).toEqual([
-        'nx g @aws/nx-plugin:open-api#ts-hooks --openApiSpecPath="dist/apps/api-model/build/openapi/openapi.json" --outputPath="apps/frontend/src/generated/test-api" --no-interactive',
-      ]);
+      expect(projectConfig.targets['generate:test-api-client'].options).toEqual(
+        {
+          generator: 'ts-hooks',
+          openApiSpecPath: 'dist/apps/api-model/build/openapi/openapi.json',
+          outputPath: 'apps/frontend/src/generated/test-api',
+        },
+      );
       expect(
         projectConfig.targets['generate:test-api-client'].dependsOn,
       ).toContain('api-model:build');
@@ -553,11 +555,13 @@ export function Main() {
       ).toContain('api-model:build');
 
       // Verify the correct spec path is used (from model project)
-      expect(
-        projectConfig.targets['generate:test-api-client'].options.commands,
-      ).toEqual([
-        'nx g @aws/nx-plugin:open-api#ts-hooks --openApiSpecPath="dist/apps/api-model/build/openapi/openapi.json" --outputPath="apps/frontend/src/generated/test-api" --no-interactive',
-      ]);
+      expect(projectConfig.targets['generate:test-api-client'].options).toEqual(
+        {
+          generator: 'ts-hooks',
+          openApiSpecPath: 'dist/apps/api-model/build/openapi/openapi.json',
+          outputPath: 'apps/frontend/src/generated/test-api',
+        },
+      );
 
       // Verify Cognito auth is used
       expect(tree.exists('apps/frontend/src/hooks/useSigV4.tsx')).toBeFalsy();

--- a/packages/nx-plugin/src/smithy/ts/api/generator.spec.ts
+++ b/packages/nx-plugin/src/smithy/ts/api/generator.spec.ts
@@ -571,9 +571,12 @@ describe('tsSmithyApiGenerator', () => {
     const openApiTarget =
       sharedConstructsConfig.targets['generate:test-api-metadata'];
     expect(openApiTarget.dependsOn).toContain('@proj/test-api-model:build');
-    expect(openApiTarget.options.commands).toContain(
-      'nx g @aws/nx-plugin:open-api#ts-metadata --openApiSpecPath="dist/test-api/model/build/openapi/openapi.json" --outputPath="packages/common/constructs/src/generated/test-api" --no-interactive',
-    );
+    expect(openApiTarget.executor).toBe('@aws/nx-plugin:open-api-codegen');
+    expect(openApiTarget.options).toEqual({
+      generator: 'ts-metadata',
+      openApiSpecPath: 'dist/test-api/model/build/openapi/openapi.json',
+      outputPath: 'packages/common/constructs/src/generated/test-api',
+    });
   });
 
   it('should handle kebab-case API names correctly', async () => {

--- a/packages/nx-plugin/src/utils/api-constructs/open-api-metadata.ts
+++ b/packages/nx-plugin/src/utils/api-constructs/open-api-metadata.ts
@@ -11,6 +11,7 @@ import {
 import { updateGitIgnore } from '../git.js';
 import type { Iac } from '../iac.js';
 import { addDependencyToTargetIfNotPresent } from '../nx.js';
+import { openApiCodegenTarget } from '../open-api-codegen-target.js';
 import {
   PACKAGES_DIR,
   SHARED_CONSTRUCTS_DIR,
@@ -79,24 +80,15 @@ const addCdkOpenApiMetadataGenerateTarget = (
       // for providing a type-safe CDK construct
       const metadataTargetName = `generate:${apiNameKebabCase}-metadata`;
       if (!config.targets[metadataTargetName]) {
-        config.targets[metadataTargetName] = {
-          cache: true,
-          executor: 'nx:run-commands',
-          inputs: [
-            {
-              dependentTasksOutputFiles: '**/*.json',
-            },
-          ],
+        config.targets[metadataTargetName] = openApiCodegenTarget({
+          generator: 'ts-metadata',
+          openApiSpecPath: specPath,
+          outputPath: generatedMetadataDirFromRoot,
+          specBuildTargetName,
           outputs: [
             joinPathFragments('{workspaceRoot}', generatedMetadataDirFromRoot),
           ],
-          options: {
-            commands: [
-              `nx g @aws/nx-plugin:open-api#ts-metadata --openApiSpecPath="${specPath}" --outputPath="${generatedMetadataDirFromRoot}" --no-interactive`,
-            ],
-          },
-          dependsOn: [specBuildTargetName],
-        };
+        });
       }
       addDependencyToTargetIfNotPresent(config, 'compile', metadataTargetName);
       return config;
@@ -151,22 +143,13 @@ const addTerraformOpenApiOperationsGenerateTarget = (
       // before plan; the target is wired into `build` below.
       const operationsTargetName = `generate:${apiNameKebabCase}-operations`;
       if (!config.targets[operationsTargetName]) {
-        config.targets[operationsTargetName] = {
-          cache: true,
-          executor: 'nx:run-commands',
-          inputs: [
-            {
-              dependentTasksOutputFiles: '**/*.json',
-            },
-          ],
+        config.targets[operationsTargetName] = openApiCodegenTarget({
+          generator: 'json-metadata',
+          openApiSpecPath: specPath,
+          outputPath: generatedDirFromRoot,
+          specBuildTargetName,
           outputs: [joinPathFragments('{workspaceRoot}', generatedDirFromRoot)],
-          options: {
-            commands: [
-              `nx g @aws/nx-plugin:open-api#json-metadata --openApiSpecPath="${specPath}" --outputPath="${generatedDirFromRoot}" --no-interactive`,
-            ],
-          },
-          dependsOn: [specBuildTargetName],
-        };
+        });
       }
       addDependencyToTargetIfNotPresent(config, 'build', operationsTargetName);
       return config;

--- a/packages/nx-plugin/src/utils/connection/open-api/react.ts
+++ b/packages/nx-plugin/src/utils/connection/open-api/react.ts
@@ -22,6 +22,7 @@ import { addDependenciesToPackageJson } from '../../dependencies.js';
 import { updateGitIgnore } from '../../git.js';
 import { kebabCase, toClassName } from '../../names.js';
 import { sortObjectKeys } from '../../object.js';
+import { openApiCodegenTarget } from '../../open-api-codegen-target.js';
 import { type ITsDepVersion, withVersions } from '../../versions.js';
 
 /** Dependencies a caller must declare to add an OpenAPI React client. */
@@ -142,24 +143,15 @@ export const addOpenApiReactClient = async <
           },
         ]),
       ),
-      [clientGenTarget]: {
-        cache: true,
-        executor: 'nx:run-commands',
-        inputs: [
-          {
-            dependentTasksOutputFiles: '**/*.json',
-          },
-        ],
+      [clientGenTarget]: openApiCodegenTarget({
+        generator: 'ts-hooks',
+        openApiSpecPath: specPath,
+        outputPath: generatedClientDirFromRoot,
+        specBuildTargetName,
         outputs: [
           joinPathFragments('{workspaceRoot}', generatedClientDirFromRoot),
         ],
-        options: {
-          commands: [
-            `nx g @aws/nx-plugin:open-api#ts-hooks --openApiSpecPath="${specPath}" --outputPath="${generatedClientDirFromRoot}" --no-interactive`,
-          ],
-        },
-        dependsOn: [specBuildTargetName],
-      },
+      }),
       // Watch target for regenerating the client
       [clientGenWatchTarget]: {
         executor: 'nx:run-commands',

--- a/packages/nx-plugin/src/utils/open-api-codegen-target.ts
+++ b/packages/nx-plugin/src/utils/open-api-codegen-target.ts
@@ -1,0 +1,54 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import type { TargetConfiguration } from '@nx/devkit';
+import type { OpenApiCodegenTarget } from '../open-api/codegen/executor-schema';
+import { normalizeTargetKeyOrder } from './nx.js';
+
+/** Executor generated OpenAPI codegen targets run. */
+export const OPEN_API_CODEGEN_EXECUTOR = '@aws/nx-plugin:open-api-codegen';
+
+export interface OpenApiCodegenTargetOptions {
+  /** Which code to generate from the specification. */
+  readonly generator: OpenApiCodegenTarget;
+  /** Path to the OpenAPI specification, from the workspace root. */
+  readonly openApiSpecPath: string;
+  /** Directory to generate into, from the workspace root. */
+  readonly outputPath: string;
+  /** Target which builds the OpenAPI specification. */
+  readonly specBuildTargetName: string;
+  /** Paths the target writes, in Nx `outputs` form. */
+  readonly outputs: string[];
+}
+
+/**
+ * A target which generates code from an OpenAPI specification.
+ *
+ * The executor runs the generator in the Nx process that is already running,
+ * rather than shelling out to `nx g`, which would pay a second full Nx
+ * bootstrap for every codegen step.
+ */
+export const openApiCodegenTarget = ({
+  generator,
+  openApiSpecPath,
+  outputPath,
+  specBuildTargetName,
+  outputs,
+}: OpenApiCodegenTargetOptions): TargetConfiguration =>
+  normalizeTargetKeyOrder({
+    executor: OPEN_API_CODEGEN_EXECUTOR,
+    dependsOn: [specBuildTargetName],
+    cache: true,
+    inputs: [
+      {
+        dependentTasksOutputFiles: '**/*.json',
+      },
+    ],
+    outputs,
+    options: {
+      generator,
+      openApiSpecPath,
+      outputPath,
+    },
+  });


### PR DESCRIPTION
### Reason for this change

Generated OpenAPI codegen targets shelled out to a nested `nx g` through `nx:run-commands`. Every codegen step therefore paid a **second full Nx bootstrap** — project graph construction, plugin resolution, generator schema validation — for work the Nx process running the target had already done.

Measured on a 14-project workspace (ts + py APIs, agents, MCP servers), `NX_DAEMON=true`, `--skip-nx-cache`, 12 randomised-order interleaved reps:

| arm | min | p50 |
|---|---|---|
| `bench-noop` (`node -e ''` through `nx:run-commands` — the outer bootstrap floor) | 1450ms | 2321ms |
| shelled-out codegen | 4435ms | 5419ms |
| in-process codegen | 2448ms | 3875ms |

So the shelled-out target cost **~3.0s over the bootstrap floor** while the same generator run in-process costs **~1.0s** — roughly 2s per target was the nested bootstrap, not the code generation. Timed from inside the executor, the actual work is ~200ms of generator plus ~200ms of module loading; a bare `node` script doing the identical generation took 1.3s against the nested `nx g`'s 5.2s in the same shell.

This compounds: `generate:<api>-metadata` lands on the shared constructs project's `compile`, so N APIs serialise N nested bootstraps into one project's compile.

### Description of changes

**Inventory** — four target families shelled out to a nested `nx g` (verified by grepping `packages/nx-plugin/src` for `commands` containing `nx g`; these are the only four):

| family | generator | vended by |
|---|---|---|
| `generate:<api>-client` | `open-api#ts-hooks` | `utils/connection/open-api/react.ts` |
| `generate:<api>-metadata` | `open-api#ts-metadata` | `utils/api-constructs/open-api-metadata.ts` (CDK) |
| `generate:<api>-operations` | `open-api#json-metadata` | `utils/api-constructs/open-api-metadata.ts` (Terraform) |
| `<agent>-generate-client` | `open-api#ts-client` | `py/agent/generator.ts` |

The `watch-generate:*` targets also invoke `nx`, but they wrap `nx watch -- nx run <project>:<codegen target>`, i.e. they invoke the codegen *target* rather than the generator. They are unchanged and out of scope.

**Changes:**

- New `@aws/nx-plugin:open-api-codegen` executor (`src/open-api/codegen/executor.ts`, registered in `executors.json`). It dynamically imports the requested generator, runs it against an `FsTree` rooted at `workspaceRoot`, then `printChanges` + `flushChanges` — the same sequence `nx g` itself performs. Generators are loaded on demand so a run only pays for the code generation it asks for.
- `src/utils/open-api-codegen-target.ts` builds the target configuration, so all four call sites agree on `cache`/`inputs`/`outputs`/`dependsOn` and on Nx's key order (via the existing `normalizeTargetKeyOrder`, keeping generation idempotent).
- Migration `latest-open-api-codegen-executor` rewrites existing targets.

**Constraints handled:**

- **Tree flushing** — `tree.lock()` then `flushChanges(workspaceRoot, tree.listChanges())`, mirroring `nx/src/command-line/generate`.
- **`--dry-run`** — declared in the executor schema so Nx normalises both `--dry-run` and `--dryRun` to `dryRun`; changes are printed and nothing is written. Verified: `--dry-run` printed the three `CREATE` lines and left the output directory absent.
- **Caching** — `cache`, `inputs` and `outputs` are unchanged, so hashing semantics are identical. Verified in a real workspace: repeat run `2/2 hit (100%)`, and deleting the output directory restored it from cache rather than re-running.
- **Formatting** — the generators call `formatFilesInSubtree` themselves; the executor does not bypass it. A test asserts the flushed files are formatted.
- **Individually runnable** — `nx run '<project>:generate:<api>-client'` and `nx run-many -t 'generate:<api>-client' -p <project>` both work. (Bare `nx run web:generate:py-api-client` fails to parse the colon in the target name — confirmed identical on `main`, so unchanged by this PR.)

**Alternatives considered:**

- **`nx:run-commands` with a `tsx` entrypoint importing the generator** — same in-process saving, but pays a `tsx`/TypeScript startup per step, needs a script vended into every workspace (more generated surface to migrate and to keep in step with the plugin), and loses schema validation. Rejected.
- **Batching several codegen steps into one invocation** — would amortise the bootstrap further, but the steps live on *different projects* (`web`, `common-constructs`, the agent project), so batching means either a synthetic owning project or cross-project outputs. Both weaken Nx's caching granularity: one changed spec would invalidate every client. Rejected; the per-target fix already removes the bootstrap, which was the actual cost.
- **`nx exec`** — still spawns a new Nx process, so it does not address the bootstrap.

**Known risk: the deep import into Nx internals.** The executor imports `FsTree`, `flushChanges` and `printChanges` from `nx/src/generators/tree.js`, which is not a documented Nx entry point — it resolves via nx's `"./src/*"` export wildcard. `@nx/devkit` re-exports `FsTree` only from its `internal` entry and does not export `flushChanges` at all, so there is no public path to the tree primitives a generator-running executor needs; this is exactly what `nx`'s own `nx g` command does internally.

Stating the exposure plainly for reviewers: this is the **first use of that deep import in shipped runtime code** (the pattern already exists in this repo, but only in `*.spec.ts`). `nx` is a pinned `peerDependencies: "23.1.2"`, so it cannot drift under an existing install — but a future Nx release that narrowed the `./src/*` export would break the executor **in user workspaces at run time**, rather than failing here at build time. Mitigations considered and rejected as worse than the risk: vendoring a copy of `FsTree` (duplicates Nx-version-sensitive behaviour we would then have to keep in step), or a runtime `try`/fallback to shelling out (reintroduces the cost this PR removes, on a path that would then be almost never exercised and so never tested). The import site carries a comment recording why it is there, so the constraint is visible to whoever next touches it.

**Out of scope: dev-server startup.** `web:dev` startup was measured before/after (7 interleaved reps, daemon on): before p50 7274ms, after p50 7381ms — **no change**, and it is not the same problem. `dev` runs `vite` directly through `nx:run-commands`, so there is no nested `nx g` on its path; its `dependsOn` codegen does get faster, but startup is dominated by the API dev servers starting in parallel, which sit on the critical path either way. The remaining gap between `nx run ... dev` and raw `npx vite` is the *outer* Nx bootstrap, which is Nx's own cost and not something this plugin can remove. Left alone deliberately.

### Description of how you validated changes

**Byte-identical output.** For each of the four families, generated into the same directory from the same spec, once via the shelled-out `nx g` the old targets ran and once via the new executor, then `diff -r`:

```
web              (ts-hooks):      IDENTICAL (3 files)
common-constructs (ts-metadata):  IDENTICAL (1 files)
py_lib           (ts-client):     IDENTICAL (2 files)
tf               (json-metadata): IDENTICAL (1 files)
```

**Before/after, real workspace, both daemon modes.** `before` = unmodified plugin, `after` = locally compiled plugin with the migration applied. Randomised-order interleaved A/B in one window so load hits both arms equally; wall clock, `--skip-nx-cache`, all runs exit 0.

`generate:py-api-client`, `NX_DAEMON=true`, n=12 — **6718ms → 2987ms p50 (-3731ms, 56% faster)**

| rep | before | after | saved |
|---|---|---|---|
| 1 | 5202 | 2894 | 2308 |
| 2 | 7064 | 3468 | 3596 |
| 3 | 6803 | 2849 | 3954 |
| 4 | 6606 | 2910 | 3696 |
| 5 | 6536 | 2866 | 3670 |
| 6 | 6950 | 2728 | 4222 |
| 7 | 7442 | 3267 | 4175 |
| 8 | 7527 | 3108 | 4419 |
| 9 | 7110 | 3516 | 3594 |
| 10 | 6634 | 3064 | 3570 |
| 11 | 6448 | 2889 | 3559 |
| 12 | 6595 | 3143 | 3452 |

`generate:py-api-client`, `NX_DAEMON=false`, n=12 — **5416ms → 4000ms p50 (-1416ms, 26% faster)**

| rep | before | after | saved |
|---|---|---|---|
| 1 | 5927 | 4370 | 1557 |
| 2 | 6586 | 4378 | 2208 |
| 3 | 5507 | 4139 | 1368 |
| 4 | 5272 | 3999 | 1273 |
| 5 | 5258 | 4163 | 1095 |
| 6 | 5647 | 3699 | 1948 |
| 7 | 5127 | 3938 | 1189 |
| 8 | 5410 | 3892 | 1518 |
| 9 | 5422 | 3797 | 1625 |
| 10 | 5784 | 4253 | 1531 |
| 11 | 5360 | 4001 | 1359 |
| 12 | 5201 | 3879 | 1322 |

All three codegen targets together (daemon on, n=10) — **7414ms → 3054ms p50 (-4360ms, 59% faster)**; and `common-constructs:compile`, where the metadata target sits (daemon on, n=8) — **10307ms → 4548ms p50 (-5759ms)**.

Note the daemon-off numbers are smaller: without the daemon the *outer* bootstrap is itself much more expensive, so it dominates a larger share of the total. The saving is the nested bootstrap either way.

**Cache still works** (real workspace, post-migration): populate → `1/2 hit`; repeat → `2/2 hit (100%)`, nothing re-run; delete the output directory → `2/2 hit`, outputs restored from cache.

**Migration** applied to a real 14-project workspace updated exactly the three codegen targets, `nextSteps: []`, and `nx run-many -t build` for the affected projects passed afterwards. It is idempotent, and reports rather than clobbers a target that has diverged (extra flag, chained command, extra option) — 11 unit tests cover all four generators, cross-project rewriting, the untouched watch target, each divergence shape, unrelated targets, and idempotency.

**Suites:** `pnpm nx run @aws/nx-plugin:test` — **3967 passed / 222 files**, including 8 new executor tests. 7 pre-existing specs asserted on the old `options.commands` string and were updated to assert the executor and its options; no snapshot changes. `pnpm nx run-many --target lint --all --configuration=fix` clean (exit 0).

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
