### PR TITLE
fix(connection): make smithy extension traits take effect on the generated client

### DIFF
--- a/docs/src/content/docs/en/guides/connection/react-agui.mdx
+++ b/docs/src/content/docs/en/guides/connection/react-agui.mdx
@@ -46,16 +46,17 @@ The generator creates a **single shared** `AguiProvider` component, one hook per
 - src
   - components
     - AguiProvider.tsx Single `CopilotKitProvider` for every AG-UI agent. Created on the first `connection` run and updated on subsequent runs to register each new agent.
+    - \<agent-name>-chat.tsx A themed `<AgentName>Chat` bound to this agent's id. One file per `connection` run.
     - copilot
       - index.tsx Re-exports `CopilotChat`, `CopilotSidebar` and `CopilotPopup` with slot defaults that match your website's `ux` (Cloudscape, Shadcn, or no theme at all).
       - *ThemeComponents*.tsx Per-slot theme components (e.g. `CloudscapeAssistantMessage.tsx`, `ShadcnChatInput.tsx`). Only vended when `ux` is `cloudscape` or `shadcn`.
   - hooks
-    - useAgui\<AgentName>.tsx Registers one AG-UI agent. One file per `connection` run.
+    - useAgui\<AgentName>.tsx Registers one AG-UI agent and exports its id as `<AGENT_NAME>_ID`. One file per `connection` run.
     - useSigV4.tsx SigV4 signing (IAM only)
 
 </FileTree>
 
-Running `connection` a second time for a different agent **adds a new `useAgui<AgentName>.tsx` hook** and updates `AguiProvider.tsx` to register both hooks — any custom edits you've made to the provider are preserved. `main.tsx` keeps its single `<AguiProvider>` wrapper — you never end up with nested providers.
+Running `connection` a second time for a different agent **adds a new `useAgui<AgentName>.tsx` hook and `<agent-name>-chat.tsx` component** and updates `AguiProvider.tsx` to register both hooks — any custom edits you've made to the provider are preserved. `main.tsx` keeps its single `<AguiProvider>` wrapper — you never end up with nested providers.
 
 The following dependencies are added to the root `package.json`:
 
@@ -119,17 +120,14 @@ Both Session ID and Thread ID are provided by the browser. To restrict each user
 
 ### Adding a Chat Interface
 
-Instantiate CopilotKit components with `agentId` to select which agent to use. The id is the agent's name — the same one you chose when you ran the <Link path="guides/ts-agent">`ts#agent`</Link> or <Link path="guides/py-agent">`py#agent`</Link> generator — and you can also find it in the generated hook file (e.g. the key returned from `packages/web/src/hooks/useAgui<AgentName>.tsx`).
-
-Import the chat components from the generated `./components/copilot` module so the theme that matches your website's `ux` is applied automatically:
+The generator vends a `<AgentName>Chat` component per connected agent, already bound to that agent's id and themed to match your website's `ux`. Drop it anywhere inside the `<AguiProvider>` wrapper:
 
 ```tsx
-import { CopilotChat } from './components/copilot';
+import { StoryAgentChat } from './components/story-agent-chat';
 
 function ChatPage() {
   return (
-    <CopilotChat
-      agentId="agent"
+    <StoryAgentChat
       labels={{
         welcomeMessageText: 'How can I help you today?',
         chatInputPlaceholder: 'Ask me anything...',
@@ -139,15 +137,24 @@ function ChatPage() {
 }
 ```
 
+It forwards every `CopilotChat` prop except `agentId`, so anything you can pass to `<CopilotChat />` works here too.
+
 ### Connecting Multiple AG-UI Agents
 
-Run the `connection` generator once per agent. Every agent registered via the shared `AguiProvider` is visible from anywhere in the app — instantiate a CopilotKit component with a different `agentId` to route each chat to the agent you want:
+Run the `connection` generator once per agent. Each run vends that agent's own chat component, so routing a chat to a particular agent is a matter of which component you render:
 
 ```tsx
-import { CopilotChat } from './components/copilot';
+import { StoryAgentChat } from './components/story-agent-chat';
+import { ResearchAgentChat } from './components/research-agent-chat';
 
-<CopilotChat agentId="story" />    {/* talks to StoryAgent */}
-<CopilotChat agentId="research" /> {/* talks to ResearchAgent */}
+<StoryAgentChat />    {/* talks to StoryAgent */}
+<ResearchAgentChat /> {/* talks to ResearchAgent */}
+```
+
+If you need the raw id — to call CopilotKit's own hooks, say — each generated hook exports it:
+
+```tsx
+import { STORY_AGENT_ID } from './hooks/useAguiStoryAgent';
 ```
 
 ## Customising the Look and Feel
@@ -164,12 +171,13 @@ The generator reads `metadata.ux` from your React website project and vends a th
 | `shadcn` | Assistant messages render in a `bg-muted` bubble with a `Sparkles` avatar; user messages render right-aligned in a `bg-primary` bubble with a `User` avatar. The input is a rounded `Textarea` + pill-shaped send/stop `Button` (Enter submits, Shift+Enter newlines). Uses shadcn primitives from the shared `common-shadcn` package. |
 | `none` (or anything else) | No theme — the module just re-exports the default CopilotKit components. |
 
-Import the themed components from the **local theme module** (not `@copilotkit/react-core/v2` directly) so the theme is applied automatically:
+The vended `<AgentName>Chat` components are already themed. For a chat you wire up yourself, import from the **local theme module** (not `@copilotkit/react-core/v2` directly) so the theme is applied automatically:
 
 ```tsx
 import { CopilotChat } from './components/copilot';
+import { STORY_AGENT_ID } from './hooks/useAguiStoryAgent';
 
-<CopilotChat agentId="agent" />
+<CopilotChat agentId={STORY_AGENT_ID} />
 ```
 
 The theme is applied as slot defaults, so any slot you explicitly pass still wins — you keep full control whenever you need a one-off override.
@@ -188,8 +196,7 @@ For example, to drop in your own user-message renderer while keeping the rest of
 Per-chat overrides still work alongside the theme — anything you pass as a slot prop overrides the themed default:
 
 ```tsx
-<CopilotChat
-  agentId="agent"
+<StoryAgentChat
   // style the input and its children
   input={{
     textArea: 'text-blue-600',
@@ -208,25 +215,23 @@ Per-chat overrides still work alongside the theme — anything you pass as a slo
 Any slot can take a React component instead of a className, so you can replace the default entirely:
 
 ```tsx
-import { CopilotChat } from './components/copilot';
+import { StoryAgentChat } from './components/story-agent-chat';
 
-const MySendButton: React.FC<{ onClick: () => void }> = ({ onClick }) => (
+const MySendButton: React.FC<React.ButtonHTMLAttributes<HTMLButtonElement>> = ({
+  onClick,
+}) => (
   <button onClick={onClick} className="my-send-btn">
     Send
   </button>
 );
 
-<CopilotChat
-  agentId="agent"
-  input={{ sendButton: MySendButton }}
-/>;
+<StoryAgentChat input={{ sendButton: MySendButton }} />;
 ```
 
 Deeper overrides follow the same shape — e.g. replace just the copy button on assistant messages:
 
 ```tsx
-<CopilotChat
-  agentId="agent"
+<StoryAgentChat
   messageView={{
     assistantMessage: {
       copyButton: ({ onClick }) => <button onClick={onClick}>Copy</button>,

--- a/docs/src/content/docs/en/guides/connection/react-fastapi.mdx
+++ b/docs/src/content/docs/en/guides/connection/react-fastapi.mdx
@@ -248,7 +248,7 @@ const createItem = useMutation({
   onSettled: () => {
     // This will run when the mutation completes (success or error)
     // Good place to invalidate queries that might be affected
-    queryClient.invalidateQueries({ queryKey: api.listItems.queryKey() });
+    queryClient.invalidateQueries({ queryKey: api.listItems.queryKey({}) });
   }
 });
 ```
@@ -495,7 +495,9 @@ function ItemList() {
 
 ### Error Handling
 
-The integration includes built-in error handling with typed error responses. An `<operation-name>Error` type is generated which encapsulates the possible error responses defined in the OpenAPI specification. Each error has a `status` and `error` property, and by checking the value of `status` you can narrow to a specific type of error.
+The integration includes built-in error handling with typed error responses. An `<OperationName>Error` type is generated which is a union of one `<OperationName><StatusCode>Error` member per error status the operation's `responses` declares. Each member has a `status` and an `error` property, so switching on `status` narrows `error` to that status's model.
+
+The example below assumes `create_item` declares the [`responses` defined further down this page](#specifying-response-models) — a `400` `ValidationErrorDetails`, a `403` `str` and a `500` `ErrorDetails`. Only the statuses you declare appear in the union (plus FastAPI's own `422`), so a `case` for a status you haven't declared is a compile error.
 
 ```tsx {12}
 import { useMutation } from '@tanstack/react-query';
@@ -511,34 +513,32 @@ function MyComponent() {
   if (createItem.error) {
     switch (createItem.error.status) {
       case 400:
-        // error.error is typed as CreateItem400Response
+        // error.error is typed as ValidationErrorDetails
         return (
           <div>
             <h2>Invalid input:</h2>
             <p>{createItem.error.error.message}</p>
             <ul>
-              {createItem.error.error.validationErrors.map((err) => (
-                <li key={err.field}>{err.message}</li>
+              {createItem.error.error.fieldErrors.map((err) => (
+                <li key={err}>{err}</li>
               ))}
             </ul>
           </div>
         );
       case 403:
-        // error.error is typed as CreateItem403Response
+        // error.error is a string as specified in the responses
         return (
           <div>
             <h2>Not authorized:</h2>
-            <p>{createItem.error.error.reason}</p>
+            <p>{createItem.error.error}</p>
           </div>
         );
       case 500:
-      case 502:
-        // error.error is typed as CreateItem5XXResponse
+        // error.error is typed as ErrorDetails
         return (
           <div>
             <h2>Server error:</h2>
             <p>{createItem.error.error.message}</p>
-            <p>Trace ID: {createItem.error.error.traceId}</p>
           </div>
         );
     }
@@ -547,6 +547,10 @@ function MyComponent() {
   return <button onClick={handleClick}>Create Item</button>;
 }
 ```
+
+:::note[Python field names]
+The generated client camelCases model fields, so a Pydantic model declaring `field_errors` is read as `error.fieldErrors`.
+:::
 
 <Drawer title="Error handling using the API client directly" trigger="Click here for an example using the vanilla client directly.">
 ```tsx {9,15}
@@ -566,34 +570,32 @@ function MyComponent() {
   if (error) {
     switch (error.status) {
       case 400:
-        // error.error is typed as CreateItem400Response
+        // error.error is typed as ValidationErrorDetails
         return (
           <div>
             <h2>Invalid input:</h2>
             <p>{error.error.message}</p>
             <ul>
-              {error.error.validationErrors.map((err) => (
-                <li key={err.field}>{err.message}</li>
+              {error.error.fieldErrors.map((err) => (
+                <li key={err}>{err}</li>
               ))}
             </ul>
           </div>
         );
       case 403:
-        // error.error is typed as CreateItem403Response
+        // error.error is a string as specified in the responses
         return (
           <div>
             <h2>Not authorized:</h2>
-            <p>{error.error.reason}</p>
+            <p>{error.error}</p>
           </div>
         );
       case 500:
-      case 502:
-        // error.error is typed as CreateItem5XXResponse
+        // error.error is typed as ErrorDetails
         return (
           <div>
             <h2>Server error:</h2>
             <p>{error.error.message}</p>
-            <p>Trace ID: {error.error.traceId}</p>
           </div>
         );
     }
@@ -784,6 +786,8 @@ def list_items(page: int = 1, limit: int = 10):
 
 The generated hooks and client methods are automatically organized based on the OpenAPI tags in your FastAPI endpoints. This helps keep your API calls organized and makes it easier to find related operations.
 
+Within a group each operation keeps its own camelCased name, taken from your endpoint function's name — so `def list_items()` tagged `"items"` is reached at `api.items.listItems`.
+
 For example:
 
 ```python title="items.py"
@@ -791,7 +795,7 @@ For example:
     "/items",
     tags=["items"],
 )
-def list():
+def list(cursor: str | None = None):
     # ...
 
 @app.post(
@@ -811,6 +815,10 @@ def list():
     # ...
 ```
 
+:::tip[Repeated function names]
+Two endpoints named `list` in different tags don't clash — the generator qualifies a duplicated name with its tag, so both are reachable at `api.items.list` and `api.users.list`.
+:::
+
 The generated hooks will be grouped by these tags:
 
 ```tsx
@@ -821,7 +829,7 @@ function ItemsAndUsers() {
   const api = useMyApi();
 
   // Items operations are grouped under api.items
-  const items = useQuery(api.items.list.queryOptions());
+  const items = useQuery(api.items.list.queryOptions({}));
   const createItem = useMutation(api.items.create.mutationOptions());
 
   // Users operations are grouped under api.users
@@ -873,7 +881,7 @@ function ItemsAndUsers() {
         setIsLoading(true);
 
         // Items operations are grouped under api.items
-        const itemsData = await api.items.list();
+        const itemsData = await api.items.list({});
         setItems(itemsData);
 
         // Users operations are grouped under api.users
@@ -943,7 +951,7 @@ from pydantic import BaseModel
 class ErrorDetails(BaseModel):
     message: str
 
-class ValidationError(BaseModel):
+class ValidationErrorDetails(BaseModel):
     message: str
     field_errors: list[str]
 ```
@@ -958,7 +966,7 @@ class NotFoundException(Exception):
         self.message = message
 
 class ValidationException(Exception):
-    def __init__(self, details: ValidationError):
+    def __init__(self, details: ValidationErrorDetails):
         self.details = details
 ```
 
@@ -997,8 +1005,8 @@ Finally, specify the response models for different error status codes in your en
 @app.get(
     "/items/{item_id}",
     responses={
-        404: {"model": str}
-        500: {"model": ErrorDetails}
+        404: {"model": str},
+        500: {"model": ErrorDetails},
     }
 )
 def get_item(item_id: str) -> Item:
@@ -1010,14 +1018,15 @@ def get_item(item_id: str) -> Item:
 @app.post(
     "/items",
     responses={
-        400: {"model": ValidationError},
-        403: {"model": str}
+        400: {"model": ValidationErrorDetails},
+        403: {"model": str},
+        500: {"model": ErrorDetails},
     }
 )
 def create_item(item: Item) -> Item:
     if not is_valid(item):
         raise ValidationException(
-            ValidationError(
+            ValidationErrorDetails(
                 message="Invalid item data",
                 field_errors=["name is required"]
             )
@@ -1035,33 +1044,18 @@ import { useMutation, useQuery } from '@tanstack/react-query';
 function ItemComponent() {
   const api = useMyApi();
 
-  // Query with typed error handling
-  const getItem = useQuery({
-    ...api.getItem.queryOptions({ itemId: '123' }),
-    onError: (error) => {
-      // Error is typed based on the responses in your FastAPI
-      switch (error.status) {
-        case 404:
-          // error.error is a string as specified in the responses
-          console.error('Not found:', error.error);
-          break;
-        case 500:
-          // error.error is typed as ErrorDetails
-          console.error('Server error:', error.error.message);
-          break;
-      }
-    }
-  });
+  const getItem = useQuery(api.getItem.queryOptions({ itemId: '123' }));
 
   // Mutation with typed error handling
   const createItem = useMutation({
     ...api.createItem.mutationOptions(),
     onError: (error) => {
+      // Error is typed based on the responses in your FastAPI
       switch (error.status) {
         case 400:
-          // error.error is typed as ValidationError
+          // error.error is typed as ValidationErrorDetails
           console.error('Validation error:', error.error.message);
-          console.error('Field errors:', error.error.field_errors);
+          console.error('Field errors:', error.error.fieldErrors);
           break;
         case 403:
           // error.error is a string as specified in the responses
@@ -1073,10 +1067,13 @@ function ItemComponent() {
 
   // Component rendering with error handling
   if (getItem.isError) {
-    if (getItem.error.status === 404) {
-      return <NotFoundMessage message={getItem.error.error} />;
-    } else {
-      return <ErrorMessage message={getItem.error.error.message} />;
+    switch (getItem.error.status) {
+      case 404:
+        // error.error is a string as specified in the responses
+        return <NotFoundMessage message={getItem.error.error} />;
+      case 500:
+        // error.error is typed as ErrorDetails
+        return <ErrorMessage message={getItem.error.error.message} />;
     }
   }
 
@@ -1137,9 +1134,9 @@ function ItemComponent() {
 
       switch (err.status) {
         case 400:
-          // err.error is typed as ValidationError
+          // err.error is typed as ValidationErrorDetails
           console.error('Validation error:', err.error.message);
-          console.error('Field errors:', err.error.field_errors);
+          console.error('Field errors:', err.error.fieldErrors);
           break;
         case 403:
           // err.error is a string as specified in the responses
@@ -1186,7 +1183,7 @@ import { useQuery } from '@tanstack/react-query';
 
 function ItemList() {
   const api = useMyApi();
-  const items = useQuery(api.listItems.queryOptions());
+  const items = useQuery(api.listItems.queryOptions({}));
 
   if (items.isLoading) {
     return <LoadingSpinner />;
@@ -1196,17 +1193,11 @@ function ItemList() {
     const err = items.error;
     switch (err.status) {
       case 403:
-        // err.error is typed as ListItems403Response
-        return <ErrorMessage message={err.error.reason} />;
+        // err.error is a string as specified in the responses
+        return <ErrorMessage message={err.error} />;
       case 500:
-      case 502:
-        // err.error is typed as ListItems5XXResponse
-        return (
-          <ErrorMessage
-            message={err.error.message}
-            details={`Trace ID: ${err.error.traceId}`}
-          />
-        );
+        // err.error is typed as ErrorDetails
+        return <ErrorMessage message={err.error.message} />;
       default:
         return <ErrorMessage message="An unknown error occurred" />;
     }
@@ -1214,7 +1205,7 @@ function ItemList() {
 
   return (
     <ul>
-      {items.data.map((item) => (
+      {items.data?.items.map((item) => (
         <li key={item.id}>{item.name}</li>
       ))}
     </ul>
@@ -1233,7 +1224,7 @@ function ItemList() {
   useEffect(() => {
     const fetchItems = async () => {
       try {
-        const data = await api.listItems();
+        const data = await api.listItems({});
         setItems(data);
       } catch (err) {
         setError(err);
@@ -1252,17 +1243,11 @@ function ItemList() {
     const err = error as ListItemsError;
     switch (err.status) {
       case 403:
-        // err.error is typed as ListItems403Response
-        return <ErrorMessage message={err.error.reason} />;
+        // err.error is a string as specified in the responses
+        return <ErrorMessage message={err.error} />;
       case 500:
-      case 502:
-        // err.error is typed as ListItems5XXResponse
-        return (
-          <ErrorMessage
-            message={err.error.message}
-            details={`Trace ID: ${err.error.traceId}`}
-          />
-        );
+        // err.error is typed as ErrorDetails
+        return <ErrorMessage message={err.error.message} />;
       default:
         return <ErrorMessage message="An unknown error occurred" />;
     }
@@ -1285,41 +1270,53 @@ Implement optimistic updates for a better user experience:
 
 ```tsx
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import type { ListItemsOutput } from '../generated/my-api/types.gen';
 
 function ItemList() {
   const api = useMyApi();
   const queryClient = useQueryClient();
 
   // Query to fetch items
-  const itemsQuery = useQuery(api.listItems.queryOptions());
+  const itemsQuery = useQuery(api.listItems.queryOptions({}));
 
   // Mutation for deleting items with optimistic updates
   const deleteMutation = useMutation({
     ...api.deleteItem.mutationOptions(),
-    onMutate: async (itemId) => {
+    onMutate: async ({ itemId }) => {
       // Cancel any outgoing refetches
-      await queryClient.cancelQueries({ queryKey: api.listItems.queryKey() });
+      await queryClient.cancelQueries({
+        queryKey: api.listItems.queryKey({}),
+      });
 
       // Snapshot the previous value
-      const previousItems = queryClient.getQueryData(api.listItems.queryKey());
+      const previousItems = queryClient.getQueryData<ListItemsOutput>(
+        api.listItems.queryKey({}),
+      );
 
       // Optimistically update to the new value
-      queryClient.setQueryData(
-        api.listItems.queryKey(),
-        (old) => old.filter((item) => item.id !== itemId)
+      queryClient.setQueryData<ListItemsOutput>(
+        api.listItems.queryKey({}),
+        (old) =>
+          old && {
+            ...old,
+            items: old.items.filter((item) => item.id !== itemId),
+          },
       );
 
       // Return a context object with the snapshot
       return { previousItems };
     },
-    onError: (err, itemId, context) => {
+    onError: (err, _input, context) => {
       // If the mutation fails, use the context returned from onMutate to roll back
-      queryClient.setQueryData(api.listItems.queryKey(), context.previousItems);
+      queryClient.setQueryData(
+        api.listItems.queryKey({}),
+        context?.previousItems,
+      );
       console.error('Failed to delete item:', err);
     },
     onSettled: () => {
       // Always refetch after error or success to ensure data is in sync with server
-      queryClient.invalidateQueries({ queryKey: api.listItems.queryKey() });
+      queryClient.invalidateQueries({ queryKey: api.listItems.queryKey({}) });
     },
   });
 
@@ -1333,11 +1330,11 @@ function ItemList() {
 
   return (
     <ul>
-      {itemsQuery.data.map((item) => (
+      {itemsQuery.data?.items.map((item) => (
         <li key={item.id}>
           {item.name}
           <button
-            onClick={() => deleteMutation.mutate(item.id)}
+            onClick={() => deleteMutation.mutate({ itemId: item.id })}
             disabled={deleteMutation.isPending}
           >
             {deleteMutation.isPending ? 'Deleting...' : 'Delete'}
@@ -1413,19 +1410,22 @@ function ItemForm() {
     const error = createItem.error;
     switch (error.status) {
       case 400:
-        // error.error is typed as CreateItem400Response
+        // error.error is typed as ValidationErrorDetails
         return (
           <FormError
             message="Invalid input"
-            errors={error.error.validationErrors}
+            errors={error.error.fieldErrors}
           />
         );
       case 403:
-        // error.error is typed as CreateItem403Response
-        return <AuthError reason={error.error.reason} />;
-      default:
-        // error.error is typed as CreateItem5XXResponse for 500, 502, etc.
+        // error.error is a string as specified in the responses
+        return <AuthError reason={error.error} />;
+      case 500:
+        // error.error is typed as ErrorDetails
         return <ServerError message={error.error.message} />;
+      default:
+        // FastAPI adds a 422 to every endpoint, so `default` isn't narrowed
+        return <ServerError message="An unknown error occurred" />;
     }
   }
 
@@ -1461,22 +1461,16 @@ function ItemForm() {
       const err = e as CreateItemError;
       switch (err.status) {
         case 400:
-          // err.error is typed as CreateItem400Response
-          console.error('Validation errors:', err.error.validationErrors);
+          // err.error is typed as ValidationErrorDetails
+          console.error('Validation errors:', err.error.fieldErrors);
           break;
         case 403:
-          // err.error is typed as CreateItem403Response
-          console.error('Not authorized:', err.error.reason);
+          // err.error is a string as specified in the responses
+          console.error('Not authorized:', err.error);
           break;
         case 500:
-        case 502:
-          // err.error is typed as CreateItem5XXResponse
-          console.error(
-            'Server error:',
-            err.error.message,
-            'Trace:',
-            err.error.traceId,
-          );
+          // err.error is typed as ErrorDetails
+          console.error('Server error:', err.error.message);
           break;
       }
       setError(err);
@@ -1490,13 +1484,15 @@ function ItemForm() {
         return (
           <FormError
             message="Invalid input"
-            errors={error.error.validationErrors}
+            errors={error.error.fieldErrors}
           />
         );
       case 403:
-        return <AuthError reason={error.error.reason} />;
-      default:
+        return <AuthError reason={error.error} />;
+      case 500:
         return <ServerError message={error.error.message} />;
+      default:
+        return <ServerError message="An unknown error occurred" />;
     }
   }
 

--- a/docs/src/content/docs/en/guides/connection/react-smithy.mdx
+++ b/docs/src/content/docs/en/guides/connection/react-smithy.mdx
@@ -245,7 +245,7 @@ const createItem = useMutation({
   onSettled: () => {
     // This will run when the mutation completes (success or error)
     // Good place to invalidate queries that might be affected
-    queryClient.invalidateQueries({ queryKey: api.listItems.queryKey() });
+    queryClient.invalidateQueries({ queryKey: api.listItems.queryKey({}) });
   }
 });
 ```
@@ -456,7 +456,9 @@ function ItemList() {
 
 ### Error Handling
 
-The integration includes built-in error handling with typed error responses. An `<operation-name>Error` type is generated which encapsulates the possible error responses defined in the Smithy model. Each error has a `status` and `error` property, and by checking the value of `status` you can narrow to a specific type of error.
+The integration includes built-in error handling with typed error responses. An `<OperationName>Error` type is generated which is a union of one `<OperationName><StatusCode>Error` member per error status the operation models. Each member has a `status` and an `error` property, so switching on `status` narrows `error` to that status's payload.
+
+The example below assumes `CreateItem` models the [error structures defined further down this page](#errors) — a `422` `InvalidRequestError`, a `403` `UnauthorizedError` and a `500` `InternalServerError`. Only the statuses your model declares appear in the union, so a `case` for a status you haven't modelled is a compile error.
 
 ```tsx {12}
 import { useMutation } from '@tanstack/react-query';
@@ -471,8 +473,8 @@ function MyComponent() {
 
   if (createItem.error) {
     switch (createItem.error.status) {
-      case 400:
-        // error.error is typed as CreateItem400Response
+      case 422:
+        // error.error is typed as InvalidRequestErrorResponseContent
         return (
           <div>
             <h2>Invalid input:</h2>
@@ -480,7 +482,7 @@ function MyComponent() {
           </div>
         );
       case 403:
-        // error.error is typed as CreateItem403Response
+        // error.error is typed as UnauthorizedErrorResponseContent
         return (
           <div>
             <h2>Not authorized:</h2>
@@ -488,8 +490,7 @@ function MyComponent() {
           </div>
         );
       case 500:
-      case 502:
-        // error.error is typed as CreateItem5XXResponse
+        // error.error is typed as InternalServerErrorResponseContent
         return (
           <div>
             <h2>Server error:</h2>
@@ -520,8 +521,8 @@ function MyComponent() {
 
   if (error) {
     switch (error.status) {
-      case 400:
-        // error.error is typed as CreateItem400Response
+      case 422:
+        // error.error is typed as InvalidRequestErrorResponseContent
         return (
           <div>
             <h2>Invalid input:</h2>
@@ -529,7 +530,7 @@ function MyComponent() {
           </div>
         );
       case 403:
-        // error.error is typed as CreateItem403Response
+        // error.error is typed as UnauthorizedErrorResponseContent
         return (
           <div>
             <h2>Not authorized:</h2>
@@ -537,8 +538,7 @@ function MyComponent() {
           </div>
         );
       case 500:
-      case 502:
-        // error.error is typed as CreateItem5XXResponse
+        // error.error is typed as InternalServerErrorResponseContent
         return (
           <div>
             <h2>Server error:</h2>
@@ -573,21 +573,21 @@ These map to OpenAPI vendor extensions using the [`@specificationExtension` trai
 
 #### @query
 
-Then Apply the `@query` trait to your Smithy operation to force it to be treated as a query:
+Apply the `@query` trait to your Smithy operation to force it to be treated as a query:
 
 ```smithy
-@http(method: "POST", uri: "/items")
+@http(method: "POST", uri: "/search-items")
 @query
-operation ListItems {
-    input: ListItemsInput
-    output: ListItemsOutput
+operation SearchItems {
+    input: SearchItemsInput
+    output: SearchItemsOutput
 }
 ```
 
 The generated hook will provide `queryOptions` even though it uses the `POST` HTTP method:
 
 ```tsx
-const items = useQuery(api.listItems.queryOptions());
+const items = useQuery(api.searchItems.queryOptions({ term: 'widget' }));
 ```
 
 #### @mutation
@@ -607,6 +607,8 @@ The generated hook will provide `mutationOptions` even though it uses the `GET` 
 
 ```tsx
 const startProcessing = useMutation(api.startProcessing.mutationOptions());
+
+startProcessing.mutate({ id: 'some-id' });
 ```
 
 ### Custom Pagination Cursor
@@ -616,38 +618,59 @@ By default, the generated hooks assume cursor-based pagination with a parameter 
 Apply the `@cursor` trait with `inputToken` to change the name of the input parameter used for the pagination token:
 
 ```smithy
-@http(method: "GET", uri: "/items")
+@http(method: "GET", uri: "/paged-items")
 @cursor(inputToken: "nextToken")
-operation ListItems {
+operation ListPagedItems {
     input := {
+      @httpQuery("nextToken")
       nextToken: String
+      @httpQuery("limit")
       limit: Integer
     }
     output := {
+      @required
       items: ItemList
       nextToken: String
     }
 }
 ```
 
+`infiniteQueryOptions` then pages on `nextToken`:
+
+```tsx
+const items = useInfiniteQuery({
+  ...api.listPagedItems.infiniteQueryOptions(
+    { limit: 10 },
+    { getNextPageParam: (lastPage) => lastPage.nextToken || undefined },
+  ),
+});
+```
+
 If you would not like to generate `infiniteQueryOptions` for an operation which has an input parameter named `cursor`, you can disable cursor-based pagination:
 
 ```smithy
+@http(method: "GET", uri: "/unpaged-items")
 @cursor(enabled: false)
-operation ListItems {
+operation ListUnpagedItems {
     input := {
       // Input parameter named 'cursor' will cause this operation to be treated as a paginated operation by default
+      @httpQuery("cursor")
       cursor: String
     }
     output := {
-      ...
+      @required
+      items: ItemList
     }
 }
 ```
 
+`api.listUnpagedItems` then only provides `queryOptions`, `queryKey` and `queryFilter`.
+
 ### Grouping Operations
 
 The generated hooks and client methods are automatically organized based on the [`@tags` trait](https://smithy.io/2.0/spec/documentation-traits.html#tags-trait) in your Smithy operations. Operations with the same tags are grouped together, which helps keep your API calls organized and provides better code completion in your IDE.
+
+Within a group each operation keeps its own camelCased name, so an operation named `ListItems` tagged `"items"` is reached at `api.items.listItems` — not `api.items.list`.
 
 For example, with this Smithy model:
 
@@ -657,27 +680,51 @@ service MyService {
 }
 
 @tags(["items"])
+@http(method: "GET", uri: "/items")
+@readonly
 operation ListItems {
-    input: ListItemsInput
-    output: ListItemsOutput
+    input := {}
+    output := {
+      @required
+      items: ItemList
+    }
 }
 
 @tags(["items"])
+@http(method: "POST", uri: "/items")
 operation CreateItem {
-    input: CreateItemInput
-    output: CreateItemOutput
+    input := {
+      @required
+      name: String
+    }
+    output := {
+      @required
+      id: String
+    }
 }
 
 @tags(["users"])
+@http(method: "GET", uri: "/users")
+@readonly
 operation ListUsers {
-    input: ListUsersInput
-    output: ListUsersOutput
+    input := {}
+    output := {
+      @required
+      users: UserList
+    }
 }
 
 @tags(["users"])
+@http(method: "POST", uri: "/users")
 operation CreateUser {
-    input: CreateUserInput
-    output: CreateUserOutput
+    input := {
+      @required
+      name: String
+    }
+    output := {
+      @required
+      id: String
+    }
 }
 ```
 
@@ -706,7 +753,7 @@ function ItemsAndUsers() {
     <div>
       <h2>Items</h2>
       <ul>
-        {items.data?.map(item => (
+        {items.data?.items.map(item => (
           <li key={item.id}>{item.name}</li>
         ))}
       </ul>
@@ -714,7 +761,7 @@ function ItemsAndUsers() {
 
       <h2>Users</h2>
       <ul>
-        {users.data?.map(user => (
+        {users.data?.users.map(user => (
           <li key={user.id}>{user.name}</li>
         ))}
       </ul>
@@ -805,7 +852,7 @@ Define your error structures in your Smithy model:
 
 ```smithy
 @error("client")
-@httpError(400)
+@httpError(422)
 structure InvalidRequestError {
     @required
     message: String
@@ -841,6 +888,10 @@ structure FieldError {
     message: String
 }
 ```
+
+:::caution[400 is taken]
+Your service already declares Smithy's `ValidationException` on `400`, so every operation gets a `400` case carrying `ValidationExceptionResponseContent`. Give your own client errors a different status (`422` above) — two errors on the same status collide and only one payload reaches the generated client.
+:::
 
 #### Adding Errors to Operations
 
@@ -884,37 +935,21 @@ import { useMutation, useQuery } from '@tanstack/react-query';
 function ItemComponent() {
   const api = useMyApi();
 
-  // Query with typed error handling
-  const getItem = useQuery({
-    ...api.getItem.queryOptions({ itemId: '123' }),
-    onError: (error) => {
-      // Error is typed based on the errors in your Smithy model
-      switch (error.status) {
-        case 404:
-          // error.error is typed as ItemNotFoundError
-          console.error('Not found:', error.error.message);
-          break;
-        case 500:
-          // error.error is typed as InternalServerError
-          console.error('Server error:', error.error.message);
-          console.error('Trace ID:', error.error.traceId);
-          break;
-      }
-    }
-  });
+  const getItem = useQuery(api.getItem.queryOptions({ itemId: '123' }));
 
   // Mutation with typed error handling
   const createItem = useMutation({
     ...api.createItem.mutationOptions(),
     onError: (error) => {
+      // Error is typed based on the errors in your Smithy model
       switch (error.status) {
-        case 400:
-          // error.error is typed as InvalidRequestError
+        case 422:
+          // error.error is typed as InvalidRequestErrorResponseContent
           console.error('Validation error:', error.error.message);
           console.error('Field errors:', error.error.fieldErrors);
           break;
         case 403:
-          // error.error is typed as UnauthorizedError
+          // error.error is typed as UnauthorizedErrorResponseContent
           console.error('Unauthorized:', error.error.reason);
           break;
       }
@@ -923,10 +958,13 @@ function ItemComponent() {
 
   // Component rendering with error handling
   if (getItem.isError) {
-    if (getItem.error.status === 404) {
-      return <NotFoundMessage message={getItem.error.error.message} />;
-    } else if (getItem.error.status === 500) {
-      return <ErrorMessage message={getItem.error.error.message} />;
+    switch (getItem.error.status) {
+      case 404:
+        // error.error is typed as ItemNotFoundErrorResponseContent
+        return <NotFoundMessage message={getItem.error.error.message} />;
+      case 500:
+        // error.error is typed as InternalServerErrorResponseContent
+        return <ErrorMessage message={getItem.error.error.message} />;
     }
   }
 
@@ -962,11 +1000,11 @@ function ItemComponent() {
 
         switch (err.status) {
           case 404:
-            // err.error is typed as ItemNotFoundError
+            // err.error is typed as ItemNotFoundErrorResponseContent
             console.error('Not found:', err.error.message);
             break;
           case 500:
-            // err.error is typed as InternalServerError
+            // err.error is typed as InternalServerErrorResponseContent
             console.error('Server error:', err.error.message);
             console.error('Trace ID:', err.error.traceId);
             break;
@@ -987,13 +1025,13 @@ function ItemComponent() {
       const err = e as CreateItemError;
 
       switch (err.status) {
-        case 400:
-          // err.error is typed as InvalidRequestError
+        case 422:
+          // err.error is typed as InvalidRequestErrorResponseContent
           console.error('Validation error:', err.error.message);
           console.error('Field errors:', err.error.fieldErrors);
           break;
         case 403:
-          // err.error is typed as UnauthorizedError
+          // err.error is typed as UnauthorizedErrorResponseContent
           console.error('Unauthorized:', err.error.reason);
           break;
       }
@@ -1037,7 +1075,7 @@ import { useQuery } from '@tanstack/react-query';
 
 function ItemList() {
   const api = useMyApi();
-  const items = useQuery(api.listItems.queryOptions());
+  const items = useQuery(api.listItems.queryOptions({}));
 
   if (items.isLoading) {
     return <LoadingSpinner />;
@@ -1047,11 +1085,10 @@ function ItemList() {
     const err = items.error;
     switch (err.status) {
       case 403:
-        // err.error is typed as ListItems403Response
+        // err.error is typed as UnauthorizedErrorResponseContent
         return <ErrorMessage message={err.error.reason} />;
       case 500:
-      case 502:
-        // err.error is typed as ListItems5XXResponse
+        // err.error is typed as InternalServerErrorResponseContent
         return (
           <ErrorMessage
             message={err.error.message}
@@ -1064,7 +1101,7 @@ function ItemList() {
 
   return (
     <ul>
-      {items.data.map((item) => (
+      {items.data?.items.map((item) => (
         <li key={item.id}>{item.name}</li>
       ))}
     </ul>
@@ -1083,7 +1120,7 @@ function ItemList() {
   useEffect(() => {
     const fetchItems = async () => {
       try {
-        const data = await api.listItems();
+        const data = await api.listItems({});
         setItems(data);
       } catch (err) {
         setError(err);
@@ -1102,11 +1139,10 @@ function ItemList() {
     const err = error as ListItemsError;
     switch (err.status) {
       case 403:
-        // err.error is typed as ListItems403Response
+        // err.error is typed as UnauthorizedErrorResponseContent
         return <ErrorMessage message={err.error.reason} />;
       case 500:
-      case 502:
-        // err.error is typed as ListItems5XXResponse
+        // err.error is typed as InternalServerErrorResponseContent
         return (
           <ErrorMessage
             message={err.error.message}
@@ -1134,41 +1170,53 @@ Implement optimistic updates for a better user experience:
 
 ```tsx
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import type { ListItemsResponseContent } from '../generated/my-api/types.gen';
 
 function ItemList() {
   const api = useMyApi();
   const queryClient = useQueryClient();
 
   // Query to fetch items
-  const itemsQuery = useQuery(api.listItems.queryOptions());
+  const itemsQuery = useQuery(api.listItems.queryOptions({}));
 
   // Mutation for deleting items with optimistic updates
   const deleteMutation = useMutation({
     ...api.deleteItem.mutationOptions(),
-    onMutate: async (itemId) => {
+    onMutate: async ({ itemId }) => {
       // Cancel any outgoing refetches
-      await queryClient.cancelQueries({ queryKey: api.listItems.queryKey() });
+      await queryClient.cancelQueries({
+        queryKey: api.listItems.queryKey({}),
+      });
 
       // Snapshot the previous value
-      const previousItems = queryClient.getQueryData(api.listItems.queryKey());
+      const previousItems = queryClient.getQueryData<ListItemsResponseContent>(
+        api.listItems.queryKey({}),
+      );
 
       // Optimistically update to the new value
-      queryClient.setQueryData(
-        api.listItems.queryKey(),
-        (old) => old.filter((item) => item.id !== itemId)
+      queryClient.setQueryData<ListItemsResponseContent>(
+        api.listItems.queryKey({}),
+        (old) =>
+          old && {
+            ...old,
+            items: old.items.filter((item) => item.id !== itemId),
+          },
       );
 
       // Return a context object with the snapshot
       return { previousItems };
     },
-    onError: (err, itemId, context) => {
+    onError: (err, _input, context) => {
       // If the mutation fails, use the context returned from onMutate to roll back
-      queryClient.setQueryData(api.listItems.queryKey(), context.previousItems);
+      queryClient.setQueryData(
+        api.listItems.queryKey({}),
+        context?.previousItems,
+      );
       console.error('Failed to delete item:', err);
     },
     onSettled: () => {
       // Always refetch after error or success to ensure data is in sync with server
-      queryClient.invalidateQueries({ queryKey: api.listItems.queryKey() });
+      queryClient.invalidateQueries({ queryKey: api.listItems.queryKey({}) });
     },
   });
 
@@ -1182,11 +1230,11 @@ function ItemList() {
 
   return (
     <ul>
-      {itemsQuery.data.map((item) => (
+      {itemsQuery.data?.items.map((item) => (
         <li key={item.id}>
           {item.name}
           <button
-            onClick={() => deleteMutation.mutate(item.id)}
+            onClick={() => deleteMutation.mutate({ itemId: item.id })}
             disabled={deleteMutation.isPending}
           >
             {deleteMutation.isPending ? 'Deleting...' : 'Delete'}
@@ -1261,8 +1309,8 @@ function ItemForm() {
   if (createItem.error) {
     const error = createItem.error;
     switch (error.status) {
-      case 400:
-        // error.error is typed as InvalidRequestError
+      case 422:
+        // error.error is typed as InvalidRequestErrorResponseContent
         return (
           <FormError
             message="Invalid input"
@@ -1270,10 +1318,10 @@ function ItemForm() {
           />
         );
       case 403:
-        // error.error is typed as UnauthorizedError
+        // error.error is typed as UnauthorizedErrorResponseContent
         return <AuthError reason={error.error.reason} />;
       default:
-        // error.error is typed as InternalServerError for 500, etc.
+        // error.error is typed as InternalServerErrorResponseContent for 500, etc.
         return <ServerError message={error.error.message} />;
     }
   }
@@ -1309,16 +1357,16 @@ function ItemForm() {
       // ✅ Error type includes all possible error responses
       const err = e as CreateItemError;
       switch (err.status) {
-        case 400:
-          // err.error is typed as InvalidRequestError
+        case 422:
+          // err.error is typed as InvalidRequestErrorResponseContent
           console.error('Validation errors:', err.error.fieldErrors);
           break;
         case 403:
-          // err.error is typed as UnauthorizedError
+          // err.error is typed as UnauthorizedErrorResponseContent
           console.error('Not authorized:', err.error.reason);
           break;
         case 500:
-          // err.error is typed as InternalServerError
+          // err.error is typed as InternalServerErrorResponseContent
           console.error('Server error:', err.error.message);
           break;
       }
@@ -1329,7 +1377,7 @@ function ItemForm() {
   // Error UI can use type narrowing to handle different error types
   if (error) {
     switch (error.status) {
-      case 400:
+      case 422:
         return (
           <FormError
             message="Invalid input"

--- a/docs/src/content/docs/en/guides/connection/react-trpc.mdx
+++ b/docs/src/content/docs/en/guides/connection/react-trpc.mdx
@@ -417,11 +417,13 @@ It is important to note that infinite queries can only be used for procedures wi
 The integration provides complete end-to-end type safety. Your IDE will provide full autocompletion and type checking for all your API calls:
 
 ```tsx
+import { useMutation } from '@tanstack/react-query';
+
 function UserForm() {
   const trpc = useMyApi();
 
   // ✅ Input is fully typed
-  const createUser = trpc.users.create.useMutation();
+  const createUser = useMutation(trpc.users.create.mutationOptions());
 
   const handleSubmit = (data: CreateUserInput) => {
     // ✅ Type error if input doesn't match schema

--- a/docs/src/content/docs/es/guides/connection/react-agui.mdx
+++ b/docs/src/content/docs/es/guides/connection/react-agui.mdx
@@ -46,16 +46,17 @@ El generador crea un componente `AguiProvider` **compartido único**, un hook po
 - src
   - components
     - AguiProvider.tsx `CopilotKitProvider` único para cada agente AG-UI. Creado en la primera ejecución de `connection` y actualizado en ejecuciones posteriores para registrar cada nuevo agente.
+    - \<agent-name>-chat.tsx Un `<AgentName>Chat` temático vinculado al id de este agente. Un archivo por ejecución de `connection`.
     - copilot
       - index.tsx Re-exporta `CopilotChat`, `CopilotSidebar` y `CopilotPopup` con valores predeterminados de slot que coinciden con el `ux` de tu sitio web (Cloudscape, Shadcn, o sin tema).
       - *ThemeComponents*.tsx Componentes de tema por slot (ej. `CloudscapeAssistantMessage.tsx`, `ShadcnChatInput.tsx`). Solo se proporcionan cuando `ux` es `cloudscape` o `shadcn`.
   - hooks
-    - useAgui\<AgentName>.tsx Registra un agente AG-UI. Un archivo por ejecución de `connection`.
+    - useAgui\<AgentName>.tsx Registra un agente AG-UI y exporta su id como `<AGENT_NAME>_ID`. Un archivo por ejecución de `connection`.
     - useSigV4.tsx Firma SigV4 (solo IAM)
 
 </FileTree>
 
-Ejecutar `connection` una segunda vez para un agente diferente **agrega un nuevo hook `useAgui<AgentName>.tsx`** y actualiza `AguiProvider.tsx` para registrar ambos hooks — cualquier edición personalizada que hayas hecho al proveedor se preserva. `main.tsx` mantiene su único wrapper `<AguiProvider>` — nunca terminas con proveedores anidados.
+Ejecutar `connection` una segunda vez para un agente diferente **agrega un nuevo hook `useAgui<AgentName>.tsx` y componente `<agent-name>-chat.tsx`** y actualiza `AguiProvider.tsx` para registrar ambos hooks — cualquier edición personalizada que hayas hecho al proveedor se preserva. `main.tsx` mantiene su único wrapper `<AguiProvider>` — nunca terminas con proveedores anidados.
 
 Las siguientes dependencias se agregan al `package.json` raíz:
 
@@ -119,17 +120,14 @@ Tanto el Session ID como el Thread ID son proporcionados por el navegador. Para 
 
 ### Agregar una interfaz de chat
 
-Instancia componentes de CopilotKit con `agentId` para seleccionar qué agente usar. El id es el nombre del agente — el mismo que elegiste cuando ejecutaste el generador <Link path="guides/ts-agent">`ts#agent`</Link> o <Link path="guides/py-agent">`py#agent`</Link> — y también puedes encontrarlo en el archivo de hook generado (ej. la clave devuelta desde `packages/web/src/hooks/useAgui<AgentName>.tsx`).
-
-Importa los componentes de chat desde el módulo generado `./components/copilot` para que el tema que coincide con el `ux` de tu sitio web se aplique automáticamente:
+El generador proporciona un componente `<AgentName>Chat` por agente conectado, ya vinculado al id de ese agente y temático para coincidir con el `ux` de tu sitio web. Colócalo en cualquier lugar dentro del wrapper `<AguiProvider>`:
 
 ```tsx
-import { CopilotChat } from './components/copilot';
+import { StoryAgentChat } from './components/story-agent-chat';
 
 function ChatPage() {
   return (
-    <CopilotChat
-      agentId="agent"
+    <StoryAgentChat
       labels={{
         welcomeMessageText: 'How can I help you today?',
         chatInputPlaceholder: 'Ask me anything...',
@@ -139,15 +137,24 @@ function ChatPage() {
 }
 ```
 
+Reenvía cada prop de `CopilotChat` excepto `agentId`, por lo que cualquier cosa que puedas pasar a `<CopilotChat />` funciona aquí también.
+
 ### Conectar múltiples agentes AG-UI
 
-Ejecuta el generador `connection` una vez por agente. Cada agente registrado a través del `AguiProvider` compartido es visible desde cualquier lugar de la aplicación — instancia un componente de CopilotKit con un `agentId` diferente para enrutar cada chat al agente que desees:
+Ejecuta el generador `connection` una vez por agente. Cada ejecución proporciona el componente de chat propio de ese agente, por lo que enrutar un chat a un agente en particular es cuestión de qué componente renderizas:
 
 ```tsx
-import { CopilotChat } from './components/copilot';
+import { StoryAgentChat } from './components/story-agent-chat';
+import { ResearchAgentChat } from './components/research-agent-chat';
 
-<CopilotChat agentId="story" />    {/* talks to StoryAgent */}
-<CopilotChat agentId="research" /> {/* talks to ResearchAgent */}
+<StoryAgentChat />    {/* talks to StoryAgent */}
+<ResearchAgentChat /> {/* talks to ResearchAgent */}
+```
+
+Si necesitas el id sin procesar — para llamar a los propios hooks de CopilotKit, digamos — cada hook generado lo exporta:
+
+```tsx
+import { STORY_AGENT_ID } from './hooks/useAguiStoryAgent';
 ```
 
 ## Personalizar la apariencia
@@ -164,12 +171,13 @@ El generador lee `metadata.ux` de tu proyecto de sitio web React y proporciona u
 | `shadcn` | Los mensajes del asistente se renderizan en una burbuja `bg-muted` con un avatar `Sparkles`; los mensajes del usuario se renderizan alineados a la derecha en una burbuja `bg-primary` con un avatar `User`. La entrada es un `Textarea` redondeado + `Button` de envío/detención en forma de píldora (Enter envía, Shift+Enter nueva línea). Usa primitivas shadcn del paquete compartido `common-shadcn`. |
 | `none` (o cualquier otra cosa) | Sin tema — el módulo solo re-exporta los componentes predeterminados de CopilotKit. |
 
-Importa los componentes temáticos desde el **módulo de tema local** (no directamente desde `@copilotkit/react-core/v2`) para que el tema se aplique automáticamente:
+Los componentes `<AgentName>Chat` proporcionados ya están temáticos. Para un chat que configures tú mismo, importa desde el **módulo de tema local** (no directamente desde `@copilotkit/react-core/v2`) para que el tema se aplique automáticamente:
 
 ```tsx
 import { CopilotChat } from './components/copilot';
+import { STORY_AGENT_ID } from './hooks/useAguiStoryAgent';
 
-<CopilotChat agentId="agent" />
+<CopilotChat agentId={STORY_AGENT_ID} />
 ```
 
 El tema se aplica como valores predeterminados de slot, por lo que cualquier slot que pases explícitamente aún gana — mantienes el control total cuando necesitas una sobrescritura puntual.
@@ -188,8 +196,7 @@ Por ejemplo, para insertar tu propio renderizador de mensajes de usuario mientra
 Las sobrescrituras por chat aún funcionan junto con el tema — cualquier cosa que pases como prop de slot sobrescribe el valor predeterminado temático:
 
 ```tsx
-<CopilotChat
-  agentId="agent"
+<StoryAgentChat
   // style the input and its children
   input={{
     textArea: 'text-blue-600',
@@ -208,25 +215,23 @@ Las sobrescrituras por chat aún funcionan junto con el tema — cualquier cosa 
 Cualquier slot puede tomar un componente React en lugar de un className, por lo que puedes reemplazar completamente el predeterminado:
 
 ```tsx
-import { CopilotChat } from './components/copilot';
+import { StoryAgentChat } from './components/story-agent-chat';
 
-const MySendButton: React.FC<{ onClick: () => void }> = ({ onClick }) => (
+const MySendButton: React.FC<React.ButtonHTMLAttributes<HTMLButtonElement>> = ({
+  onClick,
+}) => (
   <button onClick={onClick} className="my-send-btn">
     Send
   </button>
 );
 
-<CopilotChat
-  agentId="agent"
-  input={{ sendButton: MySendButton }}
-/>;
+<StoryAgentChat input={{ sendButton: MySendButton }} />;
 ```
 
 Las sobrescrituras más profundas siguen la misma forma — ej. reemplaza solo el botón de copiar en los mensajes del asistente:
 
 ```tsx
-<CopilotChat
-  agentId="agent"
+<StoryAgentChat
   messageView={{
     assistantMessage: {
       copyButton: ({ onClick }) => <button onClick={onClick}>Copy</button>,

--- a/docs/src/content/docs/es/guides/connection/react-fastapi.mdx
+++ b/docs/src/content/docs/es/guides/connection/react-fastapi.mdx
@@ -248,7 +248,7 @@ const createItem = useMutation({
   onSettled: () => {
     // This will run when the mutation completes (success or error)
     // Good place to invalidate queries that might be affected
-    queryClient.invalidateQueries({ queryKey: api.listItems.queryKey() });
+    queryClient.invalidateQueries({ queryKey: api.listItems.queryKey({}) });
   }
 });
 ```
@@ -495,7 +495,9 @@ function ItemList() {
 
 ### Manejo de errores
 
-La integración incluye manejo de errores incorporado con respuestas de error tipadas. Se genera un tipo `<operation-name>Error` que encapsula las posibles respuestas de error definidas en la especificación OpenAPI. Cada error tiene una propiedad `status` y `error`, y al verificar el valor de `status` puedes reducir a un tipo específico de error.
+La integración incluye manejo de errores incorporado con respuestas de error tipadas. Se genera un tipo `<OperationName>Error` que es una unión de un miembro `<OperationName><StatusCode>Error` por cada estado de error que declara el `responses` de la operación. Cada miembro tiene una propiedad `status` y `error`, por lo que cambiar en `status` reduce `error` al modelo de ese estado.
+
+El ejemplo a continuación asume que `create_item` declara los [`responses` definidos más adelante en esta página](#especificar-modelos-de-respuesta) — un `400` `ValidationErrorDetails`, un `403` `str` y un `500` `ErrorDetails`. Solo los estados que declares aparecen en la unión (más el propio `422` de FastAPI), por lo que un `case` para un estado que no hayas declarado es un error de compilación.
 
 ```tsx {12}
 import { useMutation } from '@tanstack/react-query';
@@ -511,34 +513,32 @@ function MyComponent() {
   if (createItem.error) {
     switch (createItem.error.status) {
       case 400:
-        // error.error is typed as CreateItem400Response
+        // error.error is typed as ValidationErrorDetails
         return (
           <div>
             <h2>Invalid input:</h2>
             <p>{createItem.error.error.message}</p>
             <ul>
-              {createItem.error.error.validationErrors.map((err) => (
-                <li key={err.field}>{err.message}</li>
+              {createItem.error.error.fieldErrors.map((err) => (
+                <li key={err}>{err}</li>
               ))}
             </ul>
           </div>
         );
       case 403:
-        // error.error is typed as CreateItem403Response
+        // error.error is a string as specified in the responses
         return (
           <div>
             <h2>Not authorized:</h2>
-            <p>{createItem.error.error.reason}</p>
+            <p>{createItem.error.error}</p>
           </div>
         );
       case 500:
-      case 502:
-        // error.error is typed as CreateItem5XXResponse
+        // error.error is typed as ErrorDetails
         return (
           <div>
             <h2>Server error:</h2>
             <p>{createItem.error.error.message}</p>
-            <p>Trace ID: {createItem.error.error.traceId}</p>
           </div>
         );
     }
@@ -547,6 +547,10 @@ function MyComponent() {
   return <button onClick={handleClick}>Create Item</button>;
 }
 ```
+
+:::note[Nombres de campos de Python]
+El cliente generado convierte los campos del modelo a camelCase, por lo que un modelo Pydantic que declara `field_errors` se lee como `error.fieldErrors`.
+:::
 
 <Drawer title="Manejo de errores usando el cliente API directamente" trigger="Haz clic aquí para ver un ejemplo usando el cliente vanilla directamente.">
 ```tsx {9,15}
@@ -566,34 +570,32 @@ function MyComponent() {
   if (error) {
     switch (error.status) {
       case 400:
-        // error.error is typed as CreateItem400Response
+        // error.error is typed as ValidationErrorDetails
         return (
           <div>
             <h2>Invalid input:</h2>
             <p>{error.error.message}</p>
             <ul>
-              {error.error.validationErrors.map((err) => (
-                <li key={err.field}>{err.message}</li>
+              {error.error.fieldErrors.map((err) => (
+                <li key={err}>{err}</li>
               ))}
             </ul>
           </div>
         );
       case 403:
-        // error.error is typed as CreateItem403Response
+        // error.error is a string as specified in the responses
         return (
           <div>
             <h2>Not authorized:</h2>
-            <p>{error.error.reason}</p>
+            <p>{error.error}</p>
           </div>
         );
       case 500:
-      case 502:
-        // error.error is typed as CreateItem5XXResponse
+        // error.error is typed as ErrorDetails
         return (
           <div>
             <h2>Server error:</h2>
             <p>{error.error.message}</p>
-            <p>Trace ID: {error.error.traceId}</p>
           </div>
         );
     }
@@ -784,6 +786,8 @@ def list_items(page: int = 1, limit: int = 10):
 
 Los hooks generados y los métodos del cliente se organizan automáticamente según las etiquetas OpenAPI en tus endpoints FastAPI. Esto ayuda a mantener tus llamadas API organizadas y facilita encontrar operaciones relacionadas.
 
+Dentro de un grupo, cada operación mantiene su propio nombre en camelCase, tomado del nombre de la función de tu endpoint — por lo que `def list_items()` etiquetado como `"items"` se alcanza en `api.items.listItems`.
+
 Por ejemplo:
 
 ```python title="items.py"
@@ -791,7 +795,7 @@ Por ejemplo:
     "/items",
     tags=["items"],
 )
-def list():
+def list(cursor: str | None = None):
     # ...
 
 @app.post(
@@ -811,6 +815,10 @@ def list():
     # ...
 ```
 
+:::tip[Nombres de función repetidos]
+Dos endpoints llamados `list` en diferentes etiquetas no entran en conflicto — el generador califica un nombre duplicado con su etiqueta, por lo que ambos son accesibles en `api.items.list` y `api.users.list`.
+:::
+
 Los hooks generados se agruparán por estas etiquetas:
 
 ```tsx
@@ -821,7 +829,7 @@ function ItemsAndUsers() {
   const api = useMyApi();
 
   // Items operations are grouped under api.items
-  const items = useQuery(api.items.list.queryOptions());
+  const items = useQuery(api.items.list.queryOptions({}));
   const createItem = useMutation(api.items.create.mutationOptions());
 
   // Users operations are grouped under api.users
@@ -873,7 +881,7 @@ function ItemsAndUsers() {
         setIsLoading(true);
 
         // Items operations are grouped under api.items
-        const itemsData = await api.items.list();
+        const itemsData = await api.items.list({});
         setItems(itemsData);
 
         // Users operations are grouped under api.users
@@ -943,7 +951,7 @@ from pydantic import BaseModel
 class ErrorDetails(BaseModel):
     message: str
 
-class ValidationError(BaseModel):
+class ValidationErrorDetails(BaseModel):
     message: str
     field_errors: list[str]
 ```
@@ -958,7 +966,7 @@ class NotFoundException(Exception):
         self.message = message
 
 class ValidationException(Exception):
-    def __init__(self, details: ValidationError):
+    def __init__(self, details: ValidationErrorDetails):
         self.details = details
 ```
 
@@ -997,8 +1005,8 @@ Finalmente, especifica los modelos de respuesta para diferentes códigos de esta
 @app.get(
     "/items/{item_id}",
     responses={
-        404: {"model": str}
-        500: {"model": ErrorDetails}
+        404: {"model": str},
+        500: {"model": ErrorDetails},
     }
 )
 def get_item(item_id: str) -> Item:
@@ -1010,14 +1018,15 @@ def get_item(item_id: str) -> Item:
 @app.post(
     "/items",
     responses={
-        400: {"model": ValidationError},
-        403: {"model": str}
+        400: {"model": ValidationErrorDetails},
+        403: {"model": str},
+        500: {"model": ErrorDetails},
     }
 )
 def create_item(item: Item) -> Item:
     if not is_valid(item):
         raise ValidationException(
-            ValidationError(
+            ValidationErrorDetails(
                 message="Invalid item data",
                 field_errors=["name is required"]
             )
@@ -1035,33 +1044,18 @@ import { useMutation, useQuery } from '@tanstack/react-query';
 function ItemComponent() {
   const api = useMyApi();
 
-  // Query with typed error handling
-  const getItem = useQuery({
-    ...api.getItem.queryOptions({ itemId: '123' }),
-    onError: (error) => {
-      // Error is typed based on the responses in your FastAPI
-      switch (error.status) {
-        case 404:
-          // error.error is a string as specified in the responses
-          console.error('Not found:', error.error);
-          break;
-        case 500:
-          // error.error is typed as ErrorDetails
-          console.error('Server error:', error.error.message);
-          break;
-      }
-    }
-  });
+  const getItem = useQuery(api.getItem.queryOptions({ itemId: '123' }));
 
   // Mutation with typed error handling
   const createItem = useMutation({
     ...api.createItem.mutationOptions(),
     onError: (error) => {
+      // Error is typed based on the responses in your FastAPI
       switch (error.status) {
         case 400:
-          // error.error is typed as ValidationError
+          // error.error is typed as ValidationErrorDetails
           console.error('Validation error:', error.error.message);
-          console.error('Field errors:', error.error.field_errors);
+          console.error('Field errors:', error.error.fieldErrors);
           break;
         case 403:
           // error.error is a string as specified in the responses
@@ -1073,10 +1067,13 @@ function ItemComponent() {
 
   // Component rendering with error handling
   if (getItem.isError) {
-    if (getItem.error.status === 404) {
-      return <NotFoundMessage message={getItem.error.error} />;
-    } else {
-      return <ErrorMessage message={getItem.error.error.message} />;
+    switch (getItem.error.status) {
+      case 404:
+        // error.error is a string as specified in the responses
+        return <NotFoundMessage message={getItem.error.error} />;
+      case 500:
+        // error.error is typed as ErrorDetails
+        return <ErrorMessage message={getItem.error.error.message} />;
     }
   }
 
@@ -1137,9 +1134,9 @@ function ItemComponent() {
 
       switch (err.status) {
         case 400:
-          // err.error is typed as ValidationError
+          // err.error is typed as ValidationErrorDetails
           console.error('Validation error:', err.error.message);
-          console.error('Field errors:', err.error.field_errors);
+          console.error('Field errors:', err.error.fieldErrors);
           break;
         case 403:
           // err.error is a string as specified in the responses
@@ -1186,7 +1183,7 @@ import { useQuery } from '@tanstack/react-query';
 
 function ItemList() {
   const api = useMyApi();
-  const items = useQuery(api.listItems.queryOptions());
+  const items = useQuery(api.listItems.queryOptions({}));
 
   if (items.isLoading) {
     return <LoadingSpinner />;
@@ -1196,17 +1193,11 @@ function ItemList() {
     const err = items.error;
     switch (err.status) {
       case 403:
-        // err.error is typed as ListItems403Response
-        return <ErrorMessage message={err.error.reason} />;
+        // err.error is a string as specified in the responses
+        return <ErrorMessage message={err.error} />;
       case 500:
-      case 502:
-        // err.error is typed as ListItems5XXResponse
-        return (
-          <ErrorMessage
-            message={err.error.message}
-            details={`Trace ID: ${err.error.traceId}`}
-          />
-        );
+        // err.error is typed as ErrorDetails
+        return <ErrorMessage message={err.error.message} />;
       default:
         return <ErrorMessage message="An unknown error occurred" />;
     }
@@ -1214,7 +1205,7 @@ function ItemList() {
 
   return (
     <ul>
-      {items.data.map((item) => (
+      {items.data?.items.map((item) => (
         <li key={item.id}>{item.name}</li>
       ))}
     </ul>
@@ -1233,7 +1224,7 @@ function ItemList() {
   useEffect(() => {
     const fetchItems = async () => {
       try {
-        const data = await api.listItems();
+        const data = await api.listItems({});
         setItems(data);
       } catch (err) {
         setError(err);
@@ -1252,17 +1243,11 @@ function ItemList() {
     const err = error as ListItemsError;
     switch (err.status) {
       case 403:
-        // err.error is typed as ListItems403Response
-        return <ErrorMessage message={err.error.reason} />;
+        // err.error is a string as specified in the responses
+        return <ErrorMessage message={err.error} />;
       case 500:
-      case 502:
-        // err.error is typed as ListItems5XXResponse
-        return (
-          <ErrorMessage
-            message={err.error.message}
-            details={`Trace ID: ${err.error.traceId}`}
-          />
-        );
+        // err.error is typed as ErrorDetails
+        return <ErrorMessage message={err.error.message} />;
       default:
         return <ErrorMessage message="An unknown error occurred" />;
     }
@@ -1285,41 +1270,53 @@ Implementa actualizaciones optimistas para una mejor experiencia de usuario:
 
 ```tsx
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import type { ListItemsOutput } from '../generated/my-api/types.gen';
 
 function ItemList() {
   const api = useMyApi();
   const queryClient = useQueryClient();
 
   // Query to fetch items
-  const itemsQuery = useQuery(api.listItems.queryOptions());
+  const itemsQuery = useQuery(api.listItems.queryOptions({}));
 
   // Mutation for deleting items with optimistic updates
   const deleteMutation = useMutation({
     ...api.deleteItem.mutationOptions(),
-    onMutate: async (itemId) => {
+    onMutate: async ({ itemId }) => {
       // Cancel any outgoing refetches
-      await queryClient.cancelQueries({ queryKey: api.listItems.queryKey() });
+      await queryClient.cancelQueries({
+        queryKey: api.listItems.queryKey({}),
+      });
 
       // Snapshot the previous value
-      const previousItems = queryClient.getQueryData(api.listItems.queryKey());
+      const previousItems = queryClient.getQueryData<ListItemsOutput>(
+        api.listItems.queryKey({}),
+      );
 
       // Optimistically update to the new value
-      queryClient.setQueryData(
-        api.listItems.queryKey(),
-        (old) => old.filter((item) => item.id !== itemId)
+      queryClient.setQueryData<ListItemsOutput>(
+        api.listItems.queryKey({}),
+        (old) =>
+          old && {
+            ...old,
+            items: old.items.filter((item) => item.id !== itemId),
+          },
       );
 
       // Return a context object with the snapshot
       return { previousItems };
     },
-    onError: (err, itemId, context) => {
+    onError: (err, _input, context) => {
       // If the mutation fails, use the context returned from onMutate to roll back
-      queryClient.setQueryData(api.listItems.queryKey(), context.previousItems);
+      queryClient.setQueryData(
+        api.listItems.queryKey({}),
+        context?.previousItems,
+      );
       console.error('Failed to delete item:', err);
     },
     onSettled: () => {
       // Always refetch after error or success to ensure data is in sync with server
-      queryClient.invalidateQueries({ queryKey: api.listItems.queryKey() });
+      queryClient.invalidateQueries({ queryKey: api.listItems.queryKey({}) });
     },
   });
 
@@ -1333,11 +1330,11 @@ function ItemList() {
 
   return (
     <ul>
-      {itemsQuery.data.map((item) => (
+      {itemsQuery.data?.items.map((item) => (
         <li key={item.id}>
           {item.name}
           <button
-            onClick={() => deleteMutation.mutate(item.id)}
+            onClick={() => deleteMutation.mutate({ itemId: item.id })}
             disabled={deleteMutation.isPending}
           >
             {deleteMutation.isPending ? 'Deleting...' : 'Delete'}
@@ -1413,19 +1410,22 @@ function ItemForm() {
     const error = createItem.error;
     switch (error.status) {
       case 400:
-        // error.error is typed as CreateItem400Response
+        // error.error is typed as ValidationErrorDetails
         return (
           <FormError
             message="Invalid input"
-            errors={error.error.validationErrors}
+            errors={error.error.fieldErrors}
           />
         );
       case 403:
-        // error.error is typed as CreateItem403Response
-        return <AuthError reason={error.error.reason} />;
-      default:
-        // error.error is typed as CreateItem5XXResponse for 500, 502, etc.
+        // error.error is a string as specified in the responses
+        return <AuthError reason={error.error} />;
+      case 500:
+        // error.error is typed as ErrorDetails
         return <ServerError message={error.error.message} />;
+      default:
+        // FastAPI adds a 422 to every endpoint, so `default` isn't narrowed
+        return <ServerError message="An unknown error occurred" />;
     }
   }
 
@@ -1461,22 +1461,16 @@ function ItemForm() {
       const err = e as CreateItemError;
       switch (err.status) {
         case 400:
-          // err.error is typed as CreateItem400Response
-          console.error('Validation errors:', err.error.validationErrors);
+          // err.error is typed as ValidationErrorDetails
+          console.error('Validation errors:', err.error.fieldErrors);
           break;
         case 403:
-          // err.error is typed as CreateItem403Response
-          console.error('Not authorized:', err.error.reason);
+          // err.error is a string as specified in the responses
+          console.error('Not authorized:', err.error);
           break;
         case 500:
-        case 502:
-          // err.error is typed as CreateItem5XXResponse
-          console.error(
-            'Server error:',
-            err.error.message,
-            'Trace:',
-            err.error.traceId,
-          );
+          // err.error is typed as ErrorDetails
+          console.error('Server error:', err.error.message);
           break;
       }
       setError(err);
@@ -1490,13 +1484,15 @@ function ItemForm() {
         return (
           <FormError
             message="Invalid input"
-            errors={error.error.validationErrors}
+            errors={error.error.fieldErrors}
           />
         );
       case 403:
-        return <AuthError reason={error.error.reason} />;
-      default:
+        return <AuthError reason={error.error} />;
+      case 500:
         return <ServerError message={error.error.message} />;
+      default:
+        return <ServerError message="An unknown error occurred" />;
     }
   }
 

--- a/docs/src/content/docs/es/guides/connection/react-smithy.mdx
+++ b/docs/src/content/docs/es/guides/connection/react-smithy.mdx
@@ -245,7 +245,7 @@ const createItem = useMutation({
   onSettled: () => {
     // This will run when the mutation completes (success or error)
     // Good place to invalidate queries that might be affected
-    queryClient.invalidateQueries({ queryKey: api.listItems.queryKey() });
+    queryClient.invalidateQueries({ queryKey: api.listItems.queryKey({}) });
   }
 });
 ```
@@ -456,7 +456,9 @@ function ItemList() {
 
 ### Manejo de errores
 
-La integración incluye manejo de errores incorporado con respuestas de error tipadas. Se genera un tipo `<operation-name>Error` que encapsula las posibles respuestas de error definidas en el modelo Smithy. Cada error tiene una propiedad `status` y `error`, y al verificar el valor de `status` puedes reducir a un tipo específico de error.
+La integración incluye manejo de errores incorporado con respuestas de error tipadas. Se genera un tipo `<OperationName>Error` que es una unión de un miembro `<OperationName><StatusCode>Error` por cada estado de error que modela la operación. Cada miembro tiene una propiedad `status` y una propiedad `error`, por lo que cambiar en `status` reduce `error` a la carga útil de ese estado.
+
+El ejemplo a continuación asume que `CreateItem` modela las [estructuras de error definidas más adelante en esta página](#errores) — un `InvalidRequestError` de `422`, un `UnauthorizedError` de `403` y un `InternalServerError` de `500`. Solo los estados que declara tu modelo aparecen en la unión, por lo que un `case` para un estado que no has modelado es un error de compilación.
 
 ```tsx {12}
 import { useMutation } from '@tanstack/react-query';
@@ -471,8 +473,8 @@ function MyComponent() {
 
   if (createItem.error) {
     switch (createItem.error.status) {
-      case 400:
-        // error.error is typed as CreateItem400Response
+      case 422:
+        // error.error is typed as InvalidRequestErrorResponseContent
         return (
           <div>
             <h2>Invalid input:</h2>
@@ -480,7 +482,7 @@ function MyComponent() {
           </div>
         );
       case 403:
-        // error.error is typed as CreateItem403Response
+        // error.error is typed as UnauthorizedErrorResponseContent
         return (
           <div>
             <h2>Not authorized:</h2>
@@ -488,8 +490,7 @@ function MyComponent() {
           </div>
         );
       case 500:
-      case 502:
-        // error.error is typed as CreateItem5XXResponse
+        // error.error is typed as InternalServerErrorResponseContent
         return (
           <div>
             <h2>Server error:</h2>
@@ -520,8 +521,8 @@ function MyComponent() {
 
   if (error) {
     switch (error.status) {
-      case 400:
-        // error.error is typed as CreateItem400Response
+      case 422:
+        // error.error is typed as InvalidRequestErrorResponseContent
         return (
           <div>
             <h2>Invalid input:</h2>
@@ -529,7 +530,7 @@ function MyComponent() {
           </div>
         );
       case 403:
-        // error.error is typed as CreateItem403Response
+        // error.error is typed as UnauthorizedErrorResponseContent
         return (
           <div>
             <h2>Not authorized:</h2>
@@ -537,8 +538,7 @@ function MyComponent() {
           </div>
         );
       case 500:
-      case 502:
-        // error.error is typed as CreateItem5XXResponse
+        // error.error is typed as InternalServerErrorResponseContent
         return (
           <div>
             <h2>Server error:</h2>
@@ -573,21 +573,21 @@ Estos se mapean a extensiones de proveedor OpenAPI usando el [trait `@specificat
 
 #### @query
 
-Luego aplica el trait `@query` a tu operación Smithy para forzar que se trate como una consulta:
+Aplica el trait `@query` a tu operación Smithy para forzar que se trate como una consulta:
 
 ```smithy
-@http(method: "POST", uri: "/items")
+@http(method: "POST", uri: "/search-items")
 @query
-operation ListItems {
-    input: ListItemsInput
-    output: ListItemsOutput
+operation SearchItems {
+    input: SearchItemsInput
+    output: SearchItemsOutput
 }
 ```
 
 El hook generado proporcionará `queryOptions` aunque use el método HTTP `POST`:
 
 ```tsx
-const items = useQuery(api.listItems.queryOptions());
+const items = useQuery(api.searchItems.queryOptions({ term: 'widget' }));
 ```
 
 #### @mutation
@@ -607,6 +607,8 @@ El hook generado proporcionará `mutationOptions` aunque use el método HTTP `GE
 
 ```tsx
 const startProcessing = useMutation(api.startProcessing.mutationOptions());
+
+startProcessing.mutate({ id: 'some-id' });
 ```
 
 ### Cursor de paginación personalizado
@@ -616,38 +618,59 @@ Por defecto, los hooks generados asumen paginación basada en cursor con un par�
 Aplica el trait `@cursor` con `inputToken` para cambiar el nombre del parámetro de entrada usado para el token de paginación:
 
 ```smithy
-@http(method: "GET", uri: "/items")
+@http(method: "GET", uri: "/paged-items")
 @cursor(inputToken: "nextToken")
-operation ListItems {
+operation ListPagedItems {
     input := {
+      @httpQuery("nextToken")
       nextToken: String
+      @httpQuery("limit")
       limit: Integer
     }
     output := {
+      @required
       items: ItemList
       nextToken: String
     }
 }
 ```
 
+`infiniteQueryOptions` entonces pagina en `nextToken`:
+
+```tsx
+const items = useInfiniteQuery({
+  ...api.listPagedItems.infiniteQueryOptions(
+    { limit: 10 },
+    { getNextPageParam: (lastPage) => lastPage.nextToken || undefined },
+  ),
+});
+```
+
 Si no deseas generar `infiniteQueryOptions` para una operación que tiene un parámetro de entrada llamado `cursor`, puedes deshabilitar la paginación basada en cursor:
 
 ```smithy
+@http(method: "GET", uri: "/unpaged-items")
 @cursor(enabled: false)
-operation ListItems {
+operation ListUnpagedItems {
     input := {
       // Input parameter named 'cursor' will cause this operation to be treated as a paginated operation by default
+      @httpQuery("cursor")
       cursor: String
     }
     output := {
-      ...
+      @required
+      items: ItemList
     }
 }
 ```
 
+`api.listUnpagedItems` entonces solo proporciona `queryOptions`, `queryKey` y `queryFilter`.
+
 ### Agrupación de operaciones
 
 Los hooks y métodos de cliente generados se organizan automáticamente según el [trait `@tags`](https://smithy.io/2.0/spec/documentation-traits.html#tags-trait) en tus operaciones Smithy. Las operaciones con las mismas etiquetas se agrupan juntas, lo que ayuda a mantener tus llamadas API organizadas y proporciona una mejor finalización de código en tu IDE.
+
+Dentro de un grupo, cada operación mantiene su propio nombre en camelCase, por lo que una operación llamada `ListItems` etiquetada como `"items"` se alcanza en `api.items.listItems` — no en `api.items.list`.
 
 Por ejemplo, con este modelo Smithy:
 
@@ -657,27 +680,51 @@ service MyService {
 }
 
 @tags(["items"])
+@http(method: "GET", uri: "/items")
+@readonly
 operation ListItems {
-    input: ListItemsInput
-    output: ListItemsOutput
+    input := {}
+    output := {
+      @required
+      items: ItemList
+    }
 }
 
 @tags(["items"])
+@http(method: "POST", uri: "/items")
 operation CreateItem {
-    input: CreateItemInput
-    output: CreateItemOutput
+    input := {
+      @required
+      name: String
+    }
+    output := {
+      @required
+      id: String
+    }
 }
 
 @tags(["users"])
+@http(method: "GET", uri: "/users")
+@readonly
 operation ListUsers {
-    input: ListUsersInput
-    output: ListUsersOutput
+    input := {}
+    output := {
+      @required
+      users: UserList
+    }
 }
 
 @tags(["users"])
+@http(method: "POST", uri: "/users")
 operation CreateUser {
-    input: CreateUserInput
-    output: CreateUserOutput
+    input := {
+      @required
+      name: String
+    }
+    output := {
+      @required
+      id: String
+    }
 }
 ```
 
@@ -706,7 +753,7 @@ function ItemsAndUsers() {
     <div>
       <h2>Items</h2>
       <ul>
-        {items.data?.map(item => (
+        {items.data?.items.map(item => (
           <li key={item.id}>{item.name}</li>
         ))}
       </ul>
@@ -714,7 +761,7 @@ function ItemsAndUsers() {
 
       <h2>Users</h2>
       <ul>
-        {users.data?.map(user => (
+        {users.data?.users.map(user => (
           <li key={user.id}>{user.name}</li>
         ))}
       </ul>
@@ -805,7 +852,7 @@ Define tus estructuras de error en tu modelo Smithy:
 
 ```smithy
 @error("client")
-@httpError(400)
+@httpError(422)
 structure InvalidRequestError {
     @required
     message: String
@@ -841,6 +888,10 @@ structure FieldError {
     message: String
 }
 ```
+
+:::caution[400 está tomado]
+Tu servicio ya declara `ValidationException` de Smithy en `400`, por lo que cada operación obtiene un caso `400` que lleva `ValidationExceptionResponseContent`. Dale a tus propios errores de cliente un estado diferente (`422` arriba) — dos errores en el mismo estado colisionan y solo una carga útil llega al cliente generado.
+:::
 
 #### Agregar errores a las operaciones
 
@@ -884,37 +935,21 @@ import { useMutation, useQuery } from '@tanstack/react-query';
 function ItemComponent() {
   const api = useMyApi();
 
-  // Query with typed error handling
-  const getItem = useQuery({
-    ...api.getItem.queryOptions({ itemId: '123' }),
-    onError: (error) => {
-      // Error is typed based on the errors in your Smithy model
-      switch (error.status) {
-        case 404:
-          // error.error is typed as ItemNotFoundError
-          console.error('Not found:', error.error.message);
-          break;
-        case 500:
-          // error.error is typed as InternalServerError
-          console.error('Server error:', error.error.message);
-          console.error('Trace ID:', error.error.traceId);
-          break;
-      }
-    }
-  });
+  const getItem = useQuery(api.getItem.queryOptions({ itemId: '123' }));
 
   // Mutation with typed error handling
   const createItem = useMutation({
     ...api.createItem.mutationOptions(),
     onError: (error) => {
+      // Error is typed based on the errors in your Smithy model
       switch (error.status) {
-        case 400:
-          // error.error is typed as InvalidRequestError
+        case 422:
+          // error.error is typed as InvalidRequestErrorResponseContent
           console.error('Validation error:', error.error.message);
           console.error('Field errors:', error.error.fieldErrors);
           break;
         case 403:
-          // error.error is typed as UnauthorizedError
+          // error.error is typed as UnauthorizedErrorResponseContent
           console.error('Unauthorized:', error.error.reason);
           break;
       }
@@ -923,10 +958,13 @@ function ItemComponent() {
 
   // Component rendering with error handling
   if (getItem.isError) {
-    if (getItem.error.status === 404) {
-      return <NotFoundMessage message={getItem.error.error.message} />;
-    } else if (getItem.error.status === 500) {
-      return <ErrorMessage message={getItem.error.error.message} />;
+    switch (getItem.error.status) {
+      case 404:
+        // error.error is typed as ItemNotFoundErrorResponseContent
+        return <NotFoundMessage message={getItem.error.error.message} />;
+      case 500:
+        // error.error is typed as InternalServerErrorResponseContent
+        return <ErrorMessage message={getItem.error.error.message} />;
     }
   }
 
@@ -962,11 +1000,11 @@ function ItemComponent() {
 
         switch (err.status) {
           case 404:
-            // err.error is typed as ItemNotFoundError
+            // err.error is typed as ItemNotFoundErrorResponseContent
             console.error('Not found:', err.error.message);
             break;
           case 500:
-            // err.error is typed as InternalServerError
+            // err.error is typed as InternalServerErrorResponseContent
             console.error('Server error:', err.error.message);
             console.error('Trace ID:', err.error.traceId);
             break;
@@ -987,13 +1025,13 @@ function ItemComponent() {
       const err = e as CreateItemError;
 
       switch (err.status) {
-        case 400:
-          // err.error is typed as InvalidRequestError
+        case 422:
+          // err.error is typed as InvalidRequestErrorResponseContent
           console.error('Validation error:', err.error.message);
           console.error('Field errors:', err.error.fieldErrors);
           break;
         case 403:
-          // err.error is typed as UnauthorizedError
+          // err.error is typed as UnauthorizedErrorResponseContent
           console.error('Unauthorized:', err.error.reason);
           break;
       }
@@ -1037,7 +1075,7 @@ import { useQuery } from '@tanstack/react-query';
 
 function ItemList() {
   const api = useMyApi();
-  const items = useQuery(api.listItems.queryOptions());
+  const items = useQuery(api.listItems.queryOptions({}));
 
   if (items.isLoading) {
     return <LoadingSpinner />;
@@ -1047,11 +1085,10 @@ function ItemList() {
     const err = items.error;
     switch (err.status) {
       case 403:
-        // err.error is typed as ListItems403Response
+        // err.error is typed as UnauthorizedErrorResponseContent
         return <ErrorMessage message={err.error.reason} />;
       case 500:
-      case 502:
-        // err.error is typed as ListItems5XXResponse
+        // err.error is typed as InternalServerErrorResponseContent
         return (
           <ErrorMessage
             message={err.error.message}
@@ -1064,7 +1101,7 @@ function ItemList() {
 
   return (
     <ul>
-      {items.data.map((item) => (
+      {items.data?.items.map((item) => (
         <li key={item.id}>{item.name}</li>
       ))}
     </ul>
@@ -1083,7 +1120,7 @@ function ItemList() {
   useEffect(() => {
     const fetchItems = async () => {
       try {
-        const data = await api.listItems();
+        const data = await api.listItems({});
         setItems(data);
       } catch (err) {
         setError(err);
@@ -1102,11 +1139,10 @@ function ItemList() {
     const err = error as ListItemsError;
     switch (err.status) {
       case 403:
-        // err.error is typed as ListItems403Response
+        // err.error is typed as UnauthorizedErrorResponseContent
         return <ErrorMessage message={err.error.reason} />;
       case 500:
-      case 502:
-        // err.error is typed as ListItems5XXResponse
+        // err.error is typed as InternalServerErrorResponseContent
         return (
           <ErrorMessage
             message={err.error.message}
@@ -1134,41 +1170,53 @@ Implementa actualizaciones optimistas para una mejor experiencia de usuario:
 
 ```tsx
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import type { ListItemsResponseContent } from '../generated/my-api/types.gen';
 
 function ItemList() {
   const api = useMyApi();
   const queryClient = useQueryClient();
 
   // Query to fetch items
-  const itemsQuery = useQuery(api.listItems.queryOptions());
+  const itemsQuery = useQuery(api.listItems.queryOptions({}));
 
   // Mutation for deleting items with optimistic updates
   const deleteMutation = useMutation({
     ...api.deleteItem.mutationOptions(),
-    onMutate: async (itemId) => {
+    onMutate: async ({ itemId }) => {
       // Cancel any outgoing refetches
-      await queryClient.cancelQueries({ queryKey: api.listItems.queryKey() });
+      await queryClient.cancelQueries({
+        queryKey: api.listItems.queryKey({}),
+      });
 
       // Snapshot the previous value
-      const previousItems = queryClient.getQueryData(api.listItems.queryKey());
+      const previousItems = queryClient.getQueryData<ListItemsResponseContent>(
+        api.listItems.queryKey({}),
+      );
 
       // Optimistically update to the new value
-      queryClient.setQueryData(
-        api.listItems.queryKey(),
-        (old) => old.filter((item) => item.id !== itemId)
+      queryClient.setQueryData<ListItemsResponseContent>(
+        api.listItems.queryKey({}),
+        (old) =>
+          old && {
+            ...old,
+            items: old.items.filter((item) => item.id !== itemId),
+          },
       );
 
       // Return a context object with the snapshot
       return { previousItems };
     },
-    onError: (err, itemId, context) => {
+    onError: (err, _input, context) => {
       // If the mutation fails, use the context returned from onMutate to roll back
-      queryClient.setQueryData(api.listItems.queryKey(), context.previousItems);
+      queryClient.setQueryData(
+        api.listItems.queryKey({}),
+        context?.previousItems,
+      );
       console.error('Failed to delete item:', err);
     },
     onSettled: () => {
       // Always refetch after error or success to ensure data is in sync with server
-      queryClient.invalidateQueries({ queryKey: api.listItems.queryKey() });
+      queryClient.invalidateQueries({ queryKey: api.listItems.queryKey({}) });
     },
   });
 
@@ -1182,11 +1230,11 @@ function ItemList() {
 
   return (
     <ul>
-      {itemsQuery.data.map((item) => (
+      {itemsQuery.data?.items.map((item) => (
         <li key={item.id}>
           {item.name}
           <button
-            onClick={() => deleteMutation.mutate(item.id)}
+            onClick={() => deleteMutation.mutate({ itemId: item.id })}
             disabled={deleteMutation.isPending}
           >
             {deleteMutation.isPending ? 'Deleting...' : 'Delete'}
@@ -1261,8 +1309,8 @@ function ItemForm() {
   if (createItem.error) {
     const error = createItem.error;
     switch (error.status) {
-      case 400:
-        // error.error is typed as InvalidRequestError
+      case 422:
+        // error.error is typed as InvalidRequestErrorResponseContent
         return (
           <FormError
             message="Invalid input"
@@ -1270,10 +1318,10 @@ function ItemForm() {
           />
         );
       case 403:
-        // error.error is typed as UnauthorizedError
+        // error.error is typed as UnauthorizedErrorResponseContent
         return <AuthError reason={error.error.reason} />;
       default:
-        // error.error is typed as InternalServerError for 500, etc.
+        // error.error is typed as InternalServerErrorResponseContent for 500, etc.
         return <ServerError message={error.error.message} />;
     }
   }
@@ -1309,16 +1357,16 @@ function ItemForm() {
       // ✅ Error type includes all possible error responses
       const err = e as CreateItemError;
       switch (err.status) {
-        case 400:
-          // err.error is typed as InvalidRequestError
+        case 422:
+          // err.error is typed as InvalidRequestErrorResponseContent
           console.error('Validation errors:', err.error.fieldErrors);
           break;
         case 403:
-          // err.error is typed as UnauthorizedError
+          // err.error is typed as UnauthorizedErrorResponseContent
           console.error('Not authorized:', err.error.reason);
           break;
         case 500:
-          // err.error is typed as InternalServerError
+          // err.error is typed as InternalServerErrorResponseContent
           console.error('Server error:', err.error.message);
           break;
       }
@@ -1329,7 +1377,7 @@ function ItemForm() {
   // Error UI can use type narrowing to handle different error types
   if (error) {
     switch (error.status) {
-      case 400:
+      case 422:
         return (
           <FormError
             message="Invalid input"

--- a/docs/src/content/docs/es/guides/connection/react-trpc.mdx
+++ b/docs/src/content/docs/es/guides/connection/react-trpc.mdx
@@ -417,11 +417,13 @@ Es importante tener en cuenta que las consultas infinitas solo se pueden usar pa
 La integración proporciona seguridad de tipos de extremo a extremo completa. Tu IDE proporcionará autocompletado completo y verificación de tipos para todas tus llamadas a la API:
 
 ```tsx
+import { useMutation } from '@tanstack/react-query';
+
 function UserForm() {
   const trpc = useMyApi();
 
   // ✅ Input is fully typed
-  const createUser = trpc.users.create.useMutation();
+  const createUser = useMutation(trpc.users.create.mutationOptions());
 
   const handleSubmit = (data: CreateUserInput) => {
     // ✅ Type error if input doesn't match schema

--- a/docs/src/content/docs/fr/guides/connection/react-agui.mdx
+++ b/docs/src/content/docs/fr/guides/connection/react-agui.mdx
@@ -46,16 +46,17 @@ Le générateur crée un composant `AguiProvider` **unique partagé**, un hook p
 - src
   - components
     - AguiProvider.tsx `CopilotKitProvider` unique pour chaque agent AG-UI. Créé lors de la première exécution de `connection` et mis à jour lors des exécutions suivantes pour enregistrer chaque nouvel agent.
+    - \<agent-name>-chat.tsx Un `<AgentName>Chat` thématisé lié à l'id de cet agent. Un fichier par exécution de `connection`.
     - copilot
       - index.tsx Ré-exporte `CopilotChat`, `CopilotSidebar` et `CopilotPopup` avec des valeurs par défaut de slot qui correspondent à l'`ux` de votre site web (Cloudscape, Shadcn, ou aucun thème).
       - *ThemeComponents*.tsx Composants de thème par slot (par ex. `CloudscapeAssistantMessage.tsx`, `ShadcnChatInput.tsx`). Fournis uniquement lorsque `ux` est `cloudscape` ou `shadcn`.
   - hooks
-    - useAgui\<AgentName>.tsx Enregistre un agent AG-UI. Un fichier par exécution de `connection`.
+    - useAgui\<AgentName>.tsx Enregistre un agent AG-UI et exporte son id en tant que `<AGENT_NAME>_ID`. Un fichier par exécution de `connection`.
     - useSigV4.tsx Signature SigV4 (IAM uniquement)
 
 </FileTree>
 
-Exécuter `connection` une deuxième fois pour un agent différent **ajoute un nouveau hook `useAgui<AgentName>.tsx`** et met à jour `AguiProvider.tsx` pour enregistrer les deux hooks — toutes les modifications personnalisées que vous avez apportées au provider sont préservées. `main.tsx` conserve son unique wrapper `<AguiProvider>` — vous ne vous retrouvez jamais avec des providers imbriqués.
+Exécuter `connection` une deuxième fois pour un agent différent **ajoute un nouveau hook `useAgui<AgentName>.tsx` et un composant `<agent-name>-chat.tsx`** et met à jour `AguiProvider.tsx` pour enregistrer les deux hooks — toutes les modifications personnalisées que vous avez apportées au provider sont préservées. `main.tsx` conserve son unique wrapper `<AguiProvider>` — vous ne vous retrouvez jamais avec des providers imbriqués.
 
 Les dépendances suivantes sont ajoutées au `package.json` racine :
 
@@ -119,17 +120,14 @@ L'ID de session et l'ID de thread sont tous deux fournis par le navigateur. Pour
 
 ### Ajout d'une interface de chat
 
-Instanciez les composants CopilotKit avec `agentId` pour sélectionner l'agent à utiliser. L'id est le nom de l'agent — le même que celui que vous avez choisi lorsque vous avez exécuté le générateur <Link path="guides/ts-agent">`ts#agent`</Link> ou <Link path="guides/py-agent">`py#agent`</Link> — et vous pouvez également le trouver dans le fichier de hook généré (par ex. la clé retournée par `packages/web/src/hooks/useAgui<AgentName>.tsx`).
-
-Importez les composants de chat depuis le module `./components/copilot` généré afin que le thème correspondant à l'`ux` de votre site web soit appliqué automatiquement :
+Le générateur fournit un composant `<AgentName>Chat` par agent connecté, déjà lié à l'id de cet agent et thématisé pour correspondre à l'`ux` de votre site web. Placez-le n'importe où à l'intérieur du wrapper `<AguiProvider>` :
 
 ```tsx
-import { CopilotChat } from './components/copilot';
+import { StoryAgentChat } from './components/story-agent-chat';
 
 function ChatPage() {
   return (
-    <CopilotChat
-      agentId="agent"
+    <StoryAgentChat
       labels={{
         welcomeMessageText: 'How can I help you today?',
         chatInputPlaceholder: 'Ask me anything...',
@@ -139,15 +137,24 @@ function ChatPage() {
 }
 ```
 
+Il transmet toutes les props de `CopilotChat` sauf `agentId`, donc tout ce que vous pouvez passer à `<CopilotChat />` fonctionne ici aussi.
+
 ### Connexion de plusieurs agents AG-UI
 
-Exécutez le générateur `connection` une fois par agent. Chaque agent enregistré via le `AguiProvider` partagé est visible depuis n'importe où dans l'application — instanciez un composant CopilotKit avec un `agentId` différent pour router chaque chat vers l'agent souhaité :
+Exécutez le générateur `connection` une fois par agent. Chaque exécution fournit le composant de chat propre à cet agent, donc router un chat vers un agent particulier est une question de quel composant vous affichez :
 
 ```tsx
-import { CopilotChat } from './components/copilot';
+import { StoryAgentChat } from './components/story-agent-chat';
+import { ResearchAgentChat } from './components/research-agent-chat';
 
-<CopilotChat agentId="story" />    {/* talks to StoryAgent */}
-<CopilotChat agentId="research" /> {/* talks to ResearchAgent */}
+<StoryAgentChat />    {/* talks to StoryAgent */}
+<ResearchAgentChat /> {/* talks to ResearchAgent */}
+```
+
+Si vous avez besoin de l'id brut — pour appeler les propres hooks de CopilotKit, par exemple — chaque hook généré l'exporte :
+
+```tsx
+import { STORY_AGENT_ID } from './hooks/useAguiStoryAgent';
 ```
 
 ## Personnalisation de l'apparence
@@ -164,12 +171,13 @@ Le générateur lit `metadata.ux` depuis votre projet de site web React et fourn
 | `shadcn` | Les messages de l'assistant s'affichent dans une bulle `bg-muted` avec un avatar `Sparkles` ; les messages de l'utilisateur s'affichent alignés à droite dans une bulle `bg-primary` avec un avatar `User`. L'entrée est un `Textarea` arrondi + un `Button` d'envoi/arrêt en forme de pilule (Entrée soumet, Maj+Entrée nouvelle ligne). Utilise les primitives shadcn du package partagé `common-shadcn`. |
 | `none` (ou autre) | Pas de thème — le module ré-exporte simplement les composants CopilotKit par défaut. |
 
-Importez les composants thématisés depuis le **module de thème local** (pas directement depuis `@copilotkit/react-core/v2`) afin que le thème soit appliqué automatiquement :
+Les composants `<AgentName>Chat` fournis sont déjà thématisés. Pour un chat que vous câblez vous-même, importez depuis le **module de thème local** (pas directement depuis `@copilotkit/react-core/v2`) afin que le thème soit appliqué automatiquement :
 
 ```tsx
 import { CopilotChat } from './components/copilot';
+import { STORY_AGENT_ID } from './hooks/useAguiStoryAgent';
 
-<CopilotChat agentId="agent" />
+<CopilotChat agentId={STORY_AGENT_ID} />
 ```
 
 Le thème est appliqué en tant que valeurs par défaut de slot, donc tout slot que vous passez explicitement l'emporte toujours — vous gardez le contrôle total chaque fois que vous avez besoin d'un remplacement ponctuel.
@@ -188,8 +196,7 @@ Par exemple, pour intégrer votre propre rendu de message utilisateur tout en co
 Les remplacements par chat fonctionnent toujours avec le thème — tout ce que vous passez comme prop de slot remplace la valeur par défaut du thème :
 
 ```tsx
-<CopilotChat
-  agentId="agent"
+<StoryAgentChat
   // style the input and its children
   input={{
     textArea: 'text-blue-600',
@@ -208,25 +215,23 @@ Les remplacements par chat fonctionnent toujours avec le thème — tout ce que 
 N'importe quel slot peut prendre un composant React au lieu d'un className, vous pouvez donc remplacer complètement la valeur par défaut :
 
 ```tsx
-import { CopilotChat } from './components/copilot';
+import { StoryAgentChat } from './components/story-agent-chat';
 
-const MySendButton: React.FC<{ onClick: () => void }> = ({ onClick }) => (
+const MySendButton: React.FC<React.ButtonHTMLAttributes<HTMLButtonElement>> = ({
+  onClick,
+}) => (
   <button onClick={onClick} className="my-send-btn">
     Send
   </button>
 );
 
-<CopilotChat
-  agentId="agent"
-  input={{ sendButton: MySendButton }}
-/>;
+<StoryAgentChat input={{ sendButton: MySendButton }} />;
 ```
 
 Les remplacements plus profonds suivent la même structure — par ex. remplacer uniquement le bouton de copie sur les messages de l'assistant :
 
 ```tsx
-<CopilotChat
-  agentId="agent"
+<StoryAgentChat
   messageView={{
     assistantMessage: {
       copyButton: ({ onClick }) => <button onClick={onClick}>Copy</button>,

--- a/docs/src/content/docs/fr/guides/connection/react-fastapi.mdx
+++ b/docs/src/content/docs/fr/guides/connection/react-fastapi.mdx
@@ -248,7 +248,7 @@ const createItem = useMutation({
   onSettled: () => {
     // This will run when the mutation completes (success or error)
     // Good place to invalidate queries that might be affected
-    queryClient.invalidateQueries({ queryKey: api.listItems.queryKey() });
+    queryClient.invalidateQueries({ queryKey: api.listItems.queryKey({}) });
   }
 });
 ```
@@ -495,7 +495,9 @@ function ItemList() {
 
 ### Gestion des erreurs
 
-L'intégration inclut une gestion des erreurs intégrée avec des réponses d'erreur typées. Un type `<operation-name>Error` est généré qui encapsule les réponses d'erreur possibles définies dans la spécification OpenAPI. Chaque erreur a une propriété `status` et `error`, et en vérifiant la valeur de `status`, vous pouvez réduire à un type d'erreur spécifique.
+L'intégration inclut une gestion des erreurs intégrée avec des réponses d'erreur typées. Un type `<OperationName>Error` est généré qui est une union d'un membre `<OperationName><StatusCode>Error` par statut d'erreur que les `responses` de l'opération déclarent. Chaque membre a une propriété `status` et `error`, donc basculer sur `status` réduit `error` au modèle de ce statut.
+
+L'exemple ci-dessous suppose que `create_item` déclare les [`responses` définies plus bas dans cette page](#spécification-des-modèles-de-réponse) — un `400` `ValidationErrorDetails`, un `403` `str` et un `500` `ErrorDetails`. Seuls les statuts que vous déclarez apparaissent dans l'union (plus le `422` propre à FastAPI), donc un `case` pour un statut que vous n'avez pas déclaré est une erreur de compilation.
 
 ```tsx {12}
 import { useMutation } from '@tanstack/react-query';
@@ -511,34 +513,32 @@ function MyComponent() {
   if (createItem.error) {
     switch (createItem.error.status) {
       case 400:
-        // error.error is typed as CreateItem400Response
+        // error.error is typed as ValidationErrorDetails
         return (
           <div>
             <h2>Invalid input:</h2>
             <p>{createItem.error.error.message}</p>
             <ul>
-              {createItem.error.error.validationErrors.map((err) => (
-                <li key={err.field}>{err.message}</li>
+              {createItem.error.error.fieldErrors.map((err) => (
+                <li key={err}>{err}</li>
               ))}
             </ul>
           </div>
         );
       case 403:
-        // error.error is typed as CreateItem403Response
+        // error.error is a string as specified in the responses
         return (
           <div>
             <h2>Not authorized:</h2>
-            <p>{createItem.error.error.reason}</p>
+            <p>{createItem.error.error}</p>
           </div>
         );
       case 500:
-      case 502:
-        // error.error is typed as CreateItem5XXResponse
+        // error.error is typed as ErrorDetails
         return (
           <div>
             <h2>Server error:</h2>
             <p>{createItem.error.error.message}</p>
-            <p>Trace ID: {createItem.error.error.traceId}</p>
           </div>
         );
     }
@@ -547,6 +547,10 @@ function MyComponent() {
   return <button onClick={handleClick}>Create Item</button>;
 }
 ```
+
+:::note[Noms de champs Python]
+Le client généré met en camelCase les champs du modèle, donc un modèle Pydantic déclarant `field_errors` est lu comme `error.fieldErrors`.
+:::
 
 <Drawer title="Gestion des erreurs utilisant directement le client API" trigger="Cliquez ici pour un exemple utilisant directement le client vanilla.">
 ```tsx {9,15}
@@ -566,34 +570,32 @@ function MyComponent() {
   if (error) {
     switch (error.status) {
       case 400:
-        // error.error is typed as CreateItem400Response
+        // error.error is typed as ValidationErrorDetails
         return (
           <div>
             <h2>Invalid input:</h2>
             <p>{error.error.message}</p>
             <ul>
-              {error.error.validationErrors.map((err) => (
-                <li key={err.field}>{err.message}</li>
+              {error.error.fieldErrors.map((err) => (
+                <li key={err}>{err}</li>
               ))}
             </ul>
           </div>
         );
       case 403:
-        // error.error is typed as CreateItem403Response
+        // error.error is a string as specified in the responses
         return (
           <div>
             <h2>Not authorized:</h2>
-            <p>{error.error.reason}</p>
+            <p>{error.error}</p>
           </div>
         );
       case 500:
-      case 502:
-        // error.error is typed as CreateItem5XXResponse
+        // error.error is typed as ErrorDetails
         return (
           <div>
             <h2>Server error:</h2>
             <p>{error.error.message}</p>
-            <p>Trace ID: {error.error.traceId}</p>
           </div>
         );
     }
@@ -784,6 +786,8 @@ def list_items(page: int = 1, limit: int = 10):
 
 Les hooks et méthodes client générés sont automatiquement organisés en fonction des tags OpenAPI dans vos endpoints FastAPI. Cela aide à garder vos appels API organisés et facilite la recherche d'opérations liées.
 
+Au sein d'un groupe, chaque opération conserve son propre nom en camelCase, tiré du nom de la fonction de votre endpoint — donc `def list_items()` taggé `"items"` est accessible à `api.items.listItems`.
+
 Par exemple :
 
 ```python title="items.py"
@@ -791,7 +795,7 @@ Par exemple :
     "/items",
     tags=["items"],
 )
-def list():
+def list(cursor: str | None = None):
     # ...
 
 @app.post(
@@ -811,6 +815,10 @@ def list():
     # ...
 ```
 
+:::tip[Noms de fonction répétés]
+Deux endpoints nommés `list` dans des tags différents n'entrent pas en conflit — le générateur qualifie un nom dupliqué avec son tag, donc les deux sont accessibles à `api.items.list` et `api.users.list`.
+:::
+
 Les hooks générés seront regroupés par ces tags :
 
 ```tsx
@@ -821,7 +829,7 @@ function ItemsAndUsers() {
   const api = useMyApi();
 
   // Items operations are grouped under api.items
-  const items = useQuery(api.items.list.queryOptions());
+  const items = useQuery(api.items.list.queryOptions({}));
   const createItem = useMutation(api.items.create.mutationOptions());
 
   // Users operations are grouped under api.users
@@ -873,7 +881,7 @@ function ItemsAndUsers() {
         setIsLoading(true);
 
         // Items operations are grouped under api.items
-        const itemsData = await api.items.list();
+        const itemsData = await api.items.list({});
         setItems(itemsData);
 
         // Users operations are grouped under api.users
@@ -943,7 +951,7 @@ from pydantic import BaseModel
 class ErrorDetails(BaseModel):
     message: str
 
-class ValidationError(BaseModel):
+class ValidationErrorDetails(BaseModel):
     message: str
     field_errors: list[str]
 ```
@@ -958,7 +966,7 @@ class NotFoundException(Exception):
         self.message = message
 
 class ValidationException(Exception):
-    def __init__(self, details: ValidationError):
+    def __init__(self, details: ValidationErrorDetails):
         self.details = details
 ```
 
@@ -997,8 +1005,8 @@ Enfin, spécifiez les modèles de réponse pour différents codes d'état d'erre
 @app.get(
     "/items/{item_id}",
     responses={
-        404: {"model": str}
-        500: {"model": ErrorDetails}
+        404: {"model": str},
+        500: {"model": ErrorDetails},
     }
 )
 def get_item(item_id: str) -> Item:
@@ -1010,21 +1018,21 @@ def get_item(item_id: str) -> Item:
 @app.post(
     "/items",
     responses={
-        400: {"model": ValidationError},
-        403: {"model": str}
+        400: {"model": ValidationErrorDetails},
+        403: {"model": str},
+        500: {"model": ErrorDetails},
     }
 )
 def create_item(item: Item) -> Item:
     if not is_valid(item):
         raise ValidationException(
-            ValidationError(
+            ValidationErrorDetails(
                 message="Invalid item data",
                 field_errors=["name is required"]
             )
         )
     return save_item(item)
 ```
-
 #### Utilisation de types d'erreur personnalisés dans React
 
 Le client généré gérera automatiquement ces types d'erreur personnalisés, vous permettant de vérifier le type et de gérer différentes réponses d'erreur :
@@ -1035,33 +1043,18 @@ import { useMutation, useQuery } from '@tanstack/react-query';
 function ItemComponent() {
   const api = useMyApi();
 
-  // Query with typed error handling
-  const getItem = useQuery({
-    ...api.getItem.queryOptions({ itemId: '123' }),
-    onError: (error) => {
-      // Error is typed based on the responses in your FastAPI
-      switch (error.status) {
-        case 404:
-          // error.error is a string as specified in the responses
-          console.error('Not found:', error.error);
-          break;
-        case 500:
-          // error.error is typed as ErrorDetails
-          console.error('Server error:', error.error.message);
-          break;
-      }
-    }
-  });
+  const getItem = useQuery(api.getItem.queryOptions({ itemId: '123' }));
 
   // Mutation with typed error handling
   const createItem = useMutation({
     ...api.createItem.mutationOptions(),
     onError: (error) => {
+      // Error is typed based on the responses in your FastAPI
       switch (error.status) {
         case 400:
-          // error.error is typed as ValidationError
+          // error.error is typed as ValidationErrorDetails
           console.error('Validation error:', error.error.message);
-          console.error('Field errors:', error.error.field_errors);
+          console.error('Field errors:', error.error.fieldErrors);
           break;
         case 403:
           // error.error is a string as specified in the responses
@@ -1073,10 +1066,13 @@ function ItemComponent() {
 
   // Component rendering with error handling
   if (getItem.isError) {
-    if (getItem.error.status === 404) {
-      return <NotFoundMessage message={getItem.error.error} />;
-    } else {
-      return <ErrorMessage message={getItem.error.error.message} />;
+    switch (getItem.error.status) {
+      case 404:
+        // error.error is a string as specified in the responses
+        return <NotFoundMessage message={getItem.error.error} />;
+      case 500:
+        // error.error is typed as ErrorDetails
+        return <ErrorMessage message={getItem.error.error.message} />;
     }
   }
 
@@ -1137,9 +1133,9 @@ function ItemComponent() {
 
       switch (err.status) {
         case 400:
-          // err.error is typed as ValidationError
+          // err.error is typed as ValidationErrorDetails
           console.error('Validation error:', err.error.message);
-          console.error('Field errors:', err.error.field_errors);
+          console.error('Field errors:', err.error.fieldErrors);
           break;
         case 403:
           // err.error is a string as specified in the responses
@@ -1186,7 +1182,7 @@ import { useQuery } from '@tanstack/react-query';
 
 function ItemList() {
   const api = useMyApi();
-  const items = useQuery(api.listItems.queryOptions());
+  const items = useQuery(api.listItems.queryOptions({}));
 
   if (items.isLoading) {
     return <LoadingSpinner />;
@@ -1196,17 +1192,11 @@ function ItemList() {
     const err = items.error;
     switch (err.status) {
       case 403:
-        // err.error is typed as ListItems403Response
-        return <ErrorMessage message={err.error.reason} />;
+        // err.error is a string as specified in the responses
+        return <ErrorMessage message={err.error} />;
       case 500:
-      case 502:
-        // err.error is typed as ListItems5XXResponse
-        return (
-          <ErrorMessage
-            message={err.error.message}
-            details={`Trace ID: ${err.error.traceId}`}
-          />
-        );
+        // err.error is typed as ErrorDetails
+        return <ErrorMessage message={err.error.message} />;
       default:
         return <ErrorMessage message="An unknown error occurred" />;
     }
@@ -1214,7 +1204,7 @@ function ItemList() {
 
   return (
     <ul>
-      {items.data.map((item) => (
+      {items.data?.items.map((item) => (
         <li key={item.id}>{item.name}</li>
       ))}
     </ul>
@@ -1233,7 +1223,7 @@ function ItemList() {
   useEffect(() => {
     const fetchItems = async () => {
       try {
-        const data = await api.listItems();
+        const data = await api.listItems({});
         setItems(data);
       } catch (err) {
         setError(err);
@@ -1252,17 +1242,11 @@ function ItemList() {
     const err = error as ListItemsError;
     switch (err.status) {
       case 403:
-        // err.error is typed as ListItems403Response
-        return <ErrorMessage message={err.error.reason} />;
+        // err.error is a string as specified in the responses
+        return <ErrorMessage message={err.error} />;
       case 500:
-      case 502:
-        // err.error is typed as ListItems5XXResponse
-        return (
-          <ErrorMessage
-            message={err.error.message}
-            details={`Trace ID: ${err.error.traceId}`}
-          />
-        );
+        // err.error is typed as ErrorDetails
+        return <ErrorMessage message={err.error.message} />;
       default:
         return <ErrorMessage message="An unknown error occurred" />;
     }
@@ -1285,41 +1269,53 @@ Implémentez des mises à jour optimistes pour une meilleure expérience utilisa
 
 ```tsx
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import type { ListItemsOutput } from '../generated/my-api/types.gen';
 
 function ItemList() {
   const api = useMyApi();
   const queryClient = useQueryClient();
 
   // Query to fetch items
-  const itemsQuery = useQuery(api.listItems.queryOptions());
+  const itemsQuery = useQuery(api.listItems.queryOptions({}));
 
   // Mutation for deleting items with optimistic updates
   const deleteMutation = useMutation({
     ...api.deleteItem.mutationOptions(),
-    onMutate: async (itemId) => {
+    onMutate: async ({ itemId }) => {
       // Cancel any outgoing refetches
-      await queryClient.cancelQueries({ queryKey: api.listItems.queryKey() });
+      await queryClient.cancelQueries({
+        queryKey: api.listItems.queryKey({}),
+      });
 
       // Snapshot the previous value
-      const previousItems = queryClient.getQueryData(api.listItems.queryKey());
+      const previousItems = queryClient.getQueryData<ListItemsOutput>(
+        api.listItems.queryKey({}),
+      );
 
       // Optimistically update to the new value
-      queryClient.setQueryData(
-        api.listItems.queryKey(),
-        (old) => old.filter((item) => item.id !== itemId)
+      queryClient.setQueryData<ListItemsOutput>(
+        api.listItems.queryKey({}),
+        (old) =>
+          old && {
+            ...old,
+            items: old.items.filter((item) => item.id !== itemId),
+          },
       );
 
       // Return a context object with the snapshot
       return { previousItems };
     },
-    onError: (err, itemId, context) => {
+    onError: (err, _input, context) => {
       // If the mutation fails, use the context returned from onMutate to roll back
-      queryClient.setQueryData(api.listItems.queryKey(), context.previousItems);
+      queryClient.setQueryData(
+        api.listItems.queryKey({}),
+        context?.previousItems,
+      );
       console.error('Failed to delete item:', err);
     },
     onSettled: () => {
       // Always refetch after error or success to ensure data is in sync with server
-      queryClient.invalidateQueries({ queryKey: api.listItems.queryKey() });
+      queryClient.invalidateQueries({ queryKey: api.listItems.queryKey({}) });
     },
   });
 
@@ -1333,11 +1329,11 @@ function ItemList() {
 
   return (
     <ul>
-      {itemsQuery.data.map((item) => (
+      {itemsQuery.data?.items.map((item) => (
         <li key={item.id}>
           {item.name}
           <button
-            onClick={() => deleteMutation.mutate(item.id)}
+            onClick={() => deleteMutation.mutate({ itemId: item.id })}
             disabled={deleteMutation.isPending}
           >
             {deleteMutation.isPending ? 'Deleting...' : 'Delete'}
@@ -1413,19 +1409,22 @@ function ItemForm() {
     const error = createItem.error;
     switch (error.status) {
       case 400:
-        // error.error is typed as CreateItem400Response
+        // error.error is typed as ValidationErrorDetails
         return (
           <FormError
             message="Invalid input"
-            errors={error.error.validationErrors}
+            errors={error.error.fieldErrors}
           />
         );
       case 403:
-        // error.error is typed as CreateItem403Response
-        return <AuthError reason={error.error.reason} />;
-      default:
-        // error.error is typed as CreateItem5XXResponse for 500, 502, etc.
+        // error.error is a string as specified in the responses
+        return <AuthError reason={error.error} />;
+      case 500:
+        // error.error is typed as ErrorDetails
         return <ServerError message={error.error.message} />;
+      default:
+        // FastAPI adds a 422 to every endpoint, so `default` isn't narrowed
+        return <ServerError message="An unknown error occurred" />;
     }
   }
 
@@ -1461,22 +1460,16 @@ function ItemForm() {
       const err = e as CreateItemError;
       switch (err.status) {
         case 400:
-          // err.error is typed as CreateItem400Response
-          console.error('Validation errors:', err.error.validationErrors);
+          // err.error is typed as ValidationErrorDetails
+          console.error('Validation errors:', err.error.fieldErrors);
           break;
         case 403:
-          // err.error is typed as CreateItem403Response
-          console.error('Not authorized:', err.error.reason);
+          // err.error is a string as specified in the responses
+          console.error('Not authorized:', err.error);
           break;
         case 500:
-        case 502:
-          // err.error is typed as CreateItem5XXResponse
-          console.error(
-            'Server error:',
-            err.error.message,
-            'Trace:',
-            err.error.traceId,
-          );
+          // err.error is typed as ErrorDetails
+          console.error('Server error:', err.error.message);
           break;
       }
       setError(err);
@@ -1490,13 +1483,15 @@ function ItemForm() {
         return (
           <FormError
             message="Invalid input"
-            errors={error.error.validationErrors}
+            errors={error.error.fieldErrors}
           />
         );
       case 403:
-        return <AuthError reason={error.error.reason} />;
-      default:
+        return <AuthError reason={error.error} />;
+      case 500:
         return <ServerError message={error.error.message} />;
+      default:
+        return <ServerError message="An unknown error occurred" />;
     }
   }
 

--- a/docs/src/content/docs/fr/guides/connection/react-smithy.mdx
+++ b/docs/src/content/docs/fr/guides/connection/react-smithy.mdx
@@ -245,7 +245,7 @@ const createItem = useMutation({
   onSettled: () => {
     // This will run when the mutation completes (success or error)
     // Good place to invalidate queries that might be affected
-    queryClient.invalidateQueries({ queryKey: api.listItems.queryKey() });
+    queryClient.invalidateQueries({ queryKey: api.listItems.queryKey({}) });
   }
 });
 ```
@@ -456,7 +456,9 @@ function ItemList() {
 
 ### Gestion des erreurs
 
-L'intégration inclut une gestion des erreurs intégrée avec des réponses d'erreur typées. Un type `<operation-name>Error` est généré qui encapsule les réponses d'erreur possibles définies dans le modèle Smithy. Chaque erreur a une propriété `status` et `error`, et en vérifiant la valeur de `status`, vous pouvez réduire à un type d'erreur spécifique.
+L'intégration inclut une gestion des erreurs intégrée avec des réponses d'erreur typées. Un type `<OperationName>Error` est généré qui est une union d'un membre `<OperationName><StatusCode>Error` par statut d'erreur que l'opération modélise. Chaque membre a une propriété `status` et une propriété `error`, donc en vérifiant `status`, vous réduisez `error` à la charge utile de ce statut.
+
+L'exemple ci-dessous suppose que `CreateItem` modélise les [structures d'erreur définies plus bas dans cette page](#errors) — une `InvalidRequestError` `422`, une `UnauthorizedError` `403` et une `InternalServerError` `500`. Seuls les statuts que votre modèle déclare apparaissent dans l'union, donc un `case` pour un statut que vous n'avez pas modélisé est une erreur de compilation.
 
 ```tsx {12}
 import { useMutation } from '@tanstack/react-query';
@@ -471,8 +473,8 @@ function MyComponent() {
 
   if (createItem.error) {
     switch (createItem.error.status) {
-      case 400:
-        // error.error is typed as CreateItem400Response
+      case 422:
+        // error.error is typed as InvalidRequestErrorResponseContent
         return (
           <div>
             <h2>Invalid input:</h2>
@@ -480,7 +482,7 @@ function MyComponent() {
           </div>
         );
       case 403:
-        // error.error is typed as CreateItem403Response
+        // error.error is typed as UnauthorizedErrorResponseContent
         return (
           <div>
             <h2>Not authorized:</h2>
@@ -488,8 +490,7 @@ function MyComponent() {
           </div>
         );
       case 500:
-      case 502:
-        // error.error is typed as CreateItem5XXResponse
+        // error.error is typed as InternalServerErrorResponseContent
         return (
           <div>
             <h2>Server error:</h2>
@@ -520,8 +521,8 @@ function MyComponent() {
 
   if (error) {
     switch (error.status) {
-      case 400:
-        // error.error is typed as CreateItem400Response
+      case 422:
+        // error.error is typed as InvalidRequestErrorResponseContent
         return (
           <div>
             <h2>Invalid input:</h2>
@@ -529,7 +530,7 @@ function MyComponent() {
           </div>
         );
       case 403:
-        // error.error is typed as CreateItem403Response
+        // error.error is typed as UnauthorizedErrorResponseContent
         return (
           <div>
             <h2>Not authorized:</h2>
@@ -537,8 +538,7 @@ function MyComponent() {
           </div>
         );
       case 500:
-      case 502:
-        // error.error is typed as CreateItem5XXResponse
+        // error.error is typed as InternalServerErrorResponseContent
         return (
           <div>
             <h2>Server error:</h2>
@@ -573,21 +573,21 @@ Celles-ci correspondent aux extensions vendor OpenAPI utilisant le [trait `@spec
 
 #### @query
 
-Appliquez ensuite le trait `@query` à votre opération Smithy pour la forcer à être traitée comme une requête :
+Appliquez le trait `@query` à votre opération Smithy pour la forcer à être traitée comme une requête :
 
 ```smithy
-@http(method: "POST", uri: "/items")
+@http(method: "POST", uri: "/search-items")
 @query
-operation ListItems {
-    input: ListItemsInput
-    output: ListItemsOutput
+operation SearchItems {
+    input: SearchItemsInput
+    output: SearchItemsOutput
 }
 ```
 
 Le hook généré fournira `queryOptions` même s'il utilise la méthode HTTP `POST` :
 
 ```tsx
-const items = useQuery(api.listItems.queryOptions());
+const items = useQuery(api.searchItems.queryOptions({ term: 'widget' }));
 ```
 
 #### @mutation
@@ -607,6 +607,8 @@ Le hook généré fournira `mutationOptions` même s'il utilise la méthode HTTP
 
 ```tsx
 const startProcessing = useMutation(api.startProcessing.mutationOptions());
+
+startProcessing.mutate({ id: 'some-id' });
 ```
 
 ### Curseur de pagination personnalisé
@@ -616,38 +618,59 @@ Par défaut, les hooks générés supposent une pagination basée sur le curseur
 Appliquez le trait `@cursor` avec `inputToken` pour modifier le nom du paramètre d'entrée utilisé pour le jeton de pagination :
 
 ```smithy
-@http(method: "GET", uri: "/items")
+@http(method: "GET", uri: "/paged-items")
 @cursor(inputToken: "nextToken")
-operation ListItems {
+operation ListPagedItems {
     input := {
+      @httpQuery("nextToken")
       nextToken: String
+      @httpQuery("limit")
       limit: Integer
     }
     output := {
+      @required
       items: ItemList
       nextToken: String
     }
 }
 ```
 
+`infiniteQueryOptions` pagine alors sur `nextToken` :
+
+```tsx
+const items = useInfiniteQuery({
+  ...api.listPagedItems.infiniteQueryOptions(
+    { limit: 10 },
+    { getNextPageParam: (lastPage) => lastPage.nextToken || undefined },
+  ),
+});
+```
+
 Si vous ne souhaitez pas générer `infiniteQueryOptions` pour une opération qui a un paramètre d'entrée nommé `cursor`, vous pouvez désactiver la pagination basée sur le curseur :
 
 ```smithy
+@http(method: "GET", uri: "/unpaged-items")
 @cursor(enabled: false)
-operation ListItems {
+operation ListUnpagedItems {
     input := {
       // Input parameter named 'cursor' will cause this operation to be treated as a paginated operation by default
+      @httpQuery("cursor")
       cursor: String
     }
     output := {
-      ...
+      @required
+      items: ItemList
     }
 }
 ```
 
+`api.listUnpagedItems` ne fournit alors que `queryOptions`, `queryKey` et `queryFilter`.
+
 ### Regroupement des opérations
 
 Les hooks et méthodes client générés sont automatiquement organisés en fonction du [trait `@tags`](https://smithy.io/2.0/spec/documentation-traits.html#tags-trait) dans vos opérations Smithy. Les opérations avec les mêmes tags sont regroupées, ce qui aide à garder vos appels d'API organisés et fournit une meilleure complétion de code dans votre IDE.
+
+Au sein d'un groupe, chaque opération conserve son propre nom en camelCase, donc une opération nommée `ListItems` taguée `"items"` est accessible à `api.items.listItems` — pas `api.items.list`.
 
 Par exemple, avec ce modèle Smithy :
 
@@ -657,27 +680,51 @@ service MyService {
 }
 
 @tags(["items"])
+@http(method: "GET", uri: "/items")
+@readonly
 operation ListItems {
-    input: ListItemsInput
-    output: ListItemsOutput
+    input := {}
+    output := {
+      @required
+      items: ItemList
+    }
 }
 
 @tags(["items"])
+@http(method: "POST", uri: "/items")
 operation CreateItem {
-    input: CreateItemInput
-    output: CreateItemOutput
+    input := {
+      @required
+      name: String
+    }
+    output := {
+      @required
+      id: String
+    }
 }
 
 @tags(["users"])
+@http(method: "GET", uri: "/users")
+@readonly
 operation ListUsers {
-    input: ListUsersInput
-    output: ListUsersOutput
+    input := {}
+    output := {
+      @required
+      users: UserList
+    }
 }
 
 @tags(["users"])
+@http(method: "POST", uri: "/users")
 operation CreateUser {
-    input: CreateUserInput
-    output: CreateUserOutput
+    input := {
+      @required
+      name: String
+    }
+    output := {
+      @required
+      id: String
+    }
 }
 ```
 
@@ -706,7 +753,7 @@ function ItemsAndUsers() {
     <div>
       <h2>Items</h2>
       <ul>
-        {items.data?.map(item => (
+        {items.data?.items.map(item => (
           <li key={item.id}>{item.name}</li>
         ))}
       </ul>
@@ -714,7 +761,7 @@ function ItemsAndUsers() {
 
       <h2>Users</h2>
       <ul>
-        {users.data?.map(user => (
+        {users.data?.users.map(user => (
           <li key={user.id}>{user.name}</li>
         ))}
       </ul>
@@ -805,7 +852,7 @@ Définissez vos structures d'erreur dans votre modèle Smithy :
 
 ```smithy
 @error("client")
-@httpError(400)
+@httpError(422)
 structure InvalidRequestError {
     @required
     message: String
@@ -841,6 +888,10 @@ structure FieldError {
     message: String
 }
 ```
+
+:::caution[400 est pris]
+Votre service déclare déjà la `ValidationException` de Smithy sur `400`, donc chaque opération obtient un cas `400` portant `ValidationExceptionResponseContent`. Donnez à vos propres erreurs client un statut différent (`422` ci-dessus) — deux erreurs sur le même statut entrent en collision et une seule charge utile atteint le client généré.
+:::
 
 #### Ajout d'erreurs aux opérations
 
@@ -884,37 +935,21 @@ import { useMutation, useQuery } from '@tanstack/react-query';
 function ItemComponent() {
   const api = useMyApi();
 
-  // Query with typed error handling
-  const getItem = useQuery({
-    ...api.getItem.queryOptions({ itemId: '123' }),
-    onError: (error) => {
-      // Error is typed based on the errors in your Smithy model
-      switch (error.status) {
-        case 404:
-          // error.error is typed as ItemNotFoundError
-          console.error('Not found:', error.error.message);
-          break;
-        case 500:
-          // error.error is typed as InternalServerError
-          console.error('Server error:', error.error.message);
-          console.error('Trace ID:', error.error.traceId);
-          break;
-      }
-    }
-  });
+  const getItem = useQuery(api.getItem.queryOptions({ itemId: '123' }));
 
   // Mutation with typed error handling
   const createItem = useMutation({
     ...api.createItem.mutationOptions(),
     onError: (error) => {
+      // Error is typed based on the errors in your Smithy model
       switch (error.status) {
-        case 400:
-          // error.error is typed as InvalidRequestError
+        case 422:
+          // error.error is typed as InvalidRequestErrorResponseContent
           console.error('Validation error:', error.error.message);
           console.error('Field errors:', error.error.fieldErrors);
           break;
         case 403:
-          // error.error is typed as UnauthorizedError
+          // error.error is typed as UnauthorizedErrorResponseContent
           console.error('Unauthorized:', error.error.reason);
           break;
       }
@@ -923,10 +958,13 @@ function ItemComponent() {
 
   // Component rendering with error handling
   if (getItem.isError) {
-    if (getItem.error.status === 404) {
-      return <NotFoundMessage message={getItem.error.error.message} />;
-    } else if (getItem.error.status === 500) {
-      return <ErrorMessage message={getItem.error.error.message} />;
+    switch (getItem.error.status) {
+      case 404:
+        // error.error is typed as ItemNotFoundErrorResponseContent
+        return <NotFoundMessage message={getItem.error.error.message} />;
+      case 500:
+        // error.error is typed as InternalServerErrorResponseContent
+        return <ErrorMessage message={getItem.error.error.message} />;
     }
   }
 
@@ -962,11 +1000,11 @@ function ItemComponent() {
 
         switch (err.status) {
           case 404:
-            // err.error is typed as ItemNotFoundError
+            // err.error is typed as ItemNotFoundErrorResponseContent
             console.error('Not found:', err.error.message);
             break;
           case 500:
-            // err.error is typed as InternalServerError
+            // err.error is typed as InternalServerErrorResponseContent
             console.error('Server error:', err.error.message);
             console.error('Trace ID:', err.error.traceId);
             break;
@@ -987,13 +1025,13 @@ function ItemComponent() {
       const err = e as CreateItemError;
 
       switch (err.status) {
-        case 400:
-          // err.error is typed as InvalidRequestError
+        case 422:
+          // err.error is typed as InvalidRequestErrorResponseContent
           console.error('Validation error:', err.error.message);
           console.error('Field errors:', err.error.fieldErrors);
           break;
         case 403:
-          // err.error is typed as UnauthorizedError
+          // err.error is typed as UnauthorizedErrorResponseContent
           console.error('Unauthorized:', err.error.reason);
           break;
       }
@@ -1037,7 +1075,7 @@ import { useQuery } from '@tanstack/react-query';
 
 function ItemList() {
   const api = useMyApi();
-  const items = useQuery(api.listItems.queryOptions());
+  const items = useQuery(api.listItems.queryOptions({}));
 
   if (items.isLoading) {
     return <LoadingSpinner />;
@@ -1047,11 +1085,10 @@ function ItemList() {
     const err = items.error;
     switch (err.status) {
       case 403:
-        // err.error is typed as ListItems403Response
+        // err.error is typed as UnauthorizedErrorResponseContent
         return <ErrorMessage message={err.error.reason} />;
       case 500:
-      case 502:
-        // err.error is typed as ListItems5XXResponse
+        // err.error is typed as InternalServerErrorResponseContent
         return (
           <ErrorMessage
             message={err.error.message}
@@ -1064,7 +1101,7 @@ function ItemList() {
 
   return (
     <ul>
-      {items.data.map((item) => (
+      {items.data?.items.map((item) => (
         <li key={item.id}>{item.name}</li>
       ))}
     </ul>
@@ -1083,7 +1120,7 @@ function ItemList() {
   useEffect(() => {
     const fetchItems = async () => {
       try {
-        const data = await api.listItems();
+        const data = await api.listItems({});
         setItems(data);
       } catch (err) {
         setError(err);
@@ -1102,11 +1139,10 @@ function ItemList() {
     const err = error as ListItemsError;
     switch (err.status) {
       case 403:
-        // err.error is typed as ListItems403Response
+        // err.error is typed as UnauthorizedErrorResponseContent
         return <ErrorMessage message={err.error.reason} />;
       case 500:
-      case 502:
-        // err.error is typed as ListItems5XXResponse
+        // err.error is typed as InternalServerErrorResponseContent
         return (
           <ErrorMessage
             message={err.error.message}
@@ -1134,41 +1170,53 @@ Implémentez des mises à jour optimistes pour une meilleure expérience utilisa
 
 ```tsx
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import type { ListItemsResponseContent } from '../generated/my-api/types.gen';
 
 function ItemList() {
   const api = useMyApi();
   const queryClient = useQueryClient();
 
   // Query to fetch items
-  const itemsQuery = useQuery(api.listItems.queryOptions());
+  const itemsQuery = useQuery(api.listItems.queryOptions({}));
 
   // Mutation for deleting items with optimistic updates
   const deleteMutation = useMutation({
     ...api.deleteItem.mutationOptions(),
-    onMutate: async (itemId) => {
+    onMutate: async ({ itemId }) => {
       // Cancel any outgoing refetches
-      await queryClient.cancelQueries({ queryKey: api.listItems.queryKey() });
+      await queryClient.cancelQueries({
+        queryKey: api.listItems.queryKey({}),
+      });
 
       // Snapshot the previous value
-      const previousItems = queryClient.getQueryData(api.listItems.queryKey());
+      const previousItems = queryClient.getQueryData<ListItemsResponseContent>(
+        api.listItems.queryKey({}),
+      );
 
       // Optimistically update to the new value
-      queryClient.setQueryData(
-        api.listItems.queryKey(),
-        (old) => old.filter((item) => item.id !== itemId)
+      queryClient.setQueryData<ListItemsResponseContent>(
+        api.listItems.queryKey({}),
+        (old) =>
+          old && {
+            ...old,
+            items: old.items.filter((item) => item.id !== itemId),
+          },
       );
 
       // Return a context object with the snapshot
       return { previousItems };
     },
-    onError: (err, itemId, context) => {
+    onError: (err, _input, context) => {
       // If the mutation fails, use the context returned from onMutate to roll back
-      queryClient.setQueryData(api.listItems.queryKey(), context.previousItems);
+      queryClient.setQueryData(
+        api.listItems.queryKey({}),
+        context?.previousItems,
+      );
       console.error('Failed to delete item:', err);
     },
     onSettled: () => {
       // Always refetch after error or success to ensure data is in sync with server
-      queryClient.invalidateQueries({ queryKey: api.listItems.queryKey() });
+      queryClient.invalidateQueries({ queryKey: api.listItems.queryKey({}) });
     },
   });
 
@@ -1182,11 +1230,11 @@ function ItemList() {
 
   return (
     <ul>
-      {itemsQuery.data.map((item) => (
+      {itemsQuery.data?.items.map((item) => (
         <li key={item.id}>
           {item.name}
           <button
-            onClick={() => deleteMutation.mutate(item.id)}
+            onClick={() => deleteMutation.mutate({ itemId: item.id })}
             disabled={deleteMutation.isPending}
           >
             {deleteMutation.isPending ? 'Deleting...' : 'Delete'}
@@ -1261,8 +1309,8 @@ function ItemForm() {
   if (createItem.error) {
     const error = createItem.error;
     switch (error.status) {
-      case 400:
-        // error.error is typed as InvalidRequestError
+      case 422:
+        // error.error is typed as InvalidRequestErrorResponseContent
         return (
           <FormError
             message="Invalid input"
@@ -1270,10 +1318,10 @@ function ItemForm() {
           />
         );
       case 403:
-        // error.error is typed as UnauthorizedError
+        // error.error is typed as UnauthorizedErrorResponseContent
         return <AuthError reason={error.error.reason} />;
       default:
-        // error.error is typed as InternalServerError for 500, etc.
+        // error.error is typed as InternalServerErrorResponseContent for 500, etc.
         return <ServerError message={error.error.message} />;
     }
   }
@@ -1309,16 +1357,16 @@ function ItemForm() {
       // ✅ Error type includes all possible error responses
       const err = e as CreateItemError;
       switch (err.status) {
-        case 400:
-          // err.error is typed as InvalidRequestError
+        case 422:
+          // err.error is typed as InvalidRequestErrorResponseContent
           console.error('Validation errors:', err.error.fieldErrors);
           break;
         case 403:
-          // err.error is typed as UnauthorizedError
+          // err.error is typed as UnauthorizedErrorResponseContent
           console.error('Not authorized:', err.error.reason);
           break;
         case 500:
-          // err.error is typed as InternalServerError
+          // err.error is typed as InternalServerErrorResponseContent
           console.error('Server error:', err.error.message);
           break;
       }
@@ -1329,7 +1377,7 @@ function ItemForm() {
   // Error UI can use type narrowing to handle different error types
   if (error) {
     switch (error.status) {
-      case 400:
+      case 422:
         return (
           <FormError
             message="Invalid input"

--- a/docs/src/content/docs/fr/guides/connection/react-trpc.mdx
+++ b/docs/src/content/docs/fr/guides/connection/react-trpc.mdx
@@ -417,11 +417,13 @@ Il est important de noter que les requêtes infinies ne peuvent être utilisées
 L'intégration fournit une sécurité de type de bout en bout complète. Votre IDE fournira une autocomplétion complète et une vérification de type pour tous vos appels d'API :
 
 ```tsx
+import { useMutation } from '@tanstack/react-query';
+
 function UserForm() {
   const trpc = useMyApi();
 
   // ✅ Input is fully typed
-  const createUser = trpc.users.create.useMutation();
+  const createUser = useMutation(trpc.users.create.mutationOptions());
 
   const handleSubmit = (data: CreateUserInput) => {
     // ✅ Type error if input doesn't match schema

--- a/docs/src/content/docs/it/guides/connection/react-agui.mdx
+++ b/docs/src/content/docs/it/guides/connection/react-agui.mdx
@@ -46,16 +46,17 @@ Il generatore crea un **singolo componente condiviso** `AguiProvider`, un hook p
 - src
   - components
     - AguiProvider.tsx Singolo `CopilotKitProvider` per ogni agent AG-UI. Creato alla prima esecuzione di `connection` e aggiornato nelle esecuzioni successive per registrare ogni nuovo agent.
+    - \<agent-name>-chat.tsx Un `<AgentName>Chat` tematizzato associato all'id di questo agent. Un file per esecuzione di `connection`.
     - copilot
       - index.tsx Ri-esporta `CopilotChat`, `CopilotSidebar` e `CopilotPopup` con valori predefiniti per gli slot che corrispondono al `ux` del tuo sito web (Cloudscape, Shadcn, o nessun tema).
       - *ThemeComponents*.tsx Componenti tema per slot (ad es. `CloudscapeAssistantMessage.tsx`, `ShadcnChatInput.tsx`). Forniti solo quando `ux` è `cloudscape` o `shadcn`.
   - hooks
-    - useAgui\<AgentName>.tsx Registra un agent AG-UI. Un file per esecuzione di `connection`.
+    - useAgui\<AgentName>.tsx Registra un agent AG-UI ed esporta il suo id come `<AGENT_NAME>_ID`. Un file per esecuzione di `connection`.
     - useSigV4.tsx Firma SigV4 (solo IAM)
 
 </FileTree>
 
-Eseguire `connection` una seconda volta per un agent diverso **aggiunge un nuovo hook `useAgui<AgentName>.tsx`** e aggiorna `AguiProvider.tsx` per registrare entrambi gli hook — eventuali modifiche personalizzate apportate al provider vengono preservate. `main.tsx` mantiene il suo singolo wrapper `<AguiProvider>` — non ti ritroverai mai con provider annidati.
+Eseguire `connection` una seconda volta per un agent diverso **aggiunge un nuovo hook `useAgui<AgentName>.tsx` e componente `<agent-name>-chat.tsx`** e aggiorna `AguiProvider.tsx` per registrare entrambi gli hook — eventuali modifiche personalizzate apportate al provider vengono preservate. `main.tsx` mantiene il suo singolo wrapper `<AguiProvider>` — non ti ritroverai mai con provider annidati.
 
 Le seguenti dipendenze vengono aggiunte al `package.json` radice:
 
@@ -119,17 +120,14 @@ Sia il Session ID che il Thread ID sono forniti dal browser. Per limitare ogni u
 
 ### Aggiungere un'Interfaccia Chat
 
-Istanzia i componenti CopilotKit con `agentId` per selezionare quale agent utilizzare. L'id è il nome dell'agent — lo stesso che hai scelto quando hai eseguito il generatore <Link path="guides/ts-agent">`ts#agent`</Link> o <Link path="guides/py-agent">`py#agent`</Link> — e puoi anche trovarlo nel file hook generato (ad es. la chiave restituita da `packages/web/src/hooks/useAgui<AgentName>.tsx`).
-
-Importa i componenti chat dal modulo generato `./components/copilot` in modo che il tema corrispondente al `ux` del tuo sito web venga applicato automaticamente:
+Il generatore fornisce un componente `<AgentName>Chat` per ogni agent connesso, già associato all'id di quell'agent e tematizzato per corrispondere al `ux` del tuo sito web. Inseriscilo ovunque all'interno del wrapper `<AguiProvider>`:
 
 ```tsx
-import { CopilotChat } from './components/copilot';
+import { StoryAgentChat } from './components/story-agent-chat';
 
 function ChatPage() {
   return (
-    <CopilotChat
-      agentId="agent"
+    <StoryAgentChat
       labels={{
         welcomeMessageText: 'How can I help you today?',
         chatInputPlaceholder: 'Ask me anything...',
@@ -139,15 +137,24 @@ function ChatPage() {
 }
 ```
 
+Inoltra ogni prop di `CopilotChat` tranne `agentId`, quindi tutto ciò che puoi passare a `<CopilotChat />` funziona anche qui.
+
 ### Connettere Più Agent AG-UI
 
-Esegui il generatore `connection` una volta per agent. Ogni agent registrato tramite l'`AguiProvider` condiviso è visibile da qualsiasi punto dell'app — istanzia un componente CopilotKit con un `agentId` diverso per instradare ogni chat all'agent desiderato:
+Esegui il generatore `connection` una volta per agent. Ogni esecuzione fornisce il componente chat proprio di quell'agent, quindi instradare una chat a un particolare agent è una questione di quale componente renderizzi:
 
 ```tsx
-import { CopilotChat } from './components/copilot';
+import { StoryAgentChat } from './components/story-agent-chat';
+import { ResearchAgentChat } from './components/research-agent-chat';
 
-<CopilotChat agentId="story" />    {/* talks to StoryAgent */}
-<CopilotChat agentId="research" /> {/* talks to ResearchAgent */}
+<StoryAgentChat />    {/* talks to StoryAgent */}
+<ResearchAgentChat /> {/* talks to ResearchAgent */}
+```
+
+Se hai bisogno dell'id grezzo — per chiamare gli hook propri di CopilotKit, ad esempio — ogni hook generato lo esporta:
+
+```tsx
+import { STORY_AGENT_ID } from './hooks/useAguiStoryAgent';
 ```
 
 ## Personalizzare l'Aspetto
@@ -164,12 +171,13 @@ Il generatore legge `metadata.ux` dal tuo progetto sito web React e fornisce un 
 | `shadcn` | I messaggi dell'assistente vengono renderizzati in una bolla `bg-muted` con un avatar `Sparkles`; i messaggi utente vengono renderizzati allineati a destra in una bolla `bg-primary` con un avatar `User`. L'input è una `Textarea` arrotondata + `Button` di invio/stop a forma di pillola (Invio invia, Shift+Invio nuova riga). Utilizza primitive shadcn dal package condiviso `common-shadcn`. |
 | `none` (o qualsiasi altro) | Nessun tema — il modulo ri-esporta semplicemente i componenti CopilotKit predefiniti. |
 
-Importa i componenti tematizzati dal **modulo tema locale** (non direttamente da `@copilotkit/react-core/v2`) in modo che il tema venga applicato automaticamente:
+I componenti `<AgentName>Chat` forniti sono già tematizzati. Per una chat che colleghi tu stesso, importa dal **modulo tema locale** (non direttamente da `@copilotkit/react-core/v2`) in modo che il tema venga applicato automaticamente:
 
 ```tsx
 import { CopilotChat } from './components/copilot';
+import { STORY_AGENT_ID } from './hooks/useAguiStoryAgent';
 
-<CopilotChat agentId="agent" />
+<CopilotChat agentId={STORY_AGENT_ID} />
 ```
 
 Il tema viene applicato come valori predefiniti degli slot, quindi qualsiasi slot che passi esplicitamente ha comunque la precedenza — mantieni il pieno controllo ogni volta che hai bisogno di una sovrascrittura una tantum.
@@ -188,8 +196,7 @@ Ad esempio, per inserire il tuo renderer di messaggi utente personalizzato mante
 Le sovrascritture per chat funzionano ancora insieme al tema — qualsiasi cosa passi come prop slot sovrascrive il valore predefinito del tema:
 
 ```tsx
-<CopilotChat
-  agentId="agent"
+<StoryAgentChat
   // style the input and its children
   input={{
     textArea: 'text-blue-600',
@@ -208,25 +215,23 @@ Le sovrascritture per chat funzionano ancora insieme al tema — qualsiasi cosa 
 Qualsiasi slot può accettare un componente React invece di un className, quindi puoi sostituire completamente il valore predefinito:
 
 ```tsx
-import { CopilotChat } from './components/copilot';
+import { StoryAgentChat } from './components/story-agent-chat';
 
-const MySendButton: React.FC<{ onClick: () => void }> = ({ onClick }) => (
+const MySendButton: React.FC<React.ButtonHTMLAttributes<HTMLButtonElement>> = ({
+  onClick,
+}) => (
   <button onClick={onClick} className="my-send-btn">
     Send
   </button>
 );
 
-<CopilotChat
-  agentId="agent"
-  input={{ sendButton: MySendButton }}
-/>;
+<StoryAgentChat input={{ sendButton: MySendButton }} />;
 ```
 
 Le sovrascritture più profonde seguono la stessa forma — ad es. sostituisci solo il pulsante copia sui messaggi dell'assistente:
 
 ```tsx
-<CopilotChat
-  agentId="agent"
+<StoryAgentChat
   messageView={{
     assistantMessage: {
       copyButton: ({ onClick }) => <button onClick={onClick}>Copy</button>,

--- a/docs/src/content/docs/it/guides/connection/react-fastapi.mdx
+++ b/docs/src/content/docs/it/guides/connection/react-fastapi.mdx
@@ -248,7 +248,7 @@ const createItem = useMutation({
   onSettled: () => {
     // This will run when the mutation completes (success or error)
     // Good place to invalidate queries that might be affected
-    queryClient.invalidateQueries({ queryKey: api.listItems.queryKey() });
+    queryClient.invalidateQueries({ queryKey: api.listItems.queryKey({}) });
   }
 });
 ```
@@ -495,7 +495,9 @@ function ItemList() {
 
 ### Gestione degli Errori
 
-L'integrazione include una gestione errori integrata con risposte tipizzate. Viene generato un tipo `<operation-name>Error` che incapsula le possibili risposte di errore definite nella specifica OpenAPI. Ogni errore ha una proprietà `status` e `error`, e controllando il valore di `status` puoi restringere a un tipo specifico di errore.
+L'integrazione include una gestione errori integrata con risposte tipizzate. Viene generato un tipo `<OperationName>Error` che è un'unione di un membro `<OperationName><StatusCode>Error` per ogni stato di errore che le `responses` dell'operazione dichiarano. Ogni membro ha una proprietà `status` e `error`, quindi lo switch su `status` restringe `error` al modello di quello stato.
+
+L'esempio seguente presuppone che `create_item` dichiari le [`responses` definite più avanti in questa pagina](#specifica-dei-modelli-di-risposta) — un `400` `ValidationErrorDetails`, un `403` `str` e un `500` `ErrorDetails`. Solo gli stati che dichiari appaiono nell'unione (più il `422` proprio di FastAPI), quindi un `case` per uno stato che non hai dichiarato è un errore di compilazione.
 
 ```tsx {12}
 import { useMutation } from '@tanstack/react-query';
@@ -511,34 +513,32 @@ function MyComponent() {
   if (createItem.error) {
     switch (createItem.error.status) {
       case 400:
-        // error.error is typed as CreateItem400Response
+        // error.error is typed as ValidationErrorDetails
         return (
           <div>
             <h2>Invalid input:</h2>
             <p>{createItem.error.error.message}</p>
             <ul>
-              {createItem.error.error.validationErrors.map((err) => (
-                <li key={err.field}>{err.message}</li>
+              {createItem.error.error.fieldErrors.map((err) => (
+                <li key={err}>{err}</li>
               ))}
             </ul>
           </div>
         );
       case 403:
-        // error.error is typed as CreateItem403Response
+        // error.error is a string as specified in the responses
         return (
           <div>
             <h2>Not authorized:</h2>
-            <p>{createItem.error.error.reason}</p>
+            <p>{createItem.error.error}</p>
           </div>
         );
       case 500:
-      case 502:
-        // error.error is typed as CreateItem5XXResponse
+        // error.error is typed as ErrorDetails
         return (
           <div>
             <h2>Server error:</h2>
             <p>{createItem.error.error.message}</p>
-            <p>Trace ID: {createItem.error.error.traceId}</p>
           </div>
         );
     }
@@ -547,6 +547,10 @@ function MyComponent() {
   return <button onClick={handleClick}>Create Item</button>;
 }
 ```
+
+:::note[Nomi dei campi Python]
+Il client generato converte i campi del modello in camelCase, quindi un modello Pydantic che dichiara `field_errors` viene letto come `error.fieldErrors`.
+:::
 
 <Drawer title="Gestione degli errori utilizzando direttamente il client API" trigger="Clicca qui per un esempio utilizzando direttamente il client vanilla.">
 ```tsx {9,15}
@@ -566,34 +570,32 @@ function MyComponent() {
   if (error) {
     switch (error.status) {
       case 400:
-        // error.error is typed as CreateItem400Response
+        // error.error is typed as ValidationErrorDetails
         return (
           <div>
             <h2>Invalid input:</h2>
             <p>{error.error.message}</p>
             <ul>
-              {error.error.validationErrors.map((err) => (
-                <li key={err.field}>{err.message}</li>
+              {error.error.fieldErrors.map((err) => (
+                <li key={err}>{err}</li>
               ))}
             </ul>
           </div>
         );
       case 403:
-        // error.error is typed as CreateItem403Response
+        // error.error is a string as specified in the responses
         return (
           <div>
             <h2>Not authorized:</h2>
-            <p>{error.error.reason}</p>
+            <p>{error.error}</p>
           </div>
         );
       case 500:
-      case 502:
-        // error.error is typed as CreateItem5XXResponse
+        // error.error is typed as ErrorDetails
         return (
           <div>
             <h2>Server error:</h2>
             <p>{error.error.message}</p>
-            <p>Trace ID: {error.error.traceId}</p>
           </div>
         );
     }
@@ -784,6 +786,8 @@ def list_items(page: int = 1, limit: int = 10):
 
 Gli hook e i metodi del client generati sono organizzati automaticamente in base ai tag OpenAPI nei tuoi endpoint FastAPI. Questo aiuta a mantenere organizzate le tue chiamate API e rende più facile trovare le operazioni correlate.
 
+All'interno di un gruppo ogni operazione mantiene il proprio nome in camelCase, preso dal nome della funzione del tuo endpoint — quindi `def list_items()` con tag `"items"` è raggiungibile a `api.items.listItems`.
+
 Esempio:
 
 ```python title="items.py"
@@ -791,7 +795,7 @@ Esempio:
     "/items",
     tags=["items"],
 )
-def list():
+def list(cursor: str | None = None):
     # ...
 
 @app.post(
@@ -811,6 +815,10 @@ def list():
     # ...
 ```
 
+:::tip[Nomi di funzione ripetuti]
+Due endpoint denominati `list` in tag diversi non entrano in conflitto — il generatore qualifica un nome duplicato con il suo tag, quindi entrambi sono raggiungibili a `api.items.list` e `api.users.list`.
+:::
+
 Gli hook generati saranno raggruppati per tag:
 
 ```tsx
@@ -821,7 +829,7 @@ function ItemsAndUsers() {
   const api = useMyApi();
 
   // Items operations are grouped under api.items
-  const items = useQuery(api.items.list.queryOptions());
+  const items = useQuery(api.items.list.queryOptions({}));
   const createItem = useMutation(api.items.create.mutationOptions());
 
   // Users operations are grouped under api.users
@@ -873,7 +881,7 @@ function ItemsAndUsers() {
         setIsLoading(true);
 
         // Items operations are grouped under api.items
-        const itemsData = await api.items.list();
+        const itemsData = await api.items.list({});
         setItems(itemsData);
 
         // Users operations are grouped under api.users
@@ -943,7 +951,7 @@ from pydantic import BaseModel
 class ErrorDetails(BaseModel):
     message: str
 
-class ValidationError(BaseModel):
+class ValidationErrorDetails(BaseModel):
     message: str
     field_errors: list[str]
 ```
@@ -958,7 +966,7 @@ class NotFoundException(Exception):
         self.message = message
 
 class ValidationException(Exception):
-    def __init__(self, details: ValidationError):
+    def __init__(self, details: ValidationErrorDetails):
         self.details = details
 ```
 
@@ -997,8 +1005,8 @@ Infine, specifica i modelli di risposta per diversi codici di stato di errore ne
 @app.get(
     "/items/{item_id}",
     responses={
-        404: {"model": str}
-        500: {"model": ErrorDetails}
+        404: {"model": str},
+        500: {"model": ErrorDetails},
     }
 )
 def get_item(item_id: str) -> Item:
@@ -1010,14 +1018,15 @@ def get_item(item_id: str) -> Item:
 @app.post(
     "/items",
     responses={
-        400: {"model": ValidationError},
-        403: {"model": str}
+        400: {"model": ValidationErrorDetails},
+        403: {"model": str},
+        500: {"model": ErrorDetails},
     }
 )
 def create_item(item: Item) -> Item:
     if not is_valid(item):
         raise ValidationException(
-            ValidationError(
+            ValidationErrorDetails(
                 message="Invalid item data",
                 field_errors=["name is required"]
             )
@@ -1035,33 +1044,18 @@ import { useMutation, useQuery } from '@tanstack/react-query';
 function ItemComponent() {
   const api = useMyApi();
 
-  // Query with typed error handling
-  const getItem = useQuery({
-    ...api.getItem.queryOptions({ itemId: '123' }),
-    onError: (error) => {
-      // Error is typed based on the responses in your FastAPI
-      switch (error.status) {
-        case 404:
-          // error.error is a string as specified in the responses
-          console.error('Not found:', error.error);
-          break;
-        case 500:
-          // error.error is typed as ErrorDetails
-          console.error('Server error:', error.error.message);
-          break;
-      }
-    }
-  });
+  const getItem = useQuery(api.getItem.queryOptions({ itemId: '123' }));
 
   // Mutation with typed error handling
   const createItem = useMutation({
     ...api.createItem.mutationOptions(),
     onError: (error) => {
+      // Error is typed based on the responses in your FastAPI
       switch (error.status) {
         case 400:
-          // error.error is typed as ValidationError
+          // error.error is typed as ValidationErrorDetails
           console.error('Validation error:', error.error.message);
-          console.error('Field errors:', error.error.field_errors);
+          console.error('Field errors:', error.error.fieldErrors);
           break;
         case 403:
           // error.error is a string as specified in the responses
@@ -1073,10 +1067,13 @@ function ItemComponent() {
 
   // Component rendering with error handling
   if (getItem.isError) {
-    if (getItem.error.status === 404) {
-      return <NotFoundMessage message={getItem.error.error} />;
-    } else {
-      return <ErrorMessage message={getItem.error.error.message} />;
+    switch (getItem.error.status) {
+      case 404:
+        // error.error is a string as specified in the responses
+        return <NotFoundMessage message={getItem.error.error} />;
+      case 500:
+        // error.error is typed as ErrorDetails
+        return <ErrorMessage message={getItem.error.error.message} />;
     }
   }
 
@@ -1137,9 +1134,9 @@ function ItemComponent() {
 
       switch (err.status) {
         case 400:
-          // err.error is typed as ValidationError
+          // err.error is typed as ValidationErrorDetails
           console.error('Validation error:', err.error.message);
-          console.error('Field errors:', err.error.field_errors);
+          console.error('Field errors:', err.error.fieldErrors);
           break;
         case 403:
           // err.error is a string as specified in the responses
@@ -1186,7 +1183,7 @@ import { useQuery } from '@tanstack/react-query';
 
 function ItemList() {
   const api = useMyApi();
-  const items = useQuery(api.listItems.queryOptions());
+  const items = useQuery(api.listItems.queryOptions({}));
 
   if (items.isLoading) {
     return <LoadingSpinner />;
@@ -1196,17 +1193,11 @@ function ItemList() {
     const err = items.error;
     switch (err.status) {
       case 403:
-        // err.error is typed as ListItems403Response
-        return <ErrorMessage message={err.error.reason} />;
+        // err.error is a string as specified in the responses
+        return <ErrorMessage message={err.error} />;
       case 500:
-      case 502:
-        // err.error is typed as ListItems5XXResponse
-        return (
-          <ErrorMessage
-            message={err.error.message}
-            details={`Trace ID: ${err.error.traceId}`}
-          />
-        );
+        // err.error is typed as ErrorDetails
+        return <ErrorMessage message={err.error.message} />;
       default:
         return <ErrorMessage message="An unknown error occurred" />;
     }
@@ -1214,7 +1205,7 @@ function ItemList() {
 
   return (
     <ul>
-      {items.data.map((item) => (
+      {items.data?.items.map((item) => (
         <li key={item.id}>{item.name}</li>
       ))}
     </ul>
@@ -1233,7 +1224,7 @@ function ItemList() {
   useEffect(() => {
     const fetchItems = async () => {
       try {
-        const data = await api.listItems();
+        const data = await api.listItems({});
         setItems(data);
       } catch (err) {
         setError(err);
@@ -1252,17 +1243,11 @@ function ItemList() {
     const err = error as ListItemsError;
     switch (err.status) {
       case 403:
-        // err.error is typed as ListItems403Response
-        return <ErrorMessage message={err.error.reason} />;
+        // err.error is a string as specified in the responses
+        return <ErrorMessage message={err.error} />;
       case 500:
-      case 502:
-        // err.error is typed as ListItems5XXResponse
-        return (
-          <ErrorMessage
-            message={err.error.message}
-            details={`Trace ID: ${err.error.traceId}`}
-          />
-        );
+        // err.error is typed as ErrorDetails
+        return <ErrorMessage message={err.error.message} />;
       default:
         return <ErrorMessage message="An unknown error occurred" />;
     }
@@ -1285,41 +1270,53 @@ Implementa aggiornamenti ottimistici per una migliore esperienza utente:
 
 ```tsx
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import type { ListItemsOutput } from '../generated/my-api/types.gen';
 
 function ItemList() {
   const api = useMyApi();
   const queryClient = useQueryClient();
 
   // Query to fetch items
-  const itemsQuery = useQuery(api.listItems.queryOptions());
+  const itemsQuery = useQuery(api.listItems.queryOptions({}));
 
   // Mutation for deleting items with optimistic updates
   const deleteMutation = useMutation({
     ...api.deleteItem.mutationOptions(),
-    onMutate: async (itemId) => {
+    onMutate: async ({ itemId }) => {
       // Cancel any outgoing refetches
-      await queryClient.cancelQueries({ queryKey: api.listItems.queryKey() });
+      await queryClient.cancelQueries({
+        queryKey: api.listItems.queryKey({}),
+      });
 
       // Snapshot the previous value
-      const previousItems = queryClient.getQueryData(api.listItems.queryKey());
+      const previousItems = queryClient.getQueryData<ListItemsOutput>(
+        api.listItems.queryKey({}),
+      );
 
       // Optimistically update to the new value
-      queryClient.setQueryData(
-        api.listItems.queryKey(),
-        (old) => old.filter((item) => item.id !== itemId)
+      queryClient.setQueryData<ListItemsOutput>(
+        api.listItems.queryKey({}),
+        (old) =>
+          old && {
+            ...old,
+            items: old.items.filter((item) => item.id !== itemId),
+          },
       );
 
       // Return a context object with the snapshot
       return { previousItems };
     },
-    onError: (err, itemId, context) => {
+    onError: (err, _input, context) => {
       // If the mutation fails, use the context returned from onMutate to roll back
-      queryClient.setQueryData(api.listItems.queryKey(), context.previousItems);
+      queryClient.setQueryData(
+        api.listItems.queryKey({}),
+        context?.previousItems,
+      );
       console.error('Failed to delete item:', err);
     },
     onSettled: () => {
       // Always refetch after error or success to ensure data is in sync with server
-      queryClient.invalidateQueries({ queryKey: api.listItems.queryKey() });
+      queryClient.invalidateQueries({ queryKey: api.listItems.queryKey({}) });
     },
   });
 
@@ -1333,11 +1330,11 @@ function ItemList() {
 
   return (
     <ul>
-      {itemsQuery.data.map((item) => (
+      {itemsQuery.data?.items.map((item) => (
         <li key={item.id}>
           {item.name}
           <button
-            onClick={() => deleteMutation.mutate(item.id)}
+            onClick={() => deleteMutation.mutate({ itemId: item.id })}
             disabled={deleteMutation.isPending}
           >
             {deleteMutation.isPending ? 'Deleting...' : 'Delete'}
@@ -1413,19 +1410,22 @@ function ItemForm() {
     const error = createItem.error;
     switch (error.status) {
       case 400:
-        // error.error is typed as CreateItem400Response
+        // error.error is typed as ValidationErrorDetails
         return (
           <FormError
             message="Invalid input"
-            errors={error.error.validationErrors}
+            errors={error.error.fieldErrors}
           />
         );
       case 403:
-        // error.error is typed as CreateItem403Response
-        return <AuthError reason={error.error.reason} />;
-      default:
-        // error.error is typed as CreateItem5XXResponse for 500, 502, etc.
+        // error.error is a string as specified in the responses
+        return <AuthError reason={error.error} />;
+      case 500:
+        // error.error is typed as ErrorDetails
         return <ServerError message={error.error.message} />;
+      default:
+        // FastAPI adds a 422 to every endpoint, so `default` isn't narrowed
+        return <ServerError message="An unknown error occurred" />;
     }
   }
 
@@ -1461,22 +1461,16 @@ function ItemForm() {
       const err = e as CreateItemError;
       switch (err.status) {
         case 400:
-          // err.error is typed as CreateItem400Response
-          console.error('Validation errors:', err.error.validationErrors);
+          // err.error is typed as ValidationErrorDetails
+          console.error('Validation errors:', err.error.fieldErrors);
           break;
         case 403:
-          // err.error is typed as CreateItem403Response
-          console.error('Not authorized:', err.error.reason);
+          // err.error is a string as specified in the responses
+          console.error('Not authorized:', err.error);
           break;
         case 500:
-        case 502:
-          // err.error is typed as CreateItem5XXResponse
-          console.error(
-            'Server error:',
-            err.error.message,
-            'Trace:',
-            err.error.traceId,
-          );
+          // err.error is typed as ErrorDetails
+          console.error('Server error:', err.error.message);
           break;
       }
       setError(err);
@@ -1490,13 +1484,15 @@ function ItemForm() {
         return (
           <FormError
             message="Invalid input"
-            errors={error.error.validationErrors}
+            errors={error.error.fieldErrors}
           />
         );
       case 403:
-        return <AuthError reason={error.error.reason} />;
-      default:
+        return <AuthError reason={error.error} />;
+      case 500:
         return <ServerError message={error.error.message} />;
+      default:
+        return <ServerError message="An unknown error occurred" />;
     }
   }
 

--- a/docs/src/content/docs/it/guides/connection/react-smithy.mdx
+++ b/docs/src/content/docs/it/guides/connection/react-smithy.mdx
@@ -245,7 +245,7 @@ const createItem = useMutation({
   onSettled: () => {
     // This will run when the mutation completes (success or error)
     // Good place to invalidate queries that might be affected
-    queryClient.invalidateQueries({ queryKey: api.listItems.queryKey() });
+    queryClient.invalidateQueries({ queryKey: api.listItems.queryKey({}) });
   }
 });
 ```
@@ -456,7 +456,9 @@ function ItemList() {
 
 ### Gestione degli Errori
 
-L'integrazione include una gestione degli errori integrata con risposte di errore tipizzate. Viene generato un tipo `<operation-name>Error` che incapsula le possibili risposte di errore definite nel modello Smithy. Ogni errore ha una proprietà `status` e `error`, e controllando il valore di `status` puoi restringere a un tipo specifico di errore.
+L'integrazione include una gestione degli errori integrata con risposte di errore tipizzate. Viene generato un tipo `<OperationName>Error` che è un'unione di un membro `<OperationName><StatusCode>Error` per ogni stato di errore che l'operazione modella. Ogni membro ha una proprietà `status` e una proprietà `error`, quindi lo switch su `status` restringe `error` al payload di quello stato.
+
+L'esempio seguente presuppone che `CreateItem` modelli le [strutture di errore definite più avanti in questa pagina](#errors) — un `InvalidRequestError` `422`, un `UnauthorizedError` `403` e un `InternalServerError` `500`. Solo gli stati dichiarati dal tuo modello appaiono nell'unione, quindi un `case` per uno stato che non hai modellato è un errore di compilazione.
 
 ```tsx {12}
 import { useMutation } from '@tanstack/react-query';
@@ -471,8 +473,8 @@ function MyComponent() {
 
   if (createItem.error) {
     switch (createItem.error.status) {
-      case 400:
-        // error.error is typed as CreateItem400Response
+      case 422:
+        // error.error is typed as InvalidRequestErrorResponseContent
         return (
           <div>
             <h2>Invalid input:</h2>
@@ -480,7 +482,7 @@ function MyComponent() {
           </div>
         );
       case 403:
-        // error.error is typed as CreateItem403Response
+        // error.error is typed as UnauthorizedErrorResponseContent
         return (
           <div>
             <h2>Not authorized:</h2>
@@ -488,8 +490,7 @@ function MyComponent() {
           </div>
         );
       case 500:
-      case 502:
-        // error.error is typed as CreateItem5XXResponse
+        // error.error is typed as InternalServerErrorResponseContent
         return (
           <div>
             <h2>Server error:</h2>
@@ -520,8 +521,8 @@ function MyComponent() {
 
   if (error) {
     switch (error.status) {
-      case 400:
-        // error.error is typed as CreateItem400Response
+      case 422:
+        // error.error is typed as InvalidRequestErrorResponseContent
         return (
           <div>
             <h2>Invalid input:</h2>
@@ -529,7 +530,7 @@ function MyComponent() {
           </div>
         );
       case 403:
-        // error.error is typed as CreateItem403Response
+        // error.error is typed as UnauthorizedErrorResponseContent
         return (
           <div>
             <h2>Not authorized:</h2>
@@ -537,8 +538,7 @@ function MyComponent() {
           </div>
         );
       case 500:
-      case 502:
-        // error.error is typed as CreateItem5XXResponse
+        // error.error is typed as InternalServerErrorResponseContent
         return (
           <div>
             <h2>Server error:</h2>
@@ -573,21 +573,21 @@ Questi si mappano alle estensioni vendor OpenAPI usando il [trait `@specificatio
 
 #### @query
 
-Quindi applica il trait `@query` alla tua operazione Smithy per forzarla a essere trattata come una query:
+Applica il trait `@query` alla tua operazione Smithy per forzarla a essere trattata come una query:
 
 ```smithy
-@http(method: "POST", uri: "/items")
+@http(method: "POST", uri: "/search-items")
 @query
-operation ListItems {
-    input: ListItemsInput
-    output: ListItemsOutput
+operation SearchItems {
+    input: SearchItemsInput
+    output: SearchItemsOutput
 }
 ```
 
 L'hook generato fornirà `queryOptions` anche se utilizza il metodo HTTP `POST`:
 
 ```tsx
-const items = useQuery(api.listItems.queryOptions());
+const items = useQuery(api.searchItems.queryOptions({ term: 'widget' }));
 ```
 
 #### @mutation
@@ -607,6 +607,8 @@ L'hook generato fornirà `mutationOptions` anche se utilizza il metodo HTTP `GET
 
 ```tsx
 const startProcessing = useMutation(api.startProcessing.mutationOptions());
+
+startProcessing.mutate({ id: 'some-id' });
 ```
 
 ### Cursore di Paginazione Personalizzato
@@ -616,38 +618,59 @@ Per impostazione predefinita, gli hook generati assumono una paginazione basata 
 Applica il trait `@cursor` con `inputToken` per modificare il nome del parametro di input utilizzato per il token di paginazione:
 
 ```smithy
-@http(method: "GET", uri: "/items")
+@http(method: "GET", uri: "/paged-items")
 @cursor(inputToken: "nextToken")
-operation ListItems {
+operation ListPagedItems {
     input := {
+      @httpQuery("nextToken")
       nextToken: String
+      @httpQuery("limit")
       limit: Integer
     }
     output := {
+      @required
       items: ItemList
       nextToken: String
     }
 }
 ```
 
+`infiniteQueryOptions` quindi pagina su `nextToken`:
+
+```tsx
+const items = useInfiniteQuery({
+  ...api.listPagedItems.infiniteQueryOptions(
+    { limit: 10 },
+    { getNextPageParam: (lastPage) => lastPage.nextToken || undefined },
+  ),
+});
+```
+
 Se non desideri generare `infiniteQueryOptions` per un'operazione che ha un parametro di input chiamato `cursor`, puoi disabilitare la paginazione basata su cursore:
 
 ```smithy
+@http(method: "GET", uri: "/unpaged-items")
 @cursor(enabled: false)
-operation ListItems {
+operation ListUnpagedItems {
     input := {
       // Input parameter named 'cursor' will cause this operation to be treated as a paginated operation by default
+      @httpQuery("cursor")
       cursor: String
     }
     output := {
-      ...
+      @required
+      items: ItemList
     }
 }
 ```
 
+`api.listUnpagedItems` quindi fornisce solo `queryOptions`, `queryKey` e `queryFilter`.
+
 ### Raggruppamento delle Operazioni
 
 Gli hook generati e i metodi del client sono organizzati automaticamente in base al [trait `@tags`](https://smithy.io/2.0/spec/documentation-traits.html#tags-trait) nelle tue operazioni Smithy. Le operazioni con gli stessi tag vengono raggruppate insieme, il che aiuta a mantenere organizzate le chiamate API e fornisce un migliore completamento del codice nel tuo IDE.
+
+All'interno di un gruppo ogni operazione mantiene il proprio nome in camelCase, quindi un'operazione chiamata `ListItems` taggata `"items"` si raggiunge a `api.items.listItems` — non `api.items.list`.
 
 Ad esempio, con questo modello Smithy:
 
@@ -657,27 +680,51 @@ service MyService {
 }
 
 @tags(["items"])
+@http(method: "GET", uri: "/items")
+@readonly
 operation ListItems {
-    input: ListItemsInput
-    output: ListItemsOutput
+    input := {}
+    output := {
+      @required
+      items: ItemList
+    }
 }
 
 @tags(["items"])
+@http(method: "POST", uri: "/items")
 operation CreateItem {
-    input: CreateItemInput
-    output: CreateItemOutput
+    input := {
+      @required
+      name: String
+    }
+    output := {
+      @required
+      id: String
+    }
 }
 
 @tags(["users"])
+@http(method: "GET", uri: "/users")
+@readonly
 operation ListUsers {
-    input: ListUsersInput
-    output: ListUsersOutput
+    input := {}
+    output := {
+      @required
+      users: UserList
+    }
 }
 
 @tags(["users"])
+@http(method: "POST", uri: "/users")
 operation CreateUser {
-    input: CreateUserInput
-    output: CreateUserOutput
+    input := {
+      @required
+      name: String
+    }
+    output := {
+      @required
+      id: String
+    }
 }
 ```
 
@@ -706,7 +753,7 @@ function ItemsAndUsers() {
     <div>
       <h2>Items</h2>
       <ul>
-        {items.data?.map(item => (
+        {items.data?.items.map(item => (
           <li key={item.id}>{item.name}</li>
         ))}
       </ul>
@@ -714,7 +761,7 @@ function ItemsAndUsers() {
 
       <h2>Users</h2>
       <ul>
-        {users.data?.map(user => (
+        {users.data?.users.map(user => (
           <li key={user.id}>{user.name}</li>
         ))}
       </ul>
@@ -805,7 +852,7 @@ Definisci le tue strutture di errore nel tuo modello Smithy:
 
 ```smithy
 @error("client")
-@httpError(400)
+@httpError(422)
 structure InvalidRequestError {
     @required
     message: String
@@ -841,6 +888,10 @@ structure FieldError {
     message: String
 }
 ```
+
+:::caution[400 è occupato]
+Il tuo servizio dichiara già la `ValidationException` di Smithy su `400`, quindi ogni operazione ottiene un caso `400` che trasporta `ValidationExceptionResponseContent`. Dai ai tuoi errori client uno stato diverso (`422` sopra) — due errori sullo stesso stato collidono e solo un payload raggiunge il client generato.
+:::
 
 #### Aggiunta di Errori alle Operazioni
 
@@ -884,37 +935,21 @@ import { useMutation, useQuery } from '@tanstack/react-query';
 function ItemComponent() {
   const api = useMyApi();
 
-  // Query with typed error handling
-  const getItem = useQuery({
-    ...api.getItem.queryOptions({ itemId: '123' }),
-    onError: (error) => {
-      // Error is typed based on the errors in your Smithy model
-      switch (error.status) {
-        case 404:
-          // error.error is typed as ItemNotFoundError
-          console.error('Not found:', error.error.message);
-          break;
-        case 500:
-          // error.error is typed as InternalServerError
-          console.error('Server error:', error.error.message);
-          console.error('Trace ID:', error.error.traceId);
-          break;
-      }
-    }
-  });
+  const getItem = useQuery(api.getItem.queryOptions({ itemId: '123' }));
 
   // Mutation with typed error handling
   const createItem = useMutation({
     ...api.createItem.mutationOptions(),
     onError: (error) => {
+      // Error is typed based on the errors in your Smithy model
       switch (error.status) {
-        case 400:
-          // error.error is typed as InvalidRequestError
+        case 422:
+          // error.error is typed as InvalidRequestErrorResponseContent
           console.error('Validation error:', error.error.message);
           console.error('Field errors:', error.error.fieldErrors);
           break;
         case 403:
-          // error.error is typed as UnauthorizedError
+          // error.error is typed as UnauthorizedErrorResponseContent
           console.error('Unauthorized:', error.error.reason);
           break;
       }
@@ -923,10 +958,13 @@ function ItemComponent() {
 
   // Component rendering with error handling
   if (getItem.isError) {
-    if (getItem.error.status === 404) {
-      return <NotFoundMessage message={getItem.error.error.message} />;
-    } else if (getItem.error.status === 500) {
-      return <ErrorMessage message={getItem.error.error.message} />;
+    switch (getItem.error.status) {
+      case 404:
+        // error.error is typed as ItemNotFoundErrorResponseContent
+        return <NotFoundMessage message={getItem.error.error.message} />;
+      case 500:
+        // error.error is typed as InternalServerErrorResponseContent
+        return <ErrorMessage message={getItem.error.error.message} />;
     }
   }
 
@@ -962,11 +1000,11 @@ function ItemComponent() {
 
         switch (err.status) {
           case 404:
-            // err.error is typed as ItemNotFoundError
+            // err.error is typed as ItemNotFoundErrorResponseContent
             console.error('Not found:', err.error.message);
             break;
           case 500:
-            // err.error is typed as InternalServerError
+            // err.error is typed as InternalServerErrorResponseContent
             console.error('Server error:', err.error.message);
             console.error('Trace ID:', err.error.traceId);
             break;
@@ -987,13 +1025,13 @@ function ItemComponent() {
       const err = e as CreateItemError;
 
       switch (err.status) {
-        case 400:
-          // err.error is typed as InvalidRequestError
+        case 422:
+          // err.error is typed as InvalidRequestErrorResponseContent
           console.error('Validation error:', err.error.message);
           console.error('Field errors:', err.error.fieldErrors);
           break;
         case 403:
-          // err.error is typed as UnauthorizedError
+          // err.error is typed as UnauthorizedErrorResponseContent
           console.error('Unauthorized:', err.error.reason);
           break;
       }
@@ -1037,7 +1075,7 @@ import { useQuery } from '@tanstack/react-query';
 
 function ItemList() {
   const api = useMyApi();
-  const items = useQuery(api.listItems.queryOptions());
+  const items = useQuery(api.listItems.queryOptions({}));
 
   if (items.isLoading) {
     return <LoadingSpinner />;
@@ -1047,11 +1085,10 @@ function ItemList() {
     const err = items.error;
     switch (err.status) {
       case 403:
-        // err.error is typed as ListItems403Response
+        // err.error is typed as UnauthorizedErrorResponseContent
         return <ErrorMessage message={err.error.reason} />;
       case 500:
-      case 502:
-        // err.error is typed as ListItems5XXResponse
+        // err.error is typed as InternalServerErrorResponseContent
         return (
           <ErrorMessage
             message={err.error.message}
@@ -1064,7 +1101,7 @@ function ItemList() {
 
   return (
     <ul>
-      {items.data.map((item) => (
+      {items.data?.items.map((item) => (
         <li key={item.id}>{item.name}</li>
       ))}
     </ul>
@@ -1083,7 +1120,7 @@ function ItemList() {
   useEffect(() => {
     const fetchItems = async () => {
       try {
-        const data = await api.listItems();
+        const data = await api.listItems({});
         setItems(data);
       } catch (err) {
         setError(err);
@@ -1102,11 +1139,10 @@ function ItemList() {
     const err = error as ListItemsError;
     switch (err.status) {
       case 403:
-        // err.error is typed as ListItems403Response
+        // err.error is typed as UnauthorizedErrorResponseContent
         return <ErrorMessage message={err.error.reason} />;
       case 500:
-      case 502:
-        // err.error is typed as ListItems5XXResponse
+        // err.error is typed as InternalServerErrorResponseContent
         return (
           <ErrorMessage
             message={err.error.message}
@@ -1134,41 +1170,53 @@ Implementa aggiornamenti ottimistici per una migliore esperienza utente:
 
 ```tsx
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import type { ListItemsResponseContent } from '../generated/my-api/types.gen';
 
 function ItemList() {
   const api = useMyApi();
   const queryClient = useQueryClient();
 
   // Query to fetch items
-  const itemsQuery = useQuery(api.listItems.queryOptions());
+  const itemsQuery = useQuery(api.listItems.queryOptions({}));
 
   // Mutation for deleting items with optimistic updates
   const deleteMutation = useMutation({
     ...api.deleteItem.mutationOptions(),
-    onMutate: async (itemId) => {
+    onMutate: async ({ itemId }) => {
       // Cancel any outgoing refetches
-      await queryClient.cancelQueries({ queryKey: api.listItems.queryKey() });
+      await queryClient.cancelQueries({
+        queryKey: api.listItems.queryKey({}),
+      });
 
       // Snapshot the previous value
-      const previousItems = queryClient.getQueryData(api.listItems.queryKey());
+      const previousItems = queryClient.getQueryData<ListItemsResponseContent>(
+        api.listItems.queryKey({}),
+      );
 
       // Optimistically update to the new value
-      queryClient.setQueryData(
-        api.listItems.queryKey(),
-        (old) => old.filter((item) => item.id !== itemId)
+      queryClient.setQueryData<ListItemsResponseContent>(
+        api.listItems.queryKey({}),
+        (old) =>
+          old && {
+            ...old,
+            items: old.items.filter((item) => item.id !== itemId),
+          },
       );
 
       // Return a context object with the snapshot
       return { previousItems };
     },
-    onError: (err, itemId, context) => {
+    onError: (err, _input, context) => {
       // If the mutation fails, use the context returned from onMutate to roll back
-      queryClient.setQueryData(api.listItems.queryKey(), context.previousItems);
+      queryClient.setQueryData(
+        api.listItems.queryKey({}),
+        context?.previousItems,
+      );
       console.error('Failed to delete item:', err);
     },
     onSettled: () => {
       // Always refetch after error or success to ensure data is in sync with server
-      queryClient.invalidateQueries({ queryKey: api.listItems.queryKey() });
+      queryClient.invalidateQueries({ queryKey: api.listItems.queryKey({}) });
     },
   });
 
@@ -1182,11 +1230,11 @@ function ItemList() {
 
   return (
     <ul>
-      {itemsQuery.data.map((item) => (
+      {itemsQuery.data?.items.map((item) => (
         <li key={item.id}>
           {item.name}
           <button
-            onClick={() => deleteMutation.mutate(item.id)}
+            onClick={() => deleteMutation.mutate({ itemId: item.id })}
             disabled={deleteMutation.isPending}
           >
             {deleteMutation.isPending ? 'Deleting...' : 'Delete'}
@@ -1261,8 +1309,8 @@ function ItemForm() {
   if (createItem.error) {
     const error = createItem.error;
     switch (error.status) {
-      case 400:
-        // error.error is typed as InvalidRequestError
+      case 422:
+        // error.error is typed as InvalidRequestErrorResponseContent
         return (
           <FormError
             message="Invalid input"
@@ -1270,10 +1318,10 @@ function ItemForm() {
           />
         );
       case 403:
-        // error.error is typed as UnauthorizedError
+        // error.error is typed as UnauthorizedErrorResponseContent
         return <AuthError reason={error.error.reason} />;
       default:
-        // error.error is typed as InternalServerError for 500, etc.
+        // error.error is typed as InternalServerErrorResponseContent for 500, etc.
         return <ServerError message={error.error.message} />;
     }
   }
@@ -1309,16 +1357,16 @@ function ItemForm() {
       // ✅ Error type includes all possible error responses
       const err = e as CreateItemError;
       switch (err.status) {
-        case 400:
-          // err.error is typed as InvalidRequestError
+        case 422:
+          // err.error is typed as InvalidRequestErrorResponseContent
           console.error('Validation errors:', err.error.fieldErrors);
           break;
         case 403:
-          // err.error is typed as UnauthorizedError
+          // err.error is typed as UnauthorizedErrorResponseContent
           console.error('Not authorized:', err.error.reason);
           break;
         case 500:
-          // err.error is typed as InternalServerError
+          // err.error is typed as InternalServerErrorResponseContent
           console.error('Server error:', err.error.message);
           break;
       }
@@ -1329,7 +1377,7 @@ function ItemForm() {
   // Error UI can use type narrowing to handle different error types
   if (error) {
     switch (error.status) {
-      case 400:
+      case 422:
         return (
           <FormError
             message="Invalid input"

--- a/docs/src/content/docs/it/guides/connection/react-trpc.mdx
+++ b/docs/src/content/docs/it/guides/connection/react-trpc.mdx
@@ -417,11 +417,13 @@ function UserList() {
 L'integrazione fornisce una completa type safety end-to-end. Il tuo IDE fornirà il completamento automatico completo e il controllo dei tipi per tutte le tue chiamate API:
 
 ```tsx
+import { useMutation } from '@tanstack/react-query';
+
 function UserForm() {
   const trpc = useMyApi();
 
   // ✅ Input is fully typed
-  const createUser = trpc.users.create.useMutation();
+  const createUser = useMutation(trpc.users.create.mutationOptions());
 
   const handleSubmit = (data: CreateUserInput) => {
     // ✅ Type error if input doesn't match schema

--- a/docs/src/content/docs/jp/guides/connection/react-agui.mdx
+++ b/docs/src/content/docs/jp/guides/connection/react-agui.mdx
@@ -46,16 +46,17 @@ React ウェブサイトをソースプロジェクトとして、AG-UI Agent �
 - src
   - components
     - AguiProvider.tsx すべての AG-UI Agent 用の単一の `CopilotKitProvider`。最初の `connection` 実行時に作成され、後続の実行で各新しい Agent を登録するために更新されます。
+    - \<agent-name>-chat.tsx この Agent の id にバインドされたテーマ付き `<AgentName>Chat`。`connection` 実行ごとに 1 つのファイル。
     - copilot
       - index.tsx ウェブサイトの `ux`（Cloudscape、Shadcn、またはテーマなし）に一致するスロットデフォルトを持つ `CopilotChat`、`CopilotSidebar`、`CopilotPopup` を再エクスポートします。
       - *ThemeComponents*.tsx スロットごとのテーマコンポーネント（例：`CloudscapeAssistantMessage.tsx`、`ShadcnChatInput.tsx`）。`ux` が `cloudscape` または `shadcn` の場合のみ提供されます。
   - hooks
-    - useAgui\<AgentName>.tsx 1 つの AG-UI Agent を登録します。`connection` 実行ごとに 1 つのファイル。
+    - useAgui\<AgentName>.tsx 1 つの AG-UI Agent を登録し、その id を `<AGENT_NAME>_ID` としてエクスポートします。`connection` 実行ごとに 1 つのファイル。
     - useSigV4.tsx SigV4 署名（IAM のみ）
 
 </FileTree>
 
-異なる Agent に対して 2 回目の `connection` を実行すると、**新しい `useAgui<AgentName>.tsx` フックが追加**され、`AguiProvider.tsx` が更新されて両方のフックが登録されます — プロバイダーに加えたカスタム編集は保持されます。`main.tsx` は単一の `<AguiProvider>` ラッパーを保持します — ネストされたプロバイダーになることはありません。
+異なる Agent に対して 2 回目の `connection` を実行すると、**新しい `useAgui<AgentName>.tsx` フックと `<agent-name>-chat.tsx` コンポーネントが追加**され、`AguiProvider.tsx` が更新されて両方のフックが登録されます — プロバイダーに加えたカスタム編集は保持されます。`main.tsx` は単一の `<AguiProvider>` ラッパーを保持します — ネストされたプロバイダーになることはありません。
 
 以下の依存関係がルートの `package.json` に追加されます：
 
@@ -119,17 +120,14 @@ Session ID と Thread ID の両方はブラウザーによって提供されま�
 
 ### チャットインターフェースの追加
 
-使用する Agent を選択するために `agentId` を指定して CopilotKit コンポーネントをインスタンス化します。id は Agent の名前です — <Link path="guides/ts-agent">`ts#agent`</Link> または <Link path="guides/py-agent">`py#agent`</Link> ジェネレーターを実行したときに選択したものと同じです — また、生成されたフックファイル（例：`packages/web/src/hooks/useAgui<AgentName>.tsx` から返されるキー）でも確認できます。
-
-ウェブサイトの `ux` に一致するテーマが自動的に適用されるように、生成された `./components/copilot` モジュールからチャットコンポーネントをインポートします：
+ジェネレーターは、接続された Agent ごとに `<AgentName>Chat` コンポーネントを提供します。これはすでにその Agent の id にバインドされており、ウェブサイトの `ux` に一致するようにテーマが設定されています。`<AguiProvider>` ラッパー内の任意の場所に配置します：
 
 ```tsx
-import { CopilotChat } from './components/copilot';
+import { StoryAgentChat } from './components/story-agent-chat';
 
 function ChatPage() {
   return (
-    <CopilotChat
-      agentId="agent"
+    <StoryAgentChat
       labels={{
         welcomeMessageText: 'How can I help you today?',
         chatInputPlaceholder: 'Ask me anything...',
@@ -139,15 +137,24 @@ function ChatPage() {
 }
 ```
 
+これは `agentId` を除くすべての `CopilotChat` プロップを転送するため、`<CopilotChat />` に渡せるものはすべてここでも機能します。
+
 ### 複数の AG-UI Agent の接続
 
-Agent ごとに 1 回 `connection` ジェネレーターを実行します。共有 `AguiProvider` 経由で登録されたすべての Agent は、アプリ内のどこからでも表示されます — 異なる `agentId` を持つ CopilotKit コンポーネントをインスタンス化して、各チャットを目的の Agent にルーティングします：
+Agent ごとに 1 回 `connection` ジェネレーターを実行します。各実行はその Agent 独自のチャットコンポーネントを提供するため、特定の Agent にチャットをルーティングするのは、どのコンポーネントをレンダリングするかの問題です：
 
 ```tsx
-import { CopilotChat } from './components/copilot';
+import { StoryAgentChat } from './components/story-agent-chat';
+import { ResearchAgentChat } from './components/research-agent-chat';
 
-<CopilotChat agentId="story" />    {/* talks to StoryAgent */}
-<CopilotChat agentId="research" /> {/* talks to ResearchAgent */}
+<StoryAgentChat />    {/* talks to StoryAgent */}
+<ResearchAgentChat /> {/* talks to ResearchAgent */}
+```
+
+生の id が必要な場合 — たとえば CopilotKit 独自のフックを呼び出すために — 各生成されたフックはそれをエクスポートします：
+
+```tsx
+import { STORY_AGENT_ID } from './hooks/useAguiStoryAgent';
 ```
 
 ## ルック＆フィールのカスタマイズ
@@ -164,12 +171,13 @@ import { CopilotChat } from './components/copilot';
 | `shadcn` | アシスタントメッセージは `bg-muted` バブル内に `Sparkles` アバターとともにレンダリングされます；ユーザーメッセージは `bg-primary` バブル内に `User` アバターとともに右揃えでレンダリングされます。入力は丸みを帯びた `Textarea` + ピル型の送信/停止 `Button` です（Enter で送信、Shift+Enter で改行）。共有 `common-shadcn` パッケージの shadcn プリミティブを使用します。 |
 | `none`（またはその他） | テーマなし — モジュールはデフォルトの CopilotKit コンポーネントを再エクスポートするだけです。 |
 
-テーマが自動的に適用されるように、**ローカルテーマモジュール**からテーマ付きコンポーネントをインポートします（`@copilotkit/react-core/v2` から直接ではなく）：
+提供される `<AgentName>Chat` コンポーネントはすでにテーマが設定されています。自分で配線するチャットの場合は、テーマが自動的に適用されるように、**ローカルテーマモジュール**からインポートします（`@copilotkit/react-core/v2` から直接ではなく）：
 
 ```tsx
 import { CopilotChat } from './components/copilot';
+import { STORY_AGENT_ID } from './hooks/useAguiStoryAgent';
 
-<CopilotChat agentId="agent" />
+<CopilotChat agentId={STORY_AGENT_ID} />
 ```
 
 テーマはスロットデフォルトとして適用されるため、明示的に渡すスロットは引き続き優先されます — 一回限りのオーバーライドが必要な場合でも、完全な制御を維持できます。
@@ -188,8 +196,7 @@ import { CopilotChat } from './components/copilot';
 チャットごとのオーバーライドは、テーマと並行して機能します — スロットプロップとして渡すものは、テーマのデフォルトをオーバーライドします：
 
 ```tsx
-<CopilotChat
-  agentId="agent"
+<StoryAgentChat
   // style the input and its children
   input={{
     textArea: 'text-blue-600',
@@ -208,25 +215,23 @@ import { CopilotChat } from './components/copilot';
 任意のスロットは className の代わりに React コンポーネントを取ることができるため、デフォルトを完全に置き換えることができます：
 
 ```tsx
-import { CopilotChat } from './components/copilot';
+import { StoryAgentChat } from './components/story-agent-chat';
 
-const MySendButton: React.FC<{ onClick: () => void }> = ({ onClick }) => (
+const MySendButton: React.FC<React.ButtonHTMLAttributes<HTMLButtonElement>> = ({
+  onClick,
+}) => (
   <button onClick={onClick} className="my-send-btn">
     Send
   </button>
 );
 
-<CopilotChat
-  agentId="agent"
-  input={{ sendButton: MySendButton }}
-/>;
+<StoryAgentChat input={{ sendButton: MySendButton }} />;
 ```
 
 より深いオーバーライドも同じ形状に従います — 例えば、アシスタントメッセージのコピーボタンだけを置き換える：
 
 ```tsx
-<CopilotChat
-  agentId="agent"
+<StoryAgentChat
   messageView={{
     assistantMessage: {
       copyButton: ({ onClick }) => <button onClick={onClick}>Copy</button>,

--- a/docs/src/content/docs/jp/guides/connection/react-fastapi.mdx
+++ b/docs/src/content/docs/jp/guides/connection/react-fastapi.mdx
@@ -248,7 +248,7 @@ const createItem = useMutation({
   onSettled: () => {
     // This will run when the mutation completes (success or error)
     // Good place to invalidate queries that might be affected
-    queryClient.invalidateQueries({ queryKey: api.listItems.queryKey() });
+    queryClient.invalidateQueries({ queryKey: api.listItems.queryKey({}) });
   }
 });
 ```
@@ -495,7 +495,9 @@ function ItemList() {
 
 ### エラーハンドリング
 
-統合には、型付きエラーレスポンスを使用した組み込みのエラーハンドリングが含まれています。`<operation-name>Error`型が生成され、OpenAPI仕様で定義された可能なエラーレスポンスをカプセル化します。各エラーには`status`と`error`プロパティがあり、`status`の値をチェックすることで、特定のタイプのエラーに絞り込むことができます。
+統合には、型付きエラーレスポンスを使用した組み込みのエラーハンドリングが含まれています。`<OperationName>Error`型が生成され、これは操作の`responses`が宣言する各エラーステータスに対して1つの`<OperationName><StatusCode>Error`メンバーのユニオンです。各メンバーには`status`と`error`プロパティがあるため、`status`で切り替えることで`error`をそのステータスのモデルに絞り込むことができます。
+
+以下の例は、`create_item`が[このページの下部で定義された`responses`](#レスポンスモデルの指定)を宣言していることを前提としています — `400` `ValidationErrorDetails`、`403` `str`、`500` `ErrorDetails`。宣言したステータスのみがユニオンに表示されます（FastAPI自身の`422`に加えて）。したがって、宣言していないステータスの`case`はコンパイルエラーになります。
 
 ```tsx {12}
 import { useMutation } from '@tanstack/react-query';
@@ -511,34 +513,32 @@ function MyComponent() {
   if (createItem.error) {
     switch (createItem.error.status) {
       case 400:
-        // error.error is typed as CreateItem400Response
+        // error.error is typed as ValidationErrorDetails
         return (
           <div>
             <h2>Invalid input:</h2>
             <p>{createItem.error.error.message}</p>
             <ul>
-              {createItem.error.error.validationErrors.map((err) => (
-                <li key={err.field}>{err.message}</li>
+              {createItem.error.error.fieldErrors.map((err) => (
+                <li key={err}>{err}</li>
               ))}
             </ul>
           </div>
         );
       case 403:
-        // error.error is typed as CreateItem403Response
+        // error.error is a string as specified in the responses
         return (
           <div>
             <h2>Not authorized:</h2>
-            <p>{createItem.error.error.reason}</p>
+            <p>{createItem.error.error}</p>
           </div>
         );
       case 500:
-      case 502:
-        // error.error is typed as CreateItem5XXResponse
+        // error.error is typed as ErrorDetails
         return (
           <div>
             <h2>Server error:</h2>
             <p>{createItem.error.error.message}</p>
-            <p>Trace ID: {createItem.error.error.traceId}</p>
           </div>
         );
     }
@@ -547,6 +547,10 @@ function MyComponent() {
   return <button onClick={handleClick}>Create Item</button>;
 }
 ```
+
+:::note[Pythonフィールド名]
+生成されたクライアントはモデルフィールドをキャメルケースにするため、`field_errors`を宣言するPydanticモデルは`error.fieldErrors`として読み取られます。
+:::
 
 <Drawer title="APIクライアントを直接使用したエラーハンドリング" trigger="バニラクライアントを直接使用する例はこちらをクリックしてください。">
 ```tsx {9,15}
@@ -566,34 +570,32 @@ function MyComponent() {
   if (error) {
     switch (error.status) {
       case 400:
-        // error.error is typed as CreateItem400Response
+        // error.error is typed as ValidationErrorDetails
         return (
           <div>
             <h2>Invalid input:</h2>
             <p>{error.error.message}</p>
             <ul>
-              {error.error.validationErrors.map((err) => (
-                <li key={err.field}>{err.message}</li>
+              {error.error.fieldErrors.map((err) => (
+                <li key={err}>{err}</li>
               ))}
             </ul>
           </div>
         );
       case 403:
-        // error.error is typed as CreateItem403Response
+        // error.error is a string as specified in the responses
         return (
           <div>
             <h2>Not authorized:</h2>
-            <p>{error.error.reason}</p>
+            <p>{error.error}</p>
           </div>
         );
       case 500:
-      case 502:
-        // error.error is typed as CreateItem5XXResponse
+        // error.error is typed as ErrorDetails
         return (
           <div>
             <h2>Server error:</h2>
             <p>{error.error.message}</p>
-            <p>Trace ID: {error.error.traceId}</p>
           </div>
         );
     }
@@ -784,6 +786,8 @@ def list_items(page: int = 1, limit: int = 10):
 
 生成されたフックとクライアントメソッドは、FastAPIエンドポイントのOpenAPIタグに基づいて自動的に整理されます。これにより、API呼び出しを整理しやすくなり、関連する操作を見つけやすくなります。
 
+グループ内では、各操作はエンドポイント関数の名前から取得された独自のキャメルケース名を保持します — したがって、`"items"`タグが付けられた`def list_items()`は`api.items.listItems`でアクセスできます。
+
 例：
 
 ```python title="items.py"
@@ -791,7 +795,7 @@ def list_items(page: int = 1, limit: int = 10):
     "/items",
     tags=["items"],
 )
-def list():
+def list(cursor: str | None = None):
     # ...
 
 @app.post(
@@ -811,6 +815,10 @@ def list():
     # ...
 ```
 
+:::tip[繰り返される関数名]
+異なるタグで`list`という名前の2つのエンドポイントは衝突しません — ジェネレーターは重複した名前をそのタグで修飾するため、両方とも`api.items.list`と`api.users.list`でアクセスできます。
+:::
+
 生成されたフックはこれらのタグによってグループ化されます：
 
 ```tsx
@@ -821,7 +829,7 @@ function ItemsAndUsers() {
   const api = useMyApi();
 
   // Items operations are grouped under api.items
-  const items = useQuery(api.items.list.queryOptions());
+  const items = useQuery(api.items.list.queryOptions({}));
   const createItem = useMutation(api.items.create.mutationOptions());
 
   // Users operations are grouped under api.users
@@ -873,7 +881,7 @@ function ItemsAndUsers() {
         setIsLoading(true);
 
         // Items operations are grouped under api.items
-        const itemsData = await api.items.list();
+        const itemsData = await api.items.list({});
         setItems(itemsData);
 
         // Users operations are grouped under api.users
@@ -943,7 +951,7 @@ from pydantic import BaseModel
 class ErrorDetails(BaseModel):
     message: str
 
-class ValidationError(BaseModel):
+class ValidationErrorDetails(BaseModel):
     message: str
     field_errors: list[str]
 ```
@@ -958,7 +966,7 @@ class NotFoundException(Exception):
         self.message = message
 
 class ValidationException(Exception):
-    def __init__(self, details: ValidationError):
+    def __init__(self, details: ValidationErrorDetails):
         self.details = details
 ```
 
@@ -997,8 +1005,8 @@ async def validation_error_handler(request: Request, exc: ValidationException):
 @app.get(
     "/items/{item_id}",
     responses={
-        404: {"model": str}
-        500: {"model": ErrorDetails}
+        404: {"model": str},
+        500: {"model": ErrorDetails},
     }
 )
 def get_item(item_id: str) -> Item:
@@ -1010,14 +1018,15 @@ def get_item(item_id: str) -> Item:
 @app.post(
     "/items",
     responses={
-        400: {"model": ValidationError},
-        403: {"model": str}
+        400: {"model": ValidationErrorDetails},
+        403: {"model": str},
+        500: {"model": ErrorDetails},
     }
 )
 def create_item(item: Item) -> Item:
     if not is_valid(item):
         raise ValidationException(
-            ValidationError(
+            ValidationErrorDetails(
                 message="Invalid item data",
                 field_errors=["name is required"]
             )
@@ -1035,33 +1044,18 @@ import { useMutation, useQuery } from '@tanstack/react-query';
 function ItemComponent() {
   const api = useMyApi();
 
-  // Query with typed error handling
-  const getItem = useQuery({
-    ...api.getItem.queryOptions({ itemId: '123' }),
-    onError: (error) => {
-      // Error is typed based on the responses in your FastAPI
-      switch (error.status) {
-        case 404:
-          // error.error is a string as specified in the responses
-          console.error('Not found:', error.error);
-          break;
-        case 500:
-          // error.error is typed as ErrorDetails
-          console.error('Server error:', error.error.message);
-          break;
-      }
-    }
-  });
+  const getItem = useQuery(api.getItem.queryOptions({ itemId: '123' }));
 
   // Mutation with typed error handling
   const createItem = useMutation({
     ...api.createItem.mutationOptions(),
     onError: (error) => {
+      // Error is typed based on the responses in your FastAPI
       switch (error.status) {
         case 400:
-          // error.error is typed as ValidationError
+          // error.error is typed as ValidationErrorDetails
           console.error('Validation error:', error.error.message);
-          console.error('Field errors:', error.error.field_errors);
+          console.error('Field errors:', error.error.fieldErrors);
           break;
         case 403:
           // error.error is a string as specified in the responses
@@ -1073,10 +1067,13 @@ function ItemComponent() {
 
   // Component rendering with error handling
   if (getItem.isError) {
-    if (getItem.error.status === 404) {
-      return <NotFoundMessage message={getItem.error.error} />;
-    } else {
-      return <ErrorMessage message={getItem.error.error.message} />;
+    switch (getItem.error.status) {
+      case 404:
+        // error.error is a string as specified in the responses
+        return <NotFoundMessage message={getItem.error.error} />;
+      case 500:
+        // error.error is typed as ErrorDetails
+        return <ErrorMessage message={getItem.error.error.message} />;
     }
   }
 
@@ -1137,9 +1134,9 @@ function ItemComponent() {
 
       switch (err.status) {
         case 400:
-          // err.error is typed as ValidationError
+          // err.error is typed as ValidationErrorDetails
           console.error('Validation error:', err.error.message);
-          console.error('Field errors:', err.error.field_errors);
+          console.error('Field errors:', err.error.fieldErrors);
           break;
         case 403:
           // err.error is a string as specified in the responses
@@ -1186,7 +1183,7 @@ import { useQuery } from '@tanstack/react-query';
 
 function ItemList() {
   const api = useMyApi();
-  const items = useQuery(api.listItems.queryOptions());
+  const items = useQuery(api.listItems.queryOptions({}));
 
   if (items.isLoading) {
     return <LoadingSpinner />;
@@ -1196,17 +1193,11 @@ function ItemList() {
     const err = items.error;
     switch (err.status) {
       case 403:
-        // err.error is typed as ListItems403Response
-        return <ErrorMessage message={err.error.reason} />;
+        // err.error is a string as specified in the responses
+        return <ErrorMessage message={err.error} />;
       case 500:
-      case 502:
-        // err.error is typed as ListItems5XXResponse
-        return (
-          <ErrorMessage
-            message={err.error.message}
-            details={`Trace ID: ${err.error.traceId}`}
-          />
-        );
+        // err.error is typed as ErrorDetails
+        return <ErrorMessage message={err.error.message} />;
       default:
         return <ErrorMessage message="An unknown error occurred" />;
     }
@@ -1214,7 +1205,7 @@ function ItemList() {
 
   return (
     <ul>
-      {items.data.map((item) => (
+      {items.data?.items.map((item) => (
         <li key={item.id}>{item.name}</li>
       ))}
     </ul>
@@ -1233,7 +1224,7 @@ function ItemList() {
   useEffect(() => {
     const fetchItems = async () => {
       try {
-        const data = await api.listItems();
+        const data = await api.listItems({});
         setItems(data);
       } catch (err) {
         setError(err);
@@ -1252,17 +1243,11 @@ function ItemList() {
     const err = error as ListItemsError;
     switch (err.status) {
       case 403:
-        // err.error is typed as ListItems403Response
-        return <ErrorMessage message={err.error.reason} />;
+        // err.error is a string as specified in the responses
+        return <ErrorMessage message={err.error} />;
       case 500:
-      case 502:
-        // err.error is typed as ListItems5XXResponse
-        return (
-          <ErrorMessage
-            message={err.error.message}
-            details={`Trace ID: ${err.error.traceId}`}
-          />
-        );
+        // err.error is typed as ErrorDetails
+        return <ErrorMessage message={err.error.message} />;
       default:
         return <ErrorMessage message="An unknown error occurred" />;
     }
@@ -1285,41 +1270,53 @@ function ItemList() {
 
 ```tsx
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import type { ListItemsOutput } from '../generated/my-api/types.gen';
 
 function ItemList() {
   const api = useMyApi();
   const queryClient = useQueryClient();
 
   // Query to fetch items
-  const itemsQuery = useQuery(api.listItems.queryOptions());
+  const itemsQuery = useQuery(api.listItems.queryOptions({}));
 
   // Mutation for deleting items with optimistic updates
   const deleteMutation = useMutation({
     ...api.deleteItem.mutationOptions(),
-    onMutate: async (itemId) => {
+    onMutate: async ({ itemId }) => {
       // Cancel any outgoing refetches
-      await queryClient.cancelQueries({ queryKey: api.listItems.queryKey() });
+      await queryClient.cancelQueries({
+        queryKey: api.listItems.queryKey({}),
+      });
 
       // Snapshot the previous value
-      const previousItems = queryClient.getQueryData(api.listItems.queryKey());
+      const previousItems = queryClient.getQueryData<ListItemsOutput>(
+        api.listItems.queryKey({}),
+      );
 
       // Optimistically update to the new value
-      queryClient.setQueryData(
-        api.listItems.queryKey(),
-        (old) => old.filter((item) => item.id !== itemId)
+      queryClient.setQueryData<ListItemsOutput>(
+        api.listItems.queryKey({}),
+        (old) =>
+          old && {
+            ...old,
+            items: old.items.filter((item) => item.id !== itemId),
+          },
       );
 
       // Return a context object with the snapshot
       return { previousItems };
     },
-    onError: (err, itemId, context) => {
+    onError: (err, _input, context) => {
       // If the mutation fails, use the context returned from onMutate to roll back
-      queryClient.setQueryData(api.listItems.queryKey(), context.previousItems);
+      queryClient.setQueryData(
+        api.listItems.queryKey({}),
+        context?.previousItems,
+      );
       console.error('Failed to delete item:', err);
     },
     onSettled: () => {
       // Always refetch after error or success to ensure data is in sync with server
-      queryClient.invalidateQueries({ queryKey: api.listItems.queryKey() });
+      queryClient.invalidateQueries({ queryKey: api.listItems.queryKey({}) });
     },
   });
 
@@ -1333,11 +1330,11 @@ function ItemList() {
 
   return (
     <ul>
-      {itemsQuery.data.map((item) => (
+      {itemsQuery.data?.items.map((item) => (
         <li key={item.id}>
           {item.name}
           <button
-            onClick={() => deleteMutation.mutate(item.id)}
+            onClick={() => deleteMutation.mutate({ itemId: item.id })}
             disabled={deleteMutation.isPending}
           >
             {deleteMutation.isPending ? 'Deleting...' : 'Delete'}
@@ -1413,19 +1410,22 @@ function ItemForm() {
     const error = createItem.error;
     switch (error.status) {
       case 400:
-        // error.error is typed as CreateItem400Response
+        // error.error is typed as ValidationErrorDetails
         return (
           <FormError
             message="Invalid input"
-            errors={error.error.validationErrors}
+            errors={error.error.fieldErrors}
           />
         );
       case 403:
-        // error.error is typed as CreateItem403Response
-        return <AuthError reason={error.error.reason} />;
-      default:
-        // error.error is typed as CreateItem5XXResponse for 500, 502, etc.
+        // error.error is a string as specified in the responses
+        return <AuthError reason={error.error} />;
+      case 500:
+        // error.error is typed as ErrorDetails
         return <ServerError message={error.error.message} />;
+      default:
+        // FastAPI adds a 422 to every endpoint, so `default` isn't narrowed
+        return <ServerError message="An unknown error occurred" />;
     }
   }
 
@@ -1461,22 +1461,16 @@ function ItemForm() {
       const err = e as CreateItemError;
       switch (err.status) {
         case 400:
-          // err.error is typed as CreateItem400Response
-          console.error('Validation errors:', err.error.validationErrors);
+          // err.error is typed as ValidationErrorDetails
+          console.error('Validation errors:', err.error.fieldErrors);
           break;
         case 403:
-          // err.error is typed as CreateItem403Response
-          console.error('Not authorized:', err.error.reason);
+          // err.error is a string as specified in the responses
+          console.error('Not authorized:', err.error);
           break;
         case 500:
-        case 502:
-          // err.error is typed as CreateItem5XXResponse
-          console.error(
-            'Server error:',
-            err.error.message,
-            'Trace:',
-            err.error.traceId,
-          );
+          // err.error is typed as ErrorDetails
+          console.error('Server error:', err.error.message);
           break;
       }
       setError(err);
@@ -1490,13 +1484,15 @@ function ItemForm() {
         return (
           <FormError
             message="Invalid input"
-            errors={error.error.validationErrors}
+            errors={error.error.fieldErrors}
           />
         );
       case 403:
-        return <AuthError reason={error.error.reason} />;
-      default:
+        return <AuthError reason={error.error} />;
+      case 500:
         return <ServerError message={error.error.message} />;
+      default:
+        return <ServerError message="An unknown error occurred" />;
     }
   }
 

--- a/docs/src/content/docs/jp/guides/connection/react-smithy.mdx
+++ b/docs/src/content/docs/jp/guides/connection/react-smithy.mdx
@@ -245,7 +245,7 @@ const createItem = useMutation({
   onSettled: () => {
     // This will run when the mutation completes (success or error)
     // Good place to invalidate queries that might be affected
-    queryClient.invalidateQueries({ queryKey: api.listItems.queryKey() });
+    queryClient.invalidateQueries({ queryKey: api.listItems.queryKey({}) });
   }
 });
 ```
@@ -456,7 +456,9 @@ function ItemList() {
 
 ### エラーハンドリング
 
-統合には、型付きエラーレスポンスを使用した組み込みのエラーハンドリングが含まれています。`<operation-name>Error`型が生成され、Smithyモデルで定義された可能性のあるエラーレスポンスをカプセル化します。各エラーには`status`と`error`プロパティがあり、`status`の値をチェックすることで、特定のタイプのエラーに絞り込むことができます。
+統合には、型付きエラーレスポンスを使用した組み込みのエラーハンドリングが含まれています。`<OperationName>Error`型が生成され、これは操作がモデル化する各エラーステータスごとに1つの`<OperationName><StatusCode>Error`メンバーのユニオンです。各メンバーには`status`と`error`プロパティがあるため、`status`で切り替えることで、`error`がそのステータスのペイロードに絞り込まれます。
+
+以下の例では、`CreateItem`が[このページの下部で定義されているエラー構造](#errors)をモデル化していることを前提としています — `422` `InvalidRequestError`、`403` `UnauthorizedError`、`500` `InternalServerError`。モデルで宣言したステータスのみがユニオンに表示されるため、モデル化していないステータスの`case`はコンパイルエラーになります。
 
 ```tsx {12}
 import { useMutation } from '@tanstack/react-query';
@@ -471,8 +473,8 @@ function MyComponent() {
 
   if (createItem.error) {
     switch (createItem.error.status) {
-      case 400:
-        // error.error is typed as CreateItem400Response
+      case 422:
+        // error.error is typed as InvalidRequestErrorResponseContent
         return (
           <div>
             <h2>Invalid input:</h2>
@@ -480,7 +482,7 @@ function MyComponent() {
           </div>
         );
       case 403:
-        // error.error is typed as CreateItem403Response
+        // error.error is typed as UnauthorizedErrorResponseContent
         return (
           <div>
             <h2>Not authorized:</h2>
@@ -488,8 +490,7 @@ function MyComponent() {
           </div>
         );
       case 500:
-      case 502:
-        // error.error is typed as CreateItem5XXResponse
+        // error.error is typed as InternalServerErrorResponseContent
         return (
           <div>
             <h2>Server error:</h2>
@@ -520,8 +521,8 @@ function MyComponent() {
 
   if (error) {
     switch (error.status) {
-      case 400:
-        // error.error is typed as CreateItem400Response
+      case 422:
+        // error.error is typed as InvalidRequestErrorResponseContent
         return (
           <div>
             <h2>Invalid input:</h2>
@@ -529,7 +530,7 @@ function MyComponent() {
           </div>
         );
       case 403:
-        // error.error is typed as CreateItem403Response
+        // error.error is typed as UnauthorizedErrorResponseContent
         return (
           <div>
             <h2>Not authorized:</h2>
@@ -537,8 +538,7 @@ function MyComponent() {
           </div>
         );
       case 500:
-      case 502:
-        // error.error is typed as CreateItem5XXResponse
+        // error.error is typed as InternalServerErrorResponseContent
         return (
           <div>
             <h2>Server error:</h2>
@@ -576,18 +576,18 @@ function MyComponent() {
 Smithy操作に`@query`特性を適用して、クエリとして扱うように強制します：
 
 ```smithy
-@http(method: "POST", uri: "/items")
+@http(method: "POST", uri: "/search-items")
 @query
-operation ListItems {
-    input: ListItemsInput
-    output: ListItemsOutput
+operation SearchItems {
+    input: SearchItemsInput
+    output: SearchItemsOutput
 }
 ```
 
 生成されたフックは、`POST` HTTPメソッドを使用していても`queryOptions`を提供します：
 
 ```tsx
-const items = useQuery(api.listItems.queryOptions());
+const items = useQuery(api.searchItems.queryOptions({ term: 'widget' }));
 ```
 
 #### @mutation
@@ -607,6 +607,8 @@ operation StartProcessing {
 
 ```tsx
 const startProcessing = useMutation(api.startProcessing.mutationOptions());
+
+startProcessing.mutate({ id: 'some-id' });
 ```
 
 ### カスタムページネーションカーソル
@@ -616,38 +618,59 @@ const startProcessing = useMutation(api.startProcessing.mutationOptions());
 ページネーショントークンに使用される入力パラメータの名前を変更するには、`inputToken`を指定して`@cursor`特性を適用します：
 
 ```smithy
-@http(method: "GET", uri: "/items")
+@http(method: "GET", uri: "/paged-items")
 @cursor(inputToken: "nextToken")
-operation ListItems {
+operation ListPagedItems {
     input := {
+      @httpQuery("nextToken")
       nextToken: String
+      @httpQuery("limit")
       limit: Integer
     }
     output := {
+      @required
       items: ItemList
       nextToken: String
     }
 }
 ```
 
+`infiniteQueryOptions`は`nextToken`でページングします：
+
+```tsx
+const items = useInfiniteQuery({
+  ...api.listPagedItems.infiniteQueryOptions(
+    { limit: 10 },
+    { getNextPageParam: (lastPage) => lastPage.nextToken || undefined },
+  ),
+});
+```
+
 `cursor`という名前の入力パラメータを持つ操作に対して`infiniteQueryOptions`を生成したくない場合は、カーソルベースのページネーションを無効にできます：
 
 ```smithy
+@http(method: "GET", uri: "/unpaged-items")
 @cursor(enabled: false)
-operation ListItems {
+operation ListUnpagedItems {
     input := {
       // Input parameter named 'cursor' will cause this operation to be treated as a paginated operation by default
+      @httpQuery("cursor")
       cursor: String
     }
     output := {
-      ...
+      @required
+      items: ItemList
     }
 }
 ```
 
+`api.listUnpagedItems`は`queryOptions`、`queryKey`、`queryFilter`のみを提供します。
+
 ### 操作のグループ化
 
 生成されたフックとクライアントメソッドは、Smithy操作の[`@tags`特性](https://smithy.io/2.0/spec/documentation-traits.html#tags-trait)に基づいて自動的に整理されます。同じタグを持つ操作はグループ化され、API呼び出しを整理し、IDEでより良いコード補完を提供します。
+
+グループ内では、各操作は独自のキャメルケース名を保持するため、`"items"`とタグ付けされた`ListItems`という名前の操作は`api.items.listItems`でアクセスされます — `api.items.list`ではありません。
 
 例えば、このSmithy モデルの場合：
 
@@ -657,27 +680,51 @@ service MyService {
 }
 
 @tags(["items"])
+@http(method: "GET", uri: "/items")
+@readonly
 operation ListItems {
-    input: ListItemsInput
-    output: ListItemsOutput
+    input := {}
+    output := {
+      @required
+      items: ItemList
+    }
 }
 
 @tags(["items"])
+@http(method: "POST", uri: "/items")
 operation CreateItem {
-    input: CreateItemInput
-    output: CreateItemOutput
+    input := {
+      @required
+      name: String
+    }
+    output := {
+      @required
+      id: String
+    }
 }
 
 @tags(["users"])
+@http(method: "GET", uri: "/users")
+@readonly
 operation ListUsers {
-    input: ListUsersInput
-    output: ListUsersOutput
+    input := {}
+    output := {
+      @required
+      users: UserList
+    }
 }
 
 @tags(["users"])
+@http(method: "POST", uri: "/users")
 operation CreateUser {
-    input: CreateUserInput
-    output: CreateUserOutput
+    input := {
+      @required
+      name: String
+    }
+    output := {
+      @required
+      id: String
+    }
 }
 ```
 
@@ -706,7 +753,7 @@ function ItemsAndUsers() {
     <div>
       <h2>Items</h2>
       <ul>
-        {items.data?.map(item => (
+        {items.data?.items.map(item => (
           <li key={item.id}>{item.name}</li>
         ))}
       </ul>
@@ -714,7 +761,7 @@ function ItemsAndUsers() {
 
       <h2>Users</h2>
       <ul>
-        {users.data?.map(user => (
+        {users.data?.users.map(user => (
           <li key={user.id}>{user.name}</li>
         ))}
       </ul>
@@ -805,7 +852,7 @@ Smithyモデルでエラー構造を定義します：
 
 ```smithy
 @error("client")
-@httpError(400)
+@httpError(422)
 structure InvalidRequestError {
     @required
     message: String
@@ -841,6 +888,10 @@ structure FieldError {
     message: String
 }
 ```
+
+:::caution[400は使用済み]
+サービスはすでに`400`でSmithy の`ValidationException`を宣言しているため、すべての操作が`ValidationExceptionResponseContent`を運ぶ`400`ケースを取得します。独自のクライアントエラーには別のステータス（上記の`422`）を指定してください — 同じステータスの2つのエラーは衝突し、1つのペイロードのみが生成されたクライアントに到達します。
+:::
 
 #### 操作へのエラーの追加
 
@@ -884,37 +935,21 @@ import { useMutation, useQuery } from '@tanstack/react-query';
 function ItemComponent() {
   const api = useMyApi();
 
-  // Query with typed error handling
-  const getItem = useQuery({
-    ...api.getItem.queryOptions({ itemId: '123' }),
-    onError: (error) => {
-      // Error is typed based on the errors in your Smithy model
-      switch (error.status) {
-        case 404:
-          // error.error is typed as ItemNotFoundError
-          console.error('Not found:', error.error.message);
-          break;
-        case 500:
-          // error.error is typed as InternalServerError
-          console.error('Server error:', error.error.message);
-          console.error('Trace ID:', error.error.traceId);
-          break;
-      }
-    }
-  });
+  const getItem = useQuery(api.getItem.queryOptions({ itemId: '123' }));
 
   // Mutation with typed error handling
   const createItem = useMutation({
     ...api.createItem.mutationOptions(),
     onError: (error) => {
+      // Error is typed based on the errors in your Smithy model
       switch (error.status) {
-        case 400:
-          // error.error is typed as InvalidRequestError
+        case 422:
+          // error.error is typed as InvalidRequestErrorResponseContent
           console.error('Validation error:', error.error.message);
           console.error('Field errors:', error.error.fieldErrors);
           break;
         case 403:
-          // error.error is typed as UnauthorizedError
+          // error.error is typed as UnauthorizedErrorResponseContent
           console.error('Unauthorized:', error.error.reason);
           break;
       }
@@ -923,10 +958,13 @@ function ItemComponent() {
 
   // Component rendering with error handling
   if (getItem.isError) {
-    if (getItem.error.status === 404) {
-      return <NotFoundMessage message={getItem.error.error.message} />;
-    } else if (getItem.error.status === 500) {
-      return <ErrorMessage message={getItem.error.error.message} />;
+    switch (getItem.error.status) {
+      case 404:
+        // error.error is typed as ItemNotFoundErrorResponseContent
+        return <NotFoundMessage message={getItem.error.error.message} />;
+      case 500:
+        // error.error is typed as InternalServerErrorResponseContent
+        return <ErrorMessage message={getItem.error.error.message} />;
     }
   }
 
@@ -962,11 +1000,11 @@ function ItemComponent() {
 
         switch (err.status) {
           case 404:
-            // err.error is typed as ItemNotFoundError
+            // err.error is typed as ItemNotFoundErrorResponseContent
             console.error('Not found:', err.error.message);
             break;
           case 500:
-            // err.error is typed as InternalServerError
+            // err.error is typed as InternalServerErrorResponseContent
             console.error('Server error:', err.error.message);
             console.error('Trace ID:', err.error.traceId);
             break;
@@ -987,13 +1025,13 @@ function ItemComponent() {
       const err = e as CreateItemError;
 
       switch (err.status) {
-        case 400:
-          // err.error is typed as InvalidRequestError
+        case 422:
+          // err.error is typed as InvalidRequestErrorResponseContent
           console.error('Validation error:', err.error.message);
           console.error('Field errors:', err.error.fieldErrors);
           break;
         case 403:
-          // err.error is typed as UnauthorizedError
+          // err.error is typed as UnauthorizedErrorResponseContent
           console.error('Unauthorized:', err.error.reason);
           break;
       }
@@ -1037,7 +1075,7 @@ import { useQuery } from '@tanstack/react-query';
 
 function ItemList() {
   const api = useMyApi();
-  const items = useQuery(api.listItems.queryOptions());
+  const items = useQuery(api.listItems.queryOptions({}));
 
   if (items.isLoading) {
     return <LoadingSpinner />;
@@ -1047,11 +1085,10 @@ function ItemList() {
     const err = items.error;
     switch (err.status) {
       case 403:
-        // err.error is typed as ListItems403Response
+        // err.error is typed as UnauthorizedErrorResponseContent
         return <ErrorMessage message={err.error.reason} />;
       case 500:
-      case 502:
-        // err.error is typed as ListItems5XXResponse
+        // err.error is typed as InternalServerErrorResponseContent
         return (
           <ErrorMessage
             message={err.error.message}
@@ -1064,7 +1101,7 @@ function ItemList() {
 
   return (
     <ul>
-      {items.data.map((item) => (
+      {items.data?.items.map((item) => (
         <li key={item.id}>{item.name}</li>
       ))}
     </ul>
@@ -1083,7 +1120,7 @@ function ItemList() {
   useEffect(() => {
     const fetchItems = async () => {
       try {
-        const data = await api.listItems();
+        const data = await api.listItems({});
         setItems(data);
       } catch (err) {
         setError(err);
@@ -1102,11 +1139,10 @@ function ItemList() {
     const err = error as ListItemsError;
     switch (err.status) {
       case 403:
-        // err.error is typed as ListItems403Response
+        // err.error is typed as UnauthorizedErrorResponseContent
         return <ErrorMessage message={err.error.reason} />;
       case 500:
-      case 502:
-        // err.error is typed as ListItems5XXResponse
+        // err.error is typed as InternalServerErrorResponseContent
         return (
           <ErrorMessage
             message={err.error.message}
@@ -1134,41 +1170,53 @@ function ItemList() {
 
 ```tsx
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import type { ListItemsResponseContent } from '../generated/my-api/types.gen';
 
 function ItemList() {
   const api = useMyApi();
   const queryClient = useQueryClient();
 
   // Query to fetch items
-  const itemsQuery = useQuery(api.listItems.queryOptions());
+  const itemsQuery = useQuery(api.listItems.queryOptions({}));
 
   // Mutation for deleting items with optimistic updates
   const deleteMutation = useMutation({
     ...api.deleteItem.mutationOptions(),
-    onMutate: async (itemId) => {
+    onMutate: async ({ itemId }) => {
       // Cancel any outgoing refetches
-      await queryClient.cancelQueries({ queryKey: api.listItems.queryKey() });
+      await queryClient.cancelQueries({
+        queryKey: api.listItems.queryKey({}),
+      });
 
       // Snapshot the previous value
-      const previousItems = queryClient.getQueryData(api.listItems.queryKey());
+      const previousItems = queryClient.getQueryData<ListItemsResponseContent>(
+        api.listItems.queryKey({}),
+      );
 
       // Optimistically update to the new value
-      queryClient.setQueryData(
-        api.listItems.queryKey(),
-        (old) => old.filter((item) => item.id !== itemId)
+      queryClient.setQueryData<ListItemsResponseContent>(
+        api.listItems.queryKey({}),
+        (old) =>
+          old && {
+            ...old,
+            items: old.items.filter((item) => item.id !== itemId),
+          },
       );
 
       // Return a context object with the snapshot
       return { previousItems };
     },
-    onError: (err, itemId, context) => {
+    onError: (err, _input, context) => {
       // If the mutation fails, use the context returned from onMutate to roll back
-      queryClient.setQueryData(api.listItems.queryKey(), context.previousItems);
+      queryClient.setQueryData(
+        api.listItems.queryKey({}),
+        context?.previousItems,
+      );
       console.error('Failed to delete item:', err);
     },
     onSettled: () => {
       // Always refetch after error or success to ensure data is in sync with server
-      queryClient.invalidateQueries({ queryKey: api.listItems.queryKey() });
+      queryClient.invalidateQueries({ queryKey: api.listItems.queryKey({}) });
     },
   });
 
@@ -1182,11 +1230,11 @@ function ItemList() {
 
   return (
     <ul>
-      {itemsQuery.data.map((item) => (
+      {itemsQuery.data?.items.map((item) => (
         <li key={item.id}>
           {item.name}
           <button
-            onClick={() => deleteMutation.mutate(item.id)}
+            onClick={() => deleteMutation.mutate({ itemId: item.id })}
             disabled={deleteMutation.isPending}
           >
             {deleteMutation.isPending ? 'Deleting...' : 'Delete'}
@@ -1261,8 +1309,8 @@ function ItemForm() {
   if (createItem.error) {
     const error = createItem.error;
     switch (error.status) {
-      case 400:
-        // error.error is typed as InvalidRequestError
+      case 422:
+        // error.error is typed as InvalidRequestErrorResponseContent
         return (
           <FormError
             message="Invalid input"
@@ -1270,10 +1318,10 @@ function ItemForm() {
           />
         );
       case 403:
-        // error.error is typed as UnauthorizedError
+        // error.error is typed as UnauthorizedErrorResponseContent
         return <AuthError reason={error.error.reason} />;
       default:
-        // error.error is typed as InternalServerError for 500, etc.
+        // error.error is typed as InternalServerErrorResponseContent for 500, etc.
         return <ServerError message={error.error.message} />;
     }
   }
@@ -1309,16 +1357,16 @@ function ItemForm() {
       // ✅ Error type includes all possible error responses
       const err = e as CreateItemError;
       switch (err.status) {
-        case 400:
-          // err.error is typed as InvalidRequestError
+        case 422:
+          // err.error is typed as InvalidRequestErrorResponseContent
           console.error('Validation errors:', err.error.fieldErrors);
           break;
         case 403:
-          // err.error is typed as UnauthorizedError
+          // err.error is typed as UnauthorizedErrorResponseContent
           console.error('Not authorized:', err.error.reason);
           break;
         case 500:
-          // err.error is typed as InternalServerError
+          // err.error is typed as InternalServerErrorResponseContent
           console.error('Server error:', err.error.message);
           break;
       }
@@ -1329,7 +1377,7 @@ function ItemForm() {
   // Error UI can use type narrowing to handle different error types
   if (error) {
     switch (error.status) {
-      case 400:
+      case 422:
         return (
           <FormError
             message="Invalid input"

--- a/docs/src/content/docs/jp/guides/connection/react-trpc.mdx
+++ b/docs/src/content/docs/jp/guides/connection/react-trpc.mdx
@@ -417,11 +417,13 @@ function UserList() {
 統合は完全なエンドツーエンドの型安全性を提供します。IDE は、すべての API 呼び出しに対して完全な自動補完と型チェックを提供します:
 
 ```tsx
+import { useMutation } from '@tanstack/react-query';
+
 function UserForm() {
   const trpc = useMyApi();
 
   // ✅ Input is fully typed
-  const createUser = trpc.users.create.useMutation();
+  const createUser = useMutation(trpc.users.create.mutationOptions());
 
   const handleSubmit = (data: CreateUserInput) => {
     // ✅ Type error if input doesn't match schema

--- a/docs/src/content/docs/ko/guides/connection/react-agui.mdx
+++ b/docs/src/content/docs/ko/guides/connection/react-agui.mdx
@@ -46,16 +46,17 @@ Nx Plugin for AWS는 [AG-UI 프로토콜](https://docs.ag-ui.com/)을 노출하�
 - src
   - components
     - AguiProvider.tsx 모든 AG-UI 에이전트를 위한 단일 `CopilotKitProvider`. 첫 번째 `connection` 실행 시 생성되고 후속 실행 시 각 새 에이전트를 등록하도록 업데이트됩니다.
+    - \<agent-name>-chat.tsx 이 에이전트의 id에 바인딩된 테마가 적용된 `<AgentName>Chat`. `connection` 실행당 하나의 파일.
     - copilot
       - index.tsx 웹사이트의 `ux`(Cloudscape, Shadcn 또는 테마 없음)와 일치하는 슬롯 기본값으로 `CopilotChat`, `CopilotSidebar` 및 `CopilotPopup`을 재내보냅니다.
       - *ThemeComponents*.tsx 슬롯별 테마 컴포넌트(예: `CloudscapeAssistantMessage.tsx`, `ShadcnChatInput.tsx`). `ux`가 `cloudscape` 또는 `shadcn`일 때만 제공됩니다.
   - hooks
-    - useAgui\<AgentName>.tsx 하나의 AG-UI 에이전트를 등록합니다. `connection` 실행당 하나의 파일.
+    - useAgui\<AgentName>.tsx 하나의 AG-UI 에이전트를 등록하고 해당 id를 `<AGENT_NAME>_ID`로 내보냅니다. `connection` 실행당 하나의 파일.
     - useSigV4.tsx SigV4 서명 (IAM 전용)
 
 </FileTree>
 
-다른 에이전트에 대해 두 번째로 `connection`을 실행하면 **새로운 `useAgui<AgentName>.tsx` 훅이 추가**되고 `AguiProvider.tsx`가 두 훅을 모두 등록하도록 업데이트됩니다 — 프로바이더에 대한 사용자 정의 편집 내용은 보존됩니다. `main.tsx`는 단일 `<AguiProvider>` 래퍼를 유지하므로 중첩된 프로바이더가 생기지 않습니다.
+다른 에이전트에 대해 두 번째로 `connection`을 실행하면 **새로운 `useAgui<AgentName>.tsx` 훅과 `<agent-name>-chat.tsx` 컴포넌트가 추가**되고 `AguiProvider.tsx`가 두 훅을 모두 등록하도록 업데이트됩니다 — 프로바이더에 대한 사용자 정의 편집 내용은 보존됩니다. `main.tsx`는 단일 `<AguiProvider>` 래퍼를 유지하므로 중첩된 프로바이더가 생기지 않습니다.
 
 다음 종속성이 루트 `package.json`에 추가됩니다:
 
@@ -119,17 +120,14 @@ Session ID와 Thread ID는 모두 브라우저에서 제공됩니다. 각 사용
 
 ### 채팅 인터페이스 추가
 
-사용할 에이전트를 선택하려면 `agentId`와 함께 CopilotKit 컴포넌트를 인스턴스화합니다. id는 에이전트의 이름입니다 — <Link path="guides/ts-agent">`ts#agent`</Link> 또는 <Link path="guides/py-agent">`py#agent`</Link> 생성기를 실행할 때 선택한 것과 동일하며 — 생성된 훅 파일(예: `packages/web/src/hooks/useAgui<AgentName>.tsx`에서 반환된 키)에서도 찾을 수 있습니다.
-
-웹사이트의 `ux`와 일치하는 테마가 자동으로 적용되도록 생성된 `./components/copilot` 모듈에서 채팅 컴포넌트를 가져옵니다:
+생성기는 연결된 에이전트당 `<AgentName>Chat` 컴포넌트를 제공하며, 이미 해당 에이전트의 id에 바인딩되어 있고 웹사이트의 `ux`와 일치하도록 테마가 적용되어 있습니다. `<AguiProvider>` 래퍼 내부 어디에나 배치할 수 있습니다:
 
 ```tsx
-import { CopilotChat } from './components/copilot';
+import { StoryAgentChat } from './components/story-agent-chat';
 
 function ChatPage() {
   return (
-    <CopilotChat
-      agentId="agent"
+    <StoryAgentChat
       labels={{
         welcomeMessageText: 'How can I help you today?',
         chatInputPlaceholder: 'Ask me anything...',
@@ -139,15 +137,24 @@ function ChatPage() {
 }
 ```
 
+이는 `agentId`를 제외한 모든 `CopilotChat` prop을 전달하므로 `<CopilotChat />`에 전달할 수 있는 모든 것이 여기서도 작동합니다.
+
 ### 여러 AG-UI Agent 연결
 
-에이전트당 한 번씩 `connection` 생성기를 실행합니다. 공유 `AguiProvider`를 통해 등록된 모든 에이전트는 앱의 어디에서나 볼 수 있습니다 — 각 채팅을 원하는 에이전트로 라우팅하려면 다른 `agentId`로 CopilotKit 컴포넌트를 인스턴스화합니다:
+에이전트당 한 번씩 `connection` 생성기를 실행합니다. 각 실행은 해당 에이전트의 자체 채팅 컴포넌트를 제공하므로 특정 에이전트로 채팅을 라우팅하는 것은 어떤 컴포넌트를 렌더링하느냐의 문제입니다:
 
 ```tsx
-import { CopilotChat } from './components/copilot';
+import { StoryAgentChat } from './components/story-agent-chat';
+import { ResearchAgentChat } from './components/research-agent-chat';
 
-<CopilotChat agentId="story" />    {/* talks to StoryAgent */}
-<CopilotChat agentId="research" /> {/* talks to ResearchAgent */}
+<StoryAgentChat />    {/* talks to StoryAgent */}
+<ResearchAgentChat /> {/* talks to ResearchAgent */}
+```
+
+원시 id가 필요한 경우 — 예를 들어 CopilotKit의 자체 훅을 호출하려면 — 각 생성된 훅이 이를 내보냅니다:
+
+```tsx
+import { STORY_AGENT_ID } from './hooks/useAguiStoryAgent';
 ```
 
 ## 모양과 느낌 사용자 정의
@@ -164,12 +171,13 @@ import { CopilotChat } from './components/copilot';
 | `shadcn` | 어시스턴트 메시지는 `Sparkles` 아바타가 있는 `bg-muted` 버블에 렌더링됩니다; 사용자 메시지는 `User` 아바타가 있는 `bg-primary` 버블에 오른쪽 정렬로 렌더링됩니다. 입력은 둥근 `Textarea` + 알약 모양의 전송/중지 `Button`입니다(Enter는 제출, Shift+Enter는 줄바꿈). 공유 `common-shadcn` 패키지의 shadcn 프리미티브를 사용합니다. |
 | `none` (또는 기타) | 테마 없음 — 모듈은 기본 CopilotKit 컴포넌트를 재내보냅니다. |
 
-테마가 자동으로 적용되도록 **로컬 테마 모듈**에서 테마 컴포넌트를 가져옵니다(`@copilotkit/react-core/v2`에서 직접 가져오지 않음):
+제공된 `<AgentName>Chat` 컴포넌트는 이미 테마가 적용되어 있습니다. 직접 연결하는 채팅의 경우, 테마가 자동으로 적용되도록 **로컬 테마 모듈**에서 가져옵니다(`@copilotkit/react-core/v2`에서 직접 가져오지 않음):
 
 ```tsx
 import { CopilotChat } from './components/copilot';
+import { STORY_AGENT_ID } from './hooks/useAguiStoryAgent';
 
-<CopilotChat agentId="agent" />
+<CopilotChat agentId={STORY_AGENT_ID} />
 ```
 
 테마는 슬롯 기본값으로 적용되므로 명시적으로 전달하는 슬롯은 여전히 우선합니다 — 일회성 재정의가 필요할 때마다 완전한 제어를 유지합니다.
@@ -188,8 +196,7 @@ import { CopilotChat } from './components/copilot';
 채팅별 재정의는 테마와 함께 작동합니다 — 슬롯 prop으로 전달하는 모든 것은 테마 기본값을 재정의합니다:
 
 ```tsx
-<CopilotChat
-  agentId="agent"
+<StoryAgentChat
   // style the input and its children
   input={{
     textArea: 'text-blue-600',
@@ -208,25 +215,23 @@ import { CopilotChat } from './components/copilot';
 모든 슬롯은 className 대신 React 컴포넌트를 사용할 수 있으므로 기본값을 완전히 교체할 수 있습니다:
 
 ```tsx
-import { CopilotChat } from './components/copilot';
+import { StoryAgentChat } from './components/story-agent-chat';
 
-const MySendButton: React.FC<{ onClick: () => void }> = ({ onClick }) => (
+const MySendButton: React.FC<React.ButtonHTMLAttributes<HTMLButtonElement>> = ({
+  onClick,
+}) => (
   <button onClick={onClick} className="my-send-btn">
     Send
   </button>
 );
 
-<CopilotChat
-  agentId="agent"
-  input={{ sendButton: MySendButton }}
-/>;
+<StoryAgentChat input={{ sendButton: MySendButton }} />;
 ```
 
 더 깊은 재정의는 동일한 형태를 따릅니다 — 예를 들어 어시스턴트 메시지의 복사 버튼만 교체:
 
 ```tsx
-<CopilotChat
-  agentId="agent"
+<StoryAgentChat
   messageView={{
     assistantMessage: {
       copyButton: ({ onClick }) => <button onClick={onClick}>Copy</button>,

--- a/docs/src/content/docs/ko/guides/connection/react-fastapi.mdx
+++ b/docs/src/content/docs/ko/guides/connection/react-fastapi.mdx
@@ -248,7 +248,7 @@ const createItem = useMutation({
   onSettled: () => {
     // This will run when the mutation completes (success or error)
     // Good place to invalidate queries that might be affected
-    queryClient.invalidateQueries({ queryKey: api.listItems.queryKey() });
+    queryClient.invalidateQueries({ queryKey: api.listItems.queryKey({}) });
   }
 });
 ```
@@ -495,7 +495,9 @@ function ItemList() {
 
 ### 오류 처리
 
-통합에는 타입이 지정된 오류 응답과 함께 내장된 오류 처리가 포함되어 있습니다. OpenAPI 사양에 정의된 가능한 오류 응답을 캡슐화하는 `<operation-name>Error` 타입이 생성됩니다. 각 오류에는 `status` 및 `error` 속성이 있으며, `status` 값을 확인하여 특정 오류 타입으로 좁힐 수 있습니다.
+통합에는 타입이 지정된 오류 응답과 함께 내장된 오류 처리가 포함되어 있습니다. `<OperationName>Error` 타입이 생성되며, 이는 작업의 `responses`가 선언하는 각 오류 상태에 대해 하나의 `<OperationName><StatusCode>Error` 멤버로 구성된 유니온입니다. 각 멤버에는 `status` 및 `error` 속성이 있으므로 `status`로 전환하면 `error`가 해당 상태의 모델로 좁혀집니다.
+
+아래 예시는 `create_item`이 [이 페이지 아래에 정의된 `responses`](#specifying-response-models)를 선언한다고 가정합니다 — `400` `ValidationErrorDetails`, `403` `str` 및 `500` `ErrorDetails`. 선언한 상태만 유니온에 나타나므로(FastAPI 자체의 `422` 제외), 선언하지 않은 상태에 대한 `case`는 컴파일 오류입니다.
 
 ```tsx {12}
 import { useMutation } from '@tanstack/react-query';
@@ -511,34 +513,32 @@ function MyComponent() {
   if (createItem.error) {
     switch (createItem.error.status) {
       case 400:
-        // error.error is typed as CreateItem400Response
+        // error.error is typed as ValidationErrorDetails
         return (
           <div>
             <h2>Invalid input:</h2>
             <p>{createItem.error.error.message}</p>
             <ul>
-              {createItem.error.error.validationErrors.map((err) => (
-                <li key={err.field}>{err.message}</li>
+              {createItem.error.error.fieldErrors.map((err) => (
+                <li key={err}>{err}</li>
               ))}
             </ul>
           </div>
         );
       case 403:
-        // error.error is typed as CreateItem403Response
+        // error.error is a string as specified in the responses
         return (
           <div>
             <h2>Not authorized:</h2>
-            <p>{createItem.error.error.reason}</p>
+            <p>{createItem.error.error}</p>
           </div>
         );
       case 500:
-      case 502:
-        // error.error is typed as CreateItem5XXResponse
+        // error.error is typed as ErrorDetails
         return (
           <div>
             <h2>Server error:</h2>
             <p>{createItem.error.error.message}</p>
-            <p>Trace ID: {createItem.error.error.traceId}</p>
           </div>
         );
     }
@@ -547,6 +547,10 @@ function MyComponent() {
   return <button onClick={handleClick}>Create Item</button>;
 }
 ```
+
+:::note[Python 필드 이름]
+생성된 클라이언트는 모델 필드를 camelCase로 변환하므로 `field_errors`를 선언하는 Pydantic 모델은 `error.fieldErrors`로 읽힙니다.
+:::
 
 <Drawer title="API 클라이언트를 직접 사용한 오류 처리" trigger="바닐라 클라이언트를 직접 사용하는 예시를 보려면 여기를 클릭하세요.">
 ```tsx {9,15}
@@ -566,34 +570,32 @@ function MyComponent() {
   if (error) {
     switch (error.status) {
       case 400:
-        // error.error is typed as CreateItem400Response
+        // error.error is typed as ValidationErrorDetails
         return (
           <div>
             <h2>Invalid input:</h2>
             <p>{error.error.message}</p>
             <ul>
-              {error.error.validationErrors.map((err) => (
-                <li key={err.field}>{err.message}</li>
+              {error.error.fieldErrors.map((err) => (
+                <li key={err}>{err}</li>
               ))}
             </ul>
           </div>
         );
       case 403:
-        // error.error is typed as CreateItem403Response
+        // error.error is a string as specified in the responses
         return (
           <div>
             <h2>Not authorized:</h2>
-            <p>{error.error.reason}</p>
+            <p>{error.error}</p>
           </div>
         );
       case 500:
-      case 502:
-        // error.error is typed as CreateItem5XXResponse
+        // error.error is typed as ErrorDetails
         return (
           <div>
             <h2>Server error:</h2>
             <p>{error.error.message}</p>
-            <p>Trace ID: {error.error.traceId}</p>
           </div>
         );
     }
@@ -784,6 +786,8 @@ def list_items(page: int = 1, limit: int = 10):
 
 생성된 훅과 클라이언트 메서드는 FastAPI 엔드포인트의 OpenAPI 태그를 기반으로 자동으로 구성됩니다. 이를 통해 API 호출을 체계적으로 유지하고 관련 작업을 쉽게 찾을 수 있습니다.
 
+그룹 내에서 각 작업은 엔드포인트 함수 이름에서 가져온 자체 camelCase 이름을 유지합니다 — 따라서 `"items"` 태그가 지정된 `def list_items()`는 `api.items.listItems`에서 접근할 수 있습니다.
+
 예시:
 
 ```python title="items.py"
@@ -791,7 +795,7 @@ def list_items(page: int = 1, limit: int = 10):
     "/items",
     tags=["items"],
 )
-def list():
+def list(cursor: str | None = None):
     # ...
 
 @app.post(
@@ -811,6 +815,10 @@ def list():
     # ...
 ```
 
+:::tip[반복되는 함수 이름]
+서로 다른 태그에 있는 `list`라는 이름의 두 엔드포인트는 충돌하지 않습니다 — 생성기는 중복된 이름을 태그로 한정하므로 둘 다 `api.items.list` 및 `api.users.list`에서 접근할 수 있습니다.
+:::
+
 생성된 훅은 태그별로 그룹화됩니다:
 
 ```tsx
@@ -821,7 +829,7 @@ function ItemsAndUsers() {
   const api = useMyApi();
 
   // Items operations are grouped under api.items
-  const items = useQuery(api.items.list.queryOptions());
+  const items = useQuery(api.items.list.queryOptions({}));
   const createItem = useMutation(api.items.create.mutationOptions());
 
   // Users operations are grouped under api.users
@@ -873,7 +881,7 @@ function ItemsAndUsers() {
         setIsLoading(true);
 
         // Items operations are grouped under api.items
-        const itemsData = await api.items.list();
+        const itemsData = await api.items.list({});
         setItems(itemsData);
 
         // Users operations are grouped under api.users
@@ -943,7 +951,7 @@ from pydantic import BaseModel
 class ErrorDetails(BaseModel):
     message: str
 
-class ValidationError(BaseModel):
+class ValidationErrorDetails(BaseModel):
     message: str
     field_errors: list[str]
 ```
@@ -958,7 +966,7 @@ class NotFoundException(Exception):
         self.message = message
 
 class ValidationException(Exception):
-    def __init__(self, details: ValidationError):
+    def __init__(self, details: ValidationErrorDetails):
         self.details = details
 ```
 
@@ -997,8 +1005,8 @@ async def validation_error_handler(request: Request, exc: ValidationException):
 @app.get(
     "/items/{item_id}",
     responses={
-        404: {"model": str}
-        500: {"model": ErrorDetails}
+        404: {"model": str},
+        500: {"model": ErrorDetails},
     }
 )
 def get_item(item_id: str) -> Item:
@@ -1010,14 +1018,15 @@ def get_item(item_id: str) -> Item:
 @app.post(
     "/items",
     responses={
-        400: {"model": ValidationError},
-        403: {"model": str}
+        400: {"model": ValidationErrorDetails},
+        403: {"model": str},
+        500: {"model": ErrorDetails},
     }
 )
 def create_item(item: Item) -> Item:
     if not is_valid(item):
         raise ValidationException(
-            ValidationError(
+            ValidationErrorDetails(
                 message="Invalid item data",
                 field_errors=["name is required"]
             )
@@ -1035,33 +1044,18 @@ import { useMutation, useQuery } from '@tanstack/react-query';
 function ItemComponent() {
   const api = useMyApi();
 
-  // Query with typed error handling
-  const getItem = useQuery({
-    ...api.getItem.queryOptions({ itemId: '123' }),
-    onError: (error) => {
-      // Error is typed based on the responses in your FastAPI
-      switch (error.status) {
-        case 404:
-          // error.error is a string as specified in the responses
-          console.error('Not found:', error.error);
-          break;
-        case 500:
-          // error.error is typed as ErrorDetails
-          console.error('Server error:', error.error.message);
-          break;
-      }
-    }
-  });
+  const getItem = useQuery(api.getItem.queryOptions({ itemId: '123' }));
 
   // Mutation with typed error handling
   const createItem = useMutation({
     ...api.createItem.mutationOptions(),
     onError: (error) => {
+      // Error is typed based on the responses in your FastAPI
       switch (error.status) {
         case 400:
-          // error.error is typed as ValidationError
+          // error.error is typed as ValidationErrorDetails
           console.error('Validation error:', error.error.message);
-          console.error('Field errors:', error.error.field_errors);
+          console.error('Field errors:', error.error.fieldErrors);
           break;
         case 403:
           // error.error is a string as specified in the responses
@@ -1073,10 +1067,13 @@ function ItemComponent() {
 
   // Component rendering with error handling
   if (getItem.isError) {
-    if (getItem.error.status === 404) {
-      return <NotFoundMessage message={getItem.error.error} />;
-    } else {
-      return <ErrorMessage message={getItem.error.error.message} />;
+    switch (getItem.error.status) {
+      case 404:
+        // error.error is a string as specified in the responses
+        return <NotFoundMessage message={getItem.error.error} />;
+      case 500:
+        // error.error is typed as ErrorDetails
+        return <ErrorMessage message={getItem.error.error.message} />;
     }
   }
 
@@ -1137,9 +1134,9 @@ function ItemComponent() {
 
       switch (err.status) {
         case 400:
-          // err.error is typed as ValidationError
+          // err.error is typed as ValidationErrorDetails
           console.error('Validation error:', err.error.message);
-          console.error('Field errors:', err.error.field_errors);
+          console.error('Field errors:', err.error.fieldErrors);
           break;
         case 403:
           // err.error is a string as specified in the responses
@@ -1186,7 +1183,7 @@ import { useQuery } from '@tanstack/react-query';
 
 function ItemList() {
   const api = useMyApi();
-  const items = useQuery(api.listItems.queryOptions());
+  const items = useQuery(api.listItems.queryOptions({}));
 
   if (items.isLoading) {
     return <LoadingSpinner />;
@@ -1196,17 +1193,11 @@ function ItemList() {
     const err = items.error;
     switch (err.status) {
       case 403:
-        // err.error is typed as ListItems403Response
-        return <ErrorMessage message={err.error.reason} />;
+        // err.error is a string as specified in the responses
+        return <ErrorMessage message={err.error} />;
       case 500:
-      case 502:
-        // err.error is typed as ListItems5XXResponse
-        return (
-          <ErrorMessage
-            message={err.error.message}
-            details={`Trace ID: ${err.error.traceId}`}
-          />
-        );
+        // err.error is typed as ErrorDetails
+        return <ErrorMessage message={err.error.message} />;
       default:
         return <ErrorMessage message="An unknown error occurred" />;
     }
@@ -1214,7 +1205,7 @@ function ItemList() {
 
   return (
     <ul>
-      {items.data.map((item) => (
+      {items.data?.items.map((item) => (
         <li key={item.id}>{item.name}</li>
       ))}
     </ul>
@@ -1233,7 +1224,7 @@ function ItemList() {
   useEffect(() => {
     const fetchItems = async () => {
       try {
-        const data = await api.listItems();
+        const data = await api.listItems({});
         setItems(data);
       } catch (err) {
         setError(err);
@@ -1252,17 +1243,11 @@ function ItemList() {
     const err = error as ListItemsError;
     switch (err.status) {
       case 403:
-        // err.error is typed as ListItems403Response
-        return <ErrorMessage message={err.error.reason} />;
+        // err.error is a string as specified in the responses
+        return <ErrorMessage message={err.error} />;
       case 500:
-      case 502:
-        // err.error is typed as ListItems5XXResponse
-        return (
-          <ErrorMessage
-            message={err.error.message}
-            details={`Trace ID: ${err.error.traceId}`}
-          />
-        );
+        // err.error is typed as ErrorDetails
+        return <ErrorMessage message={err.error.message} />;
       default:
         return <ErrorMessage message="An unknown error occurred" />;
     }
@@ -1285,41 +1270,53 @@ function ItemList() {
 
 ```tsx
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import type { ListItemsOutput } from '../generated/my-api/types.gen';
 
 function ItemList() {
   const api = useMyApi();
   const queryClient = useQueryClient();
 
   // Query to fetch items
-  const itemsQuery = useQuery(api.listItems.queryOptions());
+  const itemsQuery = useQuery(api.listItems.queryOptions({}));
 
   // Mutation for deleting items with optimistic updates
   const deleteMutation = useMutation({
     ...api.deleteItem.mutationOptions(),
-    onMutate: async (itemId) => {
+    onMutate: async ({ itemId }) => {
       // Cancel any outgoing refetches
-      await queryClient.cancelQueries({ queryKey: api.listItems.queryKey() });
+      await queryClient.cancelQueries({
+        queryKey: api.listItems.queryKey({}),
+      });
 
       // Snapshot the previous value
-      const previousItems = queryClient.getQueryData(api.listItems.queryKey());
+      const previousItems = queryClient.getQueryData<ListItemsOutput>(
+        api.listItems.queryKey({}),
+      );
 
       // Optimistically update to the new value
-      queryClient.setQueryData(
-        api.listItems.queryKey(),
-        (old) => old.filter((item) => item.id !== itemId)
+      queryClient.setQueryData<ListItemsOutput>(
+        api.listItems.queryKey({}),
+        (old) =>
+          old && {
+            ...old,
+            items: old.items.filter((item) => item.id !== itemId),
+          },
       );
 
       // Return a context object with the snapshot
       return { previousItems };
     },
-    onError: (err, itemId, context) => {
+    onError: (err, _input, context) => {
       // If the mutation fails, use the context returned from onMutate to roll back
-      queryClient.setQueryData(api.listItems.queryKey(), context.previousItems);
+      queryClient.setQueryData(
+        api.listItems.queryKey({}),
+        context?.previousItems,
+      );
       console.error('Failed to delete item:', err);
     },
     onSettled: () => {
       // Always refetch after error or success to ensure data is in sync with server
-      queryClient.invalidateQueries({ queryKey: api.listItems.queryKey() });
+      queryClient.invalidateQueries({ queryKey: api.listItems.queryKey({}) });
     },
   });
 
@@ -1333,11 +1330,11 @@ function ItemList() {
 
   return (
     <ul>
-      {itemsQuery.data.map((item) => (
+      {itemsQuery.data?.items.map((item) => (
         <li key={item.id}>
           {item.name}
           <button
-            onClick={() => deleteMutation.mutate(item.id)}
+            onClick={() => deleteMutation.mutate({ itemId: item.id })}
             disabled={deleteMutation.isPending}
           >
             {deleteMutation.isPending ? 'Deleting...' : 'Delete'}
@@ -1413,19 +1410,22 @@ function ItemForm() {
     const error = createItem.error;
     switch (error.status) {
       case 400:
-        // error.error is typed as CreateItem400Response
+        // error.error is typed as ValidationErrorDetails
         return (
           <FormError
             message="Invalid input"
-            errors={error.error.validationErrors}
+            errors={error.error.fieldErrors}
           />
         );
       case 403:
-        // error.error is typed as CreateItem403Response
-        return <AuthError reason={error.error.reason} />;
-      default:
-        // error.error is typed as CreateItem5XXResponse for 500, 502, etc.
+        // error.error is a string as specified in the responses
+        return <AuthError reason={error.error} />;
+      case 500:
+        // error.error is typed as ErrorDetails
         return <ServerError message={error.error.message} />;
+      default:
+        // FastAPI adds a 422 to every endpoint, so `default` isn't narrowed
+        return <ServerError message="An unknown error occurred" />;
     }
   }
 
@@ -1461,22 +1461,16 @@ function ItemForm() {
       const err = e as CreateItemError;
       switch (err.status) {
         case 400:
-          // err.error is typed as CreateItem400Response
-          console.error('Validation errors:', err.error.validationErrors);
+          // err.error is typed as ValidationErrorDetails
+          console.error('Validation errors:', err.error.fieldErrors);
           break;
         case 403:
-          // err.error is typed as CreateItem403Response
-          console.error('Not authorized:', err.error.reason);
+          // err.error is a string as specified in the responses
+          console.error('Not authorized:', err.error);
           break;
         case 500:
-        case 502:
-          // err.error is typed as CreateItem5XXResponse
-          console.error(
-            'Server error:',
-            err.error.message,
-            'Trace:',
-            err.error.traceId,
-          );
+          // err.error is typed as ErrorDetails
+          console.error('Server error:', err.error.message);
           break;
       }
       setError(err);
@@ -1490,13 +1484,15 @@ function ItemForm() {
         return (
           <FormError
             message="Invalid input"
-            errors={error.error.validationErrors}
+            errors={error.error.fieldErrors}
           />
         );
       case 403:
-        return <AuthError reason={error.error.reason} />;
-      default:
+        return <AuthError reason={error.error} />;
+      case 500:
         return <ServerError message={error.error.message} />;
+      default:
+        return <ServerError message="An unknown error occurred" />;
     }
   }
 

--- a/docs/src/content/docs/ko/guides/connection/react-smithy.mdx
+++ b/docs/src/content/docs/ko/guides/connection/react-smithy.mdx
@@ -245,7 +245,7 @@ const createItem = useMutation({
   onSettled: () => {
     // This will run when the mutation completes (success or error)
     // Good place to invalidate queries that might be affected
-    queryClient.invalidateQueries({ queryKey: api.listItems.queryKey() });
+    queryClient.invalidateQueries({ queryKey: api.listItems.queryKey({}) });
   }
 });
 ```
@@ -456,7 +456,9 @@ function ItemList() {
 
 ### 오류 처리
 
-통합에는 타입이 지정된 오류 응답과 함께 내장 오류 처리가 포함되어 있습니다. Smithy 모델에 정의된 가능한 오류 응답을 캡슐화하는 `<operation-name>Error` 타입이 생성됩니다. 각 오류에는 `status` 및 `error` 속성이 있으며, `status` 값을 확인하여 특정 오류 타입으로 좁힐 수 있습니다.
+통합에는 타입이 지정된 오류 응답과 함께 내장 오류 처리가 포함되어 있습니다. `<OperationName>Error` 타입이 생성되며, 이는 작업이 모델링하는 각 오류 상태에 대해 하나의 `<OperationName><StatusCode>Error` 멤버로 구성된 유니온입니다. 각 멤버에는 `status` 및 `error` 속성이 있으므로 `status`를 전환하면 `error`가 해당 상태의 페이로드로 좁혀집니다.
+
+아래 예시는 `CreateItem`이 [이 페이지 아래에 정의된 오류 구조](#errors)를 모델링한다고 가정합니다 — `422` `InvalidRequestError`, `403` `UnauthorizedError` 및 `500` `InternalServerError`. 모델이 선언한 상태만 유니온에 나타나므로 모델링하지 않은 상태에 대한 `case`는 컴파일 오류입니다.
 
 ```tsx {12}
 import { useMutation } from '@tanstack/react-query';
@@ -471,8 +473,8 @@ function MyComponent() {
 
   if (createItem.error) {
     switch (createItem.error.status) {
-      case 400:
-        // error.error is typed as CreateItem400Response
+      case 422:
+        // error.error is typed as InvalidRequestErrorResponseContent
         return (
           <div>
             <h2>Invalid input:</h2>
@@ -480,7 +482,7 @@ function MyComponent() {
           </div>
         );
       case 403:
-        // error.error is typed as CreateItem403Response
+        // error.error is typed as UnauthorizedErrorResponseContent
         return (
           <div>
             <h2>Not authorized:</h2>
@@ -488,8 +490,7 @@ function MyComponent() {
           </div>
         );
       case 500:
-      case 502:
-        // error.error is typed as CreateItem5XXResponse
+        // error.error is typed as InternalServerErrorResponseContent
         return (
           <div>
             <h2>Server error:</h2>
@@ -520,8 +521,8 @@ function MyComponent() {
 
   if (error) {
     switch (error.status) {
-      case 400:
-        // error.error is typed as CreateItem400Response
+      case 422:
+        // error.error is typed as InvalidRequestErrorResponseContent
         return (
           <div>
             <h2>Invalid input:</h2>
@@ -529,7 +530,7 @@ function MyComponent() {
           </div>
         );
       case 403:
-        // error.error is typed as CreateItem403Response
+        // error.error is typed as UnauthorizedErrorResponseContent
         return (
           <div>
             <h2>Not authorized:</h2>
@@ -537,8 +538,7 @@ function MyComponent() {
           </div>
         );
       case 500:
-      case 502:
-        // error.error is typed as CreateItem5XXResponse
+        // error.error is typed as InternalServerErrorResponseContent
         return (
           <div>
             <h2>Server error:</h2>
@@ -576,18 +576,18 @@ function MyComponent() {
 Smithy 작업에 `@query` trait를 적용하여 쿼리로 처리되도록 강제합니다:
 
 ```smithy
-@http(method: "POST", uri: "/items")
+@http(method: "POST", uri: "/search-items")
 @query
-operation ListItems {
-    input: ListItemsInput
-    output: ListItemsOutput
+operation SearchItems {
+    input: SearchItemsInput
+    output: SearchItemsOutput
 }
 ```
 
 생성된 훅은 `POST` HTTP 메서드를 사용하더라도 `queryOptions`를 제공합니다:
 
 ```tsx
-const items = useQuery(api.listItems.queryOptions());
+const items = useQuery(api.searchItems.queryOptions({ term: 'widget' }));
 ```
 
 #### @mutation
@@ -607,6 +607,8 @@ operation StartProcessing {
 
 ```tsx
 const startProcessing = useMutation(api.startProcessing.mutationOptions());
+
+startProcessing.mutate({ id: 'some-id' });
 ```
 
 ### 커스텀 페이지네이션 커서
@@ -616,38 +618,59 @@ const startProcessing = useMutation(api.startProcessing.mutationOptions());
 페이지네이션 토큰에 사용되는 입력 매개변수의 이름을 변경하려면 `inputToken`과 함께 `@cursor` trait를 적용합니다:
 
 ```smithy
-@http(method: "GET", uri: "/items")
+@http(method: "GET", uri: "/paged-items")
 @cursor(inputToken: "nextToken")
-operation ListItems {
+operation ListPagedItems {
     input := {
+      @httpQuery("nextToken")
       nextToken: String
+      @httpQuery("limit")
       limit: Integer
     }
     output := {
+      @required
       items: ItemList
       nextToken: String
     }
 }
 ```
 
+`infiniteQueryOptions`는 그런 다음 `nextToken`에서 페이지를 매깁니다:
+
+```tsx
+const items = useInfiniteQuery({
+  ...api.listPagedItems.infiniteQueryOptions(
+    { limit: 10 },
+    { getNextPageParam: (lastPage) => lastPage.nextToken || undefined },
+  ),
+});
+```
+
 `cursor`라는 이름의 입력 매개변수가 있는 작업에 대해 `infiniteQueryOptions`를 생성하지 않으려면 커서 기반 페이지네이션을 비활성화할 수 있습니다:
 
 ```smithy
+@http(method: "GET", uri: "/unpaged-items")
 @cursor(enabled: false)
-operation ListItems {
+operation ListUnpagedItems {
     input := {
       // Input parameter named 'cursor' will cause this operation to be treated as a paginated operation by default
+      @httpQuery("cursor")
       cursor: String
     }
     output := {
-      ...
+      @required
+      items: ItemList
     }
 }
 ```
 
+`api.listUnpagedItems`는 그런 다음 `queryOptions`, `queryKey` 및 `queryFilter`만 제공합니다.
+
 ### 작업 그룹화
 
 생성된 훅과 클라이언트 메서드는 Smithy 작업의 [`@tags` trait](https://smithy.io/2.0/spec/documentation-traits.html#tags-trait)를 기반으로 자동으로 구성됩니다. 동일한 태그를 가진 작업은 함께 그룹화되어 API 호출을 체계적으로 유지하고 IDE에서 더 나은 코드 완성을 제공합니다.
+
+그룹 내에서 각 작업은 자체 camelCase 이름을 유지하므로 `"items"` 태그가 지정된 `ListItems`라는 작업은 `api.items.listItems`에서 도달합니다 — `api.items.list`가 아닙니다.
 
 예를 들어, 다음 Smithy 모델의 경우:
 
@@ -657,27 +680,51 @@ service MyService {
 }
 
 @tags(["items"])
+@http(method: "GET", uri: "/items")
+@readonly
 operation ListItems {
-    input: ListItemsInput
-    output: ListItemsOutput
+    input := {}
+    output := {
+      @required
+      items: ItemList
+    }
 }
 
 @tags(["items"])
+@http(method: "POST", uri: "/items")
 operation CreateItem {
-    input: CreateItemInput
-    output: CreateItemOutput
+    input := {
+      @required
+      name: String
+    }
+    output := {
+      @required
+      id: String
+    }
 }
 
 @tags(["users"])
+@http(method: "GET", uri: "/users")
+@readonly
 operation ListUsers {
-    input: ListUsersInput
-    output: ListUsersOutput
+    input := {}
+    output := {
+      @required
+      users: UserList
+    }
 }
 
 @tags(["users"])
+@http(method: "POST", uri: "/users")
 operation CreateUser {
-    input: CreateUserInput
-    output: CreateUserOutput
+    input := {
+      @required
+      name: String
+    }
+    output := {
+      @required
+      id: String
+    }
 }
 ```
 
@@ -706,7 +753,7 @@ function ItemsAndUsers() {
     <div>
       <h2>Items</h2>
       <ul>
-        {items.data?.map(item => (
+        {items.data?.items.map(item => (
           <li key={item.id}>{item.name}</li>
         ))}
       </ul>
@@ -714,7 +761,7 @@ function ItemsAndUsers() {
 
       <h2>Users</h2>
       <ul>
-        {users.data?.map(user => (
+        {users.data?.users.map(user => (
           <li key={user.id}>{user.name}</li>
         ))}
       </ul>
@@ -805,7 +852,7 @@ Smithy 모델에서 오류 구조를 정의합니다:
 
 ```smithy
 @error("client")
-@httpError(400)
+@httpError(422)
 structure InvalidRequestError {
     @required
     message: String
@@ -841,6 +888,10 @@ structure FieldError {
     message: String
 }
 ```
+
+:::caution[400은 이미 사용됨]
+서비스는 이미 `400`에 Smithy의 `ValidationException`을 선언하므로 모든 작업은 `ValidationExceptionResponseContent`를 전달하는 `400` 케이스를 갖습니다. 자체 클라이언트 오류에 다른 상태(`422` 위)를 지정하세요 — 동일한 상태의 두 오류가 충돌하고 하나의 페이로드만 생성된 클라이언트에 도달합니다.
+:::
 
 #### 작업에 오류 추가
 
@@ -884,37 +935,21 @@ import { useMutation, useQuery } from '@tanstack/react-query';
 function ItemComponent() {
   const api = useMyApi();
 
-  // Query with typed error handling
-  const getItem = useQuery({
-    ...api.getItem.queryOptions({ itemId: '123' }),
-    onError: (error) => {
-      // Error is typed based on the errors in your Smithy model
-      switch (error.status) {
-        case 404:
-          // error.error is typed as ItemNotFoundError
-          console.error('Not found:', error.error.message);
-          break;
-        case 500:
-          // error.error is typed as InternalServerError
-          console.error('Server error:', error.error.message);
-          console.error('Trace ID:', error.error.traceId);
-          break;
-      }
-    }
-  });
+  const getItem = useQuery(api.getItem.queryOptions({ itemId: '123' }));
 
   // Mutation with typed error handling
   const createItem = useMutation({
     ...api.createItem.mutationOptions(),
     onError: (error) => {
+      // Error is typed based on the errors in your Smithy model
       switch (error.status) {
-        case 400:
-          // error.error is typed as InvalidRequestError
+        case 422:
+          // error.error is typed as InvalidRequestErrorResponseContent
           console.error('Validation error:', error.error.message);
           console.error('Field errors:', error.error.fieldErrors);
           break;
         case 403:
-          // error.error is typed as UnauthorizedError
+          // error.error is typed as UnauthorizedErrorResponseContent
           console.error('Unauthorized:', error.error.reason);
           break;
       }
@@ -923,10 +958,13 @@ function ItemComponent() {
 
   // Component rendering with error handling
   if (getItem.isError) {
-    if (getItem.error.status === 404) {
-      return <NotFoundMessage message={getItem.error.error.message} />;
-    } else if (getItem.error.status === 500) {
-      return <ErrorMessage message={getItem.error.error.message} />;
+    switch (getItem.error.status) {
+      case 404:
+        // error.error is typed as ItemNotFoundErrorResponseContent
+        return <NotFoundMessage message={getItem.error.error.message} />;
+      case 500:
+        // error.error is typed as InternalServerErrorResponseContent
+        return <ErrorMessage message={getItem.error.error.message} />;
     }
   }
 
@@ -962,11 +1000,11 @@ function ItemComponent() {
 
         switch (err.status) {
           case 404:
-            // err.error is typed as ItemNotFoundError
+            // err.error is typed as ItemNotFoundErrorResponseContent
             console.error('Not found:', err.error.message);
             break;
           case 500:
-            // err.error is typed as InternalServerError
+            // err.error is typed as InternalServerErrorResponseContent
             console.error('Server error:', err.error.message);
             console.error('Trace ID:', err.error.traceId);
             break;
@@ -987,13 +1025,13 @@ function ItemComponent() {
       const err = e as CreateItemError;
 
       switch (err.status) {
-        case 400:
-          // err.error is typed as InvalidRequestError
+        case 422:
+          // err.error is typed as InvalidRequestErrorResponseContent
           console.error('Validation error:', err.error.message);
           console.error('Field errors:', err.error.fieldErrors);
           break;
         case 403:
-          // err.error is typed as UnauthorizedError
+          // err.error is typed as UnauthorizedErrorResponseContent
           console.error('Unauthorized:', err.error.reason);
           break;
       }
@@ -1037,7 +1075,7 @@ import { useQuery } from '@tanstack/react-query';
 
 function ItemList() {
   const api = useMyApi();
-  const items = useQuery(api.listItems.queryOptions());
+  const items = useQuery(api.listItems.queryOptions({}));
 
   if (items.isLoading) {
     return <LoadingSpinner />;
@@ -1047,11 +1085,10 @@ function ItemList() {
     const err = items.error;
     switch (err.status) {
       case 403:
-        // err.error is typed as ListItems403Response
+        // err.error is typed as UnauthorizedErrorResponseContent
         return <ErrorMessage message={err.error.reason} />;
       case 500:
-      case 502:
-        // err.error is typed as ListItems5XXResponse
+        // err.error is typed as InternalServerErrorResponseContent
         return (
           <ErrorMessage
             message={err.error.message}
@@ -1064,7 +1101,7 @@ function ItemList() {
 
   return (
     <ul>
-      {items.data.map((item) => (
+      {items.data?.items.map((item) => (
         <li key={item.id}>{item.name}</li>
       ))}
     </ul>
@@ -1083,7 +1120,7 @@ function ItemList() {
   useEffect(() => {
     const fetchItems = async () => {
       try {
-        const data = await api.listItems();
+        const data = await api.listItems({});
         setItems(data);
       } catch (err) {
         setError(err);
@@ -1102,11 +1139,10 @@ function ItemList() {
     const err = error as ListItemsError;
     switch (err.status) {
       case 403:
-        // err.error is typed as ListItems403Response
+        // err.error is typed as UnauthorizedErrorResponseContent
         return <ErrorMessage message={err.error.reason} />;
       case 500:
-      case 502:
-        // err.error is typed as ListItems5XXResponse
+        // err.error is typed as InternalServerErrorResponseContent
         return (
           <ErrorMessage
             message={err.error.message}
@@ -1134,41 +1170,53 @@ function ItemList() {
 
 ```tsx
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import type { ListItemsResponseContent } from '../generated/my-api/types.gen';
 
 function ItemList() {
   const api = useMyApi();
   const queryClient = useQueryClient();
 
   // Query to fetch items
-  const itemsQuery = useQuery(api.listItems.queryOptions());
+  const itemsQuery = useQuery(api.listItems.queryOptions({}));
 
   // Mutation for deleting items with optimistic updates
   const deleteMutation = useMutation({
     ...api.deleteItem.mutationOptions(),
-    onMutate: async (itemId) => {
+    onMutate: async ({ itemId }) => {
       // Cancel any outgoing refetches
-      await queryClient.cancelQueries({ queryKey: api.listItems.queryKey() });
+      await queryClient.cancelQueries({
+        queryKey: api.listItems.queryKey({}),
+      });
 
       // Snapshot the previous value
-      const previousItems = queryClient.getQueryData(api.listItems.queryKey());
+      const previousItems = queryClient.getQueryData<ListItemsResponseContent>(
+        api.listItems.queryKey({}),
+      );
 
       // Optimistically update to the new value
-      queryClient.setQueryData(
-        api.listItems.queryKey(),
-        (old) => old.filter((item) => item.id !== itemId)
+      queryClient.setQueryData<ListItemsResponseContent>(
+        api.listItems.queryKey({}),
+        (old) =>
+          old && {
+            ...old,
+            items: old.items.filter((item) => item.id !== itemId),
+          },
       );
 
       // Return a context object with the snapshot
       return { previousItems };
     },
-    onError: (err, itemId, context) => {
+    onError: (err, _input, context) => {
       // If the mutation fails, use the context returned from onMutate to roll back
-      queryClient.setQueryData(api.listItems.queryKey(), context.previousItems);
+      queryClient.setQueryData(
+        api.listItems.queryKey({}),
+        context?.previousItems,
+      );
       console.error('Failed to delete item:', err);
     },
     onSettled: () => {
       // Always refetch after error or success to ensure data is in sync with server
-      queryClient.invalidateQueries({ queryKey: api.listItems.queryKey() });
+      queryClient.invalidateQueries({ queryKey: api.listItems.queryKey({}) });
     },
   });
 
@@ -1182,11 +1230,11 @@ function ItemList() {
 
   return (
     <ul>
-      {itemsQuery.data.map((item) => (
+      {itemsQuery.data?.items.map((item) => (
         <li key={item.id}>
           {item.name}
           <button
-            onClick={() => deleteMutation.mutate(item.id)}
+            onClick={() => deleteMutation.mutate({ itemId: item.id })}
             disabled={deleteMutation.isPending}
           >
             {deleteMutation.isPending ? 'Deleting...' : 'Delete'}
@@ -1261,8 +1309,8 @@ function ItemForm() {
   if (createItem.error) {
     const error = createItem.error;
     switch (error.status) {
-      case 400:
-        // error.error is typed as InvalidRequestError
+      case 422:
+        // error.error is typed as InvalidRequestErrorResponseContent
         return (
           <FormError
             message="Invalid input"
@@ -1270,10 +1318,10 @@ function ItemForm() {
           />
         );
       case 403:
-        // error.error is typed as UnauthorizedError
+        // error.error is typed as UnauthorizedErrorResponseContent
         return <AuthError reason={error.error.reason} />;
       default:
-        // error.error is typed as InternalServerError for 500, etc.
+        // error.error is typed as InternalServerErrorResponseContent for 500, etc.
         return <ServerError message={error.error.message} />;
     }
   }
@@ -1309,16 +1357,16 @@ function ItemForm() {
       // ✅ Error type includes all possible error responses
       const err = e as CreateItemError;
       switch (err.status) {
-        case 400:
-          // err.error is typed as InvalidRequestError
+        case 422:
+          // err.error is typed as InvalidRequestErrorResponseContent
           console.error('Validation errors:', err.error.fieldErrors);
           break;
         case 403:
-          // err.error is typed as UnauthorizedError
+          // err.error is typed as UnauthorizedErrorResponseContent
           console.error('Not authorized:', err.error.reason);
           break;
         case 500:
-          // err.error is typed as InternalServerError
+          // err.error is typed as InternalServerErrorResponseContent
           console.error('Server error:', err.error.message);
           break;
       }
@@ -1329,7 +1377,7 @@ function ItemForm() {
   // Error UI can use type narrowing to handle different error types
   if (error) {
     switch (error.status) {
-      case 400:
+      case 422:
         return (
           <FormError
             message="Invalid input"

--- a/docs/src/content/docs/ko/guides/connection/react-trpc.mdx
+++ b/docs/src/content/docs/ko/guides/connection/react-trpc.mdx
@@ -417,11 +417,13 @@ function UserList() {
 통합은 완전한 엔드투엔드 타입 안전성을 제공합니다. IDE는 모든 API 호출에 대해 완전한 자동 완성 및 타입 검사를 제공합니다:
 
 ```tsx
+import { useMutation } from '@tanstack/react-query';
+
 function UserForm() {
   const trpc = useMyApi();
 
   // ✅ Input is fully typed
-  const createUser = trpc.users.create.useMutation();
+  const createUser = useMutation(trpc.users.create.mutationOptions());
 
   const handleSubmit = (data: CreateUserInput) => {
     // ✅ Type error if input doesn't match schema

--- a/docs/src/content/docs/pt/guides/connection/react-agui.mdx
+++ b/docs/src/content/docs/pt/guides/connection/react-agui.mdx
@@ -46,16 +46,17 @@ O gerador cria um componente `AguiProvider` **único compartilhado**, um hook po
 - src
   - components
     - AguiProvider.tsx `CopilotKitProvider` único para cada agente AG-UI. Criado na primeira execução de `connection` e atualizado em execuções subsequentes para registrar cada novo agente.
+    - \<agent-name>-chat.tsx Um `<AgentName>Chat` temático vinculado ao id deste agente. Um arquivo por execução de `connection`.
     - copilot
       - index.tsx Re-exporta `CopilotChat`, `CopilotSidebar` e `CopilotPopup` com padrões de slot que correspondem ao `ux` do seu site (Cloudscape, Shadcn, ou nenhum tema).
       - *ThemeComponents*.tsx Componentes de tema por slot (por exemplo, `CloudscapeAssistantMessage.tsx`, `ShadcnChatInput.tsx`). Fornecidos apenas quando `ux` é `cloudscape` ou `shadcn`.
   - hooks
-    - useAgui\<AgentName>.tsx Registra um agente AG-UI. Um arquivo por execução de `connection`.
+    - useAgui\<AgentName>.tsx Registra um agente AG-UI e exporta seu id como `<AGENT_NAME>_ID`. Um arquivo por execução de `connection`.
     - useSigV4.tsx Assinatura SigV4 (apenas IAM)
 
 </FileTree>
 
-Executar `connection` uma segunda vez para um agente diferente **adiciona um novo hook `useAgui<AgentName>.tsx`** e atualiza `AguiProvider.tsx` para registrar ambos os hooks — quaisquer edições personalizadas que você tenha feito no provider são preservadas. `main.tsx` mantém seu único wrapper `<AguiProvider>` — você nunca acaba com providers aninhados.
+Executar `connection` uma segunda vez para um agente diferente **adiciona um novo hook `useAgui<AgentName>.tsx` e componente `<agent-name>-chat.tsx`** e atualiza `AguiProvider.tsx` para registrar ambos os hooks — quaisquer edições personalizadas que você tenha feito no provider são preservadas. `main.tsx` mantém seu único wrapper `<AguiProvider>` — você nunca acaba com providers aninhados.
 
 As seguintes dependências são adicionadas ao `package.json` raiz:
 
@@ -119,17 +120,14 @@ Tanto o Session ID quanto o Thread ID são fornecidos pelo navegador. Para restr
 
 ### Adicionando uma Interface de Chat
 
-Instancie componentes CopilotKit com `agentId` para selecionar qual agente usar. O id é o nome do agente — o mesmo que você escolheu quando executou o gerador <Link path="guides/ts-agent">`ts#agent`</Link> ou <Link path="guides/py-agent">`py#agent`</Link> — e você também pode encontrá-lo no arquivo de hook gerado (por exemplo, a chave retornada de `packages/web/src/hooks/useAgui<AgentName>.tsx`).
-
-Importe os componentes de chat do módulo `./components/copilot` gerado para que o tema que corresponde ao `ux` do seu site seja aplicado automaticamente:
+O gerador fornece um componente `<AgentName>Chat` por agente conectado, já vinculado ao id desse agente e temático para corresponder ao `ux` do seu site. Coloque-o em qualquer lugar dentro do wrapper `<AguiProvider>`:
 
 ```tsx
-import { CopilotChat } from './components/copilot';
+import { StoryAgentChat } from './components/story-agent-chat';
 
 function ChatPage() {
   return (
-    <CopilotChat
-      agentId="agent"
+    <StoryAgentChat
       labels={{
         welcomeMessageText: 'How can I help you today?',
         chatInputPlaceholder: 'Ask me anything...',
@@ -139,15 +137,24 @@ function ChatPage() {
 }
 ```
 
+Ele encaminha todas as props de `CopilotChat` exceto `agentId`, então qualquer coisa que você possa passar para `<CopilotChat />` funciona aqui também.
+
 ### Conectando Múltiplos Agentes AG-UI
 
-Execute o gerador `connection` uma vez por agente. Cada agente registrado via `AguiProvider` compartilhado é visível de qualquer lugar no aplicativo — instancie um componente CopilotKit com um `agentId` diferente para rotear cada chat para o agente que você deseja:
+Execute o gerador `connection` uma vez por agente. Cada execução fornece o componente de chat próprio desse agente, então rotear um chat para um agente específico é uma questão de qual componente você renderiza:
 
 ```tsx
-import { CopilotChat } from './components/copilot';
+import { StoryAgentChat } from './components/story-agent-chat';
+import { ResearchAgentChat } from './components/research-agent-chat';
 
-<CopilotChat agentId="story" />    {/* talks to StoryAgent */}
-<CopilotChat agentId="research" /> {/* talks to ResearchAgent */}
+<StoryAgentChat />    {/* talks to StoryAgent */}
+<ResearchAgentChat /> {/* talks to ResearchAgent */}
+```
+
+Se você precisar do id bruto — para chamar os próprios hooks do CopilotKit, digamos — cada hook gerado o exporta:
+
+```tsx
+import { STORY_AGENT_ID } from './hooks/useAguiStoryAgent';
 ```
 
 ## Personalizando a Aparência
@@ -164,12 +171,13 @@ O gerador lê `metadata.ux` do seu projeto de site React e fornece um módulo wr
 | `shadcn` | Mensagens do assistente renderizadas em uma bolha `bg-muted` com um avatar `Sparkles`; mensagens do usuário renderizadas alinhadas à direita em uma bolha `bg-primary` com um avatar `User`. A entrada é um `Textarea` arredondado + `Button` de enviar/parar em forma de pílula (Enter envia, Shift+Enter nova linha). Usa primitivos shadcn do pacote compartilhado `common-shadcn`. |
 | `none` (ou qualquer outra coisa) | Sem tema — o módulo apenas re-exporta os componentes padrão do CopilotKit. |
 
-Importe os componentes temáticos do **módulo de tema local** (não diretamente de `@copilotkit/react-core/v2`) para que o tema seja aplicado automaticamente:
+Os componentes `<AgentName>Chat` fornecidos já estão temáticos. Para um chat que você configura manualmente, importe do **módulo de tema local** (não diretamente de `@copilotkit/react-core/v2`) para que o tema seja aplicado automaticamente:
 
 ```tsx
 import { CopilotChat } from './components/copilot';
+import { STORY_AGENT_ID } from './hooks/useAguiStoryAgent';
 
-<CopilotChat agentId="agent" />
+<CopilotChat agentId={STORY_AGENT_ID} />
 ```
 
 O tema é aplicado como padrões de slot, então qualquer slot que você passar explicitamente ainda prevalece — você mantém controle total sempre que precisar de uma substituição pontual.
@@ -188,8 +196,7 @@ Por exemplo, para inserir seu próprio renderizador de mensagem de usuário mant
 Substituições por chat ainda funcionam junto com o tema — qualquer coisa que você passar como prop de slot substitui o padrão temático:
 
 ```tsx
-<CopilotChat
-  agentId="agent"
+<StoryAgentChat
   // style the input and its children
   input={{
     textArea: 'text-blue-600',
@@ -208,25 +215,23 @@ Substituições por chat ainda funcionam junto com o tema — qualquer coisa que
 Qualquer slot pode receber um componente React em vez de um className, então você pode substituir o padrão inteiramente:
 
 ```tsx
-import { CopilotChat } from './components/copilot';
+import { StoryAgentChat } from './components/story-agent-chat';
 
-const MySendButton: React.FC<{ onClick: () => void }> = ({ onClick }) => (
+const MySendButton: React.FC<React.ButtonHTMLAttributes<HTMLButtonElement>> = ({
+  onClick,
+}) => (
   <button onClick={onClick} className="my-send-btn">
     Send
   </button>
 );
 
-<CopilotChat
-  agentId="agent"
-  input={{ sendButton: MySendButton }}
-/>;
+<StoryAgentChat input={{ sendButton: MySendButton }} />;
 ```
 
 Substituições mais profundas seguem a mesma forma — por exemplo, substitua apenas o botão de copiar nas mensagens do assistente:
 
 ```tsx
-<CopilotChat
-  agentId="agent"
+<StoryAgentChat
   messageView={{
     assistantMessage: {
       copyButton: ({ onClick }) => <button onClick={onClick}>Copy</button>,

--- a/docs/src/content/docs/pt/guides/connection/react-fastapi.mdx
+++ b/docs/src/content/docs/pt/guides/connection/react-fastapi.mdx
@@ -248,7 +248,7 @@ const createItem = useMutation({
   onSettled: () => {
     // This will run when the mutation completes (success or error)
     // Good place to invalidate queries that might be affected
-    queryClient.invalidateQueries({ queryKey: api.listItems.queryKey() });
+    queryClient.invalidateQueries({ queryKey: api.listItems.queryKey({}) });
   }
 });
 ```
@@ -495,7 +495,9 @@ function ItemList() {
 
 ### Tratamento de Erros
 
-A integração inclui tratamento de erros embutido com respostas de erro tipadas. Um tipo `<operation-name>Error` é gerado, encapsulando as possíveis respostas de erro definidas na especificação OpenAPI. Cada erro possui uma propriedade `status` e `error`, e ao verificar o valor de `status` você pode tratar tipos específicos de erros.
+A integração inclui tratamento de erros embutido com respostas de erro tipadas. Um tipo `<OperationName>Error` é gerado que é uma união de um membro `<OperationName><StatusCode>Error` por status de erro que os `responses` da operação declaram. Cada membro tem uma propriedade `status` e uma propriedade `error`, então ao verificar o `status` você restringe o `error` ao modelo daquele status.
+
+O exemplo abaixo assume que `create_item` declara os [`responses` definidos mais adiante nesta página](#especificando-modelos-de-resposta) — um `400` `ValidationErrorDetails`, um `403` `str` e um `500` `ErrorDetails`. Apenas os status que você declara aparecem na união (mais o próprio `422` do FastAPI), então um `case` para um status que você não declarou é um erro de compilação.
 
 ```tsx {12}
 import { useMutation } from '@tanstack/react-query';
@@ -511,34 +513,32 @@ function MyComponent() {
   if (createItem.error) {
     switch (createItem.error.status) {
       case 400:
-        // error.error is typed as CreateItem400Response
+        // error.error is typed as ValidationErrorDetails
         return (
           <div>
             <h2>Invalid input:</h2>
             <p>{createItem.error.error.message}</p>
             <ul>
-              {createItem.error.error.validationErrors.map((err) => (
-                <li key={err.field}>{err.message}</li>
+              {createItem.error.error.fieldErrors.map((err) => (
+                <li key={err}>{err}</li>
               ))}
             </ul>
           </div>
         );
       case 403:
-        // error.error is typed as CreateItem403Response
+        // error.error is a string as specified in the responses
         return (
           <div>
             <h2>Not authorized:</h2>
-            <p>{createItem.error.error.reason}</p>
+            <p>{createItem.error.error}</p>
           </div>
         );
       case 500:
-      case 502:
-        // error.error is typed as CreateItem5XXResponse
+        // error.error is typed as ErrorDetails
         return (
           <div>
             <h2>Server error:</h2>
             <p>{createItem.error.error.message}</p>
-            <p>Trace ID: {createItem.error.error.traceId}</p>
           </div>
         );
     }
@@ -547,6 +547,10 @@ function MyComponent() {
   return <button onClick={handleClick}>Create Item</button>;
 }
 ```
+
+:::note[Nomes de campos Python]
+O cliente gerado converte campos de modelo para camelCase, então um modelo Pydantic declarando `field_errors` é lido como `error.fieldErrors`.
+:::
 
 <Drawer title="Tratamento de erros usando o cliente da API diretamente" trigger="Clique aqui para um exemplo usando o cliente vanilla diretamente.">
 ```tsx {9,15}
@@ -566,34 +570,32 @@ function MyComponent() {
   if (error) {
     switch (error.status) {
       case 400:
-        // error.error is typed as CreateItem400Response
+        // error.error is typed as ValidationErrorDetails
         return (
           <div>
             <h2>Invalid input:</h2>
             <p>{error.error.message}</p>
             <ul>
-              {error.error.validationErrors.map((err) => (
-                <li key={err.field}>{err.message}</li>
+              {error.error.fieldErrors.map((err) => (
+                <li key={err}>{err}</li>
               ))}
             </ul>
           </div>
         );
       case 403:
-        // error.error is typed as CreateItem403Response
+        // error.error is a string as specified in the responses
         return (
           <div>
             <h2>Not authorized:</h2>
-            <p>{error.error.reason}</p>
+            <p>{error.error}</p>
           </div>
         );
       case 500:
-      case 502:
-        // error.error is typed as CreateItem5XXResponse
+        // error.error is typed as ErrorDetails
         return (
           <div>
             <h2>Server error:</h2>
             <p>{error.error.message}</p>
-            <p>Trace ID: {error.error.traceId}</p>
           </div>
         );
     }
@@ -784,6 +786,8 @@ def list_items(page: int = 1, limit: int = 10):
 
 Os hooks e métodos do cliente gerados são organizados automaticamente com base nas tags OpenAPI dos endpoints do FastAPI. Isso ajuda a manter suas chamadas de API organizadas e facilita encontrar operações relacionadas.
 
+Dentro de um grupo, cada operação mantém seu próprio nome em camelCase, retirado do nome da função do seu endpoint — então `def list_items()` com tag `"items"` é acessado em `api.items.listItems`.
+
 Por exemplo:
 
 ```python title="items.py"
@@ -791,7 +795,7 @@ Por exemplo:
     "/items",
     tags=["items"],
 )
-def list():
+def list(cursor: str | None = None):
     # ...
 
 @app.post(
@@ -811,6 +815,10 @@ def list():
     # ...
 ```
 
+:::tip[Nomes de função repetidos]
+Dois endpoints chamados `list` em tags diferentes não entram em conflito — o gerador qualifica um nome duplicado com sua tag, então ambos são acessíveis em `api.items.list` e `api.users.list`.
+:::
+
 Os hooks gerados serão agrupados por essas tags:
 
 ```tsx
@@ -821,7 +829,7 @@ function ItemsAndUsers() {
   const api = useMyApi();
 
   // Items operations are grouped under api.items
-  const items = useQuery(api.items.list.queryOptions());
+  const items = useQuery(api.items.list.queryOptions({}));
   const createItem = useMutation(api.items.create.mutationOptions());
 
   // Users operations are grouped under api.users
@@ -873,7 +881,7 @@ function ItemsAndUsers() {
         setIsLoading(true);
 
         // Items operations are grouped under api.items
-        const itemsData = await api.items.list();
+        const itemsData = await api.items.list({});
         setItems(itemsData);
 
         // Users operations are grouped under api.users
@@ -943,7 +951,7 @@ from pydantic import BaseModel
 class ErrorDetails(BaseModel):
     message: str
 
-class ValidationError(BaseModel):
+class ValidationErrorDetails(BaseModel):
     message: str
     field_errors: list[str]
 ```
@@ -958,7 +966,7 @@ class NotFoundException(Exception):
         self.message = message
 
 class ValidationException(Exception):
-    def __init__(self, details: ValidationError):
+    def __init__(self, details: ValidationErrorDetails):
         self.details = details
 ```
 
@@ -997,8 +1005,8 @@ Finalmente, especifique os modelos de resposta para diferentes códigos de statu
 @app.get(
     "/items/{item_id}",
     responses={
-        404: {"model": str}
-        500: {"model": ErrorDetails}
+        404: {"model": str},
+        500: {"model": ErrorDetails},
     }
 )
 def get_item(item_id: str) -> Item:
@@ -1010,14 +1018,15 @@ def get_item(item_id: str) -> Item:
 @app.post(
     "/items",
     responses={
-        400: {"model": ValidationError},
-        403: {"model": str}
+        400: {"model": ValidationErrorDetails},
+        403: {"model": str},
+        500: {"model": ErrorDetails},
     }
 )
 def create_item(item: Item) -> Item:
     if not is_valid(item):
         raise ValidationException(
-            ValidationError(
+            ValidationErrorDetails(
                 message="Invalid item data",
                 field_errors=["name is required"]
             )
@@ -1035,33 +1044,18 @@ import { useMutation, useQuery } from '@tanstack/react-query';
 function ItemComponent() {
   const api = useMyApi();
 
-  // Query with typed error handling
-  const getItem = useQuery({
-    ...api.getItem.queryOptions({ itemId: '123' }),
-    onError: (error) => {
-      // Error is typed based on the responses in your FastAPI
-      switch (error.status) {
-        case 404:
-          // error.error is a string as specified in the responses
-          console.error('Not found:', error.error);
-          break;
-        case 500:
-          // error.error is typed as ErrorDetails
-          console.error('Server error:', error.error.message);
-          break;
-      }
-    }
-  });
+  const getItem = useQuery(api.getItem.queryOptions({ itemId: '123' }));
 
   // Mutation with typed error handling
   const createItem = useMutation({
     ...api.createItem.mutationOptions(),
     onError: (error) => {
+      // Error is typed based on the responses in your FastAPI
       switch (error.status) {
         case 400:
-          // error.error is typed as ValidationError
+          // error.error is typed as ValidationErrorDetails
           console.error('Validation error:', error.error.message);
-          console.error('Field errors:', error.error.field_errors);
+          console.error('Field errors:', error.error.fieldErrors);
           break;
         case 403:
           // error.error is a string as specified in the responses
@@ -1073,10 +1067,13 @@ function ItemComponent() {
 
   // Component rendering with error handling
   if (getItem.isError) {
-    if (getItem.error.status === 404) {
-      return <NotFoundMessage message={getItem.error.error} />;
-    } else {
-      return <ErrorMessage message={getItem.error.error.message} />;
+    switch (getItem.error.status) {
+      case 404:
+        // error.error is a string as specified in the responses
+        return <NotFoundMessage message={getItem.error.error} />;
+      case 500:
+        // error.error is typed as ErrorDetails
+        return <ErrorMessage message={getItem.error.error.message} />;
     }
   }
 
@@ -1137,9 +1134,9 @@ function ItemComponent() {
 
       switch (err.status) {
         case 400:
-          // err.error is typed as ValidationError
+          // err.error is typed as ValidationErrorDetails
           console.error('Validation error:', err.error.message);
-          console.error('Field errors:', err.error.field_errors);
+          console.error('Field errors:', err.error.fieldErrors);
           break;
         case 403:
           // err.error is a string as specified in the responses
@@ -1186,7 +1183,7 @@ import { useQuery } from '@tanstack/react-query';
 
 function ItemList() {
   const api = useMyApi();
-  const items = useQuery(api.listItems.queryOptions());
+  const items = useQuery(api.listItems.queryOptions({}));
 
   if (items.isLoading) {
     return <LoadingSpinner />;
@@ -1196,17 +1193,11 @@ function ItemList() {
     const err = items.error;
     switch (err.status) {
       case 403:
-        // err.error is typed as ListItems403Response
-        return <ErrorMessage message={err.error.reason} />;
+        // err.error is a string as specified in the responses
+        return <ErrorMessage message={err.error} />;
       case 500:
-      case 502:
-        // err.error is typed as ListItems5XXResponse
-        return (
-          <ErrorMessage
-            message={err.error.message}
-            details={`Trace ID: ${err.error.traceId}`}
-          />
-        );
+        // err.error is typed as ErrorDetails
+        return <ErrorMessage message={err.error.message} />;
       default:
         return <ErrorMessage message="An unknown error occurred" />;
     }
@@ -1214,7 +1205,7 @@ function ItemList() {
 
   return (
     <ul>
-      {items.data.map((item) => (
+      {items.data?.items.map((item) => (
         <li key={item.id}>{item.name}</li>
       ))}
     </ul>
@@ -1233,7 +1224,7 @@ function ItemList() {
   useEffect(() => {
     const fetchItems = async () => {
       try {
-        const data = await api.listItems();
+        const data = await api.listItems({});
         setItems(data);
       } catch (err) {
         setError(err);
@@ -1252,17 +1243,11 @@ function ItemList() {
     const err = error as ListItemsError;
     switch (err.status) {
       case 403:
-        // err.error is typed as ListItems403Response
-        return <ErrorMessage message={err.error.reason} />;
+        // err.error is a string as specified in the responses
+        return <ErrorMessage message={err.error} />;
       case 500:
-      case 502:
-        // err.error is typed as ListItems5XXResponse
-        return (
-          <ErrorMessage
-            message={err.error.message}
-            details={`Trace ID: ${err.error.traceId}`}
-          />
-        );
+        // err.error is typed as ErrorDetails
+        return <ErrorMessage message={err.error.message} />;
       default:
         return <ErrorMessage message="An unknown error occurred" />;
     }
@@ -1285,41 +1270,53 @@ Implemente atualizações otimistas para uma melhor experiência do usuário:
 
 ```tsx
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import type { ListItemsOutput } from '../generated/my-api/types.gen';
 
 function ItemList() {
   const api = useMyApi();
   const queryClient = useQueryClient();
 
   // Query to fetch items
-  const itemsQuery = useQuery(api.listItems.queryOptions());
+  const itemsQuery = useQuery(api.listItems.queryOptions({}));
 
   // Mutation for deleting items with optimistic updates
   const deleteMutation = useMutation({
     ...api.deleteItem.mutationOptions(),
-    onMutate: async (itemId) => {
+    onMutate: async ({ itemId }) => {
       // Cancel any outgoing refetches
-      await queryClient.cancelQueries({ queryKey: api.listItems.queryKey() });
+      await queryClient.cancelQueries({
+        queryKey: api.listItems.queryKey({}),
+      });
 
       // Snapshot the previous value
-      const previousItems = queryClient.getQueryData(api.listItems.queryKey());
+      const previousItems = queryClient.getQueryData<ListItemsOutput>(
+        api.listItems.queryKey({}),
+      );
 
       // Optimistically update to the new value
-      queryClient.setQueryData(
-        api.listItems.queryKey(),
-        (old) => old.filter((item) => item.id !== itemId)
+      queryClient.setQueryData<ListItemsOutput>(
+        api.listItems.queryKey({}),
+        (old) =>
+          old && {
+            ...old,
+            items: old.items.filter((item) => item.id !== itemId),
+          },
       );
 
       // Return a context object with the snapshot
       return { previousItems };
     },
-    onError: (err, itemId, context) => {
+    onError: (err, _input, context) => {
       // If the mutation fails, use the context returned from onMutate to roll back
-      queryClient.setQueryData(api.listItems.queryKey(), context.previousItems);
+      queryClient.setQueryData(
+        api.listItems.queryKey({}),
+        context?.previousItems,
+      );
       console.error('Failed to delete item:', err);
     },
     onSettled: () => {
       // Always refetch after error or success to ensure data is in sync with server
-      queryClient.invalidateQueries({ queryKey: api.listItems.queryKey() });
+      queryClient.invalidateQueries({ queryKey: api.listItems.queryKey({}) });
     },
   });
 
@@ -1333,11 +1330,11 @@ function ItemList() {
 
   return (
     <ul>
-      {itemsQuery.data.map((item) => (
+      {itemsQuery.data?.items.map((item) => (
         <li key={item.id}>
           {item.name}
           <button
-            onClick={() => deleteMutation.mutate(item.id)}
+            onClick={() => deleteMutation.mutate({ itemId: item.id })}
             disabled={deleteMutation.isPending}
           >
             {deleteMutation.isPending ? 'Deleting...' : 'Delete'}
@@ -1413,19 +1410,22 @@ function ItemForm() {
     const error = createItem.error;
     switch (error.status) {
       case 400:
-        // error.error is typed as CreateItem400Response
+        // error.error is typed as ValidationErrorDetails
         return (
           <FormError
             message="Invalid input"
-            errors={error.error.validationErrors}
+            errors={error.error.fieldErrors}
           />
         );
       case 403:
-        // error.error is typed as CreateItem403Response
-        return <AuthError reason={error.error.reason} />;
-      default:
-        // error.error is typed as CreateItem5XXResponse for 500, 502, etc.
+        // error.error is a string as specified in the responses
+        return <AuthError reason={error.error} />;
+      case 500:
+        // error.error is typed as ErrorDetails
         return <ServerError message={error.error.message} />;
+      default:
+        // FastAPI adds a 422 to every endpoint, so `default` isn't narrowed
+        return <ServerError message="An unknown error occurred" />;
     }
   }
 
@@ -1461,22 +1461,16 @@ function ItemForm() {
       const err = e as CreateItemError;
       switch (err.status) {
         case 400:
-          // err.error is typed as CreateItem400Response
-          console.error('Validation errors:', err.error.validationErrors);
+          // err.error is typed as ValidationErrorDetails
+          console.error('Validation errors:', err.error.fieldErrors);
           break;
         case 403:
-          // err.error is typed as CreateItem403Response
-          console.error('Not authorized:', err.error.reason);
+          // err.error is a string as specified in the responses
+          console.error('Not authorized:', err.error);
           break;
         case 500:
-        case 502:
-          // err.error is typed as CreateItem5XXResponse
-          console.error(
-            'Server error:',
-            err.error.message,
-            'Trace:',
-            err.error.traceId,
-          );
+          // err.error is typed as ErrorDetails
+          console.error('Server error:', err.error.message);
           break;
       }
       setError(err);
@@ -1490,13 +1484,15 @@ function ItemForm() {
         return (
           <FormError
             message="Invalid input"
-            errors={error.error.validationErrors}
+            errors={error.error.fieldErrors}
           />
         );
       case 403:
-        return <AuthError reason={error.error.reason} />;
-      default:
+        return <AuthError reason={error.error} />;
+      case 500:
         return <ServerError message={error.error.message} />;
+      default:
+        return <ServerError message="An unknown error occurred" />;
     }
   }
 

--- a/docs/src/content/docs/pt/guides/connection/react-smithy.mdx
+++ b/docs/src/content/docs/pt/guides/connection/react-smithy.mdx
@@ -245,7 +245,7 @@ const createItem = useMutation({
   onSettled: () => {
     // This will run when the mutation completes (success or error)
     // Good place to invalidate queries that might be affected
-    queryClient.invalidateQueries({ queryKey: api.listItems.queryKey() });
+    queryClient.invalidateQueries({ queryKey: api.listItems.queryKey({}) });
   }
 });
 ```
@@ -456,7 +456,9 @@ function ItemList() {
 
 ### Tratamento de Erros
 
-A integração inclui tratamento de erros com respostas tipadas. Um tipo `<operation-name>Error` é gerado, encapsulando as possíveis respostas de erro definidas no modelo Smithy. Cada erro possui uma propriedade `status` e `error`, e ao verificar o valor de `status` você pode identificar um tipo específico de erro.
+A integração inclui tratamento de erros com respostas tipadas. Um tipo `<OperationName>Error` é gerado que é uma união de um membro `<OperationName><StatusCode>Error` por status de erro que a operação modela. Cada membro tem uma propriedade `status` e uma propriedade `error`, então ao verificar `status` você restringe `error` ao payload daquele status.
+
+O exemplo abaixo assume que `CreateItem` modela as [estruturas de erro definidas mais abaixo nesta página](#errors) — um `InvalidRequestError` `422`, um `UnauthorizedError` `403` e um `InternalServerError` `500`. Apenas os status que seu modelo declara aparecem na união, então um `case` para um status que você não modelou é um erro de compilação.
 
 ```tsx {12}
 import { useMutation } from '@tanstack/react-query';
@@ -471,8 +473,8 @@ function MyComponent() {
 
   if (createItem.error) {
     switch (createItem.error.status) {
-      case 400:
-        // error.error is typed as CreateItem400Response
+      case 422:
+        // error.error is typed as InvalidRequestErrorResponseContent
         return (
           <div>
             <h2>Invalid input:</h2>
@@ -480,7 +482,7 @@ function MyComponent() {
           </div>
         );
       case 403:
-        // error.error is typed as CreateItem403Response
+        // error.error is typed as UnauthorizedErrorResponseContent
         return (
           <div>
             <h2>Not authorized:</h2>
@@ -488,8 +490,7 @@ function MyComponent() {
           </div>
         );
       case 500:
-      case 502:
-        // error.error is typed as CreateItem5XXResponse
+        // error.error is typed as InternalServerErrorResponseContent
         return (
           <div>
             <h2>Server error:</h2>
@@ -520,8 +521,8 @@ function MyComponent() {
 
   if (error) {
     switch (error.status) {
-      case 400:
-        // error.error is typed as CreateItem400Response
+      case 422:
+        // error.error is typed as InvalidRequestErrorResponseContent
         return (
           <div>
             <h2>Invalid input:</h2>
@@ -529,7 +530,7 @@ function MyComponent() {
           </div>
         );
       case 403:
-        // error.error is typed as CreateItem403Response
+        // error.error is typed as UnauthorizedErrorResponseContent
         return (
           <div>
             <h2>Not authorized:</h2>
@@ -537,8 +538,7 @@ function MyComponent() {
           </div>
         );
       case 500:
-      case 502:
-        // error.error is typed as CreateItem5XXResponse
+        // error.error is typed as InternalServerErrorResponseContent
         return (
           <div>
             <h2>Server error:</h2>
@@ -576,18 +576,18 @@ Estes mapeiam para extensões OpenAPI usando o trait [`@specificationExtension`]
 Aplique o trait `@query` à sua operação Smithy para forçá-la a ser tratada como query:
 
 ```smithy
-@http(method: "POST", uri: "/items")
+@http(method: "POST", uri: "/search-items")
 @query
-operation ListItems {
-    input: ListItemsInput
-    output: ListItemsOutput
+operation SearchItems {
+    input: SearchItemsInput
+    output: SearchItemsOutput
 }
 ```
 
 O hook gerado fornecerá `queryOptions` mesmo usando o método HTTP `POST`:
 
 ```tsx
-const items = useQuery(api.listItems.queryOptions());
+const items = useQuery(api.searchItems.queryOptions({ term: 'widget' }));
 ```
 
 #### @mutation
@@ -607,6 +607,8 @@ O hook gerado fornecerá `mutationOptions` mesmo usando o método HTTP `GET`:
 
 ```tsx
 const startProcessing = useMutation(api.startProcessing.mutationOptions());
+
+startProcessing.mutate({ id: 'some-id' });
 ```
 
 ### Cursor de Paginação Personalizado
@@ -616,38 +618,59 @@ Por padrão, os hooks gerados assumem paginação baseada em cursor com um parâ
 Aplique o trait `@cursor` com `inputToken` para alterar o nome do parâmetro de entrada usado para o token de paginação:
 
 ```smithy
-@http(method: "GET", uri: "/items")
+@http(method: "GET", uri: "/paged-items")
 @cursor(inputToken: "nextToken")
-operation ListItems {
+operation ListPagedItems {
     input := {
+      @httpQuery("nextToken")
       nextToken: String
+      @httpQuery("limit")
       limit: Integer
     }
     output := {
+      @required
       items: ItemList
       nextToken: String
     }
 }
 ```
 
+`infiniteQueryOptions` então pagina em `nextToken`:
+
+```tsx
+const items = useInfiniteQuery({
+  ...api.listPagedItems.infiniteQueryOptions(
+    { limit: 10 },
+    { getNextPageParam: (lastPage) => lastPage.nextToken || undefined },
+  ),
+});
+```
+
 Se não quiser gerar `infiniteQueryOptions` para uma operação que tem um parâmetro de entrada chamado `cursor`, você pode desativar a paginação baseada em cursor:
 
 ```smithy
+@http(method: "GET", uri: "/unpaged-items")
 @cursor(enabled: false)
-operation ListItems {
+operation ListUnpagedItems {
     input := {
       // Input parameter named 'cursor' will cause this operation to be treated as a paginated operation by default
+      @httpQuery("cursor")
       cursor: String
     }
     output := {
-      ...
+      @required
+      items: ItemList
     }
 }
 ```
 
+`api.listUnpagedItems` então fornece apenas `queryOptions`, `queryKey` e `queryFilter`.
+
 ### Agrupamento de Operações
 
 Os hooks e métodos do cliente gerado são organizados automaticamente com base no trait [`@tags`](https://smithy.io/2.0/spec/documentation-traits.html#tags-trait) em suas operações Smithy. Operações com as mesmas tags são agrupadas, o que ajuda a manter suas chamadas de API organizadas e fornece melhor completação de código em sua IDE.
+
+Dentro de um grupo, cada operação mantém seu próprio nome em camelCase, então uma operação chamada `ListItems` com tag `"items"` é acessada em `api.items.listItems` — não `api.items.list`.
 
 Por exemplo, com este modelo Smithy:
 
@@ -657,27 +680,51 @@ service MyService {
 }
 
 @tags(["items"])
+@http(method: "GET", uri: "/items")
+@readonly
 operation ListItems {
-    input: ListItemsInput
-    output: ListItemsOutput
+    input := {}
+    output := {
+      @required
+      items: ItemList
+    }
 }
 
 @tags(["items"])
+@http(method: "POST", uri: "/items")
 operation CreateItem {
-    input: CreateItemInput
-    output: CreateItemOutput
+    input := {
+      @required
+      name: String
+    }
+    output := {
+      @required
+      id: String
+    }
 }
 
 @tags(["users"])
+@http(method: "GET", uri: "/users")
+@readonly
 operation ListUsers {
-    input: ListUsersInput
-    output: ListUsersOutput
+    input := {}
+    output := {
+      @required
+      users: UserList
+    }
 }
 
 @tags(["users"])
+@http(method: "POST", uri: "/users")
 operation CreateUser {
-    input: CreateUserInput
-    output: CreateUserOutput
+    input := {
+      @required
+      name: String
+    }
+    output := {
+      @required
+      id: String
+    }
 }
 ```
 
@@ -706,7 +753,7 @@ function ItemsAndUsers() {
     <div>
       <h2>Items</h2>
       <ul>
-        {items.data?.map(item => (
+        {items.data?.items.map(item => (
           <li key={item.id}>{item.name}</li>
         ))}
       </ul>
@@ -714,7 +761,7 @@ function ItemsAndUsers() {
 
       <h2>Users</h2>
       <ul>
-        {users.data?.map(user => (
+        {users.data?.users.map(user => (
           <li key={user.id}>{user.name}</li>
         ))}
       </ul>
@@ -805,7 +852,7 @@ Defina suas estruturas de erro em seu modelo Smithy:
 
 ```smithy
 @error("client")
-@httpError(400)
+@httpError(422)
 structure InvalidRequestError {
     @required
     message: String
@@ -841,6 +888,10 @@ structure FieldError {
     message: String
 }
 ```
+
+:::caution[400 está reservado]
+Seu serviço já declara o `ValidationException` do Smithy em `400`, então toda operação recebe um caso `400` carregando `ValidationExceptionResponseContent`. Dê aos seus próprios erros de cliente um status diferente (`422` acima) — dois erros no mesmo status colidem e apenas um payload chega ao cliente gerado.
+:::
 
 #### Adicionando Erros a Operações
 
@@ -884,37 +935,21 @@ import { useMutation, useQuery } from '@tanstack/react-query';
 function ItemComponent() {
   const api = useMyApi();
 
-  // Query with typed error handling
-  const getItem = useQuery({
-    ...api.getItem.queryOptions({ itemId: '123' }),
-    onError: (error) => {
-      // Error is typed based on the errors in your Smithy model
-      switch (error.status) {
-        case 404:
-          // error.error is typed as ItemNotFoundError
-          console.error('Not found:', error.error.message);
-          break;
-        case 500:
-          // error.error is typed as InternalServerError
-          console.error('Server error:', error.error.message);
-          console.error('Trace ID:', error.error.traceId);
-          break;
-      }
-    }
-  });
+  const getItem = useQuery(api.getItem.queryOptions({ itemId: '123' }));
 
   // Mutation with typed error handling
   const createItem = useMutation({
     ...api.createItem.mutationOptions(),
     onError: (error) => {
+      // Error is typed based on the errors in your Smithy model
       switch (error.status) {
-        case 400:
-          // error.error is typed as InvalidRequestError
+        case 422:
+          // error.error is typed as InvalidRequestErrorResponseContent
           console.error('Validation error:', error.error.message);
           console.error('Field errors:', error.error.fieldErrors);
           break;
         case 403:
-          // error.error is typed as UnauthorizedError
+          // error.error is typed as UnauthorizedErrorResponseContent
           console.error('Unauthorized:', error.error.reason);
           break;
       }
@@ -923,10 +958,13 @@ function ItemComponent() {
 
   // Component rendering with error handling
   if (getItem.isError) {
-    if (getItem.error.status === 404) {
-      return <NotFoundMessage message={getItem.error.error.message} />;
-    } else if (getItem.error.status === 500) {
-      return <ErrorMessage message={getItem.error.error.message} />;
+    switch (getItem.error.status) {
+      case 404:
+        // error.error is typed as ItemNotFoundErrorResponseContent
+        return <NotFoundMessage message={getItem.error.error.message} />;
+      case 500:
+        // error.error is typed as InternalServerErrorResponseContent
+        return <ErrorMessage message={getItem.error.error.message} />;
     }
   }
 
@@ -962,11 +1000,11 @@ function ItemComponent() {
 
         switch (err.status) {
           case 404:
-            // err.error is typed as ItemNotFoundError
+            // err.error is typed as ItemNotFoundErrorResponseContent
             console.error('Not found:', err.error.message);
             break;
           case 500:
-            // err.error is typed as InternalServerError
+            // err.error is typed as InternalServerErrorResponseContent
             console.error('Server error:', err.error.message);
             console.error('Trace ID:', err.error.traceId);
             break;
@@ -987,13 +1025,13 @@ function ItemComponent() {
       const err = e as CreateItemError;
 
       switch (err.status) {
-        case 400:
-          // err.error is typed as InvalidRequestError
+        case 422:
+          // err.error is typed as InvalidRequestErrorResponseContent
           console.error('Validation error:', err.error.message);
           console.error('Field errors:', err.error.fieldErrors);
           break;
         case 403:
-          // err.error is typed as UnauthorizedError
+          // err.error is typed as UnauthorizedErrorResponseContent
           console.error('Unauthorized:', err.error.reason);
           break;
       }
@@ -1037,7 +1075,7 @@ import { useQuery } from '@tanstack/react-query';
 
 function ItemList() {
   const api = useMyApi();
-  const items = useQuery(api.listItems.queryOptions());
+  const items = useQuery(api.listItems.queryOptions({}));
 
   if (items.isLoading) {
     return <LoadingSpinner />;
@@ -1047,11 +1085,10 @@ function ItemList() {
     const err = items.error;
     switch (err.status) {
       case 403:
-        // err.error is typed as ListItems403Response
+        // err.error is typed as UnauthorizedErrorResponseContent
         return <ErrorMessage message={err.error.reason} />;
       case 500:
-      case 502:
-        // err.error is typed as ListItems5XXResponse
+        // err.error is typed as InternalServerErrorResponseContent
         return (
           <ErrorMessage
             message={err.error.message}
@@ -1064,7 +1101,7 @@ function ItemList() {
 
   return (
     <ul>
-      {items.data.map((item) => (
+      {items.data?.items.map((item) => (
         <li key={item.id}>{item.name}</li>
       ))}
     </ul>
@@ -1083,7 +1120,7 @@ function ItemList() {
   useEffect(() => {
     const fetchItems = async () => {
       try {
-        const data = await api.listItems();
+        const data = await api.listItems({});
         setItems(data);
       } catch (err) {
         setError(err);
@@ -1102,11 +1139,10 @@ function ItemList() {
     const err = error as ListItemsError;
     switch (err.status) {
       case 403:
-        // err.error is typed as ListItems403Response
+        // err.error is typed as UnauthorizedErrorResponseContent
         return <ErrorMessage message={err.error.reason} />;
       case 500:
-      case 502:
-        // err.error is typed as ListItems5XXResponse
+        // err.error is typed as InternalServerErrorResponseContent
         return (
           <ErrorMessage
             message={err.error.message}
@@ -1134,41 +1170,53 @@ Implemente atualizações otimistas para uma melhor experiência do usuário:
 
 ```tsx
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import type { ListItemsResponseContent } from '../generated/my-api/types.gen';
 
 function ItemList() {
   const api = useMyApi();
   const queryClient = useQueryClient();
 
   // Query to fetch items
-  const itemsQuery = useQuery(api.listItems.queryOptions());
+  const itemsQuery = useQuery(api.listItems.queryOptions({}));
 
   // Mutation for deleting items with optimistic updates
   const deleteMutation = useMutation({
     ...api.deleteItem.mutationOptions(),
-    onMutate: async (itemId) => {
+    onMutate: async ({ itemId }) => {
       // Cancel any outgoing refetches
-      await queryClient.cancelQueries({ queryKey: api.listItems.queryKey() });
+      await queryClient.cancelQueries({
+        queryKey: api.listItems.queryKey({}),
+      });
 
       // Snapshot the previous value
-      const previousItems = queryClient.getQueryData(api.listItems.queryKey());
+      const previousItems = queryClient.getQueryData<ListItemsResponseContent>(
+        api.listItems.queryKey({}),
+      );
 
       // Optimistically update to the new value
-      queryClient.setQueryData(
-        api.listItems.queryKey(),
-        (old) => old.filter((item) => item.id !== itemId)
+      queryClient.setQueryData<ListItemsResponseContent>(
+        api.listItems.queryKey({}),
+        (old) =>
+          old && {
+            ...old,
+            items: old.items.filter((item) => item.id !== itemId),
+          },
       );
 
       // Return a context object with the snapshot
       return { previousItems };
     },
-    onError: (err, itemId, context) => {
+    onError: (err, _input, context) => {
       // If the mutation fails, use the context returned from onMutate to roll back
-      queryClient.setQueryData(api.listItems.queryKey(), context.previousItems);
+      queryClient.setQueryData(
+        api.listItems.queryKey({}),
+        context?.previousItems,
+      );
       console.error('Failed to delete item:', err);
     },
     onSettled: () => {
       // Always refetch after error or success to ensure data is in sync with server
-      queryClient.invalidateQueries({ queryKey: api.listItems.queryKey() });
+      queryClient.invalidateQueries({ queryKey: api.listItems.queryKey({}) });
     },
   });
 
@@ -1182,11 +1230,11 @@ function ItemList() {
 
   return (
     <ul>
-      {itemsQuery.data.map((item) => (
+      {itemsQuery.data?.items.map((item) => (
         <li key={item.id}>
           {item.name}
           <button
-            onClick={() => deleteMutation.mutate(item.id)}
+            onClick={() => deleteMutation.mutate({ itemId: item.id })}
             disabled={deleteMutation.isPending}
           >
             {deleteMutation.isPending ? 'Deleting...' : 'Delete'}
@@ -1261,8 +1309,8 @@ function ItemForm() {
   if (createItem.error) {
     const error = createItem.error;
     switch (error.status) {
-      case 400:
-        // error.error is typed as InvalidRequestError
+      case 422:
+        // error.error is typed as InvalidRequestErrorResponseContent
         return (
           <FormError
             message="Invalid input"
@@ -1270,10 +1318,10 @@ function ItemForm() {
           />
         );
       case 403:
-        // error.error is typed as UnauthorizedError
+        // error.error is typed as UnauthorizedErrorResponseContent
         return <AuthError reason={error.error.reason} />;
       default:
-        // error.error is typed as InternalServerError for 500, etc.
+        // error.error is typed as InternalServerErrorResponseContent for 500, etc.
         return <ServerError message={error.error.message} />;
     }
   }
@@ -1309,16 +1357,16 @@ function ItemForm() {
       // ✅ Error type includes all possible error responses
       const err = e as CreateItemError;
       switch (err.status) {
-        case 400:
-          // err.error is typed as InvalidRequestError
+        case 422:
+          // err.error is typed as InvalidRequestErrorResponseContent
           console.error('Validation errors:', err.error.fieldErrors);
           break;
         case 403:
-          // err.error is typed as UnauthorizedError
+          // err.error is typed as UnauthorizedErrorResponseContent
           console.error('Not authorized:', err.error.reason);
           break;
         case 500:
-          // err.error is typed as InternalServerError
+          // err.error is typed as InternalServerErrorResponseContent
           console.error('Server error:', err.error.message);
           break;
       }
@@ -1329,7 +1377,7 @@ function ItemForm() {
   // Error UI can use type narrowing to handle different error types
   if (error) {
     switch (error.status) {
-      case 400:
+      case 422:
         return (
           <FormError
             message="Invalid input"

--- a/docs/src/content/docs/pt/guides/connection/react-trpc.mdx
+++ b/docs/src/content/docs/pt/guides/connection/react-trpc.mdx
@@ -417,11 +417,13 @@ function UserList() {
 A integração fornece segurança de tipo completa de ponta a ponta. Seu IDE fornecerá autocompletar completo e verificação de tipo para todas as suas chamadas de API:
 
 ```tsx
+import { useMutation } from '@tanstack/react-query';
+
 function UserForm() {
   const trpc = useMyApi();
 
   // ✅ Input is fully typed
-  const createUser = trpc.users.create.useMutation();
+  const createUser = useMutation(trpc.users.create.mutationOptions());
 
   const handleSubmit = (data: CreateUserInput) => {
     // ✅ Type error if input doesn't match schema

--- a/docs/src/content/docs/vi/guides/connection/react-agui.mdx
+++ b/docs/src/content/docs/vi/guides/connection/react-agui.mdx
@@ -23,7 +23,7 @@ Trước khi sử dụng generator này, hãy đảm bảo bạn có:
 
 1. Một trang web React (được tạo bằng <Link path="guides/react-website">generator `ts#website`</Link>)
 2. Một TypeScript hoặc Python Agent với `protocol=ag-ui` (được tạo bằng generator <Link path="guides/ts-agent">`ts#agent`</Link> hoặc <Link path="guides/py-agent">`py#agent`</Link>)
-3. Đối với các agent đã triển khai, Cognito Auth được thêm qua <Link path="/guides/react-website-auth">generator `ts#website#auth`</Link>
+3. Đối với các agent đã triển khai, Cognito Auth được thêm qua <Link path="/vi/guides/react-website-auth">generator `ts#website#auth`</Link>
 
 ## Cách sử dụng
 
@@ -46,16 +46,17 @@ Generator tạo ra một component `AguiProvider` **được chia sẻ duy nhấ
 - src
   - components
     - AguiProvider.tsx `CopilotKitProvider` duy nhất cho mọi AG-UI agent. Được tạo trong lần chạy `connection` đầu tiên và được cập nhật trong các lần chạy tiếp theo để đăng ký từng agent mới.
+    - \<agent-name>-chat.tsx Một `<AgentName>Chat` có theme được liên kết với id của agent này. Một file cho mỗi lần chạy `connection`.
     - copilot
       - index.tsx Re-export `CopilotChat`, `CopilotSidebar` và `CopilotPopup` với các slot mặc định khớp với `ux` của trang web của bạn (Cloudscape, Shadcn, hoặc không có theme).
       - *ThemeComponents*.tsx Các component theme theo từng slot (ví dụ: `CloudscapeAssistantMessage.tsx`, `ShadcnChatInput.tsx`). Chỉ được cung cấp khi `ux` là `cloudscape` hoặc `shadcn`.
   - hooks
-    - useAgui\<AgentName>.tsx Đăng ký một AG-UI agent. Một file cho mỗi lần chạy `connection`.
+    - useAgui\<AgentName>.tsx Đăng ký một AG-UI agent và export id của nó dưới dạng `<AGENT_NAME>_ID`. Một file cho mỗi lần chạy `connection`.
     - useSigV4.tsx Ký SigV4 (chỉ IAM)
 
 </FileTree>
 
-Chạy `connection` lần thứ hai cho một agent khác **thêm một hook `useAgui<AgentName>.tsx` mới** và cập nhật `AguiProvider.tsx` để đăng ký cả hai hook — mọi chỉnh sửa tùy chỉnh mà bạn đã thực hiện đối với provider đều được giữ nguyên. `main.tsx` giữ wrapper `<AguiProvider>` duy nhất của nó — bạn sẽ không bao giờ có các provider lồng nhau.
+Chạy `connection` lần thứ hai cho một agent khác **thêm một hook `useAgui<AgentName>.tsx` mới và component `<agent-name>-chat.tsx`** và cập nhật `AguiProvider.tsx` để đăng ký cả hai hook — mọi chỉnh sửa tùy chỉnh mà bạn đã thực hiện đối với provider đều được giữ nguyên. `main.tsx` giữ wrapper `<AguiProvider>` duy nhất của nó — bạn sẽ không bao giờ có các provider lồng nhau.
 
 Các dependency sau được thêm vào `package.json` gốc:
 
@@ -119,17 +120,14 @@ Cả Session ID và Thread ID đều được cung cấp bởi trình duyệt. �
 
 ### Thêm giao diện Chat
 
-Khởi tạo các component CopilotKit với `agentId` để chọn agent nào sẽ sử dụng. Id là tên của agent — cùng tên mà bạn đã chọn khi chạy generator <Link path="guides/ts-agent">`ts#agent`</Link> hoặc <Link path="guides/py-agent">`py#agent`</Link> — và bạn cũng có thể tìm thấy nó trong file hook được tạo (ví dụ: key được trả về từ `packages/web/src/hooks/useAgui<AgentName>.tsx`).
-
-Import các component chat từ module `./components/copilot` được tạo để theme khớp với `ux` của trang web của bạn được áp dụng tự động:
+Generator cung cấp một component `<AgentName>Chat` cho mỗi agent được kết nối, đã được liên kết với id của agent đó và có theme khớp với `ux` của trang web của bạn. Đặt nó ở bất kỳ đâu bên trong wrapper `<AguiProvider>`:
 
 ```tsx
-import { CopilotChat } from './components/copilot';
+import { StoryAgentChat } from './components/story-agent-chat';
 
 function ChatPage() {
   return (
-    <CopilotChat
-      agentId="agent"
+    <StoryAgentChat
       labels={{
         welcomeMessageText: 'How can I help you today?',
         chatInputPlaceholder: 'Ask me anything...',
@@ -139,15 +137,24 @@ function ChatPage() {
 }
 ```
 
+Nó chuyển tiếp mọi prop của `CopilotChat` ngoại trừ `agentId`, vì vậy bất cứ thứ gì bạn có thể truyền cho `<CopilotChat />` đều hoạt động ở đây.
+
 ### Kết nối nhiều AG-UI Agent
 
-Chạy generator `connection` một lần cho mỗi agent. Mọi agent được đăng ký qua `AguiProvider` được chia sẻ đều hiển thị từ bất kỳ đâu trong ứng dụng — khởi tạo một component CopilotKit với `agentId` khác nhau để định tuyến mỗi cuộc trò chuyện đến agent bạn muốn:
+Chạy generator `connection` một lần cho mỗi agent. Mỗi lần chạy cung cấp component chat riêng của agent đó, vì vậy việc định tuyến một cuộc trò chuyện đến một agent cụ thể là vấn đề của component nào bạn render:
 
 ```tsx
-import { CopilotChat } from './components/copilot';
+import { StoryAgentChat } from './components/story-agent-chat';
+import { ResearchAgentChat } from './components/research-agent-chat';
 
-<CopilotChat agentId="story" />    {/* talks to StoryAgent */}
-<CopilotChat agentId="research" /> {/* talks to ResearchAgent */}
+<StoryAgentChat />    {/* talks to StoryAgent */}
+<ResearchAgentChat /> {/* talks to ResearchAgent */}
+```
+
+Nếu bạn cần id thô — để gọi các hook riêng của CopilotKit chẳng hạn — mỗi hook được tạo đều export nó:
+
+```tsx
+import { STORY_AGENT_ID } from './hooks/useAguiStoryAgent';
 ```
 
 ## Tùy chỉnh giao diện
@@ -164,12 +171,13 @@ Generator đọc `metadata.ux` từ project trang web React của bạn và cung
 | `shadcn` | Tin nhắn của assistant được render trong bubble `bg-muted` với avatar `Sparkles`; tin nhắn của người dùng được render căn phải trong bubble `bg-primary` với avatar `User`. Input là `Textarea` bo tròn + `Button` gửi/dừng hình viên thuốc (Enter để gửi, Shift+Enter để xuống dòng). Sử dụng các primitive shadcn từ package `common-shadcn` được chia sẻ. |
 | `none` (hoặc bất kỳ giá trị nào khác) | Không có theme — module chỉ re-export các component CopilotKit mặc định. |
 
-Import các component có theme từ **module theme cục bộ** (không phải trực tiếp từ `@copilotkit/react-core/v2`) để theme được áp dụng tự động:
+Các component `<AgentName>Chat` được cung cấp đã có theme. Đối với một chat bạn tự kết nối, hãy import từ **module theme cục bộ** (không phải trực tiếp từ `@copilotkit/react-core/v2`) để theme được áp dụng tự động:
 
 ```tsx
 import { CopilotChat } from './components/copilot';
+import { STORY_AGENT_ID } from './hooks/useAguiStoryAgent';
 
-<CopilotChat agentId="agent" />
+<CopilotChat agentId={STORY_AGENT_ID} />
 ```
 
 Theme được áp dụng dưới dạng các slot mặc định, vì vậy bất kỳ slot nào bạn truyền một cách rõ ràng vẫn được ưu tiên — bạn vẫn giữ toàn quyền kiểm soát bất cứ khi nào bạn cần ghi đè một lần.
@@ -188,8 +196,7 @@ Ví dụ: để thay thế renderer tin nhắn người dùng của riêng bạn
 Các ghi đè theo từng chat vẫn hoạt động cùng với theme — bất kỳ thứ gì bạn truyền dưới dạng slot prop đều ghi đè mặc định có theme:
 
 ```tsx
-<CopilotChat
-  agentId="agent"
+<StoryAgentChat
   // style the input and its children
   input={{
     textArea: 'text-blue-600',
@@ -208,25 +215,23 @@ Các ghi đè theo từng chat vẫn hoạt động cùng với theme — bất 
 Bất kỳ slot nào cũng có thể nhận một component React thay vì className, vì vậy bạn có thể thay thế hoàn toàn mặc định:
 
 ```tsx
-import { CopilotChat } from './components/copilot';
+import { StoryAgentChat } from './components/story-agent-chat';
 
-const MySendButton: React.FC<{ onClick: () => void }> = ({ onClick }) => (
+const MySendButton: React.FC<React.ButtonHTMLAttributes<HTMLButtonElement>> = ({
+  onClick,
+}) => (
   <button onClick={onClick} className="my-send-btn">
     Send
   </button>
 );
 
-<CopilotChat
-  agentId="agent"
-  input={{ sendButton: MySendButton }}
-/>;
+<StoryAgentChat input={{ sendButton: MySendButton }} />;
 ```
 
 Các ghi đè sâu hơn tuân theo cùng một hình dạng — ví dụ: chỉ thay thế nút sao chép trên tin nhắn của assistant:
 
 ```tsx
-<CopilotChat
-  agentId="agent"
+<StoryAgentChat
   messageView={{
     assistantMessage: {
       copyButton: ({ onClick }) => <button onClick={onClick}>Copy</button>,

--- a/docs/src/content/docs/vi/guides/connection/react-fastapi.mdx
+++ b/docs/src/content/docs/vi/guides/connection/react-fastapi.mdx
@@ -248,7 +248,7 @@ const createItem = useMutation({
   onSettled: () => {
     // This will run when the mutation completes (success or error)
     // Good place to invalidate queries that might be affected
-    queryClient.invalidateQueries({ queryKey: api.listItems.queryKey() });
+    queryClient.invalidateQueries({ queryKey: api.listItems.queryKey({}) });
   }
 });
 ```
@@ -495,7 +495,9 @@ function ItemList() {
 
 ### Xử lý Lỗi
 
-Tích hợp bao gồm xử lý lỗi tích hợp sẵn với các typed error responses. Type `<operation-name>Error` được sinh bao gồm các error responses có thể có được định nghĩa trong đặc tả OpenAPI. Mỗi error có thuộc tính `status` và `error`, và bằng cách kiểm tra giá trị của `status`, bạn có thể thu hẹp xuống một loại lỗi cụ thể.
+Tích hợp bao gồm xử lý lỗi tích hợp sẵn với các typed error responses. Type `<OperationName>Error` được sinh là một union của một member `<OperationName><StatusCode>Error` cho mỗi error status mà `responses` của operation khai báo. Mỗi member có thuộc tính `status` và `error`, vì vậy việc switch trên `status` sẽ thu hẹp `error` xuống model của status đó.
+
+Ví dụ dưới đây giả định `create_item` khai báo [`responses` được định nghĩa ở phần dưới trang này](#specifying-response-models) — một `400` `ValidationErrorDetails`, một `403` `str` và một `500` `ErrorDetails`. Chỉ các statuses bạn khai báo mới xuất hiện trong union (cộng với `422` của chính FastAPI), vì vậy một `case` cho status bạn chưa khai báo là một compile error.
 
 ```tsx {12}
 import { useMutation } from '@tanstack/react-query';
@@ -511,34 +513,32 @@ function MyComponent() {
   if (createItem.error) {
     switch (createItem.error.status) {
       case 400:
-        // error.error is typed as CreateItem400Response
+        // error.error is typed as ValidationErrorDetails
         return (
           <div>
             <h2>Invalid input:</h2>
             <p>{createItem.error.error.message}</p>
             <ul>
-              {createItem.error.error.validationErrors.map((err) => (
-                <li key={err.field}>{err.message}</li>
+              {createItem.error.error.fieldErrors.map((err) => (
+                <li key={err}>{err}</li>
               ))}
             </ul>
           </div>
         );
       case 403:
-        // error.error is typed as CreateItem403Response
+        // error.error is a string as specified in the responses
         return (
           <div>
             <h2>Not authorized:</h2>
-            <p>{createItem.error.error.reason}</p>
+            <p>{createItem.error.error}</p>
           </div>
         );
       case 500:
-      case 502:
-        // error.error is typed as CreateItem5XXResponse
+        // error.error is typed as ErrorDetails
         return (
           <div>
             <h2>Server error:</h2>
             <p>{createItem.error.error.message}</p>
-            <p>Trace ID: {createItem.error.error.traceId}</p>
           </div>
         );
     }
@@ -547,6 +547,10 @@ function MyComponent() {
   return <button onClick={handleClick}>Create Item</button>;
 }
 ```
+
+:::note[Tên trường Python]
+Client được sinh camelCase các trường model, vì vậy một Pydantic model khai báo `field_errors` được đọc là `error.fieldErrors`.
+:::
 
 <Drawer title="Xử lý lỗi sử dụng vanilla client trực tiếp" trigger="Nhấn vào đây để xem ví dụ sử dụng vanilla client trực tiếp.">
 ```tsx {9,15}
@@ -566,34 +570,32 @@ function MyComponent() {
   if (error) {
     switch (error.status) {
       case 400:
-        // error.error is typed as CreateItem400Response
+        // error.error is typed as ValidationErrorDetails
         return (
           <div>
             <h2>Invalid input:</h2>
             <p>{error.error.message}</p>
             <ul>
-              {error.error.validationErrors.map((err) => (
-                <li key={err.field}>{err.message}</li>
+              {error.error.fieldErrors.map((err) => (
+                <li key={err}>{err}</li>
               ))}
             </ul>
           </div>
         );
       case 403:
-        // error.error is typed as CreateItem403Response
+        // error.error is a string as specified in the responses
         return (
           <div>
             <h2>Not authorized:</h2>
-            <p>{error.error.reason}</p>
+            <p>{error.error}</p>
           </div>
         );
       case 500:
-      case 502:
-        // error.error is typed as CreateItem5XXResponse
+        // error.error is typed as ErrorDetails
         return (
           <div>
             <h2>Server error:</h2>
             <p>{error.error.message}</p>
-            <p>Trace ID: {error.error.traceId}</p>
           </div>
         );
     }
@@ -784,6 +786,8 @@ def list_items(page: int = 1, limit: int = 10):
 
 Các hooks và client methods được sinh tự động được tổ chức dựa trên OpenAPI tags trong các endpoints FastAPI của bạn. Điều này giúp giữ các API calls của bạn được tổ chức và giúp dễ dàng tìm các operations liên quan.
 
+Trong một nhóm, mỗi operation giữ tên camelCased riêng của nó, lấy từ tên hàm endpoint của bạn — vì vậy `def list_items()` được gắn tag `"items"` được truy cập tại `api.items.listItems`.
+
 Ví dụ:
 
 ```python title="items.py"
@@ -791,7 +795,7 @@ Ví dụ:
     "/items",
     tags=["items"],
 )
-def list():
+def list(cursor: str | None = None):
     # ...
 
 @app.post(
@@ -811,6 +815,10 @@ def list():
     # ...
 ```
 
+:::tip[Tên hàm lặp lại]
+Hai endpoints có tên `list` trong các tags khác nhau không xung đột — generator đủ điều kiện một tên trùng lặp với tag của nó, vì vậy cả hai đều có thể truy cập tại `api.items.list` và `api.users.list`.
+:::
+
 Các hooks được sinh sẽ được nhóm theo các tags này:
 
 ```tsx
@@ -821,7 +829,7 @@ function ItemsAndUsers() {
   const api = useMyApi();
 
   // Items operations are grouped under api.items
-  const items = useQuery(api.items.list.queryOptions());
+  const items = useQuery(api.items.list.queryOptions({}));
   const createItem = useMutation(api.items.create.mutationOptions());
 
   // Users operations are grouped under api.users
@@ -873,7 +881,7 @@ function ItemsAndUsers() {
         setIsLoading(true);
 
         // Items operations are grouped under api.items
-        const itemsData = await api.items.list();
+        const itemsData = await api.items.list({});
         setItems(itemsData);
 
         // Users operations are grouped under api.users
@@ -943,7 +951,7 @@ from pydantic import BaseModel
 class ErrorDetails(BaseModel):
     message: str
 
-class ValidationError(BaseModel):
+class ValidationErrorDetails(BaseModel):
     message: str
     field_errors: list[str]
 ```
@@ -958,7 +966,7 @@ class NotFoundException(Exception):
         self.message = message
 
 class ValidationException(Exception):
-    def __init__(self, details: ValidationError):
+    def __init__(self, details: ValidationErrorDetails):
         self.details = details
 ```
 
@@ -997,8 +1005,8 @@ Cuối cùng, chỉ định response models cho các error status codes khác nh
 @app.get(
     "/items/{item_id}",
     responses={
-        404: {"model": str}
-        500: {"model": ErrorDetails}
+        404: {"model": str},
+        500: {"model": ErrorDetails},
     }
 )
 def get_item(item_id: str) -> Item:
@@ -1010,14 +1018,15 @@ def get_item(item_id: str) -> Item:
 @app.post(
     "/items",
     responses={
-        400: {"model": ValidationError},
-        403: {"model": str}
+        400: {"model": ValidationErrorDetails},
+        403: {"model": str},
+        500: {"model": ErrorDetails},
     }
 )
 def create_item(item: Item) -> Item:
     if not is_valid(item):
         raise ValidationException(
-            ValidationError(
+            ValidationErrorDetails(
                 message="Invalid item data",
                 field_errors=["name is required"]
             )
@@ -1035,33 +1044,18 @@ import { useMutation, useQuery } from '@tanstack/react-query';
 function ItemComponent() {
   const api = useMyApi();
 
-  // Query with typed error handling
-  const getItem = useQuery({
-    ...api.getItem.queryOptions({ itemId: '123' }),
-    onError: (error) => {
-      // Error is typed based on the responses in your FastAPI
-      switch (error.status) {
-        case 404:
-          // error.error is a string as specified in the responses
-          console.error('Not found:', error.error);
-          break;
-        case 500:
-          // error.error is typed as ErrorDetails
-          console.error('Server error:', error.error.message);
-          break;
-      }
-    }
-  });
+  const getItem = useQuery(api.getItem.queryOptions({ itemId: '123' }));
 
   // Mutation with typed error handling
   const createItem = useMutation({
     ...api.createItem.mutationOptions(),
     onError: (error) => {
+      // Error is typed based on the responses in your FastAPI
       switch (error.status) {
         case 400:
-          // error.error is typed as ValidationError
+          // error.error is typed as ValidationErrorDetails
           console.error('Validation error:', error.error.message);
-          console.error('Field errors:', error.error.field_errors);
+          console.error('Field errors:', error.error.fieldErrors);
           break;
         case 403:
           // error.error is a string as specified in the responses
@@ -1073,10 +1067,13 @@ function ItemComponent() {
 
   // Component rendering with error handling
   if (getItem.isError) {
-    if (getItem.error.status === 404) {
-      return <NotFoundMessage message={getItem.error.error} />;
-    } else {
-      return <ErrorMessage message={getItem.error.error.message} />;
+    switch (getItem.error.status) {
+      case 404:
+        // error.error is a string as specified in the responses
+        return <NotFoundMessage message={getItem.error.error} />;
+      case 500:
+        // error.error is typed as ErrorDetails
+        return <ErrorMessage message={getItem.error.error.message} />;
     }
   }
 
@@ -1137,9 +1134,9 @@ function ItemComponent() {
 
       switch (err.status) {
         case 400:
-          // err.error is typed as ValidationError
+          // err.error is typed as ValidationErrorDetails
           console.error('Validation error:', err.error.message);
-          console.error('Field errors:', err.error.field_errors);
+          console.error('Field errors:', err.error.fieldErrors);
           break;
         case 403:
           // err.error is a string as specified in the responses
@@ -1186,7 +1183,7 @@ import { useQuery } from '@tanstack/react-query';
 
 function ItemList() {
   const api = useMyApi();
-  const items = useQuery(api.listItems.queryOptions());
+  const items = useQuery(api.listItems.queryOptions({}));
 
   if (items.isLoading) {
     return <LoadingSpinner />;
@@ -1196,17 +1193,11 @@ function ItemList() {
     const err = items.error;
     switch (err.status) {
       case 403:
-        // err.error is typed as ListItems403Response
-        return <ErrorMessage message={err.error.reason} />;
+        // err.error is a string as specified in the responses
+        return <ErrorMessage message={err.error} />;
       case 500:
-      case 502:
-        // err.error is typed as ListItems5XXResponse
-        return (
-          <ErrorMessage
-            message={err.error.message}
-            details={`Trace ID: ${err.error.traceId}`}
-          />
-        );
+        // err.error is typed as ErrorDetails
+        return <ErrorMessage message={err.error.message} />;
       default:
         return <ErrorMessage message="An unknown error occurred" />;
     }
@@ -1214,7 +1205,7 @@ function ItemList() {
 
   return (
     <ul>
-      {items.data.map((item) => (
+      {items.data?.items.map((item) => (
         <li key={item.id}>{item.name}</li>
       ))}
     </ul>
@@ -1233,7 +1224,7 @@ function ItemList() {
   useEffect(() => {
     const fetchItems = async () => {
       try {
-        const data = await api.listItems();
+        const data = await api.listItems({});
         setItems(data);
       } catch (err) {
         setError(err);
@@ -1252,17 +1243,11 @@ function ItemList() {
     const err = error as ListItemsError;
     switch (err.status) {
       case 403:
-        // err.error is typed as ListItems403Response
-        return <ErrorMessage message={err.error.reason} />;
+        // err.error is a string as specified in the responses
+        return <ErrorMessage message={err.error} />;
       case 500:
-      case 502:
-        // err.error is typed as ListItems5XXResponse
-        return (
-          <ErrorMessage
-            message={err.error.message}
-            details={`Trace ID: ${err.error.traceId}`}
-          />
-        );
+        // err.error is typed as ErrorDetails
+        return <ErrorMessage message={err.error.message} />;
       default:
         return <ErrorMessage message="An unknown error occurred" />;
     }
@@ -1285,41 +1270,53 @@ Triển khai optimistic updates để có trải nghiệm người dùng tốt h
 
 ```tsx
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import type { ListItemsOutput } from '../generated/my-api/types.gen';
 
 function ItemList() {
   const api = useMyApi();
   const queryClient = useQueryClient();
 
   // Query to fetch items
-  const itemsQuery = useQuery(api.listItems.queryOptions());
+  const itemsQuery = useQuery(api.listItems.queryOptions({}));
 
   // Mutation for deleting items with optimistic updates
   const deleteMutation = useMutation({
     ...api.deleteItem.mutationOptions(),
-    onMutate: async (itemId) => {
+    onMutate: async ({ itemId }) => {
       // Cancel any outgoing refetches
-      await queryClient.cancelQueries({ queryKey: api.listItems.queryKey() });
+      await queryClient.cancelQueries({
+        queryKey: api.listItems.queryKey({}),
+      });
 
       // Snapshot the previous value
-      const previousItems = queryClient.getQueryData(api.listItems.queryKey());
+      const previousItems = queryClient.getQueryData<ListItemsOutput>(
+        api.listItems.queryKey({}),
+      );
 
       // Optimistically update to the new value
-      queryClient.setQueryData(
-        api.listItems.queryKey(),
-        (old) => old.filter((item) => item.id !== itemId)
+      queryClient.setQueryData<ListItemsOutput>(
+        api.listItems.queryKey({}),
+        (old) =>
+          old && {
+            ...old,
+            items: old.items.filter((item) => item.id !== itemId),
+          },
       );
 
       // Return a context object with the snapshot
       return { previousItems };
     },
-    onError: (err, itemId, context) => {
+    onError: (err, _input, context) => {
       // If the mutation fails, use the context returned from onMutate to roll back
-      queryClient.setQueryData(api.listItems.queryKey(), context.previousItems);
+      queryClient.setQueryData(
+        api.listItems.queryKey({}),
+        context?.previousItems,
+      );
       console.error('Failed to delete item:', err);
     },
     onSettled: () => {
       // Always refetch after error or success to ensure data is in sync with server
-      queryClient.invalidateQueries({ queryKey: api.listItems.queryKey() });
+      queryClient.invalidateQueries({ queryKey: api.listItems.queryKey({}) });
     },
   });
 
@@ -1333,11 +1330,11 @@ function ItemList() {
 
   return (
     <ul>
-      {itemsQuery.data.map((item) => (
+      {itemsQuery.data?.items.map((item) => (
         <li key={item.id}>
           {item.name}
           <button
-            onClick={() => deleteMutation.mutate(item.id)}
+            onClick={() => deleteMutation.mutate({ itemId: item.id })}
             disabled={deleteMutation.isPending}
           >
             {deleteMutation.isPending ? 'Deleting...' : 'Delete'}
@@ -1413,19 +1410,22 @@ function ItemForm() {
     const error = createItem.error;
     switch (error.status) {
       case 400:
-        // error.error is typed as CreateItem400Response
+        // error.error is typed as ValidationErrorDetails
         return (
           <FormError
             message="Invalid input"
-            errors={error.error.validationErrors}
+            errors={error.error.fieldErrors}
           />
         );
       case 403:
-        // error.error is typed as CreateItem403Response
-        return <AuthError reason={error.error.reason} />;
-      default:
-        // error.error is typed as CreateItem5XXResponse for 500, 502, etc.
+        // error.error is a string as specified in the responses
+        return <AuthError reason={error.error} />;
+      case 500:
+        // error.error is typed as ErrorDetails
         return <ServerError message={error.error.message} />;
+      default:
+        // FastAPI adds a 422 to every endpoint, so `default` isn't narrowed
+        return <ServerError message="An unknown error occurred" />;
     }
   }
 
@@ -1461,22 +1461,16 @@ function ItemForm() {
       const err = e as CreateItemError;
       switch (err.status) {
         case 400:
-          // err.error is typed as CreateItem400Response
-          console.error('Validation errors:', err.error.validationErrors);
+          // err.error is typed as ValidationErrorDetails
+          console.error('Validation errors:', err.error.fieldErrors);
           break;
         case 403:
-          // err.error is typed as CreateItem403Response
-          console.error('Not authorized:', err.error.reason);
+          // err.error is a string as specified in the responses
+          console.error('Not authorized:', err.error);
           break;
         case 500:
-        case 502:
-          // err.error is typed as CreateItem5XXResponse
-          console.error(
-            'Server error:',
-            err.error.message,
-            'Trace:',
-            err.error.traceId,
-          );
+          // err.error is typed as ErrorDetails
+          console.error('Server error:', err.error.message);
           break;
       }
       setError(err);
@@ -1490,13 +1484,15 @@ function ItemForm() {
         return (
           <FormError
             message="Invalid input"
-            errors={error.error.validationErrors}
+            errors={error.error.fieldErrors}
           />
         );
       case 403:
-        return <AuthError reason={error.error.reason} />;
-      default:
+        return <AuthError reason={error.error} />;
+      case 500:
         return <ServerError message={error.error.message} />;
+      default:
+        return <ServerError message="An unknown error occurred" />;
     }
   }
 

--- a/docs/src/content/docs/vi/guides/connection/react-smithy.mdx
+++ b/docs/src/content/docs/vi/guides/connection/react-smithy.mdx
@@ -245,7 +245,7 @@ const createItem = useMutation({
   onSettled: () => {
     // This will run when the mutation completes (success or error)
     // Good place to invalidate queries that might be affected
-    queryClient.invalidateQueries({ queryKey: api.listItems.queryKey() });
+    queryClient.invalidateQueries({ queryKey: api.listItems.queryKey({}) });
   }
 });
 ```
@@ -456,7 +456,9 @@ function ItemList() {
 
 ### Xử lý lỗi
 
-Tích hợp bao gồm xử lý lỗi tích hợp sẵn với các response lỗi được định kiểu. Một kiểu `<operation-name>Error` được tạo ra để đóng gói các response lỗi có thể xảy ra được định nghĩa trong Smithy model. Mỗi lỗi có thuộc tính `status` và `error`, và bằng cách kiểm tra giá trị của `status`, bạn có thể thu hẹp đến một loại lỗi cụ thể.
+Tích hợp bao gồm xử lý lỗi tích hợp sẵn với các response lỗi được định kiểu. Một kiểu `<OperationName>Error` được tạo ra là một union của một thành viên `<OperationName><StatusCode>Error` cho mỗi trạng thái lỗi mà operation mô hình hóa. Mỗi thành viên có thuộc tính `status` và `error`, vì vậy việc chuyển đổi trên `status` sẽ thu hẹp `error` thành payload của trạng thái đó.
+
+Ví dụ dưới đây giả định `CreateItem` mô hình hóa [các cấu trúc lỗi được định nghĩa ở phần dưới của trang này](#errors) — một `InvalidRequestError` `422`, một `UnauthorizedError` `403` và một `InternalServerError` `500`. Chỉ các trạng thái mà model của bạn khai báo mới xuất hiện trong union, vì vậy một `case` cho trạng thái bạn chưa mô hình hóa là một lỗi biên dịch.
 
 ```tsx {12}
 import { useMutation } from '@tanstack/react-query';
@@ -471,8 +473,8 @@ function MyComponent() {
 
   if (createItem.error) {
     switch (createItem.error.status) {
-      case 400:
-        // error.error is typed as CreateItem400Response
+      case 422:
+        // error.error is typed as InvalidRequestErrorResponseContent
         return (
           <div>
             <h2>Invalid input:</h2>
@@ -480,7 +482,7 @@ function MyComponent() {
           </div>
         );
       case 403:
-        // error.error is typed as CreateItem403Response
+        // error.error is typed as UnauthorizedErrorResponseContent
         return (
           <div>
             <h2>Not authorized:</h2>
@@ -488,8 +490,7 @@ function MyComponent() {
           </div>
         );
       case 500:
-      case 502:
-        // error.error is typed as CreateItem5XXResponse
+        // error.error is typed as InternalServerErrorResponseContent
         return (
           <div>
             <h2>Server error:</h2>
@@ -520,8 +521,8 @@ function MyComponent() {
 
   if (error) {
     switch (error.status) {
-      case 400:
-        // error.error is typed as CreateItem400Response
+      case 422:
+        // error.error is typed as InvalidRequestErrorResponseContent
         return (
           <div>
             <h2>Invalid input:</h2>
@@ -529,7 +530,7 @@ function MyComponent() {
           </div>
         );
       case 403:
-        // error.error is typed as CreateItem403Response
+        // error.error is typed as UnauthorizedErrorResponseContent
         return (
           <div>
             <h2>Not authorized:</h2>
@@ -537,8 +538,7 @@ function MyComponent() {
           </div>
         );
       case 500:
-      case 502:
-        // error.error is typed as CreateItem5XXResponse
+        // error.error is typed as InternalServerErrorResponseContent
         return (
           <div>
             <h2>Server error:</h2>
@@ -573,21 +573,21 @@ Chúng ánh xạ đến OpenAPI vendor extensions bằng cách sử dụng [`@sp
 
 #### @query
 
-Sau đó áp dụng trait `@query` cho Smithy operation của bạn để buộc nó được coi là query:
+Áp dụng trait `@query` cho Smithy operation của bạn để buộc nó được coi là query:
 
 ```smithy
-@http(method: "POST", uri: "/items")
+@http(method: "POST", uri: "/search-items")
 @query
-operation ListItems {
-    input: ListItemsInput
-    output: ListItemsOutput
+operation SearchItems {
+    input: SearchItemsInput
+    output: SearchItemsOutput
 }
 ```
 
 Hook được tạo ra sẽ cung cấp `queryOptions` ngay cả khi nó sử dụng phương thức HTTP `POST`:
 
 ```tsx
-const items = useQuery(api.listItems.queryOptions());
+const items = useQuery(api.searchItems.queryOptions({ term: 'widget' }));
 ```
 
 #### @mutation
@@ -607,6 +607,8 @@ Hook được tạo ra sẽ cung cấp `mutationOptions` ngay cả khi nó sử 
 
 ```tsx
 const startProcessing = useMutation(api.startProcessing.mutationOptions());
+
+startProcessing.mutate({ id: 'some-id' });
 ```
 
 ### Custom Pagination Cursor
@@ -616,38 +618,59 @@ Mặc định, các hook được tạo ra giả định phân trang dựa trên
 Áp dụng trait `@cursor` với `inputToken` để thay đổi tên của tham số đầu vào được sử dụng cho token phân trang:
 
 ```smithy
-@http(method: "GET", uri: "/items")
+@http(method: "GET", uri: "/paged-items")
 @cursor(inputToken: "nextToken")
-operation ListItems {
+operation ListPagedItems {
     input := {
+      @httpQuery("nextToken")
       nextToken: String
+      @httpQuery("limit")
       limit: Integer
     }
     output := {
+      @required
       items: ItemList
       nextToken: String
     }
 }
 ```
 
+`infiniteQueryOptions` sau đó phân trang trên `nextToken`:
+
+```tsx
+const items = useInfiniteQuery({
+  ...api.listPagedItems.infiniteQueryOptions(
+    { limit: 10 },
+    { getNextPageParam: (lastPage) => lastPage.nextToken || undefined },
+  ),
+});
+```
+
 Nếu bạn không muốn tạo `infiniteQueryOptions` cho một operation có tham số đầu vào có tên `cursor`, bạn có thể vô hiệu hóa phân trang dựa trên cursor:
 
 ```smithy
+@http(method: "GET", uri: "/unpaged-items")
 @cursor(enabled: false)
-operation ListItems {
+operation ListUnpagedItems {
     input := {
       // Input parameter named 'cursor' will cause this operation to be treated as a paginated operation by default
+      @httpQuery("cursor")
       cursor: String
     }
     output := {
-      ...
+      @required
+      items: ItemList
     }
 }
 ```
 
+`api.listUnpagedItems` sau đó chỉ cung cấp `queryOptions`, `queryKey` và `queryFilter`.
+
 ### Nhóm các Operation
 
 Các hook và phương thức client được tạo ra tự động được tổ chức dựa trên [`@tags` trait](https://smithy.io/2.0/spec/documentation-traits.html#tags-trait) trong các Smithy operation của bạn. Các operation có cùng tag được nhóm lại với nhau, điều này giúp giữ cho các lời gọi API của bạn được tổ chức và cung cấp hoàn thành mã tốt hơn trong IDE của bạn.
+
+Trong một nhóm, mỗi operation giữ tên camelCased riêng của nó, vì vậy một operation có tên `ListItems` được gắn thẻ `"items"` được truy cập tại `api.items.listItems` — không phải `api.items.list`.
 
 Ví dụ, với Smithy model này:
 
@@ -657,27 +680,51 @@ service MyService {
 }
 
 @tags(["items"])
+@http(method: "GET", uri: "/items")
+@readonly
 operation ListItems {
-    input: ListItemsInput
-    output: ListItemsOutput
+    input := {}
+    output := {
+      @required
+      items: ItemList
+    }
 }
 
 @tags(["items"])
+@http(method: "POST", uri: "/items")
 operation CreateItem {
-    input: CreateItemInput
-    output: CreateItemOutput
+    input := {
+      @required
+      name: String
+    }
+    output := {
+      @required
+      id: String
+    }
 }
 
 @tags(["users"])
+@http(method: "GET", uri: "/users")
+@readonly
 operation ListUsers {
-    input: ListUsersInput
-    output: ListUsersOutput
+    input := {}
+    output := {
+      @required
+      users: UserList
+    }
 }
 
 @tags(["users"])
+@http(method: "POST", uri: "/users")
 operation CreateUser {
-    input: CreateUserInput
-    output: CreateUserOutput
+    input := {
+      @required
+      name: String
+    }
+    output := {
+      @required
+      id: String
+    }
 }
 ```
 
@@ -706,7 +753,7 @@ function ItemsAndUsers() {
     <div>
       <h2>Items</h2>
       <ul>
-        {items.data?.map(item => (
+        {items.data?.items.map(item => (
           <li key={item.id}>{item.name}</li>
         ))}
       </ul>
@@ -714,7 +761,7 @@ function ItemsAndUsers() {
 
       <h2>Users</h2>
       <ul>
-        {users.data?.map(user => (
+        {users.data?.users.map(user => (
           <li key={user.id}>{user.name}</li>
         ))}
       </ul>
@@ -805,7 +852,7 @@ Bạn có thể tùy chỉnh các response lỗi trong Smithy API của mình b�
 
 ```smithy
 @error("client")
-@httpError(400)
+@httpError(422)
 structure InvalidRequestError {
     @required
     message: String
@@ -841,6 +888,10 @@ structure FieldError {
     message: String
 }
 ```
+
+:::caution[400 đã được sử dụng]
+Service của bạn đã khai báo `ValidationException` của Smithy trên `400`, vì vậy mọi operation đều có một trường hợp `400` mang `ValidationExceptionResponseContent`. Hãy đặt cho lỗi client của riêng bạn một trạng thái khác (`422` ở trên) — hai lỗi trên cùng một trạng thái sẽ xung đột và chỉ một payload đến được client được tạo ra.
+:::
 
 #### Thêm lỗi vào các Operation
 
@@ -884,37 +935,21 @@ import { useMutation, useQuery } from '@tanstack/react-query';
 function ItemComponent() {
   const api = useMyApi();
 
-  // Query with typed error handling
-  const getItem = useQuery({
-    ...api.getItem.queryOptions({ itemId: '123' }),
-    onError: (error) => {
-      // Error is typed based on the errors in your Smithy model
-      switch (error.status) {
-        case 404:
-          // error.error is typed as ItemNotFoundError
-          console.error('Not found:', error.error.message);
-          break;
-        case 500:
-          // error.error is typed as InternalServerError
-          console.error('Server error:', error.error.message);
-          console.error('Trace ID:', error.error.traceId);
-          break;
-      }
-    }
-  });
+  const getItem = useQuery(api.getItem.queryOptions({ itemId: '123' }));
 
   // Mutation with typed error handling
   const createItem = useMutation({
     ...api.createItem.mutationOptions(),
     onError: (error) => {
+      // Error is typed based on the errors in your Smithy model
       switch (error.status) {
-        case 400:
-          // error.error is typed as InvalidRequestError
+        case 422:
+          // error.error is typed as InvalidRequestErrorResponseContent
           console.error('Validation error:', error.error.message);
           console.error('Field errors:', error.error.fieldErrors);
           break;
         case 403:
-          // error.error is typed as UnauthorizedError
+          // error.error is typed as UnauthorizedErrorResponseContent
           console.error('Unauthorized:', error.error.reason);
           break;
       }
@@ -923,10 +958,13 @@ function ItemComponent() {
 
   // Component rendering with error handling
   if (getItem.isError) {
-    if (getItem.error.status === 404) {
-      return <NotFoundMessage message={getItem.error.error.message} />;
-    } else if (getItem.error.status === 500) {
-      return <ErrorMessage message={getItem.error.error.message} />;
+    switch (getItem.error.status) {
+      case 404:
+        // error.error is typed as ItemNotFoundErrorResponseContent
+        return <NotFoundMessage message={getItem.error.error.message} />;
+      case 500:
+        // error.error is typed as InternalServerErrorResponseContent
+        return <ErrorMessage message={getItem.error.error.message} />;
     }
   }
 
@@ -937,6 +975,10 @@ function ItemComponent() {
   );
 }
 ```
+
+:::note[Lỗi Query]
+TanStack Query v5 đã xóa `onError` khỏi `useQuery`, vì vậy lỗi query được xử lý bằng cách thu hẹp trên `error.status` nơi bạn render. `useMutation` vẫn nhận `onError`.
+:::
 
 <Drawer title="Xử lý lỗi tùy chỉnh với client trực tiếp" trigger="Nhấp vào đây để xem ví dụ sử dụng client trực tiếp.">
 ```tsx
@@ -962,11 +1004,11 @@ function ItemComponent() {
 
         switch (err.status) {
           case 404:
-            // err.error is typed as ItemNotFoundError
+            // err.error is typed as ItemNotFoundErrorResponseContent
             console.error('Not found:', err.error.message);
             break;
           case 500:
-            // err.error is typed as InternalServerError
+            // err.error is typed as InternalServerErrorResponseContent
             console.error('Server error:', err.error.message);
             console.error('Trace ID:', err.error.traceId);
             break;
@@ -987,13 +1029,13 @@ function ItemComponent() {
       const err = e as CreateItemError;
 
       switch (err.status) {
-        case 400:
-          // err.error is typed as InvalidRequestError
+        case 422:
+          // err.error is typed as InvalidRequestErrorResponseContent
           console.error('Validation error:', err.error.message);
           console.error('Field errors:', err.error.fieldErrors);
           break;
         case 403:
-          // err.error is typed as UnauthorizedError
+          // err.error is typed as UnauthorizedErrorResponseContent
           console.error('Unauthorized:', err.error.reason);
           break;
       }
@@ -1037,7 +1079,7 @@ import { useQuery } from '@tanstack/react-query';
 
 function ItemList() {
   const api = useMyApi();
-  const items = useQuery(api.listItems.queryOptions());
+  const items = useQuery(api.listItems.queryOptions({}));
 
   if (items.isLoading) {
     return <LoadingSpinner />;
@@ -1047,11 +1089,10 @@ function ItemList() {
     const err = items.error;
     switch (err.status) {
       case 403:
-        // err.error is typed as ListItems403Response
+        // err.error is typed as UnauthorizedErrorResponseContent
         return <ErrorMessage message={err.error.reason} />;
       case 500:
-      case 502:
-        // err.error is typed as ListItems5XXResponse
+        // err.error is typed as InternalServerErrorResponseContent
         return (
           <ErrorMessage
             message={err.error.message}
@@ -1064,7 +1105,7 @@ function ItemList() {
 
   return (
     <ul>
-      {items.data.map((item) => (
+      {items.data?.items.map((item) => (
         <li key={item.id}>{item.name}</li>
       ))}
     </ul>
@@ -1083,7 +1124,7 @@ function ItemList() {
   useEffect(() => {
     const fetchItems = async () => {
       try {
-        const data = await api.listItems();
+        const data = await api.listItems({});
         setItems(data);
       } catch (err) {
         setError(err);
@@ -1102,11 +1143,10 @@ function ItemList() {
     const err = error as ListItemsError;
     switch (err.status) {
       case 403:
-        // err.error is typed as ListItems403Response
+        // err.error is typed as UnauthorizedErrorResponseContent
         return <ErrorMessage message={err.error.reason} />;
       case 500:
-      case 502:
-        // err.error is typed as ListItems5XXResponse
+        // err.error is typed as InternalServerErrorResponseContent
         return (
           <ErrorMessage
             message={err.error.message}
@@ -1134,41 +1174,53 @@ Triển khai cập nhật lạc quan để có trải nghiệm người dùng t�
 
 ```tsx
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import type { ListItemsResponseContent } from '../generated/my-api/types.gen';
 
 function ItemList() {
   const api = useMyApi();
   const queryClient = useQueryClient();
 
   // Query to fetch items
-  const itemsQuery = useQuery(api.listItems.queryOptions());
+  const itemsQuery = useQuery(api.listItems.queryOptions({}));
 
   // Mutation for deleting items with optimistic updates
   const deleteMutation = useMutation({
     ...api.deleteItem.mutationOptions(),
-    onMutate: async (itemId) => {
+    onMutate: async ({ itemId }) => {
       // Cancel any outgoing refetches
-      await queryClient.cancelQueries({ queryKey: api.listItems.queryKey() });
+      await queryClient.cancelQueries({
+        queryKey: api.listItems.queryKey({}),
+      });
 
       // Snapshot the previous value
-      const previousItems = queryClient.getQueryData(api.listItems.queryKey());
+      const previousItems = queryClient.getQueryData<ListItemsResponseContent>(
+        api.listItems.queryKey({}),
+      );
 
       // Optimistically update to the new value
-      queryClient.setQueryData(
-        api.listItems.queryKey(),
-        (old) => old.filter((item) => item.id !== itemId)
+      queryClient.setQueryData<ListItemsResponseContent>(
+        api.listItems.queryKey({}),
+        (old) =>
+          old && {
+            ...old,
+            items: old.items.filter((item) => item.id !== itemId),
+          },
       );
 
       // Return a context object with the snapshot
       return { previousItems };
     },
-    onError: (err, itemId, context) => {
+    onError: (err, _input, context) => {
       // If the mutation fails, use the context returned from onMutate to roll back
-      queryClient.setQueryData(api.listItems.queryKey(), context.previousItems);
+      queryClient.setQueryData(
+        api.listItems.queryKey({}),
+        context?.previousItems,
+      );
       console.error('Failed to delete item:', err);
     },
     onSettled: () => {
       // Always refetch after error or success to ensure data is in sync with server
-      queryClient.invalidateQueries({ queryKey: api.listItems.queryKey() });
+      queryClient.invalidateQueries({ queryKey: api.listItems.queryKey({}) });
     },
   });
 
@@ -1182,11 +1234,11 @@ function ItemList() {
 
   return (
     <ul>
-      {itemsQuery.data.map((item) => (
+      {itemsQuery.data?.items.map((item) => (
         <li key={item.id}>
           {item.name}
           <button
-            onClick={() => deleteMutation.mutate(item.id)}
+            onClick={() => deleteMutation.mutate({ itemId: item.id })}
             disabled={deleteMutation.isPending}
           >
             {deleteMutation.isPending ? 'Deleting...' : 'Delete'}
@@ -1261,8 +1313,8 @@ function ItemForm() {
   if (createItem.error) {
     const error = createItem.error;
     switch (error.status) {
-      case 400:
-        // error.error is typed as InvalidRequestError
+      case 422:
+        // error.error is typed as InvalidRequestErrorResponseContent
         return (
           <FormError
             message="Invalid input"
@@ -1270,10 +1322,10 @@ function ItemForm() {
           />
         );
       case 403:
-        // error.error is typed as UnauthorizedError
+        // error.error is typed as UnauthorizedErrorResponseContent
         return <AuthError reason={error.error.reason} />;
       default:
-        // error.error is typed as InternalServerError for 500, etc.
+        // error.error is typed as InternalServerErrorResponseContent for 500, etc.
         return <ServerError message={error.error.message} />;
     }
   }
@@ -1309,16 +1361,16 @@ function ItemForm() {
       // ✅ Error type includes all possible error responses
       const err = e as CreateItemError;
       switch (err.status) {
-        case 400:
-          // err.error is typed as InvalidRequestError
+        case 422:
+          // err.error is typed as InvalidRequestErrorResponseContent
           console.error('Validation errors:', err.error.fieldErrors);
           break;
         case 403:
-          // err.error is typed as UnauthorizedError
+          // err.error is typed as UnauthorizedErrorResponseContent
           console.error('Not authorized:', err.error.reason);
           break;
         case 500:
-          // err.error is typed as InternalServerError
+          // err.error is typed as InternalServerErrorResponseContent
           console.error('Server error:', err.error.message);
           break;
       }
@@ -1329,7 +1381,7 @@ function ItemForm() {
   // Error UI can use type narrowing to handle different error types
   if (error) {
     switch (error.status) {
-      case 400:
+      case 422:
         return (
           <FormError
             message="Invalid input"
@@ -1353,3 +1405,4 @@ Các kiểu được tự động tạo từ schema OpenAPI của Smithy API, đ
 ## Xác thực tùy chỉnh
 
 Nếu Smithy API của bạn sử dụng xác thực `Custom` (Lambda Authorizer), bạn sẽ cần chỉnh sửa provider client được tạo ra để thêm các header ủy quyền mà authorizer của bạn mong đợi. Tìm cấu hình `fetch` trong `<ApiName>Provider.tsx` được tạo ra và thêm token hoặc API key của bạn vào các header yêu cầu.
+iName>Provider.tsx` được tạo ra và thêm token hoặc API key của bạn vào các header yêu cầu.

--- a/docs/src/content/docs/vi/guides/connection/react-trpc.mdx
+++ b/docs/src/content/docs/vi/guides/connection/react-trpc.mdx
@@ -417,11 +417,13 @@ function UserList() {
 Tích hợp này cung cấp type safety hoàn chỉnh từ đầu đến cuối. IDE của bạn sẽ cung cấp autocompletion và type checking đầy đủ cho tất cả các lời gọi API của bạn:
 
 ```tsx
+import { useMutation } from '@tanstack/react-query';
+
 function UserForm() {
   const trpc = useMyApi();
 
   // ✅ Input is fully typed
-  const createUser = trpc.users.create.useMutation();
+  const createUser = useMutation(trpc.users.create.mutationOptions());
 
   const handleSubmit = (data: CreateUserInput) => {
     // ✅ Type error if input doesn't match schema

--- a/docs/src/content/docs/zh/guides/connection/react-agui.mdx
+++ b/docs/src/content/docs/zh/guides/connection/react-agui.mdx
@@ -46,16 +46,17 @@ Nx Plugin for AWS 提供了一个生成器，用于将 React 网站连接到公�
 - src
   - components
     - AguiProvider.tsx 为每个 AG-UI agent 提供单一的 `CopilotKitProvider`。在第一次运行 `connection` 时创建，在后续运行时更新以注册每个新 agent。
+    - \<agent-name>-chat.tsx 绑定到此 agent id 的主题化 `<AgentName>Chat`。每次运行 `connection` 生成一个文件。
     - copilot
       - index.tsx 重新导出 `CopilotChat`、`CopilotSidebar` 和 `CopilotPopup`，并使用与您网站的 `ux`（Cloudscape、Shadcn 或无主题）匹配的插槽默认值。
       - *ThemeComponents*.tsx 每个插槽的主题组件（例如 `CloudscapeAssistantMessage.tsx`、`ShadcnChatInput.tsx`）。仅在 `ux` 为 `cloudscape` 或 `shadcn` 时提供。
   - hooks
-    - useAgui\<AgentName>.tsx 注册一个 AG-UI agent。每次运行 `connection` 生成一个文件。
+    - useAgui\<AgentName>.tsx 注册一个 AG-UI agent 并将其 id 导出为 `<AGENT_NAME>_ID`。每次运行 `connection` 生成一个文件。
     - useSigV4.tsx SigV4 签名（仅限 IAM）
 
 </FileTree>
 
-第二次为不同的 agent 运行 `connection` 会**添加一个新的 `useAgui<AgentName>.tsx` hook** 并更新 `AguiProvider.tsx` 以注册两个 hook——您对 provider 所做的任何自定义编辑都会被保留。`main.tsx` 保持其单一的 `<AguiProvider>` 包装器——您永远不会得到嵌套的 provider。
+第二次为不同的 agent 运行 `connection` 会**添加一个新的 `useAgui<AgentName>.tsx` hook 和 `<agent-name>-chat.tsx` 组件**并更新 `AguiProvider.tsx` 以注册两个 hook——您对 provider 所做的任何自定义编辑都会被保留。`main.tsx` 保持其单一的 `<AguiProvider>` 包装器——您永远不会得到嵌套的 provider。
 
 以下依赖项将添加到根 `package.json`：
 
@@ -119,17 +120,14 @@ Session ID 和 Thread ID 都由浏览器提供。要将每个用户限制为他�
 
 ### 添加聊天界面
 
-使用 `agentId` 实例化 CopilotKit 组件以选择要使用的 agent。该 id 是 agent 的名称——与您运行 <Link path="guides/ts-agent">`ts#agent`</Link> 或 <Link path="guides/py-agent">`py#agent`</Link> 生成器时选择的名称相同——您也可以在生成的 hook 文件中找到它（例如从 `packages/web/src/hooks/useAgui<AgentName>.tsx` 返回的键）。
-
-从生成的 `./components/copilot` 模块导入聊天组件，以便自动应用与您网站的 `ux` 匹配的主题：
+生成器为每个连接的 agent 提供一个 `<AgentName>Chat` 组件，该组件已绑定到该 agent 的 id 并主题化以匹配您网站的 `ux`。将其放置在 `<AguiProvider>` 包装器内的任何位置：
 
 ```tsx
-import { CopilotChat } from './components/copilot';
+import { StoryAgentChat } from './components/story-agent-chat';
 
 function ChatPage() {
   return (
-    <CopilotChat
-      agentId="agent"
+    <StoryAgentChat
       labels={{
         welcomeMessageText: 'How can I help you today?',
         chatInputPlaceholder: 'Ask me anything...',
@@ -139,15 +137,24 @@ function ChatPage() {
 }
 ```
 
+它转发除 `agentId` 之外的每个 `CopilotChat` prop，因此您可以传递给 `<CopilotChat />` 的任何内容在这里也适用。
+
 ### 连接多个 AG-UI Agent
 
-每个 agent 运行一次 `connection` 生成器。通过共享的 `AguiProvider` 注册的每个 agent 在应用程序的任何位置都可见——使用不同的 `agentId` 实例化 CopilotKit 组件，以将每个聊天路由到您想要的 agent：
+每个 agent 运行一次 `connection` 生成器。每次运行都会提供该 agent 自己的聊天组件，因此将聊天路由到特定 agent 只需渲染相应的组件：
 
 ```tsx
-import { CopilotChat } from './components/copilot';
+import { StoryAgentChat } from './components/story-agent-chat';
+import { ResearchAgentChat } from './components/research-agent-chat';
 
-<CopilotChat agentId="story" />    {/* talks to StoryAgent */}
-<CopilotChat agentId="research" /> {/* talks to ResearchAgent */}
+<StoryAgentChat />    {/* talks to StoryAgent */}
+<ResearchAgentChat /> {/* talks to ResearchAgent */}
+```
+
+如果您需要原始 id——例如调用 CopilotKit 自己的 hook——每个生成的 hook 都会导出它：
+
+```tsx
+import { STORY_AGENT_ID } from './hooks/useAguiStoryAgent';
 ```
 
 ## 自定义外观和感觉
@@ -164,12 +171,13 @@ import { CopilotChat } from './components/copilot';
 | `shadcn` | 助手消息在 `bg-muted` 气泡中渲染，带有 `Sparkles` 头像；用户消息在 `bg-primary` 气泡中右对齐渲染，带有 `User` 头像。输入是圆角 `Textarea` + 药丸形状的发送/停止 `Button`（Enter 提交，Shift+Enter 换行）。使用来自共享 `common-shadcn` 包的 shadcn 原语。 |
 | `none`（或其他任何值） | 无主题——模块只是重新导出默认的 CopilotKit 组件。 |
 
-从**本地主题模块**导入主题组件（而不是直接从 `@copilotkit/react-core/v2` 导入），以便自动应用主题：
+提供的 `<AgentName>Chat` 组件已经主题化。对于您自己连接的聊天，从**本地主题模块**导入（而不是直接从 `@copilotkit/react-core/v2` 导入），以便自动应用主题：
 
 ```tsx
 import { CopilotChat } from './components/copilot';
+import { STORY_AGENT_ID } from './hooks/useAguiStoryAgent';
 
-<CopilotChat agentId="agent" />
+<CopilotChat agentId={STORY_AGENT_ID} />
 ```
 
 主题作为插槽默认值应用，因此您显式传递的任何插槽仍然优先——每当您需要一次性覆盖时，您都可以保持完全控制。
@@ -188,8 +196,7 @@ import { CopilotChat } from './components/copilot';
 每个聊天的覆盖仍然可以与主题一起工作——您作为插槽 prop 传递的任何内容都会覆盖主题默认值：
 
 ```tsx
-<CopilotChat
-  agentId="agent"
+<StoryAgentChat
   // style the input and its children
   input={{
     textArea: 'text-blue-600',
@@ -208,25 +215,23 @@ import { CopilotChat } from './components/copilot';
 任何插槽都可以接受 React 组件而不是 className，因此您可以完全替换默认值：
 
 ```tsx
-import { CopilotChat } from './components/copilot';
+import { StoryAgentChat } from './components/story-agent-chat';
 
-const MySendButton: React.FC<{ onClick: () => void }> = ({ onClick }) => (
+const MySendButton: React.FC<React.ButtonHTMLAttributes<HTMLButtonElement>> = ({
+  onClick,
+}) => (
   <button onClick={onClick} className="my-send-btn">
     Send
   </button>
 );
 
-<CopilotChat
-  agentId="agent"
-  input={{ sendButton: MySendButton }}
-/>;
+<StoryAgentChat input={{ sendButton: MySendButton }} />;
 ```
 
 更深层次的覆盖遵循相同的形状——例如，仅替换助手消息上的复制按钮：
 
 ```tsx
-<CopilotChat
-  agentId="agent"
+<StoryAgentChat
   messageView={{
     assistantMessage: {
       copyButton: ({ onClick }) => <button onClick={onClick}>Copy</button>,

--- a/docs/src/content/docs/zh/guides/connection/react-fastapi.mdx
+++ b/docs/src/content/docs/zh/guides/connection/react-fastapi.mdx
@@ -248,7 +248,7 @@ const createItem = useMutation({
   onSettled: () => {
     // This will run when the mutation completes (success or error)
     // Good place to invalidate queries that might be affected
-    queryClient.invalidateQueries({ queryKey: api.listItems.queryKey() });
+    queryClient.invalidateQueries({ queryKey: api.listItems.queryKey({}) });
   }
 });
 ```
@@ -495,7 +495,9 @@ function ItemList() {
 
 ### 错误处理
 
-集成包括内置的错误处理和类型化的错误响应。生成一个 `<operation-name>Error` 类型，它封装了 OpenAPI 规范中定义的可能的错误响应。每个错误都有一个 `status` 和 `error` 属性，通过检查 `status` 的值，您可以缩小到特定类型的错误。
+集成包括内置的错误处理和类型化的错误响应。生成一个 `<OperationName>Error` 类型，它是一个联合类型，每个错误状态对应一个 `<OperationName><StatusCode>Error` 成员，这些错误状态是操作的 `responses` 声明的。每个成员都有一个 `status` 和一个 `error` 属性，因此通过切换 `status` 可以将 `error` 缩小到该状态的模型。
+
+下面的示例假设 `create_item` 声明了[本页进一步定义的 `responses`](#指定响应模型) — 一个 `400` `ValidationErrorDetails`、一个 `403` `str` 和一个 `500` `ErrorDetails`。只有您声明的状态才会出现在联合类型中（加上 FastAPI 自己的 `422`），因此对于您未声明的状态的 `case` 是编译错误。
 
 ```tsx {12}
 import { useMutation } from '@tanstack/react-query';
@@ -511,34 +513,32 @@ function MyComponent() {
   if (createItem.error) {
     switch (createItem.error.status) {
       case 400:
-        // error.error is typed as CreateItem400Response
+        // error.error is typed as ValidationErrorDetails
         return (
           <div>
             <h2>Invalid input:</h2>
             <p>{createItem.error.error.message}</p>
             <ul>
-              {createItem.error.error.validationErrors.map((err) => (
-                <li key={err.field}>{err.message}</li>
+              {createItem.error.error.fieldErrors.map((err) => (
+                <li key={err}>{err}</li>
               ))}
             </ul>
           </div>
         );
       case 403:
-        // error.error is typed as CreateItem403Response
+        // error.error is a string as specified in the responses
         return (
           <div>
             <h2>Not authorized:</h2>
-            <p>{createItem.error.error.reason}</p>
+            <p>{createItem.error.error}</p>
           </div>
         );
       case 500:
-      case 502:
-        // error.error is typed as CreateItem5XXResponse
+        // error.error is typed as ErrorDetails
         return (
           <div>
             <h2>Server error:</h2>
             <p>{createItem.error.error.message}</p>
-            <p>Trace ID: {createItem.error.error.traceId}</p>
           </div>
         );
     }
@@ -547,6 +547,10 @@ function MyComponent() {
   return <button onClick={handleClick}>Create Item</button>;
 }
 ```
+
+:::note[Python 字段名称]
+生成的客户端将模型字段转换为驼峰命名，因此声明 `field_errors` 的 Pydantic 模型被读取为 `error.fieldErrors`。
+:::
 
 <Drawer title="直接使用 API 客户端进行错误处理" trigger="点击此处查看直接使用原生客户端的示例。">
 ```tsx {9,15}
@@ -566,34 +570,32 @@ function MyComponent() {
   if (error) {
     switch (error.status) {
       case 400:
-        // error.error is typed as CreateItem400Response
+        // error.error is typed as ValidationErrorDetails
         return (
           <div>
             <h2>Invalid input:</h2>
             <p>{error.error.message}</p>
             <ul>
-              {error.error.validationErrors.map((err) => (
-                <li key={err.field}>{err.message}</li>
+              {error.error.fieldErrors.map((err) => (
+                <li key={err}>{err}</li>
               ))}
             </ul>
           </div>
         );
       case 403:
-        // error.error is typed as CreateItem403Response
+        // error.error is a string as specified in the responses
         return (
           <div>
             <h2>Not authorized:</h2>
-            <p>{error.error.reason}</p>
+            <p>{error.error}</p>
           </div>
         );
       case 500:
-      case 502:
-        // error.error is typed as CreateItem5XXResponse
+        // error.error is typed as ErrorDetails
         return (
           <div>
             <h2>Server error:</h2>
             <p>{error.error.message}</p>
-            <p>Trace ID: {error.error.traceId}</p>
           </div>
         );
     }
@@ -784,6 +786,8 @@ def list_items(page: int = 1, limit: int = 10):
 
 生成的钩子和客户端方法会根据 FastAPI 端点中的 OpenAPI 标签自动组织。这有助于保持 API 调用的组织性，并使查找相关操作更容易。
 
+在组内，每个操作保持其自己的驼峰命名，取自端点函数的名称 — 因此标记为 `"items"` 的 `def list_items()` 可以在 `api.items.listItems` 访问。
+
 例如：
 
 ```python title="items.py"
@@ -791,7 +795,7 @@ def list_items(page: int = 1, limit: int = 10):
     "/items",
     tags=["items"],
 )
-def list():
+def list(cursor: str | None = None):
     # ...
 
 @app.post(
@@ -811,6 +815,10 @@ def list():
     # ...
 ```
 
+:::tip[重复的函数名称]
+不同标签中名为 `list` 的两个端点不会冲突 — 生成器用其标签限定重复的名称，因此两者都可以在 `api.items.list` 和 `api.users.list` 访问。
+:::
+
 生成的钩子将按这些标签分组：
 
 ```tsx
@@ -821,7 +829,7 @@ function ItemsAndUsers() {
   const api = useMyApi();
 
   // Items operations are grouped under api.items
-  const items = useQuery(api.items.list.queryOptions());
+  const items = useQuery(api.items.list.queryOptions({}));
   const createItem = useMutation(api.items.create.mutationOptions());
 
   // Users operations are grouped under api.users
@@ -873,7 +881,7 @@ function ItemsAndUsers() {
         setIsLoading(true);
 
         // Items operations are grouped under api.items
-        const itemsData = await api.items.list();
+        const itemsData = await api.items.list({});
         setItems(itemsData);
 
         // Users operations are grouped under api.users
@@ -943,7 +951,7 @@ from pydantic import BaseModel
 class ErrorDetails(BaseModel):
     message: str
 
-class ValidationError(BaseModel):
+class ValidationErrorDetails(BaseModel):
     message: str
     field_errors: list[str]
 ```
@@ -958,7 +966,7 @@ class NotFoundException(Exception):
         self.message = message
 
 class ValidationException(Exception):
-    def __init__(self, details: ValidationError):
+    def __init__(self, details: ValidationErrorDetails):
         self.details = details
 ```
 
@@ -997,8 +1005,8 @@ async def validation_error_handler(request: Request, exc: ValidationException):
 @app.get(
     "/items/{item_id}",
     responses={
-        404: {"model": str}
-        500: {"model": ErrorDetails}
+        404: {"model": str},
+        500: {"model": ErrorDetails},
     }
 )
 def get_item(item_id: str) -> Item:
@@ -1010,14 +1018,15 @@ def get_item(item_id: str) -> Item:
 @app.post(
     "/items",
     responses={
-        400: {"model": ValidationError},
-        403: {"model": str}
+        400: {"model": ValidationErrorDetails},
+        403: {"model": str},
+        500: {"model": ErrorDetails},
     }
 )
 def create_item(item: Item) -> Item:
     if not is_valid(item):
         raise ValidationException(
-            ValidationError(
+            ValidationErrorDetails(
                 message="Invalid item data",
                 field_errors=["name is required"]
             )
@@ -1035,33 +1044,18 @@ import { useMutation, useQuery } from '@tanstack/react-query';
 function ItemComponent() {
   const api = useMyApi();
 
-  // Query with typed error handling
-  const getItem = useQuery({
-    ...api.getItem.queryOptions({ itemId: '123' }),
-    onError: (error) => {
-      // Error is typed based on the responses in your FastAPI
-      switch (error.status) {
-        case 404:
-          // error.error is a string as specified in the responses
-          console.error('Not found:', error.error);
-          break;
-        case 500:
-          // error.error is typed as ErrorDetails
-          console.error('Server error:', error.error.message);
-          break;
-      }
-    }
-  });
+  const getItem = useQuery(api.getItem.queryOptions({ itemId: '123' }));
 
   // Mutation with typed error handling
   const createItem = useMutation({
     ...api.createItem.mutationOptions(),
     onError: (error) => {
+      // Error is typed based on the responses in your FastAPI
       switch (error.status) {
         case 400:
-          // error.error is typed as ValidationError
+          // error.error is typed as ValidationErrorDetails
           console.error('Validation error:', error.error.message);
-          console.error('Field errors:', error.error.field_errors);
+          console.error('Field errors:', error.error.fieldErrors);
           break;
         case 403:
           // error.error is a string as specified in the responses
@@ -1073,10 +1067,13 @@ function ItemComponent() {
 
   // Component rendering with error handling
   if (getItem.isError) {
-    if (getItem.error.status === 404) {
-      return <NotFoundMessage message={getItem.error.error} />;
-    } else {
-      return <ErrorMessage message={getItem.error.error.message} />;
+    switch (getItem.error.status) {
+      case 404:
+        // error.error is a string as specified in the responses
+        return <NotFoundMessage message={getItem.error.error} />;
+      case 500:
+        // error.error is typed as ErrorDetails
+        return <ErrorMessage message={getItem.error.error.message} />;
     }
   }
 
@@ -1137,9 +1134,9 @@ function ItemComponent() {
 
       switch (err.status) {
         case 400:
-          // err.error is typed as ValidationError
+          // err.error is typed as ValidationErrorDetails
           console.error('Validation error:', err.error.message);
-          console.error('Field errors:', err.error.field_errors);
+          console.error('Field errors:', err.error.fieldErrors);
           break;
         case 403:
           // err.error is a string as specified in the responses
@@ -1186,7 +1183,7 @@ import { useQuery } from '@tanstack/react-query';
 
 function ItemList() {
   const api = useMyApi();
-  const items = useQuery(api.listItems.queryOptions());
+  const items = useQuery(api.listItems.queryOptions({}));
 
   if (items.isLoading) {
     return <LoadingSpinner />;
@@ -1196,17 +1193,11 @@ function ItemList() {
     const err = items.error;
     switch (err.status) {
       case 403:
-        // err.error is typed as ListItems403Response
-        return <ErrorMessage message={err.error.reason} />;
+        // err.error is a string as specified in the responses
+        return <ErrorMessage message={err.error} />;
       case 500:
-      case 502:
-        // err.error is typed as ListItems5XXResponse
-        return (
-          <ErrorMessage
-            message={err.error.message}
-            details={`Trace ID: ${err.error.traceId}`}
-          />
-        );
+        // err.error is typed as ErrorDetails
+        return <ErrorMessage message={err.error.message} />;
       default:
         return <ErrorMessage message="An unknown error occurred" />;
     }
@@ -1214,7 +1205,7 @@ function ItemList() {
 
   return (
     <ul>
-      {items.data.map((item) => (
+      {items.data?.items.map((item) => (
         <li key={item.id}>{item.name}</li>
       ))}
     </ul>
@@ -1233,7 +1224,7 @@ function ItemList() {
   useEffect(() => {
     const fetchItems = async () => {
       try {
-        const data = await api.listItems();
+        const data = await api.listItems({});
         setItems(data);
       } catch (err) {
         setError(err);
@@ -1252,17 +1243,11 @@ function ItemList() {
     const err = error as ListItemsError;
     switch (err.status) {
       case 403:
-        // err.error is typed as ListItems403Response
-        return <ErrorMessage message={err.error.reason} />;
+        // err.error is a string as specified in the responses
+        return <ErrorMessage message={err.error} />;
       case 500:
-      case 502:
-        // err.error is typed as ListItems5XXResponse
-        return (
-          <ErrorMessage
-            message={err.error.message}
-            details={`Trace ID: ${err.error.traceId}`}
-          />
-        );
+        // err.error is typed as ErrorDetails
+        return <ErrorMessage message={err.error.message} />;
       default:
         return <ErrorMessage message="An unknown error occurred" />;
     }
@@ -1285,41 +1270,53 @@ function ItemList() {
 
 ```tsx
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import type { ListItemsOutput } from '../generated/my-api/types.gen';
 
 function ItemList() {
   const api = useMyApi();
   const queryClient = useQueryClient();
 
   // Query to fetch items
-  const itemsQuery = useQuery(api.listItems.queryOptions());
+  const itemsQuery = useQuery(api.listItems.queryOptions({}));
 
   // Mutation for deleting items with optimistic updates
   const deleteMutation = useMutation({
     ...api.deleteItem.mutationOptions(),
-    onMutate: async (itemId) => {
+    onMutate: async ({ itemId }) => {
       // Cancel any outgoing refetches
-      await queryClient.cancelQueries({ queryKey: api.listItems.queryKey() });
+      await queryClient.cancelQueries({
+        queryKey: api.listItems.queryKey({}),
+      });
 
       // Snapshot the previous value
-      const previousItems = queryClient.getQueryData(api.listItems.queryKey());
+      const previousItems = queryClient.getQueryData<ListItemsOutput>(
+        api.listItems.queryKey({}),
+      );
 
       // Optimistically update to the new value
-      queryClient.setQueryData(
-        api.listItems.queryKey(),
-        (old) => old.filter((item) => item.id !== itemId)
+      queryClient.setQueryData<ListItemsOutput>(
+        api.listItems.queryKey({}),
+        (old) =>
+          old && {
+            ...old,
+            items: old.items.filter((item) => item.id !== itemId),
+          },
       );
 
       // Return a context object with the snapshot
       return { previousItems };
     },
-    onError: (err, itemId, context) => {
+    onError: (err, _input, context) => {
       // If the mutation fails, use the context returned from onMutate to roll back
-      queryClient.setQueryData(api.listItems.queryKey(), context.previousItems);
+      queryClient.setQueryData(
+        api.listItems.queryKey({}),
+        context?.previousItems,
+      );
       console.error('Failed to delete item:', err);
     },
     onSettled: () => {
       // Always refetch after error or success to ensure data is in sync with server
-      queryClient.invalidateQueries({ queryKey: api.listItems.queryKey() });
+      queryClient.invalidateQueries({ queryKey: api.listItems.queryKey({}) });
     },
   });
 
@@ -1333,11 +1330,11 @@ function ItemList() {
 
   return (
     <ul>
-      {itemsQuery.data.map((item) => (
+      {itemsQuery.data?.items.map((item) => (
         <li key={item.id}>
           {item.name}
           <button
-            onClick={() => deleteMutation.mutate(item.id)}
+            onClick={() => deleteMutation.mutate({ itemId: item.id })}
             disabled={deleteMutation.isPending}
           >
             {deleteMutation.isPending ? 'Deleting...' : 'Delete'}
@@ -1413,19 +1410,22 @@ function ItemForm() {
     const error = createItem.error;
     switch (error.status) {
       case 400:
-        // error.error is typed as CreateItem400Response
+        // error.error is typed as ValidationErrorDetails
         return (
           <FormError
             message="Invalid input"
-            errors={error.error.validationErrors}
+            errors={error.error.fieldErrors}
           />
         );
       case 403:
-        // error.error is typed as CreateItem403Response
-        return <AuthError reason={error.error.reason} />;
-      default:
-        // error.error is typed as CreateItem5XXResponse for 500, 502, etc.
+        // error.error is a string as specified in the responses
+        return <AuthError reason={error.error} />;
+      case 500:
+        // error.error is typed as ErrorDetails
         return <ServerError message={error.error.message} />;
+      default:
+        // FastAPI adds a 422 to every endpoint, so `default` isn't narrowed
+        return <ServerError message="An unknown error occurred" />;
     }
   }
 
@@ -1461,22 +1461,16 @@ function ItemForm() {
       const err = e as CreateItemError;
       switch (err.status) {
         case 400:
-          // err.error is typed as CreateItem400Response
-          console.error('Validation errors:', err.error.validationErrors);
+          // err.error is typed as ValidationErrorDetails
+          console.error('Validation errors:', err.error.fieldErrors);
           break;
         case 403:
-          // err.error is typed as CreateItem403Response
-          console.error('Not authorized:', err.error.reason);
+          // err.error is a string as specified in the responses
+          console.error('Not authorized:', err.error);
           break;
         case 500:
-        case 502:
-          // err.error is typed as CreateItem5XXResponse
-          console.error(
-            'Server error:',
-            err.error.message,
-            'Trace:',
-            err.error.traceId,
-          );
+          // err.error is typed as ErrorDetails
+          console.error('Server error:', err.error.message);
           break;
       }
       setError(err);
@@ -1490,13 +1484,15 @@ function ItemForm() {
         return (
           <FormError
             message="Invalid input"
-            errors={error.error.validationErrors}
+            errors={error.error.fieldErrors}
           />
         );
       case 403:
-        return <AuthError reason={error.error.reason} />;
-      default:
+        return <AuthError reason={error.error} />;
+      case 500:
         return <ServerError message={error.error.message} />;
+      default:
+        return <ServerError message="An unknown error occurred" />;
     }
   }
 

--- a/docs/src/content/docs/zh/guides/connection/react-smithy.mdx
+++ b/docs/src/content/docs/zh/guides/connection/react-smithy.mdx
@@ -245,7 +245,7 @@ const createItem = useMutation({
   onSettled: () => {
     // This will run when the mutation completes (success or error)
     // Good place to invalidate queries that might be affected
-    queryClient.invalidateQueries({ queryKey: api.listItems.queryKey() });
+    queryClient.invalidateQueries({ queryKey: api.listItems.queryKey({}) });
   }
 });
 ```
@@ -456,7 +456,9 @@ function ItemList() {
 
 ### 错误处理
 
-集成包括内置的错误处理和类型化的错误响应。生成一个 `<operation-name>Error` 类型，它封装了 Smithy 模型中定义的可能的错误响应。每个错误都有一个 `status` 和 `error` 属性，通过检查 `status` 的值，您可以缩小到特定类型的错误。
+集成包括内置的错误处理和类型化的错误响应。生成一个 `<OperationName>Error` 类型，它是一个联合类型，每个操作建模的错误状态都有一个 `<OperationName><StatusCode>Error` 成员。每个成员都有一个 `status` 和一个 `error` 属性，因此对 `status` 进行切换会将 `error` 缩小到该状态的有效负载。
+
+下面的示例假设 `CreateItem` 建模了[本页面下方定义的错误结构](#errors) — 一个 `422` `InvalidRequestError`、一个 `403` `UnauthorizedError` 和一个 `500` `InternalServerError`。只有您的模型声明的状态才会出现在联合类型中，因此对您未建模的状态使用 `case` 会导致编译错误。
 
 ```tsx {12}
 import { useMutation } from '@tanstack/react-query';
@@ -471,8 +473,8 @@ function MyComponent() {
 
   if (createItem.error) {
     switch (createItem.error.status) {
-      case 400:
-        // error.error is typed as CreateItem400Response
+      case 422:
+        // error.error is typed as InvalidRequestErrorResponseContent
         return (
           <div>
             <h2>Invalid input:</h2>
@@ -480,7 +482,7 @@ function MyComponent() {
           </div>
         );
       case 403:
-        // error.error is typed as CreateItem403Response
+        // error.error is typed as UnauthorizedErrorResponseContent
         return (
           <div>
             <h2>Not authorized:</h2>
@@ -488,8 +490,7 @@ function MyComponent() {
           </div>
         );
       case 500:
-      case 502:
-        // error.error is typed as CreateItem5XXResponse
+        // error.error is typed as InternalServerErrorResponseContent
         return (
           <div>
             <h2>Server error:</h2>
@@ -520,8 +521,8 @@ function MyComponent() {
 
   if (error) {
     switch (error.status) {
-      case 400:
-        // error.error is typed as CreateItem400Response
+      case 422:
+        // error.error is typed as InvalidRequestErrorResponseContent
         return (
           <div>
             <h2>Invalid input:</h2>
@@ -529,7 +530,7 @@ function MyComponent() {
           </div>
         );
       case 403:
-        // error.error is typed as CreateItem403Response
+        // error.error is typed as UnauthorizedErrorResponseContent
         return (
           <div>
             <h2>Not authorized:</h2>
@@ -537,8 +538,7 @@ function MyComponent() {
           </div>
         );
       case 500:
-      case 502:
-        // error.error is typed as CreateItem5XXResponse
+        // error.error is typed as InternalServerErrorResponseContent
         return (
           <div>
             <h2>Server error:</h2>
@@ -573,21 +573,21 @@ function MyComponent() {
 
 #### @query
 
-然后将 `@query` trait 应用于您的 Smithy 操作，以强制将其视为查询：
+将 `@query` trait 应用于您的 Smithy 操作，以强制将其视为查询：
 
 ```smithy
-@http(method: "POST", uri: "/items")
+@http(method: "POST", uri: "/search-items")
 @query
-operation ListItems {
-    input: ListItemsInput
-    output: ListItemsOutput
+operation SearchItems {
+    input: SearchItemsInput
+    output: SearchItemsOutput
 }
 ```
 
 生成的 hook 将提供 `queryOptions`，即使它使用 `POST` HTTP 方法：
 
 ```tsx
-const items = useQuery(api.listItems.queryOptions());
+const items = useQuery(api.searchItems.queryOptions({ term: 'widget' }));
 ```
 
 #### @mutation
@@ -607,6 +607,8 @@ operation StartProcessing {
 
 ```tsx
 const startProcessing = useMutation(api.startProcessing.mutationOptions());
+
+startProcessing.mutate({ id: 'some-id' });
 ```
 
 ### 自定义分页游标
@@ -616,38 +618,59 @@ const startProcessing = useMutation(api.startProcessing.mutationOptions());
 将 `@cursor` trait 与 `inputToken` 一起应用，以更改用于分页令牌的输入参数的名称：
 
 ```smithy
-@http(method: "GET", uri: "/items")
+@http(method: "GET", uri: "/paged-items")
 @cursor(inputToken: "nextToken")
-operation ListItems {
+operation ListPagedItems {
     input := {
+      @httpQuery("nextToken")
       nextToken: String
+      @httpQuery("limit")
       limit: Integer
     }
     output := {
+      @required
       items: ItemList
       nextToken: String
     }
 }
 ```
 
+`infiniteQueryOptions` 然后在 `nextToken` 上进行分页：
+
+```tsx
+const items = useInfiniteQuery({
+  ...api.listPagedItems.infiniteQueryOptions(
+    { limit: 10 },
+    { getNextPageParam: (lastPage) => lastPage.nextToken || undefined },
+  ),
+});
+```
+
 如果您不想为具有名为 `cursor` 的输入参数的操作生成 `infiniteQueryOptions`，可以禁用基于游标的分页：
 
 ```smithy
+@http(method: "GET", uri: "/unpaged-items")
 @cursor(enabled: false)
-operation ListItems {
+operation ListUnpagedItems {
     input := {
       // Input parameter named 'cursor' will cause this operation to be treated as a paginated operation by default
+      @httpQuery("cursor")
       cursor: String
     }
     output := {
-      ...
+      @required
+      items: ItemList
     }
 }
 ```
 
+`api.listUnpagedItems` 然后只提供 `queryOptions`、`queryKey` 和 `queryFilter`。
+
 ### 分组操作
 
 生成的 hooks 和客户端方法会根据 Smithy 操作中的 [`@tags` trait](https://smithy.io/2.0/spec/documentation-traits.html#tags-trait) 自动组织。具有相同标签的操作被分组在一起，这有助于保持 API 调用的组织性，并在 IDE 中提供更好的代码补全。
+
+在一个组内，每个操作都保留自己的驼峰式名称，因此标记为 `"items"` 的名为 `ListItems` 的操作位于 `api.items.listItems` — 而不是 `api.items.list`。
 
 例如，使用此 Smithy 模型：
 
@@ -657,27 +680,51 @@ service MyService {
 }
 
 @tags(["items"])
+@http(method: "GET", uri: "/items")
+@readonly
 operation ListItems {
-    input: ListItemsInput
-    output: ListItemsOutput
+    input := {}
+    output := {
+      @required
+      items: ItemList
+    }
 }
 
 @tags(["items"])
+@http(method: "POST", uri: "/items")
 operation CreateItem {
-    input: CreateItemInput
-    output: CreateItemOutput
+    input := {
+      @required
+      name: String
+    }
+    output := {
+      @required
+      id: String
+    }
 }
 
 @tags(["users"])
+@http(method: "GET", uri: "/users")
+@readonly
 operation ListUsers {
-    input: ListUsersInput
-    output: ListUsersOutput
+    input := {}
+    output := {
+      @required
+      users: UserList
+    }
 }
 
 @tags(["users"])
+@http(method: "POST", uri: "/users")
 operation CreateUser {
-    input: CreateUserInput
-    output: CreateUserOutput
+    input := {
+      @required
+      name: String
+    }
+    output := {
+      @required
+      id: String
+    }
 }
 ```
 
@@ -706,7 +753,7 @@ function ItemsAndUsers() {
     <div>
       <h2>Items</h2>
       <ul>
-        {items.data?.map(item => (
+        {items.data?.items.map(item => (
           <li key={item.id}>{item.name}</li>
         ))}
       </ul>
@@ -714,7 +761,7 @@ function ItemsAndUsers() {
 
       <h2>Users</h2>
       <ul>
-        {users.data?.map(user => (
+        {users.data?.users.map(user => (
           <li key={user.id}>{user.name}</li>
         ))}
       </ul>
@@ -805,7 +852,7 @@ function ItemsAndUsers() {
 
 ```smithy
 @error("client")
-@httpError(400)
+@httpError(422)
 structure InvalidRequestError {
     @required
     message: String
@@ -841,6 +888,10 @@ structure FieldError {
     message: String
 }
 ```
+
+:::caution[400 已被占用]
+您的服务已经在 `400` 上声明了 Smithy 的 `ValidationException`，因此每个操作都会获得一个携带 `ValidationExceptionResponseContent` 的 `400` case。给您自己的客户端错误一个不同的状态（上面的 `422`）— 同一状态上的两个错误会发生冲突，只有一个有效负载会到达生成的客户端。
+:::
 
 #### 向操作添加错误
 
@@ -884,37 +935,21 @@ import { useMutation, useQuery } from '@tanstack/react-query';
 function ItemComponent() {
   const api = useMyApi();
 
-  // Query with typed error handling
-  const getItem = useQuery({
-    ...api.getItem.queryOptions({ itemId: '123' }),
-    onError: (error) => {
-      // Error is typed based on the errors in your Smithy model
-      switch (error.status) {
-        case 404:
-          // error.error is typed as ItemNotFoundError
-          console.error('Not found:', error.error.message);
-          break;
-        case 500:
-          // error.error is typed as InternalServerError
-          console.error('Server error:', error.error.message);
-          console.error('Trace ID:', error.error.traceId);
-          break;
-      }
-    }
-  });
+  const getItem = useQuery(api.getItem.queryOptions({ itemId: '123' }));
 
   // Mutation with typed error handling
   const createItem = useMutation({
     ...api.createItem.mutationOptions(),
     onError: (error) => {
+      // Error is typed based on the errors in your Smithy model
       switch (error.status) {
-        case 400:
-          // error.error is typed as InvalidRequestError
+        case 422:
+          // error.error is typed as InvalidRequestErrorResponseContent
           console.error('Validation error:', error.error.message);
           console.error('Field errors:', error.error.fieldErrors);
           break;
         case 403:
-          // error.error is typed as UnauthorizedError
+          // error.error is typed as UnauthorizedErrorResponseContent
           console.error('Unauthorized:', error.error.reason);
           break;
       }
@@ -923,10 +958,13 @@ function ItemComponent() {
 
   // Component rendering with error handling
   if (getItem.isError) {
-    if (getItem.error.status === 404) {
-      return <NotFoundMessage message={getItem.error.error.message} />;
-    } else if (getItem.error.status === 500) {
-      return <ErrorMessage message={getItem.error.error.message} />;
+    switch (getItem.error.status) {
+      case 404:
+        // error.error is typed as ItemNotFoundErrorResponseContent
+        return <NotFoundMessage message={getItem.error.error.message} />;
+      case 500:
+        // error.error is typed as InternalServerErrorResponseContent
+        return <ErrorMessage message={getItem.error.error.message} />;
     }
   }
 
@@ -962,11 +1000,11 @@ function ItemComponent() {
 
         switch (err.status) {
           case 404:
-            // err.error is typed as ItemNotFoundError
+            // err.error is typed as ItemNotFoundErrorResponseContent
             console.error('Not found:', err.error.message);
             break;
           case 500:
-            // err.error is typed as InternalServerError
+            // err.error is typed as InternalServerErrorResponseContent
             console.error('Server error:', err.error.message);
             console.error('Trace ID:', err.error.traceId);
             break;
@@ -987,13 +1025,13 @@ function ItemComponent() {
       const err = e as CreateItemError;
 
       switch (err.status) {
-        case 400:
-          // err.error is typed as InvalidRequestError
+        case 422:
+          // err.error is typed as InvalidRequestErrorResponseContent
           console.error('Validation error:', err.error.message);
           console.error('Field errors:', err.error.fieldErrors);
           break;
         case 403:
-          // err.error is typed as UnauthorizedError
+          // err.error is typed as UnauthorizedErrorResponseContent
           console.error('Unauthorized:', err.error.reason);
           break;
       }
@@ -1037,7 +1075,7 @@ import { useQuery } from '@tanstack/react-query';
 
 function ItemList() {
   const api = useMyApi();
-  const items = useQuery(api.listItems.queryOptions());
+  const items = useQuery(api.listItems.queryOptions({}));
 
   if (items.isLoading) {
     return <LoadingSpinner />;
@@ -1047,11 +1085,10 @@ function ItemList() {
     const err = items.error;
     switch (err.status) {
       case 403:
-        // err.error is typed as ListItems403Response
+        // err.error is typed as UnauthorizedErrorResponseContent
         return <ErrorMessage message={err.error.reason} />;
       case 500:
-      case 502:
-        // err.error is typed as ListItems5XXResponse
+        // err.error is typed as InternalServerErrorResponseContent
         return (
           <ErrorMessage
             message={err.error.message}
@@ -1064,7 +1101,7 @@ function ItemList() {
 
   return (
     <ul>
-      {items.data.map((item) => (
+      {items.data?.items.map((item) => (
         <li key={item.id}>{item.name}</li>
       ))}
     </ul>
@@ -1083,7 +1120,7 @@ function ItemList() {
   useEffect(() => {
     const fetchItems = async () => {
       try {
-        const data = await api.listItems();
+        const data = await api.listItems({});
         setItems(data);
       } catch (err) {
         setError(err);
@@ -1102,11 +1139,10 @@ function ItemList() {
     const err = error as ListItemsError;
     switch (err.status) {
       case 403:
-        // err.error is typed as ListItems403Response
+        // err.error is typed as UnauthorizedErrorResponseContent
         return <ErrorMessage message={err.error.reason} />;
       case 500:
-      case 502:
-        // err.error is typed as ListItems5XXResponse
+        // err.error is typed as InternalServerErrorResponseContent
         return (
           <ErrorMessage
             message={err.error.message}
@@ -1134,41 +1170,53 @@ function ItemList() {
 
 ```tsx
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import type { ListItemsResponseContent } from '../generated/my-api/types.gen';
 
 function ItemList() {
   const api = useMyApi();
   const queryClient = useQueryClient();
 
   // Query to fetch items
-  const itemsQuery = useQuery(api.listItems.queryOptions());
+  const itemsQuery = useQuery(api.listItems.queryOptions({}));
 
   // Mutation for deleting items with optimistic updates
   const deleteMutation = useMutation({
     ...api.deleteItem.mutationOptions(),
-    onMutate: async (itemId) => {
+    onMutate: async ({ itemId }) => {
       // Cancel any outgoing refetches
-      await queryClient.cancelQueries({ queryKey: api.listItems.queryKey() });
+      await queryClient.cancelQueries({
+        queryKey: api.listItems.queryKey({}),
+      });
 
       // Snapshot the previous value
-      const previousItems = queryClient.getQueryData(api.listItems.queryKey());
+      const previousItems = queryClient.getQueryData<ListItemsResponseContent>(
+        api.listItems.queryKey({}),
+      );
 
       // Optimistically update to the new value
-      queryClient.setQueryData(
-        api.listItems.queryKey(),
-        (old) => old.filter((item) => item.id !== itemId)
+      queryClient.setQueryData<ListItemsResponseContent>(
+        api.listItems.queryKey({}),
+        (old) =>
+          old && {
+            ...old,
+            items: old.items.filter((item) => item.id !== itemId),
+          },
       );
 
       // Return a context object with the snapshot
       return { previousItems };
     },
-    onError: (err, itemId, context) => {
+    onError: (err, _input, context) => {
       // If the mutation fails, use the context returned from onMutate to roll back
-      queryClient.setQueryData(api.listItems.queryKey(), context.previousItems);
+      queryClient.setQueryData(
+        api.listItems.queryKey({}),
+        context?.previousItems,
+      );
       console.error('Failed to delete item:', err);
     },
     onSettled: () => {
       // Always refetch after error or success to ensure data is in sync with server
-      queryClient.invalidateQueries({ queryKey: api.listItems.queryKey() });
+      queryClient.invalidateQueries({ queryKey: api.listItems.queryKey({}) });
     },
   });
 
@@ -1182,11 +1230,11 @@ function ItemList() {
 
   return (
     <ul>
-      {itemsQuery.data.map((item) => (
+      {itemsQuery.data?.items.map((item) => (
         <li key={item.id}>
           {item.name}
           <button
-            onClick={() => deleteMutation.mutate(item.id)}
+            onClick={() => deleteMutation.mutate({ itemId: item.id })}
             disabled={deleteMutation.isPending}
           >
             {deleteMutation.isPending ? 'Deleting...' : 'Delete'}
@@ -1261,8 +1309,8 @@ function ItemForm() {
   if (createItem.error) {
     const error = createItem.error;
     switch (error.status) {
-      case 400:
-        // error.error is typed as InvalidRequestError
+      case 422:
+        // error.error is typed as InvalidRequestErrorResponseContent
         return (
           <FormError
             message="Invalid input"
@@ -1270,10 +1318,10 @@ function ItemForm() {
           />
         );
       case 403:
-        // error.error is typed as UnauthorizedError
+        // error.error is typed as UnauthorizedErrorResponseContent
         return <AuthError reason={error.error.reason} />;
       default:
-        // error.error is typed as InternalServerError for 500, etc.
+        // error.error is typed as InternalServerErrorResponseContent for 500, etc.
         return <ServerError message={error.error.message} />;
     }
   }
@@ -1309,16 +1357,16 @@ function ItemForm() {
       // ✅ Error type includes all possible error responses
       const err = e as CreateItemError;
       switch (err.status) {
-        case 400:
-          // err.error is typed as InvalidRequestError
+        case 422:
+          // err.error is typed as InvalidRequestErrorResponseContent
           console.error('Validation errors:', err.error.fieldErrors);
           break;
         case 403:
-          // err.error is typed as UnauthorizedError
+          // err.error is typed as UnauthorizedErrorResponseContent
           console.error('Not authorized:', err.error.reason);
           break;
         case 500:
-          // err.error is typed as InternalServerError
+          // err.error is typed as InternalServerErrorResponseContent
           console.error('Server error:', err.error.message);
           break;
       }
@@ -1329,7 +1377,7 @@ function ItemForm() {
   // Error UI can use type narrowing to handle different error types
   if (error) {
     switch (error.status) {
-      case 400:
+      case 422:
         return (
           <FormError
             message="Invalid input"

--- a/docs/src/content/docs/zh/guides/connection/react-trpc.mdx
+++ b/docs/src/content/docs/zh/guides/connection/react-trpc.mdx
@@ -417,11 +417,13 @@ function UserList() {
 该集成提供完整的端到端类型安全。您的 IDE 将为所有 API 调用提供完整的自动完成和类型检查：
 
 ```tsx
+import { useMutation } from '@tanstack/react-query';
+
 function UserForm() {
   const trpc = useMyApi();
 
   // ✅ Input is fully typed
-  const createUser = trpc.users.create.useMutation();
+  const createUser = useMutation(trpc.users.create.mutationOptions());
 
   const handleSubmit = (data: CreateUserInput) => {
     // ✅ Type error if input doesn't match schema

--- a/packages/nx-plugin/src/agentcore-gateway/react-connection/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/agentcore-gateway/react-connection/__snapshots__/generator.spec.ts.snap
@@ -51,6 +51,9 @@ class SigV4HttpAgent extends HttpAgent {
   }
 }
 
+// The id this agent is registered under, used as \`agentId\` by CopilotKit components.
+export const MY_AGENT_ID = 'my-agent';
+
 export const useAguiMyAgent = (): Record<string, AbstractAgent> => {
   const runtimeConfig = useRuntimeConfig();
   const gatewayUrl = runtimeConfig.gateways.MyGateway;
@@ -61,7 +64,7 @@ export const useAguiMyAgent = (): Record<string, AbstractAgent> => {
   return useMemo((): Record<string, AbstractAgent> => {
     const agent = new SigV4HttpAgent({ url }, sigv4);
 
-    return { 'my-agent': agent };
+    return { [MY_AGENT_ID]: agent };
   }, [url, sigv4]);
 };
 "

--- a/packages/nx-plugin/src/migrations/latest/smithy-extension-trait-aliases/__snapshots__/migration.spec.ts.snap
+++ b/packages/nx-plugin/src/migrations/latest/smithy-extension-trait-aliases/__snapshots__/migration.spec.ts.snap
@@ -1,0 +1,25 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`smithy-extension-trait-aliases migration > should alias every vended trait 1`] = `
+"$version: "2.0"
+
+namespace com.example
+
+use smithy.openapi#specificationExtension
+
+@trait
+@specificationExtension(as: "x-query")
+structure query {}
+
+@trait
+@specificationExtension(as: "x-mutation")
+structure mutation {}
+
+@trait
+@specificationExtension(as: "x-cursor")
+structure cursor {
+  inputToken: String
+  enabled: Boolean
+}
+"
+`;

--- a/packages/nx-plugin/src/migrations/latest/smithy-extension-trait-aliases/metadata.json
+++ b/packages/nx-plugin/src/migrations/latest/smithy-extension-trait-aliases/metadata.json
@@ -1,0 +1,3 @@
+{
+  "description": "Alias the extensions.smithy vendor-extension traits so Smithy emits x-query / x-mutation / x-cursor"
+}

--- a/packages/nx-plugin/src/migrations/latest/smithy-extension-trait-aliases/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/latest/smithy-extension-trait-aliases/migration.spec.ts
@@ -1,0 +1,176 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { addProjectConfiguration, type Tree } from '@nx/devkit';
+import { SMITHY_PROJECT_GENERATOR_INFO } from '../../../smithy/project/generator.js';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test.js';
+import migration from './migration.js';
+
+const EXTENSIONS_PATH = 'packages/api/model/src/extensions.smithy';
+
+/** The `extensions.smithy` shipped before the traits carried an `as:` alias. */
+const VENDED_BEFORE = `$version: "2.0"
+
+namespace com.example
+
+use smithy.openapi#specificationExtension
+
+@trait
+@specificationExtension
+structure query {}
+
+@trait
+@specificationExtension
+structure mutation {}
+
+@trait
+@specificationExtension
+structure cursor {
+  inputToken: String
+  enabled: Boolean
+}
+`;
+
+const addModelProject = (tree: Tree) =>
+  addProjectConfiguration(tree, '@ws/api-model', {
+    root: 'packages/api/model',
+    sourceRoot: 'packages/api/model/src',
+    metadata: {
+      generator: SMITHY_PROJECT_GENERATOR_INFO.id,
+    } as any,
+  });
+
+describe('smithy-extension-trait-aliases migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeUsingTsSolutionSetup();
+  });
+
+  it('should alias every vended trait', async () => {
+    addModelProject(tree);
+    tree.write(EXTENSIONS_PATH, VENDED_BEFORE);
+
+    const result = await migration(tree);
+
+    const after = tree.read(EXTENSIONS_PATH, 'utf-8');
+    expect(after).toContain('@specificationExtension(as: "x-query")');
+    expect(after).toContain('@specificationExtension(as: "x-mutation")');
+    expect(after).toContain('@specificationExtension(as: "x-cursor")');
+    expect(after).not.toMatch(/@specificationExtension\s*\n\s*structure/);
+    expect(result.nextSteps).toHaveLength(0);
+    expect(after).toMatchSnapshot();
+  });
+
+  it('should preserve user content in the file it edits', async () => {
+    addModelProject(tree);
+    tree.write(
+      EXTENSIONS_PATH,
+      `${VENDED_BEFORE}
+/// My own vendor extension
+@trait
+@specificationExtension(as: "x-my-thing")
+structure myThing {
+  value: String
+}
+`,
+    );
+
+    await migration(tree);
+
+    const after = tree.read(EXTENSIONS_PATH, 'utf-8');
+    expect(after).toContain('/// My own vendor extension');
+    expect(after).toContain('@specificationExtension(as: "x-my-thing")');
+    expect(after).toContain('structure myThing {');
+    expect(after).toContain('@specificationExtension(as: "x-query")');
+  });
+
+  it('should skip and report traits which have diverged from the vended shape', async () => {
+    addModelProject(tree);
+    tree.write(
+      EXTENSIONS_PATH,
+      `$version: "2.0"
+
+namespace com.example
+
+use smithy.openapi#specificationExtension
+
+@trait
+@specificationExtension
+structure query {}
+
+@trait
+structure mutation {}
+`,
+    );
+
+    const result = await migration(tree);
+
+    const after = tree.read(EXTENSIONS_PATH, 'utf-8');
+    expect(after).toContain('@specificationExtension(as: "x-query")');
+    // The user's `mutation` no longer carries `@specificationExtension`, so it
+    // is left exactly as it was.
+    expect(after).toContain('@trait\nstructure mutation {}');
+    expect(result.nextSteps).toHaveLength(1);
+    expect(result.nextSteps?.[0]).toContain('x-mutation');
+    expect(result.nextSteps?.[0]).toContain('x-cursor');
+    expect(result.nextSteps?.[0]).not.toContain('x-query');
+  });
+
+  it('should leave a trait which already carries an alias alone', async () => {
+    addModelProject(tree);
+    tree.write(
+      EXTENSIONS_PATH,
+      VENDED_BEFORE.replace(
+        '@specificationExtension\nstructure query',
+        '@specificationExtension(as: "x-query")\nstructure query',
+      ),
+    );
+
+    const result = await migration(tree);
+
+    const after = tree.read(EXTENSIONS_PATH, 'utf-8');
+    expect(
+      after.match(/@specificationExtension\(as: "x-query"\)/g),
+    ).toHaveLength(1);
+    expect(result.nextSteps).toHaveLength(0);
+  });
+
+  it('should be idempotent', async () => {
+    addModelProject(tree);
+    tree.write(EXTENSIONS_PATH, VENDED_BEFORE);
+
+    await migration(tree);
+    const afterFirstRun = tree.read(EXTENSIONS_PATH, 'utf-8');
+
+    const result = await migration(tree);
+
+    expect(tree.read(EXTENSIONS_PATH, 'utf-8')).toBe(afterFirstRun);
+    expect(result.nextSteps).toHaveLength(0);
+  });
+
+  it('should ignore projects which are not Smithy models', async () => {
+    addProjectConfiguration(tree, '@ws/lib', {
+      root: 'packages/lib',
+      sourceRoot: 'packages/lib/src',
+    });
+    tree.write('packages/lib/src/extensions.smithy', VENDED_BEFORE);
+
+    const result = await migration(tree);
+
+    expect(tree.read('packages/lib/src/extensions.smithy', 'utf-8')).toBe(
+      VENDED_BEFORE,
+    );
+    expect(result.nextSteps).toHaveLength(0);
+  });
+
+  it('should be a no-op when the user has deleted extensions.smithy', async () => {
+    addModelProject(tree);
+
+    const result = await migration(tree);
+
+    expect(tree.exists(EXTENSIONS_PATH)).toBe(false);
+    expect(result.nextSteps).toHaveLength(0);
+  });
+});

--- a/packages/nx-plugin/src/migrations/latest/smithy-extension-trait-aliases/migration.ts
+++ b/packages/nx-plugin/src/migrations/latest/smithy-extension-trait-aliases/migration.ts
@@ -1,0 +1,105 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import {
+  getProjects,
+  joinPathFragments,
+  type MigrationReturnObject,
+  type Tree,
+} from '@nx/devkit';
+import { SMITHY_PROJECT_GENERATOR_INFO } from '../../../smithy/project/generator.js';
+import { formatFilesInSubtree } from '../../../utils/format.js';
+
+/** The traits the connection generator vends, each named after its OpenAPI key. */
+const TRAITS = ['query', 'mutation', 'cursor'] as const;
+
+/**
+ * Matches a bare `@specificationExtension` applied to the named structure, with
+ * the `@trait` and `@specificationExtension` traits adjacent to the `structure`
+ * they annotate. A declaration that already carries an argument does not match.
+ */
+const bareDeclaration = (trait: string) =>
+  new RegExp(
+    `(@trait\\s*\\n\\s*@specificationExtension)(\\s*\\n\\s*structure\\s+${trait}\\s*\\{)`,
+  );
+
+/**
+ * Give each trait in a Smithy model's `extensions.smithy` an explicit
+ * `@specificationExtension(as: "...")` alias.
+ *
+ * Without the alias Smithy derives the OpenAPI key from the trait's shape id and
+ * emits a namespace-prefixed key (`x-<namespace>-query`), which the client code
+ * generator does not read — so the `@query`, `@mutation` and `@cursor` traits
+ * have no effect on the generated client. The alias pins each key to the
+ * unprefixed name the generator recognises.
+ *
+ * How to write a migration:
+ * - https://nx.dev/docs/kb/migration-generators
+ * - What `nextSteps` means: https://nx.dev/docs/reference/devkit/MigrationReturnObject
+ *
+ * Guardrails:
+ * - Smithy IDL is not a language GritQL parses, so each edit is anchored to the
+ *   exact `@trait` + `@specificationExtension` + `structure <name>` triple the
+ *   generator vends.
+ * - A declaration that already carries an `as:` argument, or that has diverged
+ *   from the vended shape, is left alone and reported via `nextSteps`.
+ * - Idempotent: an aliased declaration no longer matches the bare pattern.
+ */
+export default async function migration(
+  tree: Tree,
+): Promise<MigrationReturnObject> {
+  const nextSteps: string[] = [];
+
+  for (const [, project] of getProjects(tree)) {
+    if (
+      ((project.metadata as any) ?? {}).generator !==
+      SMITHY_PROJECT_GENERATOR_INFO.id
+    ) {
+      continue;
+    }
+
+    const extensionsPath = joinPathFragments(
+      project.sourceRoot ?? joinPathFragments(project.root, 'src'),
+      'extensions.smithy',
+    );
+    if (!tree.exists(extensionsPath)) {
+      continue;
+    }
+
+    const before = tree.read(extensionsPath, 'utf-8') ?? '';
+    let after = before;
+    const skipped: string[] = [];
+
+    for (const trait of TRAITS) {
+      if (after.includes(`@specificationExtension(as: "x-${trait}")`)) {
+        // Already aliased.
+        continue;
+      }
+      const bare = bareDeclaration(trait);
+      if (!bare.test(after)) {
+        skipped.push(trait);
+        continue;
+      }
+      after = after.replace(bare, `$1(as: "x-${trait}")$2`);
+    }
+
+    if (after !== before) {
+      tree.write(extensionsPath, after);
+    }
+
+    if (skipped.length > 0) {
+      nextSteps.push(
+        `${extensionsPath}: add ${skipped
+          .map((trait) => `\`(as: "x-${trait}")\``)
+          .join(
+            ', ',
+          )} to the \`@specificationExtension\` trait on ${skipped.map((trait) => `\`${trait}\``).join(', ')}, so Smithy emits the ${skipped.map((trait) => `\`x-${trait}\``).join(', ')} OpenAPI ${skipped.length === 1 ? 'key' : 'keys'} the client generator reads.`,
+      );
+    }
+  }
+
+  await formatFilesInSubtree(tree);
+
+  return { nextSteps };
+}

--- a/packages/nx-plugin/src/py/agent/react-connection/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/agent/react-connection/__snapshots__/generator.spec.ts.snap
@@ -311,6 +311,9 @@ class SigV4HttpAgent extends HttpAgent {
   }
 }
 
+// The id this agent is registered under, used as \`agentId\` by CopilotKit components.
+export const TEST_AGENT_ID = 'agent';
+
 export const useAguiTestAgent = (): Record<string, AbstractAgent> => {
   const runtimeConfig = useRuntimeConfig();
   const agentRuntimeValue = runtimeConfig.agentRuntimes.TestAgent;
@@ -327,7 +330,7 @@ export const useAguiTestAgent = (): Record<string, AbstractAgent> => {
   return useMemo((): Record<string, AbstractAgent> => {
     const agent = new SigV4HttpAgent({ url }, sigv4);
 
-    return { agent: agent };
+    return { [TEST_AGENT_ID]: agent };
   }, [url, sigv4]);
 };
 "

--- a/packages/nx-plugin/src/smithy/react-connection/files/model/extensions.smithy.template
+++ b/packages/nx-plugin/src/smithy/react-connection/files/model/extensions.smithy.template
@@ -11,19 +11,19 @@ use smithy.openapi#specificationExtension
 /// Use this trait if you have an operation with an HTTP method typically associated with a mutation (PUT, POST, etc) but
 /// wish for it to be considered as a query by the client
 @trait
-@specificationExtension
+@specificationExtension(as: "x-query")
 structure query {}
 
 /// Use this trait if you have an operation with an HTTP method typically associated with a query (GET, HEAD, etc) but
 /// wish for it to be considered as a mutation by the client
 @trait
-@specificationExtension
+@specificationExtension(as: "x-mutation")
 structure mutation {}
 
 /// By default, operations which accept a parameter named "cursor" are treated as paginated by the client
 /// Use this trait if you have an operation where the pagination cursor is named something other than "cursor"
 @trait
-@specificationExtension
+@specificationExtension(as: "x-cursor")
 structure cursor {
   // Use inputToken to change the input parameter used for pagination
   inputToken: String

--- a/packages/nx-plugin/src/smithy/react-connection/generator.spec.ts
+++ b/packages/nx-plugin/src/smithy/react-connection/generator.spec.ts
@@ -305,6 +305,34 @@ export function Main() {
       expect(extensionsContent).toContain('structure cursor {');
     });
 
+    it('should alias each trait to the vendor extension the client generator reads', async () => {
+      await smithyReactConnectionGenerator(tree, {
+        frontendProjectName: 'frontend',
+        smithyModelOrBackendProjectName: 'api-model',
+      });
+
+      const extensionsContent = tree.read(
+        'apps/api-model/src/extensions.smithy',
+        'utf-8',
+      );
+
+      // Without the alias Smithy derives the key from the trait's shape id and
+      // emits a namespace-prefixed `x-<namespace>-query`, which the code
+      // generator does not read.
+      expect(extensionsContent).toContain(
+        '@specificationExtension(as: "x-query")',
+      );
+      expect(extensionsContent).toContain(
+        '@specificationExtension(as: "x-mutation")',
+      );
+      expect(extensionsContent).toContain(
+        '@specificationExtension(as: "x-cursor")',
+      );
+      expect(extensionsContent).not.toMatch(
+        /@specificationExtension\s*\n\s*structure/,
+      );
+    });
+
     it('should use correct namespace in extensions.smithy file', async () => {
       await smithyReactConnectionGenerator(tree, {
         frontendProjectName: 'frontend',

--- a/packages/nx-plugin/src/ts/agent/react-connection/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/agent/react-connection/generator.spec.ts
@@ -376,6 +376,61 @@ export function Main() {
       packageJson.dependencies['@trpc/tanstack-react-query'],
     ).toBeUndefined();
   });
+
+  it('should export the registered agent id from the AG-UI hook', async () => {
+    await tsAgentReactConnectionGenerator(tree, {
+      sourceProject: 'frontend',
+      targetProject: 'agent-project',
+      targetComponent: {
+        generator: 'ts#agent',
+        name: 'my-agui-agent',
+        path: 'src/my-agui-agent',
+        port: 8081,
+        rc: 'MyAguiAgent',
+        auth: 'iam',
+        protocol: 'ag-ui',
+      },
+    });
+
+    const hook = tree.read(
+      'apps/frontend/src/hooks/useAguiMyAguiAgent.tsx',
+      'utf-8',
+    );
+
+    // The exported constant is the single source of truth for the id, so the
+    // vended chat component cannot drift from what the hook registers.
+    expect(hook).toContain("export const MY_AGUI_AGENT_ID = 'my-agui-agent';");
+    expect(hook).toContain('return { [MY_AGUI_AGENT_ID]: agent };');
+  });
+
+  it('should vend a chat component bound to the agent id', async () => {
+    await tsAgentReactConnectionGenerator(tree, {
+      sourceProject: 'frontend',
+      targetProject: 'agent-project',
+      targetComponent: {
+        generator: 'ts#agent',
+        name: 'my-agui-agent',
+        path: 'src/my-agui-agent',
+        port: 8081,
+        rc: 'MyAguiAgent',
+        auth: 'iam',
+        protocol: 'ag-ui',
+      },
+    });
+
+    const chat = tree.read(
+      'apps/frontend/src/components/my-agui-agent-chat.tsx',
+      'utf-8',
+    );
+
+    expect(chat).toContain('export const MyAguiAgentChat');
+    expect(chat).toContain(
+      "import { MY_AGUI_AGENT_ID } from '../hooks/useAguiMyAguiAgent'",
+    );
+    // agentId is bound, and every other CopilotChat prop is forwarded.
+    expect(chat).toContain('agentId={MY_AGUI_AGENT_ID}');
+    expect(chat).toContain("Omit<CopilotChatProps, 'agentId'>");
+  });
 });
 
 describe('ts strands agent react connection with real projects', () => {

--- a/packages/nx-plugin/src/ts/react-website/agui/files/common/src/components/__agentNameKebabCase__-chat.tsx.template
+++ b/packages/nx-plugin/src/ts/react-website/agui/files/common/src/components/__agentNameKebabCase__-chat.tsx.template
@@ -1,0 +1,9 @@
+import { CopilotChat } from './copilot';
+import type { CopilotChatProps } from '@copilotkit/react-core/v2';
+import { <%= agentNameConstantName %>_ID } from '../hooks/useAgui<%= agentNameClassName %>';
+
+export const <%= agentNameClassName %>Chat = (
+  props: Omit<CopilotChatProps, 'agentId'>,
+) => <CopilotChat agentId={<%= agentNameConstantName %>_ID} {...props} />;
+
+export default <%= agentNameClassName %>Chat;

--- a/packages/nx-plugin/src/ts/react-website/agui/files/common/src/hooks/useAgui__agentNameClassName__.tsx.template
+++ b/packages/nx-plugin/src/ts/react-website/agui/files/common/src/hooks/useAgui__agentNameClassName__.tsx.template
@@ -104,6 +104,9 @@ class AgentCoreHttpAgent extends HttpAgent {
 }
 <%_ } _%>
 
+// The id this agent is registered under, used as `agentId` by CopilotKit components.
+export const <%= agentNameConstantName %>_ID = '<%= agentName %>';
+
 export const useAgui<%= agentNameClassName %> = (): Record<string, AbstractAgent> => {
   const runtimeConfig = useRuntimeConfig();
 <%_ if (gatewayRoute) { _%>
@@ -138,6 +141,6 @@ export const useAgui<%= agentNameClassName %> = (): Record<string, AbstractAgent
     const agent = new AgentCoreHttpAgent({ url });
     <%_ } _%>
 
-    return { '<%= agentName %>': agent };
+    return { [<%= agentNameConstantName %>_ID]: agent };
   }, [url<% if (auth === 'iam') { %>, sigv4<% } else if (auth === 'cognito') { %>, auth<% } %>]);
 };

--- a/packages/nx-plugin/src/ts/react-website/agui/generator.ts
+++ b/packages/nx-plugin/src/ts/react-website/agui/generator.ts
@@ -20,7 +20,7 @@ import {
   declareDependencies,
   ownedElsewhere,
 } from '../../../utils/declared-dependencies.js';
-import { kebabCase } from '../../../utils/names.js';
+import { kebabCase, snakeCase } from '../../../utils/names.js';
 import { getNpmScopePrefix } from '../../../utils/npm-scope.js';
 import { registerPnpmBuiltDependencies } from '../../../utils/pnpm-workspace.js';
 import {
@@ -123,14 +123,23 @@ export const addAgUiReactConnection = async (
   const metadata: AgUiMetadata = { theme, auth };
   const scopeAlias = getNpmScopePrefix(tree);
 
-  // Generates `src/components/AguiProvider.tsx` (if absent) and
+  // Generates `src/components/AguiProvider.tsx` (if absent),
+  // `src/components/<agent-name>-chat.tsx` and
   // `src/hooks/useAgui<AgentName>.tsx`. Existing files are kept so re-running
   // the generator is idempotent.
   generateFiles(
     tree,
     joinPathFragments(import.meta.dirname, 'files', 'common'),
     frontendProjectConfig.root,
-    { agentName, agentNameClassName, auth, gatewayRoute },
+    {
+      agentName,
+      agentNameClassName,
+      agentNameKebabCase: kebabCase(agentNameClassName),
+      // STORY_AGENT, naming the exported `<name>_ID` constant
+      agentNameConstantName: snakeCase(agentNameClassName).toUpperCase(),
+      auth,
+      gatewayRoute,
+    },
     { overwriteStrategy: OverwriteStrategy.KeepExisting },
   );
 


### PR DESCRIPTION
### Reason for this change

Six findings from the v1.0 bug bash, all in the `conn-web` family.

**`conn-web-01`** (filed blocker, verified and reclassified major) — the `extensions.smithy` vended into the Smithy model by the react↔smithy connection declared its traits as bare `@specificationExtension`. Smithy therefore derives each OpenAPI key from the trait's shape id and emits **namespace-prefixed** keys (`x-ws-query`, `x-ws-mutation`, `x-ws-cursor`), while the client generator only reads `x-query` / `x-mutation` / `x-cursor` (`open-api/utils/codegen-data/types.ts` `VENDOR_EXTENSIONS`).

All four documented traits were therefore **silent no-ops** — no warning, the model builds, the client generates, and the shape is the *opposite* of what the guide shows. A user gets `mutationOptions` where the guide promises `queryOptions`, and no feedback loop to tell them why.

The remaining five are doc drift — the generators moved and the examples didn't. Each one is a hard compile error for anyone copying the guide:

- **`conn-web-02`** — the FastAPI/Smithy error-handling, best-practices and type-safety examples read `err.error.message` / `.reason` / `.traceId` / `.validationErrors` and use `case 502:`. No 5XX aggregate type is generated, so `case 502:` is rejected outright, and none of those field names exist on the payloads the generators actually emit.
- **`conn-web-03`** — `queryOptions()` / `queryKey()` shown with no arguments. The generator makes the input positional and **required** for any operation that accepts input at all, even when every field is optional — which is exactly the list endpoint the examples use. It cascades through the whole optimistic-update example, since `queryKey()` feeds `cancelQueries` / `getQueryData` / `setQueryData` / `invalidateQueries`.
- **`conn-web-04`** — reported as the Smithy "Grouping Operations" example reading the wrong accessor names. **Verified as not a bug** — see below.
- **`conn-web-06`** — the react-trpc "Type Safety" example calls `trpc.users.create.useMutation()`, the removed `@trpc/react-query` hooks API. The generator wires up the `@trpc/tanstack-react-query` options proxy.
- **`conn-web-07`** — every `agentId` in the react-agui guide (`'agent'`, `'story'`, `'research'`) mismatches the kebab-cased ids the generated hook registers (`'story-agent'`). `agentId` is typed as a plain `string`, so this fails **silently at runtime** — CopilotKit just never resolves the agent. No type error, no console error.

### Description of changes

**Generated output — `extensions.smithy` (`conn-web-01`)**

Added the explicit alias to each trait declaration, pinning the emitted key to the name the codegen reads:

```smithy
@specificationExtension(as: "x-query")    structure query {}
@specificationExtension(as: "x-mutation") structure mutation {}
@specificationExtension(as: "x-cursor")   structure cursor { ... }
```

This is the right layer: the codegen side already handles both the scalar and object forms Smithy produces (`getCursorOptions` accepts `false` / `{enabled:false}` / `'prop'` / `{inputToken:'prop'}`), and the unprefixed names are the documented contract shared with the FastAPI `openapi_extra` path. Renaming the keys the generator reads would instead break every FastAPI user.

**Generated output — AG-UI chat component (`conn-web-07`)**

`conn-web-07` is doc drift, but a silently-wrong string is worth more than a doc fix, so I paired it with a generated-side change. Each `connection` run now vends `src/components/<agent-name>-chat.tsx`:

```tsx
export const StoryAgentChat = (props: Omit<CopilotChatProps, 'agentId'>) => (
  <CopilotChat agentId={STORY_AGENT_ID} {...props} />
);
```

It binds `agentId` to the id the hook registers (exported as `<AGENT_NAME>_ID`) and forwards every other `CopilotChat` prop, wrapping the themed `CopilotChat` so it picks up the website's `ux` theme. The id is now a single source of truth and callers never handle it, so the class of defect the finding describes — a hand-written literal that silently fails to resolve — is gone rather than merely detectable.

**Docs**

Corrected the examples in all four guides to what the generators produce — every snippet below was pasted into a real generated workspace and typechecked (see validation).

- `queryOptions({})` / `queryKey({})` where the operation declares input (`conn-web-03`).
- Real error payload field names and only the statuses the accompanying backend actually models; dropped `case 502:` and the non-existent `*5XXResponse` / `*Response` type names in favour of the generated `*ResponseContent` / model names (`conn-web-02`).
- tRPC type-safety example switched to `useMutation(trpc.users.create.mutationOptions())` (`conn-web-06`).
- The AG-UI guide now renders the vended `<StoryAgentChat />` / `<ResearchAgentChat />` instead of passing `agentId` strings (`conn-web-07`).

Four further mismatches surfaced while verifying the above, each of which broke the corrected snippet until fixed, so they're in scope as part of making these examples compile:

- The guide's own Smithy error example put `InvalidRequestError` on `@httpError(400)`, which collides with the `ValidationException` the service already declares on 400 — only one payload reaches the client. Moved to `422`.
- The FastAPI example named a Pydantic model `ValidationError`, colliding with FastAPI's own model for the 422 it adds to every endpoint. Renamed to `ValidationErrorDetails`.
- The generated client camelCases Python fields, so `field_errors` is read as `fieldErrors`; the examples now read the camelCased name.
- Both guides passed `onError` to `useQuery`, removed in TanStack Query v5. Restructured to narrow on `error.status` at the render site. `useMutation` still takes `onError`, so those blocks are unchanged.

**`conn-web-04` — not a bug, no change**

I could not reproduce it. The finding reports that tag groups key on the full operation name, so the guide's `api.items.listItems` should be `api.items.groupedListItems` — but `groupedListItems` was an artefact of the verifier renaming the operations to avoid a collision with the untagged `ListItems` in the same model. Built with the guide's *exact* operation names and the generated proxy is:

```ts
public items = { createItem: {...}, listItems: {...} };
public users = { listUsers: {...} };
```

`groupOperationsByTag` (`open-api/utils/codegen-data.ts:650-668`) keys each member by the camelCased **full** operation name, which for `ListItems` *is* `listItems`. The collision the finding predicts doesn't arise either: `untaggedOperations` filters out anything tagged, so a tagged operation appears only in its group and never at top level.

So the guide was already correct. I left the snippet as-is and instead made the naming rule explicit in both guides, since that's the non-obvious part (FastAPI's counterpart keys on the endpoint function name, and qualifies with the tag only when a name is duplicated across tags — also verified and documented).

**Migration**

`latest/smithy-extension-trait-aliases` adds the `as:` alias to each trait in a Smithy model project's `extensions.smithy`. Smithy IDL isn't a language GritQL parses, so the edit is anchored to the exact `@trait` + `@specificationExtension` + `structure <name>` triple the generator vends (CONTRIBUTING's stated exception for formats GritQL can't parse). A declaration already carrying an argument, or diverged from the vended shape, is skipped and reported via `nextSteps`. It only rewrites what it recognises, and is idempotent.

The traits were *silent* no-ops, so an existing workspace keeps ignoring them after upgrading unless something rewrites the file — which is the argument for carrying it. I raised this on the thread offering to drop it; approved as-is, so it stays.

No migration for the AG-UI change, per review.

### Description of how you validated changes

**`conn-web-01` end to end, before and after.** Fresh workspace (`ts#react-website` + `#auth` + `ts#api --framework=smithy` + `connection`) against the locally compiled plugin, with all four documented trait examples applied to the model.

Before — every key namespace-prefixed, and the model builds clean with no warning:

```
GET  /paged-items       {'x-ws-cursor': {'inputToken': 'nextToken'}}
POST /search-items      {'x-ws-query': {}}
GET  /start-processing   {'x-ws-mutation': {}}
GET  /unpaged-items     {'x-ws-cursor': {'enabled': False}}
```

After:

```
GET  /paged-items       {'x-cursor': {'inputToken': 'nextToken'}}
POST /search-items      {'x-query': {}}
GET  /start-processing   {'x-mutation': {}}
GET  /unpaged-items     {'x-cursor': {'enabled': False}}
```

And all four traits then behave exactly as the guide documents — confirmed in the regenerated `options-proxy.gen.ts`: `searchItems` flipped to `{queryKey, queryOptions, queryFilter}`, `startProcessing` to `{mutationKey, mutationOptions}`, `listPagedItems` gained `infiniteQueryOptions`, `listUnpagedItems` lost it.

**Every corrected example compiles.** Generated all four stacks the guides need into one workspace — smithy api + react website + connection, fastapi + connection, trpc + connection, and both a `ts#agent` and a `py#agent` with `--protocol=ag-ui` + connections — modelled the backends from each guide's own accompanying model, then pasted the corrected snippets in and ran `nx run @ws/web:compile` (tsc). Green.

I first reproduced each finding the same way, so the fixes are verified against the failures rather than assumed. E.g. `conn-web-06` reproduced as `TS2339: Property 'useMutation' does not exist on type 'DecorateMutationProcedure<...>'`, and `conn-web-03` as `TS2554: Expected 1-2 arguments, but got 0`. `conn-web-07` was confirmed by reading the ids back out of the generated hooks (`'story-agent'`, `'research-agent'` — neither `'story'` nor `'research'`).

**Generated-side changes verified in the workspace**, not just in tests: recompiled the plugin, deleted and re-ran both AG-UI connections, and confirmed the hooks emit `STORY_AGENT_ID` / `RESEARCH_AGENT_ID`, that `story-agent-chat.tsx` and `research-agent-chat.tsx` are vended bound to them, and that every guide example using `<StoryAgentChat />` typechecks.

**Tests.** 7 unit tests for the Smithy migration, covering the vended shape, user content surviving, a diverged shape being skipped and reported, and idempotency. Three generator assertions: that `extensions.smithy` carries all three aliases and no bare `@specificationExtension`, that the AG-UI hook exports and uses its id constant, and that the vended chat component binds `agentId` and forwards the rest.

```
pnpm nx run @aws/nx-plugin:test -u      # 4273 passed / 242 files
pnpm nx run-many --target lint --all --fix
pnpm nx run-many --target build --projects=@aws/nx-plugin   # includes lint + test
```

Two snapshots updated, both the AG-UI hook picking up the exported constant — reviewed and intended.

MDX validated by compiling all four guides through `@mdx-js/mdx`; the full `nx build docs` is left to CI.

Not deployed to AWS — no infrastructure changed.

### Issue # (if applicable)

N/A — bug bash findings `conn-web-01`, `-02`, `-03`, `-06`, `-07`. `conn-web-04` investigated and closed as not-a-bug (rationale above).

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
