### PR TITLE
test(e2e): empty agent session buckets on deploy test teardown

### DIFF
--- a/e2e/src/files/cdk-deploy/main.ts.template
+++ b/e2e/src/files/cdk-deploy/main.ts.template
@@ -1,12 +1,29 @@
 import { ApplicationStage } from './stages/application-stage.js';
 import { App } from '@e2e-test/common-constructs';
-import { Aspects, IAspect, RemovalPolicy, Stack } from 'aws-cdk-lib';
+import { Aspects, IAspect, Mixins, RemovalPolicy, Stack } from 'aws-cdk-lib';
 import { IConstruct } from 'constructs';
 import { CfnResource } from 'aws-cdk-lib';
 import { CfnUserPool, CfnUserPoolDomain } from 'aws-cdk-lib/aws-cognito';
 import { CfnDBCluster } from 'aws-cdk-lib/aws-rds';
 import { CfnTable } from 'aws-cdk-lib/aws-dynamodb';
 import { CfnWebACLAssociation } from 'aws-cdk-lib/aws-wafv2';
+import { CfnBucket, mixins as s3Mixins } from 'aws-cdk-lib/aws-s3';
+
+const AUTO_DELETE_OBJECTS_RESOURCE_TYPE = 'Custom::S3AutoDeleteObjects';
+
+/**
+ * Whether the bucket's owning construct already vends an auto-delete custom
+ * resource, so the mixin isn't applied twice (which fails synth on a duplicate
+ * construct id).
+ */
+const hasAutoDeleteObjects = (bucket: CfnBucket): boolean =>
+  (bucket.node.scope ?? bucket).node.children.some((child) =>
+    [child, child.node.defaultChild].some(
+      (candidate) =>
+        candidate instanceof CfnResource &&
+        candidate.cfnResourceType === AUTO_DELETE_OBJECTS_RESOURCE_TYPE,
+    ),
+  );
 
 /**
  * Aspect to augment resources for integration tests
@@ -22,6 +39,11 @@ class IntegrationTestAspect implements IAspect {
     // Ensure no resources are retained for a complete teardown
     if (node instanceof CfnResource) {
       node.applyRemovalPolicy(RemovalPolicy.DESTROY);
+    }
+
+    // Empty buckets on delete, since CloudFormation cannot delete a non-empty bucket
+    if (node instanceof CfnBucket && !hasAutoDeleteObjects(node)) {
+      Mixins.of(node).apply(new s3Mixins.BucketAutoDeleteObjects());
     }
 
     // AssociateWebACL is capped at one call every 2 seconds per account per

--- a/e2e/src/files/terraform-deploy/main.tf.template
+++ b/e2e/src/files/terraform-deploy/main.tf.template
@@ -192,6 +192,8 @@ module "ts_mcp_server" {
 module "ts_a2a_agent" {
   source = "../../common/terraform/src/app/agents/my-ts-a2a-agent"
 
+  session_force_destroy = true
+
   appconfig_application_id  = module.runtime_config_appconfig.application_id
   appconfig_application_arn = module.runtime_config_appconfig.application_arn
   asset_bucket_name         = module.asset_bucket.bucket_name
@@ -201,6 +203,8 @@ module "ts_a2a_agent" {
 module "py_a2a_agent" {
   source = "../../common/terraform/src/app/agents/my-py-a2a-agent"
 
+  session_force_destroy = true
+
   appconfig_application_id  = module.runtime_config_appconfig.application_id
   appconfig_application_arn = module.runtime_config_appconfig.application_arn
   asset_bucket_name         = module.asset_bucket.bucket_name
@@ -209,6 +213,8 @@ module "py_a2a_agent" {
 
 module "ts_a2a_agent_cognito" {
   source = "../../common/terraform/src/app/agents/my-ts-a2a-agent-cognito"
+
+  session_force_destroy = true
 
   appconfig_application_id  = module.runtime_config_appconfig.application_id
   appconfig_application_arn = module.runtime_config_appconfig.application_arn
@@ -222,6 +228,8 @@ module "ts_a2a_agent_cognito" {
 module "py_a2a_agent_cognito" {
   source = "../../common/terraform/src/app/agents/my-py-a2a-agent-cognito"
 
+  session_force_destroy = true
+
   appconfig_application_id  = module.runtime_config_appconfig.application_id
   appconfig_application_arn = module.runtime_config_appconfig.application_arn
   asset_bucket_name         = module.asset_bucket.bucket_name
@@ -234,6 +242,8 @@ module "py_a2a_agent_cognito" {
 module "py_agui_agent" {
   source = "../../common/terraform/src/app/agents/my-py-agui-agent"
 
+  session_force_destroy = true
+
   appconfig_application_id  = module.runtime_config_appconfig.application_id
   appconfig_application_arn = module.runtime_config_appconfig.application_arn
   asset_bucket_name         = module.asset_bucket.bucket_name
@@ -244,6 +254,8 @@ module "py_agui_agent" {
 # agent and the gateway (its full langchain connection surface).
 module "py_langchain_agent" {
   source = "../../common/terraform/src/app/agents/my-py-langchain-agent"
+
+  session_force_destroy = true
 
   appconfig_application_id  = module.runtime_config_appconfig.application_id
   appconfig_application_arn = module.runtime_config_appconfig.application_arn
@@ -261,6 +273,8 @@ module "py_langchain_agent" {
 module "py_langchain_http_agent" {
   source = "../../common/terraform/src/app/agents/my-py-langchain-http-agent"
 
+  session_force_destroy = true
+
   appconfig_application_id  = module.runtime_config_appconfig.application_id
   appconfig_application_arn = module.runtime_config_appconfig.application_arn
   asset_bucket_name         = module.asset_bucket.bucket_name
@@ -270,6 +284,8 @@ module "py_langchain_http_agent" {
 module "py_langchain_a2a_agent" {
   source = "../../common/terraform/src/app/agents/my-py-langchain-a2a-agent"
 
+  session_force_destroy = true
+
   appconfig_application_id  = module.runtime_config_appconfig.application_id
   appconfig_application_arn = module.runtime_config_appconfig.application_arn
   asset_bucket_name         = module.asset_bucket.bucket_name
@@ -278,6 +294,8 @@ module "py_langchain_a2a_agent" {
 
 module "ts_agui_agent" {
   source = "../../common/terraform/src/app/agents/my-ts-agui-agent"
+
+  session_force_destroy = true
 
   appconfig_application_id  = module.runtime_config_appconfig.application_id
   appconfig_application_arn = module.runtime_config_appconfig.application_arn
@@ -584,6 +602,8 @@ locals {
 module "py_agent" {
   source = "../../common/terraform/src/app/agents/my-agent"
 
+  session_force_destroy = true
+
   appconfig_application_id  = module.runtime_config_appconfig.application_id
   appconfig_application_arn = module.runtime_config_appconfig.application_arn
   asset_bucket_name         = module.asset_bucket.bucket_name
@@ -600,6 +620,8 @@ module "py_agent" {
 # TypeScript HTTP agent — calls both MCP servers and both A2A agents.
 module "ts_agent" {
   source = "../../common/terraform/src/app/agents/ts-project-agent"
+
+  session_force_destroy = true
 
   appconfig_application_id  = module.runtime_config_appconfig.application_id
   appconfig_application_arn = module.runtime_config_appconfig.application_arn
@@ -622,6 +644,8 @@ module "ts_agent" {
 module "ts_ecr_agent" {
   source = "../../common/terraform/src/app/agents/my-ts-ecr-agent"
 
+  session_force_destroy = true
+
   appconfig_application_id  = module.runtime_config_appconfig.application_id
   appconfig_application_arn = module.runtime_config_appconfig.application_arn
   asset_ecr_repository_url  = module.asset_ecr.repository_url
@@ -630,6 +654,8 @@ module "ts_ecr_agent" {
 
 module "py_ecr_agent" {
   source = "../../common/terraform/src/app/agents/my-py-ecr-agent"
+
+  session_force_destroy = true
 
   appconfig_application_id  = module.runtime_config_appconfig.application_id
   appconfig_application_arn = module.runtime_config_appconfig.application_arn


### PR DESCRIPTION
### Reason for this change

The `cdk-deploy` and `terraform-deploy` smoke tests never tear down the agent session buckets.

Each agent generated with the default `session=s3` gets a session bucket, and the tests write conversation history into it while invoking the agents. Neither CloudFormation nor Terraform can delete a non-empty bucket, so teardown fails on every run.

Confirmed across 6 consecutive historic `CI` runs on `main` (33715013980, 33710267025, 33700250721, 33619640251, 33609946781, 33601813013) — every one leaks the same 11 buckets in both jobs:

```
The following resource(s) failed to delete: [MyTsAguiAgentSessionBucketC55914A4,
MyPyEcrAgentSessionBucket882D8E05, MyPyA2aAgentSessionBucket4BC532B3,
MyPyLangchainA2aAgentSessionBucket96F6A1F9, MyPyAguiAgentSessionBucket552B3F6F,
MyTsA2aAgentSessionBucket37798441, MyAgentSessionBucket332CA6DE,
MyPyLangchainHttpAgentSessionBucket1D6BF38F, MyTsEcrAgentSessionBucket2477D04C,
MyPyLangchainAgentSessionBucket583E449E, TsProjectAgentSessionBucket94399D4D]
): Resource handler returned message: "The bucket you tried to delete is not empty
(Service: S3, Status Code: 409, ...)"
```

The Application stack is left in `DELETE_FAILED`, so `deleteLeftoverStacks` re-issues the delete — which fails again for the same reason — and the buckets (plus their KMS keys and log groups) accumulate in the integ test account indefinitely.

`terraform-deploy` leaks the identical set:

```
Error: deleting S3 Bucket (my-py-a2a-agent-sessions-97df14d3): ... api error
BucketNotEmpty: The bucket you tried to delete is not empty
```

The existing `IntegrationTestAspect` only sets `RemovalPolicy.DESTROY`, which flips the `DeletionPolicy` but does nothing about bucket contents.

### Description of changes

**CDK (`e2e/src/files/cdk-deploy/main.ts.template`)** — the integration test aspect now also applies the `BucketAutoDeleteObjects` mixin to every `CfnBucket`, which attaches the auto-delete custom resource that empties the bucket before CloudFormation deletes it.

The aspect skips buckets whose owning construct already vends an auto-delete custom resource. Without that guard, buckets constructed with `autoDeleteObjects: true` (the website buckets) fail synth outright:

```
There is already a Construct with name 'AutoDeleteObjectsCustomResource' in Bucket [WebsiteBucket]
```

The guard inspects the owning construct's *direct* children rather than the whole subtree — a subtree scan produces false negatives for L1 `CfnBucket`s declared as siblings of another bucket's custom resource.

**Terraform (`e2e/src/files/terraform-deploy/main.tf.template`)** — the vended agent modules already expose a `session_force_destroy` variable (default `false`); the smoke test wiring now sets it to `true` on all 13 agent modules.

No generator or vended-construct behaviour changes — both files are e2e test fixtures, so the default remains retain-on-destroy for users. Gateway and harness modules were checked and have no buckets.

### Description of how you validated changes

Validated the aspect logic by synthesizing it against the vended `aws-cdk-lib` version (2.267.0), reproducing the deploy test's bucket topology — 11 agent constructs with `RemovalPolicy.RETAIN` KMS-encrypted session buckets, a website bucket with `autoDeleteObjects: true`, and a bare L1 `CfnBucket`:

- 12 buckets → 12 auto-delete custom resources, 1 shared provider Lambda, 0 resources with a non-`Delete` `DeletionPolicy`.
- Verified under both `@aws-cdk/core:aspectStabilization` `true` and `false`.
- Confirmed the pre-guard version fails synth on the duplicate construct id, and that a subtree-based guard skips the L1 bucket.
- Typechecked the template body under `strict` against `aws-cdk-lib@2.267.0`.

Also confirmed `Mixins` and `aws-s3`'s `mixins.BucketAutoDeleteObjects` are both exported by 2.267.0 (the version in `versions.ts`), not just by latest.

`pnpm nx run-many --target build --all` and `pnpm nx run nx-plugin-e2e:lint` pass; lint warning counts are unchanged from `main` (26 warnings / 5 infos, all pre-existing).

**Verified end-to-end against real AWS.** `cdk-deploy` and `terraform-deploy` are not in the PR check matrix (they only run in `CI` on `main`), so I ran both locally against a real account, deploying and tearing down the full matrix:

- `cdk-deploy` — deploy succeeded, every agent was invoked (which is what writes the session objects), then `✅ destroyed` with **0 `BucketNotEmpty` errors and 0 `DELETE_FAILED`**. The stack ended `DELETE_COMPLETE`, versus the 11-bucket `DELETE_FAILED` on every run today.
- `terraform-deploy` — `Apply complete! Resources: 766 added`, agents invoked, then `Destroy complete! Resources: 766 destroyed` with **0 `BucketNotEmpty` errors**. All 13 `aws_s3_bucket.session` resources reported `Destruction complete`, and the plan confirmed `force_destroy = true` on exactly those 13 agent modules.
- Account bucket count returned to its pre-run baseline (34) after both runs, with no leftover session buckets or stacks.

Both runs did hit one unrelated failure during agent invocation — `MCP error -32010: Runtime initialization time exceeded ... 30s`, an AgentCore cold-start timeout in my test environment. That happens after deploy and does not affect teardown: the `finally` block still ran destroy to completion in both cases, which is the path this PR changes.

This branch is rebased onto #1188, which touches the same aspect. The two changes are independent blocks; I re-synthesised the merged aspect over a stack with 13 buckets plus 9 web ACL associations and confirmed both behaviours hold — every bucket gets auto-delete, nothing retained, and the WAF associations remain a single serial chain (exactly one association without an association dependency).

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*