### PR TITLE
feat(init): set up git-secrets credential scanning on existing workspaces

### DIFF
--- a/.gitallowed
+++ b/.gitallowed
@@ -1,3 +1,5 @@
+# The vendored git-secrets script, whose body contains the patterns it registers
+git-secrets-dir/git-secrets:
 # Fake AWS key used in the git-secrets integration test (e2e/src/smoke-tests/git-secrets.spec.ts)
 AKIAIOSFODNN7EXAMPLA
 # Example AWS account numbers used in documentation

--- a/docs/src/content/docs/en/get_started/existing-project.mdx
+++ b/docs/src/content/docs/en/get_started/existing-project.mdx
@@ -124,12 +124,15 @@ It creates or updates the following files:
 - tsconfig.json a root TypeScript config referencing your workspace's projects, which Nx's TypeScript sync keeps up to date
 - tsconfig.base.json the shared compiler options the plugin's TypeScript projects extend (see below for what it carries)
 - pnpm-workspace.yaml (pnpm only) allow-lists the build scripts the plugin's dependencies need (`@swc/core`, `esbuild`, `nx`, `sharp`)
-- package.json convenience scripts for common tasks, plus the `@aws/nx-plugin`, `@aws/nx-plugin-mcp`, `nx`, `@nx/js`, `@nx/workspace`, `typescript` and Biome dev dependencies
+- package.json convenience scripts for common tasks, a `prepare` script that installs the git hooks, plus the `@aws/nx-plugin`, `@aws/nx-plugin-mcp`, `nx`, `@nx/js`, `@nx/workspace`, `typescript`, husky and Biome dev dependencies
 - biome.json default Biome formatter and linter configuration
+- .git-secrets/ the vendored [git-secrets](https://github.com/awslabs/git-secrets) script, with `.gitallowed` for false positives and a `.husky/pre-commit` hook that runs it — see <Link path="guides/workspace#git-secrets">Git Secrets</Link>
 - .mcp.json configures the MCP server for supported coding agents unless disabled (also .cursor/, .kiro/, .gemini/, .vscode/ and .codex/ equivalents). It runs the workspace's own `@aws/nx-plugin-mcp`, so the server always matches the version installed in your workspace
 </FileTree>
 
-The <Link path="get_started/building-with-ai">MCP server</Link> configuration can be disabled with `--mcp=false`.
+The <Link path="get_started/building-with-ai">MCP server</Link> configuration can be disabled with `--mcp=false`, and the credential scanning hooks with `--gitSecrets=false`.
+
+Files you already have are preserved: an existing `.husky/pre-commit` hook or `prepare` script is left as it is, and the generator prints what to add so credential scanning runs alongside your own checks. An existing `.gitallowed` keeps every pattern it has.
 
 <Drawer title="tsconfig.base.json" trigger="Click here to see the compiler options a created tsconfig.base.json carries.">
 The plugin's TypeScript projects rely on these compiler options. If a `tsconfig.base.json` already exists it is left as-is, so if you keep your own these are the options to align with:

--- a/docs/src/content/docs/en/guides/security.mdx
+++ b/docs/src/content/docs/en/guides/security.mdx
@@ -28,7 +28,7 @@ Projects which build container images (for example agents, MCP servers, and data
 
 ### Credential Scanning
 
-Workspaces include [git-secrets](https://github.com/awslabs/git-secrets) pre-commit hooks which scan staged files for AWS credential patterns, preventing accidental commits of access keys and other sensitive values. See the <Link path="/guides/workspace#git-secrets">Git Secrets</Link> section of the workspace guide.
+Workspaces include [git-secrets](https://github.com/awslabs/git-secrets) pre-commit hooks which scan staged files for AWS credential patterns, preventing accidental commits of access keys and other sensitive values. Both creating a workspace and adopting the plugin into an existing one set these up, unless you opt out. See the <Link path="/guides/workspace#git-secrets">Git Secrets</Link> section of the workspace guide.
 
 ### Authentication
 

--- a/docs/src/content/docs/en/guides/typescript-infrastructure.mdx
+++ b/docs/src/content/docs/en/guides/typescript-infrastructure.mdx
@@ -272,8 +272,13 @@ Shared stages (under `shared.stages`) apply to any infra project in the workspac
 
 Project-specific stages (under `projects['packages/infra'].stages`) only apply to that project. When both exist for the same stage name, the project-specific entry takes priority.
 
-:::tip[Commit Stage Config]
-We recommend committing `stages.config.ts` so the team shares a single source of truth for stage credentials. If it contains personal profile names, you can add it to `.gitignore` and use a local override instead.
+:::note[Commit Stage Config]
+If you wish to commit `stages.config.ts` so the team shares a single source of truth for stage credentials, credential scanning may flag any AWS Account IDs specified in this file. You can suppress this in `.gitallowed` as follows:
+
+```text title=".gitallowed"
+# Allow AWS Account IDs in the stage configuration
+stages\.config\.ts:[0-9]+:.*[0-9]{12}
+```
 :::
 
 ### API Infrastructure

--- a/docs/src/content/docs/en/guides/workspace.mdx
+++ b/docs/src/content/docs/en/guides/workspace.mdx
@@ -2,7 +2,7 @@
 title: Workspace
 description: Reference documentation for workspaces
 ---
-import { FileTree } from '@astrojs/starlight/components';
+import { Aside, FileTree } from '@astrojs/starlight/components';
 import Link from '@components/link.astro';
 import CreateNxWorkspaceCommand from '@components/create-nx-workspace-command.astro';
 import PackageManagerShortCommand from '@components/package-manager-short-command.astro';
@@ -29,6 +29,7 @@ When you create a new workspace with `@aws/nx-plugin`, the preset generator sets
   - tsconfig.base.json Root TypeScript configuration
   - aws-nx-plugin.config.mts Nx Plugin for AWS configuration
   - .git-secrets/ Vendored git-secrets bash script for credential scanning
+  - .gitallowed Patterns git-secrets treats as false positives
   - .husky/ Git hooks
   - .mcp.json Nx Plugin for AWS MCP server configuration for Claude Code
   - .cursor/mcp.json ...and for Cursor
@@ -167,21 +168,26 @@ New workspaces are configured with [Biome](https://biomejs.dev/) for static anal
 
 ### Git Secrets
 
-New workspaces include [git-secrets](https://github.com/awslabs/git-secrets) pre-commit hooks that scan staged files for AWS credential patterns before each commit. This prevents accidentally committing access keys, secret keys, and other sensitive values.
+Workspaces are set up with [git-secrets](https://github.com/awslabs/git-secrets) pre-commit hooks that scan staged files for AWS credential patterns before each commit. This prevents accidentally committing access keys, secret keys, and other sensitive values.
+
+The script is vendored into the workspace at `.git-secrets/git-secrets` and run by the `.husky/pre-commit` hook, so there is nothing to install — but it is not on your `PATH`, so invoke it by path rather than as `git secrets`.
 
 #### Suppressing False Positives
 
 Patterns in git-secrets use [egrep-compatible regular expressions](https://github.com/awslabs/git-secrets#options-for-add). If git-secrets blocks a commit that does not contain real credentials:
 
 ```sh
-# Allow a specific regex pattern
-git secrets --add --allowed 'my-regex-pattern'
+# Allow a specific regex pattern (-a is the allowed flag)
+bash .git-secrets/git-secrets --add -a -- 'my-regex-pattern'
 
-# Allow a literal string (special characters are escaped)
-git secrets --add --allowed --literal 'my-literal+string'
+# Allow a literal string, escaping special characters (-l is the literal flag)
+bash .git-secrets/git-secrets --add -a -l -- 'my-literal+string'
+
+# List what is currently allowed
+git config --get-all secrets.allowed
 ```
 
-You can also create a `.gitallowed` file at the repository root with one egrep-compatible regex per line (shared with your team via version control):
+These are recorded in your local git config, so they apply only to your own clone. To share a suppression with your team, add it to the `.gitallowed` file at the repository root instead — one egrep-compatible regex per line, matched against `<path>:<line-number>:<line-contents>`:
 
 ```text title=".gitallowed"
 # Allow test fixtures

--- a/docs/src/content/docs/es/get_started/existing-project.mdx
+++ b/docs/src/content/docs/es/get_started/existing-project.mdx
@@ -124,12 +124,15 @@ Crea o actualiza los siguientes archivos:
 - tsconfig.json una configuración TypeScript raíz que referencia los proyectos de tu espacio de trabajo, que la sincronización TypeScript de Nx mantiene actualizada
 - tsconfig.base.json las opciones de compilador compartidas que los proyectos TypeScript del plugin extienden (ver abajo para lo que contiene)
 - pnpm-workspace.yaml (solo pnpm) lista de permitidos de los scripts de compilación que las dependencias del plugin necesitan (`@swc/core`, `esbuild`, `nx`, `sharp`)
-- package.json scripts de conveniencia para tareas comunes, más las dependencias de desarrollo `@aws/nx-plugin`, `@aws/nx-plugin-mcp`, `nx`, `@nx/js`, `@nx/workspace`, `typescript` y Biome
+- package.json scripts de conveniencia para tareas comunes, un script `prepare` que instala los hooks de git, más las dependencias de desarrollo `@aws/nx-plugin`, `@aws/nx-plugin-mcp`, `nx`, `@nx/js`, `@nx/workspace`, `typescript`, husky y Biome
 - biome.json configuración predeterminada del formateador y linter Biome
+- .git-secrets/ el script [git-secrets](https://github.com/awslabs/git-secrets) vendorizado, con `.gitallowed` para falsos positivos y un hook `.husky/pre-commit` que lo ejecuta — consulta <Link path="guides/workspace#git-secrets">Git Secrets</Link>
 - .mcp.json configura el servidor MCP para agentes de codificación compatibles a menos que se deshabilite (también equivalentes .cursor/, .kiro/, .gemini/, .vscode/ y .codex/). Ejecuta el propio `@aws/nx-plugin-mcp` del espacio de trabajo, por lo que el servidor siempre coincide con la versión instalada en tu espacio de trabajo
 </FileTree>
 
-La configuración del <Link path="get_started/building-with-ai">servidor MCP</Link> se puede deshabilitar con `--mcp=false`.
+La configuración del <Link path="get_started/building-with-ai">servidor MCP</Link> se puede deshabilitar con `--mcp=false`, y los hooks de escaneo de credenciales con `--gitSecrets=false`.
+
+Los archivos que ya tienes se preservan: un hook `.husky/pre-commit` o script `prepare` existente se deja tal cual, y el generador imprime qué agregar para que el escaneo de credenciales se ejecute junto con tus propias verificaciones. Un `.gitallowed` existente mantiene cada patrón que tiene.
 
 <Drawer title="tsconfig.base.json" trigger="Haz clic aquí para ver las opciones de compilador que lleva un tsconfig.base.json creado.">
 Los proyectos TypeScript del plugin dependen de estas opciones de compilador. Si ya existe un `tsconfig.base.json` se deja tal cual, por lo que si mantienes el tuyo propio estas son las opciones con las que alinearte:

--- a/docs/src/content/docs/es/guides/security.mdx
+++ b/docs/src/content/docs/es/guides/security.mdx
@@ -28,7 +28,7 @@ Los proyectos que construyen imágenes de contenedor (por ejemplo, agentes, serv
 
 ### Escaneo de Credenciales
 
-Los workspaces incluyen hooks de pre-commit de [git-secrets](https://github.com/awslabs/git-secrets) que escanean archivos preparados en busca de patrones de credenciales de AWS, previniendo commits accidentales de claves de acceso y otros valores sensibles. Consulte la sección <Link path="/es/guides/workspace#git-secrets">Git Secrets</Link> de la guía del workspace.
+Los workspaces incluyen hooks de pre-commit de [git-secrets](https://github.com/awslabs/git-secrets) que escanean archivos preparados en busca de patrones de credenciales de AWS, previniendo commits accidentales de claves de acceso y otros valores sensibles. Tanto la creación de un workspace como la adopción del plugin en uno existente configuran esto, a menos que opte por no hacerlo. Consulte la sección <Link path="/es/guides/workspace#git-secrets">Git Secrets</Link> de la guía del workspace.
 
 ### Autenticación
 

--- a/docs/src/content/docs/es/guides/typescript-infrastructure.mdx
+++ b/docs/src/content/docs/es/guides/typescript-infrastructure.mdx
@@ -272,8 +272,13 @@ Los stages compartidos (bajo `shared.stages`) aplican a cualquier proyecto de in
 
 Los stages específicos del proyecto (bajo `projects['packages/infra'].stages`) solo aplican a ese proyecto. Cuando ambos existen para el mismo nombre de stage, la entrada específica del proyecto tiene prioridad.
 
-:::tip[Hacer Commit de la Configuración de Stage]
-Recomendamos hacer commit de `stages.config.ts` para que el equipo comparta una única fuente de verdad para las credenciales de stage. Si contiene nombres de perfiles personales, puedes agregarlo a `.gitignore` y usar una anulación local en su lugar.
+:::note[Hacer Commit de la Configuración de Stage]
+Si deseas hacer commit de `stages.config.ts` para que el equipo comparta una única fuente de verdad para las credenciales de stage, el escaneo de credenciales puede marcar cualquier ID de cuenta de AWS especificado en este archivo. Puedes suprimir esto en `.gitallowed` de la siguiente manera:
+
+```text title=".gitallowed"
+# Allow AWS Account IDs in the stage configuration
+stages\.config\.ts:[0-9]+:.*[0-9]{12}
+```
 :::
 
 ### Infraestructura de API

--- a/docs/src/content/docs/es/guides/workspace.mdx
+++ b/docs/src/content/docs/es/guides/workspace.mdx
@@ -2,7 +2,7 @@
 title: Workspace
 description: Documentación de referencia para workspaces
 ---
-import { FileTree } from '@astrojs/starlight/components';
+import { Aside, FileTree } from '@astrojs/starlight/components';
 import Link from '@components/link.astro';
 import CreateNxWorkspaceCommand from '@components/create-nx-workspace-command.astro';
 import PackageManagerShortCommand from '@components/package-manager-short-command.astro';
@@ -29,6 +29,7 @@ Cuando creas un nuevo workspace con `@aws/nx-plugin`, el generador preset config
   - tsconfig.base.json Root TypeScript configuration
   - aws-nx-plugin.config.mts Nx Plugin for AWS configuration
   - .git-secrets/ Vendored git-secrets bash script for credential scanning
+  - .gitallowed Patterns git-secrets treats as false positives
   - .husky/ Git hooks
   - .mcp.json Nx Plugin for AWS MCP server configuration for Claude Code
   - .cursor/mcp.json ...and for Cursor
@@ -167,21 +168,26 @@ Los nuevos workspaces están configurados con [Biome](https://biomejs.dev/) para
 
 ### Git Secrets
 
-Los nuevos workspaces incluyen hooks pre-commit de [git-secrets](https://github.com/awslabs/git-secrets) que escanean archivos preparados en busca de patrones de credenciales de AWS antes de cada commit. Esto previene la confirmación accidental de claves de acceso, claves secretas y otros valores sensibles.
+Los workspaces están configurados con hooks pre-commit de [git-secrets](https://github.com/awslabs/git-secrets) que escanean archivos preparados en busca de patrones de credenciales de AWS antes de cada commit. Esto previene la confirmación accidental de claves de acceso, claves secretas y otros valores sensibles.
+
+El script está incluido en el workspace en `.git-secrets/git-secrets` y es ejecutado por el hook `.husky/pre-commit`, por lo que no hay nada que instalar — pero no está en tu `PATH`, así que invócalo por ruta en lugar de como `git secrets`.
 
 #### Suprimir Falsos Positivos
 
 Los patrones en git-secrets usan [expresiones regulares compatibles con egrep](https://github.com/awslabs/git-secrets#options-for-add). Si git-secrets bloquea un commit que no contiene credenciales reales:
 
 ```sh
-# Allow a specific regex pattern
-git secrets --add --allowed 'my-regex-pattern'
+# Allow a specific regex pattern (-a is the allowed flag)
+bash .git-secrets/git-secrets --add -a -- 'my-regex-pattern'
 
-# Allow a literal string (special characters are escaped)
-git secrets --add --allowed --literal 'my-literal+string'
+# Allow a literal string, escaping special characters (-l is the literal flag)
+bash .git-secrets/git-secrets --add -a -l -- 'my-literal+string'
+
+# List what is currently allowed
+git config --get-all secrets.allowed
 ```
 
-También puedes crear un archivo `.gitallowed` en la raíz del repositorio con una regex compatible con egrep por línea (compartida con tu equipo a través del control de versiones):
+Estos se registran en tu configuración local de git, por lo que se aplican solo a tu propio clon. Para compartir una supresión con tu equipo, agrégala al archivo `.gitallowed` en la raíz del repositorio en su lugar — una regex compatible con egrep por línea, comparada contra `<path>:<line-number>:<line-contents>`:
 
 ```text title=".gitallowed"
 # Allow test fixtures

--- a/docs/src/content/docs/fr/get_started/existing-project.mdx
+++ b/docs/src/content/docs/fr/get_started/existing-project.mdx
@@ -124,12 +124,15 @@ Il crée ou met à jour les fichiers suivants :
 - tsconfig.json une configuration TypeScript racine référençant les projets de votre espace de travail, que la synchronisation TypeScript de Nx maintient à jour
 - tsconfig.base.json les options de compilateur partagées que les projets TypeScript du plugin étendent (voir ci-dessous pour ce qu'il contient)
 - pnpm-workspace.yaml (pnpm uniquement) autorise les scripts de build dont les dépendances du plugin ont besoin (`@swc/core`, `esbuild`, `nx`, `sharp`)
-- package.json scripts de commodité pour les tâches courantes, plus les devDependencies `@aws/nx-plugin`, `@aws/nx-plugin-mcp`, `nx`, `@nx/js`, `@nx/workspace`, `typescript` et Biome
+- package.json scripts de commodité pour les tâches courantes, un script `prepare` qui installe les hooks git, plus les devDependencies `@aws/nx-plugin`, `@aws/nx-plugin-mcp`, `nx`, `@nx/js`, `@nx/workspace`, `typescript`, husky et Biome
 - biome.json configuration par défaut du formateur et du linter Biome
+- .git-secrets/ le script [git-secrets](https://github.com/awslabs/git-secrets) vendorisé, avec `.gitallowed` pour les faux positifs et un hook `.husky/pre-commit` qui l'exécute — voir <Link path="guides/workspace#git-secrets">Git Secrets</Link>
 - .mcp.json configure le serveur MCP pour les agents de codage pris en charge sauf si désactivé (également les équivalents .cursor/, .kiro/, .gemini/, .vscode/ et .codex/). Il exécute le `@aws/nx-plugin-mcp` propre à l'espace de travail, donc le serveur correspond toujours à la version installée dans votre espace de travail
 </FileTree>
 
-La configuration du <Link path="get_started/building-with-ai">serveur MCP</Link> peut être désactivée avec `--mcp=false`.
+La configuration du <Link path="get_started/building-with-ai">serveur MCP</Link> peut être désactivée avec `--mcp=false`, et les hooks de scan des credentials avec `--gitSecrets=false`.
+
+Les fichiers que vous avez déjà sont préservés : un hook `.husky/pre-commit` ou un script `prepare` existant est laissé tel quel, et le générateur affiche ce qu'il faut ajouter pour que le scan des credentials s'exécute aux côtés de vos propres vérifications. Un `.gitallowed` existant conserve tous les motifs qu'il contient.
 
 <Drawer title="tsconfig.base.json" trigger="Cliquez ici pour voir les options de compilateur qu'un tsconfig.base.json créé contient.">
 Les projets TypeScript du plugin s'appuient sur ces options de compilateur. Si un `tsconfig.base.json` existe déjà, il est laissé tel quel, donc si vous conservez le vôtre, voici les options à aligner :

--- a/docs/src/content/docs/fr/guides/security.mdx
+++ b/docs/src/content/docs/fr/guides/security.mdx
@@ -28,7 +28,7 @@ Les projets qui construisent des images de conteneur (par exemple les agents, le
 
 ### Analyse des identifiants
 
-Les espaces de travail incluent des hooks de pré-commit [git-secrets](https://github.com/awslabs/git-secrets) qui analysent les fichiers en attente pour détecter les modèles d'identifiants AWS, empêchant les commits accidentels de clés d'accès et d'autres valeurs sensibles. Voir la section <Link path="/fr/guides/workspace#git-secrets">Git Secrets</Link> du guide de l'espace de travail.
+Les espaces de travail incluent des hooks de pré-commit [git-secrets](https://github.com/awslabs/git-secrets) qui analysent les fichiers en attente pour détecter les modèles d'identifiants AWS, empêchant les commits accidentels de clés d'accès et d'autres valeurs sensibles. La création d'un espace de travail et l'adoption du plugin dans un espace existant configurent ces hooks, sauf si vous choisissez de ne pas le faire. Voir la section <Link path="/fr/guides/workspace#git-secrets">Git Secrets</Link> du guide de l'espace de travail.
 
 ### Authentification
 

--- a/docs/src/content/docs/fr/guides/typescript-infrastructure.mdx
+++ b/docs/src/content/docs/fr/guides/typescript-infrastructure.mdx
@@ -272,8 +272,13 @@ Les stages partagés (sous `shared.stages`) s'appliquent à n'importe quel proje
 
 Les stages spécifiques au projet (sous `projects['packages/infra'].stages`) s'appliquent uniquement à ce projet. Lorsque les deux existent pour le même nom de stage, l'entrée spécifique au projet a la priorité.
 
-:::tip[Committer la configuration de stage]
-Nous recommandons de committer `stages.config.ts` afin que l'équipe partage une source de vérité unique pour les identifiants de stage. S'il contient des noms de profils personnels, vous pouvez l'ajouter à `.gitignore` et utiliser une surcharge locale à la place.
+:::note[Committer la configuration de stage]
+Si vous souhaitez committer `stages.config.ts` afin que l'équipe partage une source de vérité unique pour les identifiants de stage, l'analyse des identifiants peut signaler tous les ID de compte AWS spécifiés dans ce fichier. Vous pouvez supprimer cela dans `.gitallowed` comme suit :
+
+```text title=".gitallowed"
+# Allow AWS Account IDs in the stage configuration
+stages\.config\.ts:[0-9]+:.*[0-9]{12}
+```
 :::
 
 ### Infrastructure d'API

--- a/docs/src/content/docs/fr/guides/workspace.mdx
+++ b/docs/src/content/docs/fr/guides/workspace.mdx
@@ -2,7 +2,7 @@
 title: Espace de travail
 description: Documentation de référence pour les espaces de travail
 ---
-import { FileTree } from '@astrojs/starlight/components';
+import { Aside, FileTree } from '@astrojs/starlight/components';
 import Link from '@components/link.astro';
 import CreateNxWorkspaceCommand from '@components/create-nx-workspace-command.astro';
 import PackageManagerShortCommand from '@components/package-manager-short-command.astro';
@@ -29,6 +29,7 @@ Lorsque vous créez un nouvel espace de travail avec `@aws/nx-plugin`, le géné
   - tsconfig.base.json Root TypeScript configuration
   - aws-nx-plugin.config.mts Nx Plugin for AWS configuration
   - .git-secrets/ Vendored git-secrets bash script for credential scanning
+  - .gitallowed Patterns git-secrets treats as false positives
   - .husky/ Git hooks
   - .mcp.json Nx Plugin for AWS MCP server configuration for Claude Code
   - .cursor/mcp.json ...and for Cursor
@@ -167,21 +168,26 @@ Les nouveaux espaces de travail sont configurés avec [Biome](https://biomejs.de
 
 ### Git Secrets
 
-Les nouveaux espaces de travail incluent des hooks de pré-commit [git-secrets](https://github.com/awslabs/git-secrets) qui analysent les fichiers mis en staging pour détecter les modèles d'identifiants AWS avant chaque commit. Cela empêche de commiter accidentellement des clés d'accès, des clés secrètes et d'autres valeurs sensibles.
+Les espaces de travail sont configurés avec des hooks de pré-commit [git-secrets](https://github.com/awslabs/git-secrets) qui analysent les fichiers mis en staging pour détecter les modèles d'identifiants AWS avant chaque commit. Cela empêche de commiter accidentellement des clés d'accès, des clés secrètes et d'autres valeurs sensibles.
+
+Le script est intégré dans l'espace de travail à `.git-secrets/git-secrets` et exécuté par le hook `.husky/pre-commit`, il n'y a donc rien à installer — mais il n'est pas dans votre `PATH`, donc invoquez-le par chemin plutôt que comme `git secrets`.
 
 #### Suppression des faux positifs
 
 Les modèles dans git-secrets utilisent des [expressions régulières compatibles egrep](https://github.com/awslabs/git-secrets#options-for-add). Si git-secrets bloque un commit qui ne contient pas de véritables identifiants :
 
 ```sh
-# Allow a specific regex pattern
-git secrets --add --allowed 'my-regex-pattern'
+# Allow a specific regex pattern (-a is the allowed flag)
+bash .git-secrets/git-secrets --add -a -- 'my-regex-pattern'
 
-# Allow a literal string (special characters are escaped)
-git secrets --add --allowed --literal 'my-literal+string'
+# Allow a literal string, escaping special characters (-l is the literal flag)
+bash .git-secrets/git-secrets --add -a -l -- 'my-literal+string'
+
+# List what is currently allowed
+git config --get-all secrets.allowed
 ```
 
-Vous pouvez également créer un fichier `.gitallowed` à la racine du dépôt avec une regex compatible egrep par ligne (partagée avec votre équipe via le contrôle de version) :
+Ceux-ci sont enregistrés dans votre configuration git locale, ils ne s'appliquent donc qu'à votre propre clone. Pour partager une suppression avec votre équipe, ajoutez-la plutôt au fichier `.gitallowed` à la racine du dépôt — une regex compatible egrep par ligne, correspondant à `<path>:<line-number>:<line-contents>` :
 
 ```text title=".gitallowed"
 # Allow test fixtures

--- a/docs/src/content/docs/it/get_started/existing-project.mdx
+++ b/docs/src/content/docs/it/get_started/existing-project.mdx
@@ -124,12 +124,15 @@ Crea o aggiorna i seguenti file:
 - tsconfig.json una configurazione TypeScript root che fa riferimento ai progetti del tuo workspace, che la sincronizzazione TypeScript di Nx mantiene aggiornata
 - tsconfig.base.json le opzioni del compilatore condivise che i progetti TypeScript del plugin estendono (vedi sotto per cosa contiene)
 - pnpm-workspace.yaml (solo pnpm) lista consentita degli script di build di cui le dipendenze del plugin hanno bisogno (`@swc/core`, `esbuild`, `nx`, `sharp`)
-- package.json script di convenienza per attività comuni, più le devDependencies `@aws/nx-plugin`, `@aws/nx-plugin-mcp`, `nx`, `@nx/js`, `@nx/workspace`, `typescript` e Biome
+- package.json script di convenienza per attività comuni, uno script `prepare` che installa i git hook, più le devDependencies `@aws/nx-plugin`, `@aws/nx-plugin-mcp`, `nx`, `@nx/js`, `@nx/workspace`, `typescript`, husky e Biome
 - biome.json configurazione predefinita del formatter e linter Biome
+- .git-secrets/ lo script [git-secrets](https://github.com/awslabs/git-secrets) vendorizzato, con `.gitallowed` per i falsi positivi e un hook `.husky/pre-commit` che lo esegue — vedi <Link path="guides/workspace#git-secrets">Git Secrets</Link>
 - .mcp.json configura il server MCP per gli agenti di coding supportati a meno che non sia disabilitato (anche equivalenti .cursor/, .kiro/, .gemini/, .vscode/ e .codex/). Esegue il `@aws/nx-plugin-mcp` del workspace stesso, quindi il server corrisponde sempre alla versione installata nel tuo workspace
 </FileTree>
 
-La configurazione del <Link path="get_started/building-with-ai">server MCP</Link> può essere disabilitata con `--mcp=false`.
+La configurazione del <Link path="get_started/building-with-ai">server MCP</Link> può essere disabilitata con `--mcp=false`, e gli hook di scansione delle credenziali con `--gitSecrets=false`.
+
+I file che hai già vengono preservati: un hook `.husky/pre-commit` o uno script `prepare` esistente viene lasciato così com'è, e il generatore stampa cosa aggiungere in modo che la scansione delle credenziali venga eseguita insieme ai tuoi controlli. Un `.gitallowed` esistente mantiene ogni pattern che ha.
 
 <Drawer title="tsconfig.base.json" trigger="Clicca qui per vedere le opzioni del compilatore che un tsconfig.base.json creato contiene.">
 I progetti TypeScript del plugin si basano su queste opzioni del compilatore. Se un `tsconfig.base.json` esiste già viene lasciato così com'è, quindi se mantieni il tuo queste sono le opzioni con cui allinearti:

--- a/docs/src/content/docs/it/guides/security.mdx
+++ b/docs/src/content/docs/it/guides/security.mdx
@@ -28,7 +28,7 @@ I progetti che costruiscono immagini container (ad esempio agenti, server MCP e 
 
 ### Scansione delle Credenziali
 
-I workspace includono hook pre-commit [git-secrets](https://github.com/awslabs/git-secrets) che scansionano i file in staging alla ricerca di pattern di credenziali AWS, prevenendo commit accidentali di chiavi di accesso e altri valori sensibili. Vedere la sezione <Link path="/it/guides/workspace#git-secrets">Git Secrets</Link> della guida al workspace.
+I workspace includono hook pre-commit [git-secrets](https://github.com/awslabs/git-secrets) che scansionano i file in staging alla ricerca di pattern di credenziali AWS, prevenendo commit accidentali di chiavi di accesso e altri valori sensibili. Sia la creazione di un workspace che l'adozione del plugin in uno esistente configurano questi hook, a meno che non si scelga di rinunciare. Vedere la sezione <Link path="/it/guides/workspace#git-secrets">Git Secrets</Link> della guida al workspace.
 
 ### Autenticazione
 

--- a/docs/src/content/docs/it/guides/typescript-infrastructure.mdx
+++ b/docs/src/content/docs/it/guides/typescript-infrastructure.mdx
@@ -272,8 +272,13 @@ Gli stage condivisi (sotto `shared.stages`) si applicano a qualsiasi progetto di
 
 Gli stage specifici del progetto (sotto `projects['packages/infra'].stages`) si applicano solo a quel progetto. Quando entrambi esistono per lo stesso nome di stage, la voce specifica del progetto ha la priorità.
 
-:::tip[Commit della configurazione degli stage]
-Consigliamo di committare `stages.config.ts` in modo che il team condivida un'unica fonte di verità per le credenziali degli stage. Se contiene nomi di profili personali, puoi aggiungerlo a `.gitignore` e utilizzare invece un override locale.
+:::note[Commit della configurazione degli stage]
+Se desideri committare `stages.config.ts` in modo che il team condivida un'unica fonte di verità per le credenziali degli stage, la scansione delle credenziali potrebbe segnalare eventuali ID di account AWS specificati in questo file. Puoi sopprimere questo in `.gitallowed` come segue:
+
+```text title=".gitallowed"
+# Allow AWS Account IDs in the stage configuration
+stages\.config\.ts:[0-9]+:.*[0-9]{12}
+```
 :::
 
 ### Infrastruttura API

--- a/docs/src/content/docs/it/guides/workspace.mdx
+++ b/docs/src/content/docs/it/guides/workspace.mdx
@@ -2,7 +2,7 @@
 title: Workspace
 description: Documentazione di riferimento per i workspace
 ---
-import { FileTree } from '@astrojs/starlight/components';
+import { Aside, FileTree } from '@astrojs/starlight/components';
 import Link from '@components/link.astro';
 import CreateNxWorkspaceCommand from '@components/create-nx-workspace-command.astro';
 import PackageManagerShortCommand from '@components/package-manager-short-command.astro';
@@ -29,6 +29,7 @@ Quando crei un nuovo workspace con `@aws/nx-plugin`, il generatore preset config
   - tsconfig.base.json Root TypeScript configuration
   - aws-nx-plugin.config.mts Nx Plugin for AWS configuration
   - .git-secrets/ Vendored git-secrets bash script for credential scanning
+  - .gitallowed Patterns git-secrets treats as false positives
   - .husky/ Git hooks
   - .mcp.json Nx Plugin for AWS MCP server configuration for Claude Code
   - .cursor/mcp.json ...and for Cursor
@@ -167,21 +168,26 @@ I nuovi workspace sono configurati con [Biome](https://biomejs.dev/) per l'anali
 
 ### Git Secrets
 
-I nuovi workspace includono hook pre-commit di [git-secrets](https://github.com/awslabs/git-secrets) che scansionano i file in staging alla ricerca di pattern di credenziali AWS prima di ogni commit. Questo previene il commit accidentale di access key, secret key e altri valori sensibili.
+I workspace sono configurati con hook pre-commit di [git-secrets](https://github.com/awslabs/git-secrets) che scansionano i file in staging alla ricerca di pattern di credenziali AWS prima di ogni commit. Questo previene il commit accidentale di access key, secret key e altri valori sensibili.
+
+Lo script è incluso nel workspace in `.git-secrets/git-secrets` ed eseguito dall'hook `.husky/pre-commit`, quindi non c'è nulla da installare — ma non è nel tuo `PATH`, quindi invocalo tramite percorso piuttosto che come `git secrets`.
 
 #### Sopprimere i Falsi Positivi
 
 I pattern in git-secrets utilizzano [espressioni regolari compatibili con egrep](https://github.com/awslabs/git-secrets#options-for-add). Se git-secrets blocca un commit che non contiene credenziali reali:
 
 ```sh
-# Allow a specific regex pattern
-git secrets --add --allowed 'my-regex-pattern'
+# Allow a specific regex pattern (-a is the allowed flag)
+bash .git-secrets/git-secrets --add -a -- 'my-regex-pattern'
 
-# Allow a literal string (special characters are escaped)
-git secrets --add --allowed --literal 'my-literal+string'
+# Allow a literal string, escaping special characters (-l is the literal flag)
+bash .git-secrets/git-secrets --add -a -l -- 'my-literal+string'
+
+# List what is currently allowed
+git config --get-all secrets.allowed
 ```
 
-Puoi anche creare un file `.gitallowed` alla radice del repository con un'espressione regolare compatibile con egrep per riga (condivisa con il tuo team tramite controllo di versione):
+Questi vengono registrati nella tua configurazione git locale, quindi si applicano solo al tuo clone. Per condividere una soppressione con il tuo team, aggiungila invece al file `.gitallowed` alla radice del repository — un'espressione regolare compatibile con egrep per riga, confrontata con `<path>:<line-number>:<line-contents>`:
 
 ```text title=".gitallowed"
 # Allow test fixtures

--- a/docs/src/content/docs/jp/get_started/existing-project.mdx
+++ b/docs/src/content/docs/jp/get_started/existing-project.mdx
@@ -124,12 +124,15 @@ Nxとプラグインはnpmパッケージとして配布されるため、Node.j
 - tsconfig.json ワークスペースのプロジェクトを参照するルートTypeScript構成。NxのTypeScript同期が最新の状態に保ちます
 - tsconfig.base.json プラグインのTypeScriptプロジェクトが拡張する共有コンパイラオプション（以下で何を含むかを参照）
 - pnpm-workspace.yaml（pnpmのみ）プラグインの依存関係が必要とするビルドスクリプトを許可リストに登録します（`@swc/core`、`esbuild`、`nx`、`sharp`）
-- package.json 一般的なタスクのための便利なスクリプト、および `@aws/nx-plugin`、`@aws/nx-plugin-mcp`、`nx`、`@nx/js`、`@nx/workspace`、`typescript`、Biome開発依存関係
+- package.json 一般的なタスクのための便利なスクリプト、gitフックをインストールする `prepare` スクリプト、および `@aws/nx-plugin`、`@aws/nx-plugin-mcp`、`nx`、`@nx/js`、`@nx/workspace`、`typescript`、husky、Biome開発依存関係
 - biome.json デフォルトのBiomeフォーマッターとリンター構成
+- .git-secrets/ ベンダー化された [git-secrets](https://github.com/awslabs/git-secrets) スクリプト、誤検知用の `.gitallowed`、およびそれを実行する `.husky/pre-commit` フック — <Link path="guides/workspace#git-secrets">Git Secrets</Link>を参照
 - .mcp.json 無効にされていない限り、サポートされているコーディングエージェント用のMCPサーバーを構成します（.cursor/、.kiro/、.gemini/、.vscode/、.codex/ の同等物も含む）。ワークスペース自体の `@aws/nx-plugin-mcp` を実行するため、サーバーは常にワークスペースにインストールされているバージョンと一致します
 </FileTree>
 
-<Link path="get_started/building-with-ai">MCPサーバー</Link>の構成は `--mcp=false` で無効にできます。
+<Link path="get_started/building-with-ai">MCPサーバー</Link>の構成は `--mcp=false` で無効にでき、認証情報スキャンフックは `--gitSecrets=false` で無効にできます。
+
+既に持っているファイルは保持されます：既存の `.husky/pre-commit` フックまたは `prepare` スクリプトはそのまま残され、ジェネレーターは認証情報スキャンが独自のチェックと並行して実行されるように追加すべき内容を出力します。既存の `.gitallowed` は、持っているすべてのパターンを保持します。
 
 <Drawer title="tsconfig.base.json" trigger="作成されたtsconfig.base.jsonが持つコンパイラオプションを表示するにはここをクリックしてください。">
 プラグインのTypeScriptプロジェクトはこれらのコンパイラオプションに依存しています。`tsconfig.base.json` が既に存在する場合はそのまま残されるため、独自のものを保持する場合は、次のオプションに合わせてください：

--- a/docs/src/content/docs/jp/guides/security.mdx
+++ b/docs/src/content/docs/jp/guides/security.mdx
@@ -17,35 +17,35 @@ Nx Plugin for AWS によってスキャフォールドされたプロジェク�
 
 インフラストラクチャプロジェクトは、`build` ターゲットの一部として [Checkov](https://www.checkov.io/) で構成されているため、安全でないインフラストラクチャ設定はビルドを失敗させます：
 
-- CDK プロジェクトは CloudFormation テンプレートを合成し、Checkov によってスキャンされます。詳細は <Link path="/guides/typescript-infrastructure#security-testing">セキュリティテスト</Link> を参照してください。
-- Terraform プロジェクトは、Terraform コードに対して直接 Checkov を実行します。<Link path="/guides/terraform-project">Terraform プロジェクト</Link> を参照してください。
+- CDK プロジェクトは CloudFormation テンプレートを合成し、Checkov によってスキャンされます。詳細は <Link path="/jp/guides/typescript-infrastructure#security-testing">セキュリティテスト</Link> を参照してください。
+- Terraform プロジェクトは、Terraform コードに対して直接 Checkov を実行します。<Link path="/jp/guides/terraform-project">Terraform プロジェクト</Link> を参照してください。
 
-提供されたインフラストラクチャが Checkov ルールを抑制する場合、抑制は特定のリソースにスコープされ、正当化の注釈が付けられます。共有の `suppressRules` ヘルパーは、すべての抑制に理由を必要とし、独自のコードでも同じ慣行に従うことをお勧めします。<Link path="/guides/typescript-infrastructure#suppressing-checkov-checks">Checkov チェックの抑制</Link> を参照してください。
+提供されたインフラストラクチャが Checkov ルールを抑制する場合、抑制は特定のリソースにスコープされ、正当化の注釈が付けられます。共有の `suppressRules` ヘルパーは、すべての抑制に理由を必要とし、独自のコードでも同じ慣行に従うことをお勧めします。<Link path="/jp/guides/typescript-infrastructure#suppressing-checkov-checks">Checkov チェックの抑制</Link> を参照してください。
 
 ### コンテナイメージスキャン
 
-コンテナイメージをビルドするプロジェクト（例：エージェント、MCP サーバー、データベースマイグレーションイメージ）には、HIGH および CRITICAL の脆弱性についてイメージをスキャンする `trivy` ターゲットが含まれており、検出時には非ゼロで終了します。`.trivyignore` ファイルで検出を抑制する方法を含む詳細は、<Link path="/guides/docker-bundling">Docker バンドリング</Link> を参照してください。
+コンテナイメージをビルドするプロジェクト（例：エージェント、MCP サーバー、データベースマイグレーションイメージ）には、HIGH および CRITICAL の脆弱性についてイメージをスキャンする `trivy` ターゲットが含まれており、検出時には非ゼロで終了します。`.trivyignore` ファイルで検出を抑制する方法を含む詳細は、<Link path="/jp/guides/docker-bundling">Docker バンドリング</Link> を参照してください。
 
 ### 認証情報スキャン
 
-ワークスペースには [git-secrets](https://github.com/awslabs/git-secrets) プリコミットフックが含まれており、ステージングされたファイルを AWS 認証情報パターンでスキャンし、アクセスキーやその他の機密値の誤ったコミットを防ぎます。ワークスペースガイドの <Link path="/guides/workspace#git-secrets">Git Secrets</Link> セクションを参照してください。
+ワークスペースには [git-secrets](https://github.com/awslabs/git-secrets) プリコミットフックが含まれており、ステージングされたファイルを AWS 認証情報パターンでスキャンし、アクセスキーやその他の機密値の誤ったコミットを防ぎます。ワークスペースの作成と既存のワークスペースへのプラグインの採用の両方で、オプトアウトしない限り、これらが設定されます。ワークスペースガイドの <Link path="/jp/guides/workspace#git-secrets">Git Secrets</Link> セクションを参照してください。
 
 ### 認証
 
 API、エージェント、MCP サーバーは、デフォルトで AWS IAM（SigV4）認証を使用します：
 
-- <Link path="/guides/trpc">tRPC</Link>、<Link path="/guides/fastapi">FastAPI</Link>、<Link path="/guides/ts-smithy-api">Smithy</Link> API は、デフォルトで IAM 認証を使用し、オプションとして Cognito とカスタムオーソライザーが利用可能です。提供されるカスタムオーソライザースタブは、デフォルトでリクエストを拒否します。
-- Amazon Bedrock AgentCore Runtime にデプロイされる <Link path="/guides/ts-agent">エージェント</Link> と <Link path="/guides/ts-mcp-server">MCP サーバー</Link> は、デフォルトで IAM（SigV4）認証を使用し、オプションとして JWT ベースの Cognito 認証が利用可能です。
-- <Link path="/guides/react-website-auth">ウェブサイト認証ジェネレーター</Link> は、多要素認証（MFA）が必須で、強力なパスワードポリシーと削除保護が有効になった Amazon Cognito ユーザープールを提供します。
+- <Link path="/jp/guides/trpc">tRPC</Link>、<Link path="/jp/guides/fastapi">FastAPI</Link>、<Link path="/jp/guides/ts-smithy-api">Smithy</Link> API は、デフォルトで IAM 認証を使用し、オプションとして Cognito とカスタムオーソライザーが利用可能です。提供されるカスタムオーソライザースタブは、デフォルトでリクエストを拒否します。
+- Amazon Bedrock AgentCore Runtime にデプロイされる <Link path="/jp/guides/ts-agent">エージェント</Link> と <Link path="/jp/guides/ts-mcp-server">MCP サーバー</Link> は、デフォルトで IAM（SigV4）認証を使用し、オプションとして JWT ベースの Cognito 認証が利用可能です。
+- <Link path="/jp/guides/react-website-auth">ウェブサイト認証ジェネレーター</Link> は、多要素認証（MFA）が必須で、強力なパスワードポリシーと削除保護が有効になった Amazon Cognito ユーザープールを提供します。
 
 ### 暗号化
 
 提供されるインフラストラクチャは、転送中および保管中のデータを暗号化します：
 
-- ウェブサイトは CloudFront 経由で提供され、HTTP は HTTPS にリダイレクトされ、HTTP Strict Transport Security（HSTS）、Content Security Policy、その他の<Link path="/guides/react-website#security-headers">セキュリティヘッダー</Link>を含むレスポンスヘッダーポリシーが適用されます。AWS マネージドルールを持つ WAF がディストリビューションに関連付けられています。
+- ウェブサイトは CloudFront 経由で提供され、HTTP は HTTPS にリダイレクトされ、HTTP Strict Transport Security（HSTS）、Content Security Policy、その他の<Link path="/jp/guides/react-website#security-headers">セキュリティヘッダー</Link>を含むレスポンスヘッダーポリシーが適用されます。AWS マネージドルールを持つ WAF がディストリビューションに関連付けられています。
 - S3 バケットはすべてのパブリックアクセスをブロックし、バケットポリシーを介して SSL のみのアクセスを強制し、暗号化され（ウェブサイトコンテンツには鍵ローテーション付きの KMS）、カスタマー管理の KMS キーで暗号化された CloudWatch ロググループにサーバーアクセスログを配信します。そこで Logs Insights でクエリしたり、アラームを設定したりできます。
 - API アクセスログは、ローテーションが有効なカスタマー管理の KMS キーで暗号化された CloudWatch ロググループに書き込まれます。
-- <Link path="/guides/ts-rdb">Aurora データベース</Link>は、カスタマー管理の KMS キーでストレージ暗号化を有効にし、AWS Secrets Manager で認証情報を生成し（ハードコードされることはありません）、自動認証情報ローテーションをサポートします。
+- <Link path="/jp/guides/ts-rdb">Aurora データベース</Link>は、カスタマー管理の KMS キーでストレージ暗号化を有効にし、AWS Secrets Manager で認証情報を生成し（ハードコードされることはありません）、自動認証情報ローテーションをサポートします。
 
 ### 最小権限
 
@@ -56,7 +56,7 @@ API、エージェント、MCP サーバーは、デフォルトで AWS IAM（Si
 
 ### 依存関係ライセンス
 
-<Link path="/guides/license">ライセンスジェネレーター</Link>は、自動化されたライセンスヘッダー管理と、承認されたライセンスの許可リストに対する依存関係ライセンスチェックを構成し、問題のある推移的依存関係を出荷前に検出するのに役立ちます。
+<Link path="/jp/guides/license">ライセンスジェネレーター</Link>は、自動化されたライセンスヘッダー管理と、承認されたライセンスの許可リストに対する依存関係ライセンスチェックを構成し、問題のある推移的依存関係を出荷前に検出するのに役立ちます。
 
 ## 責任
 
@@ -73,3 +73,5 @@ Nx Plugin for AWS は、そのモデルのあなた側の一部に対処する�
 - **生成されたコードは出発点であり、完成品ではありません。** 機能を追加すると、プラグインが予測できないセキュリティ上の考慮事項が導入されます — 入力検証、データ処理、シークレット管理、依存関係の選択、他のシステムとの統合などです。
 
 したがって、生成されたコードとその上に構築するアプリケーションを、組織独自のセキュリティポリシー、標準、レビュープロセスに沿ってレビューし、本番ワークロードに適用するのと同じ脅威モデリング、セキュリティテスト、承認ゲートの対象とする必要があります。プラグインによって提供されるコントロールは、これらのプロセスを補完することを意図しており、置き換えることを意図していません。
+��
+��

--- a/docs/src/content/docs/jp/guides/typescript-infrastructure.mdx
+++ b/docs/src/content/docs/jp/guides/typescript-infrastructure.mdx
@@ -272,8 +272,13 @@ new ApplicationStage(app, 'my-app-sandbox', {
 
 プロジェクト固有のステージ（`projects['packages/infra'].stages`の下）は、そのプロジェクトにのみ適用されます。同じステージ名に対して両方が存在する場合、プロジェクト固有のエントリが優先されます。
 
-:::tip[ステージ設定のコミット]
-チームがステージ認証情報の単一の信頼できる情報源を共有できるように、`stages.config.ts`をコミットすることをお勧めします。個人のプロファイル名が含まれている場合は、`.gitignore`に追加して、代わりにローカルオーバーライドを使用できます。
+:::note[ステージ設定のコミット]
+チームがステージ認証情報の単一の信頼できる情報源を共有できるように`stages.config.ts`をコミットしたい場合、認証情報スキャンがこのファイルに指定されたAWSアカウントIDにフラグを立てる可能性があります。これは`.gitallowed`で次のように抑制できます：
+
+```text title=".gitallowed"
+# Allow AWS Account IDs in the stage configuration
+stages\.config\.ts:[0-9]+:.*[0-9]{12}
+```
 :::
 
 ### APIインフラストラクチャ

--- a/docs/src/content/docs/jp/guides/workspace.mdx
+++ b/docs/src/content/docs/jp/guides/workspace.mdx
@@ -2,7 +2,7 @@
 title: ワークスペース
 description: ワークスペースのリファレンスドキュメント
 ---
-import { FileTree } from '@astrojs/starlight/components';
+import { Aside, FileTree } from '@astrojs/starlight/components';
 import Link from '@components/link.astro';
 import CreateNxWorkspaceCommand from '@components/create-nx-workspace-command.astro';
 import PackageManagerShortCommand from '@components/package-manager-short-command.astro';
@@ -29,6 +29,7 @@ import GeneratorParameters from '@components/generator-parameters.astro';
   - tsconfig.base.json Root TypeScript configuration
   - aws-nx-plugin.config.mts Nx Plugin for AWS configuration
   - .git-secrets/ Vendored git-secrets bash script for credential scanning
+  - .gitallowed Patterns git-secrets treats as false positives
   - .husky/ Git hooks
   - .mcp.json Nx Plugin for AWS MCP server configuration for Claude Code
   - .cursor/mcp.json ...and for Cursor
@@ -167,21 +168,26 @@ Pythonの観点からは、これはモノレポのルートに単一の`.venv`�
 
 ### Git Secrets
 
-新しいワークスペースには、各コミット前にステージングされたファイルをAWS認証情報パターンでスキャンする[git-secrets](https://github.com/awslabs/git-secrets)プリコミットフックが含まれています。これにより、アクセスキー、シークレットキー、その他の機密値を誤ってコミットすることを防ぎます。
+ワークスペースには、各コミット前にステージングされたファイルをAWS認証情報パターンでスキャンする[git-secrets](https://github.com/awslabs/git-secrets)プリコミットフックがセットアップされています。これにより、アクセスキー、シークレットキー、その他の機密値を誤ってコミットすることを防ぎます。
+
+スクリプトは`.git-secrets/git-secrets`にワークスペースにベンダリングされており、`.husky/pre-commit`フックによって実行されるため、インストールする必要はありません。ただし、`PATH`には含まれていないため、`git secrets`としてではなく、パスで呼び出してください。
 
 #### 誤検知の抑制
 
 git-secretsのパターンは[egrep互換の正規表現](https://github.com/awslabs/git-secrets#options-for-add)を使用します。git-secretsが実際の認証情報を含まないコミットをブロックする場合：
 
 ```sh
-# Allow a specific regex pattern
-git secrets --add --allowed 'my-regex-pattern'
+# Allow a specific regex pattern (-a is the allowed flag)
+bash .git-secrets/git-secrets --add -a -- 'my-regex-pattern'
 
-# Allow a literal string (special characters are escaped)
-git secrets --add --allowed --literal 'my-literal+string'
+# Allow a literal string, escaping special characters (-l is the literal flag)
+bash .git-secrets/git-secrets --add -a -l -- 'my-literal+string'
+
+# List what is currently allowed
+git config --get-all secrets.allowed
 ```
 
-また、リポジトリルートに`.gitallowed`ファイルを作成し、1行に1つのegrep互換の正規表現を記述することもできます（バージョン管理を通じてチームと共有されます）：
+これらはローカルのgit設定に記録されるため、自分のクローンにのみ適用されます。抑制をチームと共有するには、代わりにリポジトリルートの`.gitallowed`ファイルに追加してください。1行に1つのegrep互換の正規表現を記述し、`<path>:<line-number>:<line-contents>`に対してマッチングされます：
 
 ```text title=".gitallowed"
 # Allow test fixtures

--- a/docs/src/content/docs/ko/get_started/existing-project.mdx
+++ b/docs/src/content/docs/ko/get_started/existing-project.mdx
@@ -124,12 +124,15 @@ Nx 설치와 호환되는 버전으로 플러그인을 설치한 다음 `init` �
 - tsconfig.json 워크스페이스의 프로젝트를 참조하는 루트 TypeScript 구성으로, Nx의 TypeScript 동기화가 최신 상태로 유지합니다
 - tsconfig.base.json 플러그인의 TypeScript 프로젝트가 확장하는 공유 컴파일러 옵션(아래에서 포함하는 내용 참조)
 - pnpm-workspace.yaml (pnpm만 해당) 플러그인의 종속성이 필요로 하는 빌드 스크립트를 허용 목록에 추가합니다(`@swc/core`, `esbuild`, `nx`, `sharp`)
-- package.json 일반적인 작업을 위한 편의 스크립트와 `@aws/nx-plugin`, `@aws/nx-plugin-mcp`, `nx`, `@nx/js`, `@nx/workspace`, `typescript` 및 Biome 개발 종속성
+- package.json 일반적인 작업을 위한 편의 스크립트, git 훅을 설치하는 `prepare` 스크립트, 그리고 `@aws/nx-plugin`, `@aws/nx-plugin-mcp`, `nx`, `@nx/js`, `@nx/workspace`, `typescript`, husky 및 Biome 개발 종속성
 - biome.json 기본 Biome 포매터 및 린터 구성
+- .git-secrets/ 벤더링된 [git-secrets](https://github.com/awslabs/git-secrets) 스크립트로, 오탐지를 위한 `.gitallowed`와 이를 실행하는 `.husky/pre-commit` 훅이 포함됩니다 — <Link path="guides/workspace#git-secrets">Git Secrets</Link> 참조
 - .mcp.json 비활성화되지 않는 한 지원되는 코딩 에이전트를 위한 MCP 서버를 구성합니다(.cursor/, .kiro/, .gemini/, .vscode/ 및 .codex/ 동등물도 포함). 워크스페이스 자체의 `@aws/nx-plugin-mcp`를 실행하므로 서버는 항상 워크스페이스에 설치된 버전과 일치합니다
 </FileTree>
 
-<Link path="get_started/building-with-ai">MCP 서버</Link> 구성은 `--mcp=false`로 비활성화할 수 있습니다.
+<Link path="get_started/building-with-ai">MCP 서버</Link> 구성은 `--mcp=false`로 비활성화할 수 있으며, 자격 증명 스캔 훅은 `--gitSecrets=false`로 비활성화할 수 있습니다.
+
+이미 가지고 있는 파일은 보존됩니다: 기존 `.husky/pre-commit` 훅이나 `prepare` 스크립트는 그대로 유지되며, 제너레이터는 자격 증명 스캔이 자체 검사와 함께 실행되도록 추가할 내용을 출력합니다. 기존 `.gitallowed`는 가지고 있는 모든 패턴을 유지합니다.
 
 <Drawer title="tsconfig.base.json" trigger="생성된 tsconfig.base.json이 포함하는 컴파일러 옵션을 보려면 여기를 클릭하세요.">
 플러그인의 TypeScript 프로젝트는 이러한 컴파일러 옵션에 의존합니다. `tsconfig.base.json`이 이미 존재하는 경우 그대로 유지되므로, 자체 옵션을 유지하는 경우 다음 옵션과 정렬해야 합니다:

--- a/docs/src/content/docs/ko/guides/security.mdx
+++ b/docs/src/content/docs/ko/guides/security.mdx
@@ -28,7 +28,7 @@ Nx Plugin for AWS에서 스캐폴딩된 프로젝트에는 기본적으로 여�
 
 ### 자격 증명 스캐닝
 
-워크스페이스에는 스테이징된 파일에서 AWS 자격 증명 패턴을 스캔하는 [git-secrets](https://github.com/awslabs/git-secrets) 사전 커밋 훅이 포함되어 있어, 액세스 키 및 기타 민감한 값의 우발적인 커밋을 방지합니다. 워크스페이스 가이드의 <Link path="/guides/workspace#git-secrets">Git Secrets</Link> 섹션을 참조하세요.
+워크스페이스에는 스테이징된 파일에서 AWS 자격 증명 패턴을 스캔하는 [git-secrets](https://github.com/awslabs/git-secrets) 사전 커밋 훅이 포함되어 있어, 액세스 키 및 기타 민감한 값의 우발적인 커밋을 방지합니다. 워크스페이스 생성과 기존 워크스페이스에 플러그인을 채택하는 것 모두 옵트아웃하지 않는 한 이를 설정합니다. 워크스페이스 가이드의 <Link path="/guides/workspace#git-secrets">Git Secrets</Link> 섹션을 참조하세요.
 
 ### 인증
 

--- a/docs/src/content/docs/ko/guides/typescript-infrastructure.mdx
+++ b/docs/src/content/docs/ko/guides/typescript-infrastructure.mdx
@@ -272,8 +272,13 @@ new ApplicationStage(app, 'my-app-sandbox', {
 
 프로젝트별 스테이지(`projects['packages/infra'].stages` 아래)는 해당 프로젝트에만 적용됩니다. 동일한 스테이지 이름에 대해 둘 다 존재하는 경우, 프로젝트별 항목이 우선합니다.
 
-:::tip[스테이지 구성 커밋]
-팀이 스테이지 자격 증명에 대한 단일 신뢰할 수 있는 소스를 공유하도록 `stages.config.ts`를 커밋하는 것을 권장합니다. 개인 프로필 이름이 포함된 경우, `.gitignore`에 추가하고 대신 로컬 재정의를 사용할 수 있습니다.
+:::note[스테이지 구성 커밋]
+팀이 스테이지 자격 증명에 대한 단일 신뢰할 수 있는 소스를 공유하도록 `stages.config.ts`를 커밋하려는 경우, 자격 증명 스캔이 이 파일에 지정된 AWS 계정 ID를 플래그할 수 있습니다. 다음과 같이 `.gitallowed`에서 이를 억제할 수 있습니다:
+
+```text title=".gitallowed"
+# Allow AWS Account IDs in the stage configuration
+stages\.config\.ts:[0-9]+:.*[0-9]{12}
+```
 :::
 
 ### API 인프라

--- a/docs/src/content/docs/ko/guides/workspace.mdx
+++ b/docs/src/content/docs/ko/guides/workspace.mdx
@@ -2,7 +2,7 @@
 title: 워크스페이스
 description: 워크스페이스에 대한 참조 문서
 ---
-import { FileTree } from '@astrojs/starlight/components';
+import { Aside, FileTree } from '@astrojs/starlight/components';
 import Link from '@components/link.astro';
 import CreateNxWorkspaceCommand from '@components/create-nx-workspace-command.astro';
 import PackageManagerShortCommand from '@components/package-manager-short-command.astro';
@@ -29,6 +29,7 @@ import GeneratorParameters from '@components/generator-parameters.astro';
   - tsconfig.base.json Root TypeScript configuration
   - aws-nx-plugin.config.mts Nx Plugin for AWS configuration
   - .git-secrets/ Vendored git-secrets bash script for credential scanning
+  - .gitallowed Patterns git-secrets treats as false positives
   - .husky/ Git hooks
   - .mcp.json Nx Plugin for AWS MCP server configuration for Claude Code
   - .cursor/mcp.json ...and for Cursor
@@ -167,21 +168,26 @@ Python 관점에서 이는 모노레포의 루트에 단일 `.venv`가 있고 �
 
 ### Git Secrets
 
-새 워크스페이스에는 각 커밋 전에 스테이징된 파일에서 AWS 자격 증명 패턴을 스캔하는 [git-secrets](https://github.com/awslabs/git-secrets) 사전 커밋 훅이 포함되어 있습니다. 이는 액세스 키, 시크릿 키 및 기타 민감한 값을 실수로 커밋하는 것을 방지합니다.
+워크스페이스는 각 커밋 전에 스테이징된 파일에서 AWS 자격 증명 패턴을 스캔하는 [git-secrets](https://github.com/awslabs/git-secrets) 사전 커밋 훅으로 설정됩니다. 이는 액세스 키, 시크릿 키 및 기타 민감한 값을 실수로 커밋하는 것을 방지합니다.
+
+스크립트는 `.git-secrets/git-secrets`에 워크스페이스에 포함되어 있으며 `.husky/pre-commit` 훅에 의해 실행되므로 설치할 것이 없습니다. 하지만 `PATH`에 없으므로 `git secrets`가 아닌 경로로 호출하세요.
 
 #### 거짓 양성 억제
 
 git-secrets의 패턴은 [egrep 호환 정규 표현식](https://github.com/awslabs/git-secrets#options-for-add)을 사용합니다. git-secrets가 실제 자격 증명을 포함하지 않는 커밋을 차단하는 경우:
 
 ```sh
-# Allow a specific regex pattern
-git secrets --add --allowed 'my-regex-pattern'
+# Allow a specific regex pattern (-a is the allowed flag)
+bash .git-secrets/git-secrets --add -a -- 'my-regex-pattern'
 
-# Allow a literal string (special characters are escaped)
-git secrets --add --allowed --literal 'my-literal+string'
+# Allow a literal string, escaping special characters (-l is the literal flag)
+bash .git-secrets/git-secrets --add -a -l -- 'my-literal+string'
+
+# List what is currently allowed
+git config --get-all secrets.allowed
 ```
 
-리포지토리 루트에 `.gitallowed` 파일을 생성하여 한 줄에 하나의 egrep 호환 정규식을 작성할 수도 있습니다(버전 관리를 통해 팀과 공유됨):
+이들은 로컬 git 구성에 기록되므로 자신의 클론에만 적용됩니다. 팀과 억제를 공유하려면 대신 리포지토리 루트의 `.gitallowed` 파일에 추가하세요. 한 줄에 하나의 egrep 호환 정규식을 작성하며, `<path>:<line-number>:<line-contents>`와 일치합니다:
 
 ```text title=".gitallowed"
 # Allow test fixtures
@@ -220,4 +226,3 @@ export default {
 <Link path="guides/license">license 제너레이터</Link>는 자체 동작을 구성하기 위해 이 동일한 파일에 `license` 키를 추가합니다.
 
 언제든지 모든 설정을 편집할 수 있으며, 이후 제너레이터 실행 시 새 값을 선택합니다.
-

--- a/docs/src/content/docs/pt/get_started/existing-project.mdx
+++ b/docs/src/content/docs/pt/get_started/existing-project.mdx
@@ -124,12 +124,15 @@ Ele cria ou atualiza os seguintes arquivos:
 - tsconfig.json uma configuração TypeScript raiz referenciando os projetos do seu workspace, que a sincronização TypeScript do Nx mantém atualizada
 - tsconfig.base.json as opções de compilador compartilhadas que os projetos TypeScript do plugin estendem (veja abaixo o que ele contém)
 - pnpm-workspace.yaml (somente pnpm) lista de permissões dos scripts de build que as dependências do plugin precisam (`@swc/core`, `esbuild`, `nx`, `sharp`)
-- package.json scripts de conveniência para tarefas comuns, além das devDependencies `@aws/nx-plugin`, `@aws/nx-plugin-mcp`, `nx`, `@nx/js`, `@nx/workspace`, `typescript` e Biome
+- package.json scripts de conveniência para tarefas comuns, um script `prepare` que instala os git hooks, além das devDependencies `@aws/nx-plugin`, `@aws/nx-plugin-mcp`, `nx`, `@nx/js`, `@nx/workspace`, `typescript`, husky e Biome
 - biome.json configuração padrão do formatador e linter Biome
+- .git-secrets/ o script [git-secrets](https://github.com/awslabs/git-secrets) vendorizado, com `.gitallowed` para falsos positivos e um hook `.husky/pre-commit` que o executa — veja <Link path="guides/workspace#git-secrets">Git Secrets</Link>
 - .mcp.json configura o servidor MCP para agentes de codificação suportados, a menos que desabilitado (também equivalentes .cursor/, .kiro/, .gemini/, .vscode/ e .codex/). Ele executa o próprio `@aws/nx-plugin-mcp` do workspace, então o servidor sempre corresponde à versão instalada no seu workspace
 </FileTree>
 
-A configuração do <Link path="get_started/building-with-ai">servidor MCP</Link> pode ser desabilitada com `--mcp=false`.
+A configuração do <Link path="get_started/building-with-ai">servidor MCP</Link> pode ser desabilitada com `--mcp=false`, e os hooks de verificação de credenciais com `--gitSecrets=false`.
+
+Arquivos que você já possui são preservados: um hook `.husky/pre-commit` ou script `prepare` existente é deixado como está, e o gerador imprime o que adicionar para que a verificação de credenciais seja executada junto com suas próprias verificações. Um `.gitallowed` existente mantém todos os padrões que possui.
 
 <Drawer title="tsconfig.base.json" trigger="Clique aqui para ver as opções de compilador que um tsconfig.base.json criado contém.">
 Os projetos TypeScript do plugin dependem dessas opções de compilador. Se um `tsconfig.base.json` já existe, ele é deixado como está, então se você mantiver o seu próprio, estas são as opções para alinhar:

--- a/docs/src/content/docs/pt/guides/security.mdx
+++ b/docs/src/content/docs/pt/guides/security.mdx
@@ -28,7 +28,7 @@ Projetos que constroem imagens de contêiner (por exemplo, agents, servidores MC
 
 ### Verificação de Credenciais
 
-Workspaces incluem hooks de pré-commit do [git-secrets](https://github.com/awslabs/git-secrets) que verificam arquivos preparados em busca de padrões de credenciais AWS, prevenindo commits acidentais de chaves de acesso e outros valores sensíveis. Veja a seção <Link path="/pt/guides/workspace#git-secrets">Git Secrets</Link> do guia de workspace.
+Workspaces incluem hooks de pré-commit do [git-secrets](https://github.com/awslabs/git-secrets) que verificam arquivos preparados em busca de padrões de credenciais AWS, prevenindo commits acidentais de chaves de acesso e outros valores sensíveis. Tanto a criação de um workspace quanto a adoção do plugin em um workspace existente configuram isso, a menos que você opte por não fazê-lo. Veja a seção <Link path="/pt/guides/workspace#git-secrets">Git Secrets</Link> do guia de workspace.
 
 ### Autenticação
 

--- a/docs/src/content/docs/pt/guides/typescript-infrastructure.mdx
+++ b/docs/src/content/docs/pt/guides/typescript-infrastructure.mdx
@@ -272,8 +272,13 @@ Stages compartilhados (em `shared.stages`) se aplicam a qualquer projeto de infr
 
 Stages específicos de projeto (em `projects['packages/infra'].stages`) se aplicam apenas a esse projeto. Quando ambos existem para o mesmo nome de stage, a entrada específica do projeto tem prioridade.
 
-:::tip[Commit da Configuração de Stage]
-Recomendamos fazer commit de `stages.config.ts` para que a equipe compartilhe uma única fonte de verdade para credenciais de stage. Se contiver nomes de perfis pessoais, você pode adicioná-lo ao `.gitignore` e usar uma substituição local.
+:::note[Commit da Configuração de Stage]
+Se você deseja fazer commit de `stages.config.ts` para que a equipe compartilhe uma única fonte de verdade para credenciais de stage, a verificação de credenciais pode sinalizar quaisquer IDs de Conta AWS especificados neste arquivo. Você pode suprimir isso em `.gitallowed` da seguinte forma:
+
+```text title=".gitallowed"
+# Allow AWS Account IDs in the stage configuration
+stages\.config\.ts:[0-9]+:.*[0-9]{12}
+```
 :::
 
 ### Infraestrutura de API

--- a/docs/src/content/docs/pt/guides/workspace.mdx
+++ b/docs/src/content/docs/pt/guides/workspace.mdx
@@ -2,7 +2,7 @@
 title: Workspace
 description: Documentação de referência para workspaces
 ---
-import { FileTree } from '@astrojs/starlight/components';
+import { Aside, FileTree } from '@astrojs/starlight/components';
 import Link from '@components/link.astro';
 import CreateNxWorkspaceCommand from '@components/create-nx-workspace-command.astro';
 import PackageManagerShortCommand from '@components/package-manager-short-command.astro';
@@ -29,6 +29,7 @@ Quando você cria um novo workspace com `@aws/nx-plugin`, o gerador preset confi
   - tsconfig.base.json Root TypeScript configuration
   - aws-nx-plugin.config.mts Nx Plugin for AWS configuration
   - .git-secrets/ Vendored git-secrets bash script for credential scanning
+  - .gitallowed Patterns git-secrets treats as false positives
   - .husky/ Git hooks
   - .mcp.json Nx Plugin for AWS MCP server configuration for Claude Code
   - .cursor/mcp.json ...and for Cursor
@@ -167,21 +168,26 @@ Novos workspaces são configurados com [Biome](https://biomejs.dev/) para análi
 
 ### Git Secrets
 
-Novos workspaces incluem hooks de pré-commit do [git-secrets](https://github.com/awslabs/git-secrets) que escaneiam arquivos staged em busca de padrões de credenciais AWS antes de cada commit. Isso evita commitar acidentalmente chaves de acesso, chaves secretas e outros valores sensíveis.
+Workspaces são configurados com hooks de pré-commit do [git-secrets](https://github.com/awslabs/git-secrets) que escaneiam arquivos staged em busca de padrões de credenciais AWS antes de cada commit. Isso evita commitar acidentalmente chaves de acesso, chaves secretas e outros valores sensíveis.
+
+O script é vendorizado no workspace em `.git-secrets/git-secrets` e executado pelo hook `.husky/pre-commit`, então não há nada para instalar — mas ele não está no seu `PATH`, então invoque-o pelo caminho em vez de como `git secrets`.
 
 #### Suprimindo Falsos Positivos
 
 Padrões no git-secrets usam [expressões regulares compatíveis com egrep](https://github.com/awslabs/git-secrets#options-for-add). Se o git-secrets bloquear um commit que não contém credenciais reais:
 
 ```sh
-# Allow a specific regex pattern
-git secrets --add --allowed 'my-regex-pattern'
+# Allow a specific regex pattern (-a is the allowed flag)
+bash .git-secrets/git-secrets --add -a -- 'my-regex-pattern'
 
-# Allow a literal string (special characters are escaped)
-git secrets --add --allowed --literal 'my-literal+string'
+# Allow a literal string, escaping special characters (-l is the literal flag)
+bash .git-secrets/git-secrets --add -a -l -- 'my-literal+string'
+
+# List what is currently allowed
+git config --get-all secrets.allowed
 ```
 
-Você também pode criar um arquivo `.gitallowed` na raiz do repositório com uma regex compatível com egrep por linha (compartilhada com sua equipe via controle de versão):
+Estes são registrados no seu git config local, então eles se aplicam apenas ao seu próprio clone. Para compartilhar uma supressão com sua equipe, adicione-a ao arquivo `.gitallowed` na raiz do repositório — uma regex compatível com egrep por linha, correspondida contra `<path>:<line-number>:<line-contents>`:
 
 ```text title=".gitallowed"
 # Allow test fixtures

--- a/docs/src/content/docs/vi/get_started/existing-project.mdx
+++ b/docs/src/content/docs/vi/get_started/existing-project.mdx
@@ -124,12 +124,15 @@ Nó tạo hoặc cập nhật các file sau:
 - tsconfig.json một config TypeScript gốc tham chiếu các dự án của workspace, mà TypeScript sync của Nx giữ cập nhật
 - tsconfig.base.json các compiler options được chia sẻ mà các dự án TypeScript của plugin mở rộng (xem bên dưới để biết nó chứa gì)
 - pnpm-workspace.yaml (chỉ pnpm) allow-list các build scripts mà các dependency của plugin cần (`@swc/core`, `esbuild`, `nx`, `sharp`)
-- package.json các script tiện lợi cho các task phổ biến, cộng với các dev dependencies `@aws/nx-plugin`, `@aws/nx-plugin-mcp`, `nx`, `@nx/js`, `@nx/workspace`, `typescript` và Biome
+- package.json các script tiện lợi cho các task phổ biến, một script `prepare` cài đặt các git hooks, cộng với các dev dependencies `@aws/nx-plugin`, `@aws/nx-plugin-mcp`, `nx`, `@nx/js`, `@nx/workspace`, `typescript`, husky và Biome
 - biome.json cấu hình formatter và linter Biome mặc định
+- .git-secrets/ script [git-secrets](https://github.com/awslabs/git-secrets) được vendored, với `.gitallowed` cho các false positives và một hook `.husky/pre-commit` chạy nó — xem <Link path="guides/workspace#git-secrets">Git Secrets</Link>
 - .mcp.json cấu hình MCP server cho các coding agent được hỗ trợ trừ khi bị vô hiệu hóa (cũng bao gồm các tương đương .cursor/, .kiro/, .gemini/, .vscode/ và .codex/). Nó chạy `@aws/nx-plugin-mcp` của chính workspace, vì vậy server luôn khớp với phiên bản được cài đặt trong workspace của bạn
 </FileTree>
 
-Cấu hình <Link path="get_started/building-with-ai">MCP server</Link> có thể bị vô hiệu hóa với `--mcp=false`.
+Cấu hình <Link path="get_started/building-with-ai">MCP server</Link> có thể bị vô hiệu hóa với `--mcp=false`, và các hooks quét thông tin xác thực với `--gitSecrets=false`.
+
+Các file bạn đã có được bảo toàn: một hook `.husky/pre-commit` hoặc script `prepare` hiện có được giữ nguyên, và generator in ra những gì cần thêm để quét thông tin xác thực chạy cùng với các kiểm tra của riêng bạn. Một `.gitallowed` hiện có giữ mọi pattern mà nó có.
 
 <Drawer title="tsconfig.base.json" trigger="Nhấp vào đây để xem các compiler options mà một tsconfig.base.json được tạo mang theo.">
 Các dự án TypeScript của plugin dựa vào các compiler options này. Nếu một `tsconfig.base.json` đã tồn tại, nó được giữ nguyên, vì vậy nếu bạn giữ của riêng mình, đây là các options cần căn chỉnh:

--- a/docs/src/content/docs/vi/guides/security.mdx
+++ b/docs/src/content/docs/vi/guides/security.mdx
@@ -28,7 +28,7 @@ Các dự án xây dựng container image (ví dụ: agent, MCP server và datab
 
 ### Quét Thông tin Xác thực
 
-Các workspace bao gồm các hook pre-commit [git-secrets](https://github.com/awslabs/git-secrets) quét các file đã staged để tìm các mẫu thông tin xác thực AWS, ngăn chặn việc commit ngẫu nhiên các access key và các giá trị nhạy cảm khác. Xem phần <Link path="/vi/guides/workspace#git-secrets">Git Secrets</Link> của hướng dẫn workspace.
+Các workspace bao gồm các hook pre-commit [git-secrets](https://github.com/awslabs/git-secrets) quét các file đã staged để tìm các mẫu thông tin xác thực AWS, ngăn chặn việc commit ngẫu nhiên các access key và các giá trị nhạy cảm khác. Cả việc tạo workspace và áp dụng plugin vào một workspace hiện có đều thiết lập những điều này, trừ khi bạn chọn không tham gia. Xem phần <Link path="/vi/guides/workspace#git-secrets">Git Secrets</Link> của hướng dẫn workspace.
 
 ### Xác thực
 

--- a/docs/src/content/docs/vi/guides/typescript-infrastructure.mdx
+++ b/docs/src/content/docs/vi/guides/typescript-infrastructure.mdx
@@ -272,8 +272,13 @@ Shared stages (dưới `shared.stages`) áp dụng cho bất kỳ dự án infra
 
 Project-specific stages (dưới `projects['packages/infra'].stages`) chỉ áp dụng cho dự án đó. Khi cả hai tồn tại cho cùng một tên stage, mục project-specific được ưu tiên.
 
-:::tip[Commit Stage Config]
-Chúng tôi khuyến nghị commit `stages.config.ts` để nhóm chia sẻ một nguồn sự thật duy nhất cho thông tin xác thực stage. Nếu nó chứa tên profile cá nhân, bạn có thể thêm nó vào `.gitignore` và sử dụng một override cục bộ thay thế.
+:::note[Commit Stage Config]
+Nếu bạn muốn commit `stages.config.ts` để nhóm chia sẻ một nguồn sự thật duy nhất cho thông tin xác thực stage, quét thông tin xác thực có thể gắn cờ bất kỳ ID Tài khoản AWS nào được chỉ định trong file này. Bạn có thể suppress điều này trong `.gitallowed` như sau:
+
+```text title=".gitallowed"
+# Allow AWS Account IDs in the stage configuration
+stages\.config\.ts:[0-9]+:.*[0-9]{12}
+```
 :::
 
 ### Hạ tầng API

--- a/docs/src/content/docs/vi/guides/workspace.mdx
+++ b/docs/src/content/docs/vi/guides/workspace.mdx
@@ -2,7 +2,7 @@
 title: Workspace
 description: Tài liệu tham khảo cho workspace
 ---
-import { FileTree } from '@astrojs/starlight/components';
+import { Aside, FileTree } from '@astrojs/starlight/components';
 import Link from '@components/link.astro';
 import CreateNxWorkspaceCommand from '@components/create-nx-workspace-command.astro';
 import PackageManagerShortCommand from '@components/package-manager-short-command.astro';
@@ -29,6 +29,7 @@ Khi bạn tạo một workspace mới với `@aws/nx-plugin`, preset generator s
   - tsconfig.base.json Root TypeScript configuration
   - aws-nx-plugin.config.mts Nx Plugin for AWS configuration
   - .git-secrets/ Vendored git-secrets bash script for credential scanning
+  - .gitallowed Patterns git-secrets treats as false positives
   - .husky/ Git hooks
   - .mcp.json Nx Plugin for AWS MCP server configuration for Claude Code
   - .cursor/mcp.json ...and for Cursor
@@ -167,21 +168,26 @@ Các workspace mới được cấu hình với [Biome](https://biomejs.dev/) ch
 
 ### Git Secrets
 
-Các workspace mới bao gồm các pre-commit hook của [git-secrets](https://github.com/awslabs/git-secrets) quét các file được staged để tìm các mẫu credential của AWS trước mỗi commit. Điều này ngăn chặn việc vô tình commit các access key, secret key và các giá trị nhạy cảm khác.
+Các workspace được thiết lập với các pre-commit hook của [git-secrets](https://github.com/awslabs/git-secrets) quét các file được staged để tìm các mẫu credential của AWS trước mỗi commit. Điều này ngăn chặn việc vô tình commit các access key, secret key và các giá trị nhạy cảm khác.
+
+Script được vendored vào workspace tại `.git-secrets/git-secrets` và chạy bởi hook `.husky/pre-commit`, vì vậy không có gì cần cài đặt — nhưng nó không có trong `PATH` của bạn, vì vậy hãy gọi nó bằng đường dẫn thay vì dùng `git secrets`.
 
 #### Loại Bỏ False Positive
 
 Các mẫu trong git-secrets sử dụng [biểu thức chính quy tương thích egrep](https://github.com/awslabs/git-secrets#options-for-add). Nếu git-secrets chặn một commit không chứa credential thực:
 
 ```sh
-# Allow a specific regex pattern
-git secrets --add --allowed 'my-regex-pattern'
+# Allow a specific regex pattern (-a is the allowed flag)
+bash .git-secrets/git-secrets --add -a -- 'my-regex-pattern'
 
-# Allow a literal string (special characters are escaped)
-git secrets --add --allowed --literal 'my-literal+string'
+# Allow a literal string, escaping special characters (-l is the literal flag)
+bash .git-secrets/git-secrets --add -a -l -- 'my-literal+string'
+
+# List what is currently allowed
+git config --get-all secrets.allowed
 ```
 
-Bạn cũng có thể tạo một file `.gitallowed` ở root của repository với một regex tương thích egrep trên mỗi dòng (được chia sẻ với nhóm của bạn thông qua version control):
+Những cấu hình này được ghi lại trong git config cục bộ của bạn, vì vậy chúng chỉ áp dụng cho bản clone của riêng bạn. Để chia sẻ một suppression với nhóm của bạn, hãy thêm nó vào file `.gitallowed` ở root của repository — một regex tương thích egrep trên mỗi dòng, được khớp với `<path>:<line-number>:<line-contents>`:
 
 ```text title=".gitallowed"
 # Allow test fixtures

--- a/docs/src/content/docs/zh/get_started/existing-project.mdx
+++ b/docs/src/content/docs/zh/get_started/existing-project.mdx
@@ -124,12 +124,15 @@ Nx 和插件作为 npm 包分发，因此没有 Node.js 工具的项目需要一
 - tsconfig.json 引用工作区项目的根 TypeScript 配置，Nx 的 TypeScript 同步会保持其最新状态
 - tsconfig.base.json 插件的 TypeScript 项目扩展的共享编译器选项（请参阅下文了解其内容）
 - pnpm-workspace.yaml（仅限 pnpm）允许列表中插件依赖项需要的构建脚本（`@swc/core`、`esbuild`、`nx`、`sharp`）
-- package.json 常见任务的便捷脚本，以及 `@aws/nx-plugin`、`@aws/nx-plugin-mcp`、`nx`、`@nx/js`、`@nx/workspace`、`typescript` 和 Biome 开发依赖项
+- package.json 常见任务的便捷脚本，安装 git 钩子的 `prepare` 脚本，以及 `@aws/nx-plugin`、`@aws/nx-plugin-mcp`、`nx`、`@nx/js`、`@nx/workspace`、`typescript`、husky 和 Biome 开发依赖项
 - biome.json 默认的 Biome 格式化程序和 linter 配置
+- .git-secrets/ 供应商提供的 [git-secrets](https://github.com/awslabs/git-secrets) 脚本，带有用于误报的 `.gitallowed` 和运行它的 `.husky/pre-commit` 钩子——请参阅 <Link path="guides/workspace#git-secrets">Git Secrets</Link>
 - .mcp.json 为支持的编码代理配置 MCP 服务器，除非禁用（还有 .cursor/、.kiro/、.gemini/、.vscode/ 和 .codex/ 等效项）。它运行工作区自己的 `@aws/nx-plugin-mcp`，因此服务器始终与工作区中安装的版本匹配
 </FileTree>
 
-可以使用 `--mcp=false` 禁用 <Link path="get_started/building-with-ai">MCP 服务器</Link>配置。
+可以使用 `--mcp=false` 禁用 <Link path="get_started/building-with-ai">MCP 服务器</Link>配置，使用 `--gitSecrets=false` 禁用凭证扫描钩子。
+
+您已有的文件会被保留：现有的 `.husky/pre-commit` 钩子或 `prepare` 脚本保持原样，生成器会打印要添加的内容，以便凭证扫描与您自己的检查一起运行。现有的 `.gitallowed` 保留其所有模式。
 
 <Drawer title="tsconfig.base.json" trigger="点击此处查看创建的 tsconfig.base.json 包含的编译器选项。">
 插件的 TypeScript 项目依赖于这些编译器选项。如果 `tsconfig.base.json` 已经存在，则保持原样，因此如果您保留自己的选项，这些是要对齐的选项：

--- a/docs/src/content/docs/zh/guides/security.mdx
+++ b/docs/src/content/docs/zh/guides/security.mdx
@@ -17,35 +17,35 @@ import Link from '@components/link.astro';
 
 基础设施项目配置了 [Checkov](https://www.checkov.io/) 作为 `build` 目标的一部分，因此不安全的基础设施配置会导致构建失败：
 
-- CDK 项目合成 CloudFormation 模板，这些模板由 Checkov 扫描。详见 <Link path="/guides/typescript-infrastructure#security-testing">安全测试</Link>。
-- Terraform 项目直接针对您的 Terraform 代码运行 Checkov。详见 <Link path="/guides/terraform-project">Terraform 项目</Link>。
+- CDK 项目合成 CloudFormation 模板，这些模板由 Checkov 扫描。详见 <Link path="/zh/guides/typescript-infrastructure#security-testing">安全测试</Link>。
+- Terraform 项目直接针对您的 Terraform 代码运行 Checkov。详见 <Link path="/zh/guides/terraform-project">Terraform 项目</Link>。
 
-当提供的基础设施抑制 Checkov 规则时，抑制范围限定于特定资源，并附有理由说明。共享的 `suppressRules` 辅助函数要求为每个抑制提供理由，我们建议您在自己的代码中遵循相同的做法。详见 <Link path="/guides/typescript-infrastructure#suppressing-checkov-checks">抑制 Checkov 检查</Link>。
+当提供的基础设施抑制 Checkov 规则时，抑制范围限定于特定资源，并附有理由说明。共享的 `suppressRules` 辅助函数要求为每个抑制提供理由，我们建议您在自己的代码中遵循相同的做法。详见 <Link path="/zh/guides/typescript-infrastructure#suppressing-checkov-checks">抑制 Checkov 检查</Link>。
 
 ### 容器镜像扫描
 
-构建容器镜像的项目（例如 agents、MCP servers 和数据库迁移镜像）包含一个 `trivy` 目标，该目标扫描镜像中的 HIGH 和 CRITICAL 漏洞，发现问题时以非零状态退出。详见 <Link path="/guides/docker-bundling">Docker 打包</Link>，包括如何使用 `.trivyignore` 文件抑制发现的问题。
+构建容器镜像的项目（例如 agents、MCP servers 和数据库迁移镜像）包含一个 `trivy` 目标，该目标扫描镜像中的 HIGH 和 CRITICAL 漏洞，发现问题时以非零状态退出。详见 <Link path="/zh/guides/docker-bundling">Docker 打包</Link>，包括如何使用 `.trivyignore` 文件抑制发现的问题。
 
 ### 凭证扫描
 
-工作空间包含 [git-secrets](https://github.com/awslabs/git-secrets) 预提交钩子，用于扫描暂存文件中的 AWS 凭证模式，防止意外提交访问密钥和其他敏感值。详见工作空间指南的 <Link path="/guides/workspace#git-secrets">Git Secrets</Link> 部分。
+工作空间包含 [git-secrets](https://github.com/awslabs/git-secrets) 预提交钩子，用于扫描暂存文件中的 AWS 凭证模式，防止意外提交访问密钥和其他敏感值。创建工作空间和将插件采用到现有工作空间都会设置这些钩子，除非您选择退出。详见工作空间指南的 <Link path="/zh/guides/workspace#git-secrets">Git Secrets</Link> 部分。
 
 ### 身份验证
 
 API、agents 和 MCP servers 默认使用 AWS IAM (SigV4) 身份验证：
 
-- <Link path="/guides/trpc">tRPC</Link>、<Link path="/guides/fastapi">FastAPI</Link> 和 <Link path="/guides/ts-smithy-api">Smithy</Link> API 默认使用 IAM 身份验证，并提供 Cognito 和自定义授权器作为选项。提供的自定义授权器存根默认拒绝请求。
-- 部署到 Amazon Bedrock AgentCore Runtime 的 <Link path="/guides/ts-agent">Agents</Link> 和 <Link path="/guides/ts-mcp-server">MCP servers</Link> 默认使用 IAM (SigV4) 身份验证，并提供基于 JWT 的 Cognito 身份验证作为选项。
-- <Link path="/guides/react-website-auth">网站身份验证生成器</Link>提供一个 Amazon Cognito 用户池，要求多因素身份验证 (MFA)，具有强密码策略，并启用删除保护。
+- <Link path="/zh/guides/trpc">tRPC</Link>、<Link path="/zh/guides/fastapi">FastAPI</Link> 和 <Link path="/zh/guides/ts-smithy-api">Smithy</Link> API 默认使用 IAM 身份验证，并提供 Cognito 和自定义授权器作为选项。提供的自定义授权器存根默认拒绝请求。
+- 部署到 Amazon Bedrock AgentCore Runtime 的 <Link path="/zh/guides/ts-agent">Agents</Link> 和 <Link path="/zh/guides/ts-mcp-server">MCP servers</Link> 默认使用 IAM (SigV4) 身份验证，并提供基于 JWT 的 Cognito 身份验证作为选项。
+- <Link path="/zh/guides/react-website-auth">网站身份验证生成器</Link>提供一个 Amazon Cognito 用户池，要求多因素身份验证 (MFA)，具有强密码策略，并启用删除保护。
 
 ### 加密
 
 提供的基础设施对传输中和静态的数据进行加密：
 
-- 网站通过 CloudFront 提供服务，HTTP 重定向到 HTTPS，响应头策略包括 HTTP 严格传输安全 (HSTS)、内容安全策略和其他<Link path="/guides/react-website#security-headers">安全头</Link>。WAF 与 AWS 托管规则关联到分发。
+- 网站通过 CloudFront 提供服务，HTTP 重定向到 HTTPS，响应头策略包括 HTTP 严格传输安全 (HSTS)、内容安全策略和其他<Link path="/zh/guides/react-website#security-headers">安全头</Link>。WAF 与 AWS 托管规则关联到分发。
 - S3 存储桶阻止所有公共访问，通过存储桶策略强制仅 SSL 访问，已加密（网站内容使用带密钥轮换的 KMS），并将服务器访问日志传送到使用客户管理的 KMS 密钥加密的 CloudWatch 日志组，可以使用 Logs Insights 查询并设置告警。
 - API 访问日志写入使用启用了轮换的客户管理 KMS 密钥加密的 CloudWatch 日志组。
-- <Link path="/guides/ts-rdb">Aurora 数据库</Link>使用客户管理的 KMS 密钥启用存储加密，在 AWS Secrets Manager 中生成凭证（从不硬编码），并支持自动凭证轮换。
+- <Link path="/zh/guides/ts-rdb">Aurora 数据库</Link>使用客户管理的 KMS 密钥启用存储加密，在 AWS Secrets Manager 中生成凭证（从不硬编码），并支持自动凭证轮换。
 
 ### 最小权限
 
@@ -56,7 +56,7 @@ API、agents 和 MCP servers 默认使用 AWS IAM (SigV4) 身份验证：
 
 ### 依赖许可
 
-<Link path="/guides/license">许可生成器</Link>配置自动许可证头管理和依赖许可证检查，针对已批准许可证的允许列表进行检查，帮助您在发布前捕获有问题的传递依赖项。
+<Link path="/zh/guides/license">许可生成器</Link>配置自动许可证头管理和依赖许可证检查，针对已批准许可证的允许列表进行检查，帮助您在发布前捕获有问题的传递依赖项。
 
 ## 责任
 

--- a/docs/src/content/docs/zh/guides/typescript-infrastructure.mdx
+++ b/docs/src/content/docs/zh/guides/typescript-infrastructure.mdx
@@ -272,8 +272,13 @@ new ApplicationStage(app, 'my-app-sandbox', {
 
 项目特定阶段（在 `projects['packages/infra'].stages` 下）仅适用于该项目。当同一阶段名称同时存在时，项目特定条目优先。
 
-:::tip[提交阶段配置]
-我们建议提交 `stages.config.ts`，以便团队共享阶段凭证的单一真实来源。如果它包含个人配置文件名称，您可以将其添加到 `.gitignore` 并使用本地覆盖。
+:::note[提交阶段配置]
+如果您希望提交 `stages.config.ts` 以便团队共享阶段凭证的单一真实来源，凭证扫描可能会标记此文件中指定的任何 AWS 账户 ID。您可以在 `.gitallowed` 中按如下方式抑制此问题：
+
+```text title=".gitallowed"
+# Allow AWS Account IDs in the stage configuration
+stages\.config\.ts:[0-9]+:.*[0-9]{12}
+```
 :::
 
 ### API 基础设施

--- a/docs/src/content/docs/zh/guides/workspace.mdx
+++ b/docs/src/content/docs/zh/guides/workspace.mdx
@@ -2,7 +2,7 @@
 title: 工作区
 description: 工作区参考文档
 ---
-import { FileTree } from '@astrojs/starlight/components';
+import { Aside, FileTree } from '@astrojs/starlight/components';
 import Link from '@components/link.astro';
 import CreateNxWorkspaceCommand from '@components/create-nx-workspace-command.astro';
 import PackageManagerShortCommand from '@components/package-manager-short-command.astro';
@@ -29,6 +29,7 @@ import GeneratorParameters from '@components/generator-parameters.astro';
   - tsconfig.base.json Root TypeScript configuration
   - aws-nx-plugin.config.mts Nx Plugin for AWS configuration
   - .git-secrets/ Vendored git-secrets bash script for credential scanning
+  - .gitallowed Patterns git-secrets treats as false positives
   - .husky/ Git hooks
   - .mcp.json Nx Plugin for AWS MCP server configuration for Claude Code
   - .cursor/mcp.json ...and for Cursor
@@ -167,21 +168,26 @@ Nx 缓存先前执行的目标的输出，并在输入未更改时重放它们�
 
 ### Git Secrets
 
-新工作区包含 [git-secrets](https://github.com/awslabs/git-secrets) 预提交钩子，在每次提交之前扫描暂存文件中的 AWS 凭证模式。这可以防止意外提交访问密钥、秘密密钥和其他敏感值。
+工作区设置了 [git-secrets](https://github.com/awslabs/git-secrets) 预提交钩子，在每次提交之前扫描暂存文件中的 AWS 凭证模式。这可以防止意外提交访问密钥、秘密密钥和其他敏感值。
+
+该脚本被供应到工作区的 `.git-secrets/git-secrets` 中，并由 `.husky/pre-commit` 钩子运行，因此无需安装任何东西——但它不在您的 `PATH` 中，因此请通过路径调用它，而不是使用 `git secrets`。
 
 #### 抑制误报
 
 git-secrets 中的模式使用 [egrep 兼容的正则表达式](https://github.com/awslabs/git-secrets#options-for-add)。如果 git-secrets 阻止了不包含真实凭证的提交：
 
 ```sh
-# Allow a specific regex pattern
-git secrets --add --allowed 'my-regex-pattern'
+# Allow a specific regex pattern (-a is the allowed flag)
+bash .git-secrets/git-secrets --add -a -- 'my-regex-pattern'
 
-# Allow a literal string (special characters are escaped)
-git secrets --add --allowed --literal 'my-literal+string'
+# Allow a literal string, escaping special characters (-l is the literal flag)
+bash .git-secrets/git-secrets --add -a -l -- 'my-literal+string'
+
+# List what is currently allowed
+git config --get-all secrets.allowed
 ```
 
-您还可以在仓库根目录创建一个 `.gitallowed` 文件，每行一个 egrep 兼容的正则表达式（通过版本控制与您的团队共享）：
+这些记录在您的本地 git 配置中，因此它们仅适用于您自己的克隆。要与您的团队共享抑制规则，请将其添加到仓库根目录的 `.gitallowed` 文件中——每行一个 egrep 兼容的正则表达式，与 `<path>:<line-number>:<line-contents>` 匹配：
 
 ```text title=".gitallowed"
 # Allow test fixtures

--- a/docs/src/i18n/schema-translations.json
+++ b/docs/src/i18n/schema-translations.json
@@ -3866,6 +3866,17 @@
       "zh": "首选的 IaC 提供商。",
       "vi": "Nhà cung cấp IaC ưa thích."
     },
+    "gitSecrets": {
+      "en": "Whether to configure git-secrets to prevent committing AWS credentials.",
+      "ko": "AWS 자격 증명 커밋을 방지하기 위해 git-secrets를 구성할지 여부입니다.",
+      "es": "Si se debe configurar git-secrets para prevenir el commit de credenciales de AWS.",
+      "fr": "Indique s'il faut configurer git-secrets pour empêcher la validation de credentials AWS.",
+      "jp": "AWSの認証情報のコミットを防ぐためにgit-secretsを設定するかどうか。",
+      "pt": "Se deve configurar git-secrets para prevenir o commit de credenciais AWS.",
+      "it": "Se configurare git-secrets per impedire il commit di credenziali AWS.",
+      "zh": "是否配置 git-secrets 以防止提交 AWS 凭证。",
+      "vi": "Có cấu hình git-secrets để ngăn chặn commit thông tin xác thực AWS hay không."
+    },
     "mcp": {
       "en": "Whether to configure the Nx Plugin for AWS MCP server for use by coding agents.",
       "pt": "Se deve configurar o Nx Plugin para servidor AWS MCP para uso por agentes de codificação.",

--- a/e2e/src/smoke-tests/git-secrets.spec.ts
+++ b/e2e/src/smoke-tests/git-secrets.spec.ts
@@ -4,7 +4,13 @@
  */
 
 import { execFileSync } from 'node:child_process';
-import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { ensureDirSync } from 'fs-extra';
@@ -101,5 +107,99 @@ describe('smoke test - git-secrets', () => {
     );
     git(['add', 'safe.ts'], projectRoot);
     git(['commit', '-m', 'add safe file'], projectRoot);
+
+    // The suppression commands the workspace guide documents must genuinely add
+    // a pattern. The vendored script parses only the short forms, so those are
+    // what the guide gives and what this asserts.
+    const gitSecrets = (args: string[]) =>
+      execFileSync('bash', ['.git-secrets/git-secrets', ...args], {
+        cwd: projectRoot,
+        encoding: 'utf-8',
+        stdio: 'pipe',
+        env: {
+          ...process.env,
+          GIT_CONFIG_GLOBAL: join(gitConfigDir, 'global'),
+          GIT_CONFIG_SYSTEM: join(gitConfigDir, 'system'),
+        },
+      });
+
+    gitSecrets(['--add', '-a', '--', 'my-regex-pattern']);
+    gitSecrets(['--add', '-a', '-l', '--', 'my-literal+string']);
+
+    const allowed = git(
+      ['config', '--get-all', 'secrets.allowed'],
+      projectRoot,
+    );
+    expect(allowed).toContain('my-regex-pattern');
+    // -l escapes the regex metacharacters.
+    expect(allowed).toContain('my-literal\\+string');
+
+    // A real secret is still caught after suppressing a false positive.
+    git(['add', 'secret.ts'], projectRoot);
+    let stillBlocked = false;
+    try {
+      git(['commit', '-m', 'add secret again'], projectRoot);
+    } catch (e) {
+      stillBlocked = true;
+      expect(e.stderr).toContain('Matched one or more prohibited patterns');
+    }
+    expect(stillBlocked).toBe(true);
+    git(['rm', '--cached', 'secret.ts'], projectRoot);
+
+    // The suppressed pattern is genuinely allowed through.
+    writeFileSync(
+      join(projectRoot, 'allowed.ts'),
+      `export const x = 'my-regex-pattern';\n`,
+    );
+    git(['add', 'allowed.ts'], projectRoot);
+    git(['commit', '-m', 'add allowed pattern'], projectRoot);
+  });
+
+  it('should commit a generated stages.config.ts once allowed', async () => {
+    await runCLI(
+      `${buildCreateNxWorkspaceCommand(pkgMgr, 'gs-stages', 'cdk')} --interactive=false`,
+      {
+        cwd: targetDir,
+        prefixWithPackageManagerCmd: false,
+        redirectStderr: true,
+        env: {
+          GIT_CONFIG_GLOBAL: join(gitConfigDir, 'global'),
+          GIT_CONFIG_SYSTEM: join(gitConfigDir, 'system'),
+        },
+      },
+    );
+    const projectRoot = `${targetDir}/gs-stages`;
+
+    await runCLI(
+      `generate @aws/nx-plugin:ts#infra --name=staged-infra --stageConfig=true --no-interactive`,
+      { cwd: projectRoot, env: { NX_DAEMON: 'false' } },
+    );
+
+    const stagesConfig = join(
+      projectRoot,
+      'packages/common/infra-config/src/stages.config.ts',
+    );
+    expect(existsSync(stagesConfig)).toBe(true);
+
+    // Account ids are flagged by default, so committing the stage config is
+    // blocked until the user allows them — as the infrastructure guide says.
+    git(['add', '-A'], projectRoot);
+    let blocked = false;
+    try {
+      git(['commit', '-m', 'add staged infra'], projectRoot);
+    } catch (e) {
+      blocked = true;
+      expect(e.stderr).toContain('Matched one or more prohibited patterns');
+    }
+    expect(blocked).toBe(true);
+
+    // The .gitallowed entry the guide documents unblocks it.
+    const gitallowed = join(projectRoot, '.gitallowed');
+    writeFileSync(
+      gitallowed,
+      `${readFileSync(gitallowed, 'utf-8')}stages\\.config\\.ts:[0-9]+:.*[0-9]{12}\n`,
+    );
+    git(['add', '-A'], projectRoot);
+    git(['commit', '-m', 'add staged infra'], projectRoot);
   });
 });

--- a/packages/nx-plugin/src/init/generator.spec.ts
+++ b/packages/nx-plugin/src/init/generator.spec.ts
@@ -2,7 +2,13 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import { readJson, readNxJson, type Tree, updateNxJson } from '@nx/devkit';
+import {
+  readJson,
+  readNxJson,
+  type Tree,
+  updateJson,
+  updateNxJson,
+} from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import yaml from 'js-yaml';
 import { beforeEach, describe, expect, it } from 'vitest';
@@ -142,6 +148,60 @@ describe('init generator', () => {
     await initGenerator(tree, { iac: 'cdk', containers: 'docker' });
     const base = readJson(tree, 'tsconfig.base.json');
     expect(base.compilerOptions.module).toBe('commonjs');
+  });
+
+  it('should set up the git-secrets pre-commit hook', async () => {
+    await initGenerator(tree, { iac: 'cdk', containers: 'docker' });
+
+    expect(tree.exists('.git-secrets/git-secrets')).toBe(true);
+    expect(tree.read('.husky/pre-commit', 'utf-8')).toContain(
+      '--pre_commit_hook',
+    );
+    expect(tree.read('.gitallowed', 'utf-8')).toContain(
+      '.git-secrets/git-secrets:',
+    );
+    const packageJson = readJson(tree, 'package.json');
+    expect(packageJson.scripts.prepare).toContain('husky');
+    expect(packageJson.devDependencies.husky).toBeDefined();
+  });
+
+  it('should not set up git-secrets when gitSecrets is false', async () => {
+    await initGenerator(tree, {
+      iac: 'cdk',
+      containers: 'docker',
+      gitSecrets: false,
+    });
+
+    expect(tree.exists('.git-secrets/git-secrets')).toBe(false);
+    expect(tree.exists('.husky/pre-commit')).toBe(false);
+    expect(tree.exists('.gitallowed')).toBe(false);
+  });
+
+  it('should preserve a pre-existing pre-commit hook and prepare script', async () => {
+    // An existing workspace commonly has its own hooks; init must not clobber
+    // them, so it reports what to add instead.
+    tree.write('.husky/pre-commit', 'pnpm my-own-checks\n');
+    updateJson(tree, 'package.json', (json) => ({
+      ...json,
+      scripts: { ...json.scripts, prepare: 'my-own-setup' },
+    }));
+
+    await initGenerator(tree, { iac: 'cdk', containers: 'docker' });
+
+    expect(tree.read('.husky/pre-commit', 'utf-8')).toBe(
+      'pnpm my-own-checks\n',
+    );
+    expect(readJson(tree, 'package.json').scripts.prepare).toBe('my-own-setup');
+  });
+
+  it('should preserve allowlist entries the user has added', async () => {
+    tree.write('.gitallowed', 'tests/fixtures/.*\n');
+
+    await initGenerator(tree, { iac: 'cdk', containers: 'docker' });
+
+    const gitallowed = tree.read('.gitallowed', 'utf-8') ?? '';
+    expect(gitallowed).toContain('tests/fixtures/.*');
+    expect(gitallowed).toContain('.git-secrets/git-secrets:');
   });
 
   it('should be idempotent when re-run', async () => {

--- a/packages/nx-plugin/src/init/generator.ts
+++ b/packages/nx-plugin/src/init/generator.ts
@@ -5,16 +5,20 @@
 import type { GeneratorCallback, Tree } from '@nx/devkit';
 import { declareDependencies } from '../utils/declared-dependencies.js';
 import { formatFilesInSubtree } from '../utils/format.js';
+import {
+  GIT_SECRETS_DEPENDENCIES,
+  setUpGitSecrets,
+} from '../utils/git-secrets.js';
 import { applyWorkspaceInit, INIT_DEPENDENCIES } from '../utils/init.js';
 import { installDependencies } from '../utils/install.js';
 import { addGeneratorMetricsIfApplicable } from '../utils/metrics.js';
 import { getGeneratorInfo, type NxGeneratorInfo } from '../utils/nx.js';
 import type { InitGeneratorSchema } from './schema';
 
-// `husky` comes from the preset, which is discovered as init: both mark the
-// workspace by writing aws-nx-plugin.config.mts, and only init has an id there.
+// `husky` is owned here rather than by the preset: both mark the workspace by
+// writing aws-nx-plugin.config.mts, and only init has an id there.
 export const DEPENDENCIES = declareDependencies()({
-  ts: [{ name: 'husky' }, ...INIT_DEPENDENCIES],
+  ts: [...GIT_SECRETS_DEPENDENCIES, ...INIT_DEPENDENCIES],
 });
 
 export const INIT_GENERATOR_INFO: NxGeneratorInfo = getGeneratorInfo(
@@ -31,9 +35,19 @@ export const INIT_GENERATOR_INFO: NxGeneratorInfo = getGeneratorInfo(
  */
 export const initGenerator = async (
   tree: Tree,
-  { iac, mcp, containers, preferInstallDependencies }: InitGeneratorSchema,
+  {
+    iac,
+    mcp,
+    containers,
+    gitSecrets,
+    preferInstallDependencies,
+  }: InitGeneratorSchema,
 ): Promise<GeneratorCallback> => {
   await applyWorkspaceInit(tree, { iac, containers, mcp }, DEPENDENCIES);
+
+  if (gitSecrets !== false) {
+    setUpGitSecrets(tree, DEPENDENCIES);
+  }
 
   await addGeneratorMetricsIfApplicable(tree, [INIT_GENERATOR_INFO]);
 

--- a/packages/nx-plugin/src/init/schema.d.ts
+++ b/packages/nx-plugin/src/init/schema.d.ts
@@ -12,5 +12,6 @@ export interface InitGeneratorSchema {
   readonly iac: Iac;
   readonly mcp?: boolean;
   readonly containers?: InitContainersOption;
+  readonly gitSecrets?: boolean;
   readonly preferInstallDependencies?: boolean;
 }

--- a/packages/nx-plugin/src/init/schema.json
+++ b/packages/nx-plugin/src/init/schema.json
@@ -13,6 +13,11 @@
       "x-priority": "important",
       "x-prompt": "Which provider would you like to manage your infrastructure?"
     },
+    "gitSecrets": {
+      "type": "boolean",
+      "description": "Whether to configure git-secrets to prevent committing AWS credentials.",
+      "default": true
+    },
     "mcp": {
       "type": "boolean",
       "description": "Whether to configure the Nx Plugin for AWS MCP server for use by coding agents.",

--- a/packages/nx-plugin/src/preset/generator.spec.ts
+++ b/packages/nx-plugin/src/preset/generator.spec.ts
@@ -153,6 +153,18 @@ describe('preset generator', () => {
     expect(packageJson.devDependencies.husky).toBeDefined();
   });
 
+  it('should vend a git-secrets whose option parser takes the short flags the guides document', async () => {
+    await presetGenerator(tree, { iac: 'cdk' });
+
+    // The script is vendored verbatim from upstream and never edited here, so
+    // the guides must document the flags this copy actually parses: `-a` and
+    // `-l`. A long form is consumed as if it were the pattern, silently adding
+    // nothing — so if a bump ever changes these arms, the docs need revisiting.
+    const script = tree.read('.git-secrets/git-secrets', 'utf-8') ?? '';
+    expect(script).toContain('-a) ALLOWED=1 ;;');
+    expect(script).toContain('-l) LITERAL=1 ;;');
+  });
+
   it('should configure MCP servers by default', async () => {
     await presetGenerator(tree, { iac: 'cdk' });
 

--- a/packages/nx-plugin/src/preset/generator.ts
+++ b/packages/nx-plugin/src/preset/generator.ts
@@ -4,29 +4,29 @@
  */
 import {
   type GeneratorCallback,
-  joinPathFragments,
   OverwriteStrategy,
   type Tree,
   updateJson,
 } from '@nx/devkit';
 import { execSync } from 'child_process';
 import enquirer from 'enquirer';
-import { readFileSync } from 'fs';
 import {
   ensureAwsNxPluginConfig,
   updateAwsNxPluginConfig,
 } from '../utils/config/utils.js';
 import { declareDependencies } from '../utils/declared-dependencies.js';
-import { addDependenciesToPackageJson } from '../utils/dependencies.js';
 import { formatFilesInSubtree } from '../utils/format.js';
+import {
+  GIT_SECRETS_DEPENDENCIES,
+  setUpGitSecrets,
+} from '../utils/git-secrets.js';
 import { applyWorkspaceInit, INIT_DEPENDENCIES } from '../utils/init.js';
 import { installDependencies } from '../utils/install.js';
 import { getGeneratorInfo, type NxGeneratorInfo } from '../utils/nx.js';
-import { withVersions } from '../utils/versions.js';
 import type { PresetGeneratorSchema } from './schema';
 
 export const DEPENDENCIES = declareDependencies()({
-  ts: [{ name: 'husky' }, ...INIT_DEPENDENCIES],
+  ts: [...GIT_SECRETS_DEPENDENCIES, ...INIT_DEPENDENCIES],
 });
 
 export const PRESET_GENERATOR_INFO: NxGeneratorInfo = getGeneratorInfo(
@@ -84,39 +84,6 @@ export function isAmazonian(): boolean {
     return false;
   }
 }
-
-const setUpGitSecrets = (tree: Tree) => {
-  const gitSecretsDir = joinPathFragments(
-    import.meta.dirname,
-    'git-secrets-files',
-    'git-secrets-dir',
-  );
-  const huskyDir = joinPathFragments(
-    import.meta.dirname,
-    'git-secrets-files',
-    'husky-dir',
-  );
-
-  tree.write(
-    '.git-secrets/git-secrets',
-    readFileSync(joinPathFragments(gitSecretsDir, 'git-secrets'), 'utf-8'),
-  );
-  tree.write(
-    '.husky/pre-commit',
-    readFileSync(joinPathFragments(huskyDir, 'pre-commit'), 'utf-8'),
-  );
-  tree.write('.gitallowed', '\\.git-secrets/git-secrets:\n');
-
-  updateJson(tree, 'package.json', (json) => ({
-    ...json,
-    scripts: {
-      ...json.scripts,
-      prepare: 'husky',
-    },
-  }));
-
-  addDependenciesToPackageJson(tree, {}, withVersions(DEPENDENCIES, ['husky']));
-};
 
 export const presetGenerator = async (
   tree: Tree,
@@ -181,7 +148,7 @@ export const presetGenerator = async (
   tree.write('packages/.gitkeep', '');
 
   if (gitSecrets !== false) {
-    setUpGitSecrets(tree);
+    setUpGitSecrets(tree, DEPENDENCIES);
   }
 
   await formatFilesInSubtree(tree);

--- a/packages/nx-plugin/src/utils/git-secrets.ts
+++ b/packages/nx-plugin/src/utils/git-secrets.ts
@@ -1,0 +1,109 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { joinPathFragments, logger, type Tree, updateJson } from '@nx/devkit';
+import { readFileSync } from 'fs';
+import {
+  type DependencyDeclaration,
+  forDependencies,
+  type MustDeclare,
+} from './declared-dependencies.js';
+import { addDependenciesToPackageJson } from './dependencies.js';
+import { type ITsDepVersion, withVersions } from './versions.js';
+
+/** Dependencies a caller must declare to set up git-secrets. */
+export const GIT_SECRETS_DEPENDENCIES = [
+  { name: 'husky' },
+] as const satisfies readonly { name: ITsDepVersion }[];
+
+/** The vended script, which the husky pre-commit hook runs. */
+export const GIT_SECRETS_SCRIPT = '.git-secrets/git-secrets';
+
+const HUSKY_PRE_COMMIT = '.husky/pre-commit';
+
+/**
+ * Patterns allowed so a generated workspace commits cleanly, matched against
+ * `<path>:<line>:<content>`. Only the vended script, whose body contains the
+ * patterns it registers.
+ */
+export const GIT_SECRETS_ALLOWED = ['\\.git-secrets/git-secrets:'];
+
+/**
+ * Vend the git-secrets pre-commit hook: the script itself, the husky hook that
+ * runs it, and the allowlist.
+ *
+ * Re-runnable. The vendored script is always rewritten so an upgrade picks up a
+ * newer copy, while everything a user owns is preserved: `.gitallowed` only
+ * gains the entries a generated workspace needs, and an existing `pre-commit`
+ * hook or `prepare` script is left alone and reported rather than replaced.
+ */
+export const setUpGitSecrets = <const D extends DependencyDeclaration>(
+  tree: Tree,
+  declaration: D & MustDeclare<typeof GIT_SECRETS_DEPENDENCIES, D>,
+) => {
+  const filesDir = joinPathFragments(
+    import.meta.dirname,
+    '..',
+    'preset',
+    'git-secrets-files',
+  );
+
+  tree.write(
+    GIT_SECRETS_SCRIPT,
+    readFileSync(
+      joinPathFragments(filesDir, 'git-secrets-dir', 'git-secrets'),
+      'utf-8',
+    ),
+  );
+
+  const hook = readFileSync(
+    joinPathFragments(filesDir, 'husky-dir', 'pre-commit'),
+    'utf-8',
+  );
+  const existingHook = tree.read(HUSKY_PRE_COMMIT, 'utf-8');
+  if (existingHook === null) {
+    tree.write(HUSKY_PRE_COMMIT, hook);
+  } else if (!existingHook.includes(GIT_SECRETS_SCRIPT)) {
+    logger.warn(
+      `Your ${HUSKY_PRE_COMMIT} was left as-is. To scan staged files for AWS credentials, add:\n\n${hook}`,
+    );
+  }
+
+  // Preserve any entries the user has added, appending only the ones missing.
+  const existingAllowed =
+    tree
+      .read('.gitallowed', 'utf-8')
+      ?.split('\n')
+      .map((line) => line.trimEnd())
+      .filter((line) => line !== '') ?? [];
+  const allowed = [
+    ...existingAllowed,
+    ...GIT_SECRETS_ALLOWED.filter(
+      (pattern) => !existingAllowed.includes(pattern),
+    ),
+  ];
+  tree.write('.gitallowed', `${allowed.join('\n')}\n`);
+
+  updateJson(tree, 'package.json', (json) => {
+    const prepare: string | undefined = json.scripts?.prepare;
+    if (prepare !== undefined && !prepare.includes('husky')) {
+      logger.warn(
+        `Your \`prepare\` script was left as-is. Git hooks are installed by husky, so add \`husky\` to it for the pre-commit hook to run.`,
+      );
+    }
+    return {
+      ...json,
+      scripts: { ...json.scripts, prepare: prepare ?? 'husky' },
+    };
+  });
+
+  addDependenciesToPackageJson(
+    tree,
+    {},
+    withVersions(
+      forDependencies<typeof GIT_SECRETS_DEPENDENCIES>(declaration),
+      ['husky'],
+    ),
+  );
+};


### PR DESCRIPTION
### Reason for this change

Three findings from the v1.0 bug bash, all on the vended git-secrets pre-commit hook.

**`quickstart-02` (major)** — `workspace.mdx`'s "Suppressing False Positives" section documented two commands and **both failed silently**:

```sh
git secrets --add --allowed 'my-regex-pattern'
git secrets --add --allowed --literal 'my-literal+string'
```

Two independent causes:

1. `git secrets` is not on `PATH` in a generated workspace — only the vendored `.git-secrets/git-secrets` exists.
2. The vendored script's option parser accepts only the **short** forms and has no `*)` fallthrough. `--allowed` matches no arm, is consumed by the loop's trailing `shift`, and so is the pattern after it. `--add` then calls `add_config secrets.patterns ''` — empty value, wrong key — returns 1 and prints **nothing**.

A reader follows the guide, sees no error, believes the false positive is suppressed, and hits the same blocked commit again:

```
$ bash .git-secrets/git-secrets --add --allowed 'my-regex-pattern'; echo rc=$?
rc=1
$ git config --get-all secrets.allowed     # unchanged
$ git secrets --add --allowed 'x'
git: 'secrets' is not a git command.
```

**`ts-core-06` (major)** — `ts#infra --stageConfig` generates `stages.config.ts` containing `account: '123456789012'`, which the workspace's own hook flags, blocking `git commit` — while the guide's tip recommends committing that file, with no mention that scanning will stop you:

```
packages/common/infra-config/src/stages.config.ts:34:    //       account: '123456789012',
[ERROR] Matched one or more prohibited patterns
husky - pre-commit script failed (code 1)
```

**`quickstart-08` (minor)** — `workspace.mdx` and `security.mdx` both state that workspaces have commit-time credential scanning, but `nx add @aws/nx-plugin` (the `init` path) produced no `.husky/`, no `.git-secrets/`, no `.gitallowed`, no `husky` devDependency and no `prepare` script.

### Description of changes

**`quickstart-02` — fixed in the docs, not the script.** The vendored script is third-party code that `scripts/update-versions.ts` rewrites wholesale from the upstream tag on every git-secrets release, so a local edit to it would be silently reverted by the next bump. It is left byte-identical to upstream 1.3.0. The guide instead documents the flags this copy actually parses, and the vendored path it must be invoked by (it is deliberately not on `PATH` — vendoring exists so nobody has to install git-secrets globally):

```sh
# Allow a specific regex pattern (-a is the allowed flag)
bash .git-secrets/git-secrets --add -a -- 'my-regex-pattern'

# Allow a literal string, escaping special characters (-l is the literal flag)
bash .git-secrets/git-secrets --add -a -l -- 'my-literal+string'
```

A preset test pins the two `case` arms the guide depends on (`-a) ALLOWED=1`, `-l) LITERAL=1`), so a future upstream bump that changes them fails here rather than silently re-breaking the docs.

**`ts-core-06` — account ids stay flagged; the user opts out knowingly.** Rather than allowlisting them by default, the infrastructure guide's tip now says scanning will flag them and gives the entry to suppress it:

```text title=".gitallowed"
# Allow AWS Account IDs in the stage configuration
stages\.config\.ts:[0-9]+:.*[0-9]{12}
```

Scoped to the 12-digit shape rather than the bare filename: `.gitallowed` matches `<path>:<line>:<content>`, so a bare `stages.config.ts:` would allowlist the whole file and let a pasted access key through.

**`quickstart-08` — `init` now sets git-secrets up**, so the two guides' claim becomes true rather than being narrowed. An adopted workspace runs the same generators and gets the same `stages.config.ts`, so it wants the same protection, and it makes `init` and `preset` converge as the shared `applyWorkspaceInit` already intends. Extracted to `utils/git-secrets.ts`, shared by both, with a `--gitSecrets=false` opt-out mirroring the preset's.

Because `init` runs against a workspace someone already owns it never clobbers: an existing `.husky/pre-commit` or `prepare` script is left alone and the required content logged, and `.gitallowed` only gains missing entries.

**No migration.** Nothing in the generated output changes for an existing workspace — the vendored script is untouched and the `.gitallowed` default is unchanged — so there is nothing to carry a workspace across.

### Description of how you validated changes

**Unit tests** — 58 pass across `src/init` and `src/preset`. 4 new `init` tests (hook set up; `--gitSecrets=false` opts out; a pre-existing `pre-commit`/`prepare` survives; user `.gitallowed` entries survive) plus the preset test pinning the parser arms the docs rely on. Lint clean. No snapshots changed.

**The documented commands, against the unmodified vendored script:**

| | result |
|---|---|
| `--add -a -- 'my-regex-pattern'` | `rc=0`, lands in `secrets.allowed` |
| `--add -a -l -- 'my-literal+string'` | `rc=0`, escaped to `my-literal\+string` |
| access key staged | still blocked |
| file containing the allowed pattern | commits |

**The `.gitallowed` snippet, through the real pre-commit hook** on a generated `stages.config.ts`: blocked without the entry, commits with it, and an access key added to that same file is still caught.

**`init` path** — a plain `create-nx-workspace` had no git-secrets; after `nx g @aws/nx-plugin:init` it has `.git-secrets/`, `.gitallowed`, `.husky/`, the `husky` dep and the `prepare` script; it blocks an access key on commit; and the documented suppression works there too. Both workspaces build, and `staged-infra:build` runs through `synth`. Not deployed to AWS.

The e2e `git-secrets` smoke test now covers the documented short-flag suppression, that a real secret is still caught afterwards, that the allowed pattern commits, and a second case asserting a generated `stages.config.ts` is blocked until the documented `.gitallowed` entry is added.

### Issue # (if applicable)

N/A — bug bash findings `quickstart-02`, `quickstart-08`, `ts-core-06`.

### Checklist

- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
