### PR TITLE
chore(agentcore-harness): mark experimental generators on every catalogue surface

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -169,7 +169,11 @@ A generator whose shape is still settling can be marked experimental by adding `
 
 An experimental generator is **permitted to change without a migration** being published to carry an existing workspace across, so its output can be reshaped freely while it stabilises. Users upgrading reconcile those changes themselves.
 
-The flag needs nothing else authored: its guide page (any page carrying `generator: <id>` in its frontmatter) automatically shows a banner saying so, and the MCP `list-generators` / `generator-guide` tools include the same warning for agents. Remove the flag once the generator is stable — from then on it follows the normal migration rules above.
+Most surfaces pick the flag up on their own: its guide page (any page carrying `generator: <id>` in its frontmatter) automatically shows a banner saying so, the MCP `list-generators` / `generator-guide` tools include the same warning for agents, and the generated `SKILL.md` / `POWER.md` tables and the README vended into new workspaces mark the generator experimental.
+
+The one surface to update by hand is the generator table in `packages/nx-plugin/README.md` — a curated subset with its own descriptions, so it isn't generated from `generators.json`. Add `(experimental)` to the generator's description there and copy the file to the root `README.md` (the pre-commit hook does this for you). A unit test fails if you forget.
+
+Remove the flag once the generator is stable — from then on it follows the normal migration rules above.
 
 #### Migrations that change infrastructure
 

--- a/README.md
+++ b/README.md
@@ -77,28 +77,28 @@ pnpm nx g @aws/nx-plugin:ts#infra
 
 ## Available Generators
 
-| Generator               | Description                                                                                                       |
-| ----------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| `ts#project`            | TypeScript library                                                                                                |
-| `ts#api`                | TypeScript API (tRPC or Smithy) with API Gateway + Lambda + [Powertools](https://github.com/aws-powertools/powertools-lambda-typescript) |
-| `ts#rdb`                | Relational databases with Aurora RDS                                                                              |
-| `ts#website`            | React app (Vite)                                                                                                  |
-| `ts#website#auth`       | Add Cognito auth to a website                                                                                     |
-| `ts#infra`              | AWS CDK infrastructure project                                                                                    |
-| `ts#lambda-function`    | TypeScript Lambda with type-safe event sources                                                                    |
-| `ts#mcp-server`         | MCP server (TypeScript)                                                                                           |
-| `ts#agent`              | [Strands Agent](https://strandsagents.com/) (TypeScript)                                                          |
-| `ts#nx-generator`       | Nx generator scaffold                                                                                             |
-| `smithy#project`        | Smithy model project — a service model, or a shape library shared between Smithy projects                          |
-| `py#project`            | Python project (uv)                                                                                               |
-| `py#api`                | Python API (FastAPI) with API Gateway + Lambda + [Powertools](https://github.com/aws-powertools/powertools-lambda-python)      |
-| `py#lambda-function`    | Python Lambda with type-safe event sources                                                                        |
-| `py#mcp-server`         | MCP server (Python)                                                                                               |
-| `py#agent`              | [Strands Agent](https://strandsagents.com/) (Python)                                                              |
-| `agentcore-harness`     | [AgentCore Harness](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/harness.html) agent loop (experimental) |
-| `connection`            | Connect projects together (e.g. frontend to API)                                                                  |
-| `terraform#project`     | Terraform project                                                                                                 |
-| `license`               | Manage LICENSE files and source headers                                                                           |
+| Generator            | Description                                                                                                                              |
+| -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `ts#project`         | TypeScript library                                                                                                                       |
+| `ts#api`             | TypeScript API (tRPC or Smithy) with API Gateway + Lambda + [Powertools](https://github.com/aws-powertools/powertools-lambda-typescript) |
+| `ts#rdb`             | Relational databases with Aurora RDS                                                                                                     |
+| `ts#website`         | React app (Vite)                                                                                                                         |
+| `ts#website#auth`    | Add Cognito auth to a website                                                                                                            |
+| `ts#infra`           | AWS CDK infrastructure project                                                                                                           |
+| `ts#lambda-function` | TypeScript Lambda with type-safe event sources                                                                                           |
+| `ts#mcp-server`      | MCP server (TypeScript)                                                                                                                  |
+| `ts#agent`           | [Strands Agent](https://strandsagents.com/) (TypeScript)                                                                                 |
+| `ts#nx-generator`    | Nx generator scaffold                                                                                                                    |
+| `smithy#project`     | Smithy model project — a service model, or a shape library shared between Smithy projects                                                |
+| `py#project`         | Python project (uv)                                                                                                                      |
+| `py#api`             | Python API (FastAPI) with API Gateway + Lambda + [Powertools](https://github.com/aws-powertools/powertools-lambda-python)                |
+| `py#lambda-function` | Python Lambda with type-safe event sources                                                                                               |
+| `py#mcp-server`      | MCP server (Python)                                                                                                                      |
+| `py#agent`           | [Strands Agent](https://strandsagents.com/) (Python)                                                                                     |
+| `agentcore-harness`  | [AgentCore Harness](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/harness.html) agent loop (experimental)                |
+| `connection`         | Connect projects together (e.g. frontend to API)                                                                                         |
+| `terraform#project`  | Terraform project                                                                                                                        |
+| `license`            | Manage LICENSE files and source headers                                                                                                  |
 
 ## Community
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ pnpm nx g @aws/nx-plugin:ts#infra
 | `py#lambda-function`    | Python Lambda with type-safe event sources                                                                        |
 | `py#mcp-server`         | MCP server (Python)                                                                                               |
 | `py#agent`              | [Strands Agent](https://strandsagents.com/) (Python)                                                              |
-| `agentcore-harness`     | [AgentCore Harness](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/harness.html) agent loop        |
+| `agentcore-harness`     | [AgentCore Harness](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/harness.html) agent loop (experimental) |
 | `connection`            | Connect projects together (e.g. frontend to API)                                                                  |
 | `terraform#project`     | Terraform project                                                                                                 |
 | `license`               | Manage LICENSE files and source headers                                                                           |

--- a/docs/src/components/experimental-banner.astro
+++ b/docs/src/components/experimental-banner.astro
@@ -3,7 +3,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import GeneratorsJson from '../../../packages/nx-plugin/generators.json';
+import { findGeneratorsJsonEntry } from '../../../packages/nx-plugin/src/utils/generators';
 import Snippet from './snippet.astro';
 
 /**
@@ -21,8 +21,7 @@ interface Props {
 
 const { generatorId } = Astro.props;
 
-const experimental =
-  GeneratorsJson.generators[generatorId]?.experimental === true;
+const experimental = findGeneratorsJsonEntry(generatorId)?.experimental === true;
 ---
 
 {experimental && <Snippet name="experimental-generator" />}

--- a/docs/src/components/markdown-content.astro
+++ b/docs/src/components/markdown-content.astro
@@ -4,9 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import Default from '@astrojs/starlight/components/MarkdownContent.astro';
-import { postProcessGuide } from '../../../packages/nx-plugin/src/mcp-server/generator-info';
+import {
+  postProcessGuide,
+  renderExperimentalWarning,
+} from '../../../packages/nx-plugin/src/mcp-server/generator-info';
 import type { SnippetContentProvider } from '../../../packages/nx-plugin/src/mcp-server/generator-info';
-import { buildGeneratorInfoList } from '../../../packages/nx-plugin/src/utils/generators';
+import {
+  buildGeneratorInfoList,
+  findGeneratorsJsonEntry,
+} from '../../../packages/nx-plugin/src/utils/generators';
 import ExperimentalBanner from './experimental-banner.astro';
 import OptionFilterBar from './option-filter-bar.astro';
 import * as path from 'path';
@@ -91,9 +97,18 @@ if (!isSnippet && starlightRoute?.entry?.id) {
         .replace(/<Snippet name="[^"]*">\n?/g, '')
         .replace(/<\/Snippet>/g, '');
 
+      // Carry the experimental caveat into the copied markdown, so pasting a
+      // guide into an agent keeps the warning the MCP tools also emit.
+      const experimental =
+        generatorFrontmatter !== undefined &&
+        findGeneratorsJsonEntry(generatorFrontmatter)?.experimental === true;
+      const body = experimental
+        ? `${renderExperimentalWarning(generatorFrontmatter)}\n\n${cleanedMarkdown.trim()}`
+        : cleanedMarkdown.trim();
+
       // Add the page title
       const title = starlightRoute.entry.data.title;
-      resolvedMarkdown = title ? `# ${title}\n\n${cleanedMarkdown.trim()}` : cleanedMarkdown.trim();
+      resolvedMarkdown = title ? `# ${title}\n\n${body}` : body;
     }
   } catch {
     // If anything fails, we just won't have the copy button

--- a/packages/nx-plugin/README.md
+++ b/packages/nx-plugin/README.md
@@ -77,28 +77,28 @@ pnpm nx g @aws/nx-plugin:ts#infra
 
 ## Available Generators
 
-| Generator               | Description                                                                                                       |
-| ----------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| `ts#project`            | TypeScript library                                                                                                |
-| `ts#api`                | TypeScript API (tRPC or Smithy) with API Gateway + Lambda + [Powertools](https://github.com/aws-powertools/powertools-lambda-typescript) |
-| `ts#rdb`                | Relational databases with Aurora RDS                                                                              |
-| `ts#website`            | React app (Vite)                                                                                                  |
-| `ts#website#auth`       | Add Cognito auth to a website                                                                                     |
-| `ts#infra`              | AWS CDK infrastructure project                                                                                    |
-| `ts#lambda-function`    | TypeScript Lambda with type-safe event sources                                                                    |
-| `ts#mcp-server`         | MCP server (TypeScript)                                                                                           |
-| `ts#agent`              | [Strands Agent](https://strandsagents.com/) (TypeScript)                                                          |
-| `ts#nx-generator`       | Nx generator scaffold                                                                                             |
-| `smithy#project`        | Smithy model project — a service model, or a shape library shared between Smithy projects                          |
-| `py#project`            | Python project (uv)                                                                                               |
-| `py#api`                | Python API (FastAPI) with API Gateway + Lambda + [Powertools](https://github.com/aws-powertools/powertools-lambda-python)      |
-| `py#lambda-function`    | Python Lambda with type-safe event sources                                                                        |
-| `py#mcp-server`         | MCP server (Python)                                                                                               |
-| `py#agent`              | [Strands Agent](https://strandsagents.com/) (Python)                                                              |
-| `agentcore-harness`     | [AgentCore Harness](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/harness.html) agent loop (experimental) |
-| `connection`            | Connect projects together (e.g. frontend to API)                                                                  |
-| `terraform#project`     | Terraform project                                                                                                 |
-| `license`               | Manage LICENSE files and source headers                                                                           |
+| Generator            | Description                                                                                                                              |
+| -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `ts#project`         | TypeScript library                                                                                                                       |
+| `ts#api`             | TypeScript API (tRPC or Smithy) with API Gateway + Lambda + [Powertools](https://github.com/aws-powertools/powertools-lambda-typescript) |
+| `ts#rdb`             | Relational databases with Aurora RDS                                                                                                     |
+| `ts#website`         | React app (Vite)                                                                                                                         |
+| `ts#website#auth`    | Add Cognito auth to a website                                                                                                            |
+| `ts#infra`           | AWS CDK infrastructure project                                                                                                           |
+| `ts#lambda-function` | TypeScript Lambda with type-safe event sources                                                                                           |
+| `ts#mcp-server`      | MCP server (TypeScript)                                                                                                                  |
+| `ts#agent`           | [Strands Agent](https://strandsagents.com/) (TypeScript)                                                                                 |
+| `ts#nx-generator`    | Nx generator scaffold                                                                                                                    |
+| `smithy#project`     | Smithy model project — a service model, or a shape library shared between Smithy projects                                                |
+| `py#project`         | Python project (uv)                                                                                                                      |
+| `py#api`             | Python API (FastAPI) with API Gateway + Lambda + [Powertools](https://github.com/aws-powertools/powertools-lambda-python)                |
+| `py#lambda-function` | Python Lambda with type-safe event sources                                                                                               |
+| `py#mcp-server`      | MCP server (Python)                                                                                                                      |
+| `py#agent`           | [Strands Agent](https://strandsagents.com/) (Python)                                                                                     |
+| `agentcore-harness`  | [AgentCore Harness](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/harness.html) agent loop (experimental)                |
+| `connection`         | Connect projects together (e.g. frontend to API)                                                                                         |
+| `terraform#project`  | Terraform project                                                                                                                        |
+| `license`            | Manage LICENSE files and source headers                                                                                                  |
 
 ## Community
 

--- a/packages/nx-plugin/README.md
+++ b/packages/nx-plugin/README.md
@@ -95,7 +95,7 @@ pnpm nx g @aws/nx-plugin:ts#infra
 | `py#lambda-function`    | Python Lambda with type-safe event sources                                                                        |
 | `py#mcp-server`         | MCP server (Python)                                                                                               |
 | `py#agent`              | [Strands Agent](https://strandsagents.com/) (Python)                                                              |
-| `agentcore-harness`     | [AgentCore Harness](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/harness.html) agent loop        |
+| `agentcore-harness`     | [AgentCore Harness](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/harness.html) agent loop (experimental) |
 | `connection`            | Connect projects together (e.g. frontend to API)                                                                  |
 | `terraform#project`     | Terraform project                                                                                                 |
 | `license`               | Manage LICENSE files and source headers                                                                           |

--- a/packages/nx-plugin/src/mcp-server/generator-info.spec.ts
+++ b/packages/nx-plugin/src/mcp-server/generator-info.spec.ts
@@ -617,6 +617,34 @@ REACT_PY_STRANDS_BODY`,
       expect(result.content).toMatch(/react.*ts#trpc-api/);
     });
 
+    it('warns that an experimental generator may change on the unsupported path', async () => {
+      const unsupportedOptions = {
+        sourceType: 'ts#trpc-api',
+        targetType: 'smithy',
+        protocol: 'http',
+      };
+
+      const experimental = await fetchGuidePagesForGenerator(
+        { ...connectionInfo, experimental: true },
+        [connectionInfo],
+        undefined,
+        undefined,
+        unsupportedOptions,
+      );
+      expect(experimental.kind).toBe('unsupported');
+      expect(experimental.content).toContain('[!WARNING] Experimental');
+
+      const stable = await fetchGuidePagesForGenerator(
+        connectionInfo,
+        [connectionInfo],
+        undefined,
+        undefined,
+        unsupportedOptions,
+      );
+      expect(stable.kind).toBe('unsupported');
+      expect(stable.content).not.toContain('Experimental');
+    });
+
     it('still shows partial matches when not every predicate key is supplied', async () => {
       // No protocol supplied — both protocol-tagged pages are kept.
       const result = await fetchGuidePagesForGenerator(

--- a/packages/nx-plugin/src/mcp-server/generator-info.ts
+++ b/packages/nx-plugin/src/mcp-server/generator-info.ts
@@ -171,7 +171,7 @@ const renderUnsupportedMessage = (
   return `## ${info.id}
 
 > [!WARNING] Unsupported combination: ${requestedDesc}. The \`${info.id}\` generator has no guide variant matching this combination — running it will likely fail.
-
+${info.experimental ? `\n${renderExperimentalWarning(info.id)}\n` : ''}
 Supported combinations:
 ${supportedList}
 

--- a/packages/nx-plugin/src/preset/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/preset/__snapshots__/generator.spec.ts.snap
@@ -94,7 +94,7 @@ The following list of generators are what is currently available in the \`@aws/n
 
 - **agentcore-gateway**: Generate an AgentCore Gateway project
 
-- **agentcore-harness**: Generate an AgentCore Harness project
+- **agentcore-harness**: Generate an AgentCore Harness project (experimental)
 
 - **connection**: Integrates a source project with a target project
 

--- a/packages/nx-plugin/src/utils/generators.spec.ts
+++ b/packages/nx-plugin/src/utils/generators.spec.ts
@@ -3,7 +3,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { buildGeneratorInfoList } from './generators.js';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import {
+  buildGeneratorInfoList,
+  describeGeneratorForCatalogue,
+  findGeneratorsJsonEntry,
+  generatorsJsonEntries,
+} from './generators.js';
 
 describe('generators', () => {
   it('should not have duplicate metrics across generators', () => {
@@ -26,14 +33,73 @@ describe('generators', () => {
     ).toEqual([]);
   });
 
-  it('should surface the experimental flag', () => {
+  it('should surface the experimental flag for every generator that sets it', () => {
     const generators = buildGeneratorInfoList(process.cwd());
 
-    expect(
-      generators.find((g) => g.id === 'agentcore-harness')?.experimental,
-    ).toBe(true);
-    expect(generators.find((g) => g.id === 'ts#project')?.experimental).toBe(
-      undefined,
+    for (const [id, entry] of Object.entries(generatorsJsonEntries)) {
+      // The flag is spread conditionally, so an unflagged generator must be
+      // `undefined` rather than `false`.
+      expect(
+        generators.find((g) => g.id === id)?.experimental,
+        `experimental flag not surfaced for ${id}`,
+      ).toBe(entry.experimental ? true : undefined);
+    }
+  });
+
+  describe('findGeneratorsJsonEntry', () => {
+    it('should return the entry for a known generator', () => {
+      expect(findGeneratorsJsonEntry('ts#project')?.metric).toBe(
+        generatorsJsonEntries['ts#project'].metric,
+      );
+    });
+
+    it('should return undefined for an unknown generator', () => {
+      expect(findGeneratorsJsonEntry('does#not-exist')).toBeUndefined();
+    });
+  });
+
+  describe('describeGeneratorForCatalogue', () => {
+    it('should mark an experimental generator', () => {
+      expect(
+        describeGeneratorForCatalogue({
+          description: 'Generate a thing',
+          experimental: true,
+        }),
+      ).toBe('Generate a thing (experimental)');
+    });
+
+    it('should leave a stable generator undecorated', () => {
+      expect(
+        describeGeneratorForCatalogue({ description: 'Generate a thing' }),
+      ).toBe('Generate a thing');
+    });
+  });
+
+  // The package README's generator table is a curated subset with its own
+  // descriptions, so nothing regenerates it when a generator is marked
+  // experimental.
+  it('should mark experimental generators in the package README table', () => {
+    const readme = readFileSync(
+      join(__dirname, '..', '..', 'README.md'),
+      'utf-8',
     );
+    const rows = [...readme.matchAll(/^\| `([^`]+)`\s*\| (.*?)\s*\|$/gm)].map(
+      (match) => ({ id: match[1], description: match[2] }),
+    );
+
+    expect(rows.length).toBeGreaterThan(0);
+
+    const unmarked = rows
+      .filter(
+        ({ id, description }) =>
+          findGeneratorsJsonEntry(id)?.experimental === true &&
+          !description.includes('(experimental)'),
+      )
+      .map(({ id }) => id);
+
+    expect(
+      unmarked,
+      `These generators are experimental in generators.json but the README table does not say so. Add "(experimental)" to their description in packages/nx-plugin/README.md, then copy it to the root README.md.\n${unmarked.join('\n')}`,
+    ).toEqual([]);
   });
 });

--- a/packages/nx-plugin/src/utils/generators.ts
+++ b/packages/nx-plugin/src/utils/generators.ts
@@ -6,6 +6,36 @@
 import * as path from 'path';
 import GeneratorsJson from '../../generators.json' with { type: 'json' };
 
+/**
+ * A single entry in `generators.json`.
+ */
+export interface GeneratorsJsonEntry {
+  readonly factory: string;
+  readonly schema: string;
+  readonly description: string;
+  readonly metric: string;
+  readonly hidden?: boolean;
+  readonly experimental?: boolean;
+  readonly guidePages?: readonly string[];
+}
+
+/**
+ * Typed view of the `generators.json` entries, keyed by generator id, so every
+ * consumer that describes a generator reads the same declared shape.
+ */
+export const generatorsJsonEntries: Readonly<
+  Record<string, GeneratorsJsonEntry>
+> = (GeneratorsJson as { generators: Record<string, GeneratorsJsonEntry> })
+  .generators;
+
+/**
+ * Look up a generator's `generators.json` entry by id, returning `undefined`
+ * when no generator has that id.
+ */
+export const findGeneratorsJsonEntry = (
+  generatorId: string,
+): GeneratorsJsonEntry | undefined => generatorsJsonEntries[generatorId];
+
 export interface GeneratorInfo {
   readonly id: string;
   readonly metric: string;
@@ -31,19 +61,22 @@ export type NxGeneratorInfo = GeneratorInfo;
  * Build the list of generator info, resolving schema/factory paths relative to the given base directory.
  */
 export const buildGeneratorInfoList = (baseDir: string): GeneratorInfo[] =>
-  Object.entries((GeneratorsJson as Record<string, any>).generators).map(
-    ([id, info]: [string, any]) => ({
-      id,
-      metric: info.metric,
-      resolvedFactoryPath: path.resolve(baseDir, info.factory),
-      resolvedSchemaPath: path.resolve(baseDir, info.schema),
-      description: info.description,
-      ...('hidden' in info && info.hidden ? { hidden: info.hidden } : {}),
-      ...('experimental' in info && info.experimental
-        ? { experimental: info.experimental }
-        : {}),
-      ...('guidePages' in info && info.guidePages
-        ? { guidePages: info.guidePages }
-        : {}),
-    }),
-  );
+  Object.entries(generatorsJsonEntries).map(([id, info]) => ({
+    id,
+    metric: info.metric,
+    resolvedFactoryPath: path.resolve(baseDir, info.factory),
+    resolvedSchemaPath: path.resolve(baseDir, info.schema),
+    description: info.description,
+    ...(info.hidden ? { hidden: info.hidden } : {}),
+    ...(info.experimental ? { experimental: info.experimental } : {}),
+    ...(info.guidePages ? { guidePages: info.guidePages } : {}),
+  }));
+
+/**
+ * Describe a generator for a catalogue listing, marking an experimental
+ * generator so a reader knows its output may change without a migration.
+ */
+export const describeGeneratorForCatalogue = (
+  info: Pick<GeneratorsJsonEntry, 'description' | 'experimental'>,
+): string =>
+  info.experimental ? `${info.description} (experimental)` : info.description;

--- a/packages/nx-plugin/src/utils/init.ts
+++ b/packages/nx-plugin/src/utils/init.ts
@@ -14,7 +14,6 @@ import {
 import { initGenerator } from '@nx/js';
 import { readFileSync } from 'fs';
 import yaml from 'js-yaml';
-import GeneratorsJson from '../../generators.json' with { type: 'json' };
 import { SYNC_GENERATOR_NAME as TS_SYNC_GENERATOR_NAME } from '../ts/sync/generator.js';
 import { BASE_TSCONFIG_COMPILER_OPTIONS } from './base-tsconfig.js';
 import {
@@ -32,6 +31,10 @@ import {
   detectWorkspacePackageManager,
 } from './dependencies.js';
 import { getDefaultBiomeConfig } from './format.js';
+import {
+  describeGeneratorForCatalogue,
+  generatorsJsonEntries,
+} from './generators.js';
 import type { Iac } from './iac.js';
 import { configureMcpServers } from './mcp.js';
 import { getNpmScope } from './npm-scope.js';
@@ -382,9 +385,12 @@ export const applyWorkspaceInit = async <const D extends DependencyDeclaration>(
     '.',
     {
       projectName: getNpmScope(tree),
-      generators: Object.entries(GeneratorsJson.generators)
-        .filter(([_, v]) => !v['hidden'])
-        .map(([k, v]) => ({ name: k, description: v.description })),
+      generators: Object.entries(generatorsJsonEntries)
+        .filter(([, info]) => !info.hidden)
+        .map(([id, info]) => ({
+          name: id,
+          description: describeGeneratorForCatalogue(info),
+        })),
       ...(() => {
         const cmds = getPackageManagerDisplayCommands();
         return {

--- a/scripts/make-skills.ts
+++ b/scripts/make-skills.ts
@@ -7,17 +7,10 @@ import { join } from 'path';
 import { generateFiles, joinPathFragments } from '@nx/devkit';
 import { flushChanges, FsTree } from 'nx/src/generators/tree';
 import { buildCreateNxWorkspaceCommand } from '../packages/nx-plugin/src/utils/commands';
-import GeneratorsJson from '../packages/nx-plugin/generators.json';
-
-interface GeneratorInfo {
-  description: string;
-  hidden?: boolean;
-  experimental?: boolean;
-}
-
-interface GeneratorsJsonSchema {
-  generators: Record<string, GeneratorInfo>;
-}
+import {
+  describeGeneratorForCatalogue,
+  generatorsJsonEntries,
+} from '../packages/nx-plugin/src/utils/generators';
 
 const ROOT = join(__dirname, '..');
 
@@ -49,19 +42,14 @@ const getCreateNxWorkspaceCommand = (): string => {
 
 /**
  * Build the generators table from generators.json, filtering out hidden
- * generators. Experimental generators are flagged in their description, since
- * their output can change without a migration to update an existing workspace.
+ * generators.
  */
 const getGeneratorsTable = (): string => {
-  const generators = Object.entries(
-    (GeneratorsJson as GeneratorsJsonSchema).generators,
-  )
+  const generators = Object.entries(generatorsJsonEntries)
     .filter(([, info]) => !info.hidden)
     .map(([id, info]) => ({
       id,
-      description: info.experimental
-        ? `${info.description} (experimental)`
-        : info.description,
+      description: describeGeneratorForCatalogue(info),
     }));
 
   const maxIdLen = Math.max(...generators.map((g) => g.id.length + 2));


### PR DESCRIPTION
### Reason for this change

#1151 added the `experimental` flag to `generators.json`. It propagates to the docs banner, the MCP `list-generators` / `generator-guide` tools and the generated `SKILL.md` / `POWER.md` tables — but two surfaces that describe a generator to a user were missed, so they disagree with the generated tables for the same data:

- **The README vended into every new workspace** (`utils/init.ts`) listed generators from `generators.json` with `description: v.description`, dropping `experimental`. The adjacent line already respected the `hidden` filter, and `make-skills.ts` was updated, so this was the one consumer left behind. A developer reading their own workspace's "Available generators" list — the closest-to-hand catalogue they have — saw no indication the harness is experimental.
- **The generator tables in `README.md` and `packages/nx-plugin/README.md`**. The latter is the npm-rendered README for `@aws/nx-plugin`, a very common first stop: `agentcore-harness` appeared identically to the stable generators, so a user could adopt it in a production workspace and be surprised on upgrade when no migration is published.

`CONTRIBUTING.md` also asserted the flag "needs nothing else authored", which was not quite true for those tables.

### Description of changes

`describeGeneratorForCatalogue` is now shared by the vended workspace README and `make-skills.ts`, so the two *generated* catalogues cannot drift apart. `SKILL.md` / `POWER.md` regenerate byte-identically.

The README table is deliberately **not** generated: it is a curated subset (20 of 29 visible generators) with hand-written marketing descriptions and markdown links that differ from every `generators.json` description, so generating it would rewrite all 20 rows and lose the curation. Instead the marker is added by hand and a unit test fails if an experimental generator's row lacks it, with a message naming the file to edit. `CONTRIBUTING.md` now documents that one manual step instead of claiming there is none.

Fixed while in the area:

- `experimental-banner.astro` indexed the JSON-inferred object literal type with a `string`, which is `error TS7053` under the repo's own `astro/tsconfigs/strict` (which `docs/tsconfig.json` extends). It compiles today only because `astro build` transpiles without type-checking and **`astro check` is not wired into any target or CI workflow** — `@astrojs/check` isn't even a dependency. Both this and `markdown-content.astro` now use a typed `findGeneratorsJsonEntry` accessor. Wiring `astro check` in would need its own PR: it is a new dependency plus a new target, and would want a look at whatever else it surfaces across the docs site.
- The **"copy as markdown"** button built `resolvedMarkdown` without the banner, which is injected as a rendered component. A user copying a guide into an agent lost the caveat entirely. It now carries the same warning string the MCP tools emit.
- **`generator-guide` skipped the warning on the unsupported-combination path**, which returns `guide.content` early and never calls `renderGeneratorInfo`. Latent for `agentcore-harness` today (single guide page, no `when:` frontmatter) but wrong for the next experimental generator with variants.

`buildGeneratorInfoList` loses its `Record<string, any>` cast, so the conditional spreads are type-checked rather than relying on `'x' in info` guards.

### Description of how you validated changes

**Every finding was reproduced before being fixed.**

- **TS7053** reproduced under the repo's own tsc with `astro/tsconfigs/strict`, then A/B'd in one harness: old form → `error TS7053`, new form → clean.
- **Vended README (the actual user-visible outcome)** verified end-to-end in a real Nx 23.1.2 workspace using the locally compiled plugin. `agentcore-harness` renders as `Generate an AgentCore Harness project (experimental)`, exactly one marker appears, and stable generators — including the adjacent `agentcore-gateway` — stay undecorated. (First attempt showed no marker: pnpm had resolved a hard-copied store entry rather than the symlink, so the stale build ran. Replacing the store copy confirmed the fix.)
- **`docs:build`** passes: exit 0, 1513 pages, "All internal links are valid", and `git status` clean so CI's mutation gate at `pr.yml:70-71` is satisfied. Verified in the **built HTML** that the harness page's `data-copy-markdown` attribute now contains the `[!WARNING] Experimental` text (previously 19213 chars with zero occurrences) while `agentcore-gateway`'s does not, and that the rendered banner still appears — checked for `en`, `jp`, `zh` and `ko`.
- **`npx tsx scripts/make-skills.ts`** reports no drift; sanity-checked by perturbing `SKILL.md` and watching it restore byte-identically.
- **Unit tests**: new coverage for `findGeneratorsJsonEntry`, `describeGeneratorForCatalogue`, the README-table guard, and the unsupported-combination path (with a negative control asserting a stable generator gets no warning). The "surfaces the experimental flag" test now iterates every entry in `generators.json` rather than hardcoding `agentcore-harness`, so it no longer fails the day the harness graduates to stable — the exact moment the flag is *correctly* removed. The 3 affected spec files pass 85/85, and the one snapshot change is the single intended vended-README line.
- **Full suite**: 284 failed / 3673 passed vs a documented `main` baseline of 284 failed / 3664 passed — same failure count, same 25-file set, same environmental root cause (`Cannot read properties of null (reading 'version')` from `@nx/js` resolving `@nx/vitest`, which fails identically on `main` in this container), no failure in any file touched here, and +6 net new passing tests matching the additions. Upstream CI is the real gate.
- `tsc -p packages/nx-plugin/tsconfig.lib.json --noEmit` and the docs tsconfig both typecheck clean, and `nx run-many --target lint --all --configuration=fix` exits 0 with no mutation.

### Issue # (if applicable)

N/A — follow-up to #1151.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*