### PR TITLE
ci: add a deps conventional commit type that releases a patch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -359,7 +359,7 @@ jobs:
         run: echo "latest_commit=$(git ls-remote origin -h ${{ github.ref }} | cut -f1)" >> $GITHUB_OUTPUT
       - name: Should skip release
         id: should_skip_release
-        run: echo "skip_release=$(git log $(git describe --tags --abbrev=0)..HEAD --oneline | grep -qE 'feat\(?.*\)?:|fix\(?.*\)?:|revert\(?.*\)?:|perf\(?.*\)?:' && echo false || echo true)" >> $GITHUB_OUTPUT
+        run: echo "skip_release=$(git log $(git describe --tags --abbrev=0)..HEAD --oneline | grep -qE 'feat\(?.*\)?:|fix\(?.*\)?:|revert\(?.*\)?:|perf\(?.*\)?:|deps\(?.*\)?:' && echo false || echo true)" >> $GITHUB_OUTPUT
       # Version, stamp migrations, tag + changelog, then publish (with retry on a
       # transient failure). The whole flow lives in scripts/release.ts.
       - name: Release

--- a/.github/workflows/update-versions.yml
+++ b/.github/workflows/update-versions.yml
@@ -63,10 +63,10 @@ jobs:
         with:
           token: ${{ secrets.UPDATE_VERSIONS_GITHUB_TOKEN }}
           commit-message: |
-            feat: update dependencies
+            deps: update dependencies
 
             ${{ steps.report.outputs.content }}
-          title: 'feat: update dependencies'
+          title: 'deps: update dependencies'
           body: |
             ## Dependency Updates
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,6 @@ Before raising a PR, validate changed generators in an example workspace using l
 
 - Always ensure the build passes before raising a PR.
 - Update snapshots if there are failures due to snapshot changes.
-- Use conventional commits, referencing the generator you are working on, eg "feat(ts#project): my commit message".
+- Use conventional commits, referencing the generator you are working on, eg "feat(ts#project): my commit message". Use the `deps` type for bumping dependency versions vended to users — see [Commit Messages](./CONTRIBUTING.md#commit-messages) for the type-to-release-bump mapping.
 - Raise PRs following the PR template.
 - After pushing to a PR, monitor the checks and iterate on any failures until all are green.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,7 @@ The type also chooses the release: `nx release` derives the semver bump from the
 | `fix`                                        | patch | 🩹 Fixes               |
 | `deps`                                       | patch | 📦 Dependencies        |
 | `perf`                                       | patch | 🔥 Performance         |
-| `revert`                                     | patch | hidden                |
+| `revert`                                     | patch | ⏪ Revert              |
 | `docs`, `test`, `chore`, `refactor`, `ci`, … | none  | hidden                |
 
 Use `deps` for bumping the dependency versions vended to users — a version bump ships in a patch, not a minor. This is the type the weekly `update-versions` PR uses.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ To send us a pull request, please:
 1. (Optional) Update snapshots if required `pnpm nx run @aws/nx-plugin:test -u`
 1. Ensure local tests pass (run a full build with `pnpm nx run-many --target build --all`).
 1. Update and run any integration tests relevant to your changes.
-1. Commit to your fork using clear commit messages ([see section below](#end-to-end-tests))
+1. Commit to your fork using clear commit messages ([see section below](#commit-messages))
 1. Send us a pull request, answering any default questions in the pull request interface.
 1. Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
 
@@ -42,6 +42,24 @@ GitHub provides additional document on [forking a repository](https://help.githu
 [creating a pull request](https://help.github.com/articles/creating-a-pull-request/).
 
 For a detailed guide on contributing a generator, check out the [Contributing a Generator tutorial here](https://awslabs.github.io/nx-plugin-for-aws/get_started/tutorials/contribute-generator).
+
+### Commit Messages
+
+Commits follow [conventional commits](https://www.conventionalcommits.org/), enforced by commitlint on `commit-msg`. Scope a commit to the generator it touches, eg `feat(ts#project): my commit message`.
+
+The type also chooses the release: `nx release` derives the semver bump from the commits since the last tag, taking the highest bump across them.
+
+| Type                                         | Bump  | In release notes |
+| -------------------------------------------- | ----- | ---------------- |
+| `feat`                                       | minor | yes              |
+| `fix`                                        | patch | yes              |
+| `deps`                                       | patch | yes              |
+| `perf`, `revert`                             | patch | no               |
+| `docs`, `test`, `chore`, `refactor`, `ci`, … | none  | no               |
+
+Use `deps` for bumping the dependency versions vended to users — a version bump ships in a patch, not a minor. This is the type the weekly `update-versions` PR uses.
+
+Any type plus `!` (or a `BREAKING CHANGE:` footer) forces a major, so a breaking upgrade of something we vend still needs `deps!:`.
 
 ### Generator Idempotency
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,6 +60,8 @@ The type also chooses the release: `nx release` derives the semver bump from the
 
 Use `deps` for bumping the dependency versions vended to users — a version bump ships in a patch, not a minor. This is the type the weekly `update-versions` PR uses.
 
+Don't confuse it with `chore(deps):`, which is `chore` with a `deps` scope and releases nothing. That's for this repo's own tooling (the dependabot PRs bumping our devDependencies and GitHub Actions). The rule is what the bump reaches: `deps:` when it changes what a user's workspace gets, `chore(deps):` when it only changes how we build.
+
 Any type plus `!` (or a `BREAKING CHANGE:` footer) forces a major, so a breaking upgrade of something we vend still needs `deps!:`.
 
 ### Generator Idempotency

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,13 +49,14 @@ Commits follow [conventional commits](https://www.conventionalcommits.org/), enf
 
 The type also chooses the release: `nx release` derives the semver bump from the commits since the last tag, taking the highest bump across them.
 
-| Type                                         | Bump  | In release notes |
-| -------------------------------------------- | ----- | ---------------- |
-| `feat`                                       | minor | yes              |
-| `fix`                                        | patch | yes              |
-| `deps`                                       | patch | yes              |
-| `perf`, `revert`                             | patch | no               |
-| `docs`, `test`, `chore`, `refactor`, `ci`, … | none  | no               |
+| Type                                         | Bump  | Release notes section |
+| -------------------------------------------- | ----- | --------------------- |
+| `feat`                                       | minor | 🚀 Features            |
+| `fix`                                        | patch | 🩹 Fixes               |
+| `deps`                                       | patch | 📦 Dependencies        |
+| `perf`                                       | patch | 🔥 Performance         |
+| `revert`                                     | patch | hidden                |
+| `docs`, `test`, `chore`, `refactor`, `ci`, … | none  | hidden                |
 
 Use `deps` for bumping the dependency versions vended to users — a version bump ships in a patch, not a minor. This is the type the weekly `update-versions` PR uses.
 

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -2,4 +2,17 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-module.exports = { extends: ['@commitlint/config-conventional'] };
+const conventional = require('@commitlint/config-conventional');
+
+const [, , conventionalTypes] = (conventional.default ?? conventional).rules[
+  'type-enum'
+];
+
+module.exports = {
+  extends: ['@commitlint/config-conventional'],
+  rules: {
+    // `deps` releases a patch for dependency versions vended to users — see the
+    // conventionalCommits types in nx.json.
+    'type-enum': [2, 'always', [...conventionalTypes, 'deps']],
+  },
+};

--- a/nx.json
+++ b/nx.json
@@ -111,7 +111,11 @@
       "useCommitScope": false,
       "types": {
         "perf": { "semverBump": "patch" },
-        "revert": { "semverBump": "patch" }
+        "revert": { "semverBump": "patch" },
+        "deps": {
+          "semverBump": "patch",
+          "changelog": { "title": "📦 Dependencies", "hidden": false }
+        }
       }
     }
   }


### PR DESCRIPTION
### Reason for this change

Dependency versions vended to users are bumped by the weekly `update-versions` PR, which commits under `feat`. `feat` maps to a minor bump, so every weekly dependency refresh inflates the minor version even though nothing new was added to the public surface. A version bump of something we vend is a patch.

Plain `chore(deps):` would not work here: `nx.json` only maps `feat`, `fix`, `perf` and `revert` to a bump, so a `chore` dependency commit would produce no release at all.

### Description of changes

Registers a dedicated `deps` conventional commit type mapped to `semverBump: patch`:

- **`nx.json`** — adds `deps` to `release.conventionalCommits.types` with `semverBump: patch` and its own `📦 Dependencies` changelog section (`hidden: false`, so it reaches the GitHub release notes — the only changelog published, since `workspaceChangelog.file` is `false`).
- **`commitlint.config.js`** — extends `type-enum` with `deps`, derived from `@commitlint/config-conventional`'s own list rather than hardcoded, so the type passes the `commit-msg` hook.
- **`.github/workflows/update-versions.yml`** — the weekly PR now commits and titles as `deps: update dependencies`.
- **`.github/workflows/ci.yml`** — adds `deps` to the `should_skip_release` grep, otherwise a release containing only dependency commits would be skipped as having no releasable changes.
- **`CONTRIBUTING.md`** — new `Commit Messages` section documenting the type-to-bump mapping, including that `!`/`BREAKING CHANGE:` still forces a major (so a breaking upgrade of something we vend needs `deps!:`). Also fixes the existing "see section below" link, which pointed at `#end-to-end-tests` — a section that does not document commit messages.
- **`CLAUDE.md`** — points contributors at the new section.

`deps` was chosen over reusing `fix` so routine version bumps do not get filed under 🩹 Fixes, which would obscure genuine bug fixes in the release notes.

### Description of how you validated changes

Validated the release behaviour end to end against a local Verdaccio registry, using a synthetic stable base tag (`v9.9.9`) so the conventional-commits derivation is observable — the `rc` release train would otherwise mask it.

**Version derivation across every type** (`nx release version`, against a synthetic `v9.9.9` base tag). Run identically on this branch and on `main` so the `main` column proves no existing type changed:

| Commit | main | this branch |
| --- | --- | --- |
| `feat: …` | minor → 9.10.0 | minor → 9.10.0 |
| `fix: …` | patch → 9.9.10 | patch → 9.9.10 |
| `perf: …` | patch → 9.9.10 | patch → 9.9.10 |
| `revert: …` | patch → 9.9.10 | patch → 9.9.10 |
| `deps: …` | 🚫 no release | **patch → 9.9.10** |
| `deps(ts#project): …` | 🚫 no release | **patch → 9.9.10** |
| `docs:` / `chore:` / `test:` / `refactor:` / `ci:` / `style:` / `build:` | 🚫 no release | 🚫 no release |
| `chore(deps): …` (dependabot) | 🚫 no release | 🚫 no release |
| `feat!:` / `fix!:` / `chore!:` / `deps!:` | major → 10.0.0 | major → 10.0.0 |

Mixed-commit precedence (highest bump wins) also verified: `deps:`+`feat:` → minor, `deps:`+`fix:` → patch, `deps:`+`docs:` → patch, `deps:`+`feat!:` → major, `docs:`+`chore:` → no release.

The `main` column is the control: `deps:` is the only row that changes, and it changes from "no release at all" to a patch. Note this also shows plain `chore(deps):` would have been the wrong choice — it releases nothing.

**Changelog with every type in one release** — each lands in its own section, and the existing sections are unaffected:

```
### 🚀 Features / ### 🩹 Fixes / ### 🔥 Performance / ### ⏪ Revert / ### 📦 Dependencies
```

**Changelog rendering** — the dry-run GitHub release renders the new section:

```
## 9.9.10 (2026-09-03)

### 📦 Dependencies

- update dependencies (d2d0676)
```

**Real publishes to Verdaccio** — ran the actual `scripts/release.ts` sequence (version dist manifests → stamp migrations → `nx release publish`) twice: once for a `deps:`-only release, and once for a realistic mixed `fix:` + `deps:` release to confirm the publish path is unaffected for ordinary releases. Both published all three packages at `9.9.10`; installed `@aws/nx-plugin@9.9.10` back out of the registry each time and confirmed the installed version, that all 73 generators are exposed, and that `migrations.json` carries the shipping version on its `everyMigration` sync entry.

**Commitlint** — verified through the real `commit-msg` hook (this PR's own commit is a `deps:` commit and passed it), plus direct checks: `deps:`, `deps(scope):` and `deps!:` accepted; `bogus:` and a message with no type still rejected.

**CI skip-release gate** — verified the updated grep matches `deps:` and `deps(scope):` while still skipping `docs`/`chore`/`test`.

**Interaction with the current `rc` train** — on the `rc` train that `scripts/release.ts` runs today, `nx` overrides the derived specifier with `prerelease` (`Resolved the specifier as "prerelease" since the current version is a prerelease`), so `deps:` cuts `1.0.0-rc.96` exactly as `feat:` does. This change is therefore behaviour-neutral for rc releases and takes effect on the version numbering once `RELEASE_TRAIN` flips to `'stable'`. The changelog section, commitlint type and skip-release gate all apply immediately.

Also ran `pnpm lint` (clean) and `pnpm nx run @aws/nx-plugin:test` (241 files, 4261 tests passing).

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*