### PR TITLE
test(ts#website): cover adding shadcn components in the react-website smoke test

### DIFF
--- a/e2e/src/smoke-tests/react-website.spec.ts
+++ b/e2e/src/smoke-tests/react-website.spec.ts
@@ -2,12 +2,22 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import { existsSync, rmSync } from 'node:fs';
+import { existsSync, readFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
 import { ensureDirSync } from 'fs-extra';
+// eslint-disable-next-line
+import {
+  PACKAGES_DIR,
+  SHARED_SHADCN_DIR,
+  SHARED_SHADCN_NAME,
+} from '../../../packages/nx-plugin/src/utils/shared-constructs-constants';
+// eslint-disable-next-line
+import { TS_VERSIONS } from '../../../packages/nx-plugin/src/utils/versions';
 import { createTestWorkspace, runCLI, tmpProjPath } from '../utils';
 
 describe('smoke test - react-website', () => {
   const pkgMgr = 'pnpm';
+  const workspaceName = 'react-website';
   const targetDir = `${tmpProjPath()}/react-website-${pkgMgr}`;
 
   beforeEach(() => {
@@ -22,7 +32,7 @@ describe('smoke test - react-website', () => {
     const projectRoot = await createTestWorkspace(
       pkgMgr,
       targetDir,
-      'react-website',
+      workspaceName,
       'cdk',
     );
     const opts = { cwd: projectRoot, env: { NX_DAEMON: 'false' } };
@@ -82,6 +92,55 @@ describe('smoke test - react-website', () => {
         opts,
       );
     }
+
+    // The shadcn CLI resolves `components.json`'s aliases through the shared
+    // package's `imports`/`exports` maps rather than a tsconfig `paths` entry.
+    // Both documented invocations are covered: a wrong alias shape makes the
+    // CLI join the alias against its own cwd and write the component to a
+    // doubled path (`packages/common/shadcn/packages/common/shadcn/...`)
+    // instead of the package's `src`.
+    const shadcnDir = `${PACKAGES_DIR}/${SHARED_SHADCN_DIR}`;
+    const shadcnRoot = join(projectRoot, shadcnDir);
+    const shadcnAddCommand = `pnpm dlx shadcn@${TS_VERSIONS.shadcn} add`;
+
+    await runCLI(`${shadcnAddCommand} dialog -c ${shadcnDir} --yes`, {
+      ...opts,
+      prefixWithPackageManagerCmd: false,
+    });
+
+    // Run from inside the package too — its README documents this form, and the
+    // CLI resolves relative to a different cwd each way.
+    await runCLI(`${shadcnAddCommand} popover --yes`, {
+      ...opts,
+      cwd: shadcnRoot,
+      prefixWithPackageManagerCmd: false,
+    });
+
+    for (const component of ['dialog', 'popover']) {
+      const componentPath = join(
+        shadcnRoot,
+        'src',
+        'components',
+        'ui',
+        `${component}.tsx`,
+      );
+      expect(existsSync(componentPath), componentPath).toBe(true);
+      // Aliases resolve to the package-local `#...` specifiers, not the
+      // public `<scope>/common-shadcn/...` name. The CLI writes its own quote
+      // style, so match either.
+      expect(readFileSync(componentPath, 'utf-8')).toMatch(
+        /from ['"]#lib\/utils['"]/,
+      );
+    }
+
+    expect(existsSync(join(shadcnRoot, 'packages'))).toBe(false);
+
+    // The shadcn CLI writes its own formatting, so the added components need a
+    // format pass before the shared package's `format` target is satisfied.
+    await runCLI(
+      `run @${workspaceName}/${SHARED_SHADCN_NAME}:format --configuration=fix`,
+      opts,
+    );
 
     await runCLI(`sync --verbose`, opts);
     await runCLI(


### PR DESCRIPTION
### Reason for this change

#1181 fixed `shadcn add` for generated workspaces: shadcn 4.x resolves `components.json`'s aliases through the shared package's `imports`/`exports` maps (Node package resolution) rather than a `tsconfig.base.json` `paths` entry. With the wrong alias shape the CLI joins a tsconfig-declared alias against whichever directory it was invoked from and writes new components to a doubled path — `packages/common/shadcn/packages/common/shadcn/src/components/ui/...` instead of the package's own `src`.

The failure mode is quiet: the CLI still **exits 0**. Nothing in the e2e suite (or the unit suite) invoked the shadcn CLI, so the exact bug #1181 fixed had no regression test. Given the cause is the CLI's own path resolution — which shadcn 4.x already changed once — only actually running `shadcn add` catches a recurrence.

### Description of changes

Extends the existing `react-website` smoke test, which already generates `ux=shadcn` websites, so this reuses that workspace rather than adding a new lane. Inserted after the generator permutations and before `sync`/`build`:

- Runs both invocations the plugin documents, because the CLI resolves relative to a different cwd each way:
  - `shadcn add dialog -c packages/common/shadcn` from the workspace root (what shadcn's own monorepo preflight tells the user to run)
  - `shadcn add popover` from inside `packages/common/shadcn` (what the vended README documents)
- Asserts, for both components: the file lands under the package's `src/components/ui/`, it imports via the package-local `#lib/utils` specifier rather than the public `<scope>/common-shadcn/...` name, and no doubled `packages/` directory was created inside the package.
- Pinned to `TS_VERSIONS.shadcn` rather than `@latest`, so a CLI release can't silently change what CI exercises.
- Adds a `format --configuration=fix` pass on the shared package before the build. The shadcn CLI writes its own formatting (double quotes), so without this the subsequent `run-many --target build` fails on `common-shadcn:format`. This is pre-existing CLI behaviour, not introduced here — but it does mean the README's documented workflow currently leaves a user's build red until they format, which may be worth a README note separately.

### Description of how you validated changes

- Ran the spec to green locally against the merged code: `✓ src/smoke-tests/react-website.spec.ts (1 test) 291042ms`, exit 0. Confirmed from the run log that both invocations actually executed (`✔ Created 1 file: src/components/ui/dialog.tsx`, likewise `popover.tsx`) rather than being silently skipped.
- Confirmed the test **fails** on the regression: reverted a generated workspace to the exact pre-#1181 shape (old fully-qualified aliases, no `imports`/`exports`, `paths` entry restored) and re-ran. The CLI exits 0 but writes to `packages/common/shadcn/packages/common/shadcn/src/components/ui/dialog.tsx`, and all three assertions fire:

  ```
  existsSync(src/.../dialog.tsx): false   <- expects true
  existsSync(shadcnRoot/packages): true   <- expects false
  doubled file imports: does NOT match #lib/utils
  ```

- `tsc --noEmit` over the e2e project and `nx run @aws/nx-plugin-e2e:lint` are both clean on the rebased branch.

### Issue # (if applicable)

N/A — follow-up test coverage for #1181.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
