### PR TITLE
chore(deps): run the repo on pnpm 11

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "license": "Apache-2.0",
-  "packageManager": "pnpm@12.2.1",
+  "packageManager": "pnpm@11.25.0",
   "scripts": {
     "prepare": "husky || true",
     "build": "nx run-many --target build",


### PR DESCRIPTION
### Reason for this change

The `v1.0.0-rc.95` release tagged and cut a GitHub release, then failed to publish anything to npm. All three publish attempts failed with:

```
pnpm publish ".../dist/packages/nx-plugin" --json --"@aws:registry=https://registry.npmjs.org/" --tag=latest --no-git-checks
error: unexpected argument '--@aws:registry' found
  tip: a similar argument exists: '--registry'
```

nx 23.1.2 gates that flag spelling on `satisfies(pnpmVersion, '>=9.15.7 <10.0.0 || >=10.5.0')` (`nx/src/utils/package-manager.js`). pnpm 12.2.1 satisfies the unbounded upper range, so nx emits `--@aws:registry`, but pnpm 11 renamed the option to `--config.@scope:registry` and pnpm 12 dropped the old spelling entirely. pnpm 11 still accepts **both**, so the release worked right up until #1176 moved the repo to pnpm 12.

Because `scripts/release.ts` tags and creates the changelog before publishing, the failure left a `v1.0.0-rc.95` git tag and GitHub release with nothing on npm. The migrate smoke test resolves its start versions from `v*` git tags (`e2e/src/smoke-tests/migrate-versions.ts`), newest first, sharded round-robin — so shard 1 drew rc.95 and failed on **every** main and PR run at workspace creation:

```
ERR_PNPM_NO_MATCHING_VERSION
Command failed: pnpm create @aws/nx-workspace@1.0.0-rc.95 migrate-test --iac=cdk --interactive=false
```

The stale tag and GitHub release have been deleted, so shard 1 falls back to rc.94 and the version can be cut again. This PR fixes the underlying publish failure so the re-cut actually lands on npm.

### Description of changes

One line: `packageManager` moves from `pnpm@12.2.1` back to `pnpm@11.25.0`, the version in place before #1176.

**pnpm 12 support is deliberately left intact** — this only changes the version the repo itself runs on. Untouched:

- the `pnpm-12` smoke test variant in `ci.yml` / `pr.yml` and `e2e/src/smoke-tests/pnpm-12.spec.ts`
- the `_tmp_*` Nx project-graph ignore and its migration
- the `allowBuilds` supply-chain decisions
- the `PNPM_CONFIG_MINIMUM_RELEASE_AGE` override
- `pnpm/setup`, which installs the native binary correctly for both majors

`pnpm-lock.yaml` is unchanged — pnpm 11 and 12 share `lockfileVersion: '9.0'`.

This is a stopgap. nx 23.2.0 fixes the root cause: it bounds the old spelling to `<11.0.0` and adds a `configForm` branch emitting `--config.@scope:registry` for pnpm >= 11. Once #1182 lands the repo can move back to pnpm 12. Note nx 23.2's fix treats pnpm >= 11 as needing the new spelling, and pnpm 11 accepts that too — so pnpm 11 publishes correctly under both nx 23.1.2 today and nx 23.2 later, either way.

### Description of how you validated changes

Verified both flag spellings directly against each pnpm major with a throwaway scoped package:

| pnpm | `--"@aws:registry=..."` | `--"config.@aws:registry=..."` |
|---|---|---|
| 11.22.0 | accepted | accepted |
| 11.25.0 | accepted | accepted |
| 12.2.1 | **`unexpected argument`** | accepted |

Confirmed nx resolves the downgraded version and emits a spelling pnpm 11 accepts:

```
pnpm version nx sees: 11.25.0
publish cmd: pnpm publish "/tmp/x" --json --"@aws:registry=https://registry.npmjs.org/" --tag=latest --no-git-checks
```

As a control, reverting to `pnpm@12.2.1` makes nx emit the identical flag, which pnpm 12 then rejects — confirming the mismatch is the pnpm version, not the nx command.

Ran the real release publish end to end against a local Verdaccio registry (nothing pointed at npm) — the exact step that failed for rc.95:

```
$ pnpm nx release publish --tag latest --registry http://127.0.0.1:14801/
Published to http://127.0.0.1:14801/ with tag "latest"
NX   Successfully ran target nx-release-publish for 3 projects
```

All three packages published with nx-parseable JSON output. Also confirmed `pnpm@11.25.0 install --frozen-lockfile` succeeds with no lockfile changes.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*