### PR TITLE
chore(local-dev): fix the flaky chat smoke test by disabling Nx's nested pty

### DIFF
--- a/e2e/src/smoke-tests/local-dev.spec.ts
+++ b/e2e/src/smoke-tests/local-dev.spec.ts
@@ -10,7 +10,6 @@ import { ensureDirSync } from 'fs-extra';
 import type { MockServer } from 'llm-mock-server';
 import { createConnection } from 'net';
 import * as pty from 'node-pty';
-import { join } from 'path';
 import { createTestWorkspace, runCLI, tmpProjPath } from '../utils';
 import { startLlmMock } from '../utils/llm-mock';
 import {
@@ -307,110 +306,34 @@ function startServer(
 }
 
 /**
- * Resolve a `<agent>-chat` target to what it actually runs, from the generated
- * `project.json`. Read rather than hardcoded so this follows whatever the
- * generators emit.
- */
-function readChatTarget(
-  projectRoot: string,
-  target: string,
-): {
-  command: string;
-  cwd: string;
-  env: Record<string, string>;
-  dependsOn: string[];
-} {
-  const [projectName, targetName] = target.split(':');
-  const project = JSON.parse(
-    execSync(`pnpm exec nx show project ${projectName} --json`, {
-      cwd: projectRoot,
-      encoding: 'utf-8',
-      windowsHide: true,
-    }),
-  );
-  const chat = project.targets?.[targetName];
-  if (!chat) {
-    throw new Error(
-      `Target "${targetName}" not found on project ${projectName}`,
-    );
-  }
-  const command: string =
-    chat.options?.command ?? chat.options?.commands?.[0] ?? '';
-  if (!command) {
-    throw new Error(`Target "${target}" declares no command`);
-  }
-  // Nx templates `cwd`/`env` with {projectRoot} / {workspaceRoot}.
-  const expand = (value: string) =>
-    value
-      .replaceAll('{projectRoot}', project.root)
-      .replaceAll('{workspaceRoot}', '.');
-  return {
-    command: expand(command),
-    cwd: expand(chat.options?.cwd ?? '{workspaceRoot}'),
-    env: Object.fromEntries(
-      Object.entries(chat.options?.env ?? {}).map(([k, v]) => [
-        k,
-        expand(String(v)),
-      ]),
-    ),
-    // Only same-project string deps are used here (the generated chat targets
-    // declare at most the client-codegen target).
-    dependsOn: (chat.dependsOn ?? []).filter(
-      (d: unknown): d is string => typeof d === 'string',
-    ),
-  };
-}
-
-/**
- * Drive a generated `<agent>-chat` script through a PTY (the Clack prompt needs
- * a TTY), send one message once the prompt is up, and resolve when the agent
- * streams `expected` back. Proves the chat CLI boots, connects, submits input
- * and renders the reply end-to-end.
+ * Drive a generated `<agent>-chat` target through a PTY (the Clack prompt needs a
+ * TTY), send one message once the prompt is up, and resolve when the agent
+ * streams `expected` back. Proves the chat CLI boots, connects, submits input and
+ * renders the reply end-to-end, through the same `nx run` a user would type.
  *
- * The chat script is spawned directly rather than via `nx run <target>`. Going
- * through Nx puts the CLI two processes down (`pnpm → nx → tsx`), and when those
- * intermediates have not wired the PTY through by the time we type, the input is
- * silently dropped and the prompt never reads it — the flake this avoids. Any
- * `dependsOn` codegen is run first, without a PTY, so the PTY has exactly one
- * process in it.
+ * `NX_NATIVE_COMMAND_RUNNER=false` matters: `nx:run-commands` otherwise wraps the
+ * command in Nx's own Rust pseudo-terminal whenever stdout is a TTY, so what we
+ * type goes to *that* terminal and only reaches the CLI if Nx has finished wiring
+ * the two together — a race that silently swallowed the message and left the run
+ * waiting out its whole timeout. With the native runner off, Nx spawns the command
+ * with `stdio: ['inherit', ...]`, so the CLI inherits this PTY directly and reads
+ * the keystrokes itself.
  */
-async function chatStreamsReply(
-  projectRoot: string,
+function chatStreamsReply(
+  cwd: string,
   target: string,
   expected: string,
   timeoutMs: number,
   message = 'What is 3 times 5?',
 ): Promise<void> {
-  const [projectName] = target.split(':');
-  const { command, cwd, env, dependsOn } = readChatTarget(projectRoot, target);
-
-  // HTTP chat imports a generated client, so run the target's `dependsOn` first.
-  // Ordinary (non-PTY) execution — only the chat script itself needs a TTY.
-  for (const dep of dependsOn) {
-    await runCLI(`run ${projectName}:${dep}`, { cwd: projectRoot });
-  }
-
-  // Spawn the binary directly so the PTY holds exactly one process — no shell
-  // or package-manager wrapper between us and the prompt. The dependency may be
-  // linked into either the project's or the workspace root's `.bin`.
-  const [bin, ...args] = command.split(' ');
-  const binPath = [
-    join(projectRoot, cwd, 'node_modules', '.bin', bin),
-    join(projectRoot, 'node_modules', '.bin', bin),
-  ].find((candidate) => existsSync(candidate));
-  if (!binPath) {
-    throw new Error(
-      `Could not resolve "${bin}" for ${target} in ${cwd} or the workspace root`,
-    );
-  }
   return new Promise((resolve, reject) => {
-    const term = pty.spawn(binPath, args, {
-      cwd: join(projectRoot, cwd),
+    const term = pty.spawn('pnpm', ['exec', 'nx', 'run', target], {
+      cwd,
       env: {
         ...process.env,
-        ...env,
         NX_DAEMON: 'true',
         RUNTIME_CONFIG_APP_ID: '',
+        NX_NATIVE_COMMAND_RUNNER: 'false',
       },
     });
     let out = '';
@@ -441,7 +364,7 @@ async function chatStreamsReply(
       out += d;
       process.stdout.write(`[${target}] ${d}`);
       const text = clean();
-      // `Connected to ` prints before the Clack prompt attaches to stdin, so wait
+      // `Connected to ` is printed before the prompt starts reading stdin, so wait
       // for the prompt's own placeholder before typing.
       if (!sent && text.includes('Type a message')) {
         sent = true;

--- a/e2e/src/smoke-tests/local-dev.spec.ts
+++ b/e2e/src/smoke-tests/local-dev.spec.ts
@@ -326,11 +326,17 @@ function chatStreamsReply(
     let out = '';
     let sent = false;
     let settled = false;
+    let resend: NodeJS.Timeout | undefined;
     const clean = () => stripVTControlCharacters(out);
+    const stopResending = () => {
+      clearInterval(resend);
+      resend = undefined;
+    };
     const finish = (err?: Error) => {
       if (settled) return;
       settled = true;
       clearTimeout(timer);
+      stopResending();
       try {
         term.kill();
       } catch {
@@ -351,9 +357,24 @@ function chatStreamsReply(
       out += d;
       process.stdout.write(`[${target}] ${d}`);
       const text = clean();
-      if (!sent && text.includes('Connected to ')) {
+      // `Connected to ` is printed before the Clack prompt attaches to stdin, so
+      // a message written on that signal alone can land while nothing is reading
+      // and be dropped — the PTY still echoes it, so the run then waits out the
+      // full timeout on a message the agent never received. Wait for the
+      // prompt's own placeholder, which is only rendered once it is reading.
+      if (!sent && text.includes('Type a message')) {
         sent = true;
-        setTimeout(() => term.write(`${message}\r`), 1000);
+        // Re-send until Clack marks this prompt submitted (`◇  You → `, vs `◆`
+        // while it is still active), since even the placeholder can be painted a
+        // beat before the prompt will accept a submission.
+        term.write(`${message}\r`);
+        resend = setInterval(() => {
+          if (/◇\s+You → /.test(clean())) {
+            stopResending();
+            return;
+          }
+          term.write(`${message}\r`);
+        }, 5000);
       }
       if (
         sent &&

--- a/e2e/src/smoke-tests/local-dev.spec.ts
+++ b/e2e/src/smoke-tests/local-dev.spec.ts
@@ -10,6 +10,7 @@ import { ensureDirSync } from 'fs-extra';
 import type { MockServer } from 'llm-mock-server';
 import { createConnection } from 'net';
 import * as pty from 'node-pty';
+import { join } from 'path';
 import { createTestWorkspace, runCLI, tmpProjPath } from '../utils';
 import { startLlmMock } from '../utils/llm-mock';
 import {
@@ -306,32 +307,117 @@ function startServer(
 }
 
 /**
- * One attempt at driving `agent-chat` through a PTY: send the message once the
- * prompt is up, and resolve when the agent streams `expected` back.
- *
- * Resolves `false` (rather than rejecting) when the prompt never consumed the
- * message, so the caller can relaunch — see `chatStreamsReply`.
+ * Resolve a `<agent>-chat` target to what it actually runs, from the generated
+ * `project.json`. Read rather than hardcoded so this follows whatever the
+ * generators emit.
  */
-function chatAttempt(
-  cwd: string,
+function readChatTarget(
+  projectRoot: string,
+  target: string,
+): {
+  command: string;
+  cwd: string;
+  env: Record<string, string>;
+  dependsOn: string[];
+} {
+  const [projectName, targetName] = target.split(':');
+  const project = JSON.parse(
+    execSync(`pnpm exec nx show project ${projectName} --json`, {
+      cwd: projectRoot,
+      encoding: 'utf-8',
+      windowsHide: true,
+    }),
+  );
+  const chat = project.targets?.[targetName];
+  if (!chat) {
+    throw new Error(
+      `Target "${targetName}" not found on project ${projectName}`,
+    );
+  }
+  const command: string =
+    chat.options?.command ?? chat.options?.commands?.[0] ?? '';
+  if (!command) {
+    throw new Error(`Target "${target}" declares no command`);
+  }
+  // Nx templates `cwd`/`env` with {projectRoot} / {workspaceRoot}.
+  const expand = (value: string) =>
+    value
+      .replaceAll('{projectRoot}', project.root)
+      .replaceAll('{workspaceRoot}', '.');
+  return {
+    command: expand(command),
+    cwd: expand(chat.options?.cwd ?? '{workspaceRoot}'),
+    env: Object.fromEntries(
+      Object.entries(chat.options?.env ?? {}).map(([k, v]) => [
+        k,
+        expand(String(v)),
+      ]),
+    ),
+    // Only same-project string deps are used here (the generated chat targets
+    // declare at most the client-codegen target).
+    dependsOn: (chat.dependsOn ?? []).filter(
+      (d: unknown): d is string => typeof d === 'string',
+    ),
+  };
+}
+
+/**
+ * Drive a generated `<agent>-chat` script through a PTY (the Clack prompt needs
+ * a TTY), send one message once the prompt is up, and resolve when the agent
+ * streams `expected` back. Proves the chat CLI boots, connects, submits input
+ * and renders the reply end-to-end.
+ *
+ * The chat script is spawned directly rather than via `nx run <target>`. Going
+ * through Nx puts the CLI two processes down (`pnpm → nx → tsx`), and when those
+ * intermediates have not wired the PTY through by the time we type, the input is
+ * silently dropped and the prompt never reads it — the flake this avoids. Any
+ * `dependsOn` codegen is run first, without a PTY, so the PTY has exactly one
+ * process in it.
+ */
+async function chatStreamsReply(
+  projectRoot: string,
   target: string,
   expected: string,
   timeoutMs: number,
-  message: string,
-): Promise<{ ok: boolean; consumed: boolean; out: string }> {
+  message = 'What is 3 times 5?',
+): Promise<void> {
+  const [projectName] = target.split(':');
+  const { command, cwd, env, dependsOn } = readChatTarget(projectRoot, target);
+
+  // HTTP chat imports a generated client, so run the target's `dependsOn` first.
+  // Ordinary (non-PTY) execution — only the chat script itself needs a TTY.
+  for (const dep of dependsOn) {
+    await runCLI(`run ${projectName}:${dep}`, { cwd: projectRoot });
+  }
+
+  // Spawn the binary directly so the PTY holds exactly one process — no shell
+  // or package-manager wrapper between us and the prompt. The dependency may be
+  // linked into either the project's or the workspace root's `.bin`.
+  const [bin, ...args] = command.split(' ');
+  const binPath = [
+    join(projectRoot, cwd, 'node_modules', '.bin', bin),
+    join(projectRoot, 'node_modules', '.bin', bin),
+  ].find((candidate) => existsSync(candidate));
+  if (!binPath) {
+    throw new Error(
+      `Could not resolve "${bin}" for ${target} in ${cwd} or the workspace root`,
+    );
+  }
   return new Promise((resolve, reject) => {
-    const term = pty.spawn('pnpm', ['exec', 'nx', 'run', target], {
-      cwd,
-      env: { ...process.env, NX_DAEMON: 'true', RUNTIME_CONFIG_APP_ID: '' },
+    const term = pty.spawn(binPath, args, {
+      cwd: join(projectRoot, cwd),
+      env: {
+        ...process.env,
+        ...env,
+        NX_DAEMON: 'true',
+        RUNTIME_CONFIG_APP_ID: '',
+      },
     });
     let out = '';
     let sent = false;
     let settled = false;
     const clean = () => stripVTControlCharacters(out);
-    // Clack reads in raw mode with echo off and repaints the line itself, so the
-    // message appearing back is proof the prompt actually consumed stdin.
-    const consumed = () => clean().includes(message);
-    const finish = (result?: { ok: boolean }, err?: Error) => {
+    const finish = (err?: Error) => {
       if (settled) return;
       settled = true;
       clearTimeout(timer);
@@ -340,11 +426,17 @@ function chatAttempt(
       } catch {
         // already dead
       }
-      err
-        ? reject(err)
-        : resolve({ ok: result!.ok, consumed: consumed(), out: clean() });
+      err ? reject(err) : resolve();
     };
-    const timer = setTimeout(() => finish({ ok: false }), timeoutMs);
+    const timer = setTimeout(
+      () =>
+        finish(
+          new Error(
+            `Chat target ${target} did not stream "${expected}" within ${timeoutMs}ms. Output:\n${clean()}`,
+          ),
+        ),
+      timeoutMs,
+    );
     term.onData((d) => {
       out += d;
       process.stdout.write(`[${target}] ${d}`);
@@ -357,62 +449,13 @@ function chatAttempt(
       }
       if (
         sent &&
-        consumed() &&
         text.slice(text.indexOf(message) + message.length).includes(expected)
       ) {
-        finish({ ok: true });
+        finish();
       }
     });
-    term.onExit(() =>
-      finish(undefined, new Error(`Chat target ${target} exited early`)),
-    );
+    term.onExit(() => finish(new Error(`Chat target ${target} exited early`)));
   });
-}
-
-/**
- * Drive `agent-chat` through a PTY (the Clack prompt needs a TTY), send one
- * message once connected, and resolve when the agent streams `expected` back.
- * Proves the standalone chat boots, connects, submits input and renders the
- * reply end-to-end. Rejects if not seen before the timeout.
- *
- * Occasionally the prompt never receives what we type: `agent-chat` runs as a
- * grandchild (pnpm → nx → tsx), and if the intermediate processes have not wired
- * the PTY through to it by the time we write, the input goes nowhere. Clack
- * renders its own input, so an attempt whose output never shows the message
- * never consumed it — relaunch rather than spend the whole budget waiting on a
- * process that will never answer.
- */
-async function chatStreamsReply(
-  cwd: string,
-  target: string,
-  expected: string,
-  timeoutMs: number,
-  message = 'What is 3 times 5?',
-): Promise<void> {
-  const attempts = 3;
-  let last = '';
-  for (let attempt = 1; attempt <= attempts; attempt++) {
-    const { ok, consumed, out } = await chatAttempt(
-      cwd,
-      target,
-      expected,
-      timeoutMs,
-      message,
-    );
-    if (ok) return;
-    last = out;
-    // The prompt did receive the message and still did not answer — a real
-    // failure, so report it rather than masking it behind a retry.
-    if (consumed) break;
-    if (attempt < attempts) {
-      console.warn(
-        `Chat target ${target} never consumed the typed message (attempt ${attempt}/${attempts}); relaunching`,
-      );
-    }
-  }
-  throw new Error(
-    `Chat target ${target} did not stream "${expected}" within ${timeoutMs}ms. Output:\n${last}`,
-  );
 }
 
 function killProcess(child: ChildProcess): Promise<void> {

--- a/e2e/src/smoke-tests/local-dev.spec.ts
+++ b/e2e/src/smoke-tests/local-dev.spec.ts
@@ -306,18 +306,19 @@ function startServer(
 }
 
 /**
- * Drive `agent-chat` through a PTY (the Clack prompt needs a TTY), send one
- * message once connected, and resolve when the agent streams `expected` back.
- * Proves the standalone chat boots, connects, submits input and renders the
- * reply end-to-end. Rejects if not seen before the timeout.
+ * One attempt at driving `agent-chat` through a PTY: send the message once the
+ * prompt is up, and resolve when the agent streams `expected` back.
+ *
+ * Resolves `false` (rather than rejecting) when the prompt never consumed the
+ * message, so the caller can relaunch — see `chatStreamsReply`.
  */
-function chatStreamsReply(
+function chatAttempt(
   cwd: string,
   target: string,
   expected: string,
   timeoutMs: number,
-  message = 'What is 3 times 5?',
-): Promise<void> {
+  message: string,
+): Promise<{ ok: boolean; consumed: boolean; out: string }> {
   return new Promise((resolve, reject) => {
     const term = pty.spawn('pnpm', ['exec', 'nx', 'run', target], {
       cwd,
@@ -326,65 +327,92 @@ function chatStreamsReply(
     let out = '';
     let sent = false;
     let settled = false;
-    let resend: NodeJS.Timeout | undefined;
     const clean = () => stripVTControlCharacters(out);
-    const stopResending = () => {
-      clearInterval(resend);
-      resend = undefined;
-    };
-    const finish = (err?: Error) => {
+    // Clack reads in raw mode with echo off and repaints the line itself, so the
+    // message appearing back is proof the prompt actually consumed stdin.
+    const consumed = () => clean().includes(message);
+    const finish = (result?: { ok: boolean }, err?: Error) => {
       if (settled) return;
       settled = true;
       clearTimeout(timer);
-      stopResending();
       try {
         term.kill();
       } catch {
         // already dead
       }
-      err ? reject(err) : resolve();
+      err
+        ? reject(err)
+        : resolve({ ok: result!.ok, consumed: consumed(), out: clean() });
     };
-    const timer = setTimeout(
-      () =>
-        finish(
-          new Error(
-            `Chat target ${target} did not stream "${expected}" within ${timeoutMs}ms. Output:\n${clean()}`,
-          ),
-        ),
-      timeoutMs,
-    );
+    const timer = setTimeout(() => finish({ ok: false }), timeoutMs);
     term.onData((d) => {
       out += d;
       process.stdout.write(`[${target}] ${d}`);
       const text = clean();
-      // `Connected to ` is printed before the Clack prompt attaches to stdin, so
-      // a message written on that signal alone can land while nothing is reading
-      // and be dropped — the PTY still echoes it, so the run then waits out the
-      // full timeout on a message the agent never received. Wait for the
-      // prompt's own placeholder, which is only rendered once it is reading.
+      // `Connected to ` prints before the Clack prompt attaches to stdin, so wait
+      // for the prompt's own placeholder before typing.
       if (!sent && text.includes('Type a message')) {
         sent = true;
-        // Re-send until Clack marks this prompt submitted (`◇  You → `, vs `◆`
-        // while it is still active), since even the placeholder can be painted a
-        // beat before the prompt will accept a submission.
-        term.write(`${message}\r`);
-        resend = setInterval(() => {
-          if (/◇\s+You → /.test(clean())) {
-            stopResending();
-            return;
-          }
-          term.write(`${message}\r`);
-        }, 5000);
+        setTimeout(() => term.write(`${message}\r`), 1000);
       }
       if (
         sent &&
+        consumed() &&
         text.slice(text.indexOf(message) + message.length).includes(expected)
       ) {
-        finish();
+        finish({ ok: true });
       }
     });
-    term.onExit(() => finish(new Error(`Chat target ${target} exited early`)));
+    term.onExit(() =>
+      finish(undefined, new Error(`Chat target ${target} exited early`)),
+    );
   });
+}
+
+/**
+ * Drive `agent-chat` through a PTY (the Clack prompt needs a TTY), send one
+ * message once connected, and resolve when the agent streams `expected` back.
+ * Proves the standalone chat boots, connects, submits input and renders the
+ * reply end-to-end. Rejects if not seen before the timeout.
+ *
+ * Occasionally the prompt never receives what we type: `agent-chat` runs as a
+ * grandchild (pnpm → nx → tsx), and if the intermediate processes have not wired
+ * the PTY through to it by the time we write, the input goes nowhere. Clack
+ * renders its own input, so an attempt whose output never shows the message
+ * never consumed it — relaunch rather than spend the whole budget waiting on a
+ * process that will never answer.
+ */
+async function chatStreamsReply(
+  cwd: string,
+  target: string,
+  expected: string,
+  timeoutMs: number,
+  message = 'What is 3 times 5?',
+): Promise<void> {
+  const attempts = 3;
+  let last = '';
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    const { ok, consumed, out } = await chatAttempt(
+      cwd,
+      target,
+      expected,
+      timeoutMs,
+      message,
+    );
+    if (ok) return;
+    last = out;
+    // The prompt did receive the message and still did not answer — a real
+    // failure, so report it rather than masking it behind a retry.
+    if (consumed) break;
+    if (attempt < attempts) {
+      console.warn(
+        `Chat target ${target} never consumed the typed message (attempt ${attempt}/${attempts}); relaunching`,
+      );
+    }
+  }
+  throw new Error(
+    `Chat target ${target} did not stream "${expected}" within ${timeoutMs}ms. Output:\n${last}`,
+  );
 }
 
 function killProcess(child: ChildProcess): Promise<void> {

--- a/scripts/update-versions.ts
+++ b/scripts/update-versions.ts
@@ -212,57 +212,6 @@ const holdRuffToWasmBuild = (
 };
 
 /**
- * `@copilotkit/react-core` depends on an exact `@ag-ui/client` and `@ag-ui/core`,
- * and the website passes an `@ag-ui/client` agent straight into CopilotKit's
- * provider. Bumping the `@ag-ui/*` pins past what CopilotKit asks for installs a
- * second copy, and the two `AbstractAgent` declarations are structurally
- * incompatible (private `_debug`), so every generated website fails to compile
- * with TS2322 — which takes out the whole smoke test matrix at once.
- *
- * So hold the shared `@ag-ui/*` packages at whatever CopilotKit pins. They move
- * again once a CopilotKit release asks for a newer one.
- */
-const holdAgUiToCopilotKit = (
-  updatedVersions: Record<string, string>,
-): ReportNote[] => {
-  const copilotKitVersion =
-    updatedVersions['@copilotkit/react-core'] ??
-    TS_VERSIONS['@copilotkit/react-core'];
-
-  let deps: Record<string, string>;
-  try {
-    deps = JSON.parse(
-      execSync(
-        `npm view @copilotkit/react-core@${copilotKitVersion} dependencies --json`,
-        { encoding: 'utf-8' },
-      ),
-    );
-  } catch {
-    return [
-      {
-        note: `could not read @copilotkit/react-core@${copilotKitVersion} dependencies to pin @ag-ui/* against — left as proposed`,
-      },
-    ];
-  }
-
-  // Only the packages CopilotKit itself depends on can duplicate against it.
-  // `@ag-ui/aws-strands` and `@ag-ui/a2ui-toolkit` are agent-side only.
-  const notes: ReportNote[] = [];
-  for (const name of ['@ag-ui/client', '@ag-ui/core', '@ag-ui/encoder']) {
-    // `@ag-ui/encoder` is not a CopilotKit dependency, but ships from the same
-    // release train as client/core and must match them.
-    const required = deps[name] ?? deps['@ag-ui/client'];
-    const proposed = updatedVersions[name];
-    if (!required || !proposed || proposed === required) continue;
-    updatedVersions[name] = required;
-    notes.push({
-      note: `${name} held at ${required} (${proposed} available): @copilotkit/react-core@${copilotKitVersion} pins ${required}, and a second copy breaks the generated website's build`,
-    });
-  }
-  return notes;
-};
-
-/**
  * Compares two `major.minor.patch` version strings.
  * @returns positive if a > b, negative if a < b, zero if equal
  */
@@ -652,18 +601,14 @@ const main = async () => {
     // Get updated TypeScript versions
     const updatedTsVersions = getUpdatedTypeScriptVersions(tmpDir);
 
-    // Applied before the rewrite so the held versions are never written
-    const agUiHold = holdAgUiToCopilotKit(updatedTsVersions);
-
     // Apply updated TypeScript versions to the versions file
-    const tsChanges: ReportChange[] = await applyUpdatedVersions(
+    const tsChanges = await applyUpdatedVersions(
       tree,
       TS_VERSIONS,
       updatedTsVersions,
       'packages/nx-plugin/src/utils/versions.ts',
       'TS_VERSIONS',
     );
-    tsChanges.push(...agUiHold);
 
     // Get updated Python versions
     const updatedPyVersions = getUpdatedPythonVersions(tmpDir);

--- a/scripts/update-versions.ts
+++ b/scripts/update-versions.ts
@@ -212,6 +212,57 @@ const holdRuffToWasmBuild = (
 };
 
 /**
+ * `@copilotkit/react-core` depends on an exact `@ag-ui/client` and `@ag-ui/core`,
+ * and the website passes an `@ag-ui/client` agent straight into CopilotKit's
+ * provider. Bumping the `@ag-ui/*` pins past what CopilotKit asks for installs a
+ * second copy, and the two `AbstractAgent` declarations are structurally
+ * incompatible (private `_debug`), so every generated website fails to compile
+ * with TS2322 — which takes out the whole smoke test matrix at once.
+ *
+ * So hold the shared `@ag-ui/*` packages at whatever CopilotKit pins. They move
+ * again once a CopilotKit release asks for a newer one.
+ */
+const holdAgUiToCopilotKit = (
+  updatedVersions: Record<string, string>,
+): ReportNote[] => {
+  const copilotKitVersion =
+    updatedVersions['@copilotkit/react-core'] ??
+    TS_VERSIONS['@copilotkit/react-core'];
+
+  let deps: Record<string, string>;
+  try {
+    deps = JSON.parse(
+      execSync(
+        `npm view @copilotkit/react-core@${copilotKitVersion} dependencies --json`,
+        { encoding: 'utf-8' },
+      ),
+    );
+  } catch {
+    return [
+      {
+        note: `could not read @copilotkit/react-core@${copilotKitVersion} dependencies to pin @ag-ui/* against — left as proposed`,
+      },
+    ];
+  }
+
+  // Only the packages CopilotKit itself depends on can duplicate against it.
+  // `@ag-ui/aws-strands` and `@ag-ui/a2ui-toolkit` are agent-side only.
+  const notes: ReportNote[] = [];
+  for (const name of ['@ag-ui/client', '@ag-ui/core', '@ag-ui/encoder']) {
+    // `@ag-ui/encoder` is not a CopilotKit dependency, but ships from the same
+    // release train as client/core and must match them.
+    const required = deps[name] ?? deps['@ag-ui/client'];
+    const proposed = updatedVersions[name];
+    if (!required || !proposed || proposed === required) continue;
+    updatedVersions[name] = required;
+    notes.push({
+      note: `${name} held at ${required} (${proposed} available): @copilotkit/react-core@${copilotKitVersion} pins ${required}, and a second copy breaks the generated website's build`,
+    });
+  }
+  return notes;
+};
+
+/**
  * Compares two `major.minor.patch` version strings.
  * @returns positive if a > b, negative if a < b, zero if equal
  */
@@ -601,14 +652,18 @@ const main = async () => {
     // Get updated TypeScript versions
     const updatedTsVersions = getUpdatedTypeScriptVersions(tmpDir);
 
+    // Applied before the rewrite so the held versions are never written
+    const agUiHold = holdAgUiToCopilotKit(updatedTsVersions);
+
     // Apply updated TypeScript versions to the versions file
-    const tsChanges = await applyUpdatedVersions(
+    const tsChanges: ReportChange[] = await applyUpdatedVersions(
       tree,
       TS_VERSIONS,
       updatedTsVersions,
       'packages/nx-plugin/src/utils/versions.ts',
       'TS_VERSIONS',
     );
+    tsChanges.push(...agUiHold);
 
     // Get updated Python versions
     const updatedPyVersions = getUpdatedPythonVersions(tmpDir);


### PR DESCRIPTION
### Reason for this change

`Smoke Tests - local-dev` was the dominant CI flake — 12 of the last 26 failed
runs, with the identical signature across unrelated branches:

```
FAIL  src/smoke-tests/local-dev.spec.ts > smoke test - local-dev > Python HTTP Agent - JSONL streaming invoke
Error: Chat target local_dev_test.py_project:my-py-agent-chat did not stream "The answer is 42" within 120000ms
```

The captured output always stops right after the prompt renders, with the typed
message never appearing at all:

```
◇  Connected to MyPyAgent
◆  You → MyPyAgent
│  Type a message... (Ctrl+C to exit)
```

**Cause.** `nx:run-commands` wraps the command in Nx's own Rust pseudo-terminal
whenever stdout is a TTY (`PseudoTerminal.isSupported()` is
`process.stdout.isTTY && supportedPtyPlatform()`). Because the harness gives Nx a
PTY, the chat CLI ends up reading a *second* pty that Nx must relay our keystrokes
into — and when that relay isn't wired up by the time we type, the message is
dropped and the run waits out its full 120s.

Confirmed by inspecting the child's stdin device through `nx run`:

| mode | child stdin | |
|---|---|---|
| default (native runner) | `/dev/pts/2` | a second pty Nx relays into |
| `NX_NATIVE_COMMAND_RUNNER=false` | `/dev/pts/1` | the harness's own pty |

With the native runner off, Nx spawns with `stdio: ['inherit', ...]`, so the CLI
inherits the harness's PTY directly — there is no relay left to race.

Evidence this is a launch-time race rather than mistiming: an earlier revision of
this PR waited for the prompt's placeholder and then re-sent every 5s. It wrote
~22 times across **112 seconds** and the prompt never repainted once, while a
prompt that is actually reading repaints in **1.0s** (measured, 8/8 healthy cases).

### Description of changes

`e2e/src/smoke-tests/local-dev.spec.ts` only — no generator changes.

- Set `NX_NATIVE_COMMAND_RUNNER=false` when spawning the chat target, so the CLI
  inherits the harness's PTY instead of a relayed one.
- Wait for the prompt's own placeholder (`Type a message`) before typing, rather
  than the earlier `Connected to ` banner, which prints before the prompt starts
  reading stdin.

The test still runs `nx run <target>` — the same command a user runs. An earlier
revision resolved the target's command/cwd/env from the project config and spawned
the binary directly; that worked but duplicated what the generators emit and would
break if that shape changed, so it has been dropped in favour of fixing the actual
cause.

### Description of how you validated changes

- **Mechanism** — built an `nx:run-commands` fixture and compared the child's
  stdin device between runner modes (table above). `inheritsOurs: true` only with
  the native runner off, which is the property that removes the race.
- **Source** — traced `createProcess` in
  `nx/src/executors/run-commands/running-tasks.js`: the native path builds a
  `PseudoTerminal`, the fallback spawns with `stdio: ['inherit', 'pipe', 'pipe']`.
- Typecheck (`tsc --noEmit -p e2e/tsconfig.json`) and lint pass.

Note the local fixture could not reproduce the race itself in either mode (CI
runners are far more loaded), so the load-bearing evidence is the stdin-device
difference plus CI. Flagging that explicitly rather than claiming a local repro.

### Note on failures deliberately *not* changed here

Investigated during triage and found to be genuine, not flakes:

- `Unit Tests - 9`, `Package` (TS2339 in `normalise.ts`) — real in-progress code
  errors on their branches.
- `Smoke Tests - idempotency` — a real generator defect on
  `fix/terraform-fmt-check-and-target-inputs`, since fixed.
- macOS `Could not resolve host: github.com`, a macOS pnpm `EINVAL`, and PyPI
  502s — infrastructure. `UV_HTTP_RETRIES` is already raised to 8.

Two further **pre-existing bugs on main** turned up and are unrelated to this PR:
a `pull-image` recursive task invocation (from #1159) and `Port 4200 not ready`
(after the website-port change in #1149). Worth their own issue.

The `@ag-ui/*` version drift found during the same triage is handled generically
in #1171.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
