### PR TITLE
fix(ts#agent,ts#mcp-server): keep a vendored npm version current in the version sync

### DIFF
--- a/packages/nx-plugin/src/utils/version-upgrade-migration/sync-embedded-versions.spec.ts
+++ b/packages/nx-plugin/src/utils/version-upgrade-migration/sync-embedded-versions.spec.ts
@@ -120,6 +120,34 @@ const terraformWithQuotedScript = (boto3 = '1.40.0') =>
 }
 `;
 
+/**
+ * A `project.json` carrying the package target a code-packaged AgentCore
+ * component gets, which vendors ADOT into the built package.
+ */
+const projectJsonWithPackageTarget = (adot = '0.9.0') => ({
+  name: 'agent',
+  root: 'packages/agent',
+  // The vendoring pins are ownership-scoped, so the metadata recording which
+  // generator owns ADOT has to survive this fixture replacing the file.
+  metadata: {
+    generator: 'ts#agent',
+    components: [{ generator: 'ts#mcp-server' }],
+  },
+  targets: {
+    'agent-package': {
+      executor: 'nx:run-commands',
+      options: {
+        commands: [
+          'rimraf dist/packages/agent/package/agent/agent',
+          'make-dir dist/packages/agent/package/agent/agent',
+          `npm install --prefix dist/packages/agent/package/agent/agent --no-save --no-audit --no-fund --omit=dev --ignore-scripts @aws/aws-distro-opentelemetry-node-autoinstrumentation@${adot}`,
+        ],
+        parallel: false,
+      },
+    },
+  },
+});
+
 /** A `project.json` carrying the trivy scan target the docker helper adds. */
 const projectJsonWithTrivyTarget = (trivy = '0.60.0') => ({
   name: 'agent',
@@ -542,6 +570,78 @@ COPY --from=builder /out /
       const projectJson = tree.read('packages/agent/project.json', 'utf-8')!;
       expect(projectJson).toContain('--severity HIGH,CRITICAL');
       expect(projectJson).toContain('rm -rf dist/packages/agent/trivy/agent');
+    });
+
+    // The ADOT the code package target vendors sits in a target command rather
+    // than in any manifest, so nothing but this sync reaches it.
+    it('should upgrade the ADOT a code package target vendors', async () => {
+      writeJson(
+        tree,
+        'packages/agent/project.json',
+        projectJsonWithPackageTarget(),
+      );
+
+      await syncVendedVersions(tree);
+
+      expect(tree.read('packages/agent/project.json', 'utf-8')).toContain(
+        `@aws/aws-distro-opentelemetry-node-autoinstrumentation@${VENDED_ADOT}`,
+      );
+    });
+
+    it('should leave the rest of a vendoring command untouched', async () => {
+      writeJson(
+        tree,
+        'packages/agent/project.json',
+        projectJsonWithPackageTarget(),
+      );
+
+      await syncVendedVersions(tree);
+
+      const projectJson = tree.read('packages/agent/project.json', 'utf-8')!;
+      expect(projectJson).toContain('--ignore-scripts');
+      expect(projectJson).toContain('--omit=dev');
+      expect(projectJson).toContain(
+        '--prefix dist/packages/agent/package/agent/agent',
+      );
+    });
+
+    it('should leave a vendored version the user raised alone', async () => {
+      writeJson(
+        tree,
+        'packages/agent/project.json',
+        projectJsonWithPackageTarget('99.0.0'),
+      );
+
+      await syncVendedVersions(tree);
+
+      expect(tree.read('packages/agent/project.json', 'utf-8')).toContain(
+        'aws-distro-opentelemetry-node-autoinstrumentation@99.0.0',
+      );
+    });
+
+    it('should leave a package no generator owns alone', async () => {
+      writeJson(tree, 'packages/agent/project.json', {
+        name: 'agent',
+        root: 'packages/agent',
+        metadata: {
+          generator: 'ts#agent',
+          components: [{ generator: 'ts#mcp-server' }],
+        },
+        targets: {
+          custom: {
+            executor: 'nx:run-commands',
+            options: {
+              commands: ['npm install --prefix out some-other-package@1.0.0'],
+            },
+          },
+        },
+      });
+
+      await syncVendedVersions(tree);
+
+      expect(tree.read('packages/agent/project.json', 'utf-8')).toContain(
+        'some-other-package@1.0.0',
+      );
     });
 
     it('should leave a trivy version the user raised alone', async () => {

--- a/packages/nx-plugin/src/utils/version-upgrade-migration/sync-embedded-versions.ts
+++ b/packages/nx-plugin/src/utils/version-upgrade-migration/sync-embedded-versions.ts
@@ -351,6 +351,20 @@ const UVX_PIN_SHAPES: readonly ((name: string) => string)[] = [
 ];
 
 /**
+ * The way a `project.json` target command vendors an npm package into a build
+ * output, e.g. the AWS Distro for OpenTelemetry a code-packaged AgentCore
+ * runtime carries.
+ *
+ * Reuses the `Dockerfile` install shape: both are shell `npm install` lines, and
+ * a command string being JSON only narrows what can terminate the version — which
+ * `VERSION_TERMINATORS` already covers. Driven off the owned set like every other
+ * pin, so a package a later release vendors this way is covered without a change
+ * here.
+ */
+const TARGET_NPM_INSTALL_SHAPE = (name: string): string =>
+  `npm (?:install|i|add)[^\\n]*?\\s${name}@([0-9][^${VERSION_TERMINATORS}']*)`;
+
+/**
  * Sync the pinned tools a `project.json` target command runs: a container image,
  * and the Python versions a `uvx` invocation pins.
  *
@@ -364,7 +378,10 @@ const UVX_PIN_SHAPES: readonly ((name: string) => string)[] = [
  * the project, so there is no dependency for a generator to own. A version is only
  * rewritten where this release vends that exact package at a higher one.
  */
-const syncTargetToolPins = async (tree: Tree): Promise<string[]> => {
+const syncTargetToolPins = async (
+  tree: Tree,
+  owned: OwnedDependencies,
+): Promise<string[]> => {
   const projectJsons: string[] = [];
 
   visitNotIgnoredFiles(tree, '.', (path) => {
@@ -403,7 +420,21 @@ const syncTargetToolPins = async (tree: Tree): Promise<string[]> => {
 
   const skipped: string[] = [];
   for (const path of projectJsons) {
-    if ((await applyPins(tree, path, pins)).skipped) {
+    // The vendoring pins are ownership-scoped, unlike the tooling ones above: a
+    // vendored package is declared by the generator that vendors it, so a
+    // package the user pinned in a command of their own is never rewritten.
+    const vendoringPins: EmbeddedPin[] = [];
+    for (const name of ownedForFile(owned, path).ts) {
+      const vended = vendedTsVersion(name);
+      if (vended) {
+        vendoringPins.push({
+          pattern: TARGET_NPM_INSTALL_SHAPE(escapeRegExp(name)),
+          vended,
+        });
+      }
+    }
+
+    if ((await applyPins(tree, path, [...pins, ...vendoringPins])).skipped) {
       skipped.push(path);
     }
   }
@@ -469,6 +500,6 @@ export const syncEmbeddedVersions = async (
 ): Promise<string[]> => [
   ...(await syncDockerfiles(tree, owned)),
   ...(await syncTerraformScriptPins(tree, owned)),
-  ...(await syncTargetToolPins(tree)),
+  ...(await syncTargetToolPins(tree, owned)),
   ...(await syncSmithyMavenPins(tree)),
 ];


### PR DESCRIPTION
### Reason for this change

The code packaging target added in #1165 vendors the AWS Distro for OpenTelemetry into the built package with an `npm install` in a `project.json` target command:

```
npm install --prefix dist/... --no-save --no-audit --no-fund --omit=dev @aws/aws-distro-opentelemetry-node-autoinstrumentation@0.12.0
```

That version is baked into the command rather than declared in any manifest, so the dependency sync never reaches it — and `syncEmbeddedVersions`, which exists precisely for versions in file bodies, did not cover it either. `syncTargetToolPins` already walks every `project.json`, but only matched container images and `smithy` / `mise` / `uvx` pins. An `npm install` pin shape existed, but was only applied to `Dockerfile`s.

The result: an upgraded workspace kept whatever ADOT version it was generated with, forever. Verified on a real workspace — a `0.9.0` pin survived `nx migrate` untouched while the release vended `0.12.0`. That is the failure mode this sync exists to prevent, on a version pinned to clear known vulnerabilities.

### Description of changes

`syncTargetToolPins` now also syncs the npm packages a target command vendors, reusing the existing `Dockerfile` install shape (both are shell `npm install` lines; a JSON command string only narrows what can terminate a version, which `VERSION_TERMINATORS` already covers).

Unlike the tooling pins beside it, the vendoring pins are **ownership-scoped**: a vendored package is declared by the generator that vendors it, so a package a user pinned in a command of their own is never rewritten. Driven off the owned set rather than a list of today's vendored packages, so **any package a later release vendors this way is covered without another change here** — the same property the Dockerfile and Terraform paths already have.

### Description of how you validated changes

Four tests added to `sync-embedded-versions.spec.ts`: the pin is upgraded; the rest of the command is untouched; a version the user raised past the vended one is left alone; and a package no generator owns is left alone. Full file passes (39 tests).

I mutation-tested the ownership assertion rather than trusting it: pointing it at an owned package with a genuinely older version makes it fail, which confirms it is proving scoping and not passing for an unrelated reason. (A first attempt used a *higher* version and passed for the wrong reason — `isVendedUpgrade` declining to downgrade — so the test now uses a lower one.)

Verified end to end through the real `nx migrate` path on a generated workspace with a stale `0.9.0` pin:

- **with this change** — rewritten to `0.12.0`
- **with it stashed** — left at `0.9.0`

`compile` and `lint` pass.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
