### PR TITLE
test(e2e): pin the pnpm 12 smoke test to 12.3.1

### DIFF
--- a/e2e/src/smoke-tests/corepack.ts
+++ b/e2e/src/smoke-tests/corepack.ts
@@ -9,12 +9,12 @@ import { join } from 'node:path';
 
 const PATH_SEP = process.platform === 'win32' ? ';' : ':';
 
-// Corepack resolves `pm@<major>` against the registry on activation, so
-// passing a major (rather than a pinned version) means the smoke test
-// always runs against the current latest release of that line.
+// Corepack resolves the spec against the registry on activation, so passing a
+// major runs the smoke test against the current latest release of that line.
+// Pass an exact version to pin a lane to a known-good release.
 export const activatePackageManagerViaCorepack = (
   packageManager: 'pnpm' | 'yarn',
-  majorVersion: number,
+  version: number | string,
   envOverrides: Record<string, string> = {},
 ): (() => void) => {
   const originalPath = process.env.PATH ?? '';
@@ -24,13 +24,13 @@ export const activatePackageManagerViaCorepack = (
   const shimDir = join(
     tmpdir(),
     'nx-plugin-for-aws',
-    `corepack-${packageManager}-${majorVersion}-bin`,
+    `corepack-${packageManager}-${version}-bin`,
   );
   mkdirSync(shimDir, { recursive: true });
   execSync(`corepack enable --install-directory "${shimDir}"`, {
     stdio: 'inherit',
   });
-  execSync(`corepack prepare ${packageManager}@${majorVersion} --activate`, {
+  execSync(`corepack prepare ${packageManager}@${version} --activate`, {
     stdio: 'inherit',
   });
   process.env.PATH = `${shimDir}${PATH_SEP}${originalPath}`;

--- a/e2e/src/smoke-tests/pnpm-12.spec.ts
+++ b/e2e/src/smoke-tests/pnpm-12.spec.ts
@@ -6,7 +6,9 @@
 import { activatePackageManagerViaCorepack } from './corepack';
 import { smokeTest } from './smoke-test';
 
+// Pinned rather than tracking the 12 line: 12.3.2 shipped without a
+// `@pnpm/exe.linux-x64` build, so corepack 404s activating it on Linux.
 smokeTest('pnpm', {
   variant: 'pnpm-12',
-  setup: () => activatePackageManagerViaCorepack('pnpm', 12),
+  setup: () => activatePackageManagerViaCorepack('pnpm', '12.3.1'),
 });


### PR DESCRIPTION
### Reason for this change

The `pnpm-12` smoke test fails on Linux while activating the package manager:

```
Downloading the pnpm 12.3.2 binary for linux-x64...
Could not download the pnpm 12.3.2 binary: Could not download
https://registry.npmjs.org/@pnpm/exe.linux-x64/12.3.2: 404 Not Found
```

**pnpm 12.3.2 is a partial publish.** The version exists on the registry and two of its three platform builds resolve, but the Linux one is missing:

| Package | 12.3.1 | 12.3.2 |
|---|---|---|
| `@pnpm/exe.linux-x64` | 200 | **404** |
| `@pnpm/exe.darwin-arm64` | 200 | 200 |
| `@pnpm/exe.win32-x64` | 200 | 200 |

That is why only the Linux lane breaks. Upstream has since deprecated the release — `npm` reports the reason as *"broken due dependency being under npm automated validation"*.

Note that `latest-12` still points at `12.3.1`, so the dist-tag was never moved. Corepack resolves `pnpm@12` to the highest published version rather than the dist-tag, so it picks up the broken release regardless.

### Description of changes

- **`pnpm-12.spec.ts` pins the lane to `12.3.1`**, whose exe packages all resolve.
- **`activatePackageManagerViaCorepack` accepts a major or an exact version** (`number | string`). All other lanes keep passing a major and continue tracking the latest release of their line, unchanged.

This pin is worth revisiting once a working 12.3.x lands upstream, so the lane resumes tracking the 12 line.

### Description of how you validated changes

- `corepack prepare pnpm@12.3.1 --activate` succeeds where `pnpm@12.3.2` 404s.
- Ran the lane locally with the pin. Corepack activates cleanly and every install in the run reports the pinned version:

  ```
  Preparing pnpm@12.3.1 for immediate activation...
  Downloading the pnpm 12.3.1 binary for linux-x64...
  Done in 17s using pnpm v12.3.1
  ```

- Confirmed the repo's own `packageManager` is `pnpm@11.25.0`, so it was never exposed to the broken release.
- Typechecked the e2e project before and after: 22 pre-existing errors in both, none in the changed files.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
