### PR TITLE
test(e2e): skip the npm audit that stalls every smoke test install

### DIFF
--- a/e2e/src/global-setup.ts
+++ b/e2e/src/global-setup.ts
@@ -47,6 +47,12 @@ export default async function () {
     // applies to anything installing from the public registry.
     process.env.PNPM_CONFIG_MINIMUM_RELEASE_AGE = '0';
 
+    // Skip the registry audit on every install these tests run. The advisory
+    // endpoint stalls for minutes at a time, and the smoke tests install
+    // throwaway workspaces whose dependencies the `audit` lane already covers.
+    process.env.npm_config_audit = 'false';
+    process.env.npm_config_fund = 'false';
+
     // On shared Windows runners the verdaccio storage outlives the process
     // and `clearStorage: true` below doesn't fully reset it, so publishes
     // on the next run hit "409 Conflict: already present". Wipe first.

--- a/e2e/vite.config.mts
+++ b/e2e/vite.config.mts
@@ -82,6 +82,10 @@ export default defineConfig({
       },
     },
     testTimeout: 120 * 60 * 1000, /// 120 mins for long running e2e tests (eg deploy)
-    hookTimeout: 2 * 60 * 1000, /// 2 mins — corepack activation + rmSync on Windows can be slow
+    // Several suites create a workspace in `beforeAll`, which installs from the
+    // network and retries a failed create. The timeout has to exceed the whole
+    // retry budget, otherwise a single slow install kills the suite before the
+    // retry that would have recovered it.
+    hookTimeout: 30 * 60 * 1000,
   },
 });


### PR DESCRIPTION
### Reason for this change

The `license-check` and `mcp-server` lanes have failed on every PR run since ~23:44 UTC on 2026-09-03. Both fail on a timeout shorter than the stall, while every other lane just gets slower.

**This is not a code regression.** A docs-only push (one line of `CONTRIBUTING.md`, `49c78cba` → `6acfc809`) flipped a PR from green to red, and lanes with generous timeouts show the same slowdown:

| Lane | Before | After |
|---|---|---|
| create-workspace | 5min | 28min |
| trpc-api | 7min | 12min |

**The cause is npm's advisory endpoint.** `POST /-/npm/v1/security/advisories/bulk` on `registry.npmjs.org` hangs on roughly half of all requests and takes 1–20s on the rest, reproduced outside CI entirely:

```
advisories probe 1: 000 30.0s   (timed out)
advisories probe 2: 200 12.9s
advisories probe 3: 200 11.0s
advisories probe 4: 000 30.0s   (timed out)
advisories probe 5: 200 19.8s
advisories probe 6: 200  1.1s
advisories probe 7: 000 30.0s   (timed out)
advisories probe 8: 000 30.0s   (timed out)
```

Packument and tarball fetches stay healthy at ~70ms, so this is specific to the audit endpoint. `npm install --timing` attributes the entire cost to it — `auditReport:getReport Completed in 25324ms` out of a 26s install. Cold `npx create-nx-workspace` runs measured 2s, 64s and 344s.

**Why only these two lanes fail** — everything else has `testTimeout: 120 * 60 * 1000` and absorbs the stalls as slowdown:

- `license-check` creates its workspace in `beforeAll` and dies with `Hook timed out in 120000ms`, never reaching the 3-attempt retry in `createTestWorkspace` that would have recovered it.
- `mcp-server` launches `npx -y @aws/nx-plugin-mcp` through `StdioClientTransport`, and the MCP SDK's default request timeout is 60s: `McpError: MCP error -32001: Request timed out` after `60073ms`. Its second test passes because the package is already installed in the workspace, so nothing is fetched.

### Description of changes

- **`global-setup.ts` sets `npm_config_audit=false` and `npm_config_fund=false`**, alongside the existing `PNPM_CONFIG_MINIMUM_RELEASE_AGE` line, so every spawned command inherits them. Measured effect on an install: 26s → 414ms, with the `auditReport` phase gone entirely.

  These are throwaway test workspaces. The dependencies the plugin actually ships are covered by the `audit` lane, which uses **Trivy** rather than `npm audit` and so is unaffected by this change.

- **`hookTimeout` raised from 2 minutes to 30 minutes** so it exceeds the full retry budget of a workspace create. Four suites create a workspace in `beforeAll` (`license-check`, `nx-plugin`, `test-matrix`, `local-dev`), and the 2-minute timeout made those retries unreachable — a single slow install failed the shard rather than being retried. Worth fixing independently of this incident.

### Description of how you validated changes

Both affected lanes run green locally against the built packages:

- `license-check` — **6/6 tests passing** (previously: suite died in `beforeAll`)
- `mcp-server` — **2/2 tests passing**; the first test went from failing at `60073ms` to passing in `5641ms`

Isolated the audit as the cause with a controlled A/B on a cold cache, using `--timing`:

```
without npm_config_audit  →  auditReport:getReport Completed in 25324ms   (install: 26s)
with    npm_config_audit  →  no auditReport phase                        (install: 414ms)
```

Also confirmed `audit.spec.ts` shells out to `trivy fs`, so the security scan that matters keeps its coverage.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
