### PR TITLE
test(ts#react-website): assert shadcn alias resolution independently of the registry's `cn` import

### DIFF
--- a/e2e/src/smoke-tests/react-website.spec.ts
+++ b/e2e/src/smoke-tests/react-website.spec.ts
@@ -125,12 +125,16 @@ describe('smoke test - react-website', () => {
         `${component}.tsx`,
       );
       expect(existsSync(componentPath), componentPath).toBe(true);
-      // Aliases resolve to the package-local `#...` specifiers, not the
-      // public `<scope>/common-shadcn/...` name. The CLI writes its own quote
+      const contents = readFileSync(componentPath, 'utf-8');
+      // A wrong alias shape leaves the registry's own `@/...` specifiers in
+      // place; a resolved one rewrites them to the package-local `#...`
+      // specifiers, never the public `<scope>/common-shadcn/...` name.
+      expect(contents).not.toMatch(/from ['"]@\//);
+      expect(contents).not.toMatch(SHARED_SHADCN_NAME);
+      // `cn` comes from the package's own `#lib/utils` unless the registry item
+      // declares a dependency on the `cn` package. The CLI writes its own quote
       // style, so match either.
-      expect(readFileSync(componentPath, 'utf-8')).toMatch(
-        /from ['"]#lib\/utils['"]/,
-      );
+      expect(contents).toMatch(/from ['"](?:#lib\/utils|cn)['"]/);
     }
 
     expect(existsSync(join(shadcnRoot, 'packages'))).toBe(false);


### PR DESCRIPTION
### Reason for this change

> **Please prioritise / merge this ahead of the other open PRs.** `Smoke Tests - react-website` is currently red on **every** open PR, so this one change unblocks the whole batch (~19 bug-bash fix PRs plus unrelated ones). It is safe to merge first: the diff touches a single e2e assertion, no `packages/**` and no generated output, so it cannot conflict with or alter the behaviour any other PR is changing. Re-running the other PRs' checks after this lands is enough — #1196, #1199 and #1204 have already gone from failing to zero failures against this branch.

`Smoke Tests - react-website` fails on every branch, including PRs that touch nothing related ([#1200](https://github.com/awslabs/nx-plugin-for-aws/pull/1200), [#1198](https://github.com/awslabs/nx-plugin-for-aws/pull/1198)); `main` was last green at 04:37 UTC today:

```
FAIL src/smoke-tests/react-website.spec.ts > smoke test - react-website > should generate and build
AssertionError: expected '"use client"\n\nimport * as React fro…' to match /from ['"]#lib\/utils['"]/
```

The shadcn registry changed upstream. Registry items now declare a dependency on the `cn` package (published today) and import from it directly:

```jsonc
// https://ui.shadcn.com/r/styles/new-york-v4/dialog.json
"dependencies": ["cn", "radix-ui"],
"content": "…import { cn } from \"cn\"…"
```

The CLI only rewrites a `@/lib/utils` specifier through `components.json`'s `utils` alias, so there is nothing left for it to rewrite and the added component keeps `from "cn"`. Nothing in the plugin or in the generated workspace is wrong — pinning `TS_VERSIONS.shadcn` pins the CLI, not the registry it reads — so only the assertion needs to change.

### Description of changes

The assertion is rewritten around the invariants the alias config actually owns, rather than which module the registry happens to source `cn` from:

- no unresolved registry `@/...` specifier survives (the symptom of a wrong alias shape),
- the public `<scope>/common-shadcn/...` name is never written where a package-local `#...` specifier belongs,
- `cn` resolves either through `#lib/utils` or the `cn` package.

The existing checks that the component lands in the package's `src` and that no doubled `packages/` directory appears are unchanged, as is the final `nx sync` + `run-many --target build --all`, which is what proves the written specifiers really resolve.

The generated shadcn package needs no change: `shadcn add` installs `cn` into that package's own manifest, and the workspace's `catalogMode: strict` lifts it into the catalog (`cn: ^0.2.5` in `pnpm-workspace.yaml`, `"cn": "catalog:"` in the package), which typechecks and builds.

#### Was a user's website ever broken, and is this weaker than before?

**No user was ever broken — only the test was.** `shadcn add` adds `cn` to the shadcn package's own `dependencies` at the same time as it writes `from "cn"`, so the import it emits resolves. That was verified by typechecking and building the generated workspace, and in an isolated repro of the CLI against the generated `components.json`. So there is no rewrite of ours that "stopped matching": the plugin never rewrote this import — the CLI did, and only ever for a `@/lib/utils` specifier, which the registry no longer emits. Nothing in `packages/**` is wrong, which is why this is test-only.

The assertion is **differently targeted, not looser**, because the old one conflated two things: that our alias config is correct, and that upstream sources `cn` from `lib/utils`. Only the first is ours to assert. The replacement still fails on every way our `components.json`/`imports` config can actually be wrong:

- drop or corrupt the `utils`/`ui`/`components` aliases → the registry's `@/...` specifiers survive untouched → **fails** (the old assertion caught this too),
- point an alias at the public package name instead of a package-local `#...` → **fails** (the old assertion did *not* catch this; this is strictly stronger),
- wrong alias *shape* → the CLI joins it against its own cwd and writes to a doubled `packages/common/shadcn/packages/...` path → **fails** on the unchanged existence and no-`packages/`-dir checks.

Most importantly, the check that the emitted specifiers genuinely **resolve** was never the regex — it is the unchanged `nx sync` + `run-many --target build --all` at the end of the test, which typechecks every added component in the generated workspace. A non-resolving import fails the build regardless of which specifier upstream picks.

#### Recurrence

`TS_VERSIONS.shadcn` already pins the CLI (`4.19.0`), but the *registry* is fetched from `ui.shadcn.com` at test time and cannot be pinned without standing up a registry fixture — upstream can change component contents at any time. Rather than pin content, this change removes the test's dependence on it: the assertions now cover only invariants our own config owns, so an upstream edit to which module a component imports can no longer redden CI. A registry fixture/proxy would be the stronger guarantee but is well beyond an unbreak-CI change; flagging rather than doing it here.

### Description of how you validated changes

Ran the failing smoke test locally against the compiled plugin, end to end:

```
pnpm nx run @aws/nx-plugin-e2e:smoke-test --name=react-website
✓ src/smoke-tests/react-website.spec.ts (1 test)
  ✓ should generate and build
```

That covers all six website permutations plus `ts#api`, `ts#website#auth` and `connection`, both documented `shadcn add` invocations (`-c <dir>` from the workspace root and bare from inside the package), the `format` pass, `nx sync` and `run-many --target build --all` — all green.

`Smoke Tests - react-website` also passes on this branch in CI (7m49s), which is the authoritative confirmation: [job](https://github.com/awslabs/nx-plugin-for-aws/actions/runs/33862375041/job/100991051594). All 70 checks on this PR are green.

In the generated workspace, confirmed the shape the new assertion describes:

- `dialog.tsx` / `popover.tsx` both `import { cn } from 'cn'`, and `dialog.tsx` still resolves the `ui` alias to `#components/ui/button` — no `@/...` specifier and no `common-shadcn` specifier in either file,
- both components land in `packages/common/shadcn/src/components/ui/` with no doubled `packages/` directory,
- `cn: ^0.2.5` was added to the workspace catalog and `"cn": "catalog:"` to the shadcn package,
- the whole workspace builds (which typechecks every component).

Also reproduced the CLI behaviour in isolation to confirm it is registry-driven rather than a config problem: with the generated `components.json` and `imports` map, `shadcn@4.19.0 add dialog` writes `from "cn"` and adds `cn` to `dependencies`, and the CLI's import transform has no branch for a bare `cn` specifier.

Not deployed to AWS.

### Issue # (if applicable)

N/A — CI break from an upstream shadcn registry change.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
