### PR TITLE
feat(shadcn): adopt shadcn 4.0's monorepo support

### DIFF
--- a/packages/nx-plugin/src/migrations/latest/shadcn-package-imports-exports/metadata.json
+++ b/packages/nx-plugin/src/migrations/latest/shadcn-package-imports-exports/metadata.json
@@ -1,0 +1,3 @@
+{
+  "description": "Move the shared shadcn package from a tsconfig paths alias to package.json imports/exports, matching the shadcn CLI's own monorepo resolution"
+}

--- a/packages/nx-plugin/src/migrations/latest/shadcn-package-imports-exports/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/latest/shadcn-package-imports-exports/migration.spec.ts
@@ -1,0 +1,275 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { addProjectConfiguration, readJson, type Tree } from '@nx/devkit';
+import { REACT_WEBSITE_APP_GENERATOR_INFO } from '../../../ts/react-website/app/generator.js';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test.js';
+import migration from './migration.js';
+
+const SHADCN_ROOT = 'packages/common/shadcn';
+const COMPONENTS_JSON = `${SHADCN_ROOT}/components.json`;
+const PACKAGE_JSON = `${SHADCN_ROOT}/package.json`;
+const BUTTON = `${SHADCN_ROOT}/src/components/ui/button.tsx`;
+const SIDEBAR = `${SHADCN_ROOT}/src/components/ui/sidebar.tsx`;
+const UTILS = `${SHADCN_ROOT}/src/lib/utils.ts`;
+const USE_MOBILE = `${SHADCN_ROOT}/src/hooks/use-mobile.ts`;
+
+const WEBSITE_ROOT = 'packages/websites/test-app';
+const WEBSITE_MANIFEST = `${WEBSITE_ROOT}/package.json`;
+
+const FQN = '@proj/common-shadcn';
+
+const OLD_BUTTON = `import { cn } from '${FQN}/lib/utils';\n\nexport function Button() { return null; }\n`;
+
+const OLD_SIDEBAR = `import { useIsMobile } from '${FQN}/hooks/use-mobile';
+import { cn } from '${FQN}/lib/utils';
+import { Button } from '${FQN}/components/ui/button';
+
+export function Sidebar() { return null; }
+`;
+
+const OLD_COMPONENTS_JSON = {
+  $schema: 'https://ui.shadcn.com/schema.json',
+  style: 'new-york',
+  aliases: {
+    components: `${FQN}/components`,
+    utils: `${FQN}/lib/utils`,
+    hooks: `${FQN}/hooks`,
+    lib: `${FQN}/lib`,
+    ui: `${FQN}/components/ui`,
+  },
+};
+
+const NEW_ALIASES = {
+  components: '#components',
+  utils: '#lib/utils',
+  hooks: '#hooks',
+  lib: '#lib',
+  ui: '#components/ui',
+};
+
+const read = (tree: Tree, path: string): string =>
+  tree.read(path, 'utf-8') ?? '';
+
+/**
+ * The shared shadcn package, and a shadcn website depending on it, as the
+ * release before the imports/exports move left them. Hardcoded rather than
+ * produced by running the generator: a migration has to keep applying to the
+ * shape that shipped, however far the generator's output moves afterwards.
+ */
+const givenSharedShadcnPackage = (
+  tree: Tree,
+  {
+    componentsJson = OLD_COMPONENTS_JSON,
+    button = OLD_BUTTON,
+    sidebar = OLD_SIDEBAR,
+  }: {
+    componentsJson?: Record<string, unknown>;
+    button?: string;
+    sidebar?: string;
+  } = {},
+): void => {
+  tree.write(
+    PACKAGE_JSON,
+    JSON.stringify(
+      { name: FQN, version: '0.0.1', private: true, dependencies: {} },
+      null,
+      2,
+    ),
+  );
+  tree.write(COMPONENTS_JSON, JSON.stringify(componentsJson, null, 2));
+  tree.write(BUTTON, button);
+  tree.write(SIDEBAR, sidebar);
+  tree.write(UTILS, `export const cn = (...args: unknown[]) => args;\n`);
+  tree.write(USE_MOBILE, `export const useIsMobile = () => false;\n`);
+
+  tree.write(
+    'tsconfig.base.json',
+    JSON.stringify(
+      {
+        compilerOptions: {
+          paths: {
+            [FQN]: [`./${SHADCN_ROOT}/src/index.ts`],
+            [`${FQN}/*`]: [`./${SHADCN_ROOT}/src/*`],
+          },
+        },
+      },
+      null,
+      2,
+    ),
+  );
+
+  addProjectConfiguration(tree, 'test-app', {
+    root: WEBSITE_ROOT,
+    sourceRoot: `${WEBSITE_ROOT}/src`,
+    metadata: {
+      generator: REACT_WEBSITE_APP_GENERATOR_INFO.id,
+      ux: 'shadcn',
+    } as Record<string, unknown>,
+  });
+  tree.write(
+    WEBSITE_MANIFEST,
+    JSON.stringify(
+      { name: '@proj/test-app', version: '0.0.1', dependencies: {} },
+      null,
+      2,
+    ),
+  );
+};
+
+describe('shadcn-package-imports-exports migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeUsingTsSolutionSetup();
+  });
+
+  it('should apply to the shape the generators produce', async () => {
+    givenSharedShadcnPackage(tree);
+
+    const result = await migration(tree);
+
+    expect(readJson(tree, COMPONENTS_JSON).aliases).toEqual(NEW_ALIASES);
+
+    const packageJson = readJson(tree, PACKAGE_JSON);
+    expect(packageJson.imports).toEqual({
+      '#components/*': './src/components/*.tsx',
+      '#lib/*': './src/lib/*.ts',
+      '#hooks/*': './src/hooks/*.ts',
+    });
+    expect(packageJson.exports).toEqual({
+      '.': './src/index.ts',
+      './styles/*': './src/styles/*',
+      './components/*': './src/components/*.tsx',
+      './lib/*': './src/lib/*.ts',
+      './hooks/*': './src/hooks/*.ts',
+    });
+
+    const button = read(tree, BUTTON);
+    expect(button).not.toContain(FQN);
+    expect(button).toContain("from '#lib/utils'");
+
+    const sidebar = read(tree, SIDEBAR);
+    expect(sidebar).not.toContain(FQN);
+    expect(sidebar).toContain("from '#hooks/use-mobile'");
+    expect(sidebar).toContain("from '#lib/utils'");
+    expect(sidebar).toContain("from '#components/ui/button'");
+    // The binding survives the move.
+    expect(sidebar).toContain('Button');
+
+    const basePaths = readJson(tree, 'tsconfig.base.json').compilerOptions
+      .paths;
+    expect(basePaths).not.toHaveProperty(`${FQN}/*`);
+
+    const websiteDeps = readJson(tree, WEBSITE_MANIFEST).dependencies;
+    expect(websiteDeps[FQN]).toBe('workspace:*');
+
+    expect(result.nextSteps).toEqual([]);
+  });
+
+  it('should keep bindings a project added of its own', async () => {
+    givenSharedShadcnPackage(tree, {
+      button: OLD_BUTTON.replace(
+        "import { cn } from '@proj/common-shadcn/lib/utils';",
+        "import { cn, cva } from '@proj/common-shadcn/lib/utils';",
+      ),
+    });
+
+    await migration(tree);
+
+    const button = read(tree, BUTTON);
+    expect(button).toContain("from '#lib/utils'");
+    expect(button).toContain('cva');
+  });
+
+  it('should skip and report a customised import form', async () => {
+    // A namespace import is not the generated shape, so it is reported for
+    // the user to move by hand rather than rewritten.
+    givenSharedShadcnPackage(tree, {
+      sidebar: `import * as utils from '${FQN}/lib/utils';\n`,
+    });
+
+    const result = await migration(tree);
+
+    expect(read(tree, SIDEBAR)).toContain(
+      `import * as utils from '${FQN}/lib/utils'`,
+    );
+    expect(result.nextSteps).toEqual([
+      expect.stringContaining(`${SIDEBAR}: still imports '${FQN}/lib/utils'`),
+    ]);
+  });
+
+  it('should leave a components.json with customised aliases alone', async () => {
+    const customAliases = {
+      $schema: 'https://ui.shadcn.com/schema.json',
+      style: 'new-york',
+      aliases: {
+        components: '~/components',
+        utils: '~/lib/utils',
+        hooks: '~/hooks',
+        lib: '~/lib',
+        ui: '~/components/ui',
+      },
+    };
+    givenSharedShadcnPackage(tree, { componentsJson: customAliases });
+
+    const result = await migration(tree);
+
+    expect(readJson(tree, COMPONENTS_JSON)).toEqual(customAliases);
+    expect(read(tree, BUTTON)).toContain(FQN);
+    expect(readJson(tree, PACKAGE_JSON)).not.toHaveProperty('imports');
+    expect(result.nextSteps).toEqual([
+      expect.stringContaining(`${COMPONENTS_JSON}: aliases have diverged`),
+    ]);
+  });
+
+  it('should leave a workspace that already moved itself alone', async () => {
+    givenSharedShadcnPackage(tree, {
+      componentsJson: {
+        $schema: 'https://ui.shadcn.com/schema.json',
+        style: 'new-york',
+        aliases: NEW_ALIASES,
+      },
+      button: `import { cn } from '#lib/utils';\n`,
+      sidebar: `import { cn } from '#lib/utils';\n`,
+    });
+
+    const result = await migration(tree);
+
+    expect(read(tree, BUTTON)).toBe(`import { cn } from '#lib/utils';\n`);
+    expect(result.nextSteps).toEqual([]);
+  });
+
+  it('should be idempotent', async () => {
+    givenSharedShadcnPackage(tree);
+
+    await migration(tree);
+    const afterFirst = {
+      button: read(tree, BUTTON),
+      sidebar: read(tree, SIDEBAR),
+      componentsJson: readJson(tree, COMPONENTS_JSON),
+      packageJson: readJson(tree, PACKAGE_JSON),
+      basePaths: readJson(tree, 'tsconfig.base.json'),
+      websiteManifest: readJson(tree, WEBSITE_MANIFEST),
+    };
+    const result = await migration(tree);
+
+    expect(read(tree, BUTTON)).toEqual(afterFirst.button);
+    expect(read(tree, SIDEBAR)).toEqual(afterFirst.sidebar);
+    expect(readJson(tree, COMPONENTS_JSON)).toEqual(afterFirst.componentsJson);
+    expect(readJson(tree, PACKAGE_JSON)).toEqual(afterFirst.packageJson);
+    expect(readJson(tree, 'tsconfig.base.json')).toEqual(afterFirst.basePaths);
+    expect(readJson(tree, WEBSITE_MANIFEST)).toEqual(
+      afterFirst.websiteManifest,
+    );
+    expect(result.nextSteps).toEqual([]);
+  });
+
+  it('should leave a workspace with no shared shadcn package alone', async () => {
+    const result = await migration(tree);
+
+    expect(tree.exists(COMPONENTS_JSON)).toBe(false);
+    expect(result.nextSteps).toEqual([]);
+  });
+});

--- a/packages/nx-plugin/src/migrations/latest/shadcn-package-imports-exports/migration.ts
+++ b/packages/nx-plugin/src/migrations/latest/shadcn-package-imports-exports/migration.ts
@@ -1,0 +1,248 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import {
+  getProjects,
+  joinPathFragments,
+  type MigrationReturnObject,
+  readJson,
+  type Tree,
+  updateJson,
+} from '@nx/devkit';
+import { REACT_WEBSITE_APP_GENERATOR_INFO } from '../../../ts/react-website/app/generator.js';
+import { applyGritQL, matchGritQL } from '../../../utils/ast.js';
+import {
+  addDependenciesToPackageJson,
+  getLocalDependencySpecifier,
+} from '../../../utils/dependencies.js';
+import { formatFilesInSubtree } from '../../../utils/format.js';
+import {
+  PACKAGES_DIR,
+  SHARED_SHADCN_DIR,
+} from '../../../utils/shared-constructs-constants.js';
+import { getSharedShadcnFullyQualifiedName } from '../../../utils/shared-shadcn.js';
+
+/**
+ * Move the shared shadcn package off a `tsconfig.base.json` `paths` alias onto
+ * `package.json` `imports`/`exports`.
+ *
+ * shadcn 4.x's CLI resolves `components.json`'s aliases via Node's package
+ * resolution (`imports`/`exports`), not tsconfig `paths` - its own resolver
+ * naively joins a tsconfig-declared alias against whichever directory it's
+ * invoked from, so the repo-root-relative `paths` mapping this plugin used to
+ * vend breaks the moment `shadcn add` is run with `-c packages/common/shadcn`
+ * (as its own monorepo-root preflight now tells the user to). This migration
+ * carries an existing workspace onto the shape today's generators produce:
+ * local `#...` imports for the package's own internal component references,
+ * a public `exports` map for every other consumer, and a real `workspace:*`
+ * dependency on each consumer so that map actually resolves.
+ *
+ * How to write a migration:
+ * - https://nx.dev/docs/kb/migration-generators
+ * - What `nextSteps` means: https://nx.dev/docs/reference/devkit/MigrationReturnObject
+ *
+ * Guardrails:
+ * - Only touches a `packages/common/shadcn` this plugin's generators produced
+ *   (guarded by `components.json`'s aliases still matching the old shape).
+ * - Internal imports are rewritten by exact module specifier per file found
+ *   under `src/{components/ui,lib,hooks}`, so a component a user added by hand
+ *   after the original generation is covered too, and a specifier the
+ *   migration doesn't recognise is left alone and reported.
+ * - Idempotent: every write is guarded by the old shape still being present.
+ */
+
+const libraryRoot = joinPathFragments(PACKAGES_DIR, SHARED_SHADCN_DIR);
+const componentsJsonPath = joinPathFragments(libraryRoot, 'components.json');
+const packageJsonPath = joinPathFragments(libraryRoot, 'package.json');
+
+interface ComponentsJsonAliases {
+  readonly components?: string;
+  readonly utils?: string;
+  readonly hooks?: string;
+  readonly lib?: string;
+  readonly ui?: string;
+}
+
+const oldAliases = (fqn: string): ComponentsJsonAliases => ({
+  components: `${fqn}/components`,
+  utils: `${fqn}/lib/utils`,
+  hooks: `${fqn}/hooks`,
+  lib: `${fqn}/lib`,
+  ui: `${fqn}/components/ui`,
+});
+
+const newAliases: Required<ComponentsJsonAliases> = {
+  components: '#components',
+  utils: '#lib/utils',
+  hooks: '#hooks',
+  lib: '#lib',
+  ui: '#components/ui',
+};
+
+const newPackageManifestFields = {
+  imports: {
+    '#components/*': './src/components/*.tsx',
+    '#lib/*': './src/lib/*.ts',
+    '#hooks/*': './src/hooks/*.ts',
+  },
+  exports: {
+    '.': './src/index.ts',
+    './styles/*': './src/styles/*',
+    './components/*': './src/components/*.tsx',
+    './lib/*': './src/lib/*.ts',
+    './hooks/*': './src/hooks/*.ts',
+  },
+};
+
+/**
+ * Rewrite an import's module specifier, keeping its bindings - `$bindings`
+ * holds whatever the file imports, so a binding a user added survives.
+ */
+const importPattern = (from: string, to: string): string =>
+  `\`import { $bindings } from '${from}'\` => \`import { $bindings } from '${to}'\``;
+
+/** Whether the file still imports the old specifier under any other form. */
+const hasRemainingImport = (from: string): string =>
+  `\`import $_ from '${from}'\``;
+
+export default async function migration(
+  tree: Tree,
+): Promise<MigrationReturnObject> {
+  const nextSteps: string[] = [];
+
+  if (!tree.exists(componentsJsonPath) || !tree.exists(packageJsonPath)) {
+    return { nextSteps };
+  }
+
+  const fullyQualifiedName = getSharedShadcnFullyQualifiedName(tree);
+  const currentAliases =
+    readJson<{ aliases?: ComponentsJsonAliases }>(tree, componentsJsonPath)
+      .aliases ?? {};
+  const expectedOldAliases = oldAliases(fullyQualifiedName);
+  const onOldShape = (
+    Object.keys(newAliases) as (keyof ComponentsJsonAliases)[]
+  ).every((key) => currentAliases[key] === expectedOldAliases[key]);
+
+  if (!onOldShape) {
+    if (
+      (Object.keys(newAliases) as (keyof ComponentsJsonAliases)[]).some(
+        (key) => currentAliases[key] !== newAliases[key],
+      )
+    ) {
+      nextSteps.push(
+        `${componentsJsonPath}: aliases have diverged from both the old and current generated shape - left untouched. Migrate them to the shadcn CLI's imports/exports monorepo pattern by hand: https://ui.shadcn.com/docs/monorepo`,
+      );
+    }
+    await formatFilesInSubtree(tree);
+    return { nextSteps };
+  }
+
+  // Rewrite every source file's internal references to this package's own
+  // components/lib/hooks, keyed off the files actually present so a
+  // hand-added component is covered too.
+  const internalDirs: Array<{
+    dir: string;
+    extension: string;
+    oldSubpath: string;
+    newPrefix: string;
+  }> = [
+    {
+      dir: joinPathFragments(libraryRoot, 'src', 'components', 'ui'),
+      extension: '.tsx',
+      oldSubpath: 'components/ui',
+      newPrefix: '#components/ui',
+    },
+    {
+      dir: joinPathFragments(libraryRoot, 'src', 'lib'),
+      extension: '.ts',
+      oldSubpath: 'lib',
+      newPrefix: '#lib',
+    },
+    {
+      dir: joinPathFragments(libraryRoot, 'src', 'hooks'),
+      extension: '.ts',
+      oldSubpath: 'hooks',
+      newPrefix: '#hooks',
+    },
+  ];
+
+  const renames: Array<{ old: string; renamed: string }> = [];
+  const sourceFiles: string[] = [];
+  for (const { dir, extension, oldSubpath, newPrefix } of internalDirs) {
+    if (!tree.exists(dir)) {
+      continue;
+    }
+    for (const entry of tree.children(dir)) {
+      if (!entry.endsWith(extension)) {
+        continue;
+      }
+      const baseName = entry.slice(0, -extension.length);
+      renames.push({
+        old: `${fullyQualifiedName}/${oldSubpath}/${baseName}`,
+        renamed: `${newPrefix}/${baseName}`,
+      });
+      sourceFiles.push(joinPathFragments(dir, entry));
+    }
+  }
+
+  for (const sourceFile of sourceFiles) {
+    for (const { old, renamed } of renames) {
+      await applyGritQL(tree, sourceFile, importPattern(old, renamed));
+      // A namespace or default import of the same specifier is left as it
+      // is - reported rather than rewritten, so a diverged file is never
+      // clobbered.
+      if (await matchGritQL(tree, sourceFile, hasRemainingImport(old))) {
+        nextSteps.push(
+          `${sourceFile}: still imports '${old}' in a form this migration does not rewrite - update it to '${renamed}' by hand.`,
+        );
+      }
+    }
+  }
+
+  updateJson(tree, componentsJsonPath, (json) => ({
+    ...json,
+    aliases: newAliases,
+  }));
+
+  updateJson(tree, packageJsonPath, (json) => ({
+    ...json,
+    ...newPackageManifestFields,
+  }));
+
+  updateJson(tree, 'tsconfig.base.json', (json) => {
+    const paths = { ...(json.compilerOptions?.paths ?? {}) };
+    delete paths[`${fullyQualifiedName}/*`];
+    return {
+      ...json,
+      compilerOptions: {
+        ...json.compilerOptions,
+        paths,
+      },
+    };
+  });
+
+  // Every website generated with ux=shadcn needs a real dependency on the
+  // shared package now that it resolves through `exports`, not `paths`.
+  for (const project of getProjects(tree).values()) {
+    const metadata = project.metadata as
+      | { generator?: string; ux?: string }
+      | undefined;
+    if (
+      metadata?.generator !== REACT_WEBSITE_APP_GENERATOR_INFO.id ||
+      metadata.ux !== 'shadcn'
+    ) {
+      continue;
+    }
+    addDependenciesToPackageJson(
+      tree,
+      { [fullyQualifiedName]: getLocalDependencySpecifier(tree) },
+      {},
+      joinPathFragments(project.root, 'package.json'),
+    );
+  }
+
+  await formatFilesInSubtree(tree);
+
+  return { nextSteps };
+}

--- a/packages/nx-plugin/src/ts/react-website/agui/generator.ts
+++ b/packages/nx-plugin/src/ts/react-website/agui/generator.ts
@@ -24,6 +24,7 @@ import { kebabCase } from '../../../utils/names.js';
 import { getNpmScopePrefix } from '../../../utils/npm-scope.js';
 import { registerPnpmBuiltDependencies } from '../../../utils/pnpm-workspace.js';
 import {
+  addSharedShadcnDependency,
   SHADCN_DEPENDENCIES,
   sharedShadcnGenerator,
 } from '../../../utils/shared-shadcn.js';
@@ -136,6 +137,7 @@ export const addAgUiReactConnection = async (
   // Shadcn theme imports from the shared shadcn library, so it must exist.
   if (theme === 'shadcn') {
     await sharedShadcnGenerator(tree, DEPENDENCIES);
+    addSharedShadcnDependency(tree, frontendProjectConfig.root);
   }
   generateFiles(
     tree,

--- a/packages/nx-plugin/src/ts/react-website/app/generator.ts
+++ b/packages/nx-plugin/src/ts/react-website/app/generator.ts
@@ -53,6 +53,7 @@ import {
   TERRAFORM_WEBSITE_RUNTIME_CONFIG_FILE,
 } from '../../../utils/shared-constructs-constants.js';
 import {
+  addSharedShadcnDependency,
   SHADCN_DEPENDENCIES,
   sharedShadcnGenerator,
 } from '../../../utils/shared-shadcn.js';
@@ -355,6 +356,7 @@ export async function tsReactWebsiteGenerator(
 
   if (ux === 'shadcn') {
     await sharedShadcnGenerator(tree, DEPENDENCIES);
+    addSharedShadcnDependency(tree, websiteContentPath);
   }
 
   if (iac) {

--- a/packages/nx-plugin/src/utils/files/common/shadcn/src/components/ui/alert.tsx.template
+++ b/packages/nx-plugin/src/utils/files/common/shadcn/src/components/ui/alert.tsx.template
@@ -1,7 +1,7 @@
 import * as React from "react"
 import { cva, type VariantProps } from "class-variance-authority"
 
-import { cn } from "<%= scopeAlias %>common-shadcn/lib/utils"
+import { cn } from "#lib/utils"
 
 const alertVariants = cva(
   "relative grid w-full grid-cols-[0_1fr] items-start gap-y-0.5 rounded-lg border px-4 py-3 text-sm has-[>svg]:grid-cols-[calc(var(--spacing)*4)_1fr] has-[>svg]:gap-x-3 [&>svg]:size-4 [&>svg]:translate-y-0.5 [&>svg]:text-current",

--- a/packages/nx-plugin/src/utils/files/common/shadcn/src/components/ui/avatar.tsx.template
+++ b/packages/nx-plugin/src/utils/files/common/shadcn/src/components/ui/avatar.tsx.template
@@ -3,7 +3,7 @@
 import * as React from "react"
 import { Avatar as AvatarPrimitive } from "radix-ui"
 
-import { cn } from "<%= scopeAlias %>common-shadcn/lib/utils"
+import { cn } from "#lib/utils"
 
 function Avatar({
   className,

--- a/packages/nx-plugin/src/utils/files/common/shadcn/src/components/ui/breadcrumb.tsx.template
+++ b/packages/nx-plugin/src/utils/files/common/shadcn/src/components/ui/breadcrumb.tsx.template
@@ -2,7 +2,7 @@ import * as React from "react"
 import { ChevronRight, MoreHorizontal } from "lucide-react"
 import { Slot } from "radix-ui"
 
-import { cn } from "<%= scopeAlias %>common-shadcn/lib/utils"
+import { cn } from "#lib/utils"
 
 function Breadcrumb({ ...props }: React.ComponentProps<"nav">) {
   return <nav aria-label="breadcrumb" data-slot="breadcrumb" {...props} />

--- a/packages/nx-plugin/src/utils/files/common/shadcn/src/components/ui/button.tsx.template
+++ b/packages/nx-plugin/src/utils/files/common/shadcn/src/components/ui/button.tsx.template
@@ -2,7 +2,7 @@ import * as React from "react"
 import { cva, type VariantProps } from "class-variance-authority"
 import { Slot } from "radix-ui"
 
-import { cn } from "<%= scopeAlias %>common-shadcn/lib/utils"
+import { cn } from "#lib/utils"
 
 const buttonVariants = cva(
   "inline-flex shrink-0 items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",

--- a/packages/nx-plugin/src/utils/files/common/shadcn/src/components/ui/card.tsx.template
+++ b/packages/nx-plugin/src/utils/files/common/shadcn/src/components/ui/card.tsx.template
@@ -1,6 +1,6 @@
 import * as React from "react"
 
-import { cn } from "<%= scopeAlias %>common-shadcn/lib/utils"
+import { cn } from "#lib/utils"
 
 function Card({ className, ...props }: React.ComponentProps<"div">) {
   return (

--- a/packages/nx-plugin/src/utils/files/common/shadcn/src/components/ui/input.tsx.template
+++ b/packages/nx-plugin/src/utils/files/common/shadcn/src/components/ui/input.tsx.template
@@ -1,6 +1,6 @@
 import * as React from "react"
 
-import { cn } from "<%= scopeAlias %>common-shadcn/lib/utils"
+import { cn } from "#lib/utils"
 
 function Input({ className, type, ...props }: React.ComponentProps<"input">) {
   return (

--- a/packages/nx-plugin/src/utils/files/common/shadcn/src/components/ui/separator.tsx.template
+++ b/packages/nx-plugin/src/utils/files/common/shadcn/src/components/ui/separator.tsx.template
@@ -3,7 +3,7 @@
 import * as React from "react"
 import { Separator as SeparatorPrimitive } from "radix-ui"
 
-import { cn } from "<%= scopeAlias %>common-shadcn/lib/utils"
+import { cn } from "#lib/utils"
 
 function Separator({
   className,

--- a/packages/nx-plugin/src/utils/files/common/shadcn/src/components/ui/sheet.tsx.template
+++ b/packages/nx-plugin/src/utils/files/common/shadcn/src/components/ui/sheet.tsx.template
@@ -4,7 +4,7 @@ import * as React from "react"
 import { XIcon } from "lucide-react"
 import { Dialog as SheetPrimitive } from "radix-ui"
 
-import { cn } from "<%= scopeAlias %>common-shadcn/lib/utils"
+import { cn } from "#lib/utils"
 
 function Sheet({ ...props }: React.ComponentProps<typeof SheetPrimitive.Root>) {
   return <SheetPrimitive.Root data-slot="sheet" {...props} />

--- a/packages/nx-plugin/src/utils/files/common/shadcn/src/components/ui/sidebar.tsx.template
+++ b/packages/nx-plugin/src/utils/files/common/shadcn/src/components/ui/sidebar.tsx.template
@@ -5,25 +5,25 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { PanelLeftIcon } from "lucide-react"
 import { Slot } from "radix-ui"
 
-import { useIsMobile } from "<%= scopeAlias %>common-shadcn/hooks/use-mobile"
-import { cn } from "<%= scopeAlias %>common-shadcn/lib/utils"
-import { Button } from "<%= scopeAlias %>common-shadcn/components/ui/button"
-import { Input } from "<%= scopeAlias %>common-shadcn/components/ui/input"
-import { Separator } from "<%= scopeAlias %>common-shadcn/components/ui/separator"
+import { useIsMobile } from "#hooks/use-mobile"
+import { cn } from "#lib/utils"
+import { Button } from "#components/ui/button"
+import { Input } from "#components/ui/input"
+import { Separator } from "#components/ui/separator"
 import {
   Sheet,
   SheetContent,
   SheetDescription,
   SheetHeader,
   SheetTitle,
-} from "<%= scopeAlias %>common-shadcn/components/ui/sheet"
-import { Skeleton } from "<%= scopeAlias %>common-shadcn/components/ui/skeleton"
+} from "#components/ui/sheet"
+import { Skeleton } from "#components/ui/skeleton"
 import {
   Tooltip,
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
-} from "<%= scopeAlias %>common-shadcn/components/ui/tooltip"
+} from "#components/ui/tooltip"
 
 const SIDEBAR_COOKIE_NAME = "sidebar_state"
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7

--- a/packages/nx-plugin/src/utils/files/common/shadcn/src/components/ui/skeleton.tsx.template
+++ b/packages/nx-plugin/src/utils/files/common/shadcn/src/components/ui/skeleton.tsx.template
@@ -1,4 +1,4 @@
-import { cn } from "<%= scopeAlias %>common-shadcn/lib/utils"
+import { cn } from "#lib/utils"
 
 function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
   return (

--- a/packages/nx-plugin/src/utils/files/common/shadcn/src/components/ui/spinner.tsx.template
+++ b/packages/nx-plugin/src/utils/files/common/shadcn/src/components/ui/spinner.tsx.template
@@ -1,6 +1,6 @@
 import { Loader2Icon } from "lucide-react"
 
-import { cn } from "<%= scopeAlias %>common-shadcn/lib/utils"
+import { cn } from "#lib/utils"
 
 function Spinner({ className, ...props }: React.ComponentProps<"svg">) {
   return (

--- a/packages/nx-plugin/src/utils/files/common/shadcn/src/components/ui/textarea.tsx.template
+++ b/packages/nx-plugin/src/utils/files/common/shadcn/src/components/ui/textarea.tsx.template
@@ -1,6 +1,6 @@
 import * as React from "react"
 
-import { cn } from "<%= scopeAlias %>common-shadcn/lib/utils"
+import { cn } from "#lib/utils"
 
 function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
   return (

--- a/packages/nx-plugin/src/utils/files/common/shadcn/src/components/ui/tooltip.tsx.template
+++ b/packages/nx-plugin/src/utils/files/common/shadcn/src/components/ui/tooltip.tsx.template
@@ -3,7 +3,7 @@
 import * as React from "react"
 import { Tooltip as TooltipPrimitive } from "radix-ui"
 
-import { cn } from "<%= scopeAlias %>common-shadcn/lib/utils"
+import { cn } from "#lib/utils"
 
 function TooltipProvider({
   delayDuration = 0,

--- a/packages/nx-plugin/src/utils/files/shadcn/components.json.template
+++ b/packages/nx-plugin/src/utils/files/shadcn/components.json.template
@@ -11,10 +11,10 @@
   },
   "iconLibrary": "lucide",
   "aliases": {
-    "components": "<%= sharedShadcnAlias %>/components",
-    "utils": "<%= sharedShadcnAlias %>/lib/utils",
-    "hooks": "<%= sharedShadcnAlias %>/hooks",
-    "lib": "<%= sharedShadcnAlias %>/lib",
-    "ui": "<%= sharedShadcnAlias %>/components/ui"
+    "components": "#components",
+    "utils": "#lib/utils",
+    "hooks": "#hooks",
+    "lib": "#lib",
+    "ui": "#components/ui"
   }
 }

--- a/packages/nx-plugin/src/utils/shared-shadcn.ts
+++ b/packages/nx-plugin/src/utils/shared-shadcn.ts
@@ -18,7 +18,10 @@ import {
   forDependencies,
   type MustDeclare,
 } from './declared-dependencies.js';
-import { addDependenciesToPackageJson } from './dependencies.js';
+import {
+  addDependenciesToPackageJson,
+  getLocalDependencySpecifier,
+} from './dependencies.js';
 import { formatFilesInSubtree } from './format.js';
 import { esmVars } from './module-format.js';
 import { getNpmScopePrefix } from './npm-scope.js';
@@ -42,13 +45,35 @@ export const SHADCN_DEPENDENCIES = [
   ...VITEST_DEPENDENCIES,
 ] as const satisfies readonly { name: ITsDepVersion }[];
 
+/** The shared shadcn package's fully-qualified npm name for this workspace. */
+export const getSharedShadcnFullyQualifiedName = (tree: Tree): string =>
+  `${getNpmScopePrefix(tree)}${SHARED_SHADCN_NAME}`;
+
+/**
+ * Declares a `workspace:*` dependency on the shared shadcn package in a
+ * consumer's own package.json, so it resolves through the shared package's
+ * `exports` map (real package resolution) rather than a tsconfig `paths`
+ * alias - see `sharedShadcnGenerator` for why.
+ */
+export const addSharedShadcnDependency = (
+  tree: Tree,
+  consumerDir: string,
+): void => {
+  addDependenciesToPackageJson(
+    tree,
+    {
+      [getSharedShadcnFullyQualifiedName(tree)]:
+        getLocalDependencySpecifier(tree),
+    },
+    {},
+    joinPathFragments(consumerDir, 'package.json'),
+  );
+};
+
 export async function sharedShadcnGenerator<
   const D extends DependencyDeclaration,
 >(tree: Tree, declaration: D & MustDeclare<typeof SHADCN_DEPENDENCIES, D>) {
-  const npmScopePrefix = getNpmScopePrefix(tree);
-  const scopeAlias = npmScopePrefix;
-  const sharedShadcnAlias = `${scopeAlias}${SHARED_SHADCN_NAME}`;
-  const fullyQualifiedName = `${npmScopePrefix}${SHARED_SHADCN_NAME}`;
+  const fullyQualifiedName = getSharedShadcnFullyQualifiedName(tree);
   const libraryRoot = joinPathFragments(PACKAGES_DIR, SHARED_SHADCN_DIR);
   const shadcnSrcRoot = joinPathFragments(libraryRoot, 'src');
 
@@ -65,10 +90,7 @@ export async function sharedShadcnGenerator<
       tree,
       joinPathFragments(import.meta.dirname, 'files', SHARED_SHADCN_DIR, 'src'),
       shadcnSrcRoot,
-      {
-        scopeAlias,
-        ...esmVars(tree),
-      },
+      esmVars(tree),
       {
         overwriteStrategy: OverwriteStrategy.KeepExisting,
       },
@@ -85,7 +107,6 @@ export async function sharedShadcnGenerator<
       libraryRoot,
       {
         fullyQualifiedName,
-        scopeAlias,
       },
       {
         overwriteStrategy: OverwriteStrategy.Overwrite,
@@ -128,20 +149,32 @@ export async function sharedShadcnGenerator<
       {},
       joinPathFragments(libraryRoot, 'package.json'),
     );
-  }
 
-  updateJson(tree, 'tsconfig.base.json', (json) => ({
-    ...json,
-    compilerOptions: {
-      ...json.compilerOptions,
-      paths: {
-        ...(json.compilerOptions?.paths ?? {}),
-        [`${sharedShadcnAlias}/*`]: [
-          `./${joinPathFragments(libraryRoot, 'src', '*')}`,
-        ],
-      },
-    },
-  }));
+    // shadcn 4.x's CLI resolves the `components.json` alias via `imports`/
+    // `exports` (Node's package resolution), not a tsconfig `paths` alias.
+    // `imports` covers this package's own internal component-to-component
+    // references (aliased in components.json below); `exports` covers every
+    // other consumer.
+    updateJson(
+      tree,
+      joinPathFragments(libraryRoot, 'package.json'),
+      (packageJson) => ({
+        ...packageJson,
+        imports: {
+          '#components/*': './src/components/*.tsx',
+          '#lib/*': './src/lib/*.ts',
+          '#hooks/*': './src/hooks/*.ts',
+        },
+        exports: {
+          '.': './src/index.ts',
+          './styles/*': './src/styles/*',
+          './components/*': './src/components/*.tsx',
+          './lib/*': './src/lib/*.ts',
+          './hooks/*': './src/hooks/*.ts',
+        },
+      }),
+    );
+  }
 
   // components.json lives in the package so `shadcn add` runs there and
   // installs component dependencies into the package's own manifest.
@@ -150,9 +183,7 @@ export async function sharedShadcnGenerator<
       tree,
       joinPathFragments(import.meta.dirname, 'files', 'shadcn'),
       libraryRoot,
-      {
-        sharedShadcnAlias,
-      },
+      {},
       {
         overwriteStrategy: OverwriteStrategy.KeepExisting,
       },

--- a/scripts/update-versions/shadcn.ts
+++ b/scripts/update-versions/shadcn.ts
@@ -13,7 +13,6 @@ import {
 import { execSync } from 'child_process';
 import { join, relative } from 'path';
 import { FsTree } from 'nx/src/generators/tree';
-import { SHARED_SHADCN_NAME } from '../../packages/nx-plugin/src/utils/shared-constructs-constants';
 
 const SHADCN_COMPONENTS = [
   'alert',
@@ -43,9 +42,6 @@ const SHADCN_TEMPLATE_ROOT = join(
   'src',
 );
 
-const applyShadcnTemplateAliases = (contents: string): string =>
-  contents.replace(/@\//g, `<%= scopeAlias %>${SHARED_SHADCN_NAME}/`);
-
 export const refreshShadcnTemplates = (
   tree: FsTree,
   tmpDir: string,
@@ -73,26 +69,11 @@ export const refreshShadcnTemplates = (
   );
 
   writeFileSync(
-    join(shadcnDir, 'package.json'),
-    JSON.stringify(
-      {
-        name: 'shadcn-template-refresh',
-        private: true,
-      },
-      null,
-      2,
-    ),
-  );
-
-  writeFileSync(
     join(shadcnDir, 'tsconfig.json'),
     JSON.stringify(
       {
         compilerOptions: {
-          baseUrl: '.',
-          paths: {
-            '@/*': ['src/*'],
-          },
+          moduleResolution: 'bundler',
         },
       },
       null,
@@ -100,6 +81,26 @@ export const refreshShadcnTemplates = (
     ),
   );
 
+  writeFileSync(
+    join(shadcnDir, 'package.json'),
+    JSON.stringify(
+      {
+        name: 'shadcn-template-refresh',
+        private: true,
+        imports: {
+          '#components/*': './src/components/*.tsx',
+          '#lib/*': './src/lib/*.ts',
+          '#hooks/*': './src/hooks/*.ts',
+        },
+      },
+      null,
+      2,
+    ),
+  );
+
+  // Mirrors the shared shadcn package's own components.json: aliases are
+  // local `#...` package imports, resolved via `package.json#imports` above,
+  // matching packages/nx-plugin/src/utils/files/shadcn/components.json.template.
   writeFileSync(
     join(shadcnDir, 'components.json'),
     JSON.stringify(
@@ -116,11 +117,11 @@ export const refreshShadcnTemplates = (
         },
         iconLibrary: 'lucide',
         aliases: {
-          components: '@/components',
-          utils: '@/lib/utils',
-          hooks: '@/hooks',
-          lib: '@/lib',
-          ui: '@/components/ui',
+          components: '#components',
+          utils: '#lib/utils',
+          hooks: '#hooks',
+          lib: '#lib',
+          ui: '#components/ui',
         },
       },
       null,
@@ -140,12 +141,11 @@ export const refreshShadcnTemplates = (
 
   const writeTemplateFile = (sourcePath: string, targetPath: string): void => {
     const sourceContents = readFileSync(sourcePath, 'utf-8');
-    const templatedContents = applyShadcnTemplateAliases(sourceContents);
     const targetRelativePath = relative(process.cwd(), targetPath);
 
     const previousContents = tree.read(targetRelativePath, 'utf-8');
-    if (previousContents !== templatedContents) {
-      tree.write(targetRelativePath, templatedContents);
+    if (previousContents !== sourceContents) {
+      tree.write(targetRelativePath, sourceContents);
       updatedTemplates.push(targetRelativePath);
     }
   };


### PR DESCRIPTION
### Reason for this change

This repo picked up shadcn 4.x in `52308dde` (2026-03-27, "feat: update dependencies (#513)", `3.8.5` → `4.1.0`) and is currently vending `4.19.0`. shadcn 4.x added monorepo support to the CLI, and it breaks `pnpm dlx shadcn add` for this plugin's generated workspaces: the CLI now resolves an alias's tsconfig-declared path relative to whichever directory it's invoked from rather than where the alias was declared. That doubles the path whether you run it with `-c packages/common/shadcn` from the workspace root (as its own monorepo preflight tells you to), or `cd` into `packages/common/shadcn` and run `shadcn add dialog` directly — both write new components under `packages/common/shadcn/packages/common/shadcn/...` instead of `packages/common/shadcn/src/...`.

### Description of changes

shadcn 4.0's [documented monorepo pattern](https://ui.shadcn.com/docs/monorepo) avoids tsconfig aliases entirely — `components.json`'s aliases become local `#...` package imports (resolved via `package.json#imports`), and other workspaces resolve the package through `package.json#exports`. This PR moves the shared shadcn package onto that shape:

- `shared-shadcn.ts` now vends `imports`/`exports` on the shared package's `package.json` instead of a `tsconfig.base.json` `paths` entry, and every `ux=shadcn` consumer (`ts#website`, the `connection` generator's shadcn theme) declares a real `workspace:*` dependency on it so `exports` actually resolves.
- `components.json.template` and all vendored `.tsx.template` component files now self-reference via local `#...` specifiers instead of the public `<scope>/common-shadcn/...` alias.
- `scripts/update-versions/shadcn.ts` (the weekly dependency-refresh script) configures its scratch scaffold with the same `#...` aliases, so future refreshes keep emitting the correct shape without a separate rewrite step.
- A new deterministic migration (`shadcn-package-imports-exports`) carries an existing workspace onto this shape: rewrites `components.json` and every internal component/lib/hooks import (discovered from files actually present, so a component a user added by hand is covered too), adds `imports`/`exports` to the package's manifest, drops the now-dead `paths` entry, and adds the `workspace:*` dependency to each consumer. Guarded and idempotent - a customised `components.json` or import form is left alone and reported via `nextSteps` rather than rewritten.

### Description of how you validated changes

- `migration.spec.ts` (7 tests): applies to the vended shape, keeps user-added bindings, skips and reports a customised import form or a customised `components.json`, no-ops on an already-migrated workspace, is idempotent, and no-ops on a workspace with no shared shadcn package.
- Existing generator suite (`ts#website`, `connection`/agui, `ts#website#auth`) still green — 123 tests, unchanged.
- Manual end-to-end validation in two scratch workspaces:
  - **Migration path**: generated a workspace on the published `1.0.0-rc.94`, reproduced the doubled-path bug for real (`shadcn add dialog -c packages/common/shadcn`), linked the local build, hand-ran the migration, and confirmed: the diff matches exactly what's described above, re-running the migration reports "No changes were made", `nx sync` + `pnpm install` produces a real `node_modules` symlink for the shared package, `nx run-many --target compile --all` is clean, a real `nx run website:build` (Vite production build) succeeds, and `shadcn add dialog -c packages/common/shadcn` now lands at the correct path with correctly-aliased imports.
  - **Generator path**: generated a second workspace from scratch against the local build - its `components.json` and `package.json` imports/exports are byte-identical to the migrated workspace's, it compiles cleanly, and `shadcn add -c packages/common/shadcn` from the workspace root, and `shadcn add` run directly from inside `packages/common/shadcn`, both work correctly.

### Issue # (if applicable)

N/A - found via manual testing, no tracked issue.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*