### PR TITLE
fix(agentcore-gateway): expose a non-optional gatewayUrl accessor and correct the DCR proxy guide

### DIFF
--- a/docs/src/content/docs/en/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/en/guides/agentcore-gateway.mdx
@@ -179,9 +179,7 @@ Refer to the [AWS documentation on AgentCore Gateway policies](https://docs.aws.
 
 ### Adding a policy
 
-To add a policy, create a new `.cedar` file alongside `permit-all.cedar`. Each `.cedar` file in `policies/` must contain exactly **one** `permit` or `forbid` statement and is deployed as a single `AWS::BedrockAgentCore::Policy` resource. Files containing multiple statements produce `unexpected token 'forbid'` errors at deploy time — split them into separate files.
-
-Policy names must be unique account-wide, so the deployed name is never the filename alone: CDK derives it from the construct path, and Terraform PascalCases the filename (`permit-all.cedar` → `PermitAll`) then appends the gateway's random suffix. The policy's **description** is what identifies its source file — `Policy loaded from permit-all.cedar` — so match on that when inspecting deployed policies.
+To add a policy, create a new `.cedar` file alongside `permit-all.cedar`. Each `.cedar` file in `policies/` must contain exactly **one** `permit` or `forbid` statement and is deployed as a single `AWS::BedrockAgentCore::Policy` resource. The policy resource's name is derived from the filename: `permit-all.cedar` becomes `PermitAll` (kebab/snake-case is converted to PascalCase). Files containing multiple statements produce `unexpected token 'forbid'` errors at deploy time — split them into separate files.
 
 For example, to permit only a specific agent role to invoke a particular tool, create:
 
@@ -334,7 +332,7 @@ The generated infrastructure creates policies with `IGNORE_ALL_FINDINGS`: AgentC
 
 One ordering constraint still applies: a policy referencing `AgentCore::Action::"<target>___<tool>"` only validates once the target has registered that tool with the Gateway, which is why the generated infrastructure creates policies after Gateway targets.
 
-If a policy fails to deploy, CloudFormation surfaces the rejection as an opaque `Resource stabilization failed` error — run `aws bedrock-agentcore-control list-policies --policy-engine-id <id>` to retrieve the validator's `statusReasons`, which contain the actual reason. Identify the offending policy by its `description` (`Policy loaded from <file>.cedar`) rather than its suffixed `name`.
+If a policy fails to deploy, CloudFormation surfaces the rejection as an opaque `Resource stabilization failed` error — run `aws bedrock-agentcore-control list-policies --policy-engine-id <id>` to retrieve the validator's `statusReasons`, which contain the actual reason.
 
 ### Example: forbid one tool while keeping a broader permit
 

--- a/docs/src/content/docs/en/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/en/guides/agentcore-gateway.mdx
@@ -133,7 +133,7 @@ The generated infrastructure consumes an existing Cognito user pool and client �
 The generated construct requires an `identity` prop supplying the user pool and client:
 
 ```ts {7,9-11} title="packages/infra/src/stacks/application-stack.ts"
-import { MyGateway, UserIdentity } from ':my-scope/common-constructs';
+import { MyGateway, UserIdentity } from '@my-scope/common-constructs';
 
 export class ApplicationStack extends Stack {
   constructor(scope: Construct, id: string, props?: StackProps) {
@@ -179,7 +179,9 @@ Refer to the [AWS documentation on AgentCore Gateway policies](https://docs.aws.
 
 ### Adding a policy
 
-To add a policy, create a new `.cedar` file alongside `permit-all.cedar`. Each `.cedar` file in `policies/` must contain exactly **one** `permit` or `forbid` statement and is deployed as a single `AWS::BedrockAgentCore::Policy` resource. The policy resource's name is derived from the filename: `permit-all.cedar` becomes `PermitAll` (kebab/snake-case is converted to PascalCase). Files containing multiple statements produce `unexpected token 'forbid'` errors at deploy time — split them into separate files.
+To add a policy, create a new `.cedar` file alongside `permit-all.cedar`. Each `.cedar` file in `policies/` must contain exactly **one** `permit` or `forbid` statement and is deployed as a single `AWS::BedrockAgentCore::Policy` resource. Files containing multiple statements produce `unexpected token 'forbid'` errors at deploy time — split them into separate files.
+
+Policy names must be unique account-wide, so the deployed name is never the filename alone: CDK derives it from the construct path, and Terraform PascalCases the filename (`permit-all.cedar` → `PermitAll`) then appends the gateway's random suffix. The policy's **description** is what identifies its source file — `Policy loaded from permit-all.cedar` — so match on that when inspecting deployed policies.
 
 For example, to permit only a specific agent role to invoke a particular tool, create:
 
@@ -332,7 +334,7 @@ The generated infrastructure creates policies with `IGNORE_ALL_FINDINGS`: AgentC
 
 One ordering constraint still applies: a policy referencing `AgentCore::Action::"<target>___<tool>"` only validates once the target has registered that tool with the Gateway, which is why the generated infrastructure creates policies after Gateway targets.
 
-If a policy fails to deploy, CloudFormation surfaces the rejection as an opaque `Resource stabilization failed` error — run `aws bedrock-agentcore-control list-policies --policy-engine-id <id>` to retrieve the validator's `statusReasons`, which contain the actual reason.
+If a policy fails to deploy, CloudFormation surfaces the rejection as an opaque `Resource stabilization failed` error — run `aws bedrock-agentcore-control list-policies --policy-engine-id <id>` to retrieve the validator's `statusReasons`, which contain the actual reason. Identify the offending policy by its `description` (`Policy loaded from <file>.cedar`) rather than its suffixed `name`.
 
 ### Example: forbid one tool while keeping a broader permit
 

--- a/docs/src/content/docs/en/guides/ts-dcr-proxy.mdx
+++ b/docs/src/content/docs/en/guides/ts-dcr-proxy.mdx
@@ -103,7 +103,7 @@ You provide:
 Instantiate the generated construct in your stack, passing the required properties:
 
 ```typescript
-import { DcrProxy } from ':my-scope/common-constructs';
+import { DcrProxy } from '@my-scope/common-constructs';
 
 new DcrProxy(this, 'DcrProxy', {
   userPoolId: userPool.userPoolId,
@@ -155,8 +155,9 @@ import {
   DcrProxy,
   MyProjectMcpServer,
   UserIdentity,
-} from ':my-scope/common-constructs';
+} from '@my-scope/common-constructs';
 import { OAuthScope } from 'aws-cdk-lib/aws-cognito';
+import * as kms from 'aws-cdk-lib/aws-kms';
 import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager';
 
 const identity = new UserIdentity(this, 'Identity');
@@ -179,6 +180,9 @@ const proxyClient = identity.userPool.addClient('DcrProxyClient', {
 // Store the App Client secret in Secrets Manager for the token handler to read
 const clientSecret = new secretsmanager.Secret(this, 'ClientSecret', {
   secretStringValue: proxyClient.userPoolClientSecret,
+  encryptionKey: new kms.Key(this, 'ClientSecretKey', {
+    enableKeyRotation: true,
+  }),
 });
 
 // The MCP server, authorizing JWTs issued for the same App Client
@@ -267,8 +271,9 @@ import {
   DcrProxy,
   MyGateway,
   UserIdentity,
-} from ':my-scope/common-constructs';
+} from '@my-scope/common-constructs';
 import { OAuthScope } from 'aws-cdk-lib/aws-cognito';
+import * as kms from 'aws-cdk-lib/aws-kms';
 import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager';
 
 const identity = new UserIdentity(this, 'Identity');
@@ -291,6 +296,9 @@ const proxyClient = identity.userPool.addClient('DcrProxyClient', {
 // Store the App Client secret in Secrets Manager for the token handler to read
 const clientSecret = new secretsmanager.Secret(this, 'ClientSecret', {
   secretStringValue: proxyClient.userPoolClientSecret,
+  encryptionKey: new kms.Key(this, 'ClientSecretKey', {
+    enableKeyRotation: true,
+  }),
 });
 
 // The gateway, authorizing JWTs issued for the same App Client
@@ -307,7 +315,7 @@ new DcrProxy(this, 'DcrProxy', {
   cognitoClientSecretArn: clientSecret.secretArn,
   cognitoHostedUiBase: identity.userPoolDomain.baseUrl(),
   // Use the gateway construct's URL rather than hardcoding it
-  upstreamUrl: gateway.gateway.gatewayUrl,
+  upstreamUrl: gateway.gatewayUrl,
 });
 ```
 </Fragment>
@@ -341,7 +349,7 @@ resource "aws_secretsmanager_secret_version" "client_secret" {
 
 # The gateway, authorizing JWTs issued for the same App Client
 module "my_gateway" {
-  source = "../../common/terraform/src/app/agentcore-gateway/my-gateway"
+  source = "../../common/terraform/src/app/gateways/my-gateway"
 
   user_pool_id         = module.user_identity.user_pool_id
   user_pool_client_ids = [aws_cognito_user_pool_client.dcr_proxy.id]
@@ -466,8 +474,9 @@ import {
   DcrProxy,
   MyProjectMcpServer,
   UserIdentity,
-} from ':my-scope/common-constructs';
+} from '@my-scope/common-constructs';
 import { OAuthScope, CfnManagedLoginBranding } from 'aws-cdk-lib/aws-cognito';
+import * as kms from 'aws-cdk-lib/aws-kms';
 import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager';
 
 // The user pool created by ts#website#auth for your website users
@@ -492,6 +501,9 @@ new CfnManagedLoginBranding(this, 'DcrProxyClientBranding', {
 
 const clientSecret = new secretsmanager.Secret(this, 'ClientSecret', {
   secretStringValue: proxyClient.userPoolClientSecret,
+  encryptionKey: new kms.Key(this, 'ClientSecretKey', {
+    enableKeyRotation: true,
+  }),
 });
 
 const mcpServer = new MyProjectMcpServer(this, 'MyProjectMcpServer', {

--- a/docs/src/content/docs/en/guides/ts-rdb.mdx
+++ b/docs/src/content/docs/en/guides/ts-rdb.mdx
@@ -264,7 +264,7 @@ module "api" {
   source = "..."
   ...
 
-  environment_variables = {
+  env = {
     NODE_EXTRA_CA_CERTS = "/var/runtime/ca-cert.pem"
   }
 }

--- a/docs/src/content/docs/en/snippets/connection/strands-agent-rdb-ssl-requirements.mdx
+++ b/docs/src/content/docs/en/snippets/connection/strands-agent-rdb-ssl-requirements.mdx
@@ -23,7 +23,7 @@ new MyAgent(this, 'MyAgent', {
 ```hcl title="packages/infra/src/main.tf"
 module "my_agent" {
   ...
-  environment_variables = {
+  env = {
     NODE_EXTRA_CA_CERTS = "/usr/local/share/ca-certificates/rds-bundle.crt"
   }
 }

--- a/docs/src/content/docs/en/snippets/connection/ts-lambda-rdb-ssl-requirements.mdx
+++ b/docs/src/content/docs/en/snippets/connection/ts-lambda-rdb-ssl-requirements.mdx
@@ -28,7 +28,7 @@ module "api" {
   source = "..."
   ...
 
-  environment_variables = {
+  env = {
     NODE_EXTRA_CA_CERTS = "/var/runtime/ca-cert.pem"
   }
 }

--- a/docs/src/content/docs/en/snippets/connection/ts-mcp-server-rdb-ssl-requirements.mdx
+++ b/docs/src/content/docs/en/snippets/connection/ts-mcp-server-rdb-ssl-requirements.mdx
@@ -23,7 +23,7 @@ new MyMcpServer(this, 'MyMcpServer', {
 ```hcl title="packages/infra/src/main.tf"
 module "my_mcp_server" {
   ...
-  environment_variables = {
+  env = {
     NODE_EXTRA_CA_CERTS = "/usr/local/share/ca-certificates/rds-bundle.crt"
   }
 }

--- a/docs/src/content/docs/es/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/es/guides/agentcore-gateway.mdx
@@ -179,9 +179,7 @@ Consulta la [documentación de AWS sobre políticas de AgentCore Gateway](https:
 
 ### Agregar una política
 
-Para agregar una política, crea un nuevo archivo `.cedar` junto a `permit-all.cedar`. Cada archivo `.cedar` en `policies/` debe contener exactamente **una** declaración `permit` o `forbid` y se despliega como un único recurso `AWS::BedrockAgentCore::Policy`. Los archivos que contienen múltiples declaraciones producen errores `unexpected token 'forbid'` en tiempo de despliegue — divídelos en archivos separados.
-
-Los nombres de políticas deben ser únicos en toda la cuenta, por lo que el nombre desplegado nunca es solo el nombre del archivo: CDK lo deriva de la ruta del constructo, y Terraform convierte el nombre del archivo a PascalCase (`permit-all.cedar` → `PermitAll`) y luego agrega el sufijo aleatorio del gateway. La **descripción** de la política es lo que identifica su archivo fuente — `Policy loaded from permit-all.cedar` — así que coincide con eso al inspeccionar políticas desplegadas.
+Para agregar una política, crea un nuevo archivo `.cedar` junto a `permit-all.cedar`. Cada archivo `.cedar` en `policies/` debe contener exactamente **una** declaración `permit` o `forbid` y se despliega como un único recurso `AWS::BedrockAgentCore::Policy`. El nombre del recurso de política se deriva del nombre del archivo: `permit-all.cedar` se convierte en `PermitAll` (kebab/snake-case se convierte a PascalCase). Los archivos que contienen múltiples declaraciones producen errores `unexpected token 'forbid'` en tiempo de despliegue — divídelos en archivos separados.
 
 Por ejemplo, para permitir solo que un rol de agente específico invoque una herramienta particular, crea:
 
@@ -334,7 +332,7 @@ La infraestructura generada crea políticas con `IGNORE_ALL_FINDINGS`: el analiz
 
 Todavía se aplica una restricción de orden: una política que hace referencia a `AgentCore::Action::"<target>___<tool>"` solo se valida una vez que el destino ha registrado esa herramienta con el Gateway, por lo que la infraestructura generada crea políticas después de los destinos del Gateway.
 
-Si una política no se despliega, CloudFormation muestra el rechazo como un error opaco `Resource stabilization failed` — ejecuta `aws bedrock-agentcore-control list-policies --policy-engine-id <id>` para recuperar los `statusReasons` del validador, que contienen la razón real. Identifica la política problemática por su `description` (`Policy loaded from <file>.cedar`) en lugar de por su `name` con sufijo.
+Si una política no se despliega, CloudFormation muestra el rechazo como un error opaco `Resource stabilization failed` — ejecuta `aws bedrock-agentcore-control list-policies --policy-engine-id <id>` para recuperar los `statusReasons` del validador, que contienen la razón real.
 
 ### Ejemplo: prohibir una herramienta mientras se mantiene un permiso más amplio
 

--- a/docs/src/content/docs/es/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/es/guides/agentcore-gateway.mdx
@@ -133,7 +133,7 @@ La infraestructura generada consume un grupo de usuarios y cliente de Cognito ex
 El constructo generado requiere una prop `identity` que proporcione el grupo de usuarios y el cliente:
 
 ```ts {7,9-11} title="packages/infra/src/stacks/application-stack.ts"
-import { MyGateway, UserIdentity } from ':my-scope/common-constructs';
+import { MyGateway, UserIdentity } from '@my-scope/common-constructs';
 
 export class ApplicationStack extends Stack {
   constructor(scope: Construct, id: string, props?: StackProps) {
@@ -179,7 +179,9 @@ Consulta la [documentación de AWS sobre políticas de AgentCore Gateway](https:
 
 ### Agregar una política
 
-Para agregar una política, crea un nuevo archivo `.cedar` junto a `permit-all.cedar`. Cada archivo `.cedar` en `policies/` debe contener exactamente **una** declaración `permit` o `forbid` y se despliega como un único recurso `AWS::BedrockAgentCore::Policy`. El nombre del recurso de política se deriva del nombre del archivo: `permit-all.cedar` se convierte en `PermitAll` (kebab/snake-case se convierte a PascalCase). Los archivos que contienen múltiples declaraciones producen errores `unexpected token 'forbid'` en tiempo de despliegue — divídelos en archivos separados.
+Para agregar una política, crea un nuevo archivo `.cedar` junto a `permit-all.cedar`. Cada archivo `.cedar` en `policies/` debe contener exactamente **una** declaración `permit` o `forbid` y se despliega como un único recurso `AWS::BedrockAgentCore::Policy`. Los archivos que contienen múltiples declaraciones producen errores `unexpected token 'forbid'` en tiempo de despliegue — divídelos en archivos separados.
+
+Los nombres de políticas deben ser únicos en toda la cuenta, por lo que el nombre desplegado nunca es solo el nombre del archivo: CDK lo deriva de la ruta del constructo, y Terraform convierte el nombre del archivo a PascalCase (`permit-all.cedar` → `PermitAll`) y luego agrega el sufijo aleatorio del gateway. La **descripción** de la política es lo que identifica su archivo fuente — `Policy loaded from permit-all.cedar` — así que coincide con eso al inspeccionar políticas desplegadas.
 
 Por ejemplo, para permitir solo que un rol de agente específico invoque una herramienta particular, crea:
 
@@ -332,7 +334,7 @@ La infraestructura generada crea políticas con `IGNORE_ALL_FINDINGS`: el analiz
 
 Todavía se aplica una restricción de orden: una política que hace referencia a `AgentCore::Action::"<target>___<tool>"` solo se valida una vez que el destino ha registrado esa herramienta con el Gateway, por lo que la infraestructura generada crea políticas después de los destinos del Gateway.
 
-Si una política no se despliega, CloudFormation muestra el rechazo como un error opaco `Resource stabilization failed` — ejecuta `aws bedrock-agentcore-control list-policies --policy-engine-id <id>` para recuperar los `statusReasons` del validador, que contienen la razón real.
+Si una política no se despliega, CloudFormation muestra el rechazo como un error opaco `Resource stabilization failed` — ejecuta `aws bedrock-agentcore-control list-policies --policy-engine-id <id>` para recuperar los `statusReasons` del validador, que contienen la razón real. Identifica la política problemática por su `description` (`Policy loaded from <file>.cedar`) en lugar de por su `name` con sufijo.
 
 ### Ejemplo: prohibir una herramienta mientras se mantiene un permiso más amplio
 

--- a/docs/src/content/docs/es/guides/ts-dcr-proxy.mdx
+++ b/docs/src/content/docs/es/guides/ts-dcr-proxy.mdx
@@ -103,7 +103,7 @@ Proporcionas:
 Instancia el constructo generado en tu stack, pasando las propiedades requeridas:
 
 ```typescript
-import { DcrProxy } from ':my-scope/common-constructs';
+import { DcrProxy } from '@my-scope/common-constructs';
 
 new DcrProxy(this, 'DcrProxy', {
   userPoolId: userPool.userPoolId,
@@ -155,8 +155,9 @@ import {
   DcrProxy,
   MyProjectMcpServer,
   UserIdentity,
-} from ':my-scope/common-constructs';
+} from '@my-scope/common-constructs';
 import { OAuthScope } from 'aws-cdk-lib/aws-cognito';
+import * as kms from 'aws-cdk-lib/aws-kms';
 import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager';
 
 const identity = new UserIdentity(this, 'Identity');
@@ -179,6 +180,9 @@ const proxyClient = identity.userPool.addClient('DcrProxyClient', {
 // Store the App Client secret in Secrets Manager for the token handler to read
 const clientSecret = new secretsmanager.Secret(this, 'ClientSecret', {
   secretStringValue: proxyClient.userPoolClientSecret,
+  encryptionKey: new kms.Key(this, 'ClientSecretKey', {
+    enableKeyRotation: true,
+  }),
 });
 
 // The MCP server, authorizing JWTs issued for the same App Client
@@ -267,8 +271,9 @@ import {
   DcrProxy,
   MyGateway,
   UserIdentity,
-} from ':my-scope/common-constructs';
+} from '@my-scope/common-constructs';
 import { OAuthScope } from 'aws-cdk-lib/aws-cognito';
+import * as kms from 'aws-cdk-lib/aws-kms';
 import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager';
 
 const identity = new UserIdentity(this, 'Identity');
@@ -291,6 +296,9 @@ const proxyClient = identity.userPool.addClient('DcrProxyClient', {
 // Store the App Client secret in Secrets Manager for the token handler to read
 const clientSecret = new secretsmanager.Secret(this, 'ClientSecret', {
   secretStringValue: proxyClient.userPoolClientSecret,
+  encryptionKey: new kms.Key(this, 'ClientSecretKey', {
+    enableKeyRotation: true,
+  }),
 });
 
 // The gateway, authorizing JWTs issued for the same App Client
@@ -307,7 +315,7 @@ new DcrProxy(this, 'DcrProxy', {
   cognitoClientSecretArn: clientSecret.secretArn,
   cognitoHostedUiBase: identity.userPoolDomain.baseUrl(),
   // Use the gateway construct's URL rather than hardcoding it
-  upstreamUrl: gateway.gateway.gatewayUrl,
+  upstreamUrl: gateway.gatewayUrl,
 });
 ```
 </Fragment>
@@ -341,7 +349,7 @@ resource "aws_secretsmanager_secret_version" "client_secret" {
 
 # The gateway, authorizing JWTs issued for the same App Client
 module "my_gateway" {
-  source = "../../common/terraform/src/app/agentcore-gateway/my-gateway"
+  source = "../../common/terraform/src/app/gateways/my-gateway"
 
   user_pool_id         = module.user_identity.user_pool_id
   user_pool_client_ids = [aws_cognito_user_pool_client.dcr_proxy.id]
@@ -466,8 +474,9 @@ import {
   DcrProxy,
   MyProjectMcpServer,
   UserIdentity,
-} from ':my-scope/common-constructs';
+} from '@my-scope/common-constructs';
 import { OAuthScope, CfnManagedLoginBranding } from 'aws-cdk-lib/aws-cognito';
+import * as kms from 'aws-cdk-lib/aws-kms';
 import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager';
 
 // The user pool created by ts#website#auth for your website users
@@ -492,6 +501,9 @@ new CfnManagedLoginBranding(this, 'DcrProxyClientBranding', {
 
 const clientSecret = new secretsmanager.Secret(this, 'ClientSecret', {
   secretStringValue: proxyClient.userPoolClientSecret,
+  encryptionKey: new kms.Key(this, 'ClientSecretKey', {
+    enableKeyRotation: true,
+  }),
 });
 
 const mcpServer = new MyProjectMcpServer(this, 'MyProjectMcpServer', {

--- a/docs/src/content/docs/es/guides/ts-rdb.mdx
+++ b/docs/src/content/docs/es/guides/ts-rdb.mdx
@@ -264,7 +264,7 @@ module "api" {
   source = "..."
   ...
 
-  environment_variables = {
+  env = {
     NODE_EXTRA_CA_CERTS = "/var/runtime/ca-cert.pem"
   }
 }

--- a/docs/src/content/docs/es/snippets/connection/strands-agent-rdb-ssl-requirements.mdx
+++ b/docs/src/content/docs/es/snippets/connection/strands-agent-rdb-ssl-requirements.mdx
@@ -23,7 +23,7 @@ new MyAgent(this, 'MyAgent', {
 ```hcl title="packages/infra/src/main.tf"
 module "my_agent" {
   ...
-  environment_variables = {
+  env = {
     NODE_EXTRA_CA_CERTS = "/usr/local/share/ca-certificates/rds-bundle.crt"
   }
 }

--- a/docs/src/content/docs/es/snippets/connection/ts-lambda-rdb-ssl-requirements.mdx
+++ b/docs/src/content/docs/es/snippets/connection/ts-lambda-rdb-ssl-requirements.mdx
@@ -28,7 +28,7 @@ module "api" {
   source = "..."
   ...
 
-  environment_variables = {
+  env = {
     NODE_EXTRA_CA_CERTS = "/var/runtime/ca-cert.pem"
   }
 }

--- a/docs/src/content/docs/es/snippets/connection/ts-mcp-server-rdb-ssl-requirements.mdx
+++ b/docs/src/content/docs/es/snippets/connection/ts-mcp-server-rdb-ssl-requirements.mdx
@@ -23,7 +23,7 @@ new MyMcpServer(this, 'MyMcpServer', {
 ```hcl title="packages/infra/src/main.tf"
 module "my_mcp_server" {
   ...
-  environment_variables = {
+  env = {
     NODE_EXTRA_CA_CERTS = "/usr/local/share/ca-certificates/rds-bundle.crt"
   }
 }

--- a/docs/src/content/docs/fr/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/fr/guides/agentcore-gateway.mdx
@@ -133,7 +133,7 @@ L'infrastructure générée consomme un pool d'utilisateurs Cognito et un client
 Le construct généré nécessite une prop `identity` fournissant le pool d'utilisateurs et le client :
 
 ```ts {7,9-11} title="packages/infra/src/stacks/application-stack.ts"
-import { MyGateway, UserIdentity } from ':my-scope/common-constructs';
+import { MyGateway, UserIdentity } from '@my-scope/common-constructs';
 
 export class ApplicationStack extends Stack {
   constructor(scope: Construct, id: string, props?: StackProps) {
@@ -179,7 +179,9 @@ Consultez la [documentation AWS sur les politiques AgentCore Gateway](https://do
 
 ### Ajouter une politique
 
-Pour ajouter une politique, créez un nouveau fichier `.cedar` à côté de `permit-all.cedar`. Chaque fichier `.cedar` dans `policies/` doit contenir exactement **une** instruction `permit` ou `forbid` et est déployé en tant que ressource `AWS::BedrockAgentCore::Policy` unique. Le nom de la ressource de politique est dérivé du nom de fichier : `permit-all.cedar` devient `PermitAll` (kebab/snake-case est converti en PascalCase). Les fichiers contenant plusieurs instructions produisent des erreurs `unexpected token 'forbid'` au moment du déploiement — divisez-les en fichiers séparés.
+Pour ajouter une politique, créez un nouveau fichier `.cedar` à côté de `permit-all.cedar`. Chaque fichier `.cedar` dans `policies/` doit contenir exactement **une** instruction `permit` ou `forbid` et est déployé en tant que ressource `AWS::BedrockAgentCore::Policy` unique. Les fichiers contenant plusieurs instructions produisent des erreurs `unexpected token 'forbid'` au moment du déploiement — divisez-les en fichiers séparés.
+
+Les noms de politique doivent être uniques à l'échelle du compte, donc le nom déployé n'est jamais le nom de fichier seul : CDK le dérive du chemin du construct, et Terraform convertit le nom de fichier en PascalCase (`permit-all.cedar` → `PermitAll`) puis ajoute le suffixe aléatoire du gateway. La **description** de la politique est ce qui identifie son fichier source — `Policy loaded from permit-all.cedar` — donc faites correspondre cela lors de l'inspection des politiques déployées.
 
 Par exemple, pour autoriser uniquement un rôle d'agent spécifique à invoquer un outil particulier, créez :
 
@@ -332,7 +334,7 @@ L'infrastructure générée crée des politiques avec `IGNORE_ALL_FINDINGS` : l'
 
 Une contrainte d'ordre s'applique toujours : une politique référençant `AgentCore::Action::"<target>___<tool>"` ne valide qu'une fois que la cible a enregistré cet outil avec le Gateway, c'est pourquoi l'infrastructure générée crée des politiques après les cibles Gateway.
 
-Si une politique échoue au déploiement, CloudFormation affiche le rejet comme une erreur opaque `Resource stabilization failed` — exécutez `aws bedrock-agentcore-control list-policies --policy-engine-id <id>` pour récupérer les `statusReasons` du validateur, qui contiennent la raison réelle.
+Si une politique échoue au déploiement, CloudFormation affiche le rejet comme une erreur opaque `Resource stabilization failed` — exécutez `aws bedrock-agentcore-control list-policies --policy-engine-id <id>` pour récupérer les `statusReasons` du validateur, qui contiennent la raison réelle. Identifiez la politique fautive par sa `description` (`Policy loaded from <file>.cedar`) plutôt que par son `name` suffixé.
 
 ### Exemple : interdire un outil tout en conservant un permit plus large
 

--- a/docs/src/content/docs/fr/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/fr/guides/agentcore-gateway.mdx
@@ -179,9 +179,7 @@ Consultez la [documentation AWS sur les politiques AgentCore Gateway](https://do
 
 ### Ajouter une politique
 
-Pour ajouter une politique, créez un nouveau fichier `.cedar` à côté de `permit-all.cedar`. Chaque fichier `.cedar` dans `policies/` doit contenir exactement **une** instruction `permit` ou `forbid` et est déployé en tant que ressource `AWS::BedrockAgentCore::Policy` unique. Les fichiers contenant plusieurs instructions produisent des erreurs `unexpected token 'forbid'` au moment du déploiement — divisez-les en fichiers séparés.
-
-Les noms de politique doivent être uniques à l'échelle du compte, donc le nom déployé n'est jamais le nom de fichier seul : CDK le dérive du chemin du construct, et Terraform convertit le nom de fichier en PascalCase (`permit-all.cedar` → `PermitAll`) puis ajoute le suffixe aléatoire du gateway. La **description** de la politique est ce qui identifie son fichier source — `Policy loaded from permit-all.cedar` — donc faites correspondre cela lors de l'inspection des politiques déployées.
+Pour ajouter une politique, créez un nouveau fichier `.cedar` à côté de `permit-all.cedar`. Chaque fichier `.cedar` dans `policies/` doit contenir exactement **une** instruction `permit` ou `forbid` et est déployé en tant que ressource `AWS::BedrockAgentCore::Policy` unique. Le nom de la ressource de politique est dérivé du nom de fichier : `permit-all.cedar` devient `PermitAll` (kebab/snake-case est converti en PascalCase). Les fichiers contenant plusieurs instructions produisent des erreurs `unexpected token 'forbid'` au moment du déploiement — divisez-les en fichiers séparés.
 
 Par exemple, pour autoriser uniquement un rôle d'agent spécifique à invoquer un outil particulier, créez :
 
@@ -334,7 +332,7 @@ L'infrastructure générée crée des politiques avec `IGNORE_ALL_FINDINGS` : l'
 
 Une contrainte d'ordre s'applique toujours : une politique référençant `AgentCore::Action::"<target>___<tool>"` ne valide qu'une fois que la cible a enregistré cet outil avec le Gateway, c'est pourquoi l'infrastructure générée crée des politiques après les cibles Gateway.
 
-Si une politique échoue au déploiement, CloudFormation affiche le rejet comme une erreur opaque `Resource stabilization failed` — exécutez `aws bedrock-agentcore-control list-policies --policy-engine-id <id>` pour récupérer les `statusReasons` du validateur, qui contiennent la raison réelle. Identifiez la politique fautive par sa `description` (`Policy loaded from <file>.cedar`) plutôt que par son `name` suffixé.
+Si une politique échoue au déploiement, CloudFormation affiche le rejet comme une erreur opaque `Resource stabilization failed` — exécutez `aws bedrock-agentcore-control list-policies --policy-engine-id <id>` pour récupérer les `statusReasons` du validateur, qui contiennent la raison réelle.
 
 ### Exemple : interdire un outil tout en conservant un permit plus large
 

--- a/docs/src/content/docs/fr/guides/ts-dcr-proxy.mdx
+++ b/docs/src/content/docs/fr/guides/ts-dcr-proxy.mdx
@@ -103,7 +103,7 @@ Vous fournissez :
 Instanciez le construct généré dans votre stack, en passant les propriétés requises :
 
 ```typescript
-import { DcrProxy } from ':my-scope/common-constructs';
+import { DcrProxy } from '@my-scope/common-constructs';
 
 new DcrProxy(this, 'DcrProxy', {
   userPoolId: userPool.userPoolId,
@@ -155,8 +155,9 @@ import {
   DcrProxy,
   MyProjectMcpServer,
   UserIdentity,
-} from ':my-scope/common-constructs';
+} from '@my-scope/common-constructs';
 import { OAuthScope } from 'aws-cdk-lib/aws-cognito';
+import * as kms from 'aws-cdk-lib/aws-kms';
 import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager';
 
 const identity = new UserIdentity(this, 'Identity');
@@ -179,6 +180,9 @@ const proxyClient = identity.userPool.addClient('DcrProxyClient', {
 // Store the App Client secret in Secrets Manager for the token handler to read
 const clientSecret = new secretsmanager.Secret(this, 'ClientSecret', {
   secretStringValue: proxyClient.userPoolClientSecret,
+  encryptionKey: new kms.Key(this, 'ClientSecretKey', {
+    enableKeyRotation: true,
+  }),
 });
 
 // The MCP server, authorizing JWTs issued for the same App Client
@@ -267,8 +271,9 @@ import {
   DcrProxy,
   MyGateway,
   UserIdentity,
-} from ':my-scope/common-constructs';
+} from '@my-scope/common-constructs';
 import { OAuthScope } from 'aws-cdk-lib/aws-cognito';
+import * as kms from 'aws-cdk-lib/aws-kms';
 import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager';
 
 const identity = new UserIdentity(this, 'Identity');
@@ -291,6 +296,9 @@ const proxyClient = identity.userPool.addClient('DcrProxyClient', {
 // Store the App Client secret in Secrets Manager for the token handler to read
 const clientSecret = new secretsmanager.Secret(this, 'ClientSecret', {
   secretStringValue: proxyClient.userPoolClientSecret,
+  encryptionKey: new kms.Key(this, 'ClientSecretKey', {
+    enableKeyRotation: true,
+  }),
 });
 
 // The gateway, authorizing JWTs issued for the same App Client
@@ -307,7 +315,7 @@ new DcrProxy(this, 'DcrProxy', {
   cognitoClientSecretArn: clientSecret.secretArn,
   cognitoHostedUiBase: identity.userPoolDomain.baseUrl(),
   // Use the gateway construct's URL rather than hardcoding it
-  upstreamUrl: gateway.gateway.gatewayUrl,
+  upstreamUrl: gateway.gatewayUrl,
 });
 ```
 </Fragment>
@@ -341,7 +349,7 @@ resource "aws_secretsmanager_secret_version" "client_secret" {
 
 # The gateway, authorizing JWTs issued for the same App Client
 module "my_gateway" {
-  source = "../../common/terraform/src/app/agentcore-gateway/my-gateway"
+  source = "../../common/terraform/src/app/gateways/my-gateway"
 
   user_pool_id         = module.user_identity.user_pool_id
   user_pool_client_ids = [aws_cognito_user_pool_client.dcr_proxy.id]
@@ -466,8 +474,9 @@ import {
   DcrProxy,
   MyProjectMcpServer,
   UserIdentity,
-} from ':my-scope/common-constructs';
+} from '@my-scope/common-constructs';
 import { OAuthScope, CfnManagedLoginBranding } from 'aws-cdk-lib/aws-cognito';
+import * as kms from 'aws-cdk-lib/aws-kms';
 import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager';
 
 // The user pool created by ts#website#auth for your website users
@@ -492,6 +501,9 @@ new CfnManagedLoginBranding(this, 'DcrProxyClientBranding', {
 
 const clientSecret = new secretsmanager.Secret(this, 'ClientSecret', {
   secretStringValue: proxyClient.userPoolClientSecret,
+  encryptionKey: new kms.Key(this, 'ClientSecretKey', {
+    enableKeyRotation: true,
+  }),
 });
 
 const mcpServer = new MyProjectMcpServer(this, 'MyProjectMcpServer', {

--- a/docs/src/content/docs/fr/guides/ts-rdb.mdx
+++ b/docs/src/content/docs/fr/guides/ts-rdb.mdx
@@ -264,7 +264,7 @@ module "api" {
   source = "..."
   ...
 
-  environment_variables = {
+  env = {
     NODE_EXTRA_CA_CERTS = "/var/runtime/ca-cert.pem"
   }
 }

--- a/docs/src/content/docs/fr/snippets/connection/strands-agent-rdb-ssl-requirements.mdx
+++ b/docs/src/content/docs/fr/snippets/connection/strands-agent-rdb-ssl-requirements.mdx
@@ -23,7 +23,7 @@ new MyAgent(this, 'MyAgent', {
 ```hcl title="packages/infra/src/main.tf"
 module "my_agent" {
   ...
-  environment_variables = {
+  env = {
     NODE_EXTRA_CA_CERTS = "/usr/local/share/ca-certificates/rds-bundle.crt"
   }
 }

--- a/docs/src/content/docs/fr/snippets/connection/ts-lambda-rdb-ssl-requirements.mdx
+++ b/docs/src/content/docs/fr/snippets/connection/ts-lambda-rdb-ssl-requirements.mdx
@@ -28,7 +28,7 @@ module "api" {
   source = "..."
   ...
 
-  environment_variables = {
+  env = {
     NODE_EXTRA_CA_CERTS = "/var/runtime/ca-cert.pem"
   }
 }

--- a/docs/src/content/docs/fr/snippets/connection/ts-mcp-server-rdb-ssl-requirements.mdx
+++ b/docs/src/content/docs/fr/snippets/connection/ts-mcp-server-rdb-ssl-requirements.mdx
@@ -23,7 +23,7 @@ new MyMcpServer(this, 'MyMcpServer', {
 ```hcl title="packages/infra/src/main.tf"
 module "my_mcp_server" {
   ...
-  environment_variables = {
+  env = {
     NODE_EXTRA_CA_CERTS = "/usr/local/share/ca-certificates/rds-bundle.crt"
   }
 }

--- a/docs/src/content/docs/it/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/it/guides/agentcore-gateway.mdx
@@ -488,9 +488,3 @@ Usa il generatore <Link path="guides/connection">`connection`</Link> per integra
     target="agentcore"
   />
 </CardGrid>
-o un AgentCore Gateway"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/react-agentcore-gateway`}
-    source="react"
-    target="agentcore"
-  />
-</CardGrid>

--- a/docs/src/content/docs/it/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/it/guides/agentcore-gateway.mdx
@@ -133,7 +133,7 @@ L'infrastruttura generata consuma un user pool e un client Cognito esistenti —
 Il costrutto generato richiede una prop `identity` che fornisce l'user pool e il client:
 
 ```ts {7,9-11} title="packages/infra/src/stacks/application-stack.ts"
-import { MyGateway, UserIdentity } from ':my-scope/common-constructs';
+import { MyGateway, UserIdentity } from '@my-scope/common-constructs';
 
 export class ApplicationStack extends Stack {
   constructor(scope: Construct, id: string, props?: StackProps) {
@@ -179,7 +179,9 @@ Fai riferimento alla [documentazione AWS sulle policy AgentCore Gateway](https:/
 
 ### Aggiungere una policy
 
-Per aggiungere una policy, crea un nuovo file `.cedar` accanto a `permit-all.cedar`. Ogni file `.cedar` in `policies/` deve contenere esattamente **una** istruzione `permit` o `forbid` e viene distribuito come una singola risorsa `AWS::BedrockAgentCore::Policy`. Il nome della risorsa policy deriva dal nome del file: `permit-all.cedar` diventa `PermitAll` (kebab/snake-case viene convertito in PascalCase). I file contenenti più istruzioni producono errori `unexpected token 'forbid'` al momento della distribuzione — dividili in file separati.
+Per aggiungere una policy, crea un nuovo file `.cedar` accanto a `permit-all.cedar`. Ogni file `.cedar` in `policies/` deve contenere esattamente **una** istruzione `permit` o `forbid` e viene distribuito come una singola risorsa `AWS::BedrockAgentCore::Policy`. I file contenenti più istruzioni producono errori `unexpected token 'forbid'` al momento della distribuzione — dividili in file separati.
+
+I nomi delle policy devono essere univoci a livello di account, quindi il nome distribuito non è mai solo il nome del file: CDK lo deriva dal percorso del costrutto, e Terraform converte il nome del file in PascalCase (`permit-all.cedar` → `PermitAll`) e poi aggiunge il suffisso casuale del gateway. La **description** della policy è ciò che identifica il suo file sorgente — `Policy loaded from permit-all.cedar` — quindi cerca quella quando ispezioni le policy distribuite.
 
 Ad esempio, per permettere solo a un ruolo agente specifico di invocare un particolare strumento, crea:
 
@@ -332,7 +334,7 @@ L'infrastruttura generata crea policy con `IGNORE_ALL_FINDINGS`: l'analizzatore 
 
 Si applica ancora un vincolo di ordinamento: una policy che fa riferimento a `AgentCore::Action::"<target>___<tool>"` si valida solo una volta che il target ha registrato quello strumento con il Gateway, motivo per cui l'infrastruttura generata crea le policy dopo i target del Gateway.
 
-Se una policy non riesce a essere distribuita, CloudFormation mostra il rifiuto come un errore opaco `Resource stabilization failed` — esegui `aws bedrock-agentcore-control list-policies --policy-engine-id <id>` per recuperare i `statusReasons` del validatore, che contengono il motivo effettivo.
+Se una policy non riesce a essere distribuita, CloudFormation mostra il rifiuto come un errore opaco `Resource stabilization failed` — esegui `aws bedrock-agentcore-control list-policies --policy-engine-id <id>` per recuperare i `statusReasons` del validatore, che contengono il motivo effettivo. Identifica la policy problematica tramite la sua `description` (`Policy loaded from <file>.cedar`) piuttosto che tramite il suo `name` con suffisso.
 
 ### Esempio: vietare uno strumento mantenendo un permit più ampio
 

--- a/docs/src/content/docs/it/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/it/guides/agentcore-gateway.mdx
@@ -179,9 +179,7 @@ Fai riferimento alla [documentazione AWS sulle policy AgentCore Gateway](https:/
 
 ### Aggiungere una policy
 
-Per aggiungere una policy, crea un nuovo file `.cedar` accanto a `permit-all.cedar`. Ogni file `.cedar` in `policies/` deve contenere esattamente **una** istruzione `permit` o `forbid` e viene distribuito come una singola risorsa `AWS::BedrockAgentCore::Policy`. I file contenenti più istruzioni producono errori `unexpected token 'forbid'` al momento della distribuzione — dividili in file separati.
-
-I nomi delle policy devono essere univoci a livello di account, quindi il nome distribuito non è mai solo il nome del file: CDK lo deriva dal percorso del costrutto, e Terraform converte il nome del file in PascalCase (`permit-all.cedar` → `PermitAll`) e poi aggiunge il suffisso casuale del gateway. La **description** della policy è ciò che identifica il suo file sorgente — `Policy loaded from permit-all.cedar` — quindi cerca quella quando ispezioni le policy distribuite.
+Per aggiungere una policy, crea un nuovo file `.cedar` accanto a `permit-all.cedar`. Ogni file `.cedar` in `policies/` deve contenere esattamente **una** istruzione `permit` o `forbid` e viene distribuito come una singola risorsa `AWS::BedrockAgentCore::Policy`. Il nome della risorsa policy è derivato dal nome del file: `permit-all.cedar` diventa `PermitAll` (kebab/snake-case viene convertito in PascalCase). I file contenenti più istruzioni producono errori `unexpected token 'forbid'` al momento della distribuzione — dividili in file separati.
 
 Ad esempio, per permettere solo a un ruolo agente specifico di invocare un particolare strumento, crea:
 
@@ -485,6 +483,12 @@ Usa il generatore <Link path="guides/connection">`connection`</Link> per integra
   <ConnectionCard
     title="React Website a AgentCore Gateway"
     description="Connetti un sito web React agli agenti attraverso un AgentCore Gateway"
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/react-agentcore-gateway`}
+    source="react"
+    target="agentcore"
+  />
+</CardGrid>
+o un AgentCore Gateway"
     href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/react-agentcore-gateway`}
     source="react"
     target="agentcore"

--- a/docs/src/content/docs/it/guides/ts-dcr-proxy.mdx
+++ b/docs/src/content/docs/it/guides/ts-dcr-proxy.mdx
@@ -103,7 +103,7 @@ Fornisci:
 Istanzia il costrutto generato nel tuo stack, passando le proprietà richieste:
 
 ```typescript
-import { DcrProxy } from ':my-scope/common-constructs';
+import { DcrProxy } from '@my-scope/common-constructs';
 
 new DcrProxy(this, 'DcrProxy', {
   userPoolId: userPool.userPoolId,
@@ -155,8 +155,9 @@ import {
   DcrProxy,
   MyProjectMcpServer,
   UserIdentity,
-} from ':my-scope/common-constructs';
+} from '@my-scope/common-constructs';
 import { OAuthScope } from 'aws-cdk-lib/aws-cognito';
+import * as kms from 'aws-cdk-lib/aws-kms';
 import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager';
 
 const identity = new UserIdentity(this, 'Identity');
@@ -179,6 +180,9 @@ const proxyClient = identity.userPool.addClient('DcrProxyClient', {
 // Store the App Client secret in Secrets Manager for the token handler to read
 const clientSecret = new secretsmanager.Secret(this, 'ClientSecret', {
   secretStringValue: proxyClient.userPoolClientSecret,
+  encryptionKey: new kms.Key(this, 'ClientSecretKey', {
+    enableKeyRotation: true,
+  }),
 });
 
 // The MCP server, authorizing JWTs issued for the same App Client
@@ -267,8 +271,9 @@ import {
   DcrProxy,
   MyGateway,
   UserIdentity,
-} from ':my-scope/common-constructs';
+} from '@my-scope/common-constructs';
 import { OAuthScope } from 'aws-cdk-lib/aws-cognito';
+import * as kms from 'aws-cdk-lib/aws-kms';
 import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager';
 
 const identity = new UserIdentity(this, 'Identity');
@@ -291,6 +296,9 @@ const proxyClient = identity.userPool.addClient('DcrProxyClient', {
 // Store the App Client secret in Secrets Manager for the token handler to read
 const clientSecret = new secretsmanager.Secret(this, 'ClientSecret', {
   secretStringValue: proxyClient.userPoolClientSecret,
+  encryptionKey: new kms.Key(this, 'ClientSecretKey', {
+    enableKeyRotation: true,
+  }),
 });
 
 // The gateway, authorizing JWTs issued for the same App Client
@@ -307,7 +315,7 @@ new DcrProxy(this, 'DcrProxy', {
   cognitoClientSecretArn: clientSecret.secretArn,
   cognitoHostedUiBase: identity.userPoolDomain.baseUrl(),
   // Use the gateway construct's URL rather than hardcoding it
-  upstreamUrl: gateway.gateway.gatewayUrl,
+  upstreamUrl: gateway.gatewayUrl,
 });
 ```
 </Fragment>
@@ -341,7 +349,7 @@ resource "aws_secretsmanager_secret_version" "client_secret" {
 
 # The gateway, authorizing JWTs issued for the same App Client
 module "my_gateway" {
-  source = "../../common/terraform/src/app/agentcore-gateway/my-gateway"
+  source = "../../common/terraform/src/app/gateways/my-gateway"
 
   user_pool_id         = module.user_identity.user_pool_id
   user_pool_client_ids = [aws_cognito_user_pool_client.dcr_proxy.id]
@@ -466,8 +474,9 @@ import {
   DcrProxy,
   MyProjectMcpServer,
   UserIdentity,
-} from ':my-scope/common-constructs';
+} from '@my-scope/common-constructs';
 import { OAuthScope, CfnManagedLoginBranding } from 'aws-cdk-lib/aws-cognito';
+import * as kms from 'aws-cdk-lib/aws-kms';
 import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager';
 
 // The user pool created by ts#website#auth for your website users
@@ -492,6 +501,9 @@ new CfnManagedLoginBranding(this, 'DcrProxyClientBranding', {
 
 const clientSecret = new secretsmanager.Secret(this, 'ClientSecret', {
   secretStringValue: proxyClient.userPoolClientSecret,
+  encryptionKey: new kms.Key(this, 'ClientSecretKey', {
+    enableKeyRotation: true,
+  }),
 });
 
 const mcpServer = new MyProjectMcpServer(this, 'MyProjectMcpServer', {

--- a/docs/src/content/docs/it/guides/ts-rdb.mdx
+++ b/docs/src/content/docs/it/guides/ts-rdb.mdx
@@ -264,7 +264,7 @@ module "api" {
   source = "..."
   ...
 
-  environment_variables = {
+  env = {
     NODE_EXTRA_CA_CERTS = "/var/runtime/ca-cert.pem"
   }
 }

--- a/docs/src/content/docs/it/snippets/connection/strands-agent-rdb-ssl-requirements.mdx
+++ b/docs/src/content/docs/it/snippets/connection/strands-agent-rdb-ssl-requirements.mdx
@@ -23,7 +23,7 @@ new MyAgent(this, 'MyAgent', {
 ```hcl title="packages/infra/src/main.tf"
 module "my_agent" {
   ...
-  environment_variables = {
+  env = {
     NODE_EXTRA_CA_CERTS = "/usr/local/share/ca-certificates/rds-bundle.crt"
   }
 }

--- a/docs/src/content/docs/it/snippets/connection/ts-lambda-rdb-ssl-requirements.mdx
+++ b/docs/src/content/docs/it/snippets/connection/ts-lambda-rdb-ssl-requirements.mdx
@@ -28,7 +28,7 @@ module "api" {
   source = "..."
   ...
 
-  environment_variables = {
+  env = {
     NODE_EXTRA_CA_CERTS = "/var/runtime/ca-cert.pem"
   }
 }

--- a/docs/src/content/docs/it/snippets/connection/ts-mcp-server-rdb-ssl-requirements.mdx
+++ b/docs/src/content/docs/it/snippets/connection/ts-mcp-server-rdb-ssl-requirements.mdx
@@ -23,7 +23,7 @@ new MyMcpServer(this, 'MyMcpServer', {
 ```hcl title="packages/infra/src/main.tf"
 module "my_mcp_server" {
   ...
-  environment_variables = {
+  env = {
     NODE_EXTRA_CA_CERTS = "/usr/local/share/ca-certificates/rds-bundle.crt"
   }
 }

--- a/docs/src/content/docs/jp/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/jp/guides/agentcore-gateway.mdx
@@ -133,7 +133,7 @@ gateway -> targets
 生成されたコンストラクトは、ユーザープールとクライアントを提供する`identity`プロパティを必要とします：
 
 ```ts {7,9-11} title="packages/infra/src/stacks/application-stack.ts"
-import { MyGateway, UserIdentity } from ':my-scope/common-constructs';
+import { MyGateway, UserIdentity } from '@my-scope/common-constructs';
 
 export class ApplicationStack extends Stack {
   constructor(scope: Construct, id: string, props?: StackProps) {
@@ -179,7 +179,9 @@ Cedarは、AgentCore Gatewayがツール呼び出しを承認するために使�
 
 ### ポリシーの追加
 
-ポリシーを追加するには、`permit-all.cedar`と並んで新しい`.cedar`ファイルを作成します。`policies/`内の各`.cedar`ファイルは、正確に**1つ**の`permit`または`forbid`ステートメントを含む必要があり、単一の`AWS::BedrockAgentCore::Policy`リソースとしてデプロイされます。ポリシーリソースの名前はファイル名から派生します：`permit-all.cedar`は`PermitAll`になります（kebab/snake-caseはPascalCaseに変換されます）。複数のステートメントを含むファイルは、デプロイ時に`unexpected token 'forbid'`エラーを生成します — それらを別々のファイルに分割してください。
+ポリシーを追加するには、`permit-all.cedar`と並んで新しい`.cedar`ファイルを作成します。`policies/`内の各`.cedar`ファイルは、正確に**1つ**の`permit`または`forbid`ステートメントを含む必要があり、単一の`AWS::BedrockAgentCore::Policy`リソースとしてデプロイされます。複数のステートメントを含むファイルは、デプロイ時に`unexpected token 'forbid'`エラーを生成します — それらを別々のファイルに分割してください。
+
+ポリシー名はアカウント全体で一意である必要があるため、デプロイされる名前はファイル名だけではありません：CDKはコンストラクトパスから派生させ、TerraformはファイルをPascalCase化（`permit-all.cedar` → `PermitAll`）してからゲートウェイのランダムサフィックスを追加します。ポリシーの**description**がソースファイルを識別するものです — `Policy loaded from permit-all.cedar` — そのため、デプロイされたポリシーを検査する際はそれで一致させます。
 
 たとえば、特定のエージェントロールのみが特定のツールを呼び出すことを許可するには、次のように作成します：
 
@@ -332,7 +334,7 @@ resource == AgentCore::Gateway::"<%= gatewayArn %>"
 
 1つの順序制約が依然として適用されます：`AgentCore::Action::"<target>___<tool>"`を参照するポリシーは、ターゲットがそのツールをGatewayに登録した後にのみ検証されます。これが、生成されたインフラストラクチャがGatewayターゲットの後にポリシーを作成する理由です。
 
-ポリシーのデプロイに失敗した場合、CloudFormationは拒否を不透明な`Resource stabilization failed`エラーとして表示します — `aws bedrock-agentcore-control list-policies --policy-engine-id <id>`を実行して、実際の理由を含むバリデーターの`statusReasons`を取得します。
+ポリシーのデプロイに失敗した場合、CloudFormationは拒否を不透明な`Resource stabilization failed`エラーとして表示します — `aws bedrock-agentcore-control list-policies --policy-engine-id <id>`を実行して、実際の理由を含むバリデーターの`statusReasons`を取得します。問題のあるポリシーは、サフィックス付きの`name`ではなく、その`description`（`Policy loaded from <file>.cedar`）で識別します。
 
 ### 例：より広範なpermitを維持しながら1つのツールを禁止する
 

--- a/docs/src/content/docs/jp/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/jp/guides/agentcore-gateway.mdx
@@ -488,9 +488,3 @@ module "my_gateway" {
     target="agentcore"
   />
 </CardGrid>
-iption="AgentCore Gatewayを通じてReactウェブサイトをエージェントに接続する"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/react-agentcore-gateway`}
-    source="react"
-    target="agentcore"
-  />
-</CardGrid>

--- a/docs/src/content/docs/jp/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/jp/guides/agentcore-gateway.mdx
@@ -179,9 +179,7 @@ Cedarは、AgentCore Gatewayがツール呼び出しを承認するために使�
 
 ### ポリシーの追加
 
-ポリシーを追加するには、`permit-all.cedar`と並んで新しい`.cedar`ファイルを作成します。`policies/`内の各`.cedar`ファイルは、正確に**1つ**の`permit`または`forbid`ステートメントを含む必要があり、単一の`AWS::BedrockAgentCore::Policy`リソースとしてデプロイされます。複数のステートメントを含むファイルは、デプロイ時に`unexpected token 'forbid'`エラーを生成します — それらを別々のファイルに分割してください。
-
-ポリシー名はアカウント全体で一意である必要があるため、デプロイされる名前はファイル名だけではありません：CDKはコンストラクトパスから派生させ、TerraformはファイルをPascalCase化（`permit-all.cedar` → `PermitAll`）してからゲートウェイのランダムサフィックスを追加します。ポリシーの**description**がソースファイルを識別するものです — `Policy loaded from permit-all.cedar` — そのため、デプロイされたポリシーを検査する際はそれで一致させます。
+ポリシーを追加するには、`permit-all.cedar`と並んで新しい`.cedar`ファイルを作成します。`policies/`内の各`.cedar`ファイルは、正確に**1つ**の`permit`または`forbid`ステートメントを含む必要があり、単一の`AWS::BedrockAgentCore::Policy`リソースとしてデプロイされます。ポリシーリソースの名前はファイル名から派生します：`permit-all.cedar`は`PermitAll`になります（kebab/snake-caseはPascalCaseに変換されます）。複数のステートメントを含むファイルは、デプロイ時に`unexpected token 'forbid'`エラーを生成します — それらを別々のファイルに分割してください。
 
 たとえば、特定のエージェントロールのみが特定のツールを呼び出すことを許可するには、次のように作成します：
 
@@ -485,6 +483,12 @@ module "my_gateway" {
   <ConnectionCard
     title="React Website to AgentCore Gateway"
     description="AgentCore Gatewayを通じてReactウェブサイトをエージェントに接続する"
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/react-agentcore-gateway`}
+    source="react"
+    target="agentcore"
+  />
+</CardGrid>
+iption="AgentCore Gatewayを通じてReactウェブサイトをエージェントに接続する"
     href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/react-agentcore-gateway`}
     source="react"
     target="agentcore"

--- a/docs/src/content/docs/jp/guides/ts-dcr-proxy.mdx
+++ b/docs/src/content/docs/jp/guides/ts-dcr-proxy.mdx
@@ -103,7 +103,7 @@ MCPクライアント（Claude Code、Kiro CLI、MCP Inspectorなど）は、Dyn
 生成されたコンストラクトをスタック内でインスタンス化し、必要なプロパティを渡します：
 
 ```typescript
-import { DcrProxy } from ':my-scope/common-constructs';
+import { DcrProxy } from '@my-scope/common-constructs';
 
 new DcrProxy(this, 'DcrProxy', {
   userPoolId: userPool.userPoolId,
@@ -155,8 +155,9 @@ import {
   DcrProxy,
   MyProjectMcpServer,
   UserIdentity,
-} from ':my-scope/common-constructs';
+} from '@my-scope/common-constructs';
 import { OAuthScope } from 'aws-cdk-lib/aws-cognito';
+import * as kms from 'aws-cdk-lib/aws-kms';
 import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager';
 
 const identity = new UserIdentity(this, 'Identity');
@@ -179,6 +180,9 @@ const proxyClient = identity.userPool.addClient('DcrProxyClient', {
 // Store the App Client secret in Secrets Manager for the token handler to read
 const clientSecret = new secretsmanager.Secret(this, 'ClientSecret', {
   secretStringValue: proxyClient.userPoolClientSecret,
+  encryptionKey: new kms.Key(this, 'ClientSecretKey', {
+    enableKeyRotation: true,
+  }),
 });
 
 // The MCP server, authorizing JWTs issued for the same App Client
@@ -267,8 +271,9 @@ import {
   DcrProxy,
   MyGateway,
   UserIdentity,
-} from ':my-scope/common-constructs';
+} from '@my-scope/common-constructs';
 import { OAuthScope } from 'aws-cdk-lib/aws-cognito';
+import * as kms from 'aws-cdk-lib/aws-kms';
 import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager';
 
 const identity = new UserIdentity(this, 'Identity');
@@ -291,6 +296,9 @@ const proxyClient = identity.userPool.addClient('DcrProxyClient', {
 // Store the App Client secret in Secrets Manager for the token handler to read
 const clientSecret = new secretsmanager.Secret(this, 'ClientSecret', {
   secretStringValue: proxyClient.userPoolClientSecret,
+  encryptionKey: new kms.Key(this, 'ClientSecretKey', {
+    enableKeyRotation: true,
+  }),
 });
 
 // The gateway, authorizing JWTs issued for the same App Client
@@ -307,7 +315,7 @@ new DcrProxy(this, 'DcrProxy', {
   cognitoClientSecretArn: clientSecret.secretArn,
   cognitoHostedUiBase: identity.userPoolDomain.baseUrl(),
   // Use the gateway construct's URL rather than hardcoding it
-  upstreamUrl: gateway.gateway.gatewayUrl,
+  upstreamUrl: gateway.gatewayUrl,
 });
 ```
 </Fragment>
@@ -341,7 +349,7 @@ resource "aws_secretsmanager_secret_version" "client_secret" {
 
 # The gateway, authorizing JWTs issued for the same App Client
 module "my_gateway" {
-  source = "../../common/terraform/src/app/agentcore-gateway/my-gateway"
+  source = "../../common/terraform/src/app/gateways/my-gateway"
 
   user_pool_id         = module.user_identity.user_pool_id
   user_pool_client_ids = [aws_cognito_user_pool_client.dcr_proxy.id]
@@ -466,8 +474,9 @@ import {
   DcrProxy,
   MyProjectMcpServer,
   UserIdentity,
-} from ':my-scope/common-constructs';
+} from '@my-scope/common-constructs';
 import { OAuthScope, CfnManagedLoginBranding } from 'aws-cdk-lib/aws-cognito';
+import * as kms from 'aws-cdk-lib/aws-kms';
 import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager';
 
 // The user pool created by ts#website#auth for your website users
@@ -492,6 +501,9 @@ new CfnManagedLoginBranding(this, 'DcrProxyClientBranding', {
 
 const clientSecret = new secretsmanager.Secret(this, 'ClientSecret', {
   secretStringValue: proxyClient.userPoolClientSecret,
+  encryptionKey: new kms.Key(this, 'ClientSecretKey', {
+    enableKeyRotation: true,
+  }),
 });
 
 const mcpServer = new MyProjectMcpServer(this, 'MyProjectMcpServer', {

--- a/docs/src/content/docs/jp/guides/ts-rdb.mdx
+++ b/docs/src/content/docs/jp/guides/ts-rdb.mdx
@@ -264,7 +264,7 @@ module "api" {
   source = "..."
   ...
 
-  environment_variables = {
+  env = {
     NODE_EXTRA_CA_CERTS = "/var/runtime/ca-cert.pem"
   }
 }

--- a/docs/src/content/docs/jp/snippets/connection/strands-agent-rdb-ssl-requirements.mdx
+++ b/docs/src/content/docs/jp/snippets/connection/strands-agent-rdb-ssl-requirements.mdx
@@ -23,7 +23,7 @@ new MyAgent(this, 'MyAgent', {
 ```hcl title="packages/infra/src/main.tf"
 module "my_agent" {
   ...
-  environment_variables = {
+  env = {
     NODE_EXTRA_CA_CERTS = "/usr/local/share/ca-certificates/rds-bundle.crt"
   }
 }

--- a/docs/src/content/docs/jp/snippets/connection/ts-lambda-rdb-ssl-requirements.mdx
+++ b/docs/src/content/docs/jp/snippets/connection/ts-lambda-rdb-ssl-requirements.mdx
@@ -28,7 +28,7 @@ module "api" {
   source = "..."
   ...
 
-  environment_variables = {
+  env = {
     NODE_EXTRA_CA_CERTS = "/var/runtime/ca-cert.pem"
   }
 }

--- a/docs/src/content/docs/jp/snippets/connection/ts-mcp-server-rdb-ssl-requirements.mdx
+++ b/docs/src/content/docs/jp/snippets/connection/ts-mcp-server-rdb-ssl-requirements.mdx
@@ -23,7 +23,7 @@ new MyMcpServer(this, 'MyMcpServer', {
 ```hcl title="packages/infra/src/main.tf"
 module "my_mcp_server" {
   ...
-  environment_variables = {
+  env = {
     NODE_EXTRA_CA_CERTS = "/usr/local/share/ca-certificates/rds-bundle.crt"
   }
 }

--- a/docs/src/content/docs/ko/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/ko/guides/agentcore-gateway.mdx
@@ -179,9 +179,7 @@ Cedar는 AgentCore Gateway가 도구 호출을 승인하는 데 사용하는 정
 
 ### 정책 추가
 
-정책을 추가하려면 `permit-all.cedar` 옆에 새 `.cedar` 파일을 생성하세요. `policies/`의 각 `.cedar` 파일은 정확히 **하나**의 `permit` 또는 `forbid` 문을 포함해야 하며 단일 `AWS::BedrockAgentCore::Policy` 리소스로 배포됩니다. 여러 문을 포함하는 파일은 배포 시 `unexpected token 'forbid'` 오류를 생성합니다 — 별도의 파일로 분할하세요.
-
-정책 이름은 계정 전체에서 고유해야 하므로 배포된 이름은 파일 이름만으로는 결정되지 않습니다: CDK는 구성 요소 경로에서 파생하고, Terraform은 파일 이름을 PascalCase로 변환(`permit-all.cedar` → `PermitAll`)한 다음 게이트웨이의 무작위 접미사를 추가합니다. 정책의 **description**이 소스 파일을 식별하는 것입니다 — `Policy loaded from permit-all.cedar` — 따라서 배포된 정책을 검사할 때 이를 기준으로 일치시키세요.
+정책을 추가하려면 `permit-all.cedar` 옆에 새 `.cedar` 파일을 생성하세요. `policies/`의 각 `.cedar` 파일은 정확히 **하나**의 `permit` 또는 `forbid` 문을 포함해야 하며 단일 `AWS::BedrockAgentCore::Policy` 리소스로 배포됩니다. 정책 리소스의 이름은 파일 이름에서 파생됩니다: `permit-all.cedar`는 `PermitAll`이 됩니다(kebab/snake-case는 PascalCase로 변환됨). 여러 문을 포함하는 파일은 배포 시 `unexpected token 'forbid'` 오류를 생성합니다 — 별도의 파일로 분할하세요.
 
 예를 들어, 특정 에이전트 역할만 특정 도구를 호출하도록 허용하려면 다음을 생성하세요:
 
@@ -334,7 +332,7 @@ resource == AgentCore::Gateway::"<%= gatewayArn %>"
 
 한 가지 순서 제약 조건이 여전히 적용됩니다: `AgentCore::Action::"<target>___<tool>"`을 참조하는 정책은 대상이 해당 도구를 Gateway에 등록한 후에만 검증됩니다. 이것이 생성된 인프라가 Gateway 대상 이후에 정책을 생성하는 이유입니다.
 
-정책 배포에 실패하면 CloudFormation은 거부를 불투명한 `Resource stabilization failed` 오류로 표시합니다 — `aws bedrock-agentcore-control list-policies --policy-engine-id <id>`를 실행하여 실제 이유를 포함하는 검증기의 `statusReasons`를 검색하세요. 접미사가 붙은 `name`이 아닌 `description`(`Policy loaded from <file>.cedar`)으로 문제가 있는 정책을 식별하세요.
+정책 배포에 실패하면 CloudFormation은 거부를 불투명한 `Resource stabilization failed` 오류로 표시합니다 — `aws bedrock-agentcore-control list-policies --policy-engine-id <id>`를 실행하여 실제 이유를 포함하는 검증기의 `statusReasons`를 검색하세요.
 
 ### 예제: 더 넓은 허용을 유지하면서 하나의 도구 금지
 

--- a/docs/src/content/docs/ko/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/ko/guides/agentcore-gateway.mdx
@@ -133,7 +133,7 @@ gateway -> targets
 생성된 구성 요소는 사용자 풀과 클라이언트를 제공하는 `identity` prop이 필요합니다:
 
 ```ts {7,9-11} title="packages/infra/src/stacks/application-stack.ts"
-import { MyGateway, UserIdentity } from ':my-scope/common-constructs';
+import { MyGateway, UserIdentity } from '@my-scope/common-constructs';
 
 export class ApplicationStack extends Stack {
   constructor(scope: Construct, id: string, props?: StackProps) {
@@ -179,7 +179,9 @@ Cedar는 AgentCore Gateway가 도구 호출을 승인하는 데 사용하는 정
 
 ### 정책 추가
 
-정책을 추가하려면 `permit-all.cedar` 옆에 새 `.cedar` 파일을 생성하세요. `policies/`의 각 `.cedar` 파일은 정확히 **하나**의 `permit` 또는 `forbid` 문을 포함해야 하며 단일 `AWS::BedrockAgentCore::Policy` 리소스로 배포됩니다. 정책 리소스의 이름은 파일 이름에서 파생됩니다: `permit-all.cedar`는 `PermitAll`이 됩니다(kebab/snake-case는 PascalCase로 변환됨). 여러 문을 포함하는 파일은 배포 시 `unexpected token 'forbid'` 오류를 생성합니다 — 별도의 파일로 분할하세요.
+정책을 추가하려면 `permit-all.cedar` 옆에 새 `.cedar` 파일을 생성하세요. `policies/`의 각 `.cedar` 파일은 정확히 **하나**의 `permit` 또는 `forbid` 문을 포함해야 하며 단일 `AWS::BedrockAgentCore::Policy` 리소스로 배포됩니다. 여러 문을 포함하는 파일은 배포 시 `unexpected token 'forbid'` 오류를 생성합니다 — 별도의 파일로 분할하세요.
+
+정책 이름은 계정 전체에서 고유해야 하므로 배포된 이름은 파일 이름만으로는 결정되지 않습니다: CDK는 구성 요소 경로에서 파생하고, Terraform은 파일 이름을 PascalCase로 변환(`permit-all.cedar` → `PermitAll`)한 다음 게이트웨이의 무작위 접미사를 추가합니다. 정책의 **description**이 소스 파일을 식별하는 것입니다 — `Policy loaded from permit-all.cedar` — 따라서 배포된 정책을 검사할 때 이를 기준으로 일치시키세요.
 
 예를 들어, 특정 에이전트 역할만 특정 도구를 호출하도록 허용하려면 다음을 생성하세요:
 
@@ -332,7 +334,7 @@ resource == AgentCore::Gateway::"<%= gatewayArn %>"
 
 한 가지 순서 제약 조건이 여전히 적용됩니다: `AgentCore::Action::"<target>___<tool>"`을 참조하는 정책은 대상이 해당 도구를 Gateway에 등록한 후에만 검증됩니다. 이것이 생성된 인프라가 Gateway 대상 이후에 정책을 생성하는 이유입니다.
 
-정책 배포에 실패하면 CloudFormation은 거부를 불투명한 `Resource stabilization failed` 오류로 표시합니다 — `aws bedrock-agentcore-control list-policies --policy-engine-id <id>`를 실행하여 실제 이유를 포함하는 검증기의 `statusReasons`를 검색하세요.
+정책 배포에 실패하면 CloudFormation은 거부를 불투명한 `Resource stabilization failed` 오류로 표시합니다 — `aws bedrock-agentcore-control list-policies --policy-engine-id <id>`를 실행하여 실제 이유를 포함하는 검증기의 `statusReasons`를 검색하세요. 접미사가 붙은 `name`이 아닌 `description`(`Policy loaded from <file>.cedar`)으로 문제가 있는 정책을 식별하세요.
 
 ### 예제: 더 넓은 허용을 유지하면서 하나의 도구 금지
 

--- a/docs/src/content/docs/ko/guides/ts-dcr-proxy.mdx
+++ b/docs/src/content/docs/ko/guides/ts-dcr-proxy.mdx
@@ -103,7 +103,7 @@ MCP 클라이언트(Claude Code, Kiro CLI 또는 MCP Inspector 등)는 Dynamic C
 스택에서 생성된 구성을 인스턴스화하고 필요한 속성을 전달합니다:
 
 ```typescript
-import { DcrProxy } from ':my-scope/common-constructs';
+import { DcrProxy } from '@my-scope/common-constructs';
 
 new DcrProxy(this, 'DcrProxy', {
   userPoolId: userPool.userPoolId,
@@ -155,8 +155,9 @@ import {
   DcrProxy,
   MyProjectMcpServer,
   UserIdentity,
-} from ':my-scope/common-constructs';
+} from '@my-scope/common-constructs';
 import { OAuthScope } from 'aws-cdk-lib/aws-cognito';
+import * as kms from 'aws-cdk-lib/aws-kms';
 import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager';
 
 const identity = new UserIdentity(this, 'Identity');
@@ -179,6 +180,9 @@ const proxyClient = identity.userPool.addClient('DcrProxyClient', {
 // Store the App Client secret in Secrets Manager for the token handler to read
 const clientSecret = new secretsmanager.Secret(this, 'ClientSecret', {
   secretStringValue: proxyClient.userPoolClientSecret,
+  encryptionKey: new kms.Key(this, 'ClientSecretKey', {
+    enableKeyRotation: true,
+  }),
 });
 
 // The MCP server, authorizing JWTs issued for the same App Client
@@ -267,8 +271,9 @@ import {
   DcrProxy,
   MyGateway,
   UserIdentity,
-} from ':my-scope/common-constructs';
+} from '@my-scope/common-constructs';
 import { OAuthScope } from 'aws-cdk-lib/aws-cognito';
+import * as kms from 'aws-cdk-lib/aws-kms';
 import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager';
 
 const identity = new UserIdentity(this, 'Identity');
@@ -291,6 +296,9 @@ const proxyClient = identity.userPool.addClient('DcrProxyClient', {
 // Store the App Client secret in Secrets Manager for the token handler to read
 const clientSecret = new secretsmanager.Secret(this, 'ClientSecret', {
   secretStringValue: proxyClient.userPoolClientSecret,
+  encryptionKey: new kms.Key(this, 'ClientSecretKey', {
+    enableKeyRotation: true,
+  }),
 });
 
 // The gateway, authorizing JWTs issued for the same App Client
@@ -307,7 +315,7 @@ new DcrProxy(this, 'DcrProxy', {
   cognitoClientSecretArn: clientSecret.secretArn,
   cognitoHostedUiBase: identity.userPoolDomain.baseUrl(),
   // Use the gateway construct's URL rather than hardcoding it
-  upstreamUrl: gateway.gateway.gatewayUrl,
+  upstreamUrl: gateway.gatewayUrl,
 });
 ```
 </Fragment>
@@ -341,7 +349,7 @@ resource "aws_secretsmanager_secret_version" "client_secret" {
 
 # The gateway, authorizing JWTs issued for the same App Client
 module "my_gateway" {
-  source = "../../common/terraform/src/app/agentcore-gateway/my-gateway"
+  source = "../../common/terraform/src/app/gateways/my-gateway"
 
   user_pool_id         = module.user_identity.user_pool_id
   user_pool_client_ids = [aws_cognito_user_pool_client.dcr_proxy.id]
@@ -466,8 +474,9 @@ import {
   DcrProxy,
   MyProjectMcpServer,
   UserIdentity,
-} from ':my-scope/common-constructs';
+} from '@my-scope/common-constructs';
 import { OAuthScope, CfnManagedLoginBranding } from 'aws-cdk-lib/aws-cognito';
+import * as kms from 'aws-cdk-lib/aws-kms';
 import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager';
 
 // The user pool created by ts#website#auth for your website users
@@ -492,6 +501,9 @@ new CfnManagedLoginBranding(this, 'DcrProxyClientBranding', {
 
 const clientSecret = new secretsmanager.Secret(this, 'ClientSecret', {
   secretStringValue: proxyClient.userPoolClientSecret,
+  encryptionKey: new kms.Key(this, 'ClientSecretKey', {
+    enableKeyRotation: true,
+  }),
 });
 
 const mcpServer = new MyProjectMcpServer(this, 'MyProjectMcpServer', {

--- a/docs/src/content/docs/ko/guides/ts-rdb.mdx
+++ b/docs/src/content/docs/ko/guides/ts-rdb.mdx
@@ -264,7 +264,7 @@ module "api" {
   source = "..."
   ...
 
-  environment_variables = {
+  env = {
     NODE_EXTRA_CA_CERTS = "/var/runtime/ca-cert.pem"
   }
 }

--- a/docs/src/content/docs/ko/snippets/connection/strands-agent-rdb-ssl-requirements.mdx
+++ b/docs/src/content/docs/ko/snippets/connection/strands-agent-rdb-ssl-requirements.mdx
@@ -23,7 +23,7 @@ new MyAgent(this, 'MyAgent', {
 ```hcl title="packages/infra/src/main.tf"
 module "my_agent" {
   ...
-  environment_variables = {
+  env = {
     NODE_EXTRA_CA_CERTS = "/usr/local/share/ca-certificates/rds-bundle.crt"
   }
 }

--- a/docs/src/content/docs/ko/snippets/connection/ts-lambda-rdb-ssl-requirements.mdx
+++ b/docs/src/content/docs/ko/snippets/connection/ts-lambda-rdb-ssl-requirements.mdx
@@ -28,7 +28,7 @@ module "api" {
   source = "..."
   ...
 
-  environment_variables = {
+  env = {
     NODE_EXTRA_CA_CERTS = "/var/runtime/ca-cert.pem"
   }
 }

--- a/docs/src/content/docs/ko/snippets/connection/ts-mcp-server-rdb-ssl-requirements.mdx
+++ b/docs/src/content/docs/ko/snippets/connection/ts-mcp-server-rdb-ssl-requirements.mdx
@@ -23,7 +23,7 @@ new MyMcpServer(this, 'MyMcpServer', {
 ```hcl title="packages/infra/src/main.tf"
 module "my_mcp_server" {
   ...
-  environment_variables = {
+  env = {
     NODE_EXTRA_CA_CERTS = "/usr/local/share/ca-certificates/rds-bundle.crt"
   }
 }

--- a/docs/src/content/docs/pt/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/pt/guides/agentcore-gateway.mdx
@@ -133,7 +133,7 @@ A infraestrutura gerada consome um user pool e cliente Cognito existentes — el
 O construto gerado requer uma propriedade `identity` fornecendo o user pool e cliente:
 
 ```ts {7,9-11} title="packages/infra/src/stacks/application-stack.ts"
-import { MyGateway, UserIdentity } from ':my-scope/common-constructs';
+import { MyGateway, UserIdentity } from '@my-scope/common-constructs';
 
 export class ApplicationStack extends Stack {
   constructor(scope: Construct, id: string, props?: StackProps) {
@@ -179,7 +179,9 @@ Consulte a [documentação AWS sobre políticas do AgentCore Gateway](https://do
 
 ### Adicionando uma política
 
-Para adicionar uma política, crie um novo arquivo `.cedar` ao lado de `permit-all.cedar`. Cada arquivo `.cedar` em `policies/` deve conter exatamente **uma** declaração `permit` ou `forbid` e é implantado como um único recurso `AWS::BedrockAgentCore::Policy`. O nome do recurso de política é derivado do nome do arquivo: `permit-all.cedar` se torna `PermitAll` (kebab/snake-case é convertido para PascalCase). Arquivos contendo múltiplas declarações produzem erros `unexpected token 'forbid'` no momento da implantação — divida-os em arquivos separados.
+Para adicionar uma política, crie um novo arquivo `.cedar` ao lado de `permit-all.cedar`. Cada arquivo `.cedar` em `policies/` deve conter exatamente **uma** declaração `permit` ou `forbid` e é implantado como um único recurso `AWS::BedrockAgentCore::Policy`. Arquivos contendo múltiplas declarações produzem erros `unexpected token 'forbid'` no momento da implantação — divida-os em arquivos separados.
+
+Os nomes de políticas devem ser únicos em toda a conta, portanto o nome implantado nunca é apenas o nome do arquivo: o CDK o deriva do caminho do construto, e o Terraform converte o nome do arquivo para PascalCase (`permit-all.cedar` → `PermitAll`) e então anexa o sufixo aleatório do gateway. A **descrição** da política é o que identifica seu arquivo de origem — `Policy loaded from permit-all.cedar` — então corresponda a isso ao inspecionar políticas implantadas.
 
 Por exemplo, para permitir apenas uma função de agente específica invocar uma ferramenta particular, crie:
 
@@ -332,7 +334,7 @@ A infraestrutura gerada cria políticas com `IGNORE_ALL_FINDINGS`: o analisador 
 
 Uma restrição de ordenação ainda se aplica: uma política referenciando `AgentCore::Action::"<target>___<tool>"` só valida uma vez que o destino tenha registrado essa ferramenta com o Gateway, razão pela qual a infraestrutura gerada cria políticas após os destinos do Gateway.
 
-Se uma política falhar ao implantar, o CloudFormation apresenta a rejeição como um erro opaco `Resource stabilization failed` — execute `aws bedrock-agentcore-control list-policies --policy-engine-id <id>` para recuperar os `statusReasons` do validador, que contêm o motivo real.
+Se uma política falhar ao implantar, o CloudFormation apresenta a rejeição como um erro opaco `Resource stabilization failed` — execute `aws bedrock-agentcore-control list-policies --policy-engine-id <id>` para recuperar os `statusReasons` do validador, que contêm o motivo real. Identifique a política problemática por sua `description` (`Policy loaded from <file>.cedar`) em vez de seu `name` com sufixo.
 
 ### Exemplo: proibir uma ferramenta mantendo um permit mais amplo
 

--- a/docs/src/content/docs/pt/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/pt/guides/agentcore-gateway.mdx
@@ -179,9 +179,7 @@ Consulte a [documentação AWS sobre políticas do AgentCore Gateway](https://do
 
 ### Adicionando uma política
 
-Para adicionar uma política, crie um novo arquivo `.cedar` ao lado de `permit-all.cedar`. Cada arquivo `.cedar` em `policies/` deve conter exatamente **uma** declaração `permit` ou `forbid` e é implantado como um único recurso `AWS::BedrockAgentCore::Policy`. Arquivos contendo múltiplas declarações produzem erros `unexpected token 'forbid'` no momento da implantação — divida-os em arquivos separados.
-
-Os nomes de políticas devem ser únicos em toda a conta, portanto o nome implantado nunca é apenas o nome do arquivo: o CDK o deriva do caminho do construto, e o Terraform converte o nome do arquivo para PascalCase (`permit-all.cedar` → `PermitAll`) e então anexa o sufixo aleatório do gateway. A **descrição** da política é o que identifica seu arquivo de origem — `Policy loaded from permit-all.cedar` — então corresponda a isso ao inspecionar políticas implantadas.
+Para adicionar uma política, crie um novo arquivo `.cedar` ao lado de `permit-all.cedar`. Cada arquivo `.cedar` em `policies/` deve conter exatamente **uma** declaração `permit` ou `forbid` e é implantado como um único recurso `AWS::BedrockAgentCore::Policy`. O nome do recurso de política é derivado do nome do arquivo: `permit-all.cedar` se torna `PermitAll` (kebab/snake-case é convertido para PascalCase). Arquivos contendo múltiplas declarações produzem erros `unexpected token 'forbid'` no momento da implantação — divida-os em arquivos separados.
 
 Por exemplo, para permitir apenas uma função de agente específica invocar uma ferramenta particular, crie:
 
@@ -334,7 +332,7 @@ A infraestrutura gerada cria políticas com `IGNORE_ALL_FINDINGS`: o analisador 
 
 Uma restrição de ordenação ainda se aplica: uma política referenciando `AgentCore::Action::"<target>___<tool>"` só valida uma vez que o destino tenha registrado essa ferramenta com o Gateway, razão pela qual a infraestrutura gerada cria políticas após os destinos do Gateway.
 
-Se uma política falhar ao implantar, o CloudFormation apresenta a rejeição como um erro opaco `Resource stabilization failed` — execute `aws bedrock-agentcore-control list-policies --policy-engine-id <id>` para recuperar os `statusReasons` do validador, que contêm o motivo real. Identifique a política problemática por sua `description` (`Policy loaded from <file>.cedar`) em vez de seu `name` com sufixo.
+Se uma política falhar ao implantar, o CloudFormation apresenta a rejeição como um erro opaco `Resource stabilization failed` — execute `aws bedrock-agentcore-control list-policies --policy-engine-id <id>` para recuperar os `statusReasons` do validador, que contêm o motivo real.
 
 ### Exemplo: proibir uma ferramenta mantendo um permit mais amplo
 

--- a/docs/src/content/docs/pt/guides/ts-dcr-proxy.mdx
+++ b/docs/src/content/docs/pt/guides/ts-dcr-proxy.mdx
@@ -103,7 +103,7 @@ Você fornece:
 Instancie o construct gerado em sua stack, passando as propriedades necessárias:
 
 ```typescript
-import { DcrProxy } from ':my-scope/common-constructs';
+import { DcrProxy } from '@my-scope/common-constructs';
 
 new DcrProxy(this, 'DcrProxy', {
   userPoolId: userPool.userPoolId,
@@ -155,8 +155,9 @@ import {
   DcrProxy,
   MyProjectMcpServer,
   UserIdentity,
-} from ':my-scope/common-constructs';
+} from '@my-scope/common-constructs';
 import { OAuthScope } from 'aws-cdk-lib/aws-cognito';
+import * as kms from 'aws-cdk-lib/aws-kms';
 import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager';
 
 const identity = new UserIdentity(this, 'Identity');
@@ -179,6 +180,9 @@ const proxyClient = identity.userPool.addClient('DcrProxyClient', {
 // Store the App Client secret in Secrets Manager for the token handler to read
 const clientSecret = new secretsmanager.Secret(this, 'ClientSecret', {
   secretStringValue: proxyClient.userPoolClientSecret,
+  encryptionKey: new kms.Key(this, 'ClientSecretKey', {
+    enableKeyRotation: true,
+  }),
 });
 
 // The MCP server, authorizing JWTs issued for the same App Client
@@ -267,8 +271,9 @@ import {
   DcrProxy,
   MyGateway,
   UserIdentity,
-} from ':my-scope/common-constructs';
+} from '@my-scope/common-constructs';
 import { OAuthScope } from 'aws-cdk-lib/aws-cognito';
+import * as kms from 'aws-cdk-lib/aws-kms';
 import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager';
 
 const identity = new UserIdentity(this, 'Identity');
@@ -291,6 +296,9 @@ const proxyClient = identity.userPool.addClient('DcrProxyClient', {
 // Store the App Client secret in Secrets Manager for the token handler to read
 const clientSecret = new secretsmanager.Secret(this, 'ClientSecret', {
   secretStringValue: proxyClient.userPoolClientSecret,
+  encryptionKey: new kms.Key(this, 'ClientSecretKey', {
+    enableKeyRotation: true,
+  }),
 });
 
 // The gateway, authorizing JWTs issued for the same App Client
@@ -307,7 +315,7 @@ new DcrProxy(this, 'DcrProxy', {
   cognitoClientSecretArn: clientSecret.secretArn,
   cognitoHostedUiBase: identity.userPoolDomain.baseUrl(),
   // Use the gateway construct's URL rather than hardcoding it
-  upstreamUrl: gateway.gateway.gatewayUrl,
+  upstreamUrl: gateway.gatewayUrl,
 });
 ```
 </Fragment>
@@ -341,7 +349,7 @@ resource "aws_secretsmanager_secret_version" "client_secret" {
 
 # The gateway, authorizing JWTs issued for the same App Client
 module "my_gateway" {
-  source = "../../common/terraform/src/app/agentcore-gateway/my-gateway"
+  source = "../../common/terraform/src/app/gateways/my-gateway"
 
   user_pool_id         = module.user_identity.user_pool_id
   user_pool_client_ids = [aws_cognito_user_pool_client.dcr_proxy.id]
@@ -466,8 +474,9 @@ import {
   DcrProxy,
   MyProjectMcpServer,
   UserIdentity,
-} from ':my-scope/common-constructs';
+} from '@my-scope/common-constructs';
 import { OAuthScope, CfnManagedLoginBranding } from 'aws-cdk-lib/aws-cognito';
+import * as kms from 'aws-cdk-lib/aws-kms';
 import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager';
 
 // The user pool created by ts#website#auth for your website users
@@ -492,6 +501,9 @@ new CfnManagedLoginBranding(this, 'DcrProxyClientBranding', {
 
 const clientSecret = new secretsmanager.Secret(this, 'ClientSecret', {
   secretStringValue: proxyClient.userPoolClientSecret,
+  encryptionKey: new kms.Key(this, 'ClientSecretKey', {
+    enableKeyRotation: true,
+  }),
 });
 
 const mcpServer = new MyProjectMcpServer(this, 'MyProjectMcpServer', {

--- a/docs/src/content/docs/pt/guides/ts-rdb.mdx
+++ b/docs/src/content/docs/pt/guides/ts-rdb.mdx
@@ -264,7 +264,7 @@ module "api" {
   source = "..."
   ...
 
-  environment_variables = {
+  env = {
     NODE_EXTRA_CA_CERTS = "/var/runtime/ca-cert.pem"
   }
 }

--- a/docs/src/content/docs/pt/snippets/connection/strands-agent-rdb-ssl-requirements.mdx
+++ b/docs/src/content/docs/pt/snippets/connection/strands-agent-rdb-ssl-requirements.mdx
@@ -23,7 +23,7 @@ new MyAgent(this, 'MyAgent', {
 ```hcl title="packages/infra/src/main.tf"
 module "my_agent" {
   ...
-  environment_variables = {
+  env = {
     NODE_EXTRA_CA_CERTS = "/usr/local/share/ca-certificates/rds-bundle.crt"
   }
 }

--- a/docs/src/content/docs/pt/snippets/connection/ts-lambda-rdb-ssl-requirements.mdx
+++ b/docs/src/content/docs/pt/snippets/connection/ts-lambda-rdb-ssl-requirements.mdx
@@ -28,7 +28,7 @@ module "api" {
   source = "..."
   ...
 
-  environment_variables = {
+  env = {
     NODE_EXTRA_CA_CERTS = "/var/runtime/ca-cert.pem"
   }
 }

--- a/docs/src/content/docs/pt/snippets/connection/ts-mcp-server-rdb-ssl-requirements.mdx
+++ b/docs/src/content/docs/pt/snippets/connection/ts-mcp-server-rdb-ssl-requirements.mdx
@@ -23,7 +23,7 @@ new MyMcpServer(this, 'MyMcpServer', {
 ```hcl title="packages/infra/src/main.tf"
 module "my_mcp_server" {
   ...
-  environment_variables = {
+  env = {
     NODE_EXTRA_CA_CERTS = "/usr/local/share/ca-certificates/rds-bundle.crt"
   }
 }

--- a/docs/src/content/docs/vi/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/vi/guides/agentcore-gateway.mdx
@@ -133,7 +133,7 @@ Cơ sở hạ tầng được tạo sử dụng một Cognito user pool và clie
 Construct được tạo yêu cầu một prop `identity` cung cấp user pool và client:
 
 ```ts {7,9-11} title="packages/infra/src/stacks/application-stack.ts"
-import { MyGateway, UserIdentity } from ':my-scope/common-constructs';
+import { MyGateway, UserIdentity } from '@my-scope/common-constructs';
 
 export class ApplicationStack extends Stack {
   constructor(scope: Construct, id: string, props?: StackProps) {
@@ -179,7 +179,9 @@ Tham khảo [tài liệu AWS về AgentCore Gateway policies](https://docs.aws.a
 
 ### Thêm một policy
 
-Để thêm một policy, tạo một file `.cedar` mới bên cạnh `permit-all.cedar`. Mỗi file `.cedar` trong `policies/` phải chứa chính xác **một** câu lệnh `permit` hoặc `forbid` và được triển khai dưới dạng một tài nguyên `AWS::BedrockAgentCore::Policy` duy nhất. Tên của tài nguyên policy được lấy từ tên file: `permit-all.cedar` trở thành `PermitAll` (kebab/snake-case được chuyển đổi thành PascalCase). Các file chứa nhiều câu lệnh tạo ra lỗi `unexpected token 'forbid'` tại thời điểm triển khai — tách chúng thành các file riêng biệt.
+Để thêm một policy, tạo một file `.cedar` mới bên cạnh `permit-all.cedar`. Mỗi file `.cedar` trong `policies/` phải chứa chính xác **một** câu lệnh `permit` hoặc `forbid` và được triển khai dưới dạng một tài nguyên `AWS::BedrockAgentCore::Policy` duy nhất. Các file chứa nhiều câu lệnh tạo ra lỗi `unexpected token 'forbid'` tại thời điểm triển khai — tách chúng thành các file riêng biệt.
+
+Tên policy phải là duy nhất trên toàn tài khoản, vì vậy tên được triển khai không bao giờ chỉ là tên file: CDK lấy nó từ đường dẫn construct, và Terraform chuyển đổi tên file thành PascalCase (`permit-all.cedar` → `PermitAll`) sau đó thêm hậu tố ngẫu nhiên của gateway. **Description** của policy là thứ xác định file nguồn của nó — `Policy loaded from permit-all.cedar` — vì vậy hãy khớp với nó khi kiểm tra các policy đã triển khai.
 
 Ví dụ, để chỉ cho phép một agent role cụ thể gọi một tool cụ thể, tạo:
 
@@ -332,7 +334,7 @@ Cơ sở hạ tầng được tạo tạo các policy với `IGNORE_ALL_FINDINGS
 
 Một ràng buộc về thứ tự vẫn áp dụng: một policy tham chiếu `AgentCore::Action::"<target>___<tool>"` chỉ xác thực khi target đã đăng ký tool đó với Gateway, đó là lý do tại sao cơ sở hạ tầng được tạo tạo các policy sau Gateway target.
 
-Nếu một policy không triển khai được, CloudFormation hiển thị việc từ chối dưới dạng lỗi `Resource stabilization failed` mơ hồ — chạy `aws bedrock-agentcore-control list-policies --policy-engine-id <id>` để lấy `statusReasons` của validator, chứa lý do thực sự.
+Nếu một policy không triển khai được, CloudFormation hiển thị việc từ chối dưới dạng lỗi `Resource stabilization failed` mơ hồ — chạy `aws bedrock-agentcore-control list-policies --policy-engine-id <id>` để lấy `statusReasons` của validator, chứa lý do thực sự. Xác định policy có lỗi bằng `description` của nó (`Policy loaded from <file>.cedar`) thay vì `name` có hậu tố.
 
 ### Ví dụ: forbid một tool trong khi giữ permit rộng hơn
 
@@ -446,21 +448,21 @@ Sử dụng <Link path="guides/connection">`connection`</Link> generator để t
   <ConnectionCard
     title="AgentCore Gateway to MCP Server"
     description="Tổng hợp một MCP server đằng sau một AgentCore Gateway"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/agentcore-gateway-mcp`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'vi'}/guides/connection/agentcore-gateway-mcp`}
     source="agentcore"
     target="mcp"
   />
   <ConnectionCard
     title="AgentCore Gateway to AgentCore Gateway"
     description="Tổng hợp một AgentCore Gateway đằng sau một AgentCore Gateway khác"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/agentcore-gateway-gateway`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'vi'}/guides/connection/agentcore-gateway-gateway`}
     source="agentcore"
     target="agentcore"
   />
   <ConnectionCard
     title="TypeScript Agent to AgentCore Gateway"
     description="Kết nối một TypeScript Agent với một AgentCore Gateway"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/ts-agent-gateway`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'vi'}/guides/connection/ts-agent-gateway`}
     source="strands"
     sourceBadge="typescript"
     target="agentcore"
@@ -468,7 +470,7 @@ Sử dụng <Link path="guides/connection">`connection`</Link> generator để t
   <ConnectionCard
     title="Python Agent to AgentCore Gateway"
     description="Kết nối một Python Agent với một AgentCore Gateway"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/py-agent-gateway`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'vi'}/guides/connection/py-agent-gateway`}
     source="strands"
     sourceBadge="python"
     target="agentcore"
@@ -476,14 +478,14 @@ Sử dụng <Link path="guides/connection">`connection`</Link> generator để t
   <ConnectionCard
     title="AgentCore Gateway to Agent"
     description="Đặt một agent trước một AgentCore Gateway dưới dạng runtime target"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/agentcore-gateway-agent`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'vi'}/guides/connection/agentcore-gateway-agent`}
     source="agentcore"
     target="strands"
   />
   <ConnectionCard
     title="React Website to AgentCore Gateway"
     description="Kết nối một React website với các agent thông qua một AgentCore Gateway"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/react-agentcore-gateway`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'vi'}/guides/connection/react-agentcore-gateway`}
     source="react"
     target="agentcore"
   />

--- a/docs/src/content/docs/vi/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/vi/guides/agentcore-gateway.mdx
@@ -179,9 +179,7 @@ Tham khảo [tài liệu AWS về AgentCore Gateway policies](https://docs.aws.a
 
 ### Thêm một policy
 
-Để thêm một policy, tạo một file `.cedar` mới bên cạnh `permit-all.cedar`. Mỗi file `.cedar` trong `policies/` phải chứa chính xác **một** câu lệnh `permit` hoặc `forbid` và được triển khai dưới dạng một tài nguyên `AWS::BedrockAgentCore::Policy` duy nhất. Các file chứa nhiều câu lệnh tạo ra lỗi `unexpected token 'forbid'` tại thời điểm triển khai — tách chúng thành các file riêng biệt.
-
-Tên policy phải là duy nhất trên toàn tài khoản, vì vậy tên được triển khai không bao giờ chỉ là tên file: CDK lấy nó từ đường dẫn construct, và Terraform chuyển đổi tên file thành PascalCase (`permit-all.cedar` → `PermitAll`) sau đó thêm hậu tố ngẫu nhiên của gateway. **Description** của policy là thứ xác định file nguồn của nó — `Policy loaded from permit-all.cedar` — vì vậy hãy khớp với nó khi kiểm tra các policy đã triển khai.
+Để thêm một policy, tạo một file `.cedar` mới bên cạnh `permit-all.cedar`. Mỗi file `.cedar` trong `policies/` phải chứa chính xác **một** câu lệnh `permit` hoặc `forbid` và được triển khai dưới dạng một tài nguyên `AWS::BedrockAgentCore::Policy` duy nhất. Tên của tài nguyên policy được lấy từ tên file: `permit-all.cedar` trở thành `PermitAll` (kebab/snake-case được chuyển đổi thành PascalCase). Các file chứa nhiều câu lệnh tạo ra lỗi `unexpected token 'forbid'` tại thời điểm triển khai — tách chúng thành các file riêng biệt.
 
 Ví dụ, để chỉ cho phép một agent role cụ thể gọi một tool cụ thể, tạo:
 
@@ -334,7 +332,7 @@ Cơ sở hạ tầng được tạo tạo các policy với `IGNORE_ALL_FINDINGS
 
 Một ràng buộc về thứ tự vẫn áp dụng: một policy tham chiếu `AgentCore::Action::"<target>___<tool>"` chỉ xác thực khi target đã đăng ký tool đó với Gateway, đó là lý do tại sao cơ sở hạ tầng được tạo tạo các policy sau Gateway target.
 
-Nếu một policy không triển khai được, CloudFormation hiển thị việc từ chối dưới dạng lỗi `Resource stabilization failed` mơ hồ — chạy `aws bedrock-agentcore-control list-policies --policy-engine-id <id>` để lấy `statusReasons` của validator, chứa lý do thực sự. Xác định policy có lỗi bằng `description` của nó (`Policy loaded from <file>.cedar`) thay vì `name` có hậu tố.
+Nếu một policy không triển khai được, CloudFormation hiển thị việc từ chối dưới dạng lỗi `Resource stabilization failed` mơ hồ — chạy `aws bedrock-agentcore-control list-policies --policy-engine-id <id>` để lấy `statusReasons` của validator, chứa lý do thực sự.
 
 ### Ví dụ: forbid một tool trong khi giữ permit rộng hơn
 

--- a/docs/src/content/docs/vi/guides/ts-dcr-proxy.mdx
+++ b/docs/src/content/docs/vi/guides/ts-dcr-proxy.mdx
@@ -103,7 +103,7 @@ Bạn cung cấp:
 Khởi tạo construct được tạo trong stack của bạn, truyền các thuộc tính bắt buộc:
 
 ```typescript
-import { DcrProxy } from ':my-scope/common-constructs';
+import { DcrProxy } from '@my-scope/common-constructs';
 
 new DcrProxy(this, 'DcrProxy', {
   userPoolId: userPool.userPoolId,
@@ -155,8 +155,9 @@ import {
   DcrProxy,
   MyProjectMcpServer,
   UserIdentity,
-} from ':my-scope/common-constructs';
+} from '@my-scope/common-constructs';
 import { OAuthScope } from 'aws-cdk-lib/aws-cognito';
+import * as kms from 'aws-cdk-lib/aws-kms';
 import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager';
 
 const identity = new UserIdentity(this, 'Identity');
@@ -179,6 +180,9 @@ const proxyClient = identity.userPool.addClient('DcrProxyClient', {
 // Store the App Client secret in Secrets Manager for the token handler to read
 const clientSecret = new secretsmanager.Secret(this, 'ClientSecret', {
   secretStringValue: proxyClient.userPoolClientSecret,
+  encryptionKey: new kms.Key(this, 'ClientSecretKey', {
+    enableKeyRotation: true,
+  }),
 });
 
 // The MCP server, authorizing JWTs issued for the same App Client
@@ -267,8 +271,9 @@ import {
   DcrProxy,
   MyGateway,
   UserIdentity,
-} from ':my-scope/common-constructs';
+} from '@my-scope/common-constructs';
 import { OAuthScope } from 'aws-cdk-lib/aws-cognito';
+import * as kms from 'aws-cdk-lib/aws-kms';
 import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager';
 
 const identity = new UserIdentity(this, 'Identity');
@@ -291,6 +296,9 @@ const proxyClient = identity.userPool.addClient('DcrProxyClient', {
 // Store the App Client secret in Secrets Manager for the token handler to read
 const clientSecret = new secretsmanager.Secret(this, 'ClientSecret', {
   secretStringValue: proxyClient.userPoolClientSecret,
+  encryptionKey: new kms.Key(this, 'ClientSecretKey', {
+    enableKeyRotation: true,
+  }),
 });
 
 // The gateway, authorizing JWTs issued for the same App Client
@@ -307,7 +315,7 @@ new DcrProxy(this, 'DcrProxy', {
   cognitoClientSecretArn: clientSecret.secretArn,
   cognitoHostedUiBase: identity.userPoolDomain.baseUrl(),
   // Use the gateway construct's URL rather than hardcoding it
-  upstreamUrl: gateway.gateway.gatewayUrl,
+  upstreamUrl: gateway.gatewayUrl,
 });
 ```
 </Fragment>
@@ -341,7 +349,7 @@ resource "aws_secretsmanager_secret_version" "client_secret" {
 
 # The gateway, authorizing JWTs issued for the same App Client
 module "my_gateway" {
-  source = "../../common/terraform/src/app/agentcore-gateway/my-gateway"
+  source = "../../common/terraform/src/app/gateways/my-gateway"
 
   user_pool_id         = module.user_identity.user_pool_id
   user_pool_client_ids = [aws_cognito_user_pool_client.dcr_proxy.id]
@@ -466,8 +474,9 @@ import {
   DcrProxy,
   MyProjectMcpServer,
   UserIdentity,
-} from ':my-scope/common-constructs';
+} from '@my-scope/common-constructs';
 import { OAuthScope, CfnManagedLoginBranding } from 'aws-cdk-lib/aws-cognito';
+import * as kms from 'aws-cdk-lib/aws-kms';
 import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager';
 
 // The user pool created by ts#website#auth for your website users
@@ -492,6 +501,9 @@ new CfnManagedLoginBranding(this, 'DcrProxyClientBranding', {
 
 const clientSecret = new secretsmanager.Secret(this, 'ClientSecret', {
   secretStringValue: proxyClient.userPoolClientSecret,
+  encryptionKey: new kms.Key(this, 'ClientSecretKey', {
+    enableKeyRotation: true,
+  }),
 });
 
 const mcpServer = new MyProjectMcpServer(this, 'MyProjectMcpServer', {

--- a/docs/src/content/docs/vi/guides/ts-rdb.mdx
+++ b/docs/src/content/docs/vi/guides/ts-rdb.mdx
@@ -264,7 +264,7 @@ module "api" {
   source = "..."
   ...
 
-  environment_variables = {
+  env = {
     NODE_EXTRA_CA_CERTS = "/var/runtime/ca-cert.pem"
   }
 }

--- a/docs/src/content/docs/vi/snippets/connection/strands-agent-rdb-ssl-requirements.mdx
+++ b/docs/src/content/docs/vi/snippets/connection/strands-agent-rdb-ssl-requirements.mdx
@@ -23,7 +23,7 @@ new MyAgent(this, 'MyAgent', {
 ```hcl title="packages/infra/src/main.tf"
 module "my_agent" {
   ...
-  environment_variables = {
+  env = {
     NODE_EXTRA_CA_CERTS = "/usr/local/share/ca-certificates/rds-bundle.crt"
   }
 }

--- a/docs/src/content/docs/vi/snippets/connection/ts-lambda-rdb-ssl-requirements.mdx
+++ b/docs/src/content/docs/vi/snippets/connection/ts-lambda-rdb-ssl-requirements.mdx
@@ -28,7 +28,7 @@ module "api" {
   source = "..."
   ...
 
-  environment_variables = {
+  env = {
     NODE_EXTRA_CA_CERTS = "/var/runtime/ca-cert.pem"
   }
 }

--- a/docs/src/content/docs/vi/snippets/connection/ts-mcp-server-rdb-ssl-requirements.mdx
+++ b/docs/src/content/docs/vi/snippets/connection/ts-mcp-server-rdb-ssl-requirements.mdx
@@ -23,7 +23,7 @@ new MyMcpServer(this, 'MyMcpServer', {
 ```hcl title="packages/infra/src/main.tf"
 module "my_mcp_server" {
   ...
-  environment_variables = {
+  env = {
     NODE_EXTRA_CA_CERTS = "/usr/local/share/ca-certificates/rds-bundle.crt"
   }
 }

--- a/docs/src/content/docs/zh/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/zh/guides/agentcore-gateway.mdx
@@ -334,7 +334,7 @@ resource == AgentCore::Gateway::"<%= gatewayArn %>"
 
 仍然适用一个排序约束：引用 `AgentCore::Action::"<target>___<tool>"` 的策略仅在目标向 Gateway 注册该工具后才验证，这就是为什么生成的基础设施在 Gateway 目标之后创建策略。
 
-如果策略部署失败，CloudFormation 会将拒绝显示为不透明的 `Resource stabilization failed` 错误 — 运行 `aws bedrock-agentcore-control list-policies --policy-engine-id <id>` 以检索验证器的 `statusReasons`，其中包含实际原因。通过其 `description`（`Policy loaded from <file>.cedar`）而不是其带后缀的 `name` 来识别有问题的策略。
+如果策略部署失败，CloudFormation 会将拒绝显示为不透明的 `Resource stabilization failed` 错误 — 运行 `aws bedrock-agentcore-control list-policies --policy-engine-id <id>` 以检索验证器的 `statusReasons`，其中包含实际原因。
 
 ### 示例：禁止一个工具同时保留更广泛的许可
 

--- a/docs/src/content/docs/zh/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/zh/guides/agentcore-gateway.mdx
@@ -133,7 +133,7 @@ gateway -> targets
 生成的构造需要一个 `identity` 属性来提供用户池和客户端：
 
 ```ts {7,9-11} title="packages/infra/src/stacks/application-stack.ts"
-import { MyGateway, UserIdentity } from ':my-scope/common-constructs';
+import { MyGateway, UserIdentity } from '@my-scope/common-constructs';
 
 export class ApplicationStack extends Stack {
   constructor(scope: Construct, id: string, props?: StackProps) {
@@ -179,7 +179,9 @@ Cedar 是 AgentCore Gateway 用于授权工具调用的策略语言。流经 Gat
 
 ### 添加策略
 
-要添加策略，请在 `permit-all.cedar` 旁边创建一个新的 `.cedar` 文件。`policies/` 中的每个 `.cedar` 文件必须恰好包含**一个** `permit` 或 `forbid` 语句，并作为单个 `AWS::BedrockAgentCore::Policy` 资源部署。策略资源的名称派生自文件名：`permit-all.cedar` 变为 `PermitAll`（kebab/snake-case 转换为 PascalCase）。包含多个语句的文件在部署时会产生 `unexpected token 'forbid'` 错误 — 将它们拆分为单独的文件。
+要添加策略，请在 `permit-all.cedar` 旁边创建一个新的 `.cedar` 文件。`policies/` 中的每个 `.cedar` 文件必须恰好包含**一个** `permit` 或 `forbid` 语句，并作为单个 `AWS::BedrockAgentCore::Policy` 资源部署。包含多个语句的文件在部署时会产生 `unexpected token 'forbid'` 错误 — 将它们拆分为单独的文件。
+
+策略名称必须在帐户范围内唯一，因此部署的名称永远不会仅仅是文件名：CDK 从构造路径派生它，Terraform 将文件名转换为 PascalCase（`permit-all.cedar` → `PermitAll`）然后附加网关的随机后缀。策略的 **description** 才是标识其源文件的内容 — `Policy loaded from permit-all.cedar` — 因此在检查已部署的策略时要匹配它。
 
 例如，要仅允许特定代理角色调用特定工具，请创建：
 
@@ -332,7 +334,7 @@ resource == AgentCore::Gateway::"<%= gatewayArn %>"
 
 仍然适用一个排序约束：引用 `AgentCore::Action::"<target>___<tool>"` 的策略仅在目标向 Gateway 注册该工具后才验证，这就是为什么生成的基础设施在 Gateway 目标之后创建策略。
 
-如果策略部署失败，CloudFormation 会将拒绝显示为不透明的 `Resource stabilization failed` 错误 — 运行 `aws bedrock-agentcore-control list-policies --policy-engine-id <id>` 以检索验证器的 `statusReasons`，其中包含实际原因。
+如果策略部署失败，CloudFormation 会将拒绝显示为不透明的 `Resource stabilization failed` 错误 — 运行 `aws bedrock-agentcore-control list-policies --policy-engine-id <id>` 以检索验证器的 `statusReasons`，其中包含实际原因。通过其 `description`（`Policy loaded from <file>.cedar`）而不是其带后缀的 `name` 来识别有问题的策略。
 
 ### 示例：禁止一个工具同时保留更广泛的许可
 

--- a/docs/src/content/docs/zh/guides/ts-dcr-proxy.mdx
+++ b/docs/src/content/docs/zh/guides/ts-dcr-proxy.mdx
@@ -103,7 +103,7 @@ MCP 客户端（如 Claude Code、Kiro CLI 或 MCP Inspector）期望针对支�
 在您的堆栈中实例化生成的构造，传递所需的属性：
 
 ```typescript
-import { DcrProxy } from ':my-scope/common-constructs';
+import { DcrProxy } from '@my-scope/common-constructs';
 
 new DcrProxy(this, 'DcrProxy', {
   userPoolId: userPool.userPoolId,
@@ -155,8 +155,9 @@ import {
   DcrProxy,
   MyProjectMcpServer,
   UserIdentity,
-} from ':my-scope/common-constructs';
+} from '@my-scope/common-constructs';
 import { OAuthScope } from 'aws-cdk-lib/aws-cognito';
+import * as kms from 'aws-cdk-lib/aws-kms';
 import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager';
 
 const identity = new UserIdentity(this, 'Identity');
@@ -179,6 +180,9 @@ const proxyClient = identity.userPool.addClient('DcrProxyClient', {
 // Store the App Client secret in Secrets Manager for the token handler to read
 const clientSecret = new secretsmanager.Secret(this, 'ClientSecret', {
   secretStringValue: proxyClient.userPoolClientSecret,
+  encryptionKey: new kms.Key(this, 'ClientSecretKey', {
+    enableKeyRotation: true,
+  }),
 });
 
 // The MCP server, authorizing JWTs issued for the same App Client
@@ -267,8 +271,9 @@ import {
   DcrProxy,
   MyGateway,
   UserIdentity,
-} from ':my-scope/common-constructs';
+} from '@my-scope/common-constructs';
 import { OAuthScope } from 'aws-cdk-lib/aws-cognito';
+import * as kms from 'aws-cdk-lib/aws-kms';
 import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager';
 
 const identity = new UserIdentity(this, 'Identity');
@@ -291,6 +296,9 @@ const proxyClient = identity.userPool.addClient('DcrProxyClient', {
 // Store the App Client secret in Secrets Manager for the token handler to read
 const clientSecret = new secretsmanager.Secret(this, 'ClientSecret', {
   secretStringValue: proxyClient.userPoolClientSecret,
+  encryptionKey: new kms.Key(this, 'ClientSecretKey', {
+    enableKeyRotation: true,
+  }),
 });
 
 // The gateway, authorizing JWTs issued for the same App Client
@@ -307,7 +315,7 @@ new DcrProxy(this, 'DcrProxy', {
   cognitoClientSecretArn: clientSecret.secretArn,
   cognitoHostedUiBase: identity.userPoolDomain.baseUrl(),
   // Use the gateway construct's URL rather than hardcoding it
-  upstreamUrl: gateway.gateway.gatewayUrl,
+  upstreamUrl: gateway.gatewayUrl,
 });
 ```
 </Fragment>
@@ -341,7 +349,7 @@ resource "aws_secretsmanager_secret_version" "client_secret" {
 
 # The gateway, authorizing JWTs issued for the same App Client
 module "my_gateway" {
-  source = "../../common/terraform/src/app/agentcore-gateway/my-gateway"
+  source = "../../common/terraform/src/app/gateways/my-gateway"
 
   user_pool_id         = module.user_identity.user_pool_id
   user_pool_client_ids = [aws_cognito_user_pool_client.dcr_proxy.id]
@@ -466,8 +474,9 @@ import {
   DcrProxy,
   MyProjectMcpServer,
   UserIdentity,
-} from ':my-scope/common-constructs';
+} from '@my-scope/common-constructs';
 import { OAuthScope, CfnManagedLoginBranding } from 'aws-cdk-lib/aws-cognito';
+import * as kms from 'aws-cdk-lib/aws-kms';
 import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager';
 
 // The user pool created by ts#website#auth for your website users
@@ -492,6 +501,9 @@ new CfnManagedLoginBranding(this, 'DcrProxyClientBranding', {
 
 const clientSecret = new secretsmanager.Secret(this, 'ClientSecret', {
   secretStringValue: proxyClient.userPoolClientSecret,
+  encryptionKey: new kms.Key(this, 'ClientSecretKey', {
+    enableKeyRotation: true,
+  }),
 });
 
 const mcpServer = new MyProjectMcpServer(this, 'MyProjectMcpServer', {

--- a/docs/src/content/docs/zh/guides/ts-rdb.mdx
+++ b/docs/src/content/docs/zh/guides/ts-rdb.mdx
@@ -264,7 +264,7 @@ module "api" {
   source = "..."
   ...
 
-  environment_variables = {
+  env = {
     NODE_EXTRA_CA_CERTS = "/var/runtime/ca-cert.pem"
   }
 }

--- a/docs/src/content/docs/zh/snippets/connection/strands-agent-rdb-ssl-requirements.mdx
+++ b/docs/src/content/docs/zh/snippets/connection/strands-agent-rdb-ssl-requirements.mdx
@@ -23,7 +23,7 @@ new MyAgent(this, 'MyAgent', {
 ```hcl title="packages/infra/src/main.tf"
 module "my_agent" {
   ...
-  environment_variables = {
+  env = {
     NODE_EXTRA_CA_CERTS = "/usr/local/share/ca-certificates/rds-bundle.crt"
   }
 }

--- a/docs/src/content/docs/zh/snippets/connection/ts-lambda-rdb-ssl-requirements.mdx
+++ b/docs/src/content/docs/zh/snippets/connection/ts-lambda-rdb-ssl-requirements.mdx
@@ -28,7 +28,7 @@ module "api" {
   source = "..."
   ...
 
-  environment_variables = {
+  env = {
     NODE_EXTRA_CA_CERTS = "/var/runtime/ca-cert.pem"
   }
 }

--- a/docs/src/content/docs/zh/snippets/connection/ts-mcp-server-rdb-ssl-requirements.mdx
+++ b/docs/src/content/docs/zh/snippets/connection/ts-mcp-server-rdb-ssl-requirements.mdx
@@ -23,7 +23,7 @@ new MyMcpServer(this, 'MyMcpServer', {
 ```hcl title="packages/infra/src/main.tf"
 module "my_mcp_server" {
   ...
-  environment_variables = {
+  env = {
     NODE_EXTRA_CA_CERTS = "/usr/local/share/ca-certificates/rds-bundle.crt"
   }
 }

--- a/packages/nx-plugin/src/agentcore-gateway/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/agentcore-gateway/__snapshots__/generator.spec.ts.snap
@@ -336,7 +336,7 @@ export class MyGateway extends AgentCoreGateway {
     const rc = RuntimeConfig.ensure(this);
     rc.set('agentcore', 'gateways', {
       ...rc.get('agentcore').gateways,
-      MyGateway: this.gateway.gatewayUrl,
+      MyGateway: this.gatewayUrl,
     });
   }
 }

--- a/packages/nx-plugin/src/agentcore-gateway/generator.spec.ts
+++ b/packages/nx-plugin/src/agentcore-gateway/generator.spec.ts
@@ -280,7 +280,17 @@ describe('agentcore-gateway generator', () => {
         )!
         .toString();
       expect(construct).toContain("rc.set('agentcore', 'gateways'");
-      expect(construct).toContain('MyGateway: this.gateway.gatewayUrl');
+      expect(construct).toContain('MyGateway: this.gatewayUrl');
+    });
+
+    it('exposes a non-optional gatewayUrl accessor on the core construct', () => {
+      const construct = tree
+        .read(
+          'packages/common/constructs/src/core/agentcore-gateway/agentcore-gateway.ts',
+        )!
+        .toString();
+      expect(construct).toContain('public get gatewayUrl(): string');
+      expect(construct).toContain('.attrGatewayUrl');
     });
 
     it('exposes grantInvokeAccess + addMcpServerTarget public methods', () => {

--- a/packages/nx-plugin/src/connection/gateway-runtime-config.ts
+++ b/packages/nx-plugin/src/connection/gateway-runtime-config.ts
@@ -47,7 +47,7 @@ export const addGatewayUrlToConnectionNamespace = async (
 
     rc.set('connection', 'gateways', {
       ...rc.get('connection').gateways,
-      ${options.gatewayNameClassName}: this.gateway.gatewayUrl,
+      ${options.gatewayNameClassName}: this.gatewayUrl,
     });\` where { $program <: not contains \`rc.set('connection', 'gateways', $_)\` }`,
     );
   }

--- a/packages/nx-plugin/src/migrations/latest/gateway-url-accessor/__snapshots__/migration.spec.ts.snap
+++ b/packages/nx-plugin/src/migrations/latest/gateway-url-accessor/__snapshots__/migration.spec.ts.snap
@@ -1,0 +1,84 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`gateway-url-accessor migration > should add the gatewayUrl accessor to the vended core construct 1`] = `
+"import * as agentcore from 'aws-cdk-lib/aws-bedrockagentcore';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import { Construct } from 'constructs';
+
+export class AgentCoreGateway extends Construct implements iam.IGrantable {
+  public readonly gateway: agentcore.Gateway;
+
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+    this.gateway = undefined as any;
+  }
+
+  /**
+   * The principal to grant permissions to.
+   */
+  public get grantPrincipal(): iam.IPrincipal {
+    return this.gateway.role.grantPrincipal;
+  }
+
+  /**
+   * The gateway's URL endpoint. The Gateway L2 types its own \`gatewayUrl\` as
+   * optional and only populates it when created from its own props, so fall
+   * back to the CloudFormation attribute.
+   */
+  public get gatewayUrl(): string {
+    return (
+      this.gateway.gatewayUrl ??
+      (this.gateway.node.defaultChild as agentcore.CfnGateway).attrGatewayUrl
+    );
+  }
+
+  public addGateway(
+    gateway: Construct & {
+      readonly gateway: agentcore.Gateway;
+      readonly gatewayName: string;
+      readonly gatewayUrl: string;
+    },
+    props?: {
+      gatewayTargetName?: string;
+    },
+  ): agentcore.CfnGatewayTarget {
+    const target = this.addGatewayTarget({
+      gatewayTargetName: props?.gatewayTargetName ?? gateway.gatewayName,
+      gatewayUrl: gateway.gatewayUrl,
+      gatewayArn: gateway.gateway.gatewayArn,
+    });
+    target.node.addDependency(gateway);
+    return target;
+  }
+
+  public addGatewayTarget(props: {
+    gatewayTargetName: string;
+    gatewayUrl: string;
+    gatewayArn: string;
+  }): agentcore.CfnGatewayTarget {
+    return undefined as any;
+  }
+}
+"
+`;
+
+exports[`gateway-url-accessor migration > should point vended app-level gateway constructs at the accessor 1`] = `
+"import { Construct } from 'constructs';
+import { AgentCoreGateway } from '../../../core/agentcore-gateway/agentcore-gateway';
+import { RuntimeConfig } from '../../../core/runtime-config';
+
+export class MyGateway extends AgentCoreGateway {
+  public readonly gatewayName = 'my-gateway';
+
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+
+    const rc = RuntimeConfig.ensure(this);
+    rc.set('agentcore', 'gateways', {
+      ...rc.get('agentcore').gateways,
+      MyGateway: this.gatewayUrl,
+    });
+  }
+}
+"
+`;

--- a/packages/nx-plugin/src/migrations/latest/gateway-url-accessor/metadata.json
+++ b/packages/nx-plugin/src/migrations/latest/gateway-url-accessor/metadata.json
@@ -1,0 +1,3 @@
+{
+  "description": "Expose a non-optional gatewayUrl accessor on the vended AgentCoreGateway construct"
+}

--- a/packages/nx-plugin/src/migrations/latest/gateway-url-accessor/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/latest/gateway-url-accessor/migration.spec.ts
@@ -1,0 +1,220 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import type { Tree } from '@nx/devkit';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test.js';
+import migration from './migration.js';
+
+const GATEWAY_CONSTRUCT_FILE =
+  'packages/common/constructs/src/core/agentcore-gateway/agentcore-gateway.ts';
+
+const APP_GATEWAY_CONSTRUCT_FILE =
+  'packages/common/constructs/src/app/gateways/my-gateway/my-gateway.ts';
+
+/**
+ * The `AgentCoreGateway` core construct as generated prior to the `gatewayUrl`
+ * accessor, condensed to the shapes the migration anchors on: the
+ * `grantPrincipal` accessor it is inserted before, and `addGateway` with its
+ * inline CloudFormation-attribute fallback.
+ */
+const OLD_GATEWAY_CONSTRUCT_FILE = `import * as agentcore from 'aws-cdk-lib/aws-bedrockagentcore';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import { Construct } from 'constructs';
+
+export class AgentCoreGateway extends Construct implements iam.IGrantable {
+  public readonly gateway: agentcore.Gateway;
+
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+    this.gateway = undefined as any;
+  }
+
+  /**
+   * The principal to grant permissions to.
+   */
+  public get grantPrincipal(): iam.IPrincipal {
+    return this.gateway.role.grantPrincipal;
+  }
+
+  public addGateway(
+    gateway: Construct & {
+      readonly gateway: agentcore.Gateway;
+      readonly gatewayName: string;
+    },
+    props?: {
+      gatewayTargetName?: string;
+    },
+  ): agentcore.CfnGatewayTarget {
+    const target = this.addGatewayTarget({
+      gatewayTargetName: props?.gatewayTargetName ?? gateway.gatewayName,
+      // The Gateway L2 only populates gatewayUrl when created from its own
+      // props; fall back to the CloudFormation attribute otherwise.
+      gatewayUrl:
+        gateway.gateway.gatewayUrl ??
+        (gateway.gateway.node.defaultChild as agentcore.CfnGateway)
+          .attrGatewayUrl,
+      gatewayArn: gateway.gateway.gatewayArn,
+    });
+    target.node.addDependency(gateway);
+    return target;
+  }
+
+  public addGatewayTarget(props: {
+    gatewayTargetName: string;
+    gatewayUrl: string;
+    gatewayArn: string;
+  }): agentcore.CfnGatewayTarget {
+    return undefined as any;
+  }
+}
+`;
+
+/**
+ * A vended app-level gateway construct as generated prior to the accessor,
+ * condensed to its runtime config registration.
+ */
+const OLD_APP_GATEWAY_CONSTRUCT_FILE = `import { Construct } from 'constructs';
+import { AgentCoreGateway } from '../../../core/agentcore-gateway/agentcore-gateway';
+import { RuntimeConfig } from '../../../core/runtime-config';
+
+export class MyGateway extends AgentCoreGateway {
+  public readonly gatewayName = 'my-gateway';
+
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+
+    const rc = RuntimeConfig.ensure(this);
+    rc.set('agentcore', 'gateways', {
+      ...rc.get('agentcore').gateways,
+      MyGateway: this.gateway.gatewayUrl,
+    });
+  }
+}
+`;
+
+describe('gateway-url-accessor migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeUsingTsSolutionSetup();
+  });
+
+  it('should do nothing when no gateway constructs are vended', async () => {
+    const result = await migration(tree);
+    expect(result.nextSteps).toEqual([]);
+  });
+
+  it('should add the gatewayUrl accessor to the vended core construct', async () => {
+    tree.write(GATEWAY_CONSTRUCT_FILE, OLD_GATEWAY_CONSTRUCT_FILE);
+
+    const result = await migration(tree);
+
+    const contents = tree.read(GATEWAY_CONSTRUCT_FILE, 'utf-8');
+    expect(contents).toContain('public get gatewayUrl(): string {');
+    expect(contents).toContain('.attrGatewayUrl');
+    // addGateway reads the accessor rather than repeating the fallback.
+    expect(contents).toContain('gatewayUrl: gateway.gatewayUrl,');
+    expect(contents).not.toContain('gateway.gateway.gatewayUrl ??');
+    // The accessor is part of the shape addGateway requires.
+    expect(contents).toContain('readonly gatewayUrl: string;');
+    expect(result.nextSteps).toEqual([]);
+    expect(contents).toMatchSnapshot();
+  });
+
+  it('should point vended app-level gateway constructs at the accessor', async () => {
+    tree.write(GATEWAY_CONSTRUCT_FILE, OLD_GATEWAY_CONSTRUCT_FILE);
+    tree.write(APP_GATEWAY_CONSTRUCT_FILE, OLD_APP_GATEWAY_CONSTRUCT_FILE);
+
+    await migration(tree);
+
+    const contents = tree.read(APP_GATEWAY_CONSTRUCT_FILE, 'utf-8');
+    expect(contents).toContain('MyGateway: this.gatewayUrl,');
+    expect(contents).not.toContain('this.gateway.gatewayUrl');
+    expect(contents).toMatchSnapshot();
+  });
+
+  it('should preserve user code around the accessor', async () => {
+    tree.write(GATEWAY_CONSTRUCT_FILE, OLD_GATEWAY_CONSTRUCT_FILE);
+    tree.write(APP_GATEWAY_CONSTRUCT_FILE, OLD_APP_GATEWAY_CONSTRUCT_FILE);
+
+    await migration(tree);
+
+    // User-authored additions between the two runs must survive the second.
+    tree.write(
+      APP_GATEWAY_CONSTRUCT_FILE,
+      tree.read(APP_GATEWAY_CONSTRUCT_FILE, 'utf-8').replace(
+        "public readonly gatewayName = 'my-gateway';",
+        `public readonly gatewayName = 'my-gateway';
+
+  /** My own helper. */
+  public get myCustomUrl(): string {
+    return \`\${this.gatewayUrl}/custom\`;
+  }`,
+      ),
+    );
+
+    await migration(tree);
+
+    const contents = tree.read(APP_GATEWAY_CONSTRUCT_FILE, 'utf-8');
+    expect(contents).toContain('My own helper.');
+    expect(contents).toContain('public get myCustomUrl(): string {');
+    expect(contents).toContain('MyGateway: this.gatewayUrl,');
+  });
+
+  it('should be idempotent', async () => {
+    tree.write(GATEWAY_CONSTRUCT_FILE, OLD_GATEWAY_CONSTRUCT_FILE);
+    tree.write(APP_GATEWAY_CONSTRUCT_FILE, OLD_APP_GATEWAY_CONSTRUCT_FILE);
+
+    await migration(tree);
+    const coreAfterFirst = tree.read(GATEWAY_CONSTRUCT_FILE, 'utf-8');
+    const appAfterFirst = tree.read(APP_GATEWAY_CONSTRUCT_FILE, 'utf-8');
+
+    const secondRun = await migration(tree);
+
+    expect(tree.read(GATEWAY_CONSTRUCT_FILE, 'utf-8')).toEqual(coreAfterFirst);
+    expect(tree.read(APP_GATEWAY_CONSTRUCT_FILE, 'utf-8')).toEqual(
+      appAfterFirst,
+    );
+    expect(secondRun.nextSteps).toEqual([]);
+  });
+
+  it('should skip and report a diverged core construct', async () => {
+    tree.write(
+      GATEWAY_CONSTRUCT_FILE,
+      `export class AgentCoreGateway { /* fully customised */ }`,
+    );
+
+    const result = await migration(tree);
+
+    expect(tree.read(GATEWAY_CONSTRUCT_FILE, 'utf-8')).toContain(
+      'fully customised',
+    );
+    expect(result.nextSteps).toEqual([
+      expect.stringContaining('diverged from the generated shape'),
+    ]);
+  });
+
+  it('should leave a construct with a user-added gatewayUrl accessor alone', async () => {
+    tree.write(
+      GATEWAY_CONSTRUCT_FILE,
+      OLD_GATEWAY_CONSTRUCT_FILE.replace(
+        '  /**\n   * The principal to grant permissions to.\n   */',
+        `  public get gatewayUrl(): string {
+    return 'https://my-own-url';
+  }
+
+  /**
+   * The principal to grant permissions to.
+   */`,
+      ),
+    );
+
+    const result = await migration(tree);
+
+    const contents = tree.read(GATEWAY_CONSTRUCT_FILE, 'utf-8');
+    expect(contents).toContain("'https://my-own-url'");
+    expect(contents.match(/public get gatewayUrl/g)).toHaveLength(1);
+    expect(result.nextSteps).toEqual([]);
+  });
+});

--- a/packages/nx-plugin/src/migrations/latest/gateway-url-accessor/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/latest/gateway-url-accessor/migration.spec.ts
@@ -195,6 +195,36 @@ describe('gateway-url-accessor migration', () => {
     ]);
   });
 
+  it('should leave app constructs alone when the core construct could not be migrated', async () => {
+    tree.write(
+      GATEWAY_CONSTRUCT_FILE,
+      `export class AgentCoreGateway { /* fully customised */ }`,
+    );
+    tree.write(APP_GATEWAY_CONSTRUCT_FILE, OLD_APP_GATEWAY_CONSTRUCT_FILE);
+
+    const result = await migration(tree);
+
+    // Pointing an app construct at an accessor the core construct does not have
+    // would leave the workspace failing to compile.
+    expect(tree.read(APP_GATEWAY_CONSTRUCT_FILE, 'utf-8')).toEqual(
+      OLD_APP_GATEWAY_CONSTRUCT_FILE,
+    );
+    expect(result.nextSteps).toEqual([
+      expect.stringContaining('diverged from the generated shape'),
+    ]);
+  });
+
+  it('should leave app constructs alone when no core construct is vended', async () => {
+    tree.write(APP_GATEWAY_CONSTRUCT_FILE, OLD_APP_GATEWAY_CONSTRUCT_FILE);
+
+    const result = await migration(tree);
+
+    expect(tree.read(APP_GATEWAY_CONSTRUCT_FILE, 'utf-8')).toEqual(
+      OLD_APP_GATEWAY_CONSTRUCT_FILE,
+    );
+    expect(result.nextSteps).toEqual([]);
+  });
+
   it('should leave a construct with a user-added gatewayUrl accessor alone', async () => {
     tree.write(
       GATEWAY_CONSTRUCT_FILE,

--- a/packages/nx-plugin/src/migrations/latest/gateway-url-accessor/migration.ts
+++ b/packages/nx-plugin/src/migrations/latest/gateway-url-accessor/migration.ts
@@ -47,14 +47,16 @@ const divergedCoreMessage = `${GATEWAY_CONSTRUCT_FILE}: the AgentCoreGateway con
 
 /**
  * Add the `gatewayUrl` accessor to the vended core construct, and route
- * `addGateway` and the shape it requires of its argument through it.
+ * `addGateway` and the shape it requires of its argument through it. Returns
+ * whether the core construct ends up carrying the accessor — app-level
+ * constructs may only be pointed at it once it exists.
  */
 const migrateCoreConstruct = async (
   tree: Tree,
   nextSteps: string[],
-): Promise<void> => {
+): Promise<boolean> => {
   if (!tree.exists(GATEWAY_CONSTRUCT_FILE)) {
-    return;
+    return false;
   }
 
   const hasAccessor = await matchGritQL(
@@ -75,7 +77,7 @@ const migrateCoreConstruct = async (
     );
     if (!added) {
       nextSteps.push(divergedCoreMessage);
-      return;
+      return false;
     }
   }
 
@@ -107,6 +109,8 @@ const migrateCoreConstruct = async (
     })\``,
     );
   }
+
+  return true;
 };
 
 /**
@@ -135,8 +139,11 @@ export default async function migration(
 ): Promise<MigrationReturnObject> {
   const nextSteps: string[] = [];
 
-  await migrateCoreConstruct(tree, nextSteps);
-  await migrateAppConstructs(tree);
+  // The app constructs read the accessor, so they may only be migrated once the
+  // core construct carries it.
+  if (await migrateCoreConstruct(tree, nextSteps)) {
+    await migrateAppConstructs(tree);
+  }
 
   await formatFilesInSubtree(tree);
 

--- a/packages/nx-plugin/src/migrations/latest/gateway-url-accessor/migration.ts
+++ b/packages/nx-plugin/src/migrations/latest/gateway-url-accessor/migration.ts
@@ -1,0 +1,144 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import type { MigrationReturnObject, Tree } from '@nx/devkit';
+import {
+  applyGritQL,
+  GRIT_INSERT_PLACEHOLDER,
+  insertViaGritQL,
+  matchGritQL,
+} from '../../../utils/ast.js';
+import { formatFilesInSubtree } from '../../../utils/format.js';
+import {
+  PACKAGES_DIR,
+  SHARED_CONSTRUCTS_DIR,
+} from '../../../utils/shared-constructs-constants.js';
+
+/**
+ * The CDK `Gateway` L2 types its `gatewayUrl` as `string | undefined`, so
+ * reaching through the vended `AgentCoreGateway` construct to
+ * `gateway.gateway.gatewayUrl` does not typecheck where a `string` is required —
+ * the DCR proxy's `upstreamUrl`, for example. `AgentCoreGateway` gains a
+ * non-optional `gatewayUrl` accessor falling back to the CloudFormation
+ * attribute, which `addGateway` and the vended app-level gateway constructs then
+ * read.
+ */
+
+const CONSTRUCTS_SRC = `${PACKAGES_DIR}/${SHARED_CONSTRUCTS_DIR}/src`;
+
+const GATEWAY_CONSTRUCT_FILE = `${CONSTRUCTS_SRC}/core/agentcore-gateway/agentcore-gateway.ts`;
+
+const GATEWAYS_DIR = `${CONSTRUCTS_SRC}/app/gateways`;
+
+const GATEWAY_URL_ACCESSOR = `/**
+   * The gateway's URL endpoint. The Gateway L2 types its own \`gatewayUrl\` as
+   * optional and only populates it when created from its own props, so fall
+   * back to the CloudFormation attribute.
+   */
+  public get gatewayUrl(): string {
+    return (
+      this.gateway.gatewayUrl ??
+      (this.gateway.node.defaultChild as agentcore.CfnGateway).attrGatewayUrl
+    );
+  }`;
+
+const divergedCoreMessage = `${GATEWAY_CONSTRUCT_FILE}: the AgentCoreGateway construct has diverged from the generated shape - left untouched. To use a gateway's URL where a \`string\` is required, add a \`public get gatewayUrl(): string\` accessor returning \`this.gateway.gatewayUrl ?? (this.gateway.node.defaultChild as agentcore.CfnGateway).attrGatewayUrl\`.`;
+
+/**
+ * Add the `gatewayUrl` accessor to the vended core construct, and route
+ * `addGateway` and the shape it requires of its argument through it.
+ */
+const migrateCoreConstruct = async (
+  tree: Tree,
+  nextSteps: string[],
+): Promise<void> => {
+  if (!tree.exists(GATEWAY_CONSTRUCT_FILE)) {
+    return;
+  }
+
+  const hasAccessor = await matchGritQL(
+    tree,
+    GATEWAY_CONSTRUCT_FILE,
+    '`public get gatewayUrl(): string { $_ }`',
+  );
+
+  if (!hasAccessor) {
+    // Anchored on the grantPrincipal accessor, present in every vended version.
+    const added = await insertViaGritQL(
+      tree,
+      GATEWAY_CONSTRUCT_FILE,
+      `\`public get grantPrincipal(): iam.IPrincipal { $body }\` as $accessor => \`$accessor
+
+  ${GRIT_INSERT_PLACEHOLDER}\``,
+      GATEWAY_URL_ACCESSOR,
+    );
+    if (!added) {
+      nextSteps.push(divergedCoreMessage);
+      return;
+    }
+  }
+
+  const addGatewayUsesAccessor = await matchGritQL(
+    tree,
+    GATEWAY_CONSTRUCT_FILE,
+    '`gatewayUrl: gateway.gatewayUrl`',
+  );
+
+  if (!addGatewayUsesAccessor) {
+    // The accessor is part of the shape addGateway requires of its argument.
+    await applyGritQL(
+      tree,
+      GATEWAY_CONSTRUCT_FILE,
+      `\`readonly gatewayName: string\` as $member => \`$member;
+      readonly gatewayUrl: string\``,
+    );
+
+    // addGateway reads the accessor rather than repeating the fallback inline.
+    await applyGritQL(
+      tree,
+      GATEWAY_CONSTRUCT_FILE,
+      `\`this.addGatewayTarget({ gatewayTargetName: $name, gatewayUrl: $url, gatewayArn: $arn })\` where {
+  $url <: contains \`attrGatewayUrl\`
+} => \`this.addGatewayTarget({
+      gatewayTargetName: $name,
+      gatewayUrl: gateway.gatewayUrl,
+      gatewayArn: $arn,
+    })\``,
+    );
+  }
+};
+
+/**
+ * Point each vended app-level gateway construct's runtime config entry at the
+ * accessor.
+ */
+const migrateAppConstructs = async (tree: Tree): Promise<void> => {
+  if (!tree.exists(GATEWAYS_DIR)) {
+    return;
+  }
+  for (const dir of tree.children(GATEWAYS_DIR)) {
+    const constructFile = `${GATEWAYS_DIR}/${dir}/${dir}.ts`;
+    if (!tree.exists(constructFile)) {
+      continue;
+    }
+    await applyGritQL(
+      tree,
+      constructFile,
+      '`this.gateway.gatewayUrl` => `this.gatewayUrl`',
+    );
+  }
+};
+
+export default async function migration(
+  tree: Tree,
+): Promise<MigrationReturnObject> {
+  const nextSteps: string[] = [];
+
+  await migrateCoreConstruct(tree, nextSteps);
+  await migrateAppConstructs(tree);
+
+  await formatFilesInSubtree(tree);
+
+  return { nextSteps };
+}

--- a/packages/nx-plugin/src/utils/agent-core-constructs/files/cdk/app/agentcore-gateway/__nameKebabCase__/__nameKebabCase__.ts.template
+++ b/packages/nx-plugin/src/utils/agent-core-constructs/files/cdk/app/agentcore-gateway/__nameKebabCase__/__nameKebabCase__.ts.template
@@ -81,7 +81,7 @@ export class <%- nameClassName %> extends AgentCoreGateway {
     const rc = RuntimeConfig.ensure(this);
     rc.set('agentcore', 'gateways', {
       ...rc.get('agentcore').gateways,
-      <%- nameClassName %>: this.gateway.gatewayUrl,
+      <%- nameClassName %>: this.gatewayUrl,
     });
   }
 }

--- a/packages/nx-plugin/src/utils/agent-core-constructs/files/cdk/core/agentcore-gateway/agentcore-gateway.ts.template
+++ b/packages/nx-plugin/src/utils/agent-core-constructs/files/cdk/core/agentcore-gateway/agentcore-gateway.ts.template
@@ -280,6 +280,18 @@ export class AgentCoreGateway extends Construct implements iam.IGrantable {
   }
 
   /**
+   * The gateway's URL endpoint. The Gateway L2 types its own `gatewayUrl` as
+   * optional and only populates it when created from its own props, so fall
+   * back to the CloudFormation attribute.
+   */
+  public get gatewayUrl(): string {
+    return (
+      this.gateway.gatewayUrl ??
+      (this.gateway.node.defaultChild as agentcore.CfnGateway).attrGatewayUrl
+    );
+  }
+
+  /**
    * The principal to grant permissions to.
    */
   public get grantPrincipal(): iam.IPrincipal {
@@ -395,6 +407,7 @@ export class AgentCoreGateway extends Construct implements iam.IGrantable {
     gateway: Construct & {
       readonly gateway: agentcore.Gateway;
       readonly gatewayName: string;
+      readonly gatewayUrl: string;
     },
     props?: {
       gatewayTargetName?: string;
@@ -402,12 +415,7 @@ export class AgentCoreGateway extends Construct implements iam.IGrantable {
   ): agentcore.CfnGatewayTarget {
     const target = this.addGatewayTarget({
       gatewayTargetName: props?.gatewayTargetName ?? gateway.gatewayName,
-      // The Gateway L2 only populates gatewayUrl when created from its own
-      // props; fall back to the CloudFormation attribute otherwise.
-      gatewayUrl:
-        gateway.gateway.gatewayUrl ??
-        (gateway.gateway.node.defaultChild as agentcore.CfnGateway)
-          .attrGatewayUrl,
+      gatewayUrl: gateway.gatewayUrl,
       gatewayArn: gateway.gateway.gatewayArn,
     });
     // AgentCore fetches the target gateway's tools during target creation,


### PR DESCRIPTION
### Reason for this change

Five bug-bash findings against the DCR proxy / AgentCore Gateway guides and one Terraform module input, three of which break a user who copies the documented code verbatim:

- **`gateway-01`** (major) — every CDK snippet in `ts-dcr-proxy.mdx` stores the App Client secret with a plain `new secretsmanager.Secret(...)`. That uses the AWS-managed key, which the `ts#infra` project's default `checkov` target flags as `CKV_AWS_149`. `checkov` is a `dependsOn` of `infra:build`, so `nx run-many --target build --all` **fails** on the copied snippet. `CKV_AWS_149` is not in the generated skip list.
- **`gateway-02`** (major) — `upstreamUrl: gateway.gateway.gatewayUrl` fails `tsc` with TS2322: the CDK `Gateway` L2 types `gatewayUrl` as `string | undefined`, but `DcrProxyProps.upstreamUrl` is `string`.
- **`gateway-03`** (major) — the Terraform tab sourced the gateway module from `src/app/agentcore-gateway/<name>`, a path the generator never creates (it writes `src/app/gateways/<name>`), so `terraform init` fails with `Unreadable module directory`.
- **`terraform-04`** (major) — the `ts-rdb` Terraform tab told the reader to pass `environment_variables` to the API module while the generated module declares `env`, so `terraform validate` rejects it with `Unsupported argument`. This is the documented path for loading the RDS CA bundle when connecting to Aurora without RDS Proxy.
- **`gateway-04`** (docs) — five snippets used a `':my-scope/common-constructs'` import specifier (leading colon instead of `@`), which resolves to nothing.

### Description of changes

**`gateway-02` fixed in the construct, not the doc.** The shared gateway construct already knew about the optional `gatewayUrl` and worked around it internally in `addGateway`, but never exposed the result to users, so the documented usage could not typecheck. Rather than papering over that in the guide with a non-null assertion, `AgentCoreGateway` now exposes a non-optional `gatewayUrl` accessor carrying the CloudFormation-attribute fallback. `addGateway` reads it (dropping its duplicated inline fallback and gaining `readonly gatewayUrl: string` in the shape it requires of its argument), the vended app-level gateway constructs use it for their runtime-config entry, and the guide's `upstreamUrl: gateway.gatewayUrl` now compiles as printed. The `connection` runtime-config patch was updated to match.

**A deterministic migration (`latest/gateway-url-accessor`) carries existing workspaces across**, since the core construct is vended `KeepExisting` and would otherwise pair new app constructs with a stale core one. The app-level pass is gated on the core construct actually carrying the accessor — a diverged or absent core construct leaves the app constructs untouched and is reported via `nextSteps`, rather than pointing them at an accessor that does not exist.

**`gateway-01` fixed in the doc.** The plain `Secret` is what fails; the generated `checkov.yml` skip list is correct not to suppress a real finding. All four CDK snippets now pass an `encryptionKey: new kms.Key(..., { enableKeyRotation: true })`, matching how every other vended construct in the plugin encrypts at rest.

The remaining three are doc-only and need no migration: the Terraform module path, the `env` input name (in `ts-rdb.mdx` plus the three `*-rdb-ssl-requirements` snippets that share the error — found by sweeping every `hcl` block's module arguments against the generated modules' declared variables; no others were wrong), and the import specifier.

**Not addressed:** finding `gateway-05` (the Cedar policy guide describing the deployed policy name) — the prose change was reverted per review.

### Description of how you validated changes

**Unit tests.** `pnpm nx run @aws/nx-plugin:test` — full suite green. Added a `gateway-url-accessor` migration spec (9 cases: applies to the vended shape, rewrites the app-level constructs, **preserves user content written between two runs**, is idempotent, skips and reports a diverged construct, leaves app constructs alone when the core construct could not be migrated or is absent, and leaves a user-added accessor alone) plus a generator assertion for the new accessor. Both gating tests were confirmed to fail without the gate. The one `agentcore-gateway` snapshot change is the intended `MyGateway: this.gatewayUrl` line.

**Repo.** `pnpm nx run-many --target lint --all --fix` and `pnpm nx run-many --target build --all` both green, including `docs:build` and `generate-migrations` (the migration is registered as `latest-gateway-url-accessor`).

**CDK end-to-end** (fresh `--iac=cdk` workspace, locally compiled plugin, `agentcore-gateway --auth=cognito` + `ts#dcr-proxy` + `ts#infra` + `ts#react-website#auth`, with the guide's "Fronting an AgentCore Gateway" snippet pasted in verbatim):

- `nx run-many --target build --all` — **passes**, where the pre-fix snippet failed at `infra:checkov`.
- `checkov`: **188 passed / 0 failed** (`CKV_AWS_149` now PASSED).
- `tsc` clean on `upstreamUrl: gateway.gatewayUrl`; the synthesized template resolves it to `{"Fn::GetAtt": ["MyGatewayCF5984F0", "GatewayUrl"]}`.

**Terraform end-to-end** (fresh `--iac=terraform` workspace, modules wired exactly as the guides instruct): `terraform init` and `terraform validate` both **succeed**. Both regressions were also reproduced against the same workspace to confirm the fixes were the right ones — `environment_variables` gives `An argument named "environment_variables" is not expected here`, and `app/agentcore-gateway/my-gateway` gives `Unreadable module directory ... no such file or directory`.

Stopped at `synth` / `validate` — nothing was deployed to AWS.

### Issue # (if applicable)

N/A — from a v1.0 bug bash. Closes findings `gateway-01`, `gateway-02`, `gateway-03`, `gateway-04` and `terraform-04`.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
