### PR TITLE
test(e2e): serialise web ACL associations in the cdk deploy test

### DIFF
--- a/e2e/src/files/cdk-deploy/main.ts.template
+++ b/e2e/src/files/cdk-deploy/main.ts.template
@@ -1,20 +1,44 @@
 import { ApplicationStage } from './stages/application-stage.js';
 import { App } from '@e2e-test/common-constructs';
-import { Aspects, IAspect, RemovalPolicy } from 'aws-cdk-lib';
+import { Aspects, IAspect, RemovalPolicy, Stack } from 'aws-cdk-lib';
 import { IConstruct } from 'constructs';
 import { CfnResource } from 'aws-cdk-lib';
 import { CfnUserPool, CfnUserPoolDomain } from 'aws-cdk-lib/aws-cognito';
 import { CfnDBCluster } from 'aws-cdk-lib/aws-rds';
 import { CfnTable } from 'aws-cdk-lib/aws-dynamodb';
+import { CfnWebACLAssociation } from 'aws-cdk-lib/aws-wafv2';
 
 /**
  * Aspect to augment resources for integration tests
  */
 class IntegrationTestAspect implements IAspect {
+  /** Last web ACL association visited in each stack, to chain the next one to. */
+  private readonly lastWebAclAssociation = new Map<
+    string,
+    CfnWebACLAssociation
+  >();
+
   public visit(node: IConstruct): void {
     // Ensure no resources are retained for a complete teardown
     if (node instanceof CfnResource) {
       node.applyRemovalPolicy(RemovalPolicy.DESTROY);
+    }
+
+    // AssociateWebACL is capped at one call every 2 seconds per account per
+    // region, and the cap cannot be raised. This stack scaffolds every API
+    // generator at once, so CloudFormation creates their associations in
+    // parallel and the burst exhausts the quota. Chain them so they are created
+    // one at a time.
+    //
+    // Test-only: a generated workspace vends far fewer associations, and
+    // serialising them would slow down every real deployment.
+    if (node instanceof CfnWebACLAssociation) {
+      const stackName = Stack.of(node).stackName;
+      const previous = this.lastWebAclAssociation.get(stackName);
+      if (previous) {
+        node.addResourceDependency(previous);
+      }
+      this.lastWebAclAssociation.set(stackName, node);
     }
 
     // Disable deletion protection on Cognito User Pools


### PR DESCRIPTION
### Reason for this change

`Smoke Tests - cdk-deploy` has been failing on main and is blocking the `v1.0.0-rc.95` release, since the Release job requires a green run. I retried it five times:

| Attempt | Failure |
|---|---|
| 1 | WAF `ThrottlingException` on `WebACLAssociation` |
| 2 | AgentCore runtime init >30s (deploy itself succeeded) |
| 3 | WAF `Rate exceeded` |
| 4 | WAF `ThrottlingException` |
| 5 | WAF `Rate exceeded` |

**4 of 5 failed on WAF rate limits**, so this is systematic rather than flaky.

The [AWS WAF quotas page](https://docs.aws.amazon.com/waf/latest/developerguide/limits.html) gives the hard number:

> | Maximum number of calls to `AssociateWebACL` | One request every 2 seconds |
>
> "AWS WAF has the following **fixed quotas** on calls per account per Region. These quotas apply to the total calls to the service through any available means, including the console, CLI, **AWS CloudFormation**, the REST API, and the SDKs. **These quotas can't be changed.**"

Two things follow: the ceiling is **0.5 calls/second**, and a Service Quotas increase is *not* an option for this API — it's fixed, and stricter than the generic "one per second" that applies to other `Create`/`Put`/`Update` actions.

The test stack scaffolds every API generator at once, producing **nine `CfnWebACLAssociation` resources** (`UserIdentity`, `AgentGateway`, `MyApiCustom`, `MyGateway`, `ParentGateway`, `PyApiCustom`, `MySmithyApi`, `PyApi`, `MyApi`) with no interdependencies. CloudFormation express mode — used by the generated `deploy` target since #1172 — schedules independent resources in parallel, so they burst. Creation-initiation timestamps from attempt 5:

```
8:41:51  UserIdentity
8:41:55  AgentGateway
8:42:19  MyApiCustom
8:42:30  MyGateway
8:42:51  ParentGateway
8:43:25  PyApiCustom
8:44:50  MySmithyApi   ┐
8:44:50  PyApi         ├─ 3 associations in ~1 second
8:44:51  MyApi         ┘
```

Counting every WAF association event in the 8:44:48–8:44:52 window gives **11 events in 5 seconds** against a budget of 2–3 — roughly **5x over quota**. CDK burns all six of its internal retries inside that window (`SDK Attempt Count: 6`) and still gives up, so the result is a hard `CREATE_FAILED` rather than a slow success. Nine associations at 0.5/s need **≥18 seconds** of serialised wall clock, so every run rolls the same dice; retrying cannot fix it.

Worth noting this was not caused by express mode landing: three main runs after #1172 passed `cdk-deploy`, so the parallelism only makes an already-tight burst unlucky rather than newly broken.

### Description of changes

Chains each `CfnWebACLAssociation` in a stack to the previously visited one, via the existing `IntegrationTestAspect` in `e2e/src/files/cdk-deploy/main.ts.template`, so CloudFormation creates them one at a time. Costs roughly 18s of deploy time on this stack.

**Deliberately test-only, not in the vended constructs.** A generated workspace vends far fewer associations than this stack's nine, and serialising them would slow every user's deployment for a limit they're unlikely to reach. The aspect is the same seam #1187 uses for its bucket auto-delete fix.

Scoped to the CDK template only — `terraform-deploy` deploys the same generators but has been consistently green (Terraform's default parallelism is lower), so there's no evidence it needs the same treatment.

### Description of how you validated changes

Synthesised the aspect over a stage containing associations across **two** stacks (4 and 2), to confirm the chain is per-stack and doesn't accidentally create cross-stack dependencies, which would fail synth:

```
--- stg-StackA
   MyApi        DependsOn= null
   PyApi        DependsOn= ["MyApi"]
   MyGateway    DependsOn= ["PyApi"]
   UserIdentity DependsOn= ["MyGateway"]
--- stg-StackB
   OtherApi     DependsOn= null
   OtherGw      DependsOn= ["OtherApi"]
```

Each stack gets an independent chain, the first association in each is unconstrained, and there are no cross-stack references. Uses `addResourceDependency` rather than the deprecated `addDependency` (confirmed: no deprecation warnings on synth).

> [!IMPORTANT]
> **CI on this PR does not exercise this change.** The deploy lanes (`cdk-deploy`, `cdk-deploy-rdb`, `terraform-deploy`, `terraform-deploy-rdb`) live only in `ci.yml`, which runs on push to `main`; `pr.yml` excludes them. So a green PR here is not evidence the fix works, and deploy coverage only happens on merge.

Validating by running the real deploy smoke test against an AWS account from a local build, and tearing down afterwards — results added below when it completes.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*