### PR TITLE
chore(docs): stop the translate import check flagging code-block imports

### DIFF
--- a/.github/workflows/translate-docs.yml
+++ b/.github/workflows/translate-docs.yml
@@ -43,6 +43,9 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_TRANSLATE_ROLE_ARN }}
           aws-region: ${{ secrets.AWS_TRANSLATE_AWS_REGION || 'us-west-2' }}
+          # A run translates every changed file into eight locales, which takes
+          # longer than the one-hour session the action requests by default.
+          role-duration-seconds: 14400
       - name: Run translation
         id: translate
         env:

--- a/scripts/translate.ts
+++ b/scripts/translate.ts
@@ -326,16 +326,24 @@ function assertFrontmatterIsParseable(text: string): void {
  * occasionally emits a component's import line twice, which acorn rejects with
  * `Identifier '<name>' has already been declared` and fails the docs build, so
  * reject it here and let the retry write the file cleanly.
+ *
+ * Only the prose carries MDX imports, so fenced code is excluded — a document
+ * quoting two Python snippets that each `import os` is valid. The name and the
+ * `from` are matched on the import's own line for the same reason.
  */
 function assertImportsAreUnique(text: string): void {
   const seen = new Set<string>();
-  for (const [, name] of text.matchAll(/^import\s+(\w+)\s+from\s+/gm)) {
-    if (seen.has(name)) {
-      throw new Error(
-        `duplicate import of "${name}" — acorn rejects a redeclared identifier and the docs build fails`,
-      );
+  for (const chunk of splitOnFences(text).prose) {
+    for (const [, name] of chunk.matchAll(
+      /^import[^\S\n]+(\w+)[^\S\n]+from[^\S\n]/gm,
+    )) {
+      if (seen.has(name)) {
+        throw new Error(
+          `duplicate import of "${name}" — acorn rejects a redeclared identifier and the docs build fails`,
+        );
+      }
+      seen.add(name);
     }
-    seen.add(name);
   }
 }
 


### PR DESCRIPTION
### Reason for this change

The Translate Documentation workflow fails on any PR that touches a docs page carrying two Python code blocks. It failed this way on #1165, where 20 translations gave up after exhausting their retries.

Two independent causes, both pre-existing on `main`:

**1. `assertImportsAreUnique` flags code-block imports (16 of the 20 failures).** The guard exists to catch the agent emitting a component's MDX `import` line twice, which acorn rejects with `Identifier 'x' has already been declared`. It scanned the whole document, so it also saw `import` lines inside fenced code — and a page quoting two Python snippets that each `import os` legitimately has two. The regex also matched across newlines, reading `import os\n\nfrom pathlib import Path` as a single `import os from`.

Nothing the agent produced could satisfy the check, because the source itself does not satisfy it: `guides/py-agent.mdx` → `os` and `dungeon-game/1.mdx` → `uuid` burned all 4 attempts in all 8 locales and reported an error every time. Running the check as shipped over the committed docs flags **45 files across every locale**, including the English sources — so these files have never been translatable since the guard landed, and the same latent failure sits in `fastapi.mdx`, `contribute-generator.mdx` and `02-migrate-website.mdx`.

**2. The AWS session expires mid-run (the remaining 4).** `configure-aws-credentials` requests a one-hour session unless told otherwise. The job ran 65 minutes — largely *because* of cause 1, whose doomed retries against two large files monopolised the concurrency limit — and every Bedrock call after the hour mark failed with `The security token included in the request is expired`.

### Description of changes

- **`scripts/translate.ts`** — `assertImportsAreUnique` now walks only the prose segments from the existing `splitOnFences` helper, and matches the identifier and `from` with `[^\S\n]` so an import must sit on one line. MDX imports only ever appear in prose, so excluding fenced code loses no coverage.
- **`.github/workflows/translate-docs.yml`** — set `role-duration-seconds: 14400`. Raising the role's `MaxSessionDuration` alone does not help; the action still asks for one hour unless the request is made explicitly. `ci.yml` already does this for the deploy role.

No change to the generator-vended `translate.ts.template` — it does not carry this check, so the bug is repo-only.

### Description of how you validated changes

Ran the fixed function as shipped over all **1485** committed `.mdx` files: **0 flagged**, down from 45. Confirmed against the four cases that matter:

| Case | Throws | Expected |
| --- | --- | --- |
| Genuine duplicate MDX `import Link` | yes | yes |
| Two Python blocks each `import os` | no | no |
| `import React from 'react'` in two code blocks | no | no |
| Distinct MDX imports | no | no |

The guard still does the job it was added for; it just no longer fires on valid documents. Verified the pre-existing prettier and biome findings in `scripts/translate.ts` are unchanged by this diff (none fall on the edited lines).

This workflow only runs on PRs touching English docs, so this PR does not exercise it. #1165 does, and should go green on it once this merges and it rebases.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*