### PR TITLE
feat(deps): add support for pnpm 12

### DIFF
--- a/.github/actions/init-monorepo/action.yml
+++ b/.github/actions/init-monorepo/action.yml
@@ -78,8 +78,6 @@ runs:
     - name: Use PNPM
       uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0
       with:
-        # Dependencies are installed further down, once the pnpm store cache
-        # has been restored.
         install: 'false'
     - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
       if: ${{ runner.os != 'Windows' && inputs.setup-bun == 'true' }}

--- a/.github/actions/init-monorepo/action.yml
+++ b/.github/actions/init-monorepo/action.yml
@@ -78,7 +78,8 @@ runs:
     - name: Use PNPM
       uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0
       with:
-        # This action installs later, once the pnpm store cache is restored.
+        # Dependencies are installed further down, once the pnpm store cache
+        # has been restored.
         install: 'false'
     - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
       if: ${{ runner.os != 'Windows' && inputs.setup-bun == 'true' }}

--- a/.github/actions/init-monorepo/action.yml
+++ b/.github/actions/init-monorepo/action.yml
@@ -76,7 +76,10 @@ runs:
       with:
         registry: public.ecr.aws
     - name: Use PNPM
-      uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
+      uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0
+      with:
+        # This action installs later, once the pnpm store cache is restored.
+        install: 'false'
     - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
       if: ${{ runner.os != 'Windows' && inputs.setup-bun == 'true' }}
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,6 @@ env:
   # limit that a runner exhausts, failing the install with a 403 — so give mise
   # the token every job already has.
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  # Smoke tests resolve the build they just published to a local registry, which
-  # pnpm's release-age cutoff would hide.
-  PNPM_CONFIG_MINIMUM_RELEASE_AGE: "0"
 
 permissions:
   pull-requests: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,7 @@ jobs:
           - yarn-4
           - pnpm-10
           - pnpm-11
+          - pnpm-12
           - bun
           - create-workspace
           - dungeon-adventure

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,9 @@ env:
   # limit that a runner exhausts, failing the install with a 403 — so give mise
   # the token every job already has.
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  # Smoke tests resolve the build they just published to a local registry, which
+  # pnpm's release-age cutoff would hide.
+  PNPM_CONFIG_MINIMUM_RELEASE_AGE: "0"
 
 permissions:
   pull-requests: write

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -18,7 +18,6 @@ jobs:
       - name: Use PNPM
         uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0
         with:
-          # Installed below, after setup-node's pnpm cache is restored.
           install: 'false'
       - name: Use Node.js 22.x
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -16,7 +16,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Use PNPM
-        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
+        uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0
+        with:
+          # Installed below, after setup-node's pnpm cache is restored.
+          install: 'false'
       - name: Use Node.js 22.x
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -104,6 +104,7 @@ jobs:
           - yarn-4
           - pnpm-10
           - pnpm-11
+          - pnpm-12
           - bun
           - create-workspace
           - dungeon-adventure

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,9 +12,6 @@ env:
   # limit that a runner exhausts, failing the install with a 403 — so give mise
   # the token every job already has.
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  # Smoke tests resolve the build they just published to a local registry, which
-  # pnpm's release-age cutoff would hide.
-  PNPM_CONFIG_MINIMUM_RELEASE_AGE: "0"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,6 +12,9 @@ env:
   # limit that a runner exhausts, failing the install with a 403 — so give mise
   # the token every job already has.
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  # Smoke tests resolve the build they just published to a local registry, which
+  # pnpm's release-age cutoff would hide.
+  PNPM_CONFIG_MINIMUM_RELEASE_AGE: "0"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,4 @@ Thumbs.db
 .cache-loader/
 vite.config.mts.timestamp-*
 .grit
-# Written at the workspace root while pnpm materialises packages. Left unignored
-# they invalidate the Nx project graph on every install.
 _tmp_*

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ Thumbs.db
 .cache-loader/
 vite.config.mts.timestamp-*
 .grit
+# Written at the workspace root while pnpm materialises packages. Left unignored
+# they invalidate the Nx project graph on every install.
+_tmp_*

--- a/e2e/src/global-setup.ts
+++ b/e2e/src/global-setup.ts
@@ -41,6 +41,12 @@ const restoreBackup = (path: string) => {
 
 export default async function () {
   try {
+    // Every smoke test installs the build this run publishes to verdaccio
+    // seconds earlier, which pnpm's release-age cutoff would hide. Set on this
+    // process so all spawned commands inherit it, rather than on the CI
+    // workflow, whose other jobs install from the public registry.
+    process.env.PNPM_CONFIG_MINIMUM_RELEASE_AGE = '0';
+
     // On shared Windows runners the verdaccio storage outlives the process
     // and `clearStorage: true` below doesn't fully reset it, so publishes
     // on the next run hit "409 Conflict: already present". Wipe first.

--- a/e2e/src/global-setup.ts
+++ b/e2e/src/global-setup.ts
@@ -42,9 +42,9 @@ const restoreBackup = (path: string) => {
 export default async function () {
   try {
     // Every smoke test installs the build this run publishes to verdaccio
-    // seconds earlier, which pnpm's release-age cutoff would hide. Set on this
-    // process so all spawned commands inherit it, rather than on the CI
-    // workflow, whose other jobs install from the public registry.
+    // seconds earlier, which pnpm's release-age cutoff hides. Scoped to this
+    // process — which every spawned command inherits — so the cutoff still
+    // applies to anything installing from the public registry.
     process.env.PNPM_CONFIG_MINIMUM_RELEASE_AGE = '0';
 
     // On shared Windows runners the verdaccio storage outlives the process

--- a/e2e/src/smoke-tests/license-check.spec.ts
+++ b/e2e/src/smoke-tests/license-check.spec.ts
@@ -37,6 +37,10 @@ describe('smoke test - license-check', () => {
       cwd: projectRoot,
       env: {
         NX_DAEMON: 'false',
+        // The installs below skip build scripts, since only license metadata is
+        // read. That leaves packages unbuilt, which pnpm otherwise refuses to
+        // install over on the next install a generator runs.
+        PNPM_CONFIG_STRICT_DEP_BUILDS: 'false',
       },
     };
 

--- a/e2e/src/smoke-tests/license-check.spec.ts
+++ b/e2e/src/smoke-tests/license-check.spec.ts
@@ -12,7 +12,12 @@ import {
   PY_VERSIONS,
   TS_VERSIONS,
 } from '../../../packages/nx-plugin/src/utils/versions';
-import { createTestWorkspace, runCLI, tmpProjPath } from '../utils';
+import {
+  createTestWorkspace,
+  declinePnpmBuilds,
+  runCLI,
+  tmpProjPath,
+} from '../utils';
 
 describe('smoke test - license-check', () => {
   const pkgMgr = 'pnpm';
@@ -37,12 +42,22 @@ describe('smoke test - license-check', () => {
       cwd: projectRoot,
       env: {
         NX_DAEMON: 'false',
-        // The installs below skip build scripts, since only license metadata is
-        // read. That leaves packages unbuilt, which pnpm otherwise refuses to
-        // install over on the next install a generator runs.
-        PNPM_CONFIG_STRICT_DEP_BUILDS: 'false',
       },
     };
+
+    // The tests below add every dependency in TS_VERSIONS to the workspace and
+    // install with `--ignore-scripts`, since only license metadata is read.
+    // pnpm then reports those packages' build scripts as unreviewed and fails
+    // the next install a generator runs. Record a decision for each one instead
+    // of relaxing the check, so the strict dep-builds gate stays on.
+    declinePnpmBuilds(projectRoot, [
+      '@modelcontextprotocol/inspector',
+      '@prisma/engines',
+      '@scarf/scarf',
+      'mise',
+      'prisma',
+      'protobufjs',
+    ]);
 
     await runCLI(`generate @aws/nx-plugin:license --no-interactive`, opts);
   });

--- a/e2e/src/smoke-tests/pnpm-12.spec.ts
+++ b/e2e/src/smoke-tests/pnpm-12.spec.ts
@@ -1,0 +1,12 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { activatePackageManagerViaCorepack } from './corepack';
+import { smokeTest } from './smoke-test';
+
+smokeTest('pnpm', {
+  variant: 'pnpm-12',
+  setup: () => activatePackageManagerViaCorepack('pnpm', 12),
+});

--- a/e2e/src/utils.ts
+++ b/e2e/src/utils.ts
@@ -65,6 +65,9 @@ export async function runCLI(
             // every lane. Drop it so each spawned package manager sets its
             // own.
             npm_config_user_agent: undefined,
+            // The local build is published to verdaccio moments before a test
+            // resolves it, and pnpm's release-age cutoff would hide it.
+            PNPM_CONFIG_MINIMUM_RELEASE_AGE: '0',
             ...opts.env,
           },
           shell: true,

--- a/e2e/src/utils.ts
+++ b/e2e/src/utils.ts
@@ -4,11 +4,12 @@
  */
 
 import { execSync, spawn } from 'node:child_process';
-import { existsSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { output, type PackageManager } from '@nx/devkit';
 import { backOff } from 'exponential-backoff';
+import { parseDocument } from 'yaml';
 // eslint-disable-next-line
 import {
   buildCreateNxWorkspaceCommand,
@@ -65,9 +66,6 @@ export async function runCLI(
             // every lane. Drop it so each spawned package manager sets its
             // own.
             npm_config_user_agent: undefined,
-            // The local build is published to verdaccio moments before a test
-            // resolves it, and pnpm's release-age cutoff would hide it.
-            PNPM_CONFIG_MINIMUM_RELEASE_AGE: '0',
             ...opts.env,
           },
           shell: true,
@@ -293,6 +291,32 @@ export const pinAwsScopeToLocalRegistry = (
     ].join('\n'),
     { encoding: 'utf-8' },
   );
+};
+
+/**
+ * Record a "reviewed, do not build" decision in `pnpm-workspace.yaml` for each
+ * of `packages`.
+ *
+ * pnpm's strict dep-builds gate fails an install that would silently skip a
+ * dependency's build scripts. A test that installs with `--ignore-scripts`
+ * leaves exactly that state behind, so the next install a generator runs
+ * fails. `allowBuilds: false` is the explicit decision that clears the gate for
+ * a package without running its scripts — keeping the gate itself on, unlike
+ * disabling the check wholesale.
+ *
+ * `onlyBuiltDependencies` is pnpm 10's key and only lists packages that *do*
+ * build, so a declined package has no entry there.
+ */
+export const declinePnpmBuilds = (
+  projectRoot: string,
+  packages: string[],
+): void => {
+  const workspacePath = join(projectRoot, 'pnpm-workspace.yaml');
+  const doc = parseDocument(readFileSync(workspacePath, 'utf-8'));
+  for (const pkg of packages) {
+    doc.setIn(['allowBuilds', pkg], false);
+  }
+  writeFileSync(workspacePath, doc.toString(), { encoding: 'utf-8' });
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "license": "Apache-2.0",
-  "packageManager": "pnpm@11.25.0",
+  "packageManager": "pnpm@12.2.1",
   "scripts": {
     "prepare": "husky || true",
     "build": "nx run-many --target build",

--- a/packages/nx-plugin/src/init/generator.spec.ts
+++ b/packages/nx-plugin/src/init/generator.spec.ts
@@ -112,7 +112,8 @@ describe('init generator', () => {
     expect(workspace.allowBuilds['@swc/core']).toBe(true);
   });
 
-  it('should ignore the temp files a package manager writes while installing', async () => {
+  it('should ignore the temp files pnpm writes while installing', async () => {
+    tree.write('pnpm-workspace.yaml', 'packages:\n  - packages/*\n');
     await initGenerator(tree, { iac: 'cdk', containers: 'docker' });
     expect(tree.read('.gitignore', 'utf-8')!.split('\n')).toContain('_tmp_*');
   });

--- a/packages/nx-plugin/src/init/generator.spec.ts
+++ b/packages/nx-plugin/src/init/generator.spec.ts
@@ -112,6 +112,11 @@ describe('init generator', () => {
     expect(workspace.allowBuilds['@swc/core']).toBe(true);
   });
 
+  it('should ignore the temp files a package manager writes while installing', async () => {
+    await initGenerator(tree, { iac: 'cdk', containers: 'docker' });
+    expect(tree.read('.gitignore', 'utf-8')!.split('\n')).toContain('_tmp_*');
+  });
+
   it('should repair a broken pnpm allowBuilds placeholder', async () => {
     tree.write(
       'pnpm-workspace.yaml',

--- a/packages/nx-plugin/src/migrations/latest/agent-connection-pin-strands-peers/metadata.json
+++ b/packages/nx-plugin/src/migrations/latest/agent-connection-pin-strands-peers/metadata.json
@@ -1,0 +1,3 @@
+{
+  "description": "Declare @aws-sdk/client-s3 in the shared agent-connection project so @strands-agents/sdk resolves to a single peer-suffixed instance"
+}

--- a/packages/nx-plugin/src/migrations/latest/agent-connection-pin-strands-peers/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/latest/agent-connection-pin-strands-peers/migration.spec.ts
@@ -1,0 +1,68 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { readJson, type Tree } from '@nx/devkit';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test.js';
+import migration from './migration.js';
+
+const PACKAGE_JSON = 'packages/common/agent-connection/package.json';
+
+const writeAgentConnection = (tree: Tree, dependencies: object) =>
+  tree.write(
+    PACKAGE_JSON,
+    JSON.stringify({
+      name: '@proj/agent-connection',
+      version: '0.0.1',
+      private: true,
+      dependencies,
+    }),
+  );
+
+describe('agent-connection-pin-strands-peers migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeUsingTsSolutionSetup();
+  });
+
+  it('should declare @aws-sdk/client-s3 alongside a strands client', async () => {
+    writeAgentConnection(tree, { '@strands-agents/sdk': '1.15.0' });
+
+    await migration(tree);
+
+    expect(
+      readJson(tree, PACKAGE_JSON).dependencies['@aws-sdk/client-s3'],
+    ).toBeDefined();
+  });
+
+  it('should leave a project without a strands client alone', async () => {
+    writeAgentConnection(tree, { '@modelcontextprotocol/sdk': '1.25.2' });
+
+    await migration(tree);
+
+    expect(
+      readJson(tree, PACKAGE_JSON).dependencies['@aws-sdk/client-s3'],
+    ).toBeUndefined();
+  });
+
+  it('should keep an already-declared peer on the catalog', async () => {
+    writeAgentConnection(tree, {
+      '@strands-agents/sdk': '1.15.0',
+      '@aws-sdk/client-s3': '3.1000.0',
+    });
+
+    await migration(tree);
+
+    // A workspace with catalogs enabled records the version centrally, which is
+    // the point: a range left in the manifest resolves to a second copy.
+    expect(
+      readJson(tree, PACKAGE_JSON).dependencies['@aws-sdk/client-s3'],
+    ).toBe('catalog:');
+  });
+
+  it('should do nothing when the workspace has no agent-connection project', async () => {
+    await expect(migration(tree)).resolves.not.toThrow();
+    expect(tree.exists(PACKAGE_JSON)).toBe(false);
+  });
+});

--- a/packages/nx-plugin/src/migrations/latest/agent-connection-pin-strands-peers/migration.ts
+++ b/packages/nx-plugin/src/migrations/latest/agent-connection-pin-strands-peers/migration.ts
@@ -1,0 +1,49 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { joinPathFragments, type Tree } from '@nx/devkit';
+import { AGENT_CONNECTION_PROJECT_DIR } from '../../../utils/agent-connection/agent-connection.js';
+import { addDependenciesToPackageJson } from '../../../utils/dependencies.js';
+import { formatFilesInSubtree } from '../../../utils/format.js';
+import { TS_VERSIONS } from '../../../utils/versions.js';
+
+const CLIENT_S3 = '@aws-sdk/client-s3';
+const STRANDS_SDK = '@strands-agents/sdk';
+
+/**
+ * `@aws-sdk/client-s3` is an optional peer of `@strands-agents/sdk` that the
+ * shared agent-connection project never imports, so it went undeclared. pnpm
+ * then auto-installs its own copy there while a project that does declare it
+ * gets the catalog's, and those two resolutions give `@strands-agents/sdk` two
+ * peer-suffixed instances of the same version.
+ *
+ * Anything importing both projects then sees two nominal identities of every SDK
+ * type — `Agent`, `McpClient`, `Plugin` — and fails to compile with "Types have
+ * separate declarations of a private property". Declaring it keeps the version
+ * on the catalog, collapsing both to one instance.
+ */
+export default async function migration(tree: Tree): Promise<void> {
+  const packageJsonPath = joinPathFragments(
+    AGENT_CONNECTION_PROJECT_DIR,
+    'package.json',
+  );
+  if (!tree.exists(packageJsonPath)) {
+    return;
+  }
+
+  // Only where a strands client is actually present — that is what pulls the peer.
+  const packageJson = JSON.parse(tree.read(packageJsonPath, 'utf-8') ?? '{}');
+  if (!packageJson.dependencies?.[STRANDS_SDK]) {
+    return;
+  }
+
+  addDependenciesToPackageJson(
+    tree,
+    { [CLIENT_S3]: TS_VERSIONS[CLIENT_S3] },
+    {},
+    packageJsonPath,
+  );
+
+  await formatFilesInSubtree(tree);
+}

--- a/packages/nx-plugin/src/migrations/latest/ignore-package-manager-temp-files/metadata.json
+++ b/packages/nx-plugin/src/migrations/latest/ignore-package-manager-temp-files/metadata.json
@@ -1,0 +1,3 @@
+{
+  "description": "Ignore the temporary files pnpm writes at the workspace root while materialising packages, which otherwise invalidate the Nx project graph"
+}

--- a/packages/nx-plugin/src/migrations/latest/ignore-package-manager-temp-files/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/latest/ignore-package-manager-temp-files/migration.spec.ts
@@ -1,0 +1,52 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import type { Tree } from '@nx/devkit';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test.js';
+import migration from './migration.js';
+
+const readGitIgnore = (tree: Tree): string[] =>
+  (tree.read('.gitignore', 'utf-8') ?? '').split('\n');
+
+describe('ignore-package-manager-temp-files migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeUsingTsSolutionSetup();
+  });
+
+  it('should ignore the temporary files pnpm writes', async () => {
+    tree.write('.gitignore', 'node_modules\ndist\n');
+
+    await migration(tree);
+
+    expect(readGitIgnore(tree)).toContain('_tmp_*');
+  });
+
+  it('should preserve existing patterns', async () => {
+    tree.write('.gitignore', 'node_modules\ndist\n');
+
+    await migration(tree);
+
+    const patterns = readGitIgnore(tree);
+    expect(patterns).toContain('node_modules');
+    expect(patterns).toContain('dist');
+  });
+
+  it('should not duplicate the pattern when already present', async () => {
+    tree.write('.gitignore', 'node_modules\n_tmp_*\n');
+
+    await migration(tree);
+
+    expect(readGitIgnore(tree).filter((p) => p === '_tmp_*')).toHaveLength(1);
+  });
+
+  it('should create a .gitignore when the workspace has none', async () => {
+    tree.delete('.gitignore');
+
+    await migration(tree);
+
+    expect(readGitIgnore(tree)).toContain('_tmp_*');
+  });
+});

--- a/packages/nx-plugin/src/migrations/latest/ignore-package-manager-temp-files/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/latest/ignore-package-manager-temp-files/migration.spec.ts
@@ -14,6 +14,7 @@ describe('ignore-package-manager-temp-files migration', () => {
 
   beforeEach(() => {
     tree = createTreeUsingTsSolutionSetup();
+    tree.write('pnpm-lock.yaml', "lockfileVersion: '9.0'\n");
   });
 
   it('should ignore the temporary files pnpm writes', async () => {
@@ -48,5 +49,14 @@ describe('ignore-package-manager-temp-files migration', () => {
     await migration(tree);
 
     expect(readGitIgnore(tree)).toContain('_tmp_*');
+  });
+
+  it('should leave a workspace on another package manager alone', async () => {
+    tree.delete('pnpm-lock.yaml');
+    tree.write('.gitignore', 'node_modules\ndist\n');
+
+    await migration(tree);
+
+    expect(readGitIgnore(tree)).not.toContain('_tmp_*');
   });
 });

--- a/packages/nx-plugin/src/migrations/latest/ignore-package-manager-temp-files/migration.ts
+++ b/packages/nx-plugin/src/migrations/latest/ignore-package-manager-temp-files/migration.ts
@@ -10,16 +10,18 @@ import { updateGitIgnore } from '../../../utils/git.js';
 const TEMP_FILE_PATTERN = '_tmp_*';
 
 /**
- * pnpm writes `_tmp_<pid>_<hash>` files at the workspace root while it
- * materialises packages into the virtual store.
- *
- * Nx watches the workspace, and an unignored file appearing and vanishing
- * invalidates the project graph. So a watch-mode `dev` target running while any
- * install happens — the `dev` cascade installing a dependency, or a generator
- * run in another terminal — rebuilds the graph continuously and never starts
- * the command it wraps.
+ * pnpm creates `_tmp_<pid>_<hash>` files at the workspace root while it
+ * materialises packages. Left unignored, Nx's watcher invalidates the project
+ * graph on every install, so a watch-mode `dev` target running at the time
+ * rebuilds the graph continuously and never starts the command it wraps.
  */
 export default async function migration(tree: Tree): Promise<void> {
+  // Only pnpm writes these, so key off its lockfile rather than the workspace
+  // file — a workspace on another package manager may still carry one.
+  if (!tree.exists('pnpm-lock.yaml')) {
+    return;
+  }
+
   updateGitIgnore(tree, '.', (patterns) =>
     patterns.includes(TEMP_FILE_PATTERN)
       ? patterns

--- a/packages/nx-plugin/src/migrations/latest/ignore-package-manager-temp-files/migration.ts
+++ b/packages/nx-plugin/src/migrations/latest/ignore-package-manager-temp-files/migration.ts
@@ -1,0 +1,30 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import type { Tree } from '@nx/devkit';
+import { formatFilesInSubtree } from '../../../utils/format.js';
+import { updateGitIgnore } from '../../../utils/git.js';
+
+/** The temporary files pnpm writes while materialising packages. */
+const TEMP_FILE_PATTERN = '_tmp_*';
+
+/**
+ * pnpm writes `_tmp_<pid>_<hash>` files at the workspace root while it
+ * materialises packages into the virtual store.
+ *
+ * Nx watches the workspace, and an unignored file appearing and vanishing
+ * invalidates the project graph. So a watch-mode `dev` target running while any
+ * install happens — the `dev` cascade installing a dependency, or a generator
+ * run in another terminal — rebuilds the graph continuously and never starts
+ * the command it wraps.
+ */
+export default async function migration(tree: Tree): Promise<void> {
+  updateGitIgnore(tree, '.', (patterns) =>
+    patterns.includes(TEMP_FILE_PATTERN)
+      ? patterns
+      : [...patterns, TEMP_FILE_PATTERN],
+  );
+
+  await formatFilesInSubtree(tree);
+}

--- a/packages/nx-plugin/src/preset/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/preset/__snapshots__/generator.spec.ts.snap
@@ -31,7 +31,10 @@ exports[`preset generator > should run successfully > .gemini/settings.json 1`] 
 "
 `;
 
-exports[`preset generator > should run successfully > .gitignore 1`] = `".grit"`;
+exports[`preset generator > should run successfully > .gitignore 1`] = `
+".grit
+_tmp_*"
+`;
 
 exports[`preset generator > should run successfully > .kiro/settings/mcp.json 1`] = `
 "{

--- a/packages/nx-plugin/src/utils/agent-connection/agent-connection.ts
+++ b/packages/nx-plugin/src/utils/agent-connection/agent-connection.ts
@@ -33,7 +33,16 @@ import {
   withVersions,
 } from '../versions.js';
 
-/** TypeScript dependencies a caller must declare to emit agent-connection clients. */
+/**
+ * TypeScript dependencies a caller must declare to emit agent-connection clients.
+ *
+ * `@aws-sdk/client-s3` is an optional peer of `@strands-agents/sdk` that this
+ * project's own code never imports. It is declared anyway so the catalog pins the
+ * version: left undeclared, pnpm auto-installs its own copy here while a project
+ * that does declare it gets the catalog's, and the two resolutions give
+ * `@strands-agents/sdk` two peer-suffixed instances of the same version. Anything
+ * importing both projects then sees two nominal identities of every SDK type.
+ */
 export const AGENT_CONNECTION_DEPENDENCIES = [
   { name: '@aws-lambda-powertools/parameters' },
   { name: '@aws-sdk/credential-providers' },
@@ -41,6 +50,7 @@ export const AGENT_CONNECTION_DEPENDENCIES = [
   { name: '@modelcontextprotocol/sdk' },
   { name: '@a2a-js/sdk' },
   { name: '@strands-agents/sdk' },
+  { name: '@aws-sdk/client-s3' },
 ] as const satisfies readonly { name: ITsDepVersion }[];
 
 /** Python dependencies a caller must declare to emit agent-connection clients. */
@@ -310,10 +320,14 @@ const TS_TEMPLATE_DEPS: Record<
     '@modelcontextprotocol/sdk',
   ],
   'core-a2a': ['@aws-sdk/credential-providers', '@a2a-js/sdk'],
-  'core-strands/base': ['@strands-agents/sdk'],
-  'core-strands/mcp': ['@strands-agents/sdk'],
-  'core-strands/gateway': ['@strands-agents/sdk'],
-  'core-strands/a2a': ['@strands-agents/sdk'],
+  // `@aws-sdk/client-s3` rides along with every strands client: it is an
+  // optional peer of `@strands-agents/sdk` that this project never imports, and
+  // declaring it keeps its version on the catalog (see
+  // AGENT_CONNECTION_DEPENDENCIES).
+  'core-strands/base': ['@strands-agents/sdk', '@aws-sdk/client-s3'],
+  'core-strands/mcp': ['@strands-agents/sdk', '@aws-sdk/client-s3'],
+  'core-strands/gateway': ['@strands-agents/sdk', '@aws-sdk/client-s3'],
+  'core-strands/a2a': ['@strands-agents/sdk', '@aws-sdk/client-s3'],
 };
 
 const emitTs = (

--- a/packages/nx-plugin/src/utils/agent-connection/agent-connection.ts
+++ b/packages/nx-plugin/src/utils/agent-connection/agent-connection.ts
@@ -33,16 +33,7 @@ import {
   withVersions,
 } from '../versions.js';
 
-/**
- * TypeScript dependencies a caller must declare to emit agent-connection clients.
- *
- * `@aws-sdk/client-s3` is an optional peer of `@strands-agents/sdk` that this
- * project's own code never imports. It is declared anyway so the catalog pins the
- * version: left undeclared, pnpm auto-installs its own copy here while a project
- * that does declare it gets the catalog's, and the two resolutions give
- * `@strands-agents/sdk` two peer-suffixed instances of the same version. Anything
- * importing both projects then sees two nominal identities of every SDK type.
- */
+/** TypeScript dependencies a caller must declare to emit agent-connection clients. */
 export const AGENT_CONNECTION_DEPENDENCIES = [
   { name: '@aws-lambda-powertools/parameters' },
   { name: '@aws-sdk/credential-providers' },
@@ -320,10 +311,6 @@ const TS_TEMPLATE_DEPS: Record<
     '@modelcontextprotocol/sdk',
   ],
   'core-a2a': ['@aws-sdk/credential-providers', '@a2a-js/sdk'],
-  // `@aws-sdk/client-s3` rides along with every strands client: it is an
-  // optional peer of `@strands-agents/sdk` that this project never imports, and
-  // declaring it keeps its version on the catalog (see
-  // AGENT_CONNECTION_DEPENDENCIES).
   'core-strands/base': ['@strands-agents/sdk', '@aws-sdk/client-s3'],
   'core-strands/mcp': ['@strands-agents/sdk', '@aws-sdk/client-s3'],
   'core-strands/gateway': ['@strands-agents/sdk', '@aws-sdk/client-s3'],

--- a/packages/nx-plugin/src/utils/init.ts
+++ b/packages/nx-plugin/src/utils/init.ts
@@ -62,10 +62,11 @@ export const INIT_DEPENDENCIES = [
 ] as const satisfies readonly { name: ITsDepVersion }[];
 
 // Built dependencies whose install scripts the generated workspace trusts.
-// `onlyBuiltDependencies` is the pnpm 10 key (silently ignored by pnpm 11);
-// pnpm 11 reads `allowBuilds` instead. Any dep NOT in this allowlist will
-// have its install scripts skipped with a warning — matching pnpm 10's
-// default behaviour. The user can opt-in later via `pnpm approve-builds`.
+// `onlyBuiltDependencies` is the pnpm 10 key (silently ignored from pnpm 11
+// onwards); pnpm 11 and above read `allowBuilds` instead. Any dep NOT in this
+// allowlist will have its install scripts skipped with a warning — matching
+// pnpm 10's default behaviour. The user can opt-in later via
+// `pnpm approve-builds`.
 export const PNPM_BUILT_DEPENDENCIES = ['@swc/core', 'esbuild', 'nx', 'sharp'];
 
 /**

--- a/packages/nx-plugin/src/utils/init.ts
+++ b/packages/nx-plugin/src/utils/init.ts
@@ -35,6 +35,7 @@ import {
   describeGeneratorForCatalogue,
   generatorsJsonEntries,
 } from './generators.js';
+import { updateGitIgnore } from './git.js';
 import type { Iac } from './iac.js';
 import { configureMcpServers } from './mcp.js';
 import { getNpmScope } from './npm-scope.js';
@@ -167,6 +168,13 @@ const setUpPnpmWorkspace = (tree: Tree, catalogs: boolean) => {
  * manager reads the `workspaces` field of the root `package.json`.
  */
 const setUpWorkspaces = (tree: Tree, catalogs: boolean) => {
+  // pnpm writes `_tmp_<pid>_<hash>` files at the workspace root while it
+  // materialises packages. Nx watches the workspace, and an unignored file
+  // appearing and vanishing invalidates the project graph — so a watch-mode
+  // `dev` target running while any install happens would otherwise rebuild the
+  // graph continuously and never start its command.
+  updateGitIgnore(tree, '.', (patterns) => [...patterns, '_tmp_*']);
+
   if (detectWorkspacePackageManager(tree) === 'pnpm') {
     setUpPnpmWorkspace(tree, catalogs);
   } else {

--- a/packages/nx-plugin/src/utils/init.ts
+++ b/packages/nx-plugin/src/utils/init.ts
@@ -168,15 +168,10 @@ const setUpPnpmWorkspace = (tree: Tree, catalogs: boolean) => {
  * manager reads the `workspaces` field of the root `package.json`.
  */
 const setUpWorkspaces = (tree: Tree, catalogs: boolean) => {
-  // pnpm writes `_tmp_<pid>_<hash>` files at the workspace root while it
-  // materialises packages. Nx watches the workspace, and an unignored file
-  // appearing and vanishing invalidates the project graph — so a watch-mode
-  // `dev` target running while any install happens would otherwise rebuild the
-  // graph continuously and never start its command.
-  updateGitIgnore(tree, '.', (patterns) => [...patterns, '_tmp_*']);
-
   if (detectWorkspacePackageManager(tree) === 'pnpm') {
     setUpPnpmWorkspace(tree, catalogs);
+    // pnpm creates these at the workspace root while it materialises packages.
+    updateGitIgnore(tree, '.', (patterns) => [...patterns, '_tmp_*']);
   } else {
     updateJson(tree, 'package.json', (json) => {
       // The `workspaces` field may be the object form ({ "packages": [...] })

--- a/packages/nx-plugin/src/utils/pnpm-workspace.ts
+++ b/packages/nx-plugin/src/utils/pnpm-workspace.ts
@@ -15,14 +15,14 @@ interface PnpmWorkspaceYaml {
 }
 
 /**
- * Merge `allowBuilds` (pnpm 11) / `onlyBuiltDependencies` (pnpm 10) entries
- * into the generated workspace's `pnpm-workspace.yaml`. No-op for non-pnpm
- * workspaces.
+ * Merge `allowBuilds` (pnpm 11 and above) / `onlyBuiltDependencies` (pnpm 10)
+ * entries into the generated workspace's `pnpm-workspace.yaml`. No-op for
+ * non-pnpm workspaces.
  *
  * Generators call this when they introduce a dependency whose install
- * script pnpm would otherwise reject under pnpm 11's default
+ * script pnpm would otherwise reject under the default
  * `strictDepBuilds=true`. Keeping the allowlist explicit — rather than
- * globally disabling strictness — preserves the supply-chain audit pnpm 11
+ * globally disabling strictness — preserves the supply-chain audit pnpm
  * intends: each build-script dep is reviewed by the generator author and
  * entered as either `true` (run the script) or `false` (known dep we
  * don't want to run but have seen).

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,3 +1,104 @@
+---
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    configDependencies: {}
+    packageManagerDependencies:
+      pnpm:
+        specifier: 12.2.1
+        version: 12.2.1
+
+packages:
+
+  '@pnpm/exe.darwin-arm64@12.2.1':
+    resolution: {integrity: sha512-efC1yfz2xbyHiMLrQAYtnoo5XP20LeAiYYcyL1962qQagZrMXIB0BoQYeZoPTLggLh0Q4MD7jpZUInU5fWxCgQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@pnpm/exe.darwin-x64@12.2.1':
+    resolution: {integrity: sha512-0bloFmxrvYY5LYex5V6SZySwg+egBk0pOW+YUeOm9fiG2U1wv+qRVLBOUvIzLAeJE7vBlAzxUwXkQAYtr12n+Q==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@pnpm/exe.linux-arm64-musl@12.2.1':
+    resolution: {integrity: sha512-AZl7apVZC4TV1/vTp/bS16XUsHeqx9AHsU4V55joiGR+iR6vl+WF0WlGvGCTjqjICS4q/kThpgNrtG8aqQ9seQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@pnpm/exe.linux-arm64@12.2.1':
+    resolution: {integrity: sha512-S36+tMEGrPz3nwtfFU9kYxbHoi8sV7WJfMO9njEL4jRaShTNaLRERMAqyI2DUCiA5QCr6/a50lt4+pKCV2mCvw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@pnpm/exe.linux-x64-musl@12.2.1':
+    resolution: {integrity: sha512-4MQClkAk1em55LFZJpeIqb7j+gEqCgX8yC42j9DFWL42q1uMX1e1tvTy2Dtd4NoWQqgdkLxOStZ+D9CYC+28ow==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@pnpm/exe.linux-x64@12.2.1':
+    resolution: {integrity: sha512-A/AlR71Leph7qgB3ThSU9yU/vLfre4HmP6nbt3/qt51fzAjQ0xuq7j+cw0f1yDskzOsGzmo5uD6ruefCwLK5uQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@pnpm/exe.win32-arm64@12.2.1':
+    resolution: {integrity: sha512-TEGUmroT6NGfo2O2+tHK9Zr1lhP1zLzpwx+QAQV19l8V4ljUoMfz8Os5V9zzNCtIpzyKcK7SuG7fkVbxFgRMzg==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@pnpm/exe.win32-x64@12.2.1':
+    resolution: {integrity: sha512-V2Q+AF8fCsw8/CC3bWF8kopOmH0aAjgk9m7H7uAQNulOYIJs9YJBiAlgByswmt+igV9axc4dBI//ZlK2NKpDcw==}
+    cpu: [x64]
+    os: [win32]
+
+  pnpm@12.2.1:
+    resolution: {integrity: sha512-9Vymiqy561q2nGb4KKmK+JoyKGcDrvH42hMcp+q01nfzS/qF4YZGepGcB5nfi29KokD33CkZszsycxkBBBYmFg==}
+    engines: {node: '>=18.*'}
+    hasBin: true
+
+snapshots:
+
+  '@pnpm/exe.darwin-arm64@12.2.1':
+    optional: true
+
+  '@pnpm/exe.darwin-x64@12.2.1':
+    optional: true
+
+  '@pnpm/exe.linux-arm64-musl@12.2.1':
+    optional: true
+
+  '@pnpm/exe.linux-arm64@12.2.1':
+    optional: true
+
+  '@pnpm/exe.linux-x64-musl@12.2.1':
+    optional: true
+
+  '@pnpm/exe.linux-x64@12.2.1':
+    optional: true
+
+  '@pnpm/exe.win32-arm64@12.2.1':
+    optional: true
+
+  '@pnpm/exe.win32-x64@12.2.1':
+    optional: true
+
+  pnpm@12.2.1:
+    optionalDependencies:
+      '@pnpm/exe.darwin-arm64': 12.2.1
+      '@pnpm/exe.darwin-x64': 12.2.1
+      '@pnpm/exe.linux-arm64': 12.2.1
+      '@pnpm/exe.linux-arm64-musl': 12.2.1
+      '@pnpm/exe.linux-x64': 12.2.1
+      '@pnpm/exe.linux-x64-musl': 12.2.1
+      '@pnpm/exe.win32-arm64': 12.2.1
+      '@pnpm/exe.win32-x64': 12.2.1
+
+---
 lockfileVersion: '9.0'
 
 settings:


### PR DESCRIPTION
### Reason for this change

pnpm 12 is out, and neither this repo nor the workspaces the plugin generates were verified
against it. Two things made that worth doing now:

**1. Generated workspaces pin no `packageManager`**, so a user who already has pnpm 12 on their
PATH gets pnpm 12 whether or not it's supported. Anything that breaks under 12 is breaking for
them today.

**2. It narrows a macOS CI flake.** `macOS Smoke Tests - standalone (N/6)` fails intermittently
while a generator runs:

```
[EINVAL] EINVAL: invalid argument, open '.../standalone-ts-dynamodb/proj/node_modules/@aws/nx-plugin/package.json'
 NX   Command failed: pnpm install --no-frozen-lockfile
```

pnpm's `removeDirectDependency` reads a dependency's `package.json` and deletes that same
directory in one `Promise.all`, and only tolerates `ENOENT` from the read. When the delete wins
the race the read throws whatever errno the partially removed path yields — `EINVAL` on macOS —
and that aborts the whole install. The dependency is pruned in the first place because
`@aws/nx-plugin` peers on `nx`, giving it a ~500-character peer-suffixed lockfile reference, so
**any** generator that adds a root devDependency changes that string and trips the removal.

Verifying pnpm 12 turned up two real bugs, both of which affect users on pnpm 12 regardless of
this PR. Those are the bulk of the change; the version bump itself is a few lines.

### Description of changes

**Support pnpm 12**

- `package.json` — `packageManager` to `pnpm@12.2.1`. `pnpm/setup` reads this field, so every
  CI job that doesn't pin its own package manager runs pnpm 12 too.
- `.github/actions/init-monorepo`, `.github/workflows/on-release.yml` — install pnpm with
  `pnpm/setup` (supersedes `pnpm/action-setup`), taking the version from `packageManager`.
  `install: 'false'` because both callers install further down, once the pnpm store cache has
  been restored.
- `e2e/src/smoke-tests/pnpm-12.spec.ts` — new variant, plus the matrix entry in both `pr.yml`
  and `ci.yml`. `pnpm-10`, `pnpm-11` and `pnpm-12` each pin their own major through corepack,
  so all three supported lines stay independently covered.
- `pnpm-lock.yaml` — additive only; pnpm 12 records itself under a new
  `packageManagerDependencies` importer key, with integrity hashes for the `@pnpm/exe.*`
  binaries. `lockfileVersion` stays `9.0`, so there is no lockfile migration.
- `packages/nx-plugin/src/utils/pnpm-workspace.ts`, `utils/init.ts` — comments that described
  `allowBuilds` and the `strictDepBuilds=true` default as "pnpm 11's" now say pnpm 11 and above,
  since both are unchanged in 12.

Confirmed generated workspaces are pnpm-12 clean: every key the generated
`pnpm-workspace.yaml` contains is recognised — which matters, because pnpm 12 hard-fails on
unrecognised workspace settings (`ERR_PNPM_UNRECOGNIZED_WORKSPACE_SETTINGS`) when the project
pins a pnpm version the running binary satisfies. Both `allowBuilds` and pnpm 10's
`onlyBuiltDependencies` are still accepted, so the dual-key allowlist the generators write needs
no change.

**Fix: pnpm's temp files invalidate the Nx project graph**

pnpm creates `_tmp_<pid>_<hash>` files at the workspace root while it materialises packages. Nx
watches the workspace, and an unignored file appearing and vanishing invalidates the project
graph — so a watch-mode `dev` target running while any install happens rebuilds the graph
continuously and never starts the command it wraps. No error, just a port that never opens. That
is what failed the `dungeon-adventure` and `local-dev` smoke tests, whose `dev` cascades install
as they come up (51,722 watcher events in one run).

- `packages/nx-plugin/src/utils/init.ts` — the generated `.gitignore` covers the pattern, inside
  the pnpm branch since only pnpm writes these.
- `migrations/latest/ignore-package-manager-temp-files/` — the same for existing workspaces,
  gated on `pnpm-lock.yaml`.
- `.gitignore` — this repo needs it too: it has a watch-mode `docs:start` target.

**Fix: an undeclared optional peer split `@strands-agents/sdk` in two**

`@aws-sdk/client-s3` is one of 22 optional peers of `@strands-agents/sdk`. The shared
`agent-connection` project's own code never imports it, so it was never declared — pnpm
auto-installed its own copy there (`3.1119.0`) while a project that does declare it got the
catalog's (`3.1121.0`). Two peer resolutions produce **two peer-suffixed instances of the same
`@strands-agents/sdk@1.15.0`**, and TypeScript treats each copy's classes as distinct nominal
types, so anything importing both projects fails to compile:

```
Type 'McpClient' is not assignable to type 'Agent | ToolList | Tool | McpClient'.
  Types have separate declarations of a private property '_clientName'.
```

That was the `migrate (5/5)` failure. Declaring the peer keeps its version on the catalog and
collapses both projects onto one instance.

- `utils/agent-connection/agent-connection.ts` — declared on the strands templates
  specifically, so it only lands where a strands client does.
- `migrations/latest/agent-connection-pin-strands-peers/` — the same for existing workspaces;
  no-ops when the project has no strands client.

This one is **latent rather than new** — nothing about it is pnpm-12-specific. A from-scratch
install happens to converge on one version, which is why it only surfaces on the incremental
upgrade path the migrate hop exercises.

**Keeping pnpm's supply-chain gates on**

Two pnpm behaviours surface in the e2e suite under 12. Both are handled without weakening a
check or writing anything into a user's workspace:

- `e2e/src/smoke-tests/license-check.spec.ts` installs with `--ignore-scripts`, since only
  license metadata is read. pnpm then treats those packages' build scripts as unreviewed and
  fails the next install a generator runs. It records an explicit `allowBuilds: <pkg>: false`
  decision per package — the same "reviewed, declined" mechanism the generators themselves use —
  rather than relaxing `strictDepBuilds`. New `declinePnpmBuilds` helper in `e2e/src/utils.ts`
  edits `pnpm-workspace.yaml` through the yaml document API, so existing entries and comments
  survive.
- `e2e/src/global-setup.ts` sets `PNPM_CONFIG_MINIMUM_RELEASE_AGE=0`, because smoke tests
  install a build published to verdaccio seconds earlier and pnpm's release-age cutoff hides it.
  Scoped to the e2e process — which every spawned command inherits, including the `spawn`/PTY
  call sites that bypass `runCLI` — so the cutoff still applies everywhere else. A `.npmrc`
  entry would not work: pnpm 12 reads only auth and registry settings from `.npmrc`, so
  `minimum-release-age` there is silently ignored.

### Description of how you validated changes

**Measured the window.** Polling the pruned path every 2ms while the install runs,
`node_modules/@aws/nx-plugin` is absent for ~254ms under pnpm 11 and ~2ms under pnpm 12.

**Confirmed pnpm 12 works on this workspace.** `pnpm@12.2.1 install --frozen-lockfile` succeeds;
the lockfile stays `9.0` and passes this repo's supply-chain policy check;
`pnpm-workspace.yaml` needs no changes. `@aws/nx-plugin:test` passes 4224 tests across 237
files, and compile and lint pass.

**Confirmed which pnpm each lane actually runs**, rather than assuming the bump propagated —
read back from `Done in … using pnpm vX` in all 39 smoke-test job logs. Every lane runs
**12.2.1** except the three deliberately pinned ones: `pnpm-10` → `10.34.5`, `pnpm-11` →
`11.25.0`, `pnpm-12` → `12.3.0` (each resolves its major's current latest through corepack, so
`pnpm-12` tests one release *ahead* of the repo's own pin). In those three lanes the `12.2.1`
that also appears is only the repo's own harness install, before the test activates its pin.

**Confirmed the dep-builds gate is still enforced**, rather than merely quiet: in a generated
workspace on pnpm 12, removing one package's `allowBuilds` decision and reinstalling fails with
`ERR_PNPM_IGNORED_BUILDS` (exit 1); restoring it passes.

**Confirmed the graph-thrash fix both ways.** Running the generated `dev` target with pnpm 12
active, the Nx daemon log shows the watcher firing on `_tmp_*` deletes and re-entering graph
construction; the spinner reprints ~1000 times in 120s and no port binds. Adding the ignore
takes that to 0 reprints with the port bound in 4s; removing it restores the hang.

**Confirmed the peer fix against a real workspace.** Scaffolded `internal#test-matrix` on rc.90
(31 projects) and bumped the catalog the way a migration does, which reproduced the two variants
CI reports **hash for hash** (`_1e213acde…` / `_b671c015…`); diffing the two virtual-store
directories' resolved peer versions showed `@aws-sdk/client-s3` as the only difference.
Declaring the peer collapses them — verified end to end on a generated workspace under pnpm 12:
one `@aws-sdk/client-s3` copy, both projects linked to the same SDK.

CI is green: 65/65 jobs, no reruns.

### Honest limits of this change

The macOS `EINVAL` flake is **narrowed, not closed**. The underlying pnpm defect is still
present in 12 — probed behaviourally, since 12 ships a native binary rather than a JS bundle:

| pnpm | forcing a non-`ENOENT` errno on that read |
|---|---|
| 12.2.1 | `ERR_PNPM_PACKAGE_MANAGER_PRUNE_DIRECT_DEPS_READ_MANIFEST (os error 21)` |
| 11.25.0 | `[EISDIR] EISDIR: illegal operation on a directory, read` |

Same defect, better error code. So this should make that flake rare rather than impossible, and
a green CI run here does **not** prove that part — the flake is intermittent and only reproduces
on macOS runners. The real fix belongs upstream (await the read before the delete, or widen the
errno guard); I could not find an existing pnpm issue for this signature, so it appears
unreported and is worth filing.

There is no negative test for the init generator's pnpm gate: with no `pnpm-workspace.yaml`,
`detectWorkspacePackageManager` falls through to the real filesystem at `tree.root` — this repo,
which is pnpm — so the assertion cannot be isolated. The migration's gate reads a tree file, so
that case is covered in its spec.

Two things deliberately left out of scope:

- `local-dev` hit `Recursive task invocation detected: postgres-db:pull-image` on one run and
  passed on the next. The `wait-for-db -> dev -> pull-image` chain arrived with #1165, so it
  predates this branch — worth its own fix rather than folding an unrelated change in here.
- Nx 23.1.2's cooldown handling treats any pnpm `>=12.0.0` as `ambiguous` and stops writing
  `minimumReleaseAgeExclude` entries, since its behaviour table ends at pnpm 11. That affects
  `nx migrate` in a pnpm 12 workspace picking up a freshly published package, and belongs
  upstream in Nx.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
