### PR TITLE
test(e2e): cover the release publish, and move the repo back to pnpm 12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,7 @@ jobs:
           - audit
           - finch
           - trivy
+          - release
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -127,6 +127,7 @@ jobs:
           - audit
           - finch
           - trivy
+          - release
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:

--- a/e2e/src/smoke-tests/release.spec.ts
+++ b/e2e/src/smoke-tests/release.spec.ts
@@ -1,0 +1,134 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { execSync } from 'node:child_process';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { afterAll, describe, expect, it } from 'vitest';
+// eslint-disable-next-line
+import { publishWithRetry } from '../../../scripts/release';
+import { MIGRATE_PACKAGES } from './migrate-versions';
+
+/**
+ * release smoke test — publishes the local build to the local registry through
+ * the release script's own `publishWithRetry`, and asserts all three packages
+ * land.
+ *
+ * The command `nx release publish` builds is derived from the active package
+ * manager's version, and a package manager that rejects the flag spelling nx
+ * picks fails every publish. Nothing else in the suite catches that: the other
+ * smoke tests publish with plain `npm publish`, and unit tests never invoke the
+ * executor. So the release lane's first signal used to be a failed release, on
+ * main, after the tag and GitHub release had already been created.
+ *
+ * Three details give this test teeth:
+ *
+ * - **It publishes a version the registry has never seen**, and asserts that
+ *   before publishing. nx short-circuits a package whose version already carries
+ *   the requested dist-tag and exits zero without running the publish command,
+ *   so reusing the `0.0.0` build `global-setup` published would pass whatever
+ *   the active package manager does.
+ * - **It publishes under a dedicated dist-tag.** `latest` keeps pointing at the
+ *   `0.0.0` build every other smoke test resolves.
+ * - **It runs the release script's own function**, not a copy of the command, so
+ *   a change to how the release publishes is covered by construction.
+ */
+const RELEASE_DIST_TAG = 'release-e2e';
+/**
+ * Version to publish under. Above every real release so it can never be
+ * mistaken for one, and unique per run so nx always performs a real publish
+ * rather than re-tagging a version the registry already holds.
+ */
+const releaseTestVersion = () => `9.9.9-release-e2e.${process.pid}`;
+
+const workspaceRoot = join(__dirname, '../../..');
+const distManifest = (pkg: string) =>
+  join(
+    workspaceRoot,
+    'dist/packages',
+    pkg.replace('@aws/', ''),
+    'package.json',
+  );
+
+/** Versions the local registry currently serves for a package. */
+const versionsOnRegistry = (pkg: string, registry: string): string[] => {
+  try {
+    const versions = JSON.parse(
+      execSync(`npm view ${pkg} versions --registry=${registry} --json`, {
+        encoding: 'utf-8',
+        env: process.env,
+        stdio: ['ignore', 'pipe', 'pipe'],
+        windowsHide: true,
+      }),
+    );
+    // npm returns a bare string when only one version exists.
+    return Array.isArray(versions) ? versions : [versions];
+  } catch {
+    // Unpublished package — nothing on the registry yet.
+    return [];
+  }
+};
+
+describe('smoke test - release', () => {
+  const version = releaseTestVersion();
+  const originalManifests = new Map<string, string>();
+
+  afterAll(() => {
+    // Restore the versions the other smoke tests' published build carries.
+    for (const [path, contents] of originalManifests) {
+      writeFileSync(path, contents);
+    }
+  });
+
+  it('should publish every package with the release script', async () => {
+    const localRegistry = process.env.NX_E2E_LOCAL_REGISTRY;
+    if (!localRegistry) {
+      throw new Error(
+        'NX_E2E_LOCAL_REGISTRY is unset — global setup did not start the local registry',
+      );
+    }
+
+    // The assertions below only prove a publish happened if the registry does
+    // not already serve this version — otherwise nx skips the publish, exits
+    // zero, and every check still passes. Assert the precondition rather than
+    // assume it.
+    for (const pkg of MIGRATE_PACKAGES) {
+      expect(
+        versionsOnRegistry(pkg, localRegistry),
+        `${pkg}@${version} is already on the local registry — this test cannot prove a publish ran`,
+      ).not.toContain(version);
+    }
+
+    // Publish a version the registry has never seen, so nx cannot skip the
+    // publish it would otherwise short-circuit as already released.
+    for (const pkg of MIGRATE_PACKAGES) {
+      const path = distManifest(pkg);
+      const contents = readFileSync(path, 'utf-8');
+      originalManifests.set(path, contents);
+      const manifest = JSON.parse(contents);
+      manifest.version = version;
+      writeFileSync(path, `${JSON.stringify(manifest, null, 2)}\n`);
+    }
+
+    await publishWithRetry({
+      tag: RELEASE_DIST_TAG,
+      additionalArgs: [`--registry=${localRegistry}`],
+      // A flag the package manager rejects fails identically on every attempt,
+      // so don't spend the backoff waiting to confirm it.
+      attempts: 1,
+      cwd: workspaceRoot,
+    });
+
+    // publishWithRetry throws on a failed publish, but a package skipped as
+    // already-present also exits zero — so confirm the registry really serves
+    // each package at this version.
+    for (const pkg of MIGRATE_PACKAGES) {
+      const published = execSync(
+        `npm view ${pkg}@${version} version --registry=${localRegistry} --json`,
+        { encoding: 'utf-8', env: process.env, windowsHide: true },
+      );
+      expect(JSON.parse(published)).toBe(version);
+    }
+  });
+});

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "license": "Apache-2.0",
-  "packageManager": "pnpm@11.25.0",
+  "packageManager": "pnpm@12.2.1",
   "scripts": {
     "prepare": "husky || true",
     "build": "nx run-many --target build",

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -82,31 +82,50 @@ const releaseArgs = (): string[] => {
   return onRcTag ? ['--specifier', STABLE_PROMOTION_BUMP, '--preid', 'rc'] : [];
 };
 
+/** Overrides for {@link publishWithRetry}, used by the release smoke test. */
+export interface PublishOptions {
+  /** Dist-tag to publish under. */
+  tag?: string;
+  /** Extra `nx release publish` args — the smoke test pins a local registry. */
+  additionalArgs?: string[];
+  /** Attempts before giving up. */
+  attempts?: number;
+  /** Directory to run from; defaults to the current working directory. */
+  cwd?: string;
+}
+
 /**
  * Publish the release, retrying a transient failure with backoff. Each attempt
  * re-runs `nx release publish`, which skips packages already on the registry and
  * tolerates an already-present 409 — so a retry only re-attempts what didn't
  * land, and a network blip or a version briefly hidden by npm's publish-time
  * scanning doesn't fail the release.
+ *
+ * Exported so the `release` smoke test drives this exact function against a
+ * local registry: the command nx builds here depends on the active pnpm version,
+ * and only running it catches a spelling the package manager rejects.
  */
-const publishWithRetry = async (): Promise<void> => {
-  for (let attempt = 1; attempt <= MAX_PUBLISH_ATTEMPTS; attempt++) {
+export const publishWithRetry = async ({
+  tag = 'latest',
+  additionalArgs = [],
+  attempts = MAX_PUBLISH_ATTEMPTS,
+  cwd,
+}: PublishOptions = {}): Promise<void> => {
+  for (let attempt = 1; attempt <= attempts; attempt++) {
     const result = spawnSync(
       'pnpm',
-      ['nx', 'release', 'publish', '--tag', 'latest'],
-      { stdio: 'inherit' },
+      ['nx', 'release', 'publish', '--tag', tag, ...additionalArgs],
+      { stdio: 'inherit', cwd },
     );
     if (result.status === 0) {
       return;
     }
-    if (attempt === MAX_PUBLISH_ATTEMPTS) {
-      throw new Error(
-        `nx release publish failed after ${MAX_PUBLISH_ATTEMPTS} attempts`,
-      );
+    if (attempt === attempts) {
+      throw new Error(`nx release publish failed after ${attempts} attempts`);
     }
     const backoffMs = 15000 * attempt;
     console.warn(
-      `nx release publish failed (attempt ${attempt}/${MAX_PUBLISH_ATTEMPTS}); retrying in ${backoffMs / 1000}s...`,
+      `nx release publish failed (attempt ${attempt}/${attempts}); retrying in ${backoffMs / 1000}s...`,
     );
     await sleep(backoffMs);
   }
@@ -136,7 +155,11 @@ const main = async (): Promise<void> => {
   await publishWithRetry();
 };
 
-main().catch((err) => {
-  console.error(err);
-  process.exit(1);
-});
+// Run as a CLI, but not when imported (the release smoke test imports
+// publishWithRetry).
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
> [!IMPORTANT]
> **The new `release` smoke test is expected to FAIL on this PR.** That failure is the test doing its job — it reproduces the exact `v1.0.0-rc.95` publish failure, which only disappears once nx 23.2 lands via #1182. See [Expected CI state](#expected-ci-state) below.

### Reason for this change

The `v1.0.0-rc.95` release tagged and cut a GitHub release, then failed to publish anything to npm:

```
pnpm publish ".../dist/packages/nx-plugin" --json --"@aws:registry=https://registry.npmjs.org/" --tag=latest --no-git-checks
error: unexpected argument '--@aws:registry' found
  tip: a similar argument exists: '--registry'
```

nx 23.1.2 gates that flag spelling on `>=9.15.7 <10.0.0 || >=10.5.0` — an unbounded upper range. pnpm 11 renamed the option to `--config.@scope:registry` and pnpm 12 dropped the old spelling, so moving the repo to pnpm 12 in #1176 broke every publish.

**Nothing in CI caught this**, and that is the real defect. The release publish had no test coverage at all:

- the other smoke tests publish with plain `npm publish` in `global-setup`, which never exercises `nx release publish`
- unit tests never invoke the release-publish executor
- the command nx builds is *derived from the active pnpm version*, so it can only be validated by running it

The first signal was a failed release on main, **after** the git tag and GitHub release had already been created. That left a `v*` tag with nothing on npm, which then broke migrate shard 1 on every subsequent run, since migrate resolves start versions from git tags.

#1185 was the stopgap that put the repo back on pnpm 11 to unblock releases. This PR reverts that and adds the missing coverage.

### Description of changes

**A `release` smoke test** (`e2e/src/smoke-tests/release.spec.ts`) that publishes the local build to verdaccio and asserts all three packages land. Added to the `smoke_tests` matrix in `ci.yml` and `pr.yml`.

It calls the release script's own `publishWithRetry` rather than re-implementing the command, so the thing under test is the thing that actually releases. `scripts/release.ts` changes to support that:

- `publishWithRetry` is exported and takes optional overrides (`tag`, `additionalArgs`, `attempts`, `cwd`); defaults are unchanged, so the release path behaves exactly as before
- `main()` is guarded behind `import.meta.url === file://${process.argv[1]}`, matching the existing pattern in `scripts/stamp-migrations.ts`, so importing the module doesn't run a release

**Three things stop the test passing vacuously** — this was the main design concern, since a release test that silently publishes nothing is worse than no test:

1. **It publishes a version the registry has never served.** nx short-circuits a package whose version already carries the requested dist-tag, exits `0`, and never runs the publish command. `global-setup` has already published `0.0.0`, so reusing that version would pass green on *any* package manager. The test publishes `9.9.9-release-e2e.<pid>` and **asserts the precondition** before publishing.
2. **It publishes under a `release-e2e` dist-tag**, so `latest` keeps pointing at the `0.0.0` build every other smoke test resolves.
3. **It queries the registry afterwards** to confirm each package is really served at that version.

**`packageManager` moves back to `pnpm@12.2.1`**, reverting #1185. `pnpm-lock.yaml` is unchanged — pnpm 11 and 12 share `lockfileVersion: '9.0'`.

### Expected CI state

The `release` smoke test **will fail on this PR**, with the same error that broke rc.95. That is intentional and is the evidence the test works — it fails precisely because the repo is back on pnpm 12 while nx is still 23.1.2.

It goes green once **#1182** (nx 23.2) lands: nx 23.2.0 bounds the old spelling to `<11.0.0` and adds a `configForm` branch emitting `--config.@scope:registry` for pnpm >= 11. Two ways to sequence this:

- merge #1182 first, then rebase this PR — it should go fully green, or
- merge this PR's test on pnpm 11 and flip to pnpm 12 with #1182

Happy to reshape into whichever you prefer; the sequencing is your call.

### Description of how you validated changes

**Proved the test fails for the right reason and passes for the right reason**, by running the real target both ways:

`pnpm@11.25.0` — passes, with three real publishes:

```
$ pnpm nx run @aws/nx-plugin-e2e:smoke-test --name=release
Published to http://localhost:4873 with tag "release-e2e"   (x3)
✓ should publish every package with the release script
Test Files  1 passed | 33 skipped
```

`pnpm@12.2.1` — fails with the exact rc.95 error:

```
error: unexpected argument '--@aws:registry' found
× should publish every package with the release script
Error: nx release publish failed after 1 attempts
```

**Verified the anti-vacuous guard by sabotaging it.** Pointed the test at `0.0.0` (already on the registry) to simulate a publish nx would skip. Before the guard it passed green while publishing nothing — the exact false negative I was trying to avoid. With the guard:

```
AssertionError: @aws/nx-plugin@0.0.0 is already on the local registry — this test cannot prove a publish ran
```

**Verified the flag behaviour directly** against each pnpm major with a throwaway scoped package:

| pnpm | `--"@aws:registry=..."` | `--"config.@aws:registry=..."` |
|---|---|---|
| 11.22.0 | accepted | accepted |
| 11.25.0 | accepted | accepted |
| 12.2.1 | **`unexpected argument`** | accepted |

**Confirmed the CLI guard didn't break the release entrypoint** — running `scripts/release.ts` directly still executes the real flow (it resolved the next version as `1.0.0-rc.95` from the git tag and wrote the dist manifests), so the guard only suppresses execution on import.

Also confirmed `pnpm@12.2.1 install --frozen-lockfile` succeeds with no lockfile changes, biome lint is clean on both changed files, and `@aws/nx-plugin-e2e:build` passes. The pre-existing `tsc -p e2e/tsconfig.spec.json` errors are unchanged by this PR (identical count on clean main) and none are in the files touched here.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*