### PR TITLE
fix(ts#project): preserve target wiring added by other generators on re-run

### DIFF
--- a/packages/nx-plugin/src/ts/lib/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/lib/generator.spec.ts
@@ -5,8 +5,8 @@
 import { readJson, readNxJson, type Tree, writeJson } from '@nx/devkit';
 import uniqBy from 'lodash.uniqby';
 import {
-  declaredNames,
   declareDependencies,
+  declaredNames,
 } from '../../utils/declared-dependencies.js';
 import { expectHasMetricTags } from '../../utils/metrics.spec.js';
 import {
@@ -15,6 +15,7 @@ import {
 } from '../../utils/shared-constructs.js';
 import { createTreeUsingTsSolutionSetup } from '../../utils/test.js';
 import { ownedDependencies } from '../../utils/version-upgrade-migration/owned-dependencies.js';
+import { tsLambdaFunctionGenerator } from '../lambda-function/generator.js';
 import {
   DEPENDENCIES,
   TS_LIB_GENERATOR_INFO,
@@ -282,6 +283,68 @@ describe('ts lib generator', () => {
     expect(readJson(tree, 'test-lib/project.json').targets).toEqual(
       targetsBefore,
     );
+  });
+
+  // Another generator wiring an artifact target into this project's build and
+  // assemble is the state a re-run must converge into rather than replace: the
+  // `bundle` target survives on its own, so losing the wiring is silent until a
+  // clean synth fails on the missing artifact.
+  it('should preserve target wiring added by other generators on re-run', async () => {
+    await tsProjectGenerator(tree, {
+      name: 'test-lib',
+      preferInstallDependencies: false,
+    });
+
+    await tsLambdaFunctionGenerator(tree, {
+      project: '@proj/test-lib',
+      name: 'MyFunction',
+      event: 'EventBridgeSchema',
+      iac: 'cdk',
+      preferInstallDependencies: false,
+    });
+
+    await tsProjectGenerator(tree, {
+      name: 'test-lib',
+      preferInstallDependencies: false,
+    });
+
+    const { targets } = readJson(tree, 'test-lib/project.json');
+    expect(targets.build.dependsOn).toEqual([
+      'lint',
+      'compile',
+      'test',
+      'bundle',
+    ]);
+    expect(targets.assemble.dependsOn).toEqual(['compile', 'bundle']);
+    expect(targets.bundle).toBeDefined();
+  });
+
+  it('should not duplicate target wiring across repeated re-runs', async () => {
+    await tsProjectGenerator(tree, {
+      name: 'test-lib',
+      preferInstallDependencies: false,
+    });
+
+    await tsLambdaFunctionGenerator(tree, {
+      project: '@proj/test-lib',
+      name: 'MyFunction',
+      event: 'EventBridgeSchema',
+      iac: 'cdk',
+      preferInstallDependencies: false,
+    });
+
+    await tsProjectGenerator(tree, {
+      name: 'test-lib',
+      preferInstallDependencies: false,
+    });
+    const afterFirstReRun = tree.read('test-lib/project.json', 'utf-8');
+
+    await tsProjectGenerator(tree, {
+      name: 'test-lib',
+      preferInstallDependencies: false,
+    });
+
+    expect(tree.read('test-lib/project.json', 'utf-8')).toBe(afterFirstReRun);
   });
 
   it('should mark the workspace as ESM by default', async () => {

--- a/packages/nx-plugin/src/ts/lib/generator.ts
+++ b/packages/nx-plugin/src/ts/lib/generator.ts
@@ -25,6 +25,7 @@ import { getNpmScopePrefix } from '../../utils/npm-scope.js';
 import {
   addGeneratorMetadata,
   getGeneratorInfo,
+  mergeTarget,
   mergeTargetDefault,
   type NxGeneratorInfo,
   projectExists,
@@ -161,21 +162,25 @@ export const tsProjectGenerator = async (
   );
   const targets = projectConfiguration.targets;
 
-  targets['compile'] = {
+  // Merged rather than assigned so a re-run converges this generator's own
+  // configuration without discarding what other generators contributed to the
+  // same targets — the `bundle` that ts#lambda-function adds to build and
+  // assemble, say, which those targets must keep depending on.
+  targets['compile'] = mergeTarget(targets['compile'], {
     executor: 'nx:run-commands',
     outputs: ['{workspaceRoot}/dist/{projectRoot}/tsc'],
     options: {
       command: 'tsc --build tsconfig.lib.json',
       cwd: '{projectRoot}',
     },
-  };
-  targets['build'] = {
+  });
+  targets['build'] = mergeTarget(targets['build'], {
     dependsOn: ['lint', 'compile', 'test'],
-  };
+  });
   // The artifact-only sibling of build, which the deploy targets depend on.
-  targets['assemble'] = {
+  targets['assemble'] = mergeTarget(targets['assemble'], {
     dependsOn: ['compile'],
-  };
+  });
   projectConfiguration.targets = sortObjectKeys(targets);
 
   updateProjectConfiguration(tree, fullyQualifiedName, projectConfiguration);

--- a/packages/nx-plugin/src/utils/nx.spec.ts
+++ b/packages/nx-plugin/src/utils/nx.spec.ts
@@ -11,6 +11,7 @@ import {
   addComponentGeneratorMetadata,
   addDependencyToTargetIfNotPresent,
   addGeneratorMetadata,
+  mergeTarget,
   mergeTargetDefault,
   type NxGeneratorInfo,
   normalizeTargetKeyOrder,
@@ -555,6 +556,88 @@ describe('addDependencyToTargetIfNotPresent', () => {
       '@e2e/website-no-router:build',
       '^build',
     ]);
+  });
+});
+
+describe('mergeTarget', () => {
+  it('should author the target when it does not exist', () => {
+    expect(
+      mergeTarget(undefined, { dependsOn: ['lint', 'compile', 'test'] }),
+    ).toEqual({ dependsOn: ['lint', 'compile', 'test'] });
+  });
+
+  it('should keep dependencies another generator added', () => {
+    expect(
+      mergeTarget(
+        { dependsOn: ['lint', 'compile', 'test', 'bundle'] },
+        { dependsOn: ['lint', 'compile', 'test'] },
+      ),
+    ).toEqual({ dependsOn: ['lint', 'compile', 'test', 'bundle'] });
+  });
+
+  it('should add a missing dependency without duplicating the existing ones', () => {
+    expect(
+      mergeTarget({ dependsOn: ['compile'] }, { dependsOn: ['compile'] }),
+    ).toEqual({ dependsOn: ['compile'] });
+    expect(
+      mergeTarget({ dependsOn: ['bundle'] }, { dependsOn: ['compile'] }),
+    ).toEqual({ dependsOn: ['bundle', 'compile'] });
+  });
+
+  it('should deduplicate object dependencies', () => {
+    expect(
+      mergeTarget(
+        { dependsOn: [{ projects: 'other', target: 'build' }] },
+        { dependsOn: [{ projects: ['other'], target: 'build' }] },
+      ).dependsOn,
+    ).toEqual([{ projects: 'other', target: 'build' }]);
+  });
+
+  it('should let the generator own every key other than dependsOn', () => {
+    expect(
+      mergeTarget(
+        {
+          executor: 'nx:noop',
+          cache: false,
+          options: { command: 'stale' },
+        },
+        {
+          executor: 'nx:run-commands',
+          outputs: ['{workspaceRoot}/dist/{projectRoot}/tsc'],
+          options: { command: 'tsc --build tsconfig.lib.json' },
+        },
+      ),
+    ).toEqual({
+      executor: 'nx:run-commands',
+      cache: false,
+      outputs: ['{workspaceRoot}/dist/{projectRoot}/tsc'],
+      options: { command: 'tsc --build tsconfig.lib.json' },
+    });
+  });
+
+  it('should serialize in the same key order whether authored or merged', () => {
+    const desired = {
+      executor: 'nx:run-commands',
+      dependsOn: ['compile'],
+      options: { command: 'rolldown -c rolldown.config.ts' },
+      cache: true,
+    };
+    expect(Object.keys(mergeTarget(undefined, desired))).toEqual(
+      Object.keys(mergeTarget(mergeTarget(undefined, desired), desired)),
+    );
+  });
+
+  it('should be idempotent when applied repeatedly', () => {
+    let target = mergeTarget(
+      { dependsOn: ['bundle'] },
+      {
+        dependsOn: ['compile'],
+      },
+    );
+    for (let i = 0; i < 5; i++) {
+      target = mergeTarget(target, { dependsOn: ['compile'] });
+    }
+    expect(target.dependsOn).toEqual(['bundle', 'compile']);
   });
 });
 

--- a/packages/nx-plugin/src/utils/nx.ts
+++ b/packages/nx-plugin/src/utils/nx.ts
@@ -318,6 +318,36 @@ export const normalizeTargetKeyOrder = <T extends object>(target: T): T =>
   ) as T;
 
 /**
+ * Merge the configuration a generator owns into a project's existing target, so
+ * re-running converges that configuration without discarding what other
+ * generators (or the user) contributed to the same target.
+ *
+ * `dependsOn` is unioned: existing entries keep their order and the desired ones
+ * are appended only when absent, so a re-run neither drops an entry (e.g. the
+ * `bundle` a lambda function adds to `build`) nor duplicates one. Every other
+ * key the caller passes wins, since those are the ones the generator owns.
+ *
+ * The result carries Nx's own key order, so a target authored on the first run
+ * serializes identically to the same target merged into on a re-run.
+ */
+export const mergeTarget = (
+  existing: TargetConfiguration | undefined,
+  desired: TargetConfiguration,
+): TargetConfiguration => {
+  const merged: TargetConfiguration = { ...existing, ...desired };
+  const dependsOn = [...(existing?.dependsOn ?? [])];
+  for (const dependency of desired.dependsOn ?? []) {
+    if (!dependsOn.some((d) => targetDependencyEquals(d, dependency))) {
+      dependsOn.push(dependency);
+    }
+  }
+  if (dependsOn.length > 0) {
+    merged.dependsOn = dependsOn;
+  }
+  return normalizeTargetKeyOrder(merged);
+};
+
+/**
  * Mutate the project to add the dependency to the target if not already present
  * Adds the target if not present.
  *


### PR DESCRIPTION
### Reason for this change

Closes bug bash finding **`ts-core-02`** (blocker, independently verified).

`ts#lambda-function` adds `bundle` to its host project's `build` and `assemble` `dependsOn` — this is what `typescript-infrastructure.mdx` relies on when it says `synth` depends on `^assemble` so "synthesizing builds the artifacts your stacks deploy, such as the Lambda bundles".

Re-running `ts#project` with the same name rewrote `project.json` from the base template and dropped `bundle` from both target lists. The `bundle` target definition itself survived, so nothing looked wrong; `assemble` simply stopped producing `dist/.../bundle`. The failure is silent — `nx run-many --target build --all` still passes from a wiped `dist` — until a clean `nx synth`, which fails with:

```
«CannotFindAsset» Cannot find asset at .../dist/packages/my-library/bundle/lambda/my-function
```

This violates the `CONTRIBUTING.md` §"Generator Idempotency" contract, which requires framework-owned config (project targets) to "update in place / merge, keyed so it overwrites rather than duplicates".

### Description of changes

**`utils/nx.ts` — new `mergeTarget` helper.** Merges the configuration a generator owns into a project's existing target:

- `dependsOn` is **unioned** — existing entries keep their order, desired ones are appended only when absent (deduplicated with the same deep equality `addDependencyToTargetIfNotPresent` uses, so the object dependency form is handled too). A re-run therefore neither drops an entry nor doubles one up.
- Every other key the caller passes wins, since those are the ones the generator owns.
- The result is passed through the existing `normalizeTargetKeyOrder`, so a target authored on the first run serializes identically to the same target merged into on a re-run.

**`ts#project` (`ts/lib/generator.ts`)** now merges rather than assigns `compile`, `build` and `assemble`. This is the right layer: `ts#project` is the generator that owns those three targets' *own* configuration, but it is not the only contributor to their `dependsOn` — `addArtifactDependencyToTargets` (used by `bundle`, `docker`, `synth`, `operations`, the AgentCore `<name>-package` targets, the RDB bundles) writes into the same lists from a dozen call sites. Fixing it in `ts#project` fixes it for all of them at once, rather than teaching each contributing generator to re-assert itself.

**No migration.** One was included initially, but per review it was removed: the window in which a user both re-ran `ts#project` over a project with an artifact target *and* has not since re-run the contributing generator is narrow enough that it is unlikely to have been hit in practice.

### Other project generators checked

Per the review request I checked whether the same replace-instead-of-merge pattern affects the other project generators that re-run over an existing project. **None of them do**, so this PR is scoped to `ts#project`:

- **`py#project`** — already guards the `compile`/`build`/`assemble` derivation behind `if (!projectConfiguration.targets.compile)`, so a re-run never touches those three. I verified by generating a Python project, adding a `py#lambda-function` to it, and re-running `py#project`: `build.dependsOn` keeps `bundle` and `assemble.dependsOn` keeps `bundle-x86`. The `project.json` **key order and JSON content are both unchanged**; the only difference is whitespace reflow (`updateProjectConfiguration` re-serializes arrays expanded, and `py#project` does not call `formatFilesInSubtree`). That is a cosmetic formatting issue with a materially different root cause, not this bug — noted here rather than fixed.
- **`ts#react-website`**, **`smithy#project`**, **`terraform#project`** — all guard their target authoring behind an existence check already.

### Description of how you validated changes

Unit tests added:

- `ts/lib/generator.spec.ts` — per §"Testing expectations", a test that generates a project, runs `ts#lambda-function` against it, re-runs `ts#project` with the same name, and asserts `build.dependsOn` is exactly `['lint', 'compile', 'test', 'bundle']` and `assemble.dependsOn` exactly `['compile', 'bundle']` — so the `bundle` wiring survives **exactly once**: present, and not duplicated by the merge. A second test re-runs again and asserts `project.json` is byte-identical, so repeated re-runs can neither drop nor grow the list.
- `utils/nx.spec.ts` — seven cases for `mergeTarget`: authoring a fresh target, keeping another generator's dependency, adding a missing one without duplicating, deduplicating the object dependency form, letting the generator own every non-`dependsOn` key, identical key order whether authored or merged, and idempotence under repeated application.

Commands run:

- `pnpm nx run @aws/nx-plugin:test` — **241 files, 4272 tests, all passing**, with no snapshot changes (the generated `project.json` for a fresh project is unchanged; only the re-run path differs).
- `pnpm nx run-many --target lint --all --fix` — clean.

End-to-end in a real workspace, against the locally compiled plugin, reproducing the finding's exact repro steps:

1. `ts#project --name=my-library`, `ts#lambda-function --project=@ws/my-library --name=MyFunction`, `ts#infra --name=infra`, instantiated `MyLibraryMyFunction` in `application-stack.ts`, committed as the baseline.
2. Re-ran `ts#project --name=my-library` → **`git diff` is completely empty**. Before this change the same command emitted `UPDATE packages/my-library/project.json` and stripped both `bundle` entries.
3. `rm -rf dist .nx/cache && nx synth @ws/infra` → **succeeds** (previously `CannotFindAsset`).
4. `rm -rf dist .nx/cache && nx run-many --target build --all` → **succeeds**, checkov included.

Stopped at `synth` — nothing was deployed to AWS.

### Issue # (if applicable)

Bug bash finding `ts-core-02`.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

