### PR TITLE
test(ts#project): assert every nx.json plugin is declared

### DIFF
--- a/e2e/src/smoke-tests/standalone.spec.ts
+++ b/e2e/src/smoke-tests/standalone.spec.ts
@@ -7,7 +7,12 @@ import { join } from 'node:path';
 import { ensureDirSync } from 'fs-extra';
 import { describe, it } from 'vitest';
 import type { ConnectionKey } from '../../../packages/nx-plugin/src/connection/supported-connections';
-import { createTestWorkspace, runCLI, tmpProjPath } from '../utils';
+import {
+  assertNxPluginsAreDeclared,
+  createTestWorkspace,
+  runCLI,
+  tmpProjPath,
+} from '../utils';
 
 /**
  * Verifies every generator builds in isolation, catching a generator that
@@ -168,6 +173,7 @@ const freshWorkspace = async (generator: string): Promise<string> => {
 
 const syncAndBuild = async (cwd: string) => {
   const opts = { cwd, env: { NX_DAEMON: 'false' } };
+  assertNxPluginsAreDeclared(cwd);
   await runCLI(`sync --verbose`, opts);
   await runCLI(
     `run-many --target build --all --output-style=stream --verbose`,

--- a/e2e/src/utils.ts
+++ b/e2e/src/utils.ts
@@ -410,6 +410,52 @@ export const assertWorkspaceUsesPackageManager = (
   }
 };
 
+/** The package a plugin entry in `nx.json` resolves to, e.g. `@nx/js/typescript` -> `@nx/js`. */
+const pluginPackageName = (plugin: string): string => {
+  const parts = plugin.split('/');
+  return plugin.startsWith('@') ? parts.slice(0, 2).join('/') : parts[0];
+};
+
+/**
+ * Assert every plugin registered in `nx.json` is declared in a package.json.
+ *
+ * A plugin is loaded by Nx itself, not imported by any source file, so nothing
+ * else catches an undeclared one: lint only sees imports, and Nx resolves
+ * plugins from its own directory, where a package manager may have placed the
+ * package as a transitive of another dependency. That makes the workspace build
+ * fine here while failing for a user whose install lays node_modules out
+ * differently.
+ */
+export const assertNxPluginsAreDeclared = (workspaceDir: string) => {
+  const readJson = (path: string) =>
+    existsSync(path) ? JSON.parse(readFileSync(path, 'utf-8')) : undefined;
+
+  const nxJson = readJson(join(workspaceDir, 'nx.json')) ?? {};
+  const rootPkg = readJson(join(workspaceDir, 'package.json')) ?? {};
+  const declared = new Set([
+    ...Object.keys(rootPkg.dependencies ?? {}),
+    ...Object.keys(rootPkg.devDependencies ?? {}),
+  ]);
+
+  const undeclared = (nxJson.plugins ?? [])
+    .map((entry: string | { plugin: string }) =>
+      typeof entry === 'string' ? entry : entry.plugin,
+    )
+    .map(pluginPackageName)
+    // Plugins the plugin itself provides are resolved from the workspace source.
+    .filter((name: string) => name !== '@aws/nx-plugin')
+    .filter((name: string) => !declared.has(name));
+
+  if (undeclared.length > 0) {
+    throw new Error(
+      `Plugins registered in nx.json but not declared in the root package.json: ${[
+        ...new Set<string>(undeclared),
+      ].join(', ')} — Nx may resolve them transitively here, but a user's ` +
+        `install can lay node_modules out so they are missing. Declare them in the generator.`,
+    );
+  }
+};
+
 // The ts#dynamodb generator already adds electrodb and @aws-sdk/client-dynamodb.
 // The Game API's actions.query procedure additionally needs the S3 client to
 // read the agent's conversation history.

--- a/packages/nx-plugin/src/utils/nx-plugin-declarations.spec.ts
+++ b/packages/nx-plugin/src/utils/nx-plugin-declarations.spec.ts
@@ -1,0 +1,80 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { readJson, readNxJson, type Tree } from '@nx/devkit';
+import { pyProjectGenerator } from '../sdk/py';
+import { tsProjectGenerator } from '../sdk/ts';
+import { declaredNames } from './declared-dependencies.js';
+import { INIT_DEPENDENCIES } from './init.js';
+import { createTreeUsingTsSolutionSetup } from './test.js';
+
+/**
+ * The package a plugin entry in `nx.json` resolves to, e.g. `@nx/js/typescript`
+ * resolves to `@nx/js`.
+ */
+const pluginPackageName = (plugin: string): string => {
+  const parts = plugin.split('/');
+  return plugin.startsWith('@') ? parts.slice(0, 2).join('/') : parts[0];
+};
+
+/** The plugin packages a workspace's `nx.json` registers. */
+const registeredPlugins = (tree: Tree): string[] => [
+  ...new Set(
+    (readNxJson(tree)?.plugins ?? [])
+      .map((entry) => (typeof entry === 'string' ? entry : entry.plugin))
+      .map(pluginPackageName),
+  ),
+];
+
+/**
+ * The plugins registered in `nx.json` that no manifest declares.
+ *
+ * `init` runs on every real workspace, so what it declares counts as declared
+ * here even though these tests run the project generators on their own.
+ */
+const undeclaredPlugins = (tree: Tree): string[] => {
+  const pkg = readJson(tree, 'package.json');
+  const declared = new Set<string>([
+    ...Object.keys(pkg.dependencies ?? {}),
+    ...Object.keys(pkg.devDependencies ?? {}),
+    ...declaredNames<string>([...INIT_DEPENDENCIES]),
+  ]);
+  return registeredPlugins(tree).filter((name) => !declared.has(name));
+};
+
+/**
+ * Nx loads a plugin named in `nx.json` itself, so nothing else in the repo
+ * catches one that no manifest declares. Lint only sees what source files
+ * import, and Nx resolves plugins from its own directory — where a package
+ * manager may have placed the package as a transitive of something else the
+ * workspace depends on. That masks a missing declaration everywhere it would
+ * otherwise surface: the workspace builds and the smoke tests pass, leaving
+ * only a user whose install lays node_modules out differently to hit
+ * `Plugin listed in nx.json not found`.
+ *
+ * Comparing the two files directly is immune to that, since it resolves nothing.
+ */
+describe('nx plugin declarations', () => {
+  it('should declare the plugins ts#project registers', async () => {
+    const tree = createTreeUsingTsSolutionSetup();
+    await tsProjectGenerator(tree, {
+      name: 'test-lib',
+      preferInstallDependencies: false,
+    });
+
+    expect(undeclaredPlugins(tree)).toEqual([]);
+  });
+
+  it('should declare the plugins py#project registers', async () => {
+    const tree = createTreeUsingTsSolutionSetup();
+    await pyProjectGenerator(tree, {
+      name: 'test_py',
+      moduleName: 'test_py',
+      preferInstallDependencies: false,
+    });
+
+    expect(undeclaredPlugins(tree)).toEqual([]);
+  });
+});


### PR DESCRIPTION
### Reason for this change

An Nx plugin registered in `nx.json` is loaded by Nx itself, not imported by any source file, so a plugin the workspace never declares as a dependency escapes every check we have today:

- **Lint** (`noUndeclaredDependencies`) only sees packages that source code imports, so it never looks at `nx.json`.
- **The smoke tests build the workspace successfully**, because Nx resolves plugins from its own directory. With pnpm that directory is under `node_modules/.pnpm`, where a plugin can be present as a transitive of another dependency — `@nx/vite` depends on `@nx/vitest`, for instance — and satisfy Nx even though nothing declares it.

The result is a gap that stays green through all of CI and only surfaces for a user whose install lays `node_modules` out differently, as:

```
Plugin listed in `nx.json` not found: @nx/vitest
 NX   Failed to load 1 Nx plugin(s):
  - @nx/vitest: Cannot find module '@nx/vitest'
```

This was hit for real while upgrading to Nx 23.2 (#1182): Nx 23.2 stopped having `@nx/js` install `@nx/vitest`, so the generated workspace registered a plugin it no longer declared. Every one of the 69 checks passed.

### Description of changes

Rather than try to defeat the resolution masking (no install mode reliably exposes it — `hoist=false` and an empty `hoistPattern` both still leave the transitive copy on Nx's resolution path), the invariant is asserted by comparing `nx.json` against the manifests directly. That resolves nothing, so no `node_modules` layout can hide a miss.

- `packages/nx-plugin/src/utils/nx-plugin-declarations.spec.ts` — a unit test that runs the project generators and asserts every plugin in the generated `nx.json` is declared. Cheap and always run. Plugin subpaths are mapped to their package (`@nx/js/typescript` → `@nx/js`), and what `init` declares counts as declared, since `init` runs on every real workspace.
- `assertNxPluginsAreDeclared` in `e2e/src/utils.ts`, called from `syncAndBuild` in the standalone smoke tests, so the same invariant holds for the workspaces the e2e suite actually generates.

### Description of how you validated changes

Verified the guard catches the exact regression rather than merely passing:

- On the Nx 23.2 branch with `{ name: '@nx/vitest' }` removed from `VITEST_DEPENDENCIES` — the state that got through CI — the test fails with `expected [ '@nx/vitest' ] to deeply equal []`.
- With the declaration restored, it passes.
- On `main` it passes (Nx 23.1's `@nx/js` seeds `@nx/vitest`, so there is no gap to find).

Also confirmed the root cause directly in a minimal workspace: with `@nx/vitest` in `nx.json` but absent from `package.json`, Nx fails immediately; adding `@nx/vite` (which depends on it) makes Nx resolve it from `node_modules/.pnpm` and the failure disappears.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
