### PR TITLE
chore(scripts): declare version pins that must move in lockstep

### DIFF
--- a/.github/workflows/update-versions.yml
+++ b/.github/workflows/update-versions.yml
@@ -30,8 +30,6 @@ jobs:
           aws-docker-login-role-arn: ${{ secrets.AWS_DOCKER_LOGIN_ROLE_ARN }}
       - name: Bump Nx Plugin for AWS versions
         run: |
-          npx -y npm-check-updates@23.0.2 --configFileName .ncurc.cjs
-          pnpm i --lockfile-only
           pnpm i
           # Record the release that shipped each migration, so source converges
           # on the versions of everything already released and the release only
@@ -44,6 +42,9 @@ jobs:
           # released version still gets its hop.
           pnpm exec tsx ./scripts/backfill-migration-versions.ts
           pnpm exec tsx ./scripts/update-versions.ts
+          # update-versions.ts writes this repo's manifests too, so refresh the
+          # lockfile and node_modules before anything builds against them.
+          pnpm i --no-frozen-lockfile
           pnpm nx reset
           pnpm nx test nx-plugin -u
           pnpm lint

--- a/packages/nx-plugin/src/utils/format.spec.ts
+++ b/packages/nx-plugin/src/utils/format.spec.ts
@@ -19,11 +19,8 @@ import { TS_VERSIONS } from './versions.js';
 
 describe('biome wasm version', () => {
   it('should match the biome pinned for generated projects', () => {
-    // Generated files are formatted here by the wasm bindings, but checked by the
-    // project's `format` target, which runs the `TS_VERSIONS` biome CLI — and the
-    // vended `biome.json` points its `$schema` at that same version. A drift
-    // between the two would make generated files fail `biome check` on a
-    // formatting change, so the two pins must be bumped together.
+    // Files formatted by the bindings are checked by the vended CLI, so a drift
+    // between the two fails `biome check` on a formatting change.
     expect(BIOME_WASM_VERSION).toBe(TS_VERSIONS['@biomejs/biome']);
   });
 });

--- a/packages/nx-plugin/src/utils/format.spec.ts
+++ b/packages/nx-plugin/src/utils/format.spec.ts
@@ -9,8 +9,24 @@ import { FsTree } from 'nx/src/generators/tree';
 import { tmpdir } from 'os';
 import path from 'path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { formatFilesInSubtree, requiresPythonToRuffTarget } from './format.js';
+import {
+  BIOME_WASM_VERSION,
+  formatFilesInSubtree,
+  requiresPythonToRuffTarget,
+} from './format.js';
 import { createTreeUsingTsSolutionSetup } from './test.js';
+import { TS_VERSIONS } from './versions.js';
+
+describe('biome wasm version', () => {
+  it('should match the biome pinned for generated projects', () => {
+    // Generated files are formatted here by the wasm bindings, but checked by the
+    // project's `format` target, which runs the `TS_VERSIONS` biome CLI — and the
+    // vended `biome.json` points its `$schema` at that same version. A drift
+    // between the two would make generated files fail `biome check` on a
+    // formatting change, so the two pins must be bumped together.
+    expect(BIOME_WASM_VERSION).toBe(TS_VERSIONS['@biomejs/biome']);
+  });
+});
 
 describe('requiresPythonToRuffTarget', () => {
   it('maps a lower-bound specifier to a ruff target', () => {

--- a/packages/nx-plugin/src/utils/format.ts
+++ b/packages/nx-plugin/src/utils/format.ts
@@ -12,15 +12,8 @@ import { tryReadToml } from './toml.js';
 import { TS_VERSIONS } from './versions.js';
 
 /**
- * The Biome release the wasm bindings here are built from. Those bindings format
- * generated TypeScript/JSON in-process, while `TS_VERSIONS['@biomejs/biome']` is
- * the CLI the vended `format`/`lint` targets run and the version the vended
- * `biome.json` `$schema` points at — so keep the two in step, or generated files
- * are formatted by one release and checked against another. A test asserts they
- * agree.
- *
- * The package exposes no version API (unlike ruff's `Workspace.version()`), so
- * this reads its manifest.
+ * The Biome release the wasm bindings are built from. Must match
+ * `TS_VERSIONS['@biomejs/biome']`, the CLI the vended targets run.
  */
 export const BIOME_WASM_VERSION: string = createRequire(import.meta.url)(
   '@biomejs/wasm-nodejs/package.json',

--- a/packages/nx-plugin/src/utils/format.ts
+++ b/packages/nx-plugin/src/utils/format.ts
@@ -5,10 +5,26 @@
 
 import { Biome } from '@biomejs/js-api/nodejs';
 import { getProjects, type Tree } from '@nx/devkit';
+import { createRequire } from 'module';
 import path from 'path';
 import { type RuffOptions, ruffFixAndFormat } from './ruff.js';
 import { tryReadToml } from './toml.js';
 import { TS_VERSIONS } from './versions.js';
+
+/**
+ * The Biome release the wasm bindings here are built from. Those bindings format
+ * generated TypeScript/JSON in-process, while `TS_VERSIONS['@biomejs/biome']` is
+ * the CLI the vended `format`/`lint` targets run and the version the vended
+ * `biome.json` `$schema` points at — so keep the two in step, or generated files
+ * are formatted by one release and checked against another. A test asserts they
+ * agree.
+ *
+ * The package exposes no version API (unlike ruff's `Workspace.version()`), so
+ * this reads its manifest.
+ */
+export const BIOME_WASM_VERSION: string = createRequire(import.meta.url)(
+  '@biomejs/wasm-nodejs/package.json',
+).version;
 
 /**
  * Excludes test reports — including the vendored scripts vitest's coverage HTML

--- a/packages/nx-plugin/src/utils/version-lockstep/lockstep.spec.ts
+++ b/packages/nx-plugin/src/utils/version-lockstep/lockstep.spec.ts
@@ -14,7 +14,7 @@ describe('holdGroupsInLockstep', () => {
     expect(ts).toEqual({ a: '1.5.0', b: '1.5.0', c: '1.5.0' });
     // Only the members that actually moved are reported.
     expect(notes).toHaveLength(2);
-    // The held name is reported separately, so callers can correct a manifest.
+    // The held name lets callers correct a manifest.
     expect(notes.map(({ name }) => name).sort()).toEqual(['a', 'c']);
     const reported = notes.map((note) => note.note).join('\n');
     expect(reported).toContain('a held at 1.5.0');
@@ -46,16 +46,14 @@ describe('holdGroupsInLockstep', () => {
   });
 
   it('ignores a member whose pin is not a comparable version', () => {
-    // A tag or protocol specifier has no version to compare, so the group is
-    // left alone rather than held against something meaningless.
+    // A tag or protocol specifier has no version to compare against.
     const ts = { a: 'workspace:*', b: '2.0.0' };
     expect(holdGroupsInLockstep([['a', 'b']], ts)).toEqual([]);
     expect(ts).toEqual({ a: 'workspace:*', b: '2.0.0' });
   });
 
   it('skips a group the run proposed fewer than two members for', () => {
-    // One pin has nothing to stay in step with, so leave the bump alone rather
-    // than holding it against a version nothing proposed.
+    // One pin has nothing to stay in step with.
     const ts = { a: '2.0.0' };
     expect(holdGroupsInLockstep([['a', 'absent']], ts)).toEqual([]);
     expect(ts.a).toBe('2.0.0');

--- a/packages/nx-plugin/src/utils/version-lockstep/lockstep.spec.ts
+++ b/packages/nx-plugin/src/utils/version-lockstep/lockstep.spec.ts
@@ -3,25 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { describe, expect, it } from 'vitest';
-import { compareVersions, holdGroupsInLockstep } from './lockstep.js';
-
-describe('compareVersions', () => {
-  it('orders by numeric segment, not lexically', () => {
-    // '9' > '10' lexically, which is the bug this guards against.
-    expect(compareVersions('0.0.9', '0.0.10')).toBeLessThan(0);
-    expect(compareVersions('1.2.0', '1.10.0')).toBeLessThan(0);
-    expect(compareVersions('2.0.0', '1.99.99')).toBeGreaterThan(0);
-  });
-
-  it('ignores range prefixes', () => {
-    expect(compareVersions('==1.2.3', '1.2.3')).toBe(0);
-    expect(compareVersions('^1.2.3', '==1.2.4')).toBeLessThan(0);
-  });
-
-  it('treats a missing segment as lower', () => {
-    expect(compareVersions('1.2', '1.2.1')).toBeLessThan(0);
-  });
-});
+import { holdGroupsInLockstep } from './lockstep.js';
 
 describe('holdGroupsInLockstep', () => {
   it('holds every member at the lowest version proposed across the group', () => {
@@ -55,9 +37,18 @@ describe('holdGroupsInLockstep', () => {
   });
 
   it('picks the lowest numerically rather than lexically', () => {
+    // '0.0.9' > '0.0.10' lexically, which is the bug semver ordering avoids.
     const ts = { a: '0.0.10', b: '0.0.9' };
     holdGroupsInLockstep([['a', 'b']], ts);
     expect(ts).toEqual({ a: '0.0.9', b: '0.0.9' });
+  });
+
+  it('ignores a member whose pin is not a comparable version', () => {
+    // A tag or protocol specifier has no version to compare, so the group is
+    // left alone rather than held against something meaningless.
+    const ts = { a: 'workspace:*', b: '2.0.0' };
+    expect(holdGroupsInLockstep([['a', 'b']], ts)).toEqual([]);
+    expect(ts).toEqual({ a: 'workspace:*', b: '2.0.0' });
   });
 
   it('skips a group the run proposed fewer than two members for', () => {

--- a/packages/nx-plugin/src/utils/version-lockstep/lockstep.spec.ts
+++ b/packages/nx-plugin/src/utils/version-lockstep/lockstep.spec.ts
@@ -1,0 +1,164 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { describe, expect, it } from 'vitest';
+import { type LockstepGroup, holdGroupsInLockstep } from './lockstep.js';
+
+describe('holdGroupsInLockstep', () => {
+  it('holds a follower at the leader version', () => {
+    const ts = { leader: '1.2.3', follower: '2.0.0' };
+    const notes = holdGroupsInLockstep(
+      [
+        {
+          reason: 'they must match',
+          leader: { name: 'leader' },
+          followers: [{ name: 'follower' }],
+        },
+      ],
+      ts,
+    );
+
+    expect(ts.follower).toBe('1.2.3');
+    expect(ts.leader).toBe('1.2.3');
+    expect(notes).toHaveLength(1);
+    expect(notes[0].note).toContain('follower held at 1.2.3');
+    expect(notes[0].note).toContain('2.0.0 available');
+    expect(notes[0].note).toContain('they must match');
+  });
+
+  it('reports nothing when the group already agrees', () => {
+    const ts = { leader: '1.2.3', follower: '1.2.3' };
+    expect(
+      holdGroupsInLockstep(
+        [
+          {
+            reason: 'they must match',
+            leader: { name: 'leader' },
+            followers: [{ name: 'follower' }],
+          },
+        ],
+        ts,
+      ),
+    ).toEqual([]);
+  });
+
+  it('spans tables, rewriting a follower declared in another one', () => {
+    const ts = { '@astral-sh/ruff-wasm-nodejs': '0.16.5' };
+    const py = { ruff: '==0.17.0' };
+
+    const notes = holdGroupsInLockstep(
+      [
+        {
+          reason: 'the formatter and its bindings must match',
+          leader: { name: '@astral-sh/ruff-wasm-nodejs' },
+          followers: [{ name: 'ruff', format: 'pep440' }],
+        },
+      ],
+      ts,
+      py,
+    );
+
+    // Rewritten in the PEP 440 form the Python pins use.
+    expect(py.ruff).toBe('==0.16.5');
+    expect(notes[0].note).toContain('ruff held at ==0.16.5');
+  });
+
+  it('normalises the leader range before applying it', () => {
+    const ts = { leader: '^1.2.3', follower: '2.0.0' };
+    holdGroupsInLockstep(
+      [
+        {
+          reason: 'r',
+          leader: { name: 'leader' },
+          followers: [{ name: 'follower' }],
+        },
+      ],
+      ts,
+    );
+    expect(ts.follower).toBe('1.2.3');
+  });
+
+  it('supports a leader resolved from outside the tables', () => {
+    const ts = { '@ag-ui/client': '0.0.59', '@ag-ui/core': '0.0.59' };
+
+    const notes = holdGroupsInLockstep(
+      [
+        {
+          reason: 'the dependant pins these exactly',
+          leader: { name: '@ag-ui/client', resolve: () => '0.0.57' },
+          followers: [{ name: '@ag-ui/client' }, { name: '@ag-ui/core' }],
+        },
+      ],
+      ts,
+    );
+
+    expect(ts['@ag-ui/client']).toBe('0.0.57');
+    expect(ts['@ag-ui/core']).toBe('0.0.57');
+    expect(notes).toHaveLength(2);
+  });
+
+  it('passes the merged proposed versions to a resolver', () => {
+    const ts = { dependant: '9.9.9', follower: '2.0.0' };
+    let seen: string | undefined;
+
+    holdGroupsInLockstep(
+      [
+        {
+          reason: 'r',
+          leader: {
+            name: 'follower',
+            resolve: (versions) => {
+              seen = versions.dependant;
+              return '1.0.0';
+            },
+          },
+          followers: [{ name: 'follower' }],
+        },
+      ],
+      ts,
+    );
+
+    expect(seen).toBe('9.9.9');
+    expect(ts.follower).toBe('1.0.0');
+  });
+
+  it('leaves the group as proposed and reports when the leader is unresolvable', () => {
+    const ts = { follower: '2.0.0' };
+
+    const notes = holdGroupsInLockstep(
+      [
+        {
+          reason: 'r',
+          leader: { name: 'missing', resolve: () => undefined },
+          followers: [{ name: 'follower' }],
+        },
+      ],
+      ts,
+    );
+
+    // Better to take the bump and let CI catch it than to silently write a
+    // wrong pin.
+    expect(ts.follower).toBe('2.0.0');
+    expect(notes).toHaveLength(1);
+    expect(notes[0].note).toContain('could not resolve missing');
+    expect(notes[0].note).toContain('follower');
+  });
+
+  it('ignores followers no run proposed a version for', () => {
+    const ts = { leader: '1.0.0' };
+    expect(
+      holdGroupsInLockstep(
+        [
+          {
+            reason: 'r',
+            leader: { name: 'leader' },
+            followers: [{ name: 'absent' }],
+          },
+        ],
+        ts,
+      ),
+    ).toEqual([]);
+    expect(ts).not.toHaveProperty('absent');
+  });
+});

--- a/packages/nx-plugin/src/utils/version-lockstep/lockstep.spec.ts
+++ b/packages/nx-plugin/src/utils/version-lockstep/lockstep.spec.ts
@@ -3,162 +3,87 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { describe, expect, it } from 'vitest';
-import { type LockstepGroup, holdGroupsInLockstep } from './lockstep.js';
+import { compareVersions, holdGroupsInLockstep } from './lockstep.js';
+
+describe('compareVersions', () => {
+  it('orders by numeric segment, not lexically', () => {
+    // '9' > '10' lexically, which is the bug this guards against.
+    expect(compareVersions('0.0.9', '0.0.10')).toBeLessThan(0);
+    expect(compareVersions('1.2.0', '1.10.0')).toBeLessThan(0);
+    expect(compareVersions('2.0.0', '1.99.99')).toBeGreaterThan(0);
+  });
+
+  it('ignores range prefixes', () => {
+    expect(compareVersions('==1.2.3', '1.2.3')).toBe(0);
+    expect(compareVersions('^1.2.3', '==1.2.4')).toBeLessThan(0);
+  });
+
+  it('treats a missing segment as lower', () => {
+    expect(compareVersions('1.2', '1.2.1')).toBeLessThan(0);
+  });
+});
 
 describe('holdGroupsInLockstep', () => {
-  it('holds a follower at the leader version', () => {
-    const ts = { leader: '1.2.3', follower: '2.0.0' };
-    const notes = holdGroupsInLockstep(
-      [
-        {
-          reason: 'they must match',
-          leader: { name: 'leader' },
-          followers: [{ name: 'follower' }],
-        },
-      ],
-      ts,
-    );
+  it('holds every member at the lowest version proposed across the group', () => {
+    const ts = { a: '2.0.0', b: '1.5.0', c: '3.0.0' };
 
-    expect(ts.follower).toBe('1.2.3');
-    expect(ts.leader).toBe('1.2.3');
-    expect(notes).toHaveLength(1);
-    expect(notes[0].note).toContain('follower held at 1.2.3');
-    expect(notes[0].note).toContain('2.0.0 available');
-    expect(notes[0].note).toContain('they must match');
+    const notes = holdGroupsInLockstep([['a', 'b', 'c']], ts);
+
+    expect(ts).toEqual({ a: '1.5.0', b: '1.5.0', c: '1.5.0' });
+    // Only the members that actually moved are reported.
+    expect(notes).toHaveLength(2);
+    const reported = notes.map((note) => note.note).join('\n');
+    expect(reported).toContain('a held at 1.5.0');
+    expect(reported).toContain('2.0.0 available');
   });
 
   it('reports nothing when the group already agrees', () => {
-    const ts = { leader: '1.2.3', follower: '1.2.3' };
-    expect(
-      holdGroupsInLockstep(
-        [
-          {
-            reason: 'they must match',
-            leader: { name: 'leader' },
-            followers: [{ name: 'follower' }],
-          },
-        ],
-        ts,
-      ),
-    ).toEqual([]);
+    const ts = { a: '1.2.3', b: '1.2.3' };
+    expect(holdGroupsInLockstep([['a', 'b']], ts)).toEqual([]);
+    expect(ts).toEqual({ a: '1.2.3', b: '1.2.3' });
   });
 
-  it('spans tables, rewriting a follower declared in another one', () => {
-    const ts = { '@astral-sh/ruff-wasm-nodejs': '0.16.5' };
-    const py = { ruff: '==0.17.0' };
+  it('spans tables, so a group may mix TypeScript and Python pins', () => {
+    const ts = { tool: '0.16.5' };
+    const py = { 'tool-cli': '==0.17.0' };
 
-    const notes = holdGroupsInLockstep(
-      [
-        {
-          reason: 'the formatter and its bindings must match',
-          leader: { name: '@astral-sh/ruff-wasm-nodejs' },
-          followers: [{ name: 'ruff', format: 'pep440' }],
-        },
-      ],
-      ts,
-      py,
-    );
+    holdGroupsInLockstep([['tool', 'tool-cli']], ts, py);
 
-    // Rewritten in the PEP 440 form the Python pins use.
-    expect(py.ruff).toBe('==0.16.5');
-    expect(notes[0].note).toContain('ruff held at ==0.16.5');
+    // Each pin keeps the range prefix it was written with.
+    expect(ts.tool).toBe('0.16.5');
+    expect(py['tool-cli']).toBe('==0.16.5');
   });
 
-  it('normalises the leader range before applying it', () => {
-    const ts = { leader: '^1.2.3', follower: '2.0.0' };
-    holdGroupsInLockstep(
-      [
-        {
-          reason: 'r',
-          leader: { name: 'leader' },
-          followers: [{ name: 'follower' }],
-        },
-      ],
-      ts,
-    );
-    expect(ts.follower).toBe('1.2.3');
+  it('picks the lowest numerically rather than lexically', () => {
+    const ts = { a: '0.0.10', b: '0.0.9' };
+    holdGroupsInLockstep([['a', 'b']], ts);
+    expect(ts).toEqual({ a: '0.0.9', b: '0.0.9' });
   });
 
-  it('supports a leader resolved from outside the tables', () => {
-    const ts = { '@ag-ui/client': '0.0.59', '@ag-ui/core': '0.0.59' };
-
-    const notes = holdGroupsInLockstep(
-      [
-        {
-          reason: 'the dependant pins these exactly',
-          leader: { name: '@ag-ui/client', resolve: () => '0.0.57' },
-          followers: [{ name: '@ag-ui/client' }, { name: '@ag-ui/core' }],
-        },
-      ],
-      ts,
-    );
-
-    expect(ts['@ag-ui/client']).toBe('0.0.57');
-    expect(ts['@ag-ui/core']).toBe('0.0.57');
-    expect(notes).toHaveLength(2);
+  it('skips a group the run proposed fewer than two members for', () => {
+    // One pin has nothing to stay in step with, so leave the bump alone rather
+    // than holding it against a version nothing proposed.
+    const ts = { a: '2.0.0' };
+    expect(holdGroupsInLockstep([['a', 'absent']], ts)).toEqual([]);
+    expect(ts.a).toBe('2.0.0');
   });
 
-  it('passes the merged proposed versions to a resolver', () => {
-    const ts = { dependant: '9.9.9', follower: '2.0.0' };
-    let seen: string | undefined;
-
-    holdGroupsInLockstep(
-      [
-        {
-          reason: 'r',
-          leader: {
-            name: 'follower',
-            resolve: (versions) => {
-              seen = versions.dependant;
-              return '1.0.0';
-            },
-          },
-          followers: [{ name: 'follower' }],
-        },
-      ],
-      ts,
-    );
-
-    expect(seen).toBe('9.9.9');
-    expect(ts.follower).toBe('1.0.0');
-  });
-
-  it('leaves the group as proposed and reports when the leader is unresolvable', () => {
-    const ts = { follower: '2.0.0' };
-
-    const notes = holdGroupsInLockstep(
-      [
-        {
-          reason: 'r',
-          leader: { name: 'missing', resolve: () => undefined },
-          followers: [{ name: 'follower' }],
-        },
-      ],
-      ts,
-    );
-
-    // Better to take the bump and let CI catch it than to silently write a
-    // wrong pin.
-    expect(ts.follower).toBe('2.0.0');
-    expect(notes).toHaveLength(1);
-    expect(notes[0].note).toContain('could not resolve missing');
-    expect(notes[0].note).toContain('follower');
-  });
-
-  it('ignores followers no run proposed a version for', () => {
-    const ts = { leader: '1.0.0' };
-    expect(
-      holdGroupsInLockstep(
-        [
-          {
-            reason: 'r',
-            leader: { name: 'leader' },
-            followers: [{ name: 'absent' }],
-          },
-        ],
-        ts,
-      ),
-    ).toEqual([]);
+  it('ignores members no table declares', () => {
+    const ts = { a: '2.0.0', b: '1.0.0' };
+    holdGroupsInLockstep([['a', 'b', 'absent']], ts);
+    expect(ts).toEqual({ a: '1.0.0', b: '1.0.0' });
     expect(ts).not.toHaveProperty('absent');
+  });
+
+  it('handles several groups independently', () => {
+    const ts = { a: '2.0.0', b: '1.0.0', c: '5.0.0', d: '4.0.0' };
+    holdGroupsInLockstep(
+      [
+        ['a', 'b'],
+        ['c', 'd'],
+      ],
+      ts,
+    );
+    expect(ts).toEqual({ a: '1.0.0', b: '1.0.0', c: '4.0.0', d: '4.0.0' });
   });
 });

--- a/packages/nx-plugin/src/utils/version-lockstep/lockstep.spec.ts
+++ b/packages/nx-plugin/src/utils/version-lockstep/lockstep.spec.ts
@@ -14,6 +14,8 @@ describe('holdGroupsInLockstep', () => {
     expect(ts).toEqual({ a: '1.5.0', b: '1.5.0', c: '1.5.0' });
     // Only the members that actually moved are reported.
     expect(notes).toHaveLength(2);
+    // The held name is reported separately, so callers can correct a manifest.
+    expect(notes.map(({ name }) => name).sort()).toEqual(['a', 'c']);
     const reported = notes.map((note) => note.note).join('\n');
     expect(reported).toContain('a held at 1.5.0');
     expect(reported).toContain('2.0.0 available');

--- a/packages/nx-plugin/src/utils/version-lockstep/lockstep.ts
+++ b/packages/nx-plugin/src/utils/version-lockstep/lockstep.ts
@@ -6,15 +6,17 @@
 /**
  * Groups of pins that must move together.
  *
- * Some packages are only correct at matching versions: a Python formatter and the
- * wasm build of it that actually runs, or an npm library and a second library
- * that depends on an exact release of it. The bumps behind those pins arrive
- * independently, so left alone a run takes one and leaves the other behind and
- * the mismatch fails the build.
+ * Packages published as a family are often only mutually resolvable at the same
+ * version, but their bumps arrive independently — so left alone a run takes one
+ * and leaves the rest behind, and the mismatch fails the build.
  *
- * A group nominates one member as the leader. Every other member is rewritten to
- * whatever the leader resolves to, so a group only ever moves as a unit — one
- * place to declare the constraint instead of a bespoke hold per pair.
+ * A group is held at the lowest version proposed across its members, so it only
+ * moves once every member can. Whichever member is furthest behind is the
+ * constraint; the rest are taken on a later run, once it catches up.
+ *
+ * This assumes the members share a version line, which is what makes "lowest"
+ * meaningful. A package coupled to something on an unrelated line (a dependant
+ * that pins it exactly, say) needs its own hold instead.
  */
 
 /** A note explaining a pin the run deliberately did not take. */
@@ -23,85 +25,49 @@ export interface LockstepNote {
 }
 
 /**
- * How a member's version is written, for groups that span registries or
- * manifests. `plain` is a bare version (npm); `pep440` is the `==x.y.z` form
- * `PY_VERSIONS` uses.
+ * The pins in one group, named as they appear in the versions tables. Members may
+ * live in different tables (e.g. the TypeScript and Python pins).
  */
-export type VersionFormat = 'plain' | 'pep440';
+export type LockstepGroup = readonly string[];
 
-export interface LockstepMember {
-  /** Key in the versions table this member lives in. */
-  readonly name: string;
-  /** Defaults to `plain`. */
-  readonly format?: VersionFormat;
-  /**
-   * Resolve the version to hold against, for a constraint that lives somewhere
-   * other than one of our own pins — e.g. a dependant's dependency range, read
-   * from the registry. Receives the merged proposed versions. Returning
-   * `undefined` leaves the group untouched and reports why.
-   */
-  readonly resolve?: (versions: Record<string, string>) => string | undefined;
-}
+/** Strip a range prefix (`==`, `^`, `~`, …) to leave a bare version. */
+const bare = (version: string): string =>
+  version.replace(/^[=~^><!\s]+/, '').trim();
 
-export interface LockstepGroup {
-  /** Shown in the report to explain why the group is coupled. */
-  readonly reason: string;
-  /**
-   * The member the rest follow. Chosen as whichever is the harder constraint to
-   * move — typically the one already installed and running, or the one whose
-   * dependant pins it exactly.
-   */
-  readonly leader: LockstepMember;
-  readonly followers: readonly LockstepMember[];
-}
-
-const stripFormat = (version: string): string =>
-  version.replace(/^[=~^><!]+/, '').trim();
-
-const applyFormat = (
-  version: string,
-  format: VersionFormat = 'plain',
-): string =>
-  format === 'pep440' ? `==${stripFormat(version)}` : stripFormat(version);
+/** The range prefix a pin was written with, so it can be preserved. */
+const prefixOf = (version: string): string =>
+  version.slice(0, version.indexOf(bare(version)));
 
 /**
- * Read a member's version from whichever of the supplied tables declares it, so
- * a group can span the TypeScript and Python pins.
+ * Compare bare `major.minor.patch[...]` versions segment by segment. Numeric
+ * segments compare numerically; anything else (prereleases) compares as a
+ * string, which is enough to order the pins these tables hold.
  */
-const readMember = (
-  member: LockstepMember,
-  tables: readonly Record<string, string>[],
-): string | undefined => {
-  for (const table of tables) {
-    const version = table[member.name];
-    if (version !== undefined) return version;
+export const compareVersions = (a: string, b: string): number => {
+  const as = bare(a).split(/[.\-+]/);
+  const bs = bare(b).split(/[.\-+]/);
+  for (let i = 0; i < Math.max(as.length, bs.length); i++) {
+    const x = as[i] ?? '';
+    const y = bs[i] ?? '';
+    if (x === y) continue;
+    const nx = Number(x);
+    const ny = Number(y);
+    if (Number.isNaN(nx) || Number.isNaN(ny)) return x < y ? -1 : 1;
+    return nx - ny;
   }
-  return undefined;
-};
-
-const writeMember = (
-  member: LockstepMember,
-  version: string,
-  tables: readonly Record<string, string>[],
-): boolean => {
-  for (const table of tables) {
-    if (member.name in table) {
-      table[member.name] = version;
-      return true;
-    }
-  }
-  return false;
+  return 0;
 };
 
 /**
- * Hold every follower in each group at the version its leader resolves to.
+ * Hold every member of each group at the lowest version proposed across it.
  *
  * Applied to the *proposed* versions before they are written, so a held pin is
- * never recorded. Followers are taken next run, once the leader catches up.
+ * never recorded. Each pin keeps the range prefix it was written with, so a
+ * `==x.y.z` Python pin stays in that form.
  *
  * @param groups the coupling declarations to enforce
- * @param tables the proposed-version tables to read and rewrite, in precedence
- *   order — a member is looked up in the first table that declares it
+ * @param tables the proposed-version tables to read and rewrite; a member is
+ *   looked up in the first table that declares it
  */
 export const holdGroupsInLockstep = (
   groups: readonly LockstepGroup[],
@@ -109,34 +75,30 @@ export const holdGroupsInLockstep = (
 ): LockstepNote[] => {
   const notes: LockstepNote[] = [];
 
-  const merged = Object.assign({}, ...[...tables].reverse()) as Record<
-    string,
-    string
-  >;
-
   for (const group of groups) {
-    const leaderVersion = group.leader.resolve
-      ? group.leader.resolve(merged)
-      : readMember(group.leader, tables);
-    if (leaderVersion === undefined) {
+    // A group can only be held where the run actually proposed something for at
+    // least two of its members; a single pin has nothing to stay in step with.
+    const members = group.flatMap((name) => {
+      const table = tables.find((candidate) => name in candidate);
+      return table ? [{ name, table }] : [];
+    });
+    if (members.length < 2) continue;
+
+    const lowest = members
+      .map(({ name, table }) => table[name])
+      .reduce((min, version) =>
+        compareVersions(version, min) < 0 ? version : min,
+      );
+
+    for (const { name, table } of members) {
+      const proposed = table[name];
+      const held = `${prefixOf(proposed)}${bare(lowest)}`;
+      if (proposed === held) continue;
+      table[name] = held;
       notes.push({
-        note: `could not resolve ${group.leader.name} to hold its group against — ${group.followers
-          .map((f) => f.name)
-          .join(', ')} left as proposed`,
-      });
-      continue;
-    }
-
-    for (const follower of group.followers) {
-      const proposed = readMember(follower, tables);
-      if (proposed === undefined) continue;
-
-      const required = applyFormat(leaderVersion, follower.format);
-      if (proposed === required) continue;
-
-      if (!writeMember(follower, required, tables)) continue;
-      notes.push({
-        note: `${follower.name} held at ${required} (${proposed} available): ${group.reason}`,
+        note: `${name} held at ${held} (${proposed} available): must move in step with ${group
+          .filter((other) => other !== name)
+          .join(', ')}`,
       });
     }
   }

--- a/packages/nx-plugin/src/utils/version-lockstep/lockstep.ts
+++ b/packages/nx-plugin/src/utils/version-lockstep/lockstep.ts
@@ -1,0 +1,145 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Groups of pins that must move together.
+ *
+ * Some packages are only correct at matching versions: a Python formatter and the
+ * wasm build of it that actually runs, or an npm library and a second library
+ * that depends on an exact release of it. The bumps behind those pins arrive
+ * independently, so left alone a run takes one and leaves the other behind and
+ * the mismatch fails the build.
+ *
+ * A group nominates one member as the leader. Every other member is rewritten to
+ * whatever the leader resolves to, so a group only ever moves as a unit — one
+ * place to declare the constraint instead of a bespoke hold per pair.
+ */
+
+/** A note explaining a pin the run deliberately did not take. */
+export interface LockstepNote {
+  note: string;
+}
+
+/**
+ * How a member's version is written, for groups that span registries or
+ * manifests. `plain` is a bare version (npm); `pep440` is the `==x.y.z` form
+ * `PY_VERSIONS` uses.
+ */
+export type VersionFormat = 'plain' | 'pep440';
+
+export interface LockstepMember {
+  /** Key in the versions table this member lives in. */
+  readonly name: string;
+  /** Defaults to `plain`. */
+  readonly format?: VersionFormat;
+  /**
+   * Resolve the version to hold against, for a constraint that lives somewhere
+   * other than one of our own pins — e.g. a dependant's dependency range, read
+   * from the registry. Receives the merged proposed versions. Returning
+   * `undefined` leaves the group untouched and reports why.
+   */
+  readonly resolve?: (versions: Record<string, string>) => string | undefined;
+}
+
+export interface LockstepGroup {
+  /** Shown in the report to explain why the group is coupled. */
+  readonly reason: string;
+  /**
+   * The member the rest follow. Chosen as whichever is the harder constraint to
+   * move — typically the one already installed and running, or the one whose
+   * dependant pins it exactly.
+   */
+  readonly leader: LockstepMember;
+  readonly followers: readonly LockstepMember[];
+}
+
+const stripFormat = (version: string): string =>
+  version.replace(/^[=~^><!]+/, '').trim();
+
+const applyFormat = (
+  version: string,
+  format: VersionFormat = 'plain',
+): string =>
+  format === 'pep440' ? `==${stripFormat(version)}` : stripFormat(version);
+
+/**
+ * Read a member's version from whichever of the supplied tables declares it, so
+ * a group can span the TypeScript and Python pins.
+ */
+const readMember = (
+  member: LockstepMember,
+  tables: readonly Record<string, string>[],
+): string | undefined => {
+  for (const table of tables) {
+    const version = table[member.name];
+    if (version !== undefined) return version;
+  }
+  return undefined;
+};
+
+const writeMember = (
+  member: LockstepMember,
+  version: string,
+  tables: readonly Record<string, string>[],
+): boolean => {
+  for (const table of tables) {
+    if (member.name in table) {
+      table[member.name] = version;
+      return true;
+    }
+  }
+  return false;
+};
+
+/**
+ * Hold every follower in each group at the version its leader resolves to.
+ *
+ * Applied to the *proposed* versions before they are written, so a held pin is
+ * never recorded. Followers are taken next run, once the leader catches up.
+ *
+ * @param groups the coupling declarations to enforce
+ * @param tables the proposed-version tables to read and rewrite, in precedence
+ *   order — a member is looked up in the first table that declares it
+ */
+export const holdGroupsInLockstep = (
+  groups: readonly LockstepGroup[],
+  ...tables: readonly Record<string, string>[]
+): LockstepNote[] => {
+  const notes: LockstepNote[] = [];
+
+  const merged = Object.assign({}, ...[...tables].reverse()) as Record<
+    string,
+    string
+  >;
+
+  for (const group of groups) {
+    const leaderVersion = group.leader.resolve
+      ? group.leader.resolve(merged)
+      : readMember(group.leader, tables);
+    if (leaderVersion === undefined) {
+      notes.push({
+        note: `could not resolve ${group.leader.name} to hold its group against — ${group.followers
+          .map((f) => f.name)
+          .join(', ')} left as proposed`,
+      });
+      continue;
+    }
+
+    for (const follower of group.followers) {
+      const proposed = readMember(follower, tables);
+      if (proposed === undefined) continue;
+
+      const required = applyFormat(leaderVersion, follower.format);
+      if (proposed === required) continue;
+
+      if (!writeMember(follower, required, tables)) continue;
+      notes.push({
+        note: `${follower.name} held at ${required} (${proposed} available): ${group.reason}`,
+      });
+    }
+  }
+
+  return notes;
+};

--- a/packages/nx-plugin/src/utils/version-lockstep/lockstep.ts
+++ b/packages/nx-plugin/src/utils/version-lockstep/lockstep.ts
@@ -3,79 +3,61 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { coerce, compare } from 'semver';
+import type {
+  IJavaVersion,
+  IMiseVersion,
+  IPyDepVersion,
+  ITsDepVersion,
+} from '../versions.js';
 
-/**
- * Groups of pins that must move together.
- *
- * Packages published as a family are often only correct at the same version, but
- * their bumps arrive independently — and one may skip a release the others got.
- * Left alone a run takes whichever moved and leaves the rest behind, and the
- * mismatch fails the build.
- *
- * A group is held at the lowest version proposed across its members, so it only
- * moves once every member can. Whichever member is furthest behind is the
- * constraint; the rest are taken on a later run, once it catches up.
- *
- * This assumes members share a version line, which is what makes "lowest"
- * meaningful. A package coupled to something on an unrelated line needs its own
- * hold instead.
- */
+/** Any dependency a version table pins. */
+export type IVersionedDep =
+  | ITsDepVersion
+  | IPyDepVersion
+  | IJavaVersion
+  | IMiseVersion;
 
 /** A pin the run deliberately did not take, and why. */
 export interface LockstepNote {
-  /** The dependency held back. */
-  name: string;
+  name: IVersionedDep;
   note: string;
 }
 
-/** A table of proposed versions, keyed by dependency name. */
-export type ProposedVersions<Name extends string = string> = Partial<
-  Record<Name, string>
->;
+/** Proposed versions from a run, keyed by dependency name. */
+export type ProposedVersions = Partial<Record<IVersionedDep, string>>;
 
 /**
- * The pins in one group, named as they appear in the versions tables. At least
- * two, since one pin has nothing to stay in step with. Members may live in
- * different tables (e.g. the TypeScript and Python pins).
+ * Dependencies that must move as a unit. At least two, since one pin has nothing
+ * to stay in step with.
  */
-export type LockstepGroup<Name extends string = string> = readonly [
-  Name,
-  Name,
-  ...Name[],
+export type LockstepGroup = readonly [
+  IVersionedDep,
+  IVersionedDep,
+  ...IVersionedDep[],
 ];
 
-/**
- * The bare version in a pin, whatever range syntax it was written with — `==` for
- * the Python pins, a plain version or `^`/`~` for the npm ones.
- */
+/** The bare version in a pin, whatever range syntax it was written with. */
 const bare = (version: string): string | undefined =>
   coerce(version, { includePrerelease: true })?.version;
 
-/** The range prefix a pin was written with, so it can be preserved. */
+/** The range prefix a pin was written with, so it is preserved. */
 const prefixOf = (version: string, bareVersion: string): string =>
   version.slice(0, version.indexOf(bareVersion));
 
 /**
- * Hold every member of each group at the lowest version proposed across it.
+ * Hold every member of each group at the lowest version proposed across it, so a
+ * group only moves once all of its members can.
  *
- * Applied to the *proposed* versions before they are written, so a held pin is
- * never recorded. Each pin keeps the range syntax it was written with, so a
- * `==x.y.z` Python pin stays in that form.
- *
- * @param groups the coupling declarations to enforce
- * @param tables the proposed-version tables to read and rewrite; a member is
- *   looked up in the first table that declares it
+ * Mutates the tables, which hold proposed versions not yet written anywhere.
+ * Groups the run proposed fewer than two comparable versions for are left alone.
  */
-export const holdGroupsInLockstep = <Name extends string>(
-  groups: readonly LockstepGroup<Name>[],
-  ...tables: readonly ProposedVersions<Name>[]
+export const holdGroupsInLockstep = (
+  groups: readonly LockstepGroup[],
+  ...tables: readonly ProposedVersions[]
 ): LockstepNote[] => {
   const notes: LockstepNote[] = [];
 
   for (const group of groups) {
-    // Only members the run proposed a comparable version for can take part. A
-    // group with fewer than two has nothing to stay in step with, so it is left
-    // alone rather than held against a version nothing proposed.
     const members = group.flatMap((name) => {
       const table = tables.find((candidate) => candidate[name] !== undefined);
       const proposed = table?.[name];

--- a/packages/nx-plugin/src/utils/version-lockstep/lockstep.ts
+++ b/packages/nx-plugin/src/utils/version-lockstep/lockstep.ts
@@ -21,16 +21,28 @@ import { coerce, compare } from 'semver';
  * hold instead.
  */
 
-/** A note explaining a pin the run deliberately did not take. */
+/** A pin the run deliberately did not take, and why. */
 export interface LockstepNote {
+  /** The dependency held back. */
+  name: string;
   note: string;
 }
 
+/** A table of proposed versions, keyed by dependency name. */
+export type ProposedVersions<Name extends string = string> = Partial<
+  Record<Name, string>
+>;
+
 /**
- * The pins in one group, named as they appear in the versions tables. Members may
- * live in different tables (e.g. the TypeScript and Python pins).
+ * The pins in one group, named as they appear in the versions tables. At least
+ * two, since one pin has nothing to stay in step with. Members may live in
+ * different tables (e.g. the TypeScript and Python pins).
  */
-export type LockstepGroup = readonly string[];
+export type LockstepGroup<Name extends string = string> = readonly [
+  Name,
+  Name,
+  ...Name[],
+];
 
 /**
  * The bare version in a pin, whatever range syntax it was written with — `==` for
@@ -54,9 +66,9 @@ const prefixOf = (version: string, bareVersion: string): string =>
  * @param tables the proposed-version tables to read and rewrite; a member is
  *   looked up in the first table that declares it
  */
-export const holdGroupsInLockstep = (
-  groups: readonly LockstepGroup[],
-  ...tables: readonly Record<string, string>[]
+export const holdGroupsInLockstep = <Name extends string>(
+  groups: readonly LockstepGroup<Name>[],
+  ...tables: readonly ProposedVersions<Name>[]
 ): LockstepNote[] => {
   const notes: LockstepNote[] = [];
 
@@ -65,9 +77,12 @@ export const holdGroupsInLockstep = (
     // group with fewer than two has nothing to stay in step with, so it is left
     // alone rather than held against a version nothing proposed.
     const members = group.flatMap((name) => {
-      const table = tables.find((candidate) => name in candidate);
-      const version = table && bare(table[name]);
-      return table && version ? [{ name, table, version }] : [];
+      const table = tables.find((candidate) => candidate[name] !== undefined);
+      const proposed = table?.[name];
+      const version = proposed && bare(proposed);
+      return table && proposed && version
+        ? [{ name, table, proposed, version }]
+        : [];
     });
     if (members.length < 2) continue;
 
@@ -75,12 +90,12 @@ export const holdGroupsInLockstep = (
       .map(({ version }) => version)
       .reduce((min, version) => (compare(version, min) < 0 ? version : min));
 
-    for (const { name, table, version } of members) {
+    for (const { name, table, proposed, version } of members) {
       if (version === lowest) continue;
-      const proposed = table[name];
       const held = `${prefixOf(proposed, version)}${lowest}`;
       table[name] = held;
       notes.push({
+        name,
         note: `${name} held at ${held} (${proposed} available): must move in step with ${group
           .filter((other) => other !== name)
           .join(', ')}`,

--- a/packages/nx-plugin/src/utils/version-lockstep/lockstep.ts
+++ b/packages/nx-plugin/src/utils/version-lockstep/lockstep.ts
@@ -2,21 +2,23 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
+import { coerce, compare } from 'semver';
 
 /**
  * Groups of pins that must move together.
  *
- * Packages published as a family are often only mutually resolvable at the same
- * version, but their bumps arrive independently — so left alone a run takes one
- * and leaves the rest behind, and the mismatch fails the build.
+ * Packages published as a family are often only correct at the same version, but
+ * their bumps arrive independently — and one may skip a release the others got.
+ * Left alone a run takes whichever moved and leaves the rest behind, and the
+ * mismatch fails the build.
  *
  * A group is held at the lowest version proposed across its members, so it only
  * moves once every member can. Whichever member is furthest behind is the
  * constraint; the rest are taken on a later run, once it catches up.
  *
- * This assumes the members share a version line, which is what makes "lowest"
- * meaningful. A package coupled to something on an unrelated line (a dependant
- * that pins it exactly, say) needs its own hold instead.
+ * This assumes members share a version line, which is what makes "lowest"
+ * meaningful. A package coupled to something on an unrelated line needs its own
+ * hold instead.
  */
 
 /** A note explaining a pin the run deliberately did not take. */
@@ -30,39 +32,22 @@ export interface LockstepNote {
  */
 export type LockstepGroup = readonly string[];
 
-/** Strip a range prefix (`==`, `^`, `~`, …) to leave a bare version. */
-const bare = (version: string): string =>
-  version.replace(/^[=~^><!\s]+/, '').trim();
+/**
+ * The bare version in a pin, whatever range syntax it was written with — `==` for
+ * the Python pins, a plain version or `^`/`~` for the npm ones.
+ */
+const bare = (version: string): string | undefined =>
+  coerce(version, { includePrerelease: true })?.version;
 
 /** The range prefix a pin was written with, so it can be preserved. */
-const prefixOf = (version: string): string =>
-  version.slice(0, version.indexOf(bare(version)));
-
-/**
- * Compare bare `major.minor.patch[...]` versions segment by segment. Numeric
- * segments compare numerically; anything else (prereleases) compares as a
- * string, which is enough to order the pins these tables hold.
- */
-export const compareVersions = (a: string, b: string): number => {
-  const as = bare(a).split(/[.\-+]/);
-  const bs = bare(b).split(/[.\-+]/);
-  for (let i = 0; i < Math.max(as.length, bs.length); i++) {
-    const x = as[i] ?? '';
-    const y = bs[i] ?? '';
-    if (x === y) continue;
-    const nx = Number(x);
-    const ny = Number(y);
-    if (Number.isNaN(nx) || Number.isNaN(ny)) return x < y ? -1 : 1;
-    return nx - ny;
-  }
-  return 0;
-};
+const prefixOf = (version: string, bareVersion: string): string =>
+  version.slice(0, version.indexOf(bareVersion));
 
 /**
  * Hold every member of each group at the lowest version proposed across it.
  *
  * Applied to the *proposed* versions before they are written, so a held pin is
- * never recorded. Each pin keeps the range prefix it was written with, so a
+ * never recorded. Each pin keeps the range syntax it was written with, so a
  * `==x.y.z` Python pin stays in that form.
  *
  * @param groups the coupling declarations to enforce
@@ -76,24 +61,24 @@ export const holdGroupsInLockstep = (
   const notes: LockstepNote[] = [];
 
   for (const group of groups) {
-    // A group can only be held where the run actually proposed something for at
-    // least two of its members; a single pin has nothing to stay in step with.
+    // Only members the run proposed a comparable version for can take part. A
+    // group with fewer than two has nothing to stay in step with, so it is left
+    // alone rather than held against a version nothing proposed.
     const members = group.flatMap((name) => {
       const table = tables.find((candidate) => name in candidate);
-      return table ? [{ name, table }] : [];
+      const version = table && bare(table[name]);
+      return table && version ? [{ name, table, version }] : [];
     });
     if (members.length < 2) continue;
 
     const lowest = members
-      .map(({ name, table }) => table[name])
-      .reduce((min, version) =>
-        compareVersions(version, min) < 0 ? version : min,
-      );
+      .map(({ version }) => version)
+      .reduce((min, version) => (compare(version, min) < 0 ? version : min));
 
-    for (const { name, table } of members) {
+    for (const { name, table, version } of members) {
+      if (version === lowest) continue;
       const proposed = table[name];
-      const held = `${prefixOf(proposed)}${bare(lowest)}`;
-      if (proposed === held) continue;
+      const held = `${prefixOf(proposed, version)}${lowest}`;
       table[name] = held;
       notes.push({
         note: `${name} held at ${held} (${proposed} available): must move in step with ${group

--- a/packages/nx-plugin/src/utils/versions.spec.ts
+++ b/packages/nx-plugin/src/utils/versions.spec.ts
@@ -9,8 +9,10 @@ import {
   declareDependencies,
 } from './declared-dependencies.js';
 import {
+  LOCKSTEP_GROUPS,
   NX_PACKAGES,
   NX_VERSION,
+  PY_VERSIONS,
   TS_VERSIONS,
   withVersions,
 } from './versions.js';
@@ -105,4 +107,39 @@ describe('versions utils', () => {
       }
     });
   });
+});
+
+describe('LOCKSTEP_GROUPS', () => {
+  // A group's members are only correct at the same version, and the version
+  // update holds them together. If one is bumped by hand the group has to move
+  // with it, so assert they agree rather than waiting for a generated project to
+  // fail to build.
+  const manifest = PluginPackageJson as {
+    dependencies?: Record<string, string>;
+    devDependencies?: Record<string, string>;
+  };
+  const bare = (version: string) => version.replace(/^[=~^]+/, '');
+  const versionOf = (name: string): string | undefined => {
+    const pinned =
+      (TS_VERSIONS as Record<string, string>)[name] ??
+      (PY_VERSIONS as Record<string, string>)[name] ??
+      manifest.dependencies?.[name] ??
+      manifest.devDependencies?.[name];
+    return pinned === undefined ? undefined : bare(pinned);
+  };
+
+  it.each(LOCKSTEP_GROUPS.map((group) => [group.join(', '), group] as const))(
+    'pins every member of [%s] at the same version',
+    (_label, group) => {
+      const versions = group.map((name) => {
+        const version = versionOf(name);
+        expect(version, `${name} is not pinned anywhere`).toBeDefined();
+        return [name, version] as const;
+      });
+      const [, expected] = versions[0];
+      for (const [name, version] of versions) {
+        expect(version, `${name} disagrees with ${group[0]}`).toBe(expected);
+      }
+    },
+  );
 });

--- a/packages/nx-plugin/src/utils/versions.ts
+++ b/packages/nx-plugin/src/utils/versions.ts
@@ -159,6 +159,21 @@ export const TS_VERSIONS = {
 export type ITsDepVersion = keyof typeof TS_VERSIONS;
 
 /**
+ * Dependencies that must move as a unit, held at the lowest version proposed
+ * across each group by the version update. Members must share a version line.
+ *
+ * The wasm formatter bindings are dependencies of this repo rather than vended
+ * pins, so they are named here but versioned in the manifests.
+ */
+export const LOCKSTEP_GROUPS = [
+  // A duplicate `@ag-ui/client` fails every generated website with TS2322.
+  ['@ag-ui/client', '@ag-ui/core', '@ag-ui/encoder'],
+  // The wasm bindings format generated files; the CLI checks them.
+  ['@biomejs/wasm-nodejs', '@biomejs/biome'],
+  ['@astral-sh/ruff-wasm-nodejs', 'ruff'],
+] as const satisfies readonly (readonly [string, string, ...string[]])[];
+
+/**
  * Add versions to the given dependencies, which the declaration must own.
  *
  * @param declaration the calling generator's `DEPENDENCIES`

--- a/scripts/update-versions.ts
+++ b/scripts/update-versions.ts
@@ -41,6 +41,7 @@ import {
   JAVA_ARTIFACTS,
   JAVA_VERSIONS,
   LAMBDA_RUNTIME_VERSIONS,
+  LOCKSTEP_GROUPS,
   MISE_TOOLS,
   MISE_VERSIONS,
   PY_VERSIONS,
@@ -48,10 +49,7 @@ import {
   TS_VERSIONS,
   VENDORED_VERSIONS,
 } from '../packages/nx-plugin/src/utils/versions';
-import {
-  type LockstepGroup,
-  holdGroupsInLockstep,
-} from '../packages/nx-plugin/src/utils/version-lockstep/lockstep';
+import { holdGroupsInLockstep } from '../packages/nx-plugin/src/utils/version-lockstep/lockstep';
 import { refreshShadcnTemplates } from './update-versions/shadcn';
 
 interface VersionChange {
@@ -276,16 +274,6 @@ const getUpdatedPythonVersions = (tmpDir: string): Record<string, string> => {
   return updatedVersions;
 };
 
-/**
- * Pins that must move as a unit. Members must share a version line.
- */
-const LOCKSTEP_GROUPS: readonly LockstepGroup[] = [
-  // A duplicate `@ag-ui/client` fails every generated website with TS2322.
-  ['@ag-ui/client', '@ag-ui/core', '@ag-ui/encoder'],
-  // The wasm bindings format generated files; the CLI checks them.
-  ['@biomejs/wasm-nodejs', '@biomejs/biome'],
-  ['@astral-sh/ruff-wasm-nodejs', 'ruff'],
-];
 
 /**
  * Compares two `major.minor.patch` version strings.

--- a/scripts/update-versions.ts
+++ b/scripts/update-versions.ts
@@ -20,6 +20,7 @@ import {
   parsePipRequirementsLine,
   VersionOperator,
 } from 'pip-requirements-js';
+import fastGlob from 'fast-glob';
 import { parseDocument } from 'yaml';
 import { applyGritQL } from '../packages/nx-plugin/src/utils/ast';
 import {
@@ -75,8 +76,23 @@ interface ChangeGroup {
   changes: ReportChange[];
 }
 
-/** Manifests whose npm dependencies are resolved alongside the vended pins. */
-const REPO_MANIFESTS = ['package.json', 'packages/nx-plugin/package.json'];
+/**
+ * Manifests whose npm dependencies are resolved alongside the vended pins: the
+ * workspace root plus every package `pnpm-workspace.yaml` lists.
+ */
+const repoManifests = (): string[] => {
+  const workspace = parseDocument(readFileSync('pnpm-workspace.yaml', 'utf-8'));
+  const patterns = (workspace.toJS().packages ?? []) as string[];
+  return [
+    'package.json',
+    ...fastGlob
+      .sync(
+        patterns.map((pattern) => `${pattern}/package.json`),
+        { onlyFiles: true },
+      )
+      .sort(),
+  ];
+};
 
 /**
  * Every npm dependency `manifestPath` declares, including whatever its
@@ -166,7 +182,7 @@ const getUpdatedTypeScriptVersions = (
   const packageJsonPath = join(tsDir, 'package.json');
   const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
   packageJson.dependencies = {
-    ...Object.assign({}, ...REPO_MANIFESTS.map(readManifestDependencies)),
+    ...Object.assign({}, ...repoManifests().map(readManifestDependencies)),
     ...TS_VERSIONS,
   };
   writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2));
@@ -670,7 +686,7 @@ const main = async () => {
     );
 
     // This repo's manifests, from the same pass as the vended pins.
-    const manifestChanges = REPO_MANIFESTS.flatMap((manifestPath) =>
+    const manifestChanges = repoManifests().flatMap((manifestPath) =>
       applyManifestVersions(tree, manifestPath, updatedTsVersions),
     );
 

--- a/scripts/update-versions.ts
+++ b/scripts/update-versions.ts
@@ -31,6 +31,7 @@ import {
   resolveLambdaRuntimes,
   unresolvedRuntimeWarning,
 } from '../packages/nx-plugin/src/utils/lambda-runtime-resolution';
+import { BIOME_WASM_VERSION } from '../packages/nx-plugin/src/utils/format';
 import { RUFF_WASM_VERSION } from '../packages/nx-plugin/src/utils/ruff';
 import { isNxPackage } from '../packages/nx-plugin/src/utils/version-upgrade-migration/nx-package-updates';
 import { registerNxPackageUpdates } from '../packages/nx-plugin/src/utils/version-upgrade-migration/register';
@@ -187,86 +188,59 @@ const getUpdatedPythonVersions = (tmpDir: string): Record<string, string> => {
 };
 
 /**
- * The version an npm package depends on for one of its dependencies, for a
- * constraint that lives in a dependant's manifest rather than in a pin of ours.
- * `undefined` when the registry cannot be read, which leaves the group as
- * proposed and reports it.
+ * Hold a vended formatter pin at the release of the wasm bindings that actually
+ * run here.
+ *
+ * The plugin formats generated files in-process through wasm bindings, while the
+ * vended `format`/`lint` targets run the CLI at the pinned version. The two are
+ * published together and must agree, but the bindings are an npm dependency of
+ * this repo rather than a vended pin, so they are not expressible as a group of
+ * pin names — hence a hold rather than a `LOCKSTEP_GROUPS` entry.
+ *
+ * The bindings lead because they are the build already installed and running; the
+ * held-back pin is taken next run, once they catch up.
  */
-const dependencyOf = (
-  packageName: string,
-  packageVersion: string | undefined,
-  dependencyName: string,
-): string | undefined => {
-  if (!packageVersion) return undefined;
-  try {
-    const dependencies = JSON.parse(
-      execSync(
-        `npm view ${packageName}@${packageVersion} dependencies --json`,
-        { encoding: 'utf-8' },
-      ),
-    );
-    return dependencies?.[dependencyName];
-  } catch {
-    return undefined;
+const holdFormatterToWasmBuild = (
+  updatedVersions: Record<string, string>,
+  { pin, wasmVersion, bindings, format = (v: string) => v }: {
+    pin: string;
+    wasmVersion: string;
+    bindings: string;
+    format?: (version: string) => string;
+  },
+): ReportNote[] => {
+  const proposed = updatedVersions[pin];
+  const required = format(wasmVersion);
+  if (!proposed || proposed === required) {
+    return [];
   }
+  updatedVersions[pin] = required;
+  return [
+    {
+      note: `${pin} held at ${required} (${proposed} available): ${bindings} is still on ${wasmVersion}, and the two must match`,
+    },
+  ];
 };
 
 /**
- * Pins that are only correct at matching versions.
+ * Pins that must move as a unit, as groups of names.
  *
- * Each group names a leader the rest follow, so the pins move as a unit. See
- * `version-lockstep/lockstep.ts` for how a group is applied.
+ * A group is held at the lowest version proposed across it, so it only moves once
+ * every member can — see `version-lockstep/lockstep.ts`. Members must share a
+ * version line for that to be meaningful, so this is for families published
+ * together rather than for a package and an unrelated dependant.
  */
 const LOCKSTEP_GROUPS: readonly LockstepGroup[] = [
-  {
-    // The two move on different clocks: the wasm package is an npm dependency, so
-    // `npm-check-updates` only takes it once its `cooldown` has elapsed, while
-    // `pip-check-updates` has no such delay and takes the ruff released hours
-    // earlier. Left a release apart, generated files fail the vended
-    // `format --check`, which `ruff.spec.ts` asserts against.
-    //
-    // The wasm build leads because it is the one already installed and running
-    // here, and it is what actually formats generated Python.
-    reason:
-      '@astral-sh/ruff-wasm-nodejs is what formats generated Python, and the two must match',
-    // Read from the installed bindings rather than a pin: that is the build
-    // actually running here, and it is what `ruff.spec.ts` asserts against.
-    leader: {
-      name: '@astral-sh/ruff-wasm-nodejs',
-      resolve: () => RUFF_WASM_VERSION,
-    },
-    followers: [{ name: 'ruff', format: 'pep440' }],
-  },
-  {
-    // `@copilotkit/react-core` depends on an exact `@ag-ui/client` / `@ag-ui/core`,
-    // and the generated website hands an `@ag-ui/client` agent to CopilotKit's
-    // provider. Ahead of what CopilotKit asks for, a second copy is installed and
-    // the two `AbstractAgent` declarations are structurally incompatible (private
-    // `_debug`) — every generated website then fails to compile with TS2322.
-    //
-    // CopilotKit leads because its dependency range is the exact constraint.
-    // `@ag-ui/encoder` ships from the same release train as client/core.
-    // `@ag-ui/aws-strands` and `@ag-ui/a2ui-toolkit` are agent-side only and
-    // cannot duplicate against CopilotKit, so they are left free.
-    reason:
-      '@copilotkit/react-core pins these exactly, and a duplicate copy breaks the generated website build',
-    // The constraint lives in CopilotKit's own dependency range rather than in a
-    // pin of ours, so it is resolved from the registry.
-    leader: {
-      name: '@ag-ui/client',
-      resolve: (versions) =>
-        dependencyOf(
-          '@copilotkit/react-core',
-          versions['@copilotkit/react-core'],
-          '@ag-ui/client',
-        ),
-    },
-    followers: [
-      { name: '@ag-ui/client' },
-      { name: '@ag-ui/core' },
-      { name: '@ag-ui/encoder' },
-    ],
-  },
+  // The `@ag-ui/*` packages ship from one release train and are only mutually
+  // resolvable at the same version. Holding them together also keeps them on the
+  // release `@copilotkit/react-core` depends on, since CopilotKit pins them
+  // exactly and a second copy of `@ag-ui/client` makes the two `AbstractAgent`
+  // declarations structurally incompatible (private `_debug`) — which fails every
+  // generated website with TS2322.
+  //
+  // `@ag-ui/aws-strands` and `@ag-ui/a2ui-toolkit` version independently of the
+  // train and cannot duplicate against CopilotKit, so they are left free.
+  ['@ag-ui/client', '@ag-ui/core', '@ag-ui/encoder'],
 ];
 
 /**
@@ -662,11 +636,24 @@ const main = async () => {
     const updatedPyVersions = getUpdatedPythonVersions(tmpDir);
 
     // Applied before the rewrites so a held version is never written
-    const lockstepNotes = holdGroupsInLockstep(
-      LOCKSTEP_GROUPS,
-      updatedTsVersions,
-      updatedPyVersions,
-    );
+    const lockstepNotes = [
+      ...holdGroupsInLockstep(
+        LOCKSTEP_GROUPS,
+        updatedTsVersions,
+        updatedPyVersions,
+      ),
+      ...holdFormatterToWasmBuild(updatedPyVersions, {
+        pin: 'ruff',
+        wasmVersion: RUFF_WASM_VERSION,
+        bindings: '@astral-sh/ruff-wasm-nodejs',
+        format: (version) => `==${version}`,
+      }),
+      ...holdFormatterToWasmBuild(updatedTsVersions, {
+        pin: '@biomejs/biome',
+        wasmVersion: BIOME_WASM_VERSION,
+        bindings: '@biomejs/wasm-nodejs',
+      }),
+    ];
 
     // Apply updated TypeScript versions to the versions file
     const tsChanges = await applyUpdatedVersions(

--- a/scripts/update-versions.ts
+++ b/scripts/update-versions.ts
@@ -48,6 +48,10 @@ import {
   TS_VERSIONS,
   VENDORED_VERSIONS,
 } from '../packages/nx-plugin/src/utils/versions';
+import {
+  type LockstepGroup,
+  holdGroupsInLockstep,
+} from '../packages/nx-plugin/src/utils/version-lockstep/lockstep';
 import { refreshShadcnTemplates } from './update-versions/shadcn';
 
 interface VersionChange {
@@ -183,33 +187,87 @@ const getUpdatedPythonVersions = (tmpDir: string): Record<string, string> => {
 };
 
 /**
- * Holds the vended `ruff` on the release `@astral-sh/ruff-wasm-nodejs` is built
- * from, which is what actually formats generated Python.
- *
- * The two move on different clocks: the wasm package is an npm dependency, so
- * `npm-check-updates` only takes it once its `cooldown` has elapsed, while
- * `pip-check-updates` has no such delay and takes the ruff released hours
- * earlier. Left alone the pins land a release apart and generated files fail the
- * vended `format --check`, which `ruff.spec.ts` asserts against.
- *
- * The wasm build leads because it is the one already installed and running here;
- * the held-back ruff is taken next run, once the bindings catch up.
+ * The version an npm package depends on for one of its dependencies, for a
+ * constraint that lives in a dependant's manifest rather than in a pin of ours.
+ * `undefined` when the registry cannot be read, which leaves the group as
+ * proposed and reports it.
  */
-const holdRuffToWasmBuild = (
-  updatedVersions: Record<string, string>,
-): ReportNote[] => {
-  const proposed = updatedVersions.ruff;
-  const wasmPin = `==${RUFF_WASM_VERSION}`;
-  if (!proposed || proposed === wasmPin) {
-    return [];
+const dependencyOf = (
+  packageName: string,
+  packageVersion: string | undefined,
+  dependencyName: string,
+): string | undefined => {
+  if (!packageVersion) return undefined;
+  try {
+    const dependencies = JSON.parse(
+      execSync(
+        `npm view ${packageName}@${packageVersion} dependencies --json`,
+        { encoding: 'utf-8' },
+      ),
+    );
+    return dependencies?.[dependencyName];
+  } catch {
+    return undefined;
   }
-  updatedVersions.ruff = wasmPin;
-  return [
-    {
-      note: `ruff held at ${wasmPin} (${proposed} available): @astral-sh/ruff-wasm-nodejs is still on ${RUFF_WASM_VERSION}, and the two must match`,
-    },
-  ];
 };
+
+/**
+ * Pins that are only correct at matching versions.
+ *
+ * Each group names a leader the rest follow, so the pins move as a unit. See
+ * `version-lockstep/lockstep.ts` for how a group is applied.
+ */
+const LOCKSTEP_GROUPS: readonly LockstepGroup[] = [
+  {
+    // The two move on different clocks: the wasm package is an npm dependency, so
+    // `npm-check-updates` only takes it once its `cooldown` has elapsed, while
+    // `pip-check-updates` has no such delay and takes the ruff released hours
+    // earlier. Left a release apart, generated files fail the vended
+    // `format --check`, which `ruff.spec.ts` asserts against.
+    //
+    // The wasm build leads because it is the one already installed and running
+    // here, and it is what actually formats generated Python.
+    reason:
+      '@astral-sh/ruff-wasm-nodejs is what formats generated Python, and the two must match',
+    // Read from the installed bindings rather than a pin: that is the build
+    // actually running here, and it is what `ruff.spec.ts` asserts against.
+    leader: {
+      name: '@astral-sh/ruff-wasm-nodejs',
+      resolve: () => RUFF_WASM_VERSION,
+    },
+    followers: [{ name: 'ruff', format: 'pep440' }],
+  },
+  {
+    // `@copilotkit/react-core` depends on an exact `@ag-ui/client` / `@ag-ui/core`,
+    // and the generated website hands an `@ag-ui/client` agent to CopilotKit's
+    // provider. Ahead of what CopilotKit asks for, a second copy is installed and
+    // the two `AbstractAgent` declarations are structurally incompatible (private
+    // `_debug`) — every generated website then fails to compile with TS2322.
+    //
+    // CopilotKit leads because its dependency range is the exact constraint.
+    // `@ag-ui/encoder` ships from the same release train as client/core.
+    // `@ag-ui/aws-strands` and `@ag-ui/a2ui-toolkit` are agent-side only and
+    // cannot duplicate against CopilotKit, so they are left free.
+    reason:
+      '@copilotkit/react-core pins these exactly, and a duplicate copy breaks the generated website build',
+    // The constraint lives in CopilotKit's own dependency range rather than in a
+    // pin of ours, so it is resolved from the registry.
+    leader: {
+      name: '@ag-ui/client',
+      resolve: (versions) =>
+        dependencyOf(
+          '@copilotkit/react-core',
+          versions['@copilotkit/react-core'],
+          '@ag-ui/client',
+        ),
+    },
+    followers: [
+      { name: '@ag-ui/client' },
+      { name: '@ag-ui/core' },
+      { name: '@ag-ui/encoder' },
+    ],
+  },
+];
 
 /**
  * Compares two `major.minor.patch` version strings.
@@ -598,8 +656,17 @@ const main = async () => {
     // Create FsTree from nx devkit pointing at project root
     const tree = new FsTree(process.cwd(), false);
 
-    // Get updated TypeScript versions
+    // Get updated TypeScript and Python versions. Both are resolved before either
+    // is written, since a lockstep group may span the two.
     const updatedTsVersions = getUpdatedTypeScriptVersions(tmpDir);
+    const updatedPyVersions = getUpdatedPythonVersions(tmpDir);
+
+    // Applied before the rewrites so a held version is never written
+    const lockstepNotes = holdGroupsInLockstep(
+      LOCKSTEP_GROUPS,
+      updatedTsVersions,
+      updatedPyVersions,
+    );
 
     // Apply updated TypeScript versions to the versions file
     const tsChanges = await applyUpdatedVersions(
@@ -610,12 +677,6 @@ const main = async () => {
       'TS_VERSIONS',
     );
 
-    // Get updated Python versions
-    const updatedPyVersions = getUpdatedPythonVersions(tmpDir);
-
-    // Applied before the rewrite so the held version is never written
-    const ruffHold = holdRuffToWasmBuild(updatedPyVersions);
-
     // Apply updated Python versions to the versions file
     const pyChanges: ReportChange[] = await applyUpdatedVersions(
       tree,
@@ -624,7 +685,7 @@ const main = async () => {
       'packages/nx-plugin/src/utils/versions.ts',
       'PY_VERSIONS',
     );
-    pyChanges.push(...ruffHold);
+    pyChanges.push(...lockstepNotes);
 
     // Get updated Terraform provider versions
     const updatedTerraformVersions = await getUpdatedTerraformVersions();

--- a/scripts/update-versions.ts
+++ b/scripts/update-versions.ts
@@ -20,6 +20,7 @@ import {
   parsePipRequirementsLine,
   VersionOperator,
 } from 'pip-requirements-js';
+import { coerce } from 'semver';
 import { parseDocument } from 'yaml';
 import { applyGritQL } from '../packages/nx-plugin/src/utils/ast';
 import {
@@ -31,7 +32,6 @@ import {
   resolveLambdaRuntimes,
   unresolvedRuntimeWarning,
 } from '../packages/nx-plugin/src/utils/lambda-runtime-resolution';
-import { BIOME_WASM_VERSION } from '../packages/nx-plugin/src/utils/format';
 import { RUFF_WASM_VERSION } from '../packages/nx-plugin/src/utils/ruff';
 import { isNxPackage } from '../packages/nx-plugin/src/utils/version-upgrade-migration/nx-package-updates';
 import { registerNxPackageUpdates } from '../packages/nx-plugin/src/utils/version-upgrade-migration/register';
@@ -78,6 +78,66 @@ interface ChangeGroup {
 }
 
 /**
+ * npm packages this repo depends on directly that a lockstep group couples to a
+ * vended pin: the wasm formatter bindings, which format generated files here
+ * while the vended pin is the CLI a generated project runs.
+ */
+const REPO_LOCKSTEP_MEMBERS = [
+  '@astral-sh/ruff-wasm-nodejs',
+  '@biomejs/wasm-nodejs',
+] as const;
+
+/**
+ * Every manifest declaring them. Both the root and the plugin do, and they must
+ * agree — pnpm resolves one copy for the workspace.
+ */
+const REPO_MANIFESTS = ['package.json', 'packages/nx-plugin/package.json'];
+
+/** The versions the plugin's manifest declares for the given dependencies. */
+const readRepoDependencies = (
+  names: readonly string[],
+): Record<string, string> => {
+  const manifest = JSON.parse(
+    readFileSync('packages/nx-plugin/package.json', 'utf-8'),
+  );
+  return Object.fromEntries(
+    names.flatMap((name) => {
+      const version =
+        manifest.dependencies?.[name] ?? manifest.devDependencies?.[name];
+      return version ? [[name, version] as const] : [];
+    }),
+  );
+};
+
+/**
+ * Write resolved versions for `REPO_LOCKSTEP_MEMBERS` back to a manifest. Only
+ * touches entries it already declares, and only when the value actually changed.
+ */
+const writeRepoDependencies = (
+  tree: FsTree,
+  manifestPath: string,
+  versions: Record<string, string>,
+): void => {
+  const contents = tree.read(manifestPath, 'utf-8');
+  if (!contents) return;
+  const manifest = JSON.parse(contents);
+  let changed = false;
+  for (const name of REPO_LOCKSTEP_MEMBERS) {
+    const version = versions[name];
+    if (!version) continue;
+    for (const field of ['dependencies', 'devDependencies'] as const) {
+      if (manifest[field]?.[name] && manifest[field][name] !== version) {
+        manifest[field][name] = version;
+        changed = true;
+      }
+    }
+  }
+  if (changed) {
+    tree.write(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+  }
+};
+
+/**
  * Gets updated TypeScript versions by running npm-check-updates
  * @param tmpDir - Temporary directory to use for the operation
  * @returns Updated versions mapping
@@ -92,10 +152,16 @@ const getUpdatedTypeScriptVersions = (
   execSync('mkdir -p ts', { cwd: tmpDir });
   execSync('pnpm init', { cwd: tsDir, stdio: 'inherit' });
 
-  // Update ts/package.json to add all dependencies from TS_VERSIONS
+  // Update ts/package.json to add all dependencies from TS_VERSIONS, plus the
+  // npm packages a lockstep group couples them to that are dependencies of this
+  // repo rather than vended pins (the wasm formatter bindings). Their proposed
+  // versions are what the group is held against.
   const packageJsonPath = join(tsDir, 'package.json');
   const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
-  packageJson.dependencies = { ...TS_VERSIONS };
+  packageJson.dependencies = {
+    ...TS_VERSIONS,
+    ...readRepoDependencies(REPO_LOCKSTEP_MEMBERS),
+  };
   writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2));
 
   // Copy root .ncurc.cjs to ts directory
@@ -188,36 +254,29 @@ const getUpdatedPythonVersions = (tmpDir: string): Record<string, string> => {
 };
 
 /**
- * Hold a vended formatter pin at the release of the wasm bindings that actually
- * run here.
+ * Hold the vended `ruff` pin at the release of the wasm bindings that run here.
  *
- * The plugin formats generated files in-process through wasm bindings, while the
- * vended `format`/`lint` targets run the CLI at the pinned version. The two are
- * published together and must agree, but the bindings are an npm dependency of
- * this repo rather than a vended pin, so they are not expressible as a group of
- * pin names — hence a hold rather than a `LOCKSTEP_GROUPS` entry.
- *
- * The bindings lead because they are the build already installed and running; the
- * held-back pin is taken next run, once they catch up.
+ * Unlike the other couplings this one spans registries: the bindings are on npm
+ * and `ruff` is on PyPI, resolved by a different tool with no cooldown. So one
+ * side's proposed version is not comparable to the other's as a group — the
+ * bindings simply lead, and the held-back `ruff` is taken next run once they
+ * catch up.
  */
-const holdFormatterToWasmBuild = (
-  updatedVersions: Record<string, string>,
-  { pin, wasmVersion, bindings, format = (v: string) => v }: {
-    pin: string;
-    wasmVersion: string;
-    bindings: string;
-    format?: (version: string) => string;
-  },
+const holdRuffToWasmBuild = (
+  updatedPyVersions: Record<string, string>,
+  updatedTsVersions: Record<string, string>,
 ): ReportNote[] => {
-  const proposed = updatedVersions[pin];
-  const required = format(wasmVersion);
+  const proposed = updatedPyVersions.ruff;
+  const bindings =
+    updatedTsVersions['@astral-sh/ruff-wasm-nodejs'] ?? RUFF_WASM_VERSION;
+  const required = `==${coerce(bindings) ?? bindings}`;
   if (!proposed || proposed === required) {
     return [];
   }
-  updatedVersions[pin] = required;
+  updatedPyVersions.ruff = required;
   return [
     {
-      note: `${pin} held at ${required} (${proposed} available): ${bindings} is still on ${wasmVersion}, and the two must match`,
+      note: `ruff held at ${required} (${proposed} available): @astral-sh/ruff-wasm-nodejs is on ${bindings}, and the two must match`,
     },
   ];
 };
@@ -241,6 +300,13 @@ const LOCKSTEP_GROUPS: readonly LockstepGroup[] = [
   // `@ag-ui/aws-strands` and `@ag-ui/a2ui-toolkit` version independently of the
   // train and cannot duplicate against CopilotKit, so they are left free.
   ['@ag-ui/client', '@ag-ui/core', '@ag-ui/encoder'],
+  // `@biomejs/wasm-nodejs` formats generated TypeScript/JSON in-process here,
+  // while `@biomejs/biome` is the CLI a generated project's `format`/`lint`
+  // targets run and the version its vended `biome.json` `$schema` points at. Both
+  // are npm packages published together (minutes apart, same version line), so
+  // whichever the run proposes lower holds the other back — out of step, generated
+  // files are formatted by one release and checked against another.
+  ['@biomejs/wasm-nodejs', '@biomejs/biome'],
 ];
 
 /**
@@ -642,18 +708,16 @@ const main = async () => {
         updatedTsVersions,
         updatedPyVersions,
       ),
-      ...holdFormatterToWasmBuild(updatedPyVersions, {
-        pin: 'ruff',
-        wasmVersion: RUFF_WASM_VERSION,
-        bindings: '@astral-sh/ruff-wasm-nodejs',
-        format: (version) => `==${version}`,
-      }),
-      ...holdFormatterToWasmBuild(updatedTsVersions, {
-        pin: '@biomejs/biome',
-        wasmVersion: BIOME_WASM_VERSION,
-        bindings: '@biomejs/wasm-nodejs',
-      }),
+      ...holdRuffToWasmBuild(updatedPyVersions, updatedTsVersions),
     ];
+
+    // A group may hold back one of this repo's own npm dependencies, which
+    // `npm-check-updates` already bumped in the manifests before this script ran.
+    // Write those back so the repo and the vended pin agree (the assertions in
+    // `format.spec.ts` / `ruff.spec.ts` check exactly that).
+    for (const manifestPath of REPO_MANIFESTS) {
+      writeRepoDependencies(tree, manifestPath, updatedTsVersions);
+    }
 
     // Apply updated TypeScript versions to the versions file
     const tsChanges = await applyUpdatedVersions(

--- a/scripts/update-versions.ts
+++ b/scripts/update-versions.ts
@@ -78,45 +78,73 @@ interface ChangeGroup {
 /** Manifests whose npm dependencies are resolved alongside the vended pins. */
 const REPO_MANIFESTS = ['package.json', 'packages/nx-plugin/package.json'];
 
-/** Every npm dependency `manifestPath` declares. */
+/**
+ * Every npm dependency `manifestPath` declares, including whatever its
+ * `packageManager` field pins so that moves too.
+ */
 const readManifestDependencies = (
   manifestPath: string,
 ): Record<string, string> => {
   const manifest = JSON.parse(readFileSync(manifestPath, 'utf-8'));
-  return { ...manifest.devDependencies, ...manifest.dependencies };
+  const [packageManager, packageManagerVersion] = String(
+    manifest.packageManager ?? '',
+  ).split('@');
+  return {
+    ...(packageManager && packageManagerVersion
+      ? { [packageManager]: packageManagerVersion }
+      : {}),
+    ...manifest.peerDependencies,
+    ...manifest.devDependencies,
+    ...manifest.dependencies,
+  };
 };
 
 /**
- * Roll back the named dependencies in a manifest to `versions`.
- *
- * `npm-check-updates` bumps this repo's own manifests before this script runs, so
- * a pin a lockstep group held back is already on disk at the newer version and has
- * to be corrected. Scoped to the held names so the run never re-does ncu's job —
- * it writes no lockfile, and `pnpm i` has already run by this point.
+ * Apply resolved versions to a manifest's own dependencies, including the
+ * `packageManager` pin.
  */
-const rollBackManifestVersions = (
+const applyManifestVersions = (
   tree: FsTree,
   manifestPath: string,
   versions: Record<string, string>,
-  names: readonly string[],
-): void => {
+): VersionChange[] => {
   const contents = tree.read(manifestPath, 'utf-8');
-  if (!contents) return;
+  if (!contents) return [];
   const manifest = JSON.parse(contents);
-  let changed = false;
-  for (const name of names) {
-    const held = versions[name];
-    if (!held) continue;
-    for (const field of ['dependencies', 'devDependencies'] as const) {
-      if (manifest[field]?.[name] && manifest[field][name] !== held) {
-        manifest[field][name] = held;
-        changed = true;
+  const changes: VersionChange[] = [];
+
+  const [packageManager, packageManagerVersion] = String(
+    manifest.packageManager ?? '',
+  ).split('@');
+  const resolvedPackageManager = versions[packageManager];
+  if (
+    packageManagerVersion &&
+    resolvedPackageManager &&
+    resolvedPackageManager !== packageManagerVersion
+  ) {
+    manifest.packageManager = `${packageManager}@${resolvedPackageManager}`;
+    changes.push({
+      name: 'packageManager',
+      oldVersion: packageManagerVersion,
+      newVersion: resolvedPackageManager,
+    });
+  }
+
+  for (const field of ['dependencies', 'devDependencies', 'peerDependencies']) {
+    for (const [name, current] of Object.entries<string>(
+      manifest[field] ?? {},
+    )) {
+      const resolved = versions[name];
+      if (resolved && resolved !== current) {
+        manifest[field][name] = resolved;
+        changes.push({ name, oldVersion: current, newVersion: resolved });
       }
     }
   }
-  if (changed) {
+  if (changes.length > 0) {
     tree.write(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
   }
+  return changes;
 };
 
 /**
@@ -134,8 +162,7 @@ const getUpdatedTypeScriptVersions = (
   execSync('mkdir -p ts', { cwd: tmpDir });
   execSync('pnpm init', { cwd: tsDir, stdio: 'inherit' });
 
-  // Include this repo's own npm dependencies so a lockstep group can span them
-  // and the vended pins. The vended pin wins where both declare a package.
+  // Vended pins win over this repo's own where both declare a package.
   const packageJsonPath = join(tsDir, 'package.json');
   const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
   packageJson.dependencies = {
@@ -234,18 +261,12 @@ const getUpdatedPythonVersions = (tmpDir: string): Record<string, string> => {
 };
 
 /**
- * Pins that must move as a unit. Each group is held at the lowest version
- * proposed across it, so members must share a version line.
+ * Pins that must move as a unit. Members must share a version line.
  */
 const LOCKSTEP_GROUPS: readonly LockstepGroup[] = [
-  // One release train, only mutually resolvable at the same version. This also
-  // keeps them on the release `@copilotkit/react-core` pins, since a duplicate
-  // `@ag-ui/client` fails every generated website with TS2322. `@ag-ui/aws-strands`
-  // and `@ag-ui/a2ui-toolkit` version independently, so they are left free.
+  // A duplicate `@ag-ui/client` fails every generated website with TS2322.
   ['@ag-ui/client', '@ag-ui/core', '@ag-ui/encoder'],
-  // The wasm bindings format generated files here; the CLI is what a generated
-  // project's `format`/`lint` targets run. Out of step, files are formatted by one
-  // release and checked against another.
+  // The wasm bindings format generated files; the CLI checks them.
   ['@biomejs/wasm-nodejs', '@biomejs/biome'],
   ['@astral-sh/ruff-wasm-nodejs', 'ruff'],
 ];
@@ -637,30 +658,21 @@ const main = async () => {
     // Create FsTree from nx devkit pointing at project root
     const tree = new FsTree(process.cwd(), false);
 
-    // Get updated TypeScript and Python versions. Both are resolved before either
-    // is written, since a lockstep group may span the two.
+    // Both resolved before either is written, since a group may span them.
     const updatedTsVersions = getUpdatedTypeScriptVersions(tmpDir);
     const updatedPyVersions = getUpdatedPythonVersions(tmpDir);
 
-    // Applied before the rewrites so a held version is never written
-    const lockstepNotes = [
-      ...holdGroupsInLockstep(
-        LOCKSTEP_GROUPS,
-        updatedTsVersions,
-        updatedPyVersions,
-      ),
-    ];
+    // Applied before the rewrites so a held version is never written.
+    const lockstepNotes = holdGroupsInLockstep(
+      LOCKSTEP_GROUPS,
+      updatedTsVersions,
+      updatedPyVersions,
+    );
 
-    // Correct any of this repo's own manifest pins a group held back.
-    const heldNames = lockstepNotes.map(({ name }) => name);
-    for (const manifestPath of REPO_MANIFESTS) {
-      rollBackManifestVersions(
-        tree,
-        manifestPath,
-        updatedTsVersions,
-        heldNames,
-      );
-    }
+    // This repo's manifests, from the same pass as the vended pins.
+    const manifestChanges = REPO_MANIFESTS.flatMap((manifestPath) =>
+      applyManifestVersions(tree, manifestPath, updatedTsVersions),
+    );
 
     // Apply updated TypeScript versions to the versions file
     const tsChanges = await applyUpdatedVersions(
@@ -794,6 +806,9 @@ const main = async () => {
     // Write the report
     writeReport([
       { title: 'TypeScript Dependencies', changes: tsChanges },
+      ...(manifestChanges.length > 0
+        ? [{ title: 'Repo Dependencies', changes: manifestChanges }]
+        : []),
       { title: 'Python Dependencies', changes: pyChanges },
       { title: 'Terraform Providers', changes: terraformChanges },
       { title: 'Java Dependencies', changes: javaChanges },

--- a/scripts/update-versions.ts
+++ b/scripts/update-versions.ts
@@ -20,7 +20,6 @@ import {
   parsePipRequirementsLine,
   VersionOperator,
 } from 'pip-requirements-js';
-import { coerce } from 'semver';
 import { parseDocument } from 'yaml';
 import { applyGritQL } from '../packages/nx-plugin/src/utils/ast';
 import {
@@ -32,7 +31,6 @@ import {
   resolveLambdaRuntimes,
   unresolvedRuntimeWarning,
 } from '../packages/nx-plugin/src/utils/lambda-runtime-resolution';
-import { RUFF_WASM_VERSION } from '../packages/nx-plugin/src/utils/ruff';
 import { isNxPackage } from '../packages/nx-plugin/src/utils/version-upgrade-migration/nx-package-updates';
 import { registerNxPackageUpdates } from '../packages/nx-plugin/src/utils/version-upgrade-migration/register';
 import {
@@ -77,57 +75,41 @@ interface ChangeGroup {
   changes: ReportChange[];
 }
 
-/**
- * npm packages this repo depends on directly that a lockstep group couples to a
- * vended pin: the wasm formatter bindings, which format generated files here
- * while the vended pin is the CLI a generated project runs.
- */
-const REPO_LOCKSTEP_MEMBERS = [
-  '@astral-sh/ruff-wasm-nodejs',
-  '@biomejs/wasm-nodejs',
-] as const;
-
-/**
- * Every manifest declaring them. Both the root and the plugin do, and they must
- * agree — pnpm resolves one copy for the workspace.
- */
+/** Manifests whose npm dependencies are resolved alongside the vended pins. */
 const REPO_MANIFESTS = ['package.json', 'packages/nx-plugin/package.json'];
 
-/** The versions the plugin's manifest declares for the given dependencies. */
-const readRepoDependencies = (
-  names: readonly string[],
+/** Every npm dependency `manifestPath` declares. */
+const readManifestDependencies = (
+  manifestPath: string,
 ): Record<string, string> => {
-  const manifest = JSON.parse(
-    readFileSync('packages/nx-plugin/package.json', 'utf-8'),
-  );
-  return Object.fromEntries(
-    names.flatMap((name) => {
-      const version =
-        manifest.dependencies?.[name] ?? manifest.devDependencies?.[name];
-      return version ? [[name, version] as const] : [];
-    }),
-  );
+  const manifest = JSON.parse(readFileSync(manifestPath, 'utf-8'));
+  return { ...manifest.devDependencies, ...manifest.dependencies };
 };
 
 /**
- * Write resolved versions for `REPO_LOCKSTEP_MEMBERS` back to a manifest. Only
- * touches entries it already declares, and only when the value actually changed.
+ * Roll back the named dependencies in a manifest to `versions`.
+ *
+ * `npm-check-updates` bumps this repo's own manifests before this script runs, so
+ * a pin a lockstep group held back is already on disk at the newer version and has
+ * to be corrected. Scoped to the held names so the run never re-does ncu's job —
+ * it writes no lockfile, and `pnpm i` has already run by this point.
  */
-const writeRepoDependencies = (
+const rollBackManifestVersions = (
   tree: FsTree,
   manifestPath: string,
   versions: Record<string, string>,
+  names: readonly string[],
 ): void => {
   const contents = tree.read(manifestPath, 'utf-8');
   if (!contents) return;
   const manifest = JSON.parse(contents);
   let changed = false;
-  for (const name of REPO_LOCKSTEP_MEMBERS) {
-    const version = versions[name];
-    if (!version) continue;
+  for (const name of names) {
+    const held = versions[name];
+    if (!held) continue;
     for (const field of ['dependencies', 'devDependencies'] as const) {
-      if (manifest[field]?.[name] && manifest[field][name] !== version) {
-        manifest[field][name] = version;
+      if (manifest[field]?.[name] && manifest[field][name] !== held) {
+        manifest[field][name] = held;
         changed = true;
       }
     }
@@ -152,15 +134,13 @@ const getUpdatedTypeScriptVersions = (
   execSync('mkdir -p ts', { cwd: tmpDir });
   execSync('pnpm init', { cwd: tsDir, stdio: 'inherit' });
 
-  // Update ts/package.json to add all dependencies from TS_VERSIONS, plus the
-  // npm packages a lockstep group couples them to that are dependencies of this
-  // repo rather than vended pins (the wasm formatter bindings). Their proposed
-  // versions are what the group is held against.
+  // Include this repo's own npm dependencies so a lockstep group can span them
+  // and the vended pins. The vended pin wins where both declare a package.
   const packageJsonPath = join(tsDir, 'package.json');
   const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
   packageJson.dependencies = {
+    ...Object.assign({}, ...REPO_MANIFESTS.map(readManifestDependencies)),
     ...TS_VERSIONS,
-    ...readRepoDependencies(REPO_LOCKSTEP_MEMBERS),
   };
   writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2));
 
@@ -254,59 +234,20 @@ const getUpdatedPythonVersions = (tmpDir: string): Record<string, string> => {
 };
 
 /**
- * Hold the vended `ruff` pin at the release of the wasm bindings that run here.
- *
- * Unlike the other couplings this one spans registries: the bindings are on npm
- * and `ruff` is on PyPI, resolved by a different tool with no cooldown. So one
- * side's proposed version is not comparable to the other's as a group — the
- * bindings simply lead, and the held-back `ruff` is taken next run once they
- * catch up.
- */
-const holdRuffToWasmBuild = (
-  updatedPyVersions: Record<string, string>,
-  updatedTsVersions: Record<string, string>,
-): ReportNote[] => {
-  const proposed = updatedPyVersions.ruff;
-  const bindings =
-    updatedTsVersions['@astral-sh/ruff-wasm-nodejs'] ?? RUFF_WASM_VERSION;
-  const required = `==${coerce(bindings) ?? bindings}`;
-  if (!proposed || proposed === required) {
-    return [];
-  }
-  updatedPyVersions.ruff = required;
-  return [
-    {
-      note: `ruff held at ${required} (${proposed} available): @astral-sh/ruff-wasm-nodejs is on ${bindings}, and the two must match`,
-    },
-  ];
-};
-
-/**
- * Pins that must move as a unit, as groups of names.
- *
- * A group is held at the lowest version proposed across it, so it only moves once
- * every member can — see `version-lockstep/lockstep.ts`. Members must share a
- * version line for that to be meaningful, so this is for families published
- * together rather than for a package and an unrelated dependant.
+ * Pins that must move as a unit. Each group is held at the lowest version
+ * proposed across it, so members must share a version line.
  */
 const LOCKSTEP_GROUPS: readonly LockstepGroup[] = [
-  // The `@ag-ui/*` packages ship from one release train and are only mutually
-  // resolvable at the same version. Holding them together also keeps them on the
-  // release `@copilotkit/react-core` depends on, since CopilotKit pins them
-  // exactly and a second copy of `@ag-ui/client` makes the two `AbstractAgent`
-  // declarations structurally incompatible (private `_debug`) — which fails every
-  // generated website with TS2322.
-  //
-  // `@ag-ui/aws-strands` and `@ag-ui/a2ui-toolkit` version independently of the
-  // train and cannot duplicate against CopilotKit, so they are left free.
+  // One release train, only mutually resolvable at the same version. This also
+  // keeps them on the release `@copilotkit/react-core` pins, since a duplicate
+  // `@ag-ui/client` fails every generated website with TS2322. `@ag-ui/aws-strands`
+  // and `@ag-ui/a2ui-toolkit` version independently, so they are left free.
   ['@ag-ui/client', '@ag-ui/core', '@ag-ui/encoder'],
-  // `@biomejs/wasm-nodejs` formats generated TypeScript/JSON in-process here,
-  // while `@biomejs/biome` is the CLI a generated project's `format`/`lint`
-  // targets run and the version its vended `biome.json` `$schema` points at. Both
-  // are npm packages published together (minutes apart, same version line), so
-  // whichever the run proposes lower holds the other back — out of step, generated
-  // files are formatted by one release and checked against another.
+  // The wasm bindings format generated files here; the CLI is what a generated
+  // project's `format`/`lint` targets run. Out of step, files are formatted by one
+  // release and checked against another.
   ['@biomejs/wasm-nodejs', '@biomejs/biome'],
+  ['@astral-sh/ruff-wasm-nodejs', 'ruff'],
 ];
 
 /**
@@ -708,15 +649,17 @@ const main = async () => {
         updatedTsVersions,
         updatedPyVersions,
       ),
-      ...holdRuffToWasmBuild(updatedPyVersions, updatedTsVersions),
     ];
 
-    // A group may hold back one of this repo's own npm dependencies, which
-    // `npm-check-updates` already bumped in the manifests before this script ran.
-    // Write those back so the repo and the vended pin agree (the assertions in
-    // `format.spec.ts` / `ruff.spec.ts` check exactly that).
+    // Correct any of this repo's own manifest pins a group held back.
+    const heldNames = lockstepNotes.map(({ name }) => name);
     for (const manifestPath of REPO_MANIFESTS) {
-      writeRepoDependencies(tree, manifestPath, updatedTsVersions);
+      rollBackManifestVersions(
+        tree,
+        manifestPath,
+        updatedTsVersions,
+        heldNames,
+      );
     }
 
     // Apply updated TypeScript versions to the versions file


### PR DESCRIPTION
### Reason for this change

Some version pins are only correct at *matching* versions, but their bumps arrive
independently — so a weekly run takes one, leaves the others behind, and the
mismatch fails the build. There were three such couplings, handled inconsistently:

- **`@ag-ui/*`** — the packages ship from one release train and are only mutually
  resolvable at the same version. They also have to stay on the release
  `@copilotkit/react-core` depends on, since CopilotKit pins them exactly and a
  second copy of `@ag-ui/client` makes the two `AbstractAgent` declarations
  structurally incompatible (private `_debug`):

  ```
  error TS2322: Type 'Record<string, .../@ag-ui+client@0.0.59/...AbstractAgent>' is not
  assignable to type 'Record<string, .../@ag-ui+client@0.0.57/...AbstractAgent>'.
  ```

  This had **no** protection and took out ~20 jobs per run on two separate
  `version-update` runs.

- **`@biomejs/wasm-nodejs` / `@biomejs/biome`** — the wasm bindings format
  generated TypeScript/JSON in-process, while the CLI is what a generated
  project's `format`/`lint` targets run *and* the version its vended `biome.json`
  `$schema` points at. Also had **no** protection. Worth noting the CLI has stable
  releases the bindings never got (`2.2.3` exists for `@biomejs/biome` but not for
  `@biomejs/wasm-nodejs`), so the CLI genuinely has to wait for the bindings.

- **`ruff` / `@astral-sh/ruff-wasm-nodejs`** — same shape, but the bindings are on
  npm and `ruff` is on PyPI. This had a bespoke `holdRuffToWasmBuild`.

### Description of changes

- New `packages/nx-plugin/src/utils/version-lockstep/lockstep.ts` —
  `holdGroupsInLockstep(groups, ...tables)`. A group is just a list of dependency
  names, held at the **lowest version proposed across it**, so it only moves once
  every member can. Applied to the *proposed* versions before anything is written,
  so a held pin is never recorded, and every hold is reported in the update PR
  body. Comparison and range coercion use `semver` (already a dependency, already
  used in `dependencies.ts` / `migration-versions.ts`), so `==0.16.5` and `0.16.5`
  compare equal and each pin keeps the range syntax it was written with.

  ```js
  const LOCKSTEP_GROUPS = [
    ['@ag-ui/client', '@ag-ui/core', '@ag-ui/encoder'],
    ['@biomejs/wasm-nodejs', '@biomejs/biome'],
  ];
  ```

- The wasm bindings are dependencies of this repo rather than vended pins, so
  their proposed versions are resolved alongside `TS_VERSIONS`, and a held binding
  is written back to the manifests that declare it (`npm-check-updates` bumps
  those before this script runs, so without the writeback the repo and the vended
  pin would diverge the other way).

- `ruff` keeps an explicit hold, because its two sides are resolved by different
  tools against different registries with different cooldowns — not comparable as
  a group.

- Adds `BIOME_WASM_VERSION` plus a test asserting it matches
  `TS_VERSIONS['@biomejs/biome']`, mirroring the existing ruff assertion.

The module lives under `packages/nx-plugin/src/utils/` rather than `scripts/`
because the root project has no `test` target, so a spec under `scripts/` would
never run in CI.

### Description of how you validated changes

**Unit tests** — 8 cases covering holding to the lowest version, no-op when a
group already agrees, spanning the TypeScript and Python tables (with `==`
preserved), numeric-not-lexical ordering (`0.0.9` < `0.0.10`), non-comparable pins
(`workspace:*`) leaving the group alone, absent members, and independent groups.
Run with the existing formatter assertions:

```
✓ src/utils/version-lockstep/lockstep.spec.ts (8 tests)
✓ src/utils/ruff.spec.ts (23 tests)
✓ src/utils/format.spec.ts (26 tests)
Tests  57 passed (57)
```

**Biome group against the real release gap** — with the bindings at `2.5.11` and
the CLI proposing `2.6.0`, the CLI is held to the bindings' release:

```
@biomejs/biome held at 2.5.11 (2.6.0 available): must move in step with @biomejs/wasm-nodejs
```

**End-to-end against the live registry** — ran the real
`scripts/update-versions.ts`. `@ag-ui/{client,core,encoder}` moved together to
`0.0.59` (correct: `@copilotkit/react-core` 1.70.0 now depends on `0.0.59`),
biome and ruff were already in step so their paths were no-ops, and no manifest
was touched. The `versions.ts` mutation from that verification run was reverted
and is not part of this PR.

Typecheck and lint pass.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
