### PR TITLE
perf(ts#agent,ts#mcp-server): cache the AgentCore ADOT install separately

### DIFF
--- a/packages/nx-plugin/src/migrations/latest/agent-core-vendor-target/metadata.json
+++ b/packages/nx-plugin/src/migrations/latest/agent-core-vendor-target/metadata.json
@@ -1,0 +1,3 @@
+{
+  "description": "Cache the AgentCore ADOT install in its own target so editing an agent no longer re-runs it"
+}

--- a/packages/nx-plugin/src/migrations/latest/agent-core-vendor-target/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/latest/agent-core-vendor-target/migration.spec.ts
@@ -1,0 +1,191 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import {
+  addProjectConfiguration,
+  readProjectConfiguration,
+  type Tree,
+} from '@nx/devkit';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test.js';
+import migration from './migration.js';
+
+const PKG = 'dist/packages/agent/package/agent/my-agent';
+const VENDOR = 'dist/packages/agent/agent-core-vendor';
+const INSTALL = `npm install --prefix ${PKG} --no-save --no-audit --no-fund --omit=dev @aws/aws-distro-opentelemetry-node-autoinstrumentation@0.12.0`;
+
+/** The packaging target as the generator vended it before the split. */
+const packageTarget = () => ({
+  cache: true,
+  inputs: ['default'],
+  outputs: [`{workspaceRoot}/${PKG}`],
+  executor: 'nx:run-commands',
+  options: {
+    commands: [
+      `shx rm -rf ${PKG}`,
+      `shx mkdir -p ${PKG}`,
+      `shx cp dist/packages/agent/bundle/agent/my-agent/index.js ${PKG}/index.js`,
+      INSTALL,
+    ],
+    parallel: false,
+  },
+  dependsOn: ['bundle'],
+});
+
+const addAgent = (tree: Tree, target = packageTarget()) =>
+  addProjectConfiguration(tree, 'agent', {
+    root: 'packages/agent',
+    targets: { 'my-agent-package': target },
+  });
+
+const targetsOf = (tree: Tree) =>
+  readProjectConfiguration(tree, 'agent').targets!;
+
+describe('agent-core-vendor-target migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeUsingTsSolutionSetup();
+  });
+
+  it('should move the install into its own uncached-by-source target', async () => {
+    addAgent(tree);
+
+    await migration(tree);
+
+    const vendor = targetsOf(tree)['agent-core-vendor'];
+    expect(vendor.inputs).toEqual([]);
+    expect(vendor.outputs).toEqual([`{workspaceRoot}/${VENDOR}`]);
+    expect(vendor.options.commands).toEqual([
+      `shx rm -rf ${VENDOR}`,
+      `shx mkdir -p ${VENDOR}`,
+      `npm install --prefix ${VENDOR} --no-save --no-audit --no-fund --omit=dev @aws/aws-distro-opentelemetry-node-autoinstrumentation@0.12.0`,
+    ]);
+  });
+
+  it('should replace the install with a copy of the vendored tree', async () => {
+    addAgent(tree);
+
+    await migration(tree);
+
+    const pkg = targetsOf(tree)['my-agent-package'];
+    expect(pkg.options.commands).toEqual([
+      `shx rm -rf ${PKG}`,
+      `shx mkdir -p ${PKG}`,
+      `shx cp dist/packages/agent/bundle/agent/my-agent/index.js ${PKG}/index.js`,
+      `shx cp -R ${VENDOR}/node_modules/. ${PKG}/node_modules`,
+    ]);
+    expect(pkg.dependsOn).toEqual(['bundle', 'agent-core-vendor']);
+  });
+
+  it('should keep the vendor output outside the package output', async () => {
+    addAgent(tree);
+
+    await migration(tree);
+
+    const targets = targetsOf(tree);
+    const vendorOut = targets['agent-core-vendor'].outputs![0];
+    const packageOut = targets['my-agent-package'].outputs![0];
+    // Either nested inside the other would have each wipe the other on a cache hit.
+    expect(vendorOut.startsWith(packageOut)).toBe(false);
+    expect(packageOut.startsWith(vendorOut)).toBe(false);
+  });
+
+  it('should share one vendor target across every code package in a project', async () => {
+    const second = packageTarget();
+    const secondPkg = 'dist/packages/agent/package/mcp/my-mcp';
+    second.outputs = [`{workspaceRoot}/${secondPkg}`];
+    second.options.commands = [
+      `shx rm -rf ${secondPkg}`,
+      `shx mkdir -p ${secondPkg}`,
+      `shx cp dist/packages/agent/bundle/mcp/my-mcp/index.js ${secondPkg}/index.js`,
+      INSTALL.replace(PKG, secondPkg),
+    ];
+    addProjectConfiguration(tree, 'agent', {
+      root: 'packages/agent',
+      targets: {
+        'my-agent-package': packageTarget(),
+        'my-mcp-package': second,
+      },
+    });
+
+    await migration(tree);
+
+    const targets = targetsOf(tree);
+    expect(
+      Object.keys(targets).filter((t) => t === 'agent-core-vendor'),
+    ).toHaveLength(1);
+    for (const name of ['my-agent-package', 'my-mcp-package']) {
+      expect(targets[name].options.commands).toContain(
+        `shx cp -R ${VENDOR}/node_modules/. ${
+          name === 'my-agent-package' ? PKG : secondPkg
+        }/node_modules`,
+      );
+    }
+  });
+
+  it('should preserve a pinned version other than the current one', async () => {
+    const target = packageTarget();
+    target.options.commands = [
+      `shx rm -rf ${PKG}`,
+      `shx mkdir -p ${PKG}`,
+      `shx cp dist/packages/agent/bundle/agent/my-agent/index.js ${PKG}/index.js`,
+      INSTALL.replace('@0.12.0', '@0.9.0'),
+    ];
+    addAgent(tree, target);
+
+    await migration(tree);
+
+    expect(targetsOf(tree)['agent-core-vendor'].options.commands[2]).toContain(
+      '@0.9.0',
+    );
+  });
+
+  it('should leave a reworked target untouched and report it', async () => {
+    const target = packageTarget();
+    // No copy to model the replacement on, so the shape is not the vended one.
+    target.options.commands = [
+      `shx rm -rf ${PKG}`,
+      `shx mkdir -p ${PKG}`,
+      INSTALL,
+    ];
+    addAgent(tree, target);
+
+    const { nextSteps } = await migration(tree);
+
+    expect(targetsOf(tree)['my-agent-package'].options.commands).toContain(
+      INSTALL,
+    );
+    expect(targetsOf(tree)['agent-core-vendor']).toBeUndefined();
+    expect(nextSteps).toHaveLength(1);
+    expect(nextSteps[0]).toContain('my-agent-package');
+  });
+
+  it('should leave a project with no code package alone', async () => {
+    addProjectConfiguration(tree, 'agent', {
+      root: 'packages/agent',
+      targets: {
+        'my-agent-docker': {
+          executor: 'nx:run-commands',
+          options: { commands: ['docker build -t img .'] },
+        },
+      },
+    });
+
+    const { nextSteps } = await migration(tree);
+
+    expect(targetsOf(tree)['agent-core-vendor']).toBeUndefined();
+    expect(nextSteps).toHaveLength(0);
+  });
+
+  it('should be a no-op on a second run', async () => {
+    addAgent(tree);
+
+    await migration(tree);
+    const afterFirst = JSON.stringify(targetsOf(tree));
+    const { nextSteps } = await migration(tree);
+
+    expect(JSON.stringify(targetsOf(tree))).toEqual(afterFirst);
+    expect(nextSteps).toHaveLength(0);
+  });
+});

--- a/packages/nx-plugin/src/migrations/latest/agent-core-vendor-target/migration.ts
+++ b/packages/nx-plugin/src/migrations/latest/agent-core-vendor-target/migration.ts
@@ -1,0 +1,138 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import {
+  getProjects,
+  joinPathFragments,
+  type MigrationReturnObject,
+  type ProjectConfiguration,
+  type TargetConfiguration,
+  type Tree,
+  updateProjectConfiguration,
+} from '@nx/devkit';
+import {
+  ADOT_VENDOR_TARGET_NAME,
+  adotVendorDir,
+} from '../../../utils/agent-core-packaging.js';
+import { formatFilesInSubtree } from '../../../utils/format.js';
+
+/**
+ * A TypeScript AgentCore code package installed the AWS Distro for OpenTelemetry
+ * into the package directory as its last packaging step. That target's `inputs`
+ * are the project's source, so editing an agent re-ran the install — several
+ * seconds of npm work whose result depends only on the pinned ADOT version.
+ *
+ * The install moves to its own target Nx caches independently. It declares no
+ * `inputs`, since the version it pins is part of the command and Nx hashes a
+ * target's configuration, so a version bump still invalidates it while a source
+ * edit no longer does. Packaging copies the vendored tree instead.
+ *
+ * The vendor directory is a sibling of the package directory, not a path inside
+ * it: Nx replaces a cached target's whole declared output directory on restore,
+ * so nesting one target's output inside another's makes each wipe the other's
+ * work on a cache hit.
+ *
+ * A packaging target that no longer matches the shape the generator vended has
+ * been reworked by the user, so it is left untouched and reported.
+ *
+ * The filesystem commands are spelled with `shx`: the migration that replaced the
+ * single purpose CLIs was committed first, and `latest` migrations run in the
+ * order their folders were committed, so it has already run by the time this one
+ * does.
+ */
+
+/** The ADOT install as the packaging target ran it, capturing its `--prefix`. */
+const ADOT_INSTALL =
+  /^npm install --prefix (\S+) .*@aws\/aws-distro-opentelemetry-node-autoinstrumentation@(\S+)\s*$/;
+
+const divergedStep = (projectName: string, targetName: string) =>
+  `${projectName}:${targetName}: installs the OpenTelemetry distro but no longer matches the shape the generator produced - left untouched. To stop the install re-running whenever the project's source changes, move it to its own target with no \`inputs\` and an \`outputs\` directory outside this target's, and copy that directory in here instead.`;
+
+/** Commands a target runs, as plain strings. */
+const commandsOf = (target: TargetConfiguration): string[] => {
+  const { commands } = (target.options ?? {}) as { commands?: unknown };
+  return Array.isArray(commands)
+    ? commands.filter((c): c is string => typeof c === 'string')
+    : [];
+};
+
+/**
+ * Copy the vendored `node_modules` into the package. `-R` and the trailing `/.`
+ * merge the directory's contents rather than nesting it inside the destination.
+ */
+const copyCommand = (vendorDir: string, packageDir: string): string =>
+  `shx cp -R ${joinPathFragments(vendorDir, 'node_modules')}/. ${joinPathFragments(packageDir, 'node_modules')}`;
+
+export default async function migration(
+  tree: Tree,
+): Promise<MigrationReturnObject> {
+  const nextSteps: string[] = [];
+
+  for (const [projectName, project] of getProjects(tree)) {
+    let changed = false;
+    const vendorDir = adotVendorDir(project.root);
+
+    for (const [targetName, target] of Object.entries(project.targets ?? {})) {
+      if (targetName === ADOT_VENDOR_TARGET_NAME) continue;
+
+      const commands = commandsOf(target);
+      const installIndex = commands.findIndex((c) => ADOT_INSTALL.test(c));
+      if (installIndex < 0) continue;
+
+      const install = commands[installIndex];
+      const [, prefix] = ADOT_INSTALL.exec(install)!;
+
+      // The install targets the directory this target packages into, and it
+      // copies the bundle in with shx. Anything else has been reworked.
+      const packageDir = prefix;
+      const copiesBundle = commands.some(
+        (c) => c !== install && c.startsWith('shx cp '),
+      );
+      const declaresPackageOutput = (target.outputs ?? []).some((o) =>
+        o.endsWith(packageDir),
+      );
+      if (!copiesBundle || !declaresPackageOutput) {
+        nextSteps.push(divergedStep(projectName, targetName));
+        continue;
+      }
+
+      project.targets![ADOT_VENDOR_TARGET_NAME] ??= {
+        cache: true,
+        inputs: [],
+        outputs: [`{workspaceRoot}/${vendorDir}`],
+        executor: 'nx:run-commands',
+        options: {
+          commands: [
+            `shx rm -rf ${vendorDir}`,
+            `shx mkdir -p ${vendorDir}`,
+            install.replace(prefix, vendorDir),
+          ],
+          parallel: false,
+        },
+      };
+
+      const updated = [...commands];
+      updated[installIndex] = copyCommand(vendorDir, packageDir);
+      target.options!.commands = updated;
+      target.dependsOn = [
+        ...(target.dependsOn ?? []),
+        ADOT_VENDOR_TARGET_NAME,
+      ].filter((d, i, all) => all.indexOf(d) === i);
+
+      changed = true;
+    }
+
+    if (changed) {
+      updateProjectConfiguration(
+        tree,
+        projectName,
+        project as ProjectConfiguration,
+      );
+    }
+  }
+
+  await formatFilesInSubtree(tree);
+
+  return { nextSteps };
+}

--- a/packages/nx-plugin/src/ts/agent/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/agent/generator.spec.ts
@@ -1039,7 +1039,7 @@ describe('ts#agent generator', () => {
       tree.read('apps/test-project/project.json', 'utf-8'),
     );
     const packageTarget = projectConfig.targets['agent-package'];
-    expect(packageTarget.dependsOn).toEqual(['bundle']);
+    expect(packageTarget.dependsOn).toEqual(['bundle', 'agent-core-vendor']);
     expect(packageTarget.outputs).toEqual([
       '{workspaceRoot}/dist/apps/test-project/package/agent/test-project-agent',
     ]);
@@ -1047,8 +1047,28 @@ describe('ts#agent generator', () => {
       'shx rm -rf dist/apps/test-project/package/agent/test-project-agent',
       'shx mkdir -p dist/apps/test-project/package/agent/test-project-agent',
       'shx cp dist/apps/test-project/bundle/agent/test-project-agent/index.js dist/apps/test-project/package/agent/test-project-agent/index.js',
-      `npm install --prefix dist/apps/test-project/package/agent/test-project-agent --no-save --no-audit --no-fund --omit=dev @aws/aws-distro-opentelemetry-node-autoinstrumentation@${TS_VERSIONS['@aws/aws-distro-opentelemetry-node-autoinstrumentation']}`,
+      'shx cp -R dist/apps/test-project/agent-core-vendor/node_modules/. dist/apps/test-project/package/agent/test-project-agent/node_modules',
     ]);
+
+    // Vendoring is cached on the pinned version alone, so a source edit replays
+    // the copy rather than re-running the install.
+    const vendorTarget = projectConfig.targets['agent-core-vendor'];
+    expect(vendorTarget.inputs).toEqual([]);
+    expect(vendorTarget.outputs).toEqual([
+      '{workspaceRoot}/dist/apps/test-project/agent-core-vendor',
+    ]);
+    expect(vendorTarget.options.commands).toEqual([
+      'shx rm -rf dist/apps/test-project/agent-core-vendor',
+      'shx mkdir -p dist/apps/test-project/agent-core-vendor',
+      `npm install --prefix dist/apps/test-project/agent-core-vendor --no-save --no-audit --no-fund --omit=dev @aws/aws-distro-opentelemetry-node-autoinstrumentation@${TS_VERSIONS['@aws/aws-distro-opentelemetry-node-autoinstrumentation']}`,
+    ]);
+    // Nested outputs would have each target wipe the other's work on a cache hit.
+    expect(vendorTarget.outputs[0].startsWith(packageTarget.outputs[0])).toBe(
+      false,
+    );
+    expect(packageTarget.outputs[0].startsWith(vendorTarget.outputs[0])).toBe(
+      false,
+    );
 
     // The build must produce the package it deploys
     expect(projectConfig.targets['build'].dependsOn).toContain('agent-package');

--- a/packages/nx-plugin/src/utils/agent-core-packaging.ts
+++ b/packages/nx-plugin/src/utils/agent-core-packaging.ts
@@ -75,6 +75,23 @@ export interface AddTypeScriptCodePackageTargetOptions {
 }
 
 /**
+ * Name of the target that installs ADOT for the project's code packages. Every
+ * code package in a project vendors the same thing, so they share one.
+ */
+export const ADOT_VENDOR_TARGET_NAME = 'agent-core-vendor';
+
+/**
+ * Directory the vendor target installs into, relative to the workspace root.
+ *
+ * A sibling of the `package` directory rather than a path inside it: Nx replaces
+ * a cached target's whole declared output directory on restore, so an output
+ * nested inside another target's output would have each wipe the other's work on
+ * a cache hit.
+ */
+export const adotVendorDir = (projectRoot: string): string =>
+  joinPathFragments('dist', projectRoot, 'agent-core-vendor');
+
+/**
  * Add a target assembling the deployable code package for a TypeScript
  * AgentCore Runtime.
  *
@@ -85,11 +102,16 @@ export interface AddTypeScriptCodePackageTargetOptions {
  * being installed at runtime — the `opentelemetry-instrument` entry point
  * prefix resolves it from there.
  *
- * The install is scoped to the package directory with `--prefix` and
- * `--no-save`, so it never touches the project's own manifest. `--omit=dev`
- * keeps the package to what the runtime loads. ADOT is pure JavaScript with no
- * native binaries, so the package is architecture independent even though
- * AgentCore only runs arm64.
+ * The install is scoped to its own directory with `--prefix` and `--no-save`, so
+ * it never touches the project's own manifest. `--omit=dev` keeps the package to
+ * what the runtime loads. ADOT is pure JavaScript with no native binaries, so the
+ * package is architecture independent even though AgentCore only runs arm64.
+ *
+ * Vendoring is a separate target so Nx caches it independently of the source. It
+ * depends on nothing but the pinned ADOT version, which the install command
+ * carries and Nx hashes as part of the target's configuration, so it declares no
+ * `inputs`: editing an agent replays a directory copy rather than re-running the
+ * install, while bumping the version still invalidates it.
  */
 export const addTypeScriptCodePackageTarget = <
   const D extends DependencyDeclaration,
@@ -112,8 +134,26 @@ export const addTypeScriptCodePackageTarget = <
   );
   const adotVersion =
     TS_VERSIONS['@aws/aws-distro-opentelemetry-node-autoinstrumentation'];
+  const vendorDir = adotVendorDir(project.root);
 
   project.targets ??= {};
+
+  // Shared by every code package in the project, so only added once.
+  project.targets[ADOT_VENDOR_TARGET_NAME] ??= {
+    cache: true,
+    inputs: [],
+    outputs: [`{workspaceRoot}/${vendorDir}`],
+    executor: 'nx:run-commands',
+    options: {
+      commands: [
+        fs.rm(vendorDir),
+        fs.mkdir(vendorDir),
+        `npm install --prefix ${vendorDir} --no-save --no-audit --no-fund --omit=dev @aws/aws-distro-opentelemetry-node-autoinstrumentation@${adotVersion}`,
+      ],
+      parallel: false,
+    },
+  };
+
   project.targets[targetName] = {
     cache: true,
     inputs: ['default'],
@@ -127,11 +167,14 @@ export const addTypeScriptCodePackageTarget = <
           joinPathFragments(bundleOutputDir, 'index.js'),
           joinPathFragments(packageOutputDir, 'index.js'),
         ),
-        `npm install --prefix ${packageOutputDir} --no-save --no-audit --no-fund --omit=dev @aws/aws-distro-opentelemetry-node-autoinstrumentation@${adotVersion}`,
+        fs.cpDir(
+          joinPathFragments(vendorDir, 'node_modules'),
+          joinPathFragments(packageOutputDir, 'node_modules'),
+        ),
       ],
       parallel: false,
     },
-    dependsOn: [bundleTargetName],
+    dependsOn: [bundleTargetName, ADOT_VENDOR_TARGET_NAME],
   };
 
   addArtifactDependencyToTargets(project, targetName);


### PR DESCRIPTION
> **Stacked on #1175** — please merge that first. This PR targets `perf/shx-fs-commands`, so its diff is the vendor change alone (5 files).

### Reason for this change

A TypeScript AgentCore code package installed the AWS Distro for OpenTelemetry into the package directory as the last step of its packaging target. That target's `inputs` are `["default"]` — the project's source — so **editing one line of an agent re-ran the whole install**, even though its result depends only on the pinned ADOT version.

The install is ~3s of npm work: 110MB across 80 packages, with `reify:unpack` alone about half of it. Notably it is **not** network bound — adding `--offline` to the exact command was indistinguishable from the current one (3070ms vs 3056ms on a warm cache), so this is npm's own reify cost and no registry flag avoids it.

### Description of changes

Vendoring moves to its own `agent-core-vendor` target that Nx caches independently, and packaging copies the vendored tree instead of installing.

The vendor target declares **no `inputs`**. The ADOT version it pins is part of the install command, and Nx hashes a target's configuration, so a version bump still invalidates it while a source edit no longer does. Both halves of that are verified below rather than assumed.

The vendor directory is a **sibling** of the package directory (`dist/<root>/agent-core-vendor`), not a path inside it. This is the collision hazard and it is real: I confirmed empirically that Nx replaces a cached target's whole declared output directory on restore — with two targets sharing an output, restoring one from cache **deleted the other's file**. Nesting the vendor output inside the package output would make each wipe the other's work on a cache hit.

Every code package in a project vendors the same ADOT, so they share one vendor target and one install (`??=`, so the second package to be generated reuses it).

A migration moves the install for existing workspaces. It matches the shape the generator vended and **skips anything reworked**, reporting it via `nextSteps`. It preserves a pinned version other than the current one.

Because this is stacked on #1175, the migration can assume the `shx` migration has already run and emits `shx` spellings unconditionally — no dual-spelling branching. That ordering is guaranteed, not incidental: `latest` migrations run in the order the commits that added their folders appear (`migration-versions.ts`: "lower running first"), and `shx-fs-commands` ranks 9 against `agent-core-vendor-target`'s 14 on this branch. I verified it end to end by running `stamp-migrations.ts` — both stamp to the same version and `latest-shx-fs-commands` is emitted first, which is the run order among equal versions.

### Description of how you validated changes

**The two cache properties, through the real `nx run`:**
- `inputs: []` cache-hits on an unchanged re-run.
- Bumping the pinned version to `0.11.0` **misses** the cache and installs 0.11.0 (verified on disk), and the change propagates through to the package's `node_modules`.

**The collision hazard, both directions:** deleting the package dir and restoring it from cache leaves the vendor tree intact (92 packages), and vice versa. A deliberate two-targets-one-output control case confirmed the wipe does happen when outputs overlap, so the sibling layout is load bearing rather than stylistic.

**Migration on a real workspace that had already been through the `shx` migration** — the realistic stacked scenario — via the real `Tree`/`flushChanges` path: rewrote correctly with consistent `shx` spelling throughout, no `nextSteps`, and the rebuilt package tree is **byte-identical** (`diff -r`) to the pre-migration build with ADOT present.

**Generator path** validated separately by generating a second code-packaged MCP server against the compiled plugin: correct `dependsOn: ['bundle', 'agent-core-vendor']`, correct copy command, `inputs: []`. Building both packages together runs **exactly one** npm install, and both end up with ADOT 0.12.0.

**Performance, interleaved A/B** (source edit, then rebuild). The first three pairs were noise from cold state; runs 4–9 stabilise:

| | baseline | split |
|---|---|---|
| runs 4–9 | 8813–9145ms | 7803–8202ms |

**~0.9s off every incremental rebuild**, per code package. On top of #1175's faster copy the delta is ~2.0–2.4s, since packaging then copies at ~0.3s instead of ~1.8s.

**Tests:** 8 migration tests (including no-op-on-second-run, the shared-vendor case, non-current pinned version, and the skip-and-report path) plus an assertion in the `ts#agent` spec that the two outputs are not nested. Full suite baseline-diffed against clean `main` — this environment has ~293 pre-existing failures from an unrelated `@nx/js`/vite bug, so raw counts are meaningless: **0 new failures**, no snapshots touched. I also grepped the tree for stale references to the removed spellings and the old inline install, since suites that fail locally for the vite reason can hide that class of breakage from a baseline diff.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
