### PR TITLE
test(e2e): stop the e2e vitest config silently dropping its pool settings

### DIFF
--- a/e2e/vite.config.mts
+++ b/e2e/vite.config.mts
@@ -2,7 +2,8 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import { defineConfig, transformWithEsbuild } from 'vite';
+import { transformWithEsbuild } from 'vite';
+import { defineConfig } from 'vitest/config';
 import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
 import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin';
 import * as fs from 'fs';
@@ -75,12 +76,10 @@ export default defineConfig({
     globalSetup: 'src/global-setup.ts',
     coverage: { reportsDirectory: '../coverage/e2e', provider: 'v8' },
     pool: 'threads',
-    poolOptions: {
-      threads: {
-        isolate: true,
-        singleThread: true,
-      },
-    },
+    isolate: true,
+    // One worker: each test already spawns an nx build that saturates the
+    // machine, and parallelism comes from sharding across machines.
+    maxWorkers: 1,
     testTimeout: 120 * 60 * 1000, /// 120 mins for long running e2e tests (eg deploy)
     hookTimeout: 2 * 60 * 1000, /// 2 mins — corepack activation + rmSync on Windows can be slow
   },

--- a/e2e/vite.config.mts
+++ b/e2e/vite.config.mts
@@ -77,9 +77,6 @@ export default defineConfig({
     coverage: { reportsDirectory: '../coverage/e2e', provider: 'v8' },
     pool: 'threads',
     isolate: true,
-    // One worker: each test already spawns an nx build that saturates the
-    // machine, and parallelism comes from sharding across machines.
-    maxWorkers: 1,
     testTimeout: 120 * 60 * 1000, /// 120 mins for long running e2e tests (eg deploy)
     hookTimeout: 2 * 60 * 1000, /// 2 mins — corepack activation + rmSync on Windows can be slow
   },

--- a/packages/create-nx-workspace/vite.config.mts
+++ b/packages/create-nx-workspace/vite.config.mts
@@ -2,8 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-/// <reference types='vitest' />
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   root: __dirname,

--- a/packages/nx-plugin/tsconfig.spec.json
+++ b/packages/nx-plugin/tsconfig.spec.json
@@ -13,7 +13,9 @@
   },
   "include": [
     "vite.config.ts",
+    "vite.config.mts",
     "vitest.config.ts",
+    "vitest.config.mts",
     "src/**/*.test.ts",
     "src/**/*.spec.ts",
     "src/**/*.test.tsx",

--- a/packages/nx-plugin/vite.config.mts
+++ b/packages/nx-plugin/vite.config.mts
@@ -2,8 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-/// <reference types='vitest' />
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 
 import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
 import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin';


### PR DESCRIPTION
### Reason for this change

Two problems, one hiding the other.

**The visible symptom** — all three `vite.config.mts` files fail to typecheck:

```
e2e/vite.config.mts(62,3): error TS2769: No overload matches this call.
  Object literal may only specify known properties, and 'test' does not exist in type 'UserConfigExport'.
```

They import `defineConfig` from `vite` and pass a `test` key, but `test` belongs to vitest's config type — vite's `UserConfig` never declared it. vite 8 + vitest 4 stopped tolerating it.

**The real bug, which that error was hiding.** Fixing the import surfaces a second error:

```
Object literal may only specify known properties, and 'poolOptions' does not exist in type 'InlineConfig'
```

**vitest 4 removed `poolOptions`**, so this block in `e2e/vite.config.mts` has been dead config:

```ts
pool: 'threads',
poolOptions: { threads: { isolate: true, singleThread: true } },   // ← silently ignored
```

The e2e suite has been running with vitest's default worker count while the config asked for one thread. `fileParallelism: false` masked it — that serialises across files, so the loss of `singleThread` never showed up as an obvious failure. tsc stopped at the first error and never reached the second.

Worth noting `/// <reference types='vitest' />` does **not** fix this, despite appearing in two of the three configs. It loads vitest's globals, not the config type — `packages/create-nx-workspace/vite.config.mts` has the directive and still errors.

### Are generated workspaces affected?

**No.** I built a workspace and checked rather than reasoning from the templates.

`@nx/vite` / `@nx/vitest` emit the **factory** form, and that's what saves them:

```ts
export default defineConfig(() => ({ root: ..., test: { ... } }));
```

The factory overload infers its return type rather than checking an object literal against `UserConfig`, so excess-property checking never runs on `test`. Our three configs all use the **object-literal** form, which is checked. That is the entire difference — isolated with a minimal probe in both repos:

| Form | Import | Result |
|---|---|---|
| `defineConfig({ test })` | `vite` | **TS2769** |
| `defineConfig(() => ({ test }))` | `vite` | clean |
| `defineConfig({ test })` | `vitest/config` | clean |

Verified against a real workspace (`ts#project` + `ts#react-website`, nx 23.2.0, vite 8.2.2, vitest 4.1.11 — same versions as here):

- `packages/mylib/vitest.config.mts` imports from `vitest/config` — clean
- `packages/web/vite.config.mts` imports from `vite` but uses the factory form — clean, `tsc -p packages/web/tsconfig.spec.json` passes
- **neither vends `poolOptions`** — `grep` across the whole repo confirms the only occurrence is `e2e/vite.config.mts`

So this is repo-only; no migration is needed and no user-facing behaviour changes.

### Description of changes

- **`defineConfig` now comes from `vitest/config`** in all three configs (it re-exports vite's and adds `test`). Dropped the two now-redundant `/// <reference types='vitest' />` directives.
- **`poolOptions` dropped** from `e2e/vite.config.mts`, keeping `isolate: true` (vitest 4 promoted `isolate` to top level; it also restates the default).

  I first translated `singleThread: true` literally to `maxWorkers: 1`. **That was wrong and CI caught it** — see the timing comparison below. Because vitest 4 ignores `poolOptions`, one worker was never the behaviour in effect, so translating it literally would have *imposed* a restriction for the first time rather than restoring one. `fileParallelism: false` already provides the serialisation the suite actually needs.
- **`vite.config.mts` added to `packages/nx-plugin/tsconfig.spec.json`'s `include`**, which listed only `vite.config.ts` — so that config was never typechecked at all, which is why only two of the three errors were visible.

### Description of how you validated changes

Typecheck is clean on all three, including `nx-plugin`'s now that it's actually included:

```
=== e2e ===                        no vite.config errors
=== packages/create-nx-workspace === no vite.config errors
=== packages/nx-plugin ===          no vite.config errors
```

Tests still pass with the corrected pool settings:

- `@aws/nx-plugin-e2e:smoke-test --name=release` — 1 passed, 25.48s (unchanged from before)
- `@aws/create-nx-workspace:test` — 32 passed
- `@aws/nx-plugin:test --shard=1/10` — 380 passed across 25 files

Confirmed causally that the import is what matters, using the probe table above — the object-literal form errors under `vite` and is clean under `vitest/config`, while the factory form is clean either way.

#### Timing comparison vs an equivalent recent PR

Compared per-lane durations against #1189 (also an e2e-only change, same runners). With `maxWorkers: 1`:

| Lane | Before | With maxWorkers:1 | |
|---|---|---|---|
| smithy-api | 254s | 722s | **x2.84** |
| mcp-server | 167s | 473s (timed out) | **x2.83** |
| nx-plugin | 218s | 480s | x2.20 |
| git-secrets | 158s | 332s | x2.10 |
| react-website | 464s | 757s | x1.63 |
| **release** | **127s** | **125s** | **x0.98** |

Two controls rule out a slower machine: the `release` lane — the only one with a single test case in its file — was unchanged, and the **Unit Tests** lanes, whose config this PR doesn't touch, were unchanged or faster over the same window. mcp-server's *in-test* time specifically went 53s → 370s.

That is the signature of losing in-file overlap. `runCLI` uses `spawn` rather than a blocking call precisely so cases within a file progress concurrently, so a single worker forces every multi-case lane to run its cases end to end. `mcp-server` (2 cases) and `smithy-api` regressed hardest; the single-case `release` lane didn't move.

With the pin removed, worker behaviour matches what has been running under vitest 4 all along, so no lane should regress.

Note the spec typechecks aren't wired into any CI target (nothing runs `tsc -p tsconfig.spec.json`), which is why this drifted unnoticed. Wiring that up is a larger change and out of scope here, but worth considering separately — it's the reason dead vitest config could sit in the repo across a major upgrade.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*