### PR TITLE
fix(open-api#ts-client): generate the specs published OpenAPI documents actually use

### DIFF
--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.complex-types.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.complex-types.spec.ts.snap
@@ -332,7 +332,7 @@ export type TestNullable200Response = {
   nullableInteger?: number | null;
   nullableBoolean?: boolean | null;
   nullableArray?: Array<string> | null;
-  nullableObject?: TestNullable200ResponseNullableObject;
+  nullableObject?: TestNullable200ResponseNullableObject | null;
 };
 export type TestNullable200ResponseNullableObject = null | {
   key?: string;
@@ -343,7 +343,7 @@ export type TestNullableRequestContent = {
   nullableInteger?: number | null;
   nullableBoolean?: boolean | null;
   nullableArray?: Array<string> | null;
-  nullableObject?: TestNullableRequestContentNullableObject;
+  nullableObject?: TestNullableRequestContentNullableObject | null;
   objectWithNullableProps?: TestNullableRequestContentObjectWithNullableProps;
 };
 export type TestNullableRequestContentNullableObject = null | {
@@ -355,7 +355,7 @@ export type TestNullableRequestContentObjectWithNullableProps = {
   nullableInteger?: number | null;
   nullableBoolean?: boolean | null;
   nullableArray?: Array<string> | null;
-  nullableObject?: TestNullableRequestContentObjectWithNullablePropsNullableObject;
+  nullableObject?: TestNullableRequestContentObjectWithNullablePropsNullableObject | null;
 };
 export type TestNullableRequestContentObjectWithNullablePropsNullableObject =
   null | {
@@ -538,9 +538,11 @@ export class $IO {
           ? {}
           : {
               nullableObject:
-                $IO.TestNullable200ResponseNullableObject.fromJson(
-                  json['nullableObject'],
-                ),
+                json['nullableObject'] === null
+                  ? null
+                  : $IO.TestNullable200ResponseNullableObject.fromJson(
+                      json['nullableObject'],
+                    ),
             }),
       };
     },
@@ -666,9 +668,11 @@ export class $IO {
           ? {}
           : {
               nullableObject:
-                $IO.TestNullableRequestContentNullableObject.fromJson(
-                  json['nullableObject'],
-                ),
+                json['nullableObject'] === null
+                  ? null
+                  : $IO.TestNullableRequestContentNullableObject.fromJson(
+                      json['nullableObject'],
+                    ),
             }),
         ...(json['objectWithNullableProps'] === undefined
           ? {}
@@ -796,9 +800,11 @@ export class $IO {
           ? {}
           : {
               nullableObject:
-                $IO.TestNullableRequestContentObjectWithNullablePropsNullableObject.fromJson(
-                  json['nullableObject'],
-                ),
+                json['nullableObject'] === null
+                  ? null
+                  : $IO.TestNullableRequestContentObjectWithNullablePropsNullableObject.fromJson(
+                      json['nullableObject'],
+                    ),
             }),
       };
     },

--- a/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.edge-cases.spec.ts.snap
+++ b/packages/nx-plugin/src/open-api/ts-client/__snapshots__/generator.edge-cases.spec.ts.snap
@@ -4262,7 +4262,10 @@ export class $IO {
         ...(json['wrapper'] === undefined
           ? {}
           : {
-              wrapper: $IO.ThingWrapper.fromJson(json['wrapper']),
+              wrapper:
+                json['wrapper'] === null
+                  ? null
+                  : $IO.ThingWrapper.fromJson(json['wrapper']),
             }),
       };
     },
@@ -4447,7 +4450,7 @@ export class TestApi {
 
 exports[`openApiTsClientGenerator - edge cases > rewrites a const declared inside a nullable (multi-type) object > types.gen.ts 1`] = `
 "export type Thing = {
-  wrapper?: ThingWrapper;
+  wrapper?: ThingWrapper | null;
 };
 export type ThingWrapper = null | {
   kind?: ThingWrapperKind;

--- a/packages/nx-plugin/src/open-api/ts-client/generator.complex-types.spec.ts
+++ b/packages/nx-plugin/src/open-api/ts-client/generator.complex-types.spec.ts
@@ -1198,4 +1198,303 @@ describe('openApiTsClientGenerator - complex types', () => {
       }),
     );
   });
+
+  /**
+   * OpenAPI 3.0 ignores a `$ref`'s siblings, so attaching a description to a
+   * referenced schema means wrapping it in a one-member `allOf` — the commonest
+   * `allOf` idiom in published specs. Such a member constrains nothing, and
+   * counting it as a non-object failed the whole document.
+   */
+  it.each([
+    ['a description', { description: 'a link' }],
+    ['an example', { example: { href: 'x' } }],
+    ['a title', { title: 'Link' }],
+    ['nothing at all', {}],
+    ['an explicit object type', { type: 'object' }],
+  ])('composes an allOf member carrying %s', async (_label, member) => {
+    const spec: Spec = {
+      openapi: '3.0.0',
+      info: { title, version: '1.0.0' },
+      paths: {
+        '/a': {
+          get: {
+            operationId: 'getA',
+            responses: {
+              '200': {
+                description: 'OK',
+                content: {
+                  'application/json': {
+                    schema: { $ref: '#/components/schemas/Out' },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      components: {
+        schemas: {
+          Link: {
+            type: 'object',
+            required: ['href'],
+            properties: { href: { type: 'string' } },
+          },
+          Out: {
+            allOf: [{ $ref: '#/components/schemas/Link' }, member],
+          },
+        },
+      },
+    } as unknown as Spec;
+
+    tree.write('openapi.json', JSON.stringify(spec));
+    await openApiTsClientGenerator(tree, {
+      openApiSpecPath: 'openapi.json',
+      outputPath: 'src/generated',
+    });
+    const types = tree.read('src/generated/types.gen.ts', 'utf-8')!;
+    // The annotation contributes nothing, so the composite is just the member it
+    // annotates rather than an intersection with the empty object.
+    expect(types).toContain('export type Out = Link;');
+    validateTypeScript(['src/generated/types.gen.ts']);
+  });
+
+  // A member declaring `required` is not empty: it raises a sibling branch's
+  // property to mandatory, and nothing carries that across branches, so dropping
+  // it would quietly make a required field optional.
+  it('still refuses an allOf member that requires a property it does not declare', async () => {
+    const spec: Spec = {
+      openapi: '3.0.0',
+      info: { title, version: '1.0.0' },
+      paths: {
+        '/a': {
+          get: {
+            operationId: 'getA',
+            responses: {
+              '200': {
+                description: 'OK',
+                content: {
+                  'application/json': {
+                    schema: { $ref: '#/components/schemas/Out' },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      components: {
+        schemas: {
+          Base: { type: 'object', properties: { a: { type: 'string' } } },
+          Out: {
+            allOf: [
+              { $ref: '#/components/schemas/Base' },
+              { type: 'object', required: ['a'] },
+            ],
+          },
+        },
+      },
+    } as unknown as Spec;
+
+    tree.write('openapi.json', JSON.stringify(spec));
+    await expect(
+      openApiTsClientGenerator(tree, {
+        openApiSpecPath: 'openapi.json',
+        outputPath: 'src/generated',
+      }),
+    ).rejects.toThrow(/an allOf member declares "required"/);
+  });
+
+  // A named scalar reached through `items` is inlined, and the array wrapping it
+  // was substituted without following through — leaving `items` pointing at a
+  // schema the same pass deleted, so the client named a type nothing declared and
+  // the emitted TypeScript did not compile.
+  it('declares every type the client refers to for an array of a named scalar', async () => {
+    const spec: Spec = {
+      openapi: '3.0.0',
+      info: { title, version: '1.0.0' },
+      paths: {
+        '/x': {
+          get: {
+            operationId: 'getX',
+            responses: {
+              '200': {
+                description: 'OK',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'array',
+                      items: { $ref: '#/components/schemas/IndexName' },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      components: {
+        schemas: { IndexName: { type: 'string', maxLength: 45 } },
+      },
+    } as unknown as Spec;
+
+    tree.write('openapi.json', JSON.stringify(spec));
+    await openApiTsClientGenerator(tree, {
+      openApiSpecPath: 'openapi.json',
+      outputPath: 'src/generated',
+    });
+    const client = tree.read('src/generated/client.gen.ts', 'utf-8')!;
+    // The chain collapses to the scalar rather than naming a schema that is gone.
+    expect(client).toContain('Promise<Array<string>>');
+    expect(client).not.toContain('IndexName');
+    // Compiling is what proves nothing dangles.
+    validateTypeScript([
+      'src/generated/types.gen.ts',
+      'src/generated/client.gen.ts',
+    ]);
+  });
+
+  // Two union members declaring a byte-identical inline object property were
+  // hoisted to distinct names, and the marshalling key was the name — so members
+  // that convert the same way were rejected as declaring "different types".
+  it('accepts a union whose members share an identical inline object property', async () => {
+    const branch = (extra: string) => ({
+      type: 'object',
+      properties: {
+        duration: {
+          type: 'object',
+          properties: { value: { type: 'string' } },
+        },
+        [extra]: { type: 'string' },
+      },
+    });
+    const spec: Spec = {
+      openapi: '3.0.0',
+      info: { title, version: '1.0.0' },
+      paths: {
+        '/x': {
+          get: {
+            operationId: 'getX',
+            responses: {
+              '200': {
+                description: 'OK',
+                content: {
+                  'application/json': {
+                    schema: { $ref: '#/components/schemas/Item' },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      components: {
+        schemas: { Item: { anyOf: [branch('a'), branch('b')] } },
+      },
+    } as unknown as Spec;
+
+    tree.write('openapi.json', JSON.stringify(spec));
+    await openApiTsClientGenerator(tree, {
+      openApiSpecPath: 'openapi.json',
+      outputPath: 'src/generated',
+    });
+    validateTypeScript(['src/generated/types.gen.ts']);
+  });
+
+  // The same check must still catch members that genuinely convert differently.
+  it('still refuses a union whose members disagree on a property type', async () => {
+    const spec: Spec = {
+      openapi: '3.0.0',
+      info: { title, version: '1.0.0' },
+      paths: {
+        '/x': {
+          get: {
+            operationId: 'getX',
+            responses: {
+              '200': {
+                description: 'OK',
+                content: {
+                  'application/json': {
+                    schema: { $ref: '#/components/schemas/Item' },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      components: {
+        schemas: {
+          Item: {
+            anyOf: [
+              {
+                type: 'object',
+                properties: {
+                  when: { type: 'string', format: 'date-time' },
+                },
+              },
+              { type: 'object', properties: { when: { type: 'string' } } },
+            ],
+          },
+        },
+      },
+    } as unknown as Spec;
+
+    tree.write('openapi.json', JSON.stringify(spec));
+    await expect(
+      openApiTsClientGenerator(tree, {
+        openApiSpecPath: 'openapi.json',
+        outputPath: 'src/generated',
+      }),
+    ).rejects.toThrow(/non-discriminated anyOf/);
+  });
+
+  // Hoisting a nullable inline object property replaced it with a bare `$ref` and
+  // moved `nullable` onto the hoisted definition, where it applied to every other
+  // user of that schema and to this property not at all.
+  it('keeps a required nullable object property nullable', async () => {
+    const spec: Spec = {
+      openapi: '3.0.0',
+      info: { title, version: '1.0.0' },
+      paths: {
+        '/t': {
+          get: {
+            operationId: 'getT',
+            responses: {
+              '200': {
+                description: 'OK',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      required: ['iso', 'scalar'],
+                      properties: {
+                        iso: {
+                          type: 'object',
+                          nullable: true,
+                          required: ['id'],
+                          properties: { id: { type: 'integer' } },
+                        },
+                        scalar: { type: 'string', nullable: true },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    } as unknown as Spec;
+
+    tree.write('openapi.json', JSON.stringify(spec));
+    await openApiTsClientGenerator(tree, {
+      openApiSpecPath: 'openapi.json',
+      outputPath: 'src/generated',
+    });
+    const types = tree.read('src/generated/types.gen.ts', 'utf-8')!;
+    expect(types).toMatch(/iso: GetT200ResponseIso \| null;/);
+    // The scalar case already worked and must stay that way.
+    expect(types).toMatch(/scalar: string \| null;/);
+    validateTypeScript(['src/generated/types.gen.ts']);
+  });
 });

--- a/packages/nx-plugin/src/open-api/utils/codegen-data.spec.ts
+++ b/packages/nx-plugin/src/open-api/utils/codegen-data.spec.ts
@@ -442,7 +442,7 @@ describe('openapi codegen data utils', () => {
       };
 
       expect(() => buildOpenApiCodeGenData(specWithInvalidAllOf)).toThrow(
-        /allOf with non-object types/,
+        /cannot be composed: an allOf member is not an object type/,
       );
     });
 

--- a/packages/nx-plugin/src/open-api/utils/codegen-data.ts
+++ b/packages/nx-plugin/src/open-api/utils/codegen-data.ts
@@ -89,7 +89,7 @@ export const buildOpenApiCodeGenData = (inSpec: Spec): CodeGenData => {
 
   for (const model of data.models) {
     assertNoClashingPropertyNames(model);
-    assertNoConflictingUnionMemberMarshalling(model);
+    assertNoConflictingUnionMemberMarshalling(model, modelsByName);
   }
 
   for (const op of allOperations) {
@@ -526,19 +526,54 @@ const assertNoClashingPropertyNames = (model: Model): void => {
  * The marshalling semantics of a property — two properties with the same key
  * convert identically on the wire (so either branch's conversion is safe).
  */
-const marshallingKey = (m: Model): string => {
+const marshallingKey = (
+  m: Model,
+  modelsByName: ModelsByName,
+  visiting: Set<string> = new Set(),
+): string => {
   if (['date', 'date-time'].includes(m.format ?? '')) return 'date';
   if (m.type === 'binary') return 'binary';
   // Enums serialise as their bare primitive (no conversion).
   if (m.isEnum || m.export === 'enum') return 'plain';
   if (COLLECTION_TYPES.has(m.export)) {
-    return `${m.export}<${m.link ? marshallingKey(m.link) : 'plain'}>`;
+    return `${m.export}<${m.link ? marshallingKey(m.link, modelsByName, visiting) : 'plain'}>`;
   }
   if (m.export === 'tuple') {
-    return `tuple<${m.properties.map(marshallingKey).join(',')}>`;
+    return `tuple<${m.properties.map((p) => marshallingKey(p, modelsByName, visiting)).join(',')}>`;
   }
   if (m.export === 'reference' && !PRIMITIVE_TYPES.has(m.type)) {
-    return `ref:${m.type}`;
+    // Key on what the reference marshals to, not what it is called. The
+    // normaliser hoists each inline schema to its own name, so two members
+    // declaring an identical property get different names — keying on the name
+    // alone rejected unions whose members convert identically.
+    const referenced = modelsByName[m.type];
+    if (!referenced || visiting.has(m.type)) return `ref:${m.type}`;
+    const nested = new Set(visiting).add(m.type);
+    if (referenced.export === 'one-of' || referenced.export === 'any-of') {
+      const members = [
+        ...(referenced.composedModels ?? []),
+        ...(referenced.composedPrimitives ?? []),
+      ]
+        .map((member) => marshallingKey(member, modelsByName, nested))
+        .sort();
+      return `union<${[...new Set(members)].join('|')}>`;
+    }
+    if (referenced.export === 'interface') {
+      // Keyed on the shape too, for the same reason: two members declaring an
+      // identical inline object property are hoisted to different names.
+      const fields = (referenced.properties ?? [])
+        .filter((property) => property.name)
+        .map(
+          (property) =>
+            `${property.name}:${property.isRequired ? '!' : '?'}${marshallingKey(property, modelsByName, nested)}`,
+        )
+        .sort();
+      return `object<${fields.join(',')}>`;
+    }
+    // An `all-of` composes members that are resolved later, so it keeps its name
+    // as its key rather than a shape this pass cannot see yet.
+    if (referenced.export === 'all-of') return `ref:${m.type}`;
+    return marshallingKey(referenced, modelsByName, nested);
   }
   return 'plain';
 };
@@ -551,7 +586,10 @@ const marshallingKey = (m: Model): string => {
  * otherwise the branch cannot be determined without guessing, so fail fast and
  * ask for a discriminator rather than corrupt data at runtime.
  */
-const assertNoConflictingUnionMemberMarshalling = (model: Model): void => {
+const assertNoConflictingUnionMemberMarshalling = (
+  model: Model,
+  modelsByName: ModelsByName,
+): void => {
   if (
     (model.export !== 'one-of' && model.export !== 'any-of') ||
     model.discriminator
@@ -562,7 +600,7 @@ const assertNoConflictingUnionMemberMarshalling = (model: Model): void => {
   for (const member of model.composedModels ?? []) {
     for (const property of member.properties) {
       if (!property.name) continue;
-      const key = marshallingKey(property);
+      const key = marshallingKey(property, modelsByName);
       const existing = seen.get(property.name);
       if (existing && existing.key !== key) {
         throw new Error(

--- a/packages/nx-plugin/src/open-api/utils/codegen-data/types.ts
+++ b/packages/nx-plugin/src/open-api/utils/codegen-data/types.ts
@@ -123,6 +123,12 @@ export interface Model {
   isReadOnly: boolean;
   /** Whether the property/parameter is required. */
   isRequired: boolean;
+  /**
+   * The `required` list this schema declared, kept even when it declares none of
+   * the properties it names — an `allOf` member may raise a sibling branch's
+   * property to mandatory, which is not the same as constraining nothing.
+   */
+  declaredRequired?: string[];
   /** Whether an array enforces uniqueness (rendered as a `Set`). */
   uniqueItems?: boolean;
   /** For arrays/dictionaries, the model describing the element/value type. */

--- a/packages/nx-plugin/src/open-api/utils/normalise.ts
+++ b/packages/nx-plugin/src/open-api/utils/normalise.ts
@@ -173,6 +173,13 @@ const hasSubSchemasToVisit = (
   !!schema &&
   !isRef(schema) &&
   (['object', 'array'].includes(schema.type as any) ||
+    // `type` is optional, and `properties` implies an object — which is how the
+    // parser already classifies one. Requiring the explicit `type` left such a
+    // schema unhoisted, so an `allOf` member written that way stayed inline and
+    // was taken for a non-object, rejecting the whole document.
+    !!schema.properties ||
+    // `patternProperties` is JSON Schema, so it is not on the 3.0 type.
+    !!(schema as { patternProperties?: unknown }).patternProperties ||
     isCompositeSchema(schema) ||
     !!schema.not ||
     (schema.type === 'string' && !!schema.enum));
@@ -325,13 +332,20 @@ const hoistInlineObjectSubSchemas = (
     hoistInlineObjectSubSchemas(s.nameParts, s.schema, seenModelNameCounts),
   );
 
-  // Clone the object subschemas to build the refs. Note that only objects with "properties" are hoisted as these are non-dictionary types
+  // Clone the object subschemas to build the refs. Note that only objects with
+  // "properties" are hoisted as these are non-dictionary types. `type` is
+  // optional in OpenAPI and `properties` implies an object, so a schema written
+  // without it counts — the parser classifies one the same way, and requiring
+  // the explicit `type` left it inline where an `allOf` member is then taken for
+  // a non-object and the whole document rejected.
+  const isObjectSchema = (s: OpenAPIV3.SchemaObject): boolean =>
+    (s.type === 'object' || s.type === undefined) &&
+    !!(s.properties || (s as any).patternProperties);
   const refs = inlineSubSchemas
     .filter(
       (s) =>
-        (s.schema.type === 'object' && s.schema.properties) ||
+        isObjectSchema(s.schema) ||
         isCompositeSchema(s.schema) ||
-        (s.schema.type === 'object' && (s.schema as any).patternProperties) ||
         (s.schema.type === 'string' && s.schema.enum),
     )
     .map((s) => {
@@ -347,7 +361,11 @@ const hoistInlineObjectSubSchemas = (
         }),
       };
 
-      // Replace each subschema with a ref in the spec
+      // Replace each subschema with a ref in the spec. `nullable` describes this
+      // use of the schema rather than the schema itself, so it stays beside the
+      // ref: moving it onto the hoisted definition made a required nullable
+      // object non-nullable here, and would have made every other user of the
+      // hoisted schema nullable instead.
       const schemaWithPropToReplace = s.propPath
         .slice(0, -1)
         .reduce(
@@ -355,7 +373,10 @@ const hoistInlineObjectSubSchemas = (
           schema,
         );
       if (schemaWithPropToReplace) {
-        schemaWithPropToReplace[s.propPath[s.propPath.length - 1]] = { $ref };
+        schemaWithPropToReplace[s.propPath[s.propPath.length - 1]] = s.schema
+          .nullable
+          ? { $ref, nullable: true }
+          : { $ref };
       }
 
       return ref;
@@ -717,22 +738,30 @@ export const normaliseOpenApiSpecForCodeGen = (inSpec: Spec): Spec => {
     }
   });
 
-  // "Inline" any refs to non objects/enums
+  // "Inline" any refs to non objects/enums.
+  //
+  // The substituted body is itself walked for refs, so a chain — an array whose
+  // items are a named scalar — collapses in one pass. Substituting the array
+  // without following through left `items` pointing at a schema this same pass
+  // deletes, so the client referred to a type nothing declared and the emitted
+  // TypeScript did not compile.
   const inlinedRefs: Set<string> = new Set();
-  spec = cloneDeepWith(spec, (v) => {
-    if (v && typeof v === 'object' && v.$ref) {
-      const resolved = resolveRef(spec, v.$ref);
-      if (
-        resolved &&
-        resolved.type &&
-        resolved.type !== 'object' &&
-        !(resolved.type === 'string' && resolved.enum)
-      ) {
-        inlinedRefs.add(v.$ref);
-        return resolved;
+  const inlineNonObjectRefs = (value: unknown): unknown =>
+    cloneDeepWith(value, (v) => {
+      if (v && typeof v === 'object' && v.$ref) {
+        const resolved = resolveRef(spec, v.$ref);
+        if (
+          resolved &&
+          resolved.type &&
+          resolved.type !== 'object' &&
+          !(resolved.type === 'string' && resolved.enum)
+        ) {
+          inlinedRefs.add(v.$ref);
+          return inlineNonObjectRefs(resolved);
+        }
       }
-    }
-  });
+    });
+  spec = inlineNonObjectRefs(spec) as Spec;
 
   // Delete the non object schemas that were inlined
   [...inlinedRefs].forEach((ref) => {

--- a/packages/nx-plugin/src/open-api/utils/parser.ts
+++ b/packages/nx-plugin/src/open-api/utils/parser.ts
@@ -191,8 +191,17 @@ const schemaStructure = (spec: Spec, schema: Schema): Partial<Model> => {
     return { export: 'array', ...collectionValue(spec, items) };
   }
 
+  // Recorded whether or not this schema declares the properties it names: an
+  // `allOf` member may raise a sibling branch's property to mandatory, and a
+  // composite has to be able to tell that apart from an empty member.
+  const declaredRequired = schema.required ?? [];
+
   if (isDictionarySchema(schema)) {
-    return { export: 'dictionary', ...dictionaryValue(spec, schema) };
+    return {
+      export: 'dictionary',
+      declaredRequired,
+      ...dictionaryValue(spec, schema),
+    };
   }
 
   if (type === 'object' || schema.properties || schema.patternProperties) {
@@ -201,13 +210,14 @@ const schemaStructure = (spec: Spec, schema: Schema): Partial<Model> => {
       export: 'interface',
       type: 'unknown',
       properties,
+      declaredRequired,
       imports: collectImports(properties),
     };
   }
 
   // A schema with no type (e.g. `{}`) is an untyped object.
   if (type === undefined) {
-    return { export: 'interface', type: 'unknown' };
+    return { export: 'interface', type: 'unknown', declaredRequired };
   }
 
   return {
@@ -268,7 +278,18 @@ export const buildInlineModel = (
 ): Model => {
   if (isRef(schemaOrRef)) {
     const name = splitRef(schemaOrRef.$ref)[2];
-    return createModel({ export: 'reference', type: name, imports: [name] });
+    // `nullable` beside a `$ref` describes this use of the schema, not the schema
+    // itself. OpenAPI 3.0 ignores a `$ref`'s siblings, but normalisation puts it
+    // here when it hoists a nullable inline schema — dropping it made a required
+    // nullable object property non-nullable.
+    return createModel({
+      export: 'reference',
+      type: name,
+      imports: [name],
+      ...((schemaOrRef as { nullable?: boolean }).nullable
+        ? { isNullable: true }
+        : {}),
+    });
   }
   return createModel({
     description: schemaOrRef.description ?? null,
@@ -822,14 +843,76 @@ const resolveComposedModel = (
     );
   }
 
-  if (model.export === 'all-of' && composedPrimitives.length > 0) {
-    throw new Error(
-      `Schema "${model.name}" defines allOf with non-object types. allOf may only compose object types in the OpenAPI specification.`,
+  /**
+   * Whether a member constrains nothing, describing the empty object.
+   * `{description: "..."}`, `{example: ...}` and `{title: ...}` are how OpenAPI
+   * 3.0 annotates a `$ref`, whose own siblings are ignored there — the commonest
+   * `allOf` idiom in published specs, and counting it as a non-object made those
+   * documents fail outright.
+   *
+   * A bare `{description}` parses as an `interface` with no properties; an
+   * explicit `{type: object}` with none parses as a `dictionary` carrying no
+   * value type.
+   *
+   * A member declaring `required` is *not* empty even with no properties of its
+   * own: it raises a sibling branch's property to mandatory, and nothing here
+   * carries that across, so dropping it would quietly make a required field
+   * optional. Those keep failing loudly until the constraint can be honoured.
+   */
+  const isStructurallyEmpty = (m: Model): boolean =>
+    (m.properties ?? []).length === 0 &&
+    !m.hasAdditionalProperties &&
+    !m.hasPatternProperties &&
+    (m.declaredRequired ?? []).length === 0 &&
+    ((m.export === 'interface' && !m.link) ||
+      (m.export === 'dictionary' && m.type === 'unknown'));
+  const constrainingPrimitives = composedPrimitives.filter(
+    (m) => !isStructurallyEmpty(m),
+  );
+
+  // A single-member `allOf` composes to exactly that member, so a scalar one is
+  // unambiguous rather than a conjunction of incompatible types — it is how a
+  // description is attached to a scalar, and specs use it for enums especially.
+  const isSingleMemberAllOf =
+    model.export === 'all-of' &&
+    members.length === 1 &&
+    composedModels.length === 0 &&
+    constrainingPrimitives.length === 1;
+
+  if (
+    model.export === 'all-of' &&
+    constrainingPrimitives.length > 0 &&
+    !isSingleMemberAllOf
+  ) {
+    // Name what the offending members actually are: the old wording said
+    // "non-object types" even for a member that is explicitly an object, which
+    // sent readers looking for the wrong thing.
+    const requiresOnly = constrainingPrimitives.filter(
+      (m) => (m.declaredRequired ?? []).length > 0 && !m.properties?.length,
     );
+    const detail =
+      requiresOnly.length > 0
+        ? `an allOf member declares "required" (${requiresOnly
+            .flatMap((m) => m.declaredRequired ?? [])
+            .map((name) => `"${name}"`)
+            .join(
+              ', ',
+            )}) for properties it does not itself declare, which this generator cannot carry across branches. Declare the property in the same member, or mark it required where it is declared`
+        : `an allOf member is not an object type, and allOf may only compose object types`;
+    throw new Error(`Schema "${model.name}" cannot be composed: ${detail}.`);
   }
 
   model.composedModels = composedModels;
-  model.composedPrimitives = composedPrimitives;
+  model.composedPrimitives =
+    model.export === 'all-of' ? constrainingPrimitives : composedPrimitives;
+  // Drop the annotation-only members from what templates render, so an `allOf`
+  // that only carried a description composes to the member it annotates rather
+  // than to an intersection with the empty object.
+  if (model.export === 'all-of') {
+    model.properties = model.properties.filter(
+      (member) => member.name || !isStructurallyEmpty(member),
+    );
+  }
 };
 
 const resolveComposedModels = (data: ClientData): void => {


### PR DESCRIPTION
### Reason for this change

Driving **515 published OpenAPI 3.x documents** through `open-api#ts-client` — APIs.guru plus hand-picked vendor specs (Stripe, GitHub, Kubernetes, Twilio, Cloudflare, OpenAI, Discord, Adyen, Jira, Box, Asana, DigitalOcean) — surfaced five defects in the shared codegen pipeline. Three refuse documents that are valid OpenAPI; one emits TypeScript that does not compile; one drops a nullability the spec declares.

Measured on a random 120-spec sample of that corpus, generation goes from **93 to 102**. The remaining refusals are genuine ambiguities that name the offending schema.

These were found while working on #586, which shares the same pipeline. Raising them separately so the fixes land for the TypeScript generators without waiting on that PR.

### Description of changes

**`allOf` members that constrain nothing were counted as non-objects.** OpenAPI 3.0 ignores a `$ref`'s siblings, so wrapping one in a single-member `allOf` is how you attach a description to a referenced schema — which makes it the commonest `allOf` idiom in published specs. A member of `{description}`, `{example}`, `{title}`, `{}`, or an explicit `{type: object}` with no properties failed the whole document:

```
Error: Schema "Out" defines allOf with non-object types.
```

Such a member composes to the empty object and is now dropped, so `allOf: [{$ref: Link}, {description: "..."}]` renders as `export type Out = Link;` rather than an intersection with `unknown`.

A member declaring `required` is deliberately **not** treated as empty: it raises a sibling branch's property to mandatory, and nothing in this pipeline carries that across branches, so dropping it would quietly make a required field optional. Those keep failing, and the message now names the member and why — it previously reported "non-object types" even for a member that is explicitly an object.

**An array of a named scalar emitted TypeScript that does not compile.** A named scalar reached through `items` is inlined, but the array wrapping it was substituted without following through, leaving `items` pointing at a schema the same pass deletes:

```ts
// types.gen.ts declares no IndexName
private async _getX(): Promise<Array<IndexName>> {
// error TS2304: Cannot find name 'IndexName'.
```

Inlining now follows the chain, collapsing it to `Promise<Array<string>>`.

**A nullable object property lost its `| null`.** Hoisting a nullable inline object property replaced it with a bare `$ref` and moved `nullable` onto the hoisted definition — where it applied to every *other* user of that schema and to this property not at all. `nullable` now stays beside the ref, and a `$ref`'s `nullable` sibling is honoured. This is what a real API returns for an absent sub-resource, so the emitted type previously refused a value the spec permits.

**Identical union members were rejected as conflicting.** `marshallingKey` keyed an object member on its name, but the normaliser hoists each inline schema to a distinct one — so two members declaring a byte-identical inline object property were rejected as declaring "different types". It now keys on the shape, which is what the comment above it already said it should do. Members that genuinely convert differently (a `date-time` in one branch, a plain `string` in the other) are still refused.

The two hoisting predicates also treat a missing `type` beside `properties` or `patternProperties` as an object, which is how the parser already classifies one — requiring the explicit `type` is what left these members inline to be misread in the first place.

### Description of how you validated changes

**Unit tests** — 373 pass (363 before, 10 added). Every new test was checked to fail without its fix; reverting all five behaviours fails 9 of them. The array-of-named-scalar and nullable-object tests go through `expectTypeScriptToCompile`, so a dangling reference or a wrong annotation fails as a compile error rather than a string mismatch. Two snapshots move, both gaining the `| null` their spec declares.

**Real specs** — the 120-spec sample above, generated on `main` and on this branch through the actual generator, counting outcomes. Individually verified as newly generating: 1Password Events, Asana, Giphy, YNAB, OpenUV, Pinecone, SoundCloud, BBC. The generated TypeScript for the array case was type checked with `tsc --strict` to confirm `TS2304` is gone.

**Rejections that must stay** — checked that a real `allOf` of scalars, an `allOf` of two scalars, an `allOf` requiring an undeclared property, and a union whose members genuinely disagree on a property type are all still refused with actionable messages.

`format`, `lint` and both `tsconfig` type checks are clean; the spec-config diagnostic count is unchanged from `main` (44 either side).

### Issue # (if applicable)

N/A.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
