### PR TITLE
feat(ts#rdb): scan RDB container images under CDK

### DIFF
--- a/docs/src/content/docs/en/guides/connection/py-agent-rdb.mdx
+++ b/docs/src/content/docs/en/guides/connection/py-agent-rdb.mdx
@@ -42,7 +42,7 @@ Select your Agent project as the source and your relational database project as 
   - pyproject.toml Adds the database package as a workspace dependency
   - my\_service
     - my\_agent
-      - Dockerfile Adds the RDS CA bundle used for direct Aurora connections
+      - Dockerfile Adds the RDS CA bundle used for direct Aurora connections (only when the agent's `infra` is `agentcore-ecr`)
 
 </FileTree>
 

--- a/docs/src/content/docs/en/guides/connection/py-fast-api-rdb.mdx
+++ b/docs/src/content/docs/en/guides/connection/py-fast-api-rdb.mdx
@@ -11,6 +11,7 @@ import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Infrastructure from '@components/infrastructure.astro';
+import Snippet from '@components/snippet.astro';
 
 The `connection` generator wires a <Link path="guides/fastapi">FastAPI</Link> to a <Link path="guides/py-rdb">Python Relational Database</Link> project, injecting a typed SQLModel session into your route handlers via a FastAPI dependency.
 
@@ -167,6 +168,10 @@ The AppConfig application exposes the `database` namespace by default, so the da
 
 </Fragment>
 </Infrastructure>
+
+### SSL Requirements When Connecting Without RDS Proxy
+
+<Snippet name="connection/py-lambda-rdb-ssl-requirements" parentHeading="SSL Requirements When Connecting Without RDS Proxy" />
 
 ## Local Development
 

--- a/docs/src/content/docs/en/guides/connection/py-mcp-server-rdb.mdx
+++ b/docs/src/content/docs/en/guides/connection/py-mcp-server-rdb.mdx
@@ -42,7 +42,7 @@ Select your MCP server project as the source and your relational database projec
   - pyproject.toml Adds the database package as a workspace dependency
   - my\_service
     - my\_mcp\_server
-      - Dockerfile Adds the RDS CA bundle used for direct Aurora connections
+      - Dockerfile Adds the RDS CA bundle used for direct Aurora connections (only when the MCP server's `infra` is `agentcore-ecr`)
 
 </FileTree>
 

--- a/docs/src/content/docs/en/guides/connection/react-agui.mdx
+++ b/docs/src/content/docs/en/guides/connection/react-agui.mdx
@@ -205,12 +205,14 @@ Per-chat overrides still work alongside the theme — anything you pass as a slo
 
 ### Replacing a slot with a custom component
 
-Any slot can take a React component instead of a className, so you can replace the default entirely:
+Any slot can take a React component instead of a className, so you can replace the default entirely. Type your component against the props the slot declares — `sendButton` renders a `<button>`, so it receives `ButtonHTMLAttributes`:
 
 ```tsx
 import { CopilotChat } from './components/copilot';
 
-const MySendButton: React.FC<{ onClick: () => void }> = ({ onClick }) => (
+const MySendButton: React.FC<React.ButtonHTMLAttributes<HTMLButtonElement>> = ({
+  onClick,
+}) => (
   <button onClick={onClick} className="my-send-btn">
     Send
   </button>
@@ -247,6 +249,10 @@ The connection generator automatically configures `dev` integration:
 
 :::tip[Hot Reloading]
 The website and connected agent hot-reload together, enabling you to quickly iterate on both sides without deploying to AWS.
+:::
+
+:::note[The dev target requires the Nx Daemon]
+The `dev` target hot-reloads local dev servers. Many of these rely on [`nx watch`](https://nx.dev/docs/guides/tasks--caching/workspace-watching) to achieve this, which requires the [Nx Daemon](https://nx.dev/docs/concepts/nx-daemon) to be enabled.
 :::
 
 ## More Information

--- a/docs/src/content/docs/en/guides/connection/react-fastapi.mdx
+++ b/docs/src/content/docs/en/guides/connection/react-fastapi.mdx
@@ -125,8 +125,8 @@ For more fine-grained control, you can use the `watch-generate:<ApiName>-client`
 />
 :::
 
-:::warning[File Watcher Dependency]
-`watch-generate:<ApiName>-client` relies on the [`nx watch`](https://nx.dev/docs/guides/tasks--caching/workspace-watching) command, which requires the [Nx Daemon](https://nx.dev/docs/concepts/nx-daemon) to be running. Therefore if you have disabled the daemon, the client won't automatically regenerate when making changes to your FastAPI.
+:::note[The dev target requires the Nx Daemon]
+The `dev` target hot-reloads local dev servers. Many of these rely on [`nx watch`](https://nx.dev/docs/guides/tasks--caching/workspace-watching) to achieve this, which requires the [Nx Daemon](https://nx.dev/docs/concepts/nx-daemon) to be enabled.
 :::
 
 ### Using the API Hook
@@ -146,12 +146,14 @@ function MyComponent() {
   const api = useMyApi();
   const item = useQuery(api.getItem.queryOptions({ itemId: 'some-id' }));
 
-  if (item.isLoading) return <div>Loading...</div>;
-  if (item.isError) return <div>Error: {item.error.message}</div>;
+  if (item.isPending) return <div>Loading...</div>;
+  if (item.isError) return <div>Error: {JSON.stringify(item.error.error)}</div>;
 
   return <div>Item: {item.data.name}</div>;
 }
 ```
+
+The error is a discriminated union of `{ status, error }` objects rather than an `Error`, so there is no top-level `message` to render. Narrow on `status` to read a specific response body — see [Error Handling](#error-handling) below.
 
 <Drawer title="Using the API client directly" trigger="Click here for an example using the vanilla client directly.">
 ```tsx {5,13}
@@ -222,7 +224,7 @@ function CreateItemForm() {
 
       {createItem.isError && (
         <div className="error">
-          Error: {createItem.error.message}
+          Error: {JSON.stringify(createItem.error.error)}
         </div>
       )}
     </form>
@@ -370,12 +372,12 @@ function ItemList() {
       }),
   });
 
-  if (items.isLoading) {
+  if (items.isPending) {
     return <LoadingSpinner />;
   }
 
   if (items.isError) {
-    return <ErrorMessage message={items.error.message} />;
+    return <ErrorMessage message={JSON.stringify(items.error.error)} />;
   }
 
   return (

--- a/docs/src/content/docs/en/guides/connection/react-py-agent.mdx
+++ b/docs/src/content/docs/en/guides/connection/react-py-agent.mdx
@@ -183,6 +183,10 @@ The connection generator automatically configures `dev` integration:
 The website and connected agent will hot-reload, enabling you to quickly iterate on both together without deploying to AWS.
 :::
 
+:::note[The dev target requires the Nx Daemon]
+The `dev` target hot-reloads local dev servers. Many of these rely on [`nx watch`](https://nx.dev/docs/guides/tasks--caching/workspace-watching) to achieve this, which requires the [Nx Daemon](https://nx.dev/docs/concepts/nx-daemon) to be enabled.
+:::
+
 ## More Information
 
 For more information, please refer to:

--- a/docs/src/content/docs/en/guides/connection/react-smithy.mdx
+++ b/docs/src/content/docs/en/guides/connection/react-smithy.mdx
@@ -126,6 +126,10 @@ For more fine-grained control, you can use the `watch-generate:<ApiName>-client`
 />
 :::
 
+:::note[The dev target requires the Nx Daemon]
+The `dev` target hot-reloads local dev servers. Many of these rely on [`nx watch`](https://nx.dev/docs/guides/tasks--caching/workspace-watching) to achieve this, which requires the [Nx Daemon](https://nx.dev/docs/concepts/nx-daemon) to be enabled.
+:::
+
 ### Using the API Hook
 
 The generator provides a `use<ApiName>` hook which you can use to call your API with TanStack Query.
@@ -143,12 +147,14 @@ function MyComponent() {
   const api = useMyApi();
   const item = useQuery(api.getItem.queryOptions({ itemId: 'some-id' }));
 
-  if (item.isLoading) return <div>Loading...</div>;
-  if (item.isError) return <div>Error: {item.error.message}</div>;
+  if (item.isPending) return <div>Loading...</div>;
+  if (item.isError) return <div>Error: {JSON.stringify(item.error.error)}</div>;
 
   return <div>Item: {item.data.name}</div>;
 }
 ```
+
+The error is a discriminated union of `{ status, error }` objects rather than an `Error`, so there is no top-level `message` to render. Narrow on `status` to read a specific response body — see [Error Handling](#error-handling) below.
 
 <Drawer title="Using the API client directly" trigger="Click here for an example using the vanilla client directly.">
 ```tsx {5,13}
@@ -219,7 +225,7 @@ function CreateItemForm() {
 
       {createItem.isError && (
         <div className="error">
-          Error: {createItem.error.message}
+          Error: {JSON.stringify(createItem.error.error)}
         </div>
       )}
     </form>
@@ -331,12 +337,12 @@ function ItemList() {
       }),
   });
 
-  if (items.isLoading) {
+  if (items.isPending) {
     return <LoadingSpinner />;
   }
 
   if (items.isError) {
-    return <ErrorMessage message={items.error.message} />;
+    return <ErrorMessage message={JSON.stringify(items.error.error)} />;
   }
 
   return (

--- a/docs/src/content/docs/en/guides/connection/react-trpc.mdx
+++ b/docs/src/content/docs/en/guides/connection/react-trpc.mdx
@@ -63,8 +63,7 @@ The generator creates the following structure in your React application:
     - QueryClientProvider.tsx TanStack React Query client provider
   - hooks
     - useSigV4.tsx Hook for signing HTTP requests with SigV4 (IAM only)
-    - use\<ApiName>.tsx A hook returning the tRPC options proxy for TanStack Query integration
-    - use\<ApiName>Client.tsx A hook returning the vanilla tRPC client for direct API calls
+    - use\<ApiName>.tsx Exports both `use<ApiName>`, returning the tRPC options proxy for TanStack Query integration, and `use<ApiName>Client`, returning the vanilla tRPC client for direct API calls
 
 </FileTree>
 
@@ -103,6 +102,8 @@ function MyComponent() {
   };
 
   if (isLoading) return <div>Loading...</div>;
+  if (error) return <div>Error: {error.message}</div>;
+  if (!data) return null;
 
   return (
     <ul>
@@ -113,6 +114,8 @@ function MyComponent() {
   );
 }
 ```
+
+`data` is `undefined` until the query resolves, so guard on it before dereferencing.
 
 ### Using the Vanilla tRPC Client
 
@@ -156,6 +159,8 @@ function MyComponent() {
       </div>
     );
   }
+
+  if (!data) return null;
 
   return (
     <ul>
@@ -278,7 +283,7 @@ function UserList() {
 
   const users = useQuery(trpc.users.list.queryOptions());
 
-  if (users.isLoading) {
+  if (users.isPending) {
     return <LoadingSpinner />;
   }
 
@@ -338,7 +343,7 @@ function UserList() {
 
   return (
     <ul>
-      {users.map((user) => (
+      {users.data?.map((user) => (
         <li key={user.id}>
           {user.name}
           <button onClick={() => deleteMutation.mutate(user.id)}>Delete</button>
@@ -366,7 +371,7 @@ function UserList() {
 
   return (
     <ul>
-      {users.map((user) => (
+      {users.data?.map((user) => (
         <li key={user.id} onMouseEnter={() => prefetchUser(user.id)}>
           <Link to={`/users/${user.id}`}>{user.name}</Link>
         </li>

--- a/docs/src/content/docs/en/guides/connection/ts-agent-rdb.mdx
+++ b/docs/src/content/docs/en/guides/connection/ts-agent-rdb.mdx
@@ -36,13 +36,13 @@ Select your Agent project as the source and your relational database project as 
 
 ## Generator Output
 
-The generator modifies two files in your agent's source directory:
+The generator modifies the following files in your agent's source directory:
 
 <FileTree>
 
 - packages/my-service/src/my-agent
   - agent.ts Prisma client fetched inside `getAgent` and available to tools
-  - Dockerfile RDS CA bundle installed for SSL connections to Aurora
+  - Dockerfile RDS CA bundle installed for SSL connections to Aurora (only when the agent's `infra` is `agentcore-ecr`)
 
 </FileTree>
 

--- a/docs/src/content/docs/en/guides/connection/ts-mcp-server-rdb.mdx
+++ b/docs/src/content/docs/en/guides/connection/ts-mcp-server-rdb.mdx
@@ -36,13 +36,13 @@ Select your MCP server project as the source and your relational database projec
 
 ## Generator Output
 
-The generator modifies two files in your MCP server's source directory:
+The generator modifies the following files in your MCP server's source directory:
 
 <FileTree>
 
 - packages/my-service/src/my-mcp
   - server.ts Prisma client fetched and available to all tools registered inside `createServer`
-  - Dockerfile RDS CA bundle installed for SSL connections to Aurora
+  - Dockerfile RDS CA bundle installed for SSL connections to Aurora (only when the MCP server's `infra` is `agentcore-ecr`)
 
 </FileTree>
 
@@ -52,11 +52,12 @@ Additionally, the `<mcp-server-name>-dev` target is updated to depend on the dat
 
 The Prisma client is fetched inside `createServer` and available to all tools and resources registered there:
 
-```ts title="packages/my-service/src/my-mcp/server.ts" {1,4}
+```ts title="packages/my-service/src/my-mcp/server.ts" {1,4,5}
 import { getPrisma as getMyDb } from '@my-scope/my-db';
 
 export const createServer = async () => {
   const myDb = await getMyDb();
+  myDb.$on('error', console.error);
   const server = new McpServer({ name: 'my-service', version: '1.0.0' });
   // register tools/resources that use myDb
   return server;

--- a/docs/src/content/docs/en/guides/ts-rdb.mdx
+++ b/docs/src/content/docs/en/guides/ts-rdb.mdx
@@ -45,11 +45,18 @@ The generator will create the following project structure in the `<directory>/<n
     - create-db-user-handler.ts Lambda handler used to create the application database user during deployment
     - migration-handler.ts Lambda handler used to run database migrations during deployment
   - .gitignore Git ignore entries including generated Prisma client output
+  - .trivyignore Vulnerability IDs to suppress when scanning the migration image
   - config.json Local development connection details and runtime config key
   - Dockerfile Container image definition for the migration handler
   - package.json Project manifest defining the project's package name and dependencies
   - project.json Project configuration and build targets
   - prisma.config.ts Configuration for Prisma CLI
+  - README.md Project readme
+  - rolldown.config.ts Bundler configuration invoked by the `bundle` target
+  - tsconfig.json TypeScript project references
+  - tsconfig.lib.json TypeScript configuration for the library build
+  - tsconfig.spec.json TypeScript configuration for tests
+  - vitest.config.mts Vitest configuration
 </FileTree>
 
 Local development scripts are shared across all database projects and generated into `packages/common/scripts/`:
@@ -342,7 +349,7 @@ export const listExampleTable = publicProcedure
 
 **Option 2: tRPC middleware**
 
-If you are using the [middleware pattern](#injecting-the-prisma-client-via-middleware), add the `$disconnect()` call to the middleware so all procedures built on it are covered automatically:
+If you are using the <Link path="guides/connection/trpc-rdb#using-the-middleware">middleware pattern</Link>, add the `$disconnect()` call to the middleware so all procedures built on it are covered automatically:
 
 ```ts title="packages/api/src/middleware/db.ts"
 import { getPrisma } from '@my-scope/db';

--- a/docs/src/content/docs/en/troubleshooting/nx.mdx
+++ b/docs/src/content/docs/en/troubleshooting/nx.mdx
@@ -24,6 +24,6 @@ For this, and any other unexpected error, it's always worth resetting Nx and ret
 
 Failing this, you can try [disabling the daemon altogether](https://nx.dev/docs/concepts/nx-daemon#turning-it-off).
 
-:::warning[Daemon Required]
-The `nx watch` command requires the daemon, and therefore some of your hot-reloading targets may not function if you disable it.
+:::note[Daemon Required]
+The `nx watch` command requires the daemon, so the `dev` targets that rely on it to hot-reload your local dev servers need the daemon enabled.
 :::

--- a/docs/src/content/docs/es/guides/connection/py-agent-rdb.mdx
+++ b/docs/src/content/docs/es/guides/connection/py-agent-rdb.mdx
@@ -42,7 +42,7 @@ Selecciona tu proyecto Agent como origen y tu proyecto de base de datos relacion
   - pyproject.toml Agrega el paquete de base de datos como una dependencia del workspace
   - my\_service
     - my\_agent
-      - Dockerfile Agrega el paquete de CA de RDS utilizado para conexiones directas a Aurora
+      - Dockerfile Agrega el paquete de CA de RDS utilizado para conexiones directas a Aurora (solo cuando el `infra` del agente es `agentcore-ecr`)
 
 </FileTree>
 

--- a/docs/src/content/docs/es/guides/connection/py-fast-api-rdb.mdx
+++ b/docs/src/content/docs/es/guides/connection/py-fast-api-rdb.mdx
@@ -11,6 +11,7 @@ import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Infrastructure from '@components/infrastructure.astro';
+import Snippet from '@components/snippet.astro';
 
 El generador `connection` conecta una <Link path="guides/fastapi">FastAPI</Link> a un proyecto de <Link path="guides/py-rdb">Base de Datos Relacional de Python</Link>, inyectando una sesión SQLModel tipada en tus manejadores de rutas a través de una dependencia de FastAPI.
 
@@ -168,9 +169,12 @@ La aplicación AppConfig expone el namespace `database` por defecto, por lo que 
 </Fragment>
 </Infrastructure>
 
+### Requisitos de SSL al Conectarse sin RDS Proxy
+
+<Snippet name="connection/py-lambda-rdb-ssl-requirements" parentHeading="Requisitos de SSL al Conectarse sin RDS Proxy" />
+
 ## Desarrollo Local
 
 <NxCommands commands={["dev <project-name>"]} />
 
 Esto inicia la FastAPI y todas las bases de datos conectadas. La variable de entorno `LOCAL_DEV=true` hace que el cliente de base de datos se conecte a su base de datos Docker local en lugar de Aurora.
-

--- a/docs/src/content/docs/es/guides/connection/py-mcp-server-rdb.mdx
+++ b/docs/src/content/docs/es/guides/connection/py-mcp-server-rdb.mdx
@@ -42,7 +42,7 @@ Selecciona tu proyecto de servidor MCP como origen y tu proyecto de base de dato
   - pyproject.toml Agrega el paquete de base de datos como una dependencia del espacio de trabajo
   - my\_service
     - my\_mcp\_server
-      - Dockerfile Agrega el paquete de CA de RDS utilizado para conexiones directas a Aurora
+      - Dockerfile Agrega el paquete de CA de RDS utilizado para conexiones directas a Aurora (solo cuando el `infra` del servidor MCP es `agentcore-ecr`)
 
 </FileTree>
 

--- a/docs/src/content/docs/es/guides/connection/react-agui.mdx
+++ b/docs/src/content/docs/es/guides/connection/react-agui.mdx
@@ -205,12 +205,14 @@ Las sobrescrituras por chat aún funcionan junto con el tema — cualquier cosa 
 
 ### Reemplazar un slot con un componente personalizado
 
-Cualquier slot puede tomar un componente React en lugar de un className, por lo que puedes reemplazar completamente el predeterminado:
+Cualquier slot puede tomar un componente React en lugar de un className, por lo que puedes reemplazar completamente el predeterminado. Tipifica tu componente contra las props que el slot declara — `sendButton` renderiza un `<button>`, por lo que recibe `ButtonHTMLAttributes`:
 
 ```tsx
 import { CopilotChat } from './components/copilot';
 
-const MySendButton: React.FC<{ onClick: () => void }> = ({ onClick }) => (
+const MySendButton: React.FC<React.ButtonHTMLAttributes<HTMLButtonElement>> = ({
+  onClick,
+}) => (
   <button onClick={onClick} className="my-send-btn">
     Send
   </button>
@@ -247,6 +249,10 @@ El generador de conexión configura automáticamente la integración con `dev`:
 
 :::tip[Recarga en caliente]
 El sitio web y el agente conectado se recargan en caliente juntos, permitiéndote iterar rápidamente en ambos lados sin desplegar a AWS.
+:::
+
+:::note[El objetivo dev requiere el Nx Daemon]
+El objetivo `dev` recarga en caliente los servidores de desarrollo locales. Muchos de estos dependen de [`nx watch`](https://nx.dev/docs/guides/tasks--caching/workspace-watching) para lograr esto, lo que requiere que el [Nx Daemon](https://nx.dev/docs/concepts/nx-daemon) esté habilitado.
 :::
 
 ## Más información

--- a/docs/src/content/docs/es/guides/connection/react-fastapi.mdx
+++ b/docs/src/content/docs/es/guides/connection/react-fastapi.mdx
@@ -125,8 +125,8 @@ Para un control más detallado, puedes usar el target `watch-generate:<ApiName>-
 />
 :::
 
-:::warning[Dependencia del observador de archivos]
-`watch-generate:<ApiName>-client` depende del comando [`nx watch`](https://nx.dev/docs/guides/tasks--caching/workspace-watching), que requiere que el [Nx Daemon](https://nx.dev/docs/concepts/nx-daemon) esté en ejecución. Por lo tanto, si has deshabilitado el daemon, el cliente no se regenerará automáticamente al realizar cambios en tu FastAPI.
+:::note[El target dev requiere el Nx Daemon]
+El target `dev` recarga en caliente los servidores de desarrollo locales. Muchos de estos dependen de [`nx watch`](https://nx.dev/docs/guides/tasks--caching/workspace-watching) para lograr esto, lo que requiere que el [Nx Daemon](https://nx.dev/docs/concepts/nx-daemon) esté habilitado.
 :::
 
 ### Usar el hook de API
@@ -146,12 +146,14 @@ function MyComponent() {
   const api = useMyApi();
   const item = useQuery(api.getItem.queryOptions({ itemId: 'some-id' }));
 
-  if (item.isLoading) return <div>Loading...</div>;
-  if (item.isError) return <div>Error: {item.error.message}</div>;
+  if (item.isPending) return <div>Loading...</div>;
+  if (item.isError) return <div>Error: {JSON.stringify(item.error.error)}</div>;
 
   return <div>Item: {item.data.name}</div>;
 }
 ```
+
+El error es una unión discriminada de objetos `{ status, error }` en lugar de un `Error`, por lo que no hay un `message` de nivel superior para renderizar. Reduce en `status` para leer un cuerpo de respuesta específico — consulta [Manejo de errores](#manejo-de-errores) a continuación.
 
 <Drawer title="Usar el cliente API directamente" trigger="Haz clic aquí para ver un ejemplo usando el cliente vanilla directamente.">
 ```tsx {5,13}
@@ -222,7 +224,7 @@ function CreateItemForm() {
 
       {createItem.isError && (
         <div className="error">
-          Error: {createItem.error.message}
+          Error: {JSON.stringify(createItem.error.error)}
         </div>
       )}
     </form>
@@ -370,12 +372,12 @@ function ItemList() {
       }),
   });
 
-  if (items.isLoading) {
+  if (items.isPending) {
     return <LoadingSpinner />;
   }
 
   if (items.isError) {
-    return <ErrorMessage message={items.error.message} />;
+    return <ErrorMessage message={JSON.stringify(items.error.error)} />;
   }
 
   return (

--- a/docs/src/content/docs/es/guides/connection/react-py-agent.mdx
+++ b/docs/src/content/docs/es/guides/connection/react-py-agent.mdx
@@ -183,6 +183,10 @@ El generador de conexión configura automáticamente la integración `dev`:
 El sitio web y el agente conectado se recargarán en caliente, lo que te permite iterar rápidamente en ambos juntos sin implementar en AWS.
 :::
 
+:::note[El target dev requiere el Nx Daemon]
+El target `dev` recarga en caliente los servidores de desarrollo locales. Muchos de estos dependen de [`nx watch`](https://nx.dev/docs/guides/tasks--caching/workspace-watching) para lograr esto, lo que requiere que el [Nx Daemon](https://nx.dev/docs/concepts/nx-daemon) esté habilitado.
+:::
+
 ## Más información
 
 Para más información, consulta:

--- a/docs/src/content/docs/es/guides/connection/react-smithy.mdx
+++ b/docs/src/content/docs/es/guides/connection/react-smithy.mdx
@@ -126,6 +126,10 @@ Para un control más detallado, puedes usar el target `watch-generate:<ApiName>-
 />
 :::
 
+:::note[El target dev requiere el Nx Daemon]
+El target `dev` recarga en caliente los servidores de desarrollo locales. Muchos de estos dependen de [`nx watch`](https://nx.dev/docs/guides/tasks--caching/workspace-watching) para lograr esto, lo que requiere que el [Nx Daemon](https://nx.dev/docs/concepts/nx-daemon) esté habilitado.
+:::
+
 ### Uso del hook de API
 
 El generador proporciona un hook `use<ApiName>` que puedes usar para llamar a tu API con TanStack Query.
@@ -143,12 +147,14 @@ function MyComponent() {
   const api = useMyApi();
   const item = useQuery(api.getItem.queryOptions({ itemId: 'some-id' }));
 
-  if (item.isLoading) return <div>Loading...</div>;
-  if (item.isError) return <div>Error: {item.error.message}</div>;
+  if (item.isPending) return <div>Loading...</div>;
+  if (item.isError) return <div>Error: {JSON.stringify(item.error.error)}</div>;
 
   return <div>Item: {item.data.name}</div>;
 }
 ```
+
+El error es una unión discriminada de objetos `{ status, error }` en lugar de un `Error`, por lo que no hay un `message` de nivel superior para renderizar. Reduce en `status` para leer un cuerpo de respuesta específico — consulta [Manejo de errores](#manejo-de-errores) a continuación.
 
 <Drawer title="Uso del cliente API directamente" trigger="Haz clic aquí para ver un ejemplo usando el cliente vanilla directamente.">
 ```tsx {5,13}
@@ -219,7 +225,7 @@ function CreateItemForm() {
 
       {createItem.isError && (
         <div className="error">
-          Error: {createItem.error.message}
+          Error: {JSON.stringify(createItem.error.error)}
         </div>
       )}
     </form>
@@ -331,12 +337,12 @@ function ItemList() {
       }),
   });
 
-  if (items.isLoading) {
+  if (items.isPending) {
     return <LoadingSpinner />;
   }
 
   if (items.isError) {
-    return <ErrorMessage message={items.error.message} />;
+    return <ErrorMessage message={JSON.stringify(items.error.error)} />;
   }
 
   return (

--- a/docs/src/content/docs/es/guides/connection/react-trpc.mdx
+++ b/docs/src/content/docs/es/guides/connection/react-trpc.mdx
@@ -63,8 +63,7 @@ El generador crea la siguiente estructura en tu aplicación React:
     - QueryClientProvider.tsx Proveedor del cliente TanStack React Query
   - hooks
     - useSigV4.tsx Hook para firmar solicitudes HTTP con SigV4 (solo IAM)
-    - use\<ApiName>.tsx Un hook que devuelve el proxy de opciones tRPC para integración con TanStack Query
-    - use\<ApiName>Client.tsx Un hook que devuelve el cliente tRPC vanilla para llamadas directas a la API
+    - use\<ApiName>.tsx Exporta tanto `use<ApiName>`, que devuelve el proxy de opciones tRPC para integración con TanStack Query, como `use<ApiName>Client`, que devuelve el cliente tRPC vanilla para llamadas directas a la API
 
 </FileTree>
 
@@ -103,6 +102,8 @@ function MyComponent() {
   };
 
   if (isLoading) return <div>Loading...</div>;
+  if (error) return <div>Error: {error.message}</div>;
+  if (!data) return null;
 
   return (
     <ul>
@@ -113,6 +114,8 @@ function MyComponent() {
   );
 }
 ```
+
+`data` es `undefined` hasta que la consulta se resuelve, así que protégelo antes de desreferenciarlo.
 
 ### Usar el cliente tRPC vanilla
 
@@ -156,6 +159,8 @@ function MyComponent() {
       </div>
     );
   }
+
+  if (!data) return null;
 
   return (
     <ul>
@@ -278,7 +283,7 @@ function UserList() {
 
   const users = useQuery(trpc.users.list.queryOptions());
 
-  if (users.isLoading) {
+  if (users.isPending) {
     return <LoadingSpinner />;
   }
 
@@ -338,7 +343,7 @@ function UserList() {
 
   return (
     <ul>
-      {users.map((user) => (
+      {users.data?.map((user) => (
         <li key={user.id}>
           {user.name}
           <button onClick={() => deleteMutation.mutate(user.id)}>Delete</button>
@@ -366,7 +371,7 @@ function UserList() {
 
   return (
     <ul>
-      {users.map((user) => (
+      {users.data?.map((user) => (
         <li key={user.id} onMouseEnter={() => prefetchUser(user.id)}>
           <Link to={`/users/${user.id}`}>{user.name}</Link>
         </li>

--- a/docs/src/content/docs/es/guides/connection/ts-agent-rdb.mdx
+++ b/docs/src/content/docs/es/guides/connection/ts-agent-rdb.mdx
@@ -36,13 +36,13 @@ Selecciona tu proyecto Agent como origen y tu proyecto de base de datos relacion
 
 ## Salida del Generador
 
-El generador modifica dos archivos en el directorio de origen de tu agente:
+El generador modifica los siguientes archivos en el directorio de origen de tu agente:
 
 <FileTree>
 
 - packages/my-service/src/my-agent
   - agent.ts Cliente Prisma obtenido dentro de `getAgent` y disponible para herramientas
-  - Dockerfile Paquete CA de RDS instalado para conexiones SSL a Aurora
+  - Dockerfile Paquete CA de RDS instalado para conexiones SSL a Aurora (solo cuando el `infra` del agente es `agentcore-ecr`)
 
 </FileTree>
 

--- a/docs/src/content/docs/es/guides/connection/ts-mcp-server-rdb.mdx
+++ b/docs/src/content/docs/es/guides/connection/ts-mcp-server-rdb.mdx
@@ -36,13 +36,13 @@ Selecciona tu proyecto de servidor MCP como origen y tu proyecto de base de dato
 
 ## Salida del Generador
 
-El generador modifica dos archivos en el directorio de origen de tu servidor MCP:
+El generador modifica los siguientes archivos en el directorio de origen de tu servidor MCP:
 
 <FileTree>
 
 - packages/my-service/src/my-mcp
   - server.ts Cliente Prisma obtenido y disponible para todas las herramientas registradas dentro de `createServer`
-  - Dockerfile Paquete CA de RDS instalado para conexiones SSL a Aurora
+  - Dockerfile Paquete CA de RDS instalado para conexiones SSL a Aurora (solo cuando el `infra` del servidor MCP es `agentcore-ecr`)
 
 </FileTree>
 
@@ -52,11 +52,12 @@ Además, el objetivo `<mcp-server-name>-dev` se actualiza para depender del obje
 
 El cliente Prisma se obtiene dentro de `createServer` y está disponible para todas las herramientas y recursos registrados allí:
 
-```ts title="packages/my-service/src/my-mcp/server.ts" {1,4}
+```ts title="packages/my-service/src/my-mcp/server.ts" {1,4,5}
 import { getPrisma as getMyDb } from '@my-scope/my-db';
 
 export const createServer = async () => {
   const myDb = await getMyDb();
+  myDb.$on('error', console.error);
   const server = new McpServer({ name: 'my-service', version: '1.0.0' });
   // register tools/resources that use myDb
   return server;

--- a/docs/src/content/docs/es/guides/ts-rdb.mdx
+++ b/docs/src/content/docs/es/guides/ts-rdb.mdx
@@ -45,11 +45,18 @@ El generador creará la siguiente estructura de proyecto en el directorio `<dire
     - create-db-user-handler.ts Lambda handler used to create the application database user during deployment
     - migration-handler.ts Lambda handler used to run database migrations during deployment
   - .gitignore Git ignore entries including generated Prisma client output
+  - .trivyignore Vulnerability IDs to suppress when scanning the migration image
   - config.json Local development connection details and runtime config key
   - Dockerfile Container image definition for the migration handler
   - package.json Project manifest defining the project's package name and dependencies
   - project.json Project configuration and build targets
   - prisma.config.ts Configuration for Prisma CLI
+  - README.md Project readme
+  - rolldown.config.ts Bundler configuration invoked by the `bundle` target
+  - tsconfig.json TypeScript project references
+  - tsconfig.lib.json TypeScript configuration for the library build
+  - tsconfig.spec.json TypeScript configuration for tests
+  - vitest.config.mts Vitest configuration
 </FileTree>
 
 Los scripts de desarrollo local se comparten entre todos los proyectos de base de datos y se generan en `packages/common/scripts/`:
@@ -342,7 +349,7 @@ export const listExampleTable = publicProcedure
 
 **Opción 2: middleware de tRPC**
 
-Si estás usando el [patrón de middleware](#injecting-the-prisma-client-via-middleware), agrega la llamada `$disconnect()` al middleware para que todos los procedimientos construidos sobre él estén cubiertos automáticamente:
+Si estás usando el <Link path="guides/connection/trpc-rdb#using-the-middleware">patrón de middleware</Link>, agrega la llamada `$disconnect()` al middleware para que todos los procedimientos construidos sobre él estén cubiertos automáticamente:
 
 ```ts title="packages/api/src/middleware/db.ts"
 import { getPrisma } from '@my-scope/db';

--- a/docs/src/content/docs/es/troubleshooting/nx.mdx
+++ b/docs/src/content/docs/es/troubleshooting/nx.mdx
@@ -24,6 +24,6 @@ Para este y cualquier otro error inesperado, siempre vale la pena restablecer Nx
 
 Si esto falla, puedes intentar [deshabilitar el daemon por completo](https://nx.dev/docs/concepts/nx-daemon#turning-it-off).
 
-:::warning[Daemon requerido]
-El comando `nx watch` requiere el daemon, por lo tanto, algunos de tus objetivos de recarga en caliente pueden no funcionar si lo deshabilitas.
+:::note[Daemon requerido]
+El comando `nx watch` requiere el daemon, por lo que los objetivos `dev` que dependen de él para recargar en caliente tus servidores de desarrollo locales necesitan que el daemon esté habilitado.
 :::

--- a/docs/src/content/docs/fr/guides/connection/py-agent-rdb.mdx
+++ b/docs/src/content/docs/fr/guides/connection/py-agent-rdb.mdx
@@ -42,7 +42,7 @@ Sélectionnez votre projet Agent comme source et votre projet de base de donnée
   - pyproject.toml Ajoute le package de base de données comme dépendance d'espace de travail
   - my\_service
     - my\_agent
-      - Dockerfile Ajoute le bundle CA RDS utilisé pour les connexions directes à Aurora
+      - Dockerfile Ajoute le bundle CA RDS utilisé pour les connexions directes à Aurora (uniquement lorsque l'`infra` de l'agent est `agentcore-ecr`)
 
 </FileTree>
 

--- a/docs/src/content/docs/fr/guides/connection/py-fast-api-rdb.mdx
+++ b/docs/src/content/docs/fr/guides/connection/py-fast-api-rdb.mdx
@@ -11,6 +11,7 @@ import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Infrastructure from '@components/infrastructure.astro';
+import Snippet from '@components/snippet.astro';
 
 Le générateur `connection` relie un projet <Link path="guides/fastapi">FastAPI</Link> à un projet <Link path="guides/py-rdb">Python Relational Database</Link>, en injectant une session SQLModel typée dans vos gestionnaires de routes via une dépendance FastAPI.
 
@@ -167,6 +168,10 @@ L'application AppConfig expose l'espace de noms `database` par défaut, de sorte
 
 </Fragment>
 </Infrastructure>
+
+### Exigences SSL lors de la connexion sans RDS Proxy
+
+<Snippet name="connection/py-lambda-rdb-ssl-requirements" parentHeading="Exigences SSL lors de la connexion sans RDS Proxy" />
 
 ## Développement local
 

--- a/docs/src/content/docs/fr/guides/connection/py-mcp-server-rdb.mdx
+++ b/docs/src/content/docs/fr/guides/connection/py-mcp-server-rdb.mdx
@@ -42,7 +42,7 @@ Sélectionnez votre projet de serveur MCP comme source et votre projet de base d
   - pyproject.toml Ajoute le package de base de données comme dépendance de workspace
   - my\_service
     - my\_mcp\_server
-      - Dockerfile Ajoute le bundle CA RDS utilisé pour les connexions directes à Aurora
+      - Dockerfile Ajoute le bundle CA RDS utilisé pour les connexions directes à Aurora (uniquement lorsque l'`infra` du serveur MCP est `agentcore-ecr`)
 
 </FileTree>
 

--- a/docs/src/content/docs/fr/guides/connection/react-agui.mdx
+++ b/docs/src/content/docs/fr/guides/connection/react-agui.mdx
@@ -205,12 +205,14 @@ Les remplacements par chat fonctionnent toujours avec le thème — tout ce que 
 
 ### Remplacement d'un slot par un composant personnalisé
 
-N'importe quel slot peut prendre un composant React au lieu d'un className, vous pouvez donc remplacer complètement la valeur par défaut :
+N'importe quel slot peut prendre un composant React au lieu d'un className, vous pouvez donc remplacer complètement la valeur par défaut. Typez votre composant en fonction des props que le slot déclare — `sendButton` rend un `<button>`, il reçoit donc `ButtonHTMLAttributes` :
 
 ```tsx
 import { CopilotChat } from './components/copilot';
 
-const MySendButton: React.FC<{ onClick: () => void }> = ({ onClick }) => (
+const MySendButton: React.FC<React.ButtonHTMLAttributes<HTMLButtonElement>> = ({
+  onClick,
+}) => (
   <button onClick={onClick} className="my-send-btn">
     Send
   </button>
@@ -247,6 +249,10 @@ Le générateur de connexion configure automatiquement l'intégration `dev` :
 
 :::tip[Rechargement à chaud]
 Le site web et l'agent connecté se rechargent à chaud ensemble, vous permettant d'itérer rapidement des deux côtés sans déployer sur AWS.
+:::
+
+:::note[La cible dev nécessite le Nx Daemon]
+La cible `dev` recharge à chaud les serveurs de développement locaux. Beaucoup d'entre eux s'appuient sur [`nx watch`](https://nx.dev/docs/guides/tasks--caching/workspace-watching) pour y parvenir, ce qui nécessite que le [Nx Daemon](https://nx.dev/docs/concepts/nx-daemon) soit activé.
 :::
 
 ## Plus d'informations

--- a/docs/src/content/docs/fr/guides/connection/react-fastapi.mdx
+++ b/docs/src/content/docs/fr/guides/connection/react-fastapi.mdx
@@ -125,8 +125,8 @@ Pour un contrôle plus précis, vous pouvez utiliser la cible `watch-generate:<A
 />
 :::
 
-:::warning[Dépendance du File Watcher]
-`watch-generate:<ApiName>-client` s'appuie sur la commande [`nx watch`](https://nx.dev/docs/guides/tasks--caching/workspace-watching), qui nécessite que le [Nx Daemon](https://nx.dev/docs/concepts/nx-daemon) soit en cours d'exécution. Par conséquent, si vous avez désactivé le daemon, le client ne se régénérera pas automatiquement lors de modifications de votre FastAPI.
+:::note[The dev target requires the Nx Daemon]
+La cible `dev` recharge à chaud les serveurs de développement locaux. Beaucoup d'entre eux s'appuient sur [`nx watch`](https://nx.dev/docs/guides/tasks--caching/workspace-watching) pour y parvenir, ce qui nécessite que le [Nx Daemon](https://nx.dev/docs/concepts/nx-daemon) soit activé.
 :::
 
 ### Utilisation du hook API
@@ -146,12 +146,14 @@ function MyComponent() {
   const api = useMyApi();
   const item = useQuery(api.getItem.queryOptions({ itemId: 'some-id' }));
 
-  if (item.isLoading) return <div>Loading...</div>;
-  if (item.isError) return <div>Error: {item.error.message}</div>;
+  if (item.isPending) return <div>Loading...</div>;
+  if (item.isError) return <div>Error: {JSON.stringify(item.error.error)}</div>;
 
   return <div>Item: {item.data.name}</div>;
 }
 ```
+
+L'erreur est une union discriminée d'objets `{ status, error }` plutôt qu'une `Error`, il n'y a donc pas de `message` de niveau supérieur à afficher. Réduisez sur `status` pour lire un corps de réponse spécifique — voir [Gestion des erreurs](#gestion-des-erreurs) ci-dessous.
 
 <Drawer title="Utilisation directe du client API" trigger="Cliquez ici pour un exemple utilisant directement le client vanilla.">
 ```tsx {5,13}
@@ -222,7 +224,7 @@ function CreateItemForm() {
 
       {createItem.isError && (
         <div className="error">
-          Error: {createItem.error.message}
+          Error: {JSON.stringify(createItem.error.error)}
         </div>
       )}
     </form>
@@ -370,12 +372,12 @@ function ItemList() {
       }),
   });
 
-  if (items.isLoading) {
+  if (items.isPending) {
     return <LoadingSpinner />;
   }
 
   if (items.isError) {
-    return <ErrorMessage message={items.error.message} />;
+    return <ErrorMessage message={JSON.stringify(items.error.error)} />;
   }
 
   return (

--- a/docs/src/content/docs/fr/guides/connection/react-py-agent.mdx
+++ b/docs/src/content/docs/fr/guides/connection/react-py-agent.mdx
@@ -183,6 +183,10 @@ Le générateur de connexion configure automatiquement l'intégration `dev` :
 Le site web et l'agent connecté se rechargeront à chaud, vous permettant d'itérer rapidement sur les deux ensemble sans déployer sur AWS.
 :::
 
+:::note[La cible dev nécessite le Nx Daemon]
+La cible `dev` recharge à chaud les serveurs de développement locaux. Beaucoup d'entre eux s'appuient sur [`nx watch`](https://nx.dev/docs/guides/tasks--caching/workspace-watching) pour y parvenir, ce qui nécessite que le [Nx Daemon](https://nx.dev/docs/concepts/nx-daemon) soit activé.
+:::
+
 ## Plus d'informations
 
 Pour plus d'informations, veuillez consulter :

--- a/docs/src/content/docs/fr/guides/connection/react-smithy.mdx
+++ b/docs/src/content/docs/fr/guides/connection/react-smithy.mdx
@@ -126,6 +126,10 @@ Pour un contrôle plus précis, vous pouvez utiliser la cible `watch-generate:<A
 />
 :::
 
+:::note[La cible dev nécessite le Nx Daemon]
+La cible `dev` recharge à chaud les serveurs de développement locaux. Beaucoup d'entre eux s'appuient sur [`nx watch`](https://nx.dev/docs/guides/tasks--caching/workspace-watching) pour y parvenir, ce qui nécessite que le [Nx Daemon](https://nx.dev/docs/concepts/nx-daemon) soit activé.
+:::
+
 ### Utilisation du hook API
 
 Le générateur fournit un hook `use<ApiName>` que vous pouvez utiliser pour appeler votre API avec TanStack Query.
@@ -143,12 +147,14 @@ function MyComponent() {
   const api = useMyApi();
   const item = useQuery(api.getItem.queryOptions({ itemId: 'some-id' }));
 
-  if (item.isLoading) return <div>Loading...</div>;
-  if (item.isError) return <div>Error: {item.error.message}</div>;
+  if (item.isPending) return <div>Loading...</div>;
+  if (item.isError) return <div>Error: {JSON.stringify(item.error.error)}</div>;
 
   return <div>Item: {item.data.name}</div>;
 }
 ```
+
+L'erreur est une union discriminée d'objets `{ status, error }` plutôt qu'une `Error`, il n'y a donc pas de `message` de niveau supérieur à afficher. Réduisez sur `status` pour lire un corps de réponse spécifique — voir [Gestion des erreurs](#gestion-des-erreurs) ci-dessous.
 
 <Drawer title="Utilisation directe du client API" trigger="Cliquez ici pour un exemple utilisant directement le client vanilla.">
 ```tsx {5,13}
@@ -219,7 +225,7 @@ function CreateItemForm() {
 
       {createItem.isError && (
         <div className="error">
-          Error: {createItem.error.message}
+          Error: {JSON.stringify(createItem.error.error)}
         </div>
       )}
     </form>
@@ -331,12 +337,12 @@ function ItemList() {
       }),
   });
 
-  if (items.isLoading) {
+  if (items.isPending) {
     return <LoadingSpinner />;
   }
 
   if (items.isError) {
-    return <ErrorMessage message={items.error.message} />;
+    return <ErrorMessage message={JSON.stringify(items.error.error)} />;
   }
 
   return (

--- a/docs/src/content/docs/fr/guides/connection/react-trpc.mdx
+++ b/docs/src/content/docs/fr/guides/connection/react-trpc.mdx
@@ -63,8 +63,7 @@ Le générateur crée la structure suivante dans votre application React :
     - QueryClientProvider.tsx Fournisseur de client TanStack React Query
   - hooks
     - useSigV4.tsx Hook pour signer les requêtes HTTP avec SigV4 (IAM uniquement)
-    - use\<ApiName>.tsx Un hook renvoyant le proxy d'options tRPC pour l'intégration TanStack Query
-    - use\<ApiName>Client.tsx Un hook renvoyant le client tRPC vanilla pour les appels d'API directs
+    - use\<ApiName>.tsx Exporte à la fois `use<ApiName>`, renvoyant le proxy d'options tRPC pour l'intégration TanStack Query, et `use<ApiName>Client`, renvoyant le client tRPC vanilla pour les appels d'API directs
 
 </FileTree>
 
@@ -103,6 +102,8 @@ function MyComponent() {
   };
 
   if (isLoading) return <div>Loading...</div>;
+  if (error) return <div>Error: {error.message}</div>;
+  if (!data) return null;
 
   return (
     <ul>
@@ -113,6 +114,8 @@ function MyComponent() {
   );
 }
 ```
+
+`data` est `undefined` jusqu'à ce que la requête soit résolue, donc protégez-la avant de la déréférencer.
 
 ### Utilisation du client tRPC vanilla
 
@@ -156,6 +159,8 @@ function MyComponent() {
       </div>
     );
   }
+
+  if (!data) return null;
 
   return (
     <ul>
@@ -278,7 +283,7 @@ function UserList() {
 
   const users = useQuery(trpc.users.list.queryOptions());
 
-  if (users.isLoading) {
+  if (users.isPending) {
     return <LoadingSpinner />;
   }
 
@@ -338,7 +343,7 @@ function UserList() {
 
   return (
     <ul>
-      {users.map((user) => (
+      {users.data?.map((user) => (
         <li key={user.id}>
           {user.name}
           <button onClick={() => deleteMutation.mutate(user.id)}>Delete</button>
@@ -366,7 +371,7 @@ function UserList() {
 
   return (
     <ul>
-      {users.map((user) => (
+      {users.data?.map((user) => (
         <li key={user.id} onMouseEnter={() => prefetchUser(user.id)}>
           <Link to={`/users/${user.id}`}>{user.name}</Link>
         </li>

--- a/docs/src/content/docs/fr/guides/connection/ts-agent-rdb.mdx
+++ b/docs/src/content/docs/fr/guides/connection/ts-agent-rdb.mdx
@@ -36,13 +36,13 @@ Sélectionnez votre projet Agent comme source et votre projet de base de donnée
 
 ## Sortie du Générateur
 
-Le générateur modifie deux fichiers dans le répertoire source de votre agent :
+Le générateur modifie les fichiers suivants dans le répertoire source de votre agent :
 
 <FileTree>
 
 - packages/my-service/src/my-agent
   - agent.ts Client Prisma récupéré dans `getAgent` et disponible pour les outils
-  - Dockerfile Bundle CA RDS installé pour les connexions SSL à Aurora
+  - Dockerfile Bundle CA RDS installé pour les connexions SSL à Aurora (uniquement lorsque l'`infra` de l'agent est `agentcore-ecr`)
 
 </FileTree>
 

--- a/docs/src/content/docs/fr/guides/connection/ts-mcp-server-rdb.mdx
+++ b/docs/src/content/docs/fr/guides/connection/ts-mcp-server-rdb.mdx
@@ -36,13 +36,13 @@ Sélectionnez votre projet de serveur MCP comme source et votre projet de base d
 
 ## Sortie du générateur
 
-Le générateur modifie deux fichiers dans le répertoire source de votre serveur MCP :
+Le générateur modifie les fichiers suivants dans le répertoire source de votre serveur MCP :
 
 <FileTree>
 
 - packages/my-service/src/my-mcp
   - server.ts Client Prisma récupéré et disponible pour tous les outils enregistrés dans `createServer`
-  - Dockerfile Bundle CA RDS installé pour les connexions SSL vers Aurora
+  - Dockerfile Bundle CA RDS installé pour les connexions SSL vers Aurora (uniquement lorsque l'`infra` du serveur MCP est `agentcore-ecr`)
 
 </FileTree>
 
@@ -57,6 +57,7 @@ import { getPrisma as getMyDb } from '@my-scope/my-db';
 
 export const createServer = async () => {
   const myDb = await getMyDb();
+  myDb.$on('error', console.error);
   const server = new McpServer({ name: 'my-service', version: '1.0.0' });
   // register tools/resources that use myDb
   return server;

--- a/docs/src/content/docs/fr/guides/ts-rdb.mdx
+++ b/docs/src/content/docs/fr/guides/ts-rdb.mdx
@@ -45,11 +45,18 @@ Le générateur créera la structure de projet suivante dans le répertoire `<di
     - create-db-user-handler.ts Lambda handler used to create the application database user during deployment
     - migration-handler.ts Lambda handler used to run database migrations during deployment
   - .gitignore Git ignore entries including generated Prisma client output
+  - .trivyignore Vulnerability IDs to suppress when scanning the migration image
   - config.json Local development connection details and runtime config key
   - Dockerfile Container image definition for the migration handler
   - package.json Project manifest defining the project's package name and dependencies
   - project.json Project configuration and build targets
   - prisma.config.ts Configuration for Prisma CLI
+  - README.md Project readme
+  - rolldown.config.ts Bundler configuration invoked by the `bundle` target
+  - tsconfig.json TypeScript project references
+  - tsconfig.lib.json TypeScript configuration for the library build
+  - tsconfig.spec.json TypeScript configuration for tests
+  - vitest.config.mts Vitest configuration
 </FileTree>
 
 Les scripts de développement local sont partagés entre tous les projets de base de données et générés dans `packages/common/scripts/` :
@@ -342,7 +349,7 @@ export const listExampleTable = publicProcedure
 
 **Option 2 : middleware tRPC**
 
-Si vous utilisez le [modèle de middleware](#injecting-the-prisma-client-via-middleware), ajoutez l'appel `$disconnect()` au middleware afin que toutes les procédures construites dessus soient automatiquement couvertes :
+Si vous utilisez le <Link path="guides/connection/trpc-rdb#using-the-middleware">modèle de middleware</Link>, ajoutez l'appel `$disconnect()` au middleware afin que toutes les procédures construites dessus soient automatiquement couvertes :
 
 ```ts title="packages/api/src/middleware/db.ts"
 import { getPrisma } from '@my-scope/db';

--- a/docs/src/content/docs/fr/troubleshooting/nx.mdx
+++ b/docs/src/content/docs/fr/troubleshooting/nx.mdx
@@ -24,6 +24,6 @@ Pour cela, et pour toute autre erreur inattendue, il vaut toujours la peine de r
 
 Si cela échoue, vous pouvez essayer de [désactiver complètement le daemon](https://nx.dev/docs/concepts/nx-daemon#turning-it-off).
 
-:::warning[Daemon Requis]
-La commande `nx watch` nécessite le daemon, et par conséquent certaines de vos cibles de rechargement à chaud peuvent ne pas fonctionner si vous le désactivez.
+:::note[Daemon Requis]
+La commande `nx watch` nécessite le daemon, donc les cibles `dev` qui s'appuient sur celui-ci pour recharger à chaud vos serveurs de développement locaux ont besoin que le daemon soit activé.
 :::

--- a/docs/src/content/docs/it/guides/connection/py-agent-rdb.mdx
+++ b/docs/src/content/docs/it/guides/connection/py-agent-rdb.mdx
@@ -42,7 +42,7 @@ Seleziona il tuo progetto Agent come sorgente e il tuo progetto database relazio
   - pyproject.toml Aggiunge il pacchetto database come dipendenza del workspace
   - my\_service
     - my\_agent
-      - Dockerfile Aggiunge il bundle CA RDS utilizzato per le connessioni dirette ad Aurora
+      - Dockerfile Aggiunge il bundle CA RDS utilizzato per le connessioni dirette ad Aurora (solo quando l'`infra` dell'agent è `agentcore-ecr`)
 
 </FileTree>
 

--- a/docs/src/content/docs/it/guides/connection/py-fast-api-rdb.mdx
+++ b/docs/src/content/docs/it/guides/connection/py-fast-api-rdb.mdx
@@ -11,6 +11,7 @@ import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Infrastructure from '@components/infrastructure.astro';
+import Snippet from '@components/snippet.astro';
 
 Il generatore `connection` collega un progetto <Link path="guides/fastapi">FastAPI</Link> a un progetto <Link path="guides/py-rdb">Python Relational Database</Link>, iniettando una sessione SQLModel tipizzata nei tuoi gestori di route tramite una dipendenza FastAPI.
 
@@ -167,6 +168,10 @@ L'applicazione AppConfig espone il namespace `database` per impostazione predefi
 
 </Fragment>
 </Infrastructure>
+
+### Requisiti SSL per la Connessione Senza RDS Proxy
+
+<Snippet name="connection/py-lambda-rdb-ssl-requirements" parentHeading="Requisiti SSL per la Connessione Senza RDS Proxy" />
 
 ## Sviluppo Locale
 

--- a/docs/src/content/docs/it/guides/connection/py-mcp-server-rdb.mdx
+++ b/docs/src/content/docs/it/guides/connection/py-mcp-server-rdb.mdx
@@ -42,7 +42,7 @@ Seleziona il tuo progetto MCP server come sorgente e il tuo progetto database re
   - pyproject.toml Aggiunge il pacchetto del database come dipendenza del workspace
   - my\_service
     - my\_mcp\_server
-      - Dockerfile Aggiunge il bundle CA RDS utilizzato per le connessioni dirette ad Aurora
+      - Dockerfile Aggiunge il bundle CA RDS utilizzato per le connessioni dirette ad Aurora (solo quando l'`infra` dell'MCP server è `agentcore-ecr`)
 
 </FileTree>
 

--- a/docs/src/content/docs/it/guides/connection/react-agui.mdx
+++ b/docs/src/content/docs/it/guides/connection/react-agui.mdx
@@ -205,12 +205,14 @@ Le sovrascritture per chat funzionano ancora insieme al tema — qualsiasi cosa 
 
 ### Sostituire uno slot con un componente personalizzato
 
-Qualsiasi slot può accettare un componente React invece di un className, quindi puoi sostituire completamente il valore predefinito:
+Qualsiasi slot può accettare un componente React invece di un className, quindi puoi sostituire completamente il valore predefinito. Tipizza il tuo componente rispetto alle props che lo slot dichiara — `sendButton` renderizza un `<button>`, quindi riceve `ButtonHTMLAttributes`:
 
 ```tsx
 import { CopilotChat } from './components/copilot';
 
-const MySendButton: React.FC<{ onClick: () => void }> = ({ onClick }) => (
+const MySendButton: React.FC<React.ButtonHTMLAttributes<HTMLButtonElement>> = ({
+  onClick,
+}) => (
   <button onClick={onClick} className="my-send-btn">
     Send
   </button>
@@ -247,6 +249,10 @@ Il generatore di connessione configura automaticamente l'integrazione `dev`:
 
 :::tip[Ricaricamento Automatico]
 Il sito web e l'agent connesso si ricaricano automaticamente insieme, consentendoti di iterare rapidamente su entrambi i lati senza distribuire su AWS.
+:::
+
+:::note[Il target dev richiede il Nx Daemon]
+Il target `dev` ricarica automaticamente i server di sviluppo locali. Molti di questi si basano su [`nx watch`](https://nx.dev/docs/guides/tasks--caching/workspace-watching) per ottenere questo risultato, il che richiede che il [Nx Daemon](https://nx.dev/docs/concepts/nx-daemon) sia abilitato.
 :::
 
 ## Ulteriori Informazioni

--- a/docs/src/content/docs/it/guides/connection/react-fastapi.mdx
+++ b/docs/src/content/docs/it/guides/connection/react-fastapi.mdx
@@ -125,8 +125,8 @@ Per un controllo più granulare, puoi utilizzare il target `watch-generate:<ApiN
 />
 :::
 
-:::warning[Dipendenza File Watcher]
-`watch-generate:<ApiName>-client` si basa sul comando [`nx watch`](https://nx.dev/docs/guides/tasks--caching/workspace-watching), che richiede che il [Nx Daemon](https://nx.dev/docs/concepts/nx-daemon) sia in esecuzione. Pertanto, se hai disabilitato il daemon, il client non si rigenererà automaticamente quando apporti modifiche al tuo FastAPI.
+:::note[Il target dev richiede il Nx Daemon]
+Il target `dev` ricarica a caldo i server di sviluppo locali. Molti di questi si basano su [`nx watch`](https://nx.dev/docs/guides/tasks--caching/workspace-watching) per ottenere questo risultato, il che richiede che il [Nx Daemon](https://nx.dev/docs/concepts/nx-daemon) sia abilitato.
 :::
 
 ### Utilizzo dell'Hook API
@@ -146,12 +146,14 @@ function MyComponent() {
   const api = useMyApi();
   const item = useQuery(api.getItem.queryOptions({ itemId: 'some-id' }));
 
-  if (item.isLoading) return <div>Loading...</div>;
-  if (item.isError) return <div>Error: {item.error.message}</div>;
+  if (item.isPending) return <div>Loading...</div>;
+  if (item.isError) return <div>Error: {JSON.stringify(item.error.error)}</div>;
 
   return <div>Item: {item.data.name}</div>;
 }
 ```
+
+L'errore è un'unione discriminata di oggetti `{ status, error }` piuttosto che un `Error`, quindi non c'è un `message` di livello superiore da renderizzare. Restringi su `status` per leggere un corpo di risposta specifico — vedi [Gestione degli Errori](#gestione-degli-errori) di seguito.
 
 <Drawer title="Utilizzo diretto del client API" trigger="Clicca qui per un esempio utilizzando direttamente il client vanilla.">
 ```tsx {5,13}
@@ -222,7 +224,7 @@ function CreateItemForm() {
 
       {createItem.isError && (
         <div className="error">
-          Error: {createItem.error.message}
+          Error: {JSON.stringify(createItem.error.error)}
         </div>
       )}
     </form>
@@ -370,12 +372,12 @@ function ItemList() {
       }),
   });
 
-  if (items.isLoading) {
+  if (items.isPending) {
     return <LoadingSpinner />;
   }
 
   if (items.isError) {
-    return <ErrorMessage message={items.error.message} />;
+    return <ErrorMessage message={JSON.stringify(items.error.error)} />;
   }
 
   return (

--- a/docs/src/content/docs/it/guides/connection/react-py-agent.mdx
+++ b/docs/src/content/docs/it/guides/connection/react-py-agent.mdx
@@ -183,6 +183,10 @@ Il generatore di connessione configura automaticamente l'integrazione `dev`:
 Il sito web e l'agent connesso si ricaricheranno automaticamente, consentendoti di iterare rapidamente su entrambi insieme senza distribuire su AWS.
 :::
 
+:::note[Il target dev richiede Nx Daemon]
+Il target `dev` ricarica automaticamente i server di sviluppo locali. Molti di questi si basano su [`nx watch`](https://nx.dev/docs/guides/tasks--caching/workspace-watching) per ottenere questo risultato, il che richiede che [Nx Daemon](https://nx.dev/docs/concepts/nx-daemon) sia abilitato.
+:::
+
 ## Ulteriori Informazioni
 
 Per ulteriori informazioni, consulta:

--- a/docs/src/content/docs/it/guides/connection/react-smithy.mdx
+++ b/docs/src/content/docs/it/guides/connection/react-smithy.mdx
@@ -126,6 +126,10 @@ Per un controllo più granulare, puoi utilizzare il target `watch-generate:<ApiN
 />
 :::
 
+:::note[Il target dev richiede Nx Daemon]
+Il target `dev` ricarica a caldo i server di sviluppo locali. Molti di questi si basano su [`nx watch`](https://nx.dev/docs/guides/tasks--caching/workspace-watching) per ottenere questo risultato, che richiede che [Nx Daemon](https://nx.dev/docs/concepts/nx-daemon) sia abilitato.
+:::
+
 ### Utilizzo dell'Hook API
 
 Il generatore fornisce un hook `use<ApiName>` che puoi utilizzare per chiamare la tua API con TanStack Query.
@@ -143,12 +147,14 @@ function MyComponent() {
   const api = useMyApi();
   const item = useQuery(api.getItem.queryOptions({ itemId: 'some-id' }));
 
-  if (item.isLoading) return <div>Loading...</div>;
-  if (item.isError) return <div>Error: {item.error.message}</div>;
+  if (item.isPending) return <div>Loading...</div>;
+  if (item.isError) return <div>Error: {JSON.stringify(item.error.error)}</div>;
 
   return <div>Item: {item.data.name}</div>;
 }
 ```
+
+L'errore è un'unione discriminata di oggetti `{ status, error }` piuttosto che un `Error`, quindi non c'è un `message` di livello superiore da renderizzare. Restringi su `status` per leggere un corpo di risposta specifico — vedi [Gestione degli Errori](#gestione-degli-errori) di seguito.
 
 <Drawer title="Utilizzo diretto del client API" trigger="Clicca qui per un esempio usando direttamente il client vanilla.">
 ```tsx {5,13}
@@ -219,7 +225,7 @@ function CreateItemForm() {
 
       {createItem.isError && (
         <div className="error">
-          Error: {createItem.error.message}
+          Error: {JSON.stringify(createItem.error.error)}
         </div>
       )}
     </form>
@@ -331,12 +337,12 @@ function ItemList() {
       }),
   });
 
-  if (items.isLoading) {
+  if (items.isPending) {
     return <LoadingSpinner />;
   }
 
   if (items.isError) {
-    return <ErrorMessage message={items.error.message} />;
+    return <ErrorMessage message={JSON.stringify(items.error.error)} />;
   }
 
   return (

--- a/docs/src/content/docs/it/guides/connection/react-trpc.mdx
+++ b/docs/src/content/docs/it/guides/connection/react-trpc.mdx
@@ -63,8 +63,7 @@ Il generatore crea la seguente struttura nella tua applicazione React:
     - QueryClientProvider.tsx Provider del client TanStack React Query
   - hooks
     - useSigV4.tsx Hook per firmare le richieste HTTP con SigV4 (solo IAM)
-    - use\<ApiName>.tsx Un hook che restituisce il proxy delle opzioni tRPC per l'integrazione con TanStack Query
-    - use\<ApiName>Client.tsx Un hook che restituisce il client tRPC vanilla per chiamate API dirette
+    - use\<ApiName>.tsx Esporta sia `use<ApiName>`, che restituisce il proxy delle opzioni tRPC per l'integrazione con TanStack Query, sia `use<ApiName>Client`, che restituisce il client tRPC vanilla per chiamate API dirette
 
 </FileTree>
 
@@ -103,6 +102,8 @@ function MyComponent() {
   };
 
   if (isLoading) return <div>Loading...</div>;
+  if (error) return <div>Error: {error.message}</div>;
+  if (!data) return null;
 
   return (
     <ul>
@@ -113,6 +114,8 @@ function MyComponent() {
   );
 }
 ```
+
+`data` è `undefined` fino a quando la query non viene risolta, quindi proteggi prima di dereferenziare.
 
 ### Utilizzo del Client tRPC Vanilla
 
@@ -156,6 +159,8 @@ function MyComponent() {
       </div>
     );
   }
+
+  if (!data) return null;
 
   return (
     <ul>
@@ -278,7 +283,7 @@ function UserList() {
 
   const users = useQuery(trpc.users.list.queryOptions());
 
-  if (users.isLoading) {
+  if (users.isPending) {
     return <LoadingSpinner />;
   }
 
@@ -338,7 +343,7 @@ function UserList() {
 
   return (
     <ul>
-      {users.map((user) => (
+      {users.data?.map((user) => (
         <li key={user.id}>
           {user.name}
           <button onClick={() => deleteMutation.mutate(user.id)}>Delete</button>
@@ -366,7 +371,7 @@ function UserList() {
 
   return (
     <ul>
-      {users.map((user) => (
+      {users.data?.map((user) => (
         <li key={user.id} onMouseEnter={() => prefetchUser(user.id)}>
           <Link to={`/users/${user.id}`}>{user.name}</Link>
         </li>

--- a/docs/src/content/docs/it/guides/connection/ts-agent-rdb.mdx
+++ b/docs/src/content/docs/it/guides/connection/ts-agent-rdb.mdx
@@ -36,13 +36,13 @@ Seleziona il tuo progetto Agent come sorgente e il tuo progetto di database rela
 
 ## Output del Generatore
 
-Il generatore modifica due file nella directory sorgente del tuo agent:
+Il generatore modifica i seguenti file nella directory sorgente del tuo agent:
 
 <FileTree>
 
 - packages/my-service/src/my-agent
   - agent.ts Prisma client recuperato all'interno di `getAgent` e disponibile per i tool
-  - Dockerfile RDS CA bundle installato per connessioni SSL ad Aurora
+  - Dockerfile RDS CA bundle installato per connessioni SSL ad Aurora (solo quando l'`infra` dell'agent è `agentcore-ecr`)
 
 </FileTree>
 

--- a/docs/src/content/docs/it/guides/connection/ts-mcp-server-rdb.mdx
+++ b/docs/src/content/docs/it/guides/connection/ts-mcp-server-rdb.mdx
@@ -36,13 +36,13 @@ Seleziona il tuo progetto MCP server come sorgente e il tuo progetto database re
 
 ## Output del Generatore
 
-Il generatore modifica due file nella directory sorgente del tuo MCP server:
+Il generatore modifica i seguenti file nella directory sorgente del tuo MCP server:
 
 <FileTree>
 
 - packages/my-service/src/my-mcp
   - server.ts Client Prisma recuperato e disponibile per tutti gli strumenti registrati all'interno di `createServer`
-  - Dockerfile Bundle CA RDS installato per connessioni SSL ad Aurora
+  - Dockerfile Bundle CA RDS installato per connessioni SSL ad Aurora (solo quando l'`infra` dell'MCP server è `agentcore-ecr`)
 
 </FileTree>
 
@@ -52,11 +52,12 @@ Inoltre, il target `<mcp-server-name>-dev` viene aggiornato per dipendere dal ta
 
 Il client Prisma viene recuperato all'interno di `createServer` ed è disponibile per tutti gli strumenti e le risorse registrati lì:
 
-```ts title="packages/my-service/src/my-mcp/server.ts" {1,4}
+```ts title="packages/my-service/src/my-mcp/server.ts" {1,4,5}
 import { getPrisma as getMyDb } from '@my-scope/my-db';
 
 export const createServer = async () => {
   const myDb = await getMyDb();
+  myDb.$on('error', console.error);
   const server = new McpServer({ name: 'my-service', version: '1.0.0' });
   // register tools/resources that use myDb
   return server;

--- a/docs/src/content/docs/it/guides/ts-rdb.mdx
+++ b/docs/src/content/docs/it/guides/ts-rdb.mdx
@@ -45,11 +45,18 @@ Il generatore creerà la seguente struttura di progetto nella directory `<direct
     - create-db-user-handler.ts Lambda handler used to create the application database user during deployment
     - migration-handler.ts Lambda handler used to run database migrations during deployment
   - .gitignore Git ignore entries including generated Prisma client output
+  - .trivyignore Vulnerability IDs to suppress when scanning the migration image
   - config.json Local development connection details and runtime config key
   - Dockerfile Container image definition for the migration handler
   - package.json Project manifest defining the project's package name and dependencies
   - project.json Project configuration and build targets
   - prisma.config.ts Configuration for Prisma CLI
+  - README.md Project readme
+  - rolldown.config.ts Bundler configuration invoked by the `bundle` target
+  - tsconfig.json TypeScript project references
+  - tsconfig.lib.json TypeScript configuration for the library build
+  - tsconfig.spec.json TypeScript configuration for tests
+  - vitest.config.mts Vitest configuration
 </FileTree>
 
 Gli script di sviluppo locale sono condivisi tra tutti i progetti di database e generati in `packages/common/scripts/`:
@@ -342,7 +349,7 @@ export const listExampleTable = publicProcedure
 
 **Opzione 2: middleware tRPC**
 
-Se stai utilizzando il [pattern middleware](#injecting-the-prisma-client-via-middleware), aggiungi la chiamata `$disconnect()` al middleware in modo che tutte le procedure costruite su di esso siano coperte automaticamente:
+Se stai utilizzando il <Link path="guides/connection/trpc-rdb#using-the-middleware">pattern middleware</Link>, aggiungi la chiamata `$disconnect()` al middleware in modo che tutte le procedure costruite su di esso siano coperte automaticamente:
 
 ```ts title="packages/api/src/middleware/db.ts"
 import { getPrisma } from '@my-scope/db';

--- a/docs/src/content/docs/it/troubleshooting/nx.mdx
+++ b/docs/src/content/docs/it/troubleshooting/nx.mdx
@@ -24,6 +24,6 @@ Per questo, e per qualsiasi altro errore imprevisto, vale sempre la pena reimpos
 
 In caso contrario, puoi provare a [disabilitare completamente il daemon](https://nx.dev/docs/concepts/nx-daemon#turning-it-off).
 
-:::warning[Daemon Richiesto]
-Il comando `nx watch` richiede il daemon, e pertanto alcuni dei tuoi target di hot-reloading potrebbero non funzionare se lo disabiliti.
+:::note[Daemon Richiesto]
+Il comando `nx watch` richiede il daemon, quindi i target `dev` che si basano su di esso per ricaricare a caldo i tuoi server di sviluppo locali necessitano che il daemon sia abilitato.
 :::

--- a/docs/src/content/docs/jp/guides/connection/py-agent-rdb.mdx
+++ b/docs/src/content/docs/jp/guides/connection/py-agent-rdb.mdx
@@ -42,7 +42,7 @@ Agent プロジェクトをソースとして、リレーショナルデータ�
   - pyproject.toml データベースパッケージをワークスペース依存関係として追加
   - my\_service
     - my\_agent
-      - Dockerfile 直接 Aurora 接続に使用される RDS CA バンドルを追加
+      - Dockerfile 直接 Aurora 接続に使用される RDS CA バンドルを追加（エージェントの `infra` が `agentcore-ecr` の場合のみ）
 
 </FileTree>
 

--- a/docs/src/content/docs/jp/guides/connection/py-fast-api-rdb.mdx
+++ b/docs/src/content/docs/jp/guides/connection/py-fast-api-rdb.mdx
@@ -11,6 +11,7 @@ import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Infrastructure from '@components/infrastructure.astro';
+import Snippet from '@components/snippet.astro';
 
 `connection` ジェネレーターは、<Link path="guides/fastapi">FastAPI</Link> を <Link path="guides/py-rdb">Python リレーショナルデータベース</Link> プロジェクトに接続し、FastAPI の依存性を介して型付き SQLModel セッションをルートハンドラーに注入します。
 
@@ -167,6 +168,10 @@ AppConfig アプリケーションはデフォルトで `database` 名前空間�
 
 </Fragment>
 </Infrastructure>
+
+### RDS Proxy を使用せずに接続する場合の SSL 要件
+
+<Snippet name="connection/py-lambda-rdb-ssl-requirements" parentHeading="RDS Proxy を使用せずに接続する場合の SSL 要件" />
 
 ## ローカル開発
 

--- a/docs/src/content/docs/jp/guides/connection/py-mcp-server-rdb.mdx
+++ b/docs/src/content/docs/jp/guides/connection/py-mcp-server-rdb.mdx
@@ -42,7 +42,7 @@ MCP サーバープロジェクトをソースとして、リレーショナル�
   - pyproject.toml データベースパッケージをワークスペース依存関係として追加
   - my\_service
     - my\_mcp\_server
-      - Dockerfile 直接 Aurora 接続に使用される RDS CA バンドルを追加
+      - Dockerfile 直接 Aurora 接続に使用される RDS CA バンドルを追加（MCP サーバーの `infra` が `agentcore-ecr` の場合のみ）
 
 </FileTree>
 

--- a/docs/src/content/docs/jp/guides/connection/react-agui.mdx
+++ b/docs/src/content/docs/jp/guides/connection/react-agui.mdx
@@ -205,12 +205,14 @@ import { CopilotChat } from './components/copilot';
 
 ### カスタムコンポーネントでスロットを置き換える
 
-任意のスロットは className の代わりに React コンポーネントを取ることができるため、デフォルトを完全に置き換えることができます：
+任意のスロットは className の代わりに React コンポーネントを取ることができるため、デフォルトを完全に置き換えることができます。コンポーネントをスロットが宣言するプロップに対して型付けします — `sendButton` は `<button>` をレンダリングするため、`ButtonHTMLAttributes` を受け取ります：
 
 ```tsx
 import { CopilotChat } from './components/copilot';
 
-const MySendButton: React.FC<{ onClick: () => void }> = ({ onClick }) => (
+const MySendButton: React.FC<React.ButtonHTMLAttributes<HTMLButtonElement>> = ({
+  onClick,
+}) => (
   <button onClick={onClick} className="my-send-btn">
     Send
   </button>
@@ -247,6 +249,10 @@ const MySendButton: React.FC<{ onClick: () => void }> = ({ onClick }) => (
 
 :::tip[ホットリロード]
 ウェブサイトと接続された Agent は一緒にホットリロードされるため、AWS にデプロイすることなく両側で迅速に反復できます。
+:::
+
+:::note[dev ターゲットには Nx Daemon が必要です]
+`dev` ターゲットはローカル開発サーバーをホットリロードします。これらの多くは [`nx watch`](https://nx.dev/docs/guides/tasks--caching/workspace-watching) に依存しており、[Nx Daemon](https://nx.dev/docs/concepts/nx-daemon) を有効にする必要があります。
 :::
 
 ## 詳細情報

--- a/docs/src/content/docs/jp/guides/connection/react-fastapi.mdx
+++ b/docs/src/content/docs/jp/guides/connection/react-fastapi.mdx
@@ -125,8 +125,8 @@ ReactアプリケーションとFastAPIの両方を積極的に開発してい�
 />
 :::
 
-:::warning[ファイルウォッチャーの依存関係]
-`watch-generate:<ApiName>-client`は[`nx watch`](https://nx.dev/docs/guides/tasks--caching/workspace-watching)コマンドに依存しており、[Nx Daemon](https://nx.dev/docs/concepts/nx-daemon)が実行されている必要があります。したがって、デーモンを無効にしている場合、FastAPIに変更を加えてもクライアントは自動的に再生成されません。
+:::note[devターゲットにはNx Daemonが必要です]
+`dev`ターゲットはローカル開発サーバーをホットリロードします。これらの多くは[`nx watch`](https://nx.dev/docs/guides/tasks--caching/workspace-watching)に依存しており、[Nx Daemon](https://nx.dev/docs/concepts/nx-daemon)が有効になっている必要があります。
 :::
 
 ### APIフックの使用
@@ -146,12 +146,14 @@ function MyComponent() {
   const api = useMyApi();
   const item = useQuery(api.getItem.queryOptions({ itemId: 'some-id' }));
 
-  if (item.isLoading) return <div>Loading...</div>;
-  if (item.isError) return <div>Error: {item.error.message}</div>;
+  if (item.isPending) return <div>Loading...</div>;
+  if (item.isError) return <div>Error: {JSON.stringify(item.error.error)}</div>;
 
   return <div>Item: {item.data.name}</div>;
 }
 ```
+
+エラーは`Error`ではなく`{ status, error }`オブジェクトの判別共用体であるため、レンダリングするトップレベルの`message`はありません。特定のレスポンスボディを読み取るには、`status`で絞り込んでください。詳細は以下の[エラーハンドリング](#エラーハンドリング)を参照してください。
 
 <Drawer title="APIクライアントを直接使用する" trigger="バニラクライアントを直接使用する例はこちらをクリックしてください。">
 ```tsx {5,13}
@@ -222,7 +224,7 @@ function CreateItemForm() {
 
       {createItem.isError && (
         <div className="error">
-          Error: {createItem.error.message}
+          Error: {JSON.stringify(createItem.error.error)}
         </div>
       )}
     </form>
@@ -370,12 +372,12 @@ function ItemList() {
       }),
   });
 
-  if (items.isLoading) {
+  if (items.isPending) {
     return <LoadingSpinner />;
   }
 
   if (items.isError) {
-    return <ErrorMessage message={items.error.message} />;
+    return <ErrorMessage message={JSON.stringify(items.error.error)} />;
   }
 
   return (

--- a/docs/src/content/docs/jp/guides/connection/react-py-agent.mdx
+++ b/docs/src/content/docs/jp/guides/connection/react-py-agent.mdx
@@ -183,6 +183,10 @@ function ChatComponent() {
 ウェブサイトと接続されたエージェントはホットリロードされるため、AWS にデプロイすることなく、両方を迅速に反復できます。
 :::
 
+:::note[dev ターゲットには Nx Daemon が必要です]
+`dev` ターゲットはローカル開発サーバーをホットリロードします。これらの多くは [`nx watch`](https://nx.dev/docs/guides/tasks--caching/workspace-watching) に依存しており、[Nx Daemon](https://nx.dev/docs/concepts/nx-daemon) を有効にする必要があります。
+:::
+
 ## 詳細情報
 
 詳細については、以下を参照してください：

--- a/docs/src/content/docs/jp/guides/connection/react-smithy.mdx
+++ b/docs/src/content/docs/jp/guides/connection/react-smithy.mdx
@@ -126,6 +126,10 @@ ReactアプリケーションとSmithy APIの両方を積極的に開発して�
 />
 :::
 
+:::note[devターゲットにはNx Daemonが必要です]
+`dev`ターゲットはローカル開発サーバーをホットリロードします。これらの多くは[`nx watch`](https://nx.dev/docs/guides/tasks--caching/workspace-watching)に依存しており、[Nx Daemon](https://nx.dev/docs/concepts/nx-daemon)を有効にする必要があります。
+:::
+
 ### APIフックの使用
 
 ジェネレーターは、TanStack QueryでAPIを呼び出すために使用できる`use<ApiName>`フックを提供します。
@@ -143,12 +147,14 @@ function MyComponent() {
   const api = useMyApi();
   const item = useQuery(api.getItem.queryOptions({ itemId: 'some-id' }));
 
-  if (item.isLoading) return <div>Loading...</div>;
-  if (item.isError) return <div>Error: {item.error.message}</div>;
+  if (item.isPending) return <div>Loading...</div>;
+  if (item.isError) return <div>Error: {JSON.stringify(item.error.error)}</div>;
 
   return <div>Item: {item.data.name}</div>;
 }
 ```
+
+エラーは`Error`ではなく`{ status, error }`オブジェクトの判別共用体であるため、レンダリングするトップレベルの`message`はありません。特定のレスポンスボディを読み取るには`status`で絞り込んでください — 以下の[エラーハンドリング](#error-handling)を参照してください。
 
 <Drawer title="APIクライアントを直接使用する" trigger="バニラクライアントを直接使用する例はこちらをクリックしてください。">
 ```tsx {5,13}
@@ -219,7 +225,7 @@ function CreateItemForm() {
 
       {createItem.isError && (
         <div className="error">
-          Error: {createItem.error.message}
+          Error: {JSON.stringify(createItem.error.error)}
         </div>
       )}
     </form>
@@ -331,12 +337,12 @@ function ItemList() {
       }),
   });
 
-  if (items.isLoading) {
+  if (items.isPending) {
     return <LoadingSpinner />;
   }
 
   if (items.isError) {
-    return <ErrorMessage message={items.error.message} />;
+    return <ErrorMessage message={JSON.stringify(items.error.error)} />;
   }
 
   return (

--- a/docs/src/content/docs/jp/guides/connection/react-trpc.mdx
+++ b/docs/src/content/docs/jp/guides/connection/react-trpc.mdx
@@ -63,8 +63,7 @@ root.render(
     - QueryClientProvider.tsx TanStack React Query client provider
   - hooks
     - useSigV4.tsx Hook for signing HTTP requests with SigV4 (IAM only)
-    - use\<ApiName>.tsx A hook returning the tRPC options proxy for TanStack Query integration
-    - use\<ApiName>Client.tsx A hook returning the vanilla tRPC client for direct API calls
+    - use\<ApiName>.tsx Exports both `use<ApiName>`, returning the tRPC options proxy for TanStack Query integration, and `use<ApiName>Client`, returning the vanilla tRPC client for direct API calls
 
 </FileTree>
 
@@ -103,6 +102,8 @@ function MyComponent() {
   };
 
   if (isLoading) return <div>Loading...</div>;
+  if (error) return <div>Error: {error.message}</div>;
+  if (!data) return null;
 
   return (
     <ul>
@@ -113,6 +114,8 @@ function MyComponent() {
   );
 }
 ```
+
+`data` は、クエリが解決されるまで `undefined` であるため、参照する前にガードしてください。
 
 ### バニラ tRPC クライアントの使用
 
@@ -156,6 +159,8 @@ function MyComponent() {
       </div>
     );
   }
+
+  if (!data) return null;
 
   return (
     <ul>
@@ -278,7 +283,7 @@ function UserList() {
 
   const users = useQuery(trpc.users.list.queryOptions());
 
-  if (users.isLoading) {
+  if (users.isPending) {
     return <LoadingSpinner />;
   }
 
@@ -338,7 +343,7 @@ function UserList() {
 
   return (
     <ul>
-      {users.map((user) => (
+      {users.data?.map((user) => (
         <li key={user.id}>
           {user.name}
           <button onClick={() => deleteMutation.mutate(user.id)}>Delete</button>
@@ -366,7 +371,7 @@ function UserList() {
 
   return (
     <ul>
-      {users.map((user) => (
+      {users.data?.map((user) => (
         <li key={user.id} onMouseEnter={() => prefetchUser(user.id)}>
           <Link to={`/users/${user.id}`}>{user.name}</Link>
         </li>

--- a/docs/src/content/docs/jp/guides/connection/ts-agent-rdb.mdx
+++ b/docs/src/content/docs/jp/guides/connection/ts-agent-rdb.mdx
@@ -36,13 +36,13 @@ Agent プロジェクトをソースとして、リレーショナルデータ�
 
 ## ジェネレーターの出力
 
-ジェネレーターは、エージェントのソースディレクトリ内の2つのファイルを変更します：
+ジェネレーターは、エージェントのソースディレクトリ内の以下のファイルを変更します：
 
 <FileTree>
 
 - packages/my-service/src/my-agent
   - agent.ts Prisma client fetched inside `getAgent` and available to tools
-  - Dockerfile RDS CA bundle installed for SSL connections to Aurora
+  - Dockerfile RDS CA bundle installed for SSL connections to Aurora (only when the agent's `infra` is `agentcore-ecr`)
 
 </FileTree>
 

--- a/docs/src/content/docs/jp/guides/connection/ts-mcp-server-rdb.mdx
+++ b/docs/src/content/docs/jp/guides/connection/ts-mcp-server-rdb.mdx
@@ -36,13 +36,13 @@ MCPサーバープロジェクトをソースとして、リレーショナル�
 
 ## ジェネレーターの出力
 
-ジェネレーターは、MCPサーバーのソースディレクトリ内の2つのファイルを変更します：
+ジェネレーターは、MCPサーバーのソースディレクトリ内の以下のファイルを変更します：
 
 <FileTree>
 
 - packages/my-service/src/my-mcp
   - server.ts Prisma client fetched and available to all tools registered inside `createServer`
-  - Dockerfile RDS CA bundle installed for SSL connections to Aurora
+  - Dockerfile RDS CA bundle installed for SSL connections to Aurora (only when the MCP server's `infra` is `agentcore-ecr`)
 
 </FileTree>
 
@@ -52,11 +52,12 @@ MCPサーバープロジェクトをソースとして、リレーショナル�
 
 Prismaクライアントは`createServer`内で取得され、そこに登録されたすべてのツールとリソースで利用できます：
 
-```ts title="packages/my-service/src/my-mcp/server.ts" {1,4}
+```ts title="packages/my-service/src/my-mcp/server.ts" {1,4,5}
 import { getPrisma as getMyDb } from '@my-scope/my-db';
 
 export const createServer = async () => {
   const myDb = await getMyDb();
+  myDb.$on('error', console.error);
   const server = new McpServer({ name: 'my-service', version: '1.0.0' });
   // register tools/resources that use myDb
   return server;

--- a/docs/src/content/docs/jp/guides/ts-rdb.mdx
+++ b/docs/src/content/docs/jp/guides/ts-rdb.mdx
@@ -45,11 +45,18 @@ import OptionFilter from '@components/option-filter.astro';
     - create-db-user-handler.ts Lambda handler used to create the application database user during deployment
     - migration-handler.ts Lambda handler used to run database migrations during deployment
   - .gitignore Git ignore entries including generated Prisma client output
+  - .trivyignore Vulnerability IDs to suppress when scanning the migration image
   - config.json Local development connection details and runtime config key
   - Dockerfile Container image definition for the migration handler
   - package.json Project manifest defining the project's package name and dependencies
   - project.json Project configuration and build targets
   - prisma.config.ts Configuration for Prisma CLI
+  - README.md Project readme
+  - rolldown.config.ts Bundler configuration invoked by the `bundle` target
+  - tsconfig.json TypeScript project references
+  - tsconfig.lib.json TypeScript configuration for the library build
+  - tsconfig.spec.json TypeScript configuration for tests
+  - vitest.config.mts Vitest configuration
 </FileTree>
 
 ローカル開発スクリプトはすべてのデータベースプロジェクト間で共有され、`packages/common/scripts/` に生成されます：
@@ -342,7 +349,7 @@ export const listExampleTable = publicProcedure
 
 **オプション 2: tRPC middleware**
 
-[ミドルウェアパターン](#injecting-the-prisma-client-via-middleware)を使用している場合は、ミドルウェアに `$disconnect()` 呼び出しを追加して、それに基づいて構築されたすべてのプロシージャが自動的にカバーされるようにします：
+<Link path="guides/connection/trpc-rdb#using-the-middleware">ミドルウェアパターン</Link>を使用している場合は、ミドルウェアに `$disconnect()` 呼び出しを追加して、それに基づいて構築されたすべてのプロシージャが自動的にカバーされるようにします：
 
 ```ts title="packages/api/src/middleware/db.ts"
 import { getPrisma } from '@my-scope/db';

--- a/docs/src/content/docs/jp/troubleshooting/nx.mdx
+++ b/docs/src/content/docs/jp/troubleshooting/nx.mdx
@@ -24,6 +24,6 @@ Pass --verbose to see the stacktrace.
 
 それでも解決しない場合は、[デーモンを完全に無効にする](https://nx.dev/docs/concepts/nx-daemon#turning-it-off)ことを試すことができます。
 
-:::warning[Daemon Required]
-`nx watch` コマンドはデーモンを必要とするため、無効にするとホットリロードターゲットの一部が機能しない可能性があります。
+:::note[Daemon Required]
+`nx watch` コマンドはデーモンを必要とするため、ローカル開発サーバーをホットリロードするために依存する `dev` ターゲットにはデーモンを有効にする必要があります。
 :::

--- a/docs/src/content/docs/ko/guides/connection/py-agent-rdb.mdx
+++ b/docs/src/content/docs/ko/guides/connection/py-agent-rdb.mdx
@@ -42,7 +42,7 @@ Agent 프로젝트를 소스로, 관계형 데이터베이스 프로젝트를 �
   - pyproject.toml 데이터베이스 패키지를 워크스페이스 의존성으로 추가
   - my\_service
     - my\_agent
-      - Dockerfile 직접 Aurora 연결에 사용되는 RDS CA 번들 추가
+      - Dockerfile 직접 Aurora 연결에 사용되는 RDS CA 번들 추가 (에이전트의 `infra`가 `agentcore-ecr`인 경우에만)
 
 </FileTree>
 

--- a/docs/src/content/docs/ko/guides/connection/py-fast-api-rdb.mdx
+++ b/docs/src/content/docs/ko/guides/connection/py-fast-api-rdb.mdx
@@ -11,6 +11,7 @@ import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Infrastructure from '@components/infrastructure.astro';
+import Snippet from '@components/snippet.astro';
 
 `connection` 생성기는 <Link path="guides/fastapi">FastAPI</Link>를 <Link path="guides/py-rdb">Python 관계형 데이터베이스</Link> 프로젝트에 연결하여, FastAPI 의존성을 통해 타입이 지정된 SQLModel 세션을 라우트 핸들러에 주입합니다.
 
@@ -167,6 +168,10 @@ AppConfig 애플리케이션은 기본적으로 `database` 네임스페이스를
 
 </Fragment>
 </Infrastructure>
+
+### RDS Proxy 없이 연결할 때 SSL 요구 사항
+
+<Snippet name="connection/py-lambda-rdb-ssl-requirements" parentHeading="RDS Proxy 없이 연결할 때 SSL 요구 사항" />
 
 ## 로컬 개발
 

--- a/docs/src/content/docs/ko/guides/connection/py-mcp-server-rdb.mdx
+++ b/docs/src/content/docs/ko/guides/connection/py-mcp-server-rdb.mdx
@@ -42,7 +42,7 @@ MCP 서버 프로젝트를 소스로, 관계형 데이터베이스 프로젝트�
   - pyproject.toml 데이터베이스 패키지를 워크스페이스 의존성으로 추가
   - my\_service
     - my\_mcp\_server
-      - Dockerfile 직접 Aurora 연결에 사용되는 RDS CA 번들 추가
+      - Dockerfile 직접 Aurora 연결에 사용되는 RDS CA 번들 추가 (MCP 서버의 `infra`가 `agentcore-ecr`인 경우에만)
 
 </FileTree>
 

--- a/docs/src/content/docs/ko/guides/connection/react-agui.mdx
+++ b/docs/src/content/docs/ko/guides/connection/react-agui.mdx
@@ -205,12 +205,14 @@ import { CopilotChat } from './components/copilot';
 
 ### 사용자 정의 컴포넌트로 슬롯 교체
 
-모든 슬롯은 className 대신 React 컴포넌트를 사용할 수 있으므로 기본값을 완전히 교체할 수 있습니다:
+모든 슬롯은 className 대신 React 컴포넌트를 사용할 수 있으므로 기본값을 완전히 교체할 수 있습니다. 슬롯이 선언하는 props에 대해 컴포넌트를 타입 지정하세요 — `sendButton`은 `<button>`을 렌더링하므로 `ButtonHTMLAttributes`를 받습니다:
 
 ```tsx
 import { CopilotChat } from './components/copilot';
 
-const MySendButton: React.FC<{ onClick: () => void }> = ({ onClick }) => (
+const MySendButton: React.FC<React.ButtonHTMLAttributes<HTMLButtonElement>> = ({
+  onClick,
+}) => (
   <button onClick={onClick} className="my-send-btn">
     Send
   </button>
@@ -247,6 +249,10 @@ const MySendButton: React.FC<{ onClick: () => void }> = ({ onClick }) => (
 
 :::tip[핫 리로딩]
 웹사이트와 연결된 에이전트가 함께 핫 리로드되어 AWS에 배포하지 않고도 양쪽을 빠르게 반복할 수 있습니다.
+:::
+
+:::note[dev 타겟은 Nx Daemon이 필요합니다]
+`dev` 타겟은 로컬 개발 서버를 핫 리로드합니다. 이들 중 다수는 이를 달성하기 위해 [`nx watch`](https://nx.dev/docs/guides/tasks--caching/workspace-watching)에 의존하며, 이는 [Nx Daemon](https://nx.dev/docs/concepts/nx-daemon)이 활성화되어 있어야 합니다.
 :::
 
 ## 추가 정보

--- a/docs/src/content/docs/ko/guides/connection/react-fastapi.mdx
+++ b/docs/src/content/docs/ko/guides/connection/react-fastapi.mdx
@@ -125,8 +125,8 @@ React 애플리케이션과 FastAPI를 함께 적극적으로 작업하는 경�
 />
 :::
 
-:::warning[파일 감시자 의존성]
-`watch-generate:<ApiName>-client`는 [`nx watch`](https://nx.dev/docs/guides/tasks--caching/workspace-watching) 명령에 의존하며, 이는 [Nx Daemon](https://nx.dev/docs/concepts/nx-daemon)이 실행 중이어야 합니다. 따라서 데몬을 비활성화한 경우 FastAPI를 변경할 때 클라이언트가 자동으로 재생성되지 않습니다.
+:::note[dev 타겟은 Nx Daemon이 필요합니다]
+`dev` 타겟은 로컬 개발 서버를 핫 리로드합니다. 이들 중 많은 것이 이를 달성하기 위해 [`nx watch`](https://nx.dev/docs/guides/tasks--caching/workspace-watching)에 의존하며, 이는 [Nx Daemon](https://nx.dev/docs/concepts/nx-daemon)이 활성화되어 있어야 합니다.
 :::
 
 ### API 훅 사용
@@ -146,12 +146,14 @@ function MyComponent() {
   const api = useMyApi();
   const item = useQuery(api.getItem.queryOptions({ itemId: 'some-id' }));
 
-  if (item.isLoading) return <div>Loading...</div>;
-  if (item.isError) return <div>Error: {item.error.message}</div>;
+  if (item.isPending) return <div>Loading...</div>;
+  if (item.isError) return <div>Error: {JSON.stringify(item.error.error)}</div>;
 
   return <div>Item: {item.data.name}</div>;
 }
 ```
+
+오류는 `Error`가 아닌 `{ status, error }` 객체의 판별된 유니온이므로 렌더링할 최상위 `message`가 없습니다. 특정 응답 본문을 읽으려면 `status`로 좁히세요 — 아래 [오류 처리](#error-handling)를 참조하세요.
 
 <Drawer title="API 클라이언트를 직접 사용" trigger="바닐라 클라이언트를 직접 사용하는 예시를 보려면 여기를 클릭하세요.">
 ```tsx {5,13}
@@ -222,7 +224,7 @@ function CreateItemForm() {
 
       {createItem.isError && (
         <div className="error">
-          Error: {createItem.error.message}
+          Error: {JSON.stringify(createItem.error.error)}
         </div>
       )}
     </form>
@@ -370,12 +372,12 @@ function ItemList() {
       }),
   });
 
-  if (items.isLoading) {
+  if (items.isPending) {
     return <LoadingSpinner />;
   }
 
   if (items.isError) {
-    return <ErrorMessage message={items.error.message} />;
+    return <ErrorMessage message={JSON.stringify(items.error.error)} />;
   }
 
   return (

--- a/docs/src/content/docs/ko/guides/connection/react-py-agent.mdx
+++ b/docs/src/content/docs/ko/guides/connection/react-py-agent.mdx
@@ -183,6 +183,10 @@ function ChatComponent() {
 웹사이트와 연결된 에이전트가 핫 리로드되므로 AWS에 배포하지 않고도 두 가지를 함께 빠르게 반복할 수 있습니다.
 :::
 
+:::note[dev 타겟은 Nx Daemon이 필요합니다]
+`dev` 타겟은 로컬 개발 서버를 핫 리로드합니다. 이들 중 다수는 이를 달성하기 위해 [`nx watch`](https://nx.dev/docs/guides/tasks--caching/workspace-watching)에 의존하며, 이는 [Nx Daemon](https://nx.dev/docs/concepts/nx-daemon)이 활성화되어 있어야 합니다.
+:::
+
 ## 추가 정보
 
 자세한 내용은 다음을 참조하세요:

--- a/docs/src/content/docs/ko/guides/connection/react-smithy.mdx
+++ b/docs/src/content/docs/ko/guides/connection/react-smithy.mdx
@@ -126,6 +126,10 @@ React 애플리케이션과 Smithy API를 함께 적극적으로 작업하는 �
 />
 :::
 
+:::note[dev 타겟은 Nx Daemon이 필요합니다]
+`dev` 타겟은 로컬 개발 서버를 핫 리로드합니다. 이들 중 많은 것들이 이를 달성하기 위해 [`nx watch`](https://nx.dev/docs/guides/tasks--caching/workspace-watching)에 의존하며, 이는 [Nx Daemon](https://nx.dev/docs/concepts/nx-daemon)이 활성화되어 있어야 합니다.
+:::
+
 ### API 훅 사용
 
 생성기는 TanStack Query로 API를 호출하는 데 사용할 수 있는 `use<ApiName>` 훅을 제공합니다.
@@ -143,12 +147,14 @@ function MyComponent() {
   const api = useMyApi();
   const item = useQuery(api.getItem.queryOptions({ itemId: 'some-id' }));
 
-  if (item.isLoading) return <div>Loading...</div>;
-  if (item.isError) return <div>Error: {item.error.message}</div>;
+  if (item.isPending) return <div>Loading...</div>;
+  if (item.isError) return <div>Error: {JSON.stringify(item.error.error)}</div>;
 
   return <div>Item: {item.data.name}</div>;
 }
 ```
+
+오류는 `Error`가 아니라 `{ status, error }` 객체의 판별된 유니온이므로 렌더링할 최상위 `message`가 없습니다. 특정 응답 본문을 읽으려면 `status`로 좁히세요 — 아래 [오류 처리](#error-handling)를 참조하세요.
 
 <Drawer title="API 클라이언트를 직접 사용" trigger="바닐라 클라이언트를 직접 사용하는 예시를 보려면 여기를 클릭하세요.">
 ```tsx {5,13}
@@ -219,7 +225,7 @@ function CreateItemForm() {
 
       {createItem.isError && (
         <div className="error">
-          Error: {createItem.error.message}
+          Error: {JSON.stringify(createItem.error.error)}
         </div>
       )}
     </form>
@@ -331,12 +337,12 @@ function ItemList() {
       }),
   });
 
-  if (items.isLoading) {
+  if (items.isPending) {
     return <LoadingSpinner />;
   }
 
   if (items.isError) {
-    return <ErrorMessage message={items.error.message} />;
+    return <ErrorMessage message={JSON.stringify(items.error.error)} />;
   }
 
   return (

--- a/docs/src/content/docs/ko/guides/connection/react-trpc.mdx
+++ b/docs/src/content/docs/ko/guides/connection/react-trpc.mdx
@@ -63,8 +63,7 @@ root.render(
     - QueryClientProvider.tsx TanStack React Query client provider
   - hooks
     - useSigV4.tsx Hook for signing HTTP requests with SigV4 (IAM only)
-    - use\<ApiName>.tsx A hook returning the tRPC options proxy for TanStack Query integration
-    - use\<ApiName>Client.tsx A hook returning the vanilla tRPC client for direct API calls
+    - use\<ApiName>.tsx Exports both `use<ApiName>`, returning the tRPC options proxy for TanStack Query integration, and `use<ApiName>Client`, returning the vanilla tRPC client for direct API calls
 
 </FileTree>
 
@@ -103,6 +102,8 @@ function MyComponent() {
   };
 
   if (isLoading) return <div>Loading...</div>;
+  if (error) return <div>Error: {error.message}</div>;
+  if (!data) return null;
 
   return (
     <ul>
@@ -113,6 +114,8 @@ function MyComponent() {
   );
 }
 ```
+
+`data`는 쿼리가 해결될 때까지 `undefined`이므로 역참조하기 전에 가드해야 합니다.
 
 ### Vanilla tRPC 클라이언트 사용하기
 
@@ -156,6 +159,8 @@ function MyComponent() {
       </div>
     );
   }
+
+  if (!data) return null;
 
   return (
     <ul>
@@ -278,7 +283,7 @@ function UserList() {
 
   const users = useQuery(trpc.users.list.queryOptions());
 
-  if (users.isLoading) {
+  if (users.isPending) {
     return <LoadingSpinner />;
   }
 
@@ -338,7 +343,7 @@ function UserList() {
 
   return (
     <ul>
-      {users.map((user) => (
+      {users.data?.map((user) => (
         <li key={user.id}>
           {user.name}
           <button onClick={() => deleteMutation.mutate(user.id)}>Delete</button>
@@ -366,7 +371,7 @@ function UserList() {
 
   return (
     <ul>
-      {users.map((user) => (
+      {users.data?.map((user) => (
         <li key={user.id} onMouseEnter={() => prefetchUser(user.id)}>
           <Link to={`/users/${user.id}`}>{user.name}</Link>
         </li>

--- a/docs/src/content/docs/ko/guides/connection/ts-agent-rdb.mdx
+++ b/docs/src/content/docs/ko/guides/connection/ts-agent-rdb.mdx
@@ -36,13 +36,13 @@ Agent 프로젝트를 소스로, 관계형 데이터베이스 프로젝트를 �
 
 ## 생성기 출력
 
-생성기는 에이전트의 소스 디렉토리에 있는 두 개의 파일을 수정합니다:
+생성기는 에이전트의 소스 디렉토리에 있는 다음 파일을 수정합니다:
 
 <FileTree>
 
 - packages/my-service/src/my-agent
   - agent.ts Prisma 클라이언트가 `getAgent` 내에서 가져와지고 도구에서 사용 가능
-  - Dockerfile Aurora에 대한 SSL 연결을 위해 RDS CA 번들 설치됨
+  - Dockerfile Aurora에 대한 SSL 연결을 위해 RDS CA 번들 설치됨 (에이전트의 `infra`가 `agentcore-ecr`인 경우에만)
 
 </FileTree>
 

--- a/docs/src/content/docs/ko/guides/connection/ts-mcp-server-rdb.mdx
+++ b/docs/src/content/docs/ko/guides/connection/ts-mcp-server-rdb.mdx
@@ -36,13 +36,13 @@ MCP 서버 프로젝트를 소스로, 관계형 데이터베이스 프로젝트�
 
 ## 생성기 출력
 
-생성기는 MCP 서버의 소스 디렉터리에 있는 두 개의 파일을 수정합니다:
+생성기는 MCP 서버의 소스 디렉터리에 있는 다음 파일들을 수정합니다:
 
 <FileTree>
 
 - packages/my-service/src/my-mcp
   - server.ts Prisma 클라이언트가 가져와지고 `createServer` 내부에 등록된 모든 도구에서 사용 가능
-  - Dockerfile Aurora에 대한 SSL 연결을 위해 RDS CA 번들 설치
+  - Dockerfile Aurora에 대한 SSL 연결을 위해 RDS CA 번들 설치 (MCP 서버의 `infra`가 `agentcore-ecr`인 경우에만)
 
 </FileTree>
 
@@ -52,11 +52,12 @@ MCP 서버 프로젝트를 소스로, 관계형 데이터베이스 프로젝트�
 
 Prisma 클라이언트는 `createServer` 내부에서 가져와지며 거기에 등록된 모든 도구와 리소스에서 사용할 수 있습니다:
 
-```ts title="packages/my-service/src/my-mcp/server.ts" {1,4}
+```ts title="packages/my-service/src/my-mcp/server.ts" {1,4,5}
 import { getPrisma as getMyDb } from '@my-scope/my-db';
 
 export const createServer = async () => {
   const myDb = await getMyDb();
+  myDb.$on('error', console.error);
   const server = new McpServer({ name: 'my-service', version: '1.0.0' });
   // register tools/resources that use myDb
   return server;

--- a/docs/src/content/docs/ko/guides/ts-rdb.mdx
+++ b/docs/src/content/docs/ko/guides/ts-rdb.mdx
@@ -45,11 +45,18 @@ import OptionFilter from '@components/option-filter.astro';
     - create-db-user-handler.ts Lambda handler used to create the application database user during deployment
     - migration-handler.ts Lambda handler used to run database migrations during deployment
   - .gitignore Git ignore entries including generated Prisma client output
+  - .trivyignore Vulnerability IDs to suppress when scanning the migration image
   - config.json Local development connection details and runtime config key
   - Dockerfile Container image definition for the migration handler
   - package.json Project manifest defining the project's package name and dependencies
   - project.json Project configuration and build targets
   - prisma.config.ts Configuration for Prisma CLI
+  - README.md Project readme
+  - rolldown.config.ts Bundler configuration invoked by the `bundle` target
+  - tsconfig.json TypeScript project references
+  - tsconfig.lib.json TypeScript configuration for the library build
+  - tsconfig.spec.json TypeScript configuration for tests
+  - vitest.config.mts Vitest configuration
 </FileTree>
 
 로컬 개발 스크립트는 모든 데이터베이스 프로젝트에서 공유되며 `packages/common/scripts/`에 생성됩니다:
@@ -342,7 +349,7 @@ export const listExampleTable = publicProcedure
 
 **옵션 2: tRPC 미들웨어**
 
-[미들웨어 패턴](#injecting-the-prisma-client-via-middleware)을 사용하는 경우, 미들웨어에 `$disconnect()` 호출을 추가하여 이를 기반으로 구축된 모든 프로시저가 자동으로 적용되도록 하세요:
+<Link path="guides/connection/trpc-rdb#using-the-middleware">미들웨어 패턴</Link>을 사용하는 경우, 미들웨어에 `$disconnect()` 호출을 추가하여 이를 기반으로 구축된 모든 프로시저가 자동으로 적용되도록 하세요:
 
 ```ts title="packages/api/src/middleware/db.ts"
 import { getPrisma } from '@my-scope/db';

--- a/docs/src/content/docs/ko/troubleshooting/nx.mdx
+++ b/docs/src/content/docs/ko/troubleshooting/nx.mdx
@@ -24,6 +24,6 @@ Pass --verbose to see the stacktrace.
 
 이것이 실패하면 [데몬을 완전히 비활성화](https://nx.dev/docs/concepts/nx-daemon#turning-it-off)해 볼 수 있습니다.
 
-:::warning[데몬 필요]
-`nx watch` 명령은 데몬이 필요하므로, 비활성화하면 일부 핫 리로딩 타겟이 작동하지 않을 수 있습니다.
+:::note[데몬 필요]
+`nx watch` 명령은 데몬이 필요하므로, 로컬 개발 서버를 핫 리로드하기 위해 이에 의존하는 `dev` 타겟은 데몬이 활성화되어 있어야 합니다.
 :::

--- a/docs/src/content/docs/pt/guides/connection/py-agent-rdb.mdx
+++ b/docs/src/content/docs/pt/guides/connection/py-agent-rdb.mdx
@@ -42,7 +42,7 @@ Selecione seu projeto Agent como origem e seu projeto de banco de dados relacion
   - pyproject.toml Adiciona o pacote do banco de dados como uma dependência do workspace
   - my\_service
     - my\_agent
-      - Dockerfile Adiciona o pacote CA do RDS usado para conexões diretas ao Aurora
+      - Dockerfile Adiciona o pacote CA do RDS usado para conexões diretas ao Aurora (somente quando o `infra` do agente é `agentcore-ecr`)
 
 </FileTree>
 

--- a/docs/src/content/docs/pt/guides/connection/py-fast-api-rdb.mdx
+++ b/docs/src/content/docs/pt/guides/connection/py-fast-api-rdb.mdx
@@ -11,6 +11,7 @@ import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Infrastructure from '@components/infrastructure.astro';
+import Snippet from '@components/snippet.astro';
 
 O gerador `connection` conecta um <Link path="guides/fastapi">FastAPI</Link> a um projeto de <Link path="guides/py-rdb">Banco de Dados Relacional Python</Link>, injetando uma sessão SQLModel tipada em seus manipuladores de rota via uma dependência FastAPI.
 
@@ -167,6 +168,10 @@ A aplicação AppConfig expõe o namespace `database` por padrão, então a entr
 
 </Fragment>
 </Infrastructure>
+
+### Requisitos SSL ao Conectar Sem RDS Proxy
+
+<Snippet name="connection/py-lambda-rdb-ssl-requirements" parentHeading="Requisitos SSL ao Conectar Sem RDS Proxy" />
 
 ## Desenvolvimento Local
 

--- a/docs/src/content/docs/pt/guides/connection/py-mcp-server-rdb.mdx
+++ b/docs/src/content/docs/pt/guides/connection/py-mcp-server-rdb.mdx
@@ -42,7 +42,7 @@ Selecione seu projeto de servidor MCP como origem e seu projeto de banco de dado
   - pyproject.toml Adiciona o pacote do banco de dados como uma dependência do workspace
   - my\_service
     - my\_mcp\_server
-      - Dockerfile Adiciona o pacote CA do RDS usado para conexões diretas ao Aurora
+      - Dockerfile Adiciona o pacote CA do RDS usado para conexões diretas ao Aurora (somente quando o `infra` do servidor MCP é `agentcore-ecr`)
 
 </FileTree>
 

--- a/docs/src/content/docs/pt/guides/connection/react-agui.mdx
+++ b/docs/src/content/docs/pt/guides/connection/react-agui.mdx
@@ -205,12 +205,14 @@ Substituições por chat ainda funcionam junto com o tema — qualquer coisa que
 
 ### Substituindo um slot com um componente personalizado
 
-Qualquer slot pode receber um componente React em vez de um className, então você pode substituir o padrão inteiramente:
+Qualquer slot pode receber um componente React em vez de um className, então você pode substituir o padrão inteiramente. Tipifique seu componente de acordo com as props que o slot declara — `sendButton` renderiza um `<button>`, então ele recebe `ButtonHTMLAttributes`:
 
 ```tsx
 import { CopilotChat } from './components/copilot';
 
-const MySendButton: React.FC<{ onClick: () => void }> = ({ onClick }) => (
+const MySendButton: React.FC<React.ButtonHTMLAttributes<HTMLButtonElement>> = ({
+  onClick,
+}) => (
   <button onClick={onClick} className="my-send-btn">
     Send
   </button>
@@ -247,6 +249,10 @@ O gerador de conexão configura automaticamente a integração `dev`:
 
 :::tip[Recarga Automática]
 O site e o agente conectado recarregam automaticamente juntos, permitindo que você itere rapidamente em ambos os lados sem implantar na AWS.
+:::
+
+:::note[O target dev requer o Nx Daemon]
+O target `dev` recarrega automaticamente os servidores de desenvolvimento locais. Muitos deles dependem de [`nx watch`](https://nx.dev/docs/guides/tasks--caching/workspace-watching) para conseguir isso, o que requer que o [Nx Daemon](https://nx.dev/docs/concepts/nx-daemon) esteja habilitado.
 :::
 
 ## Mais Informações

--- a/docs/src/content/docs/pt/guides/connection/react-fastapi.mdx
+++ b/docs/src/content/docs/pt/guides/connection/react-fastapi.mdx
@@ -125,8 +125,8 @@ Para controle mais refinado, você pode usar o target `watch-generate:<ApiName>-
 />
 :::
 
-:::warning[Dependência do File Watcher]
-`watch-generate:<ApiName>-client` depende do comando [`nx watch`](https://nx.dev/docs/guides/tasks--caching/workspace-watching), que requer que o [Nx Daemon](https://nx.dev/docs/concepts/nx-daemon) esteja em execução. Portanto, se você desabilitou o daemon, o cliente não será regenerado automaticamente ao fazer alterações em seu FastAPI.
+:::note[O target dev requer o Nx Daemon]
+O target `dev` faz hot-reload de servidores de desenvolvimento locais. Muitos deles dependem do [`nx watch`](https://nx.dev/docs/guides/tasks--caching/workspace-watching) para conseguir isso, o que requer que o [Nx Daemon](https://nx.dev/docs/concepts/nx-daemon) esteja habilitado.
 :::
 
 ### Usando o Hook da API
@@ -146,12 +146,14 @@ function MyComponent() {
   const api = useMyApi();
   const item = useQuery(api.getItem.queryOptions({ itemId: 'some-id' }));
 
-  if (item.isLoading) return <div>Loading...</div>;
-  if (item.isError) return <div>Error: {item.error.message}</div>;
+  if (item.isPending) return <div>Loading...</div>;
+  if (item.isError) return <div>Error: {JSON.stringify(item.error.error)}</div>;
 
   return <div>Item: {item.data.name}</div>;
 }
 ```
+
+O erro é uma união discriminada de objetos `{ status, error }` em vez de um `Error`, então não há `message` de nível superior para renderizar. Restrinja em `status` para ler um corpo de resposta específico — veja [Tratamento de Erros](#tratamento-de-erros) abaixo.
 
 <Drawer title="Usando o cliente de API diretamente" trigger="Clique aqui para um exemplo usando o cliente vanilla diretamente.">
 ```tsx {5,13}
@@ -222,7 +224,7 @@ function CreateItemForm() {
 
       {createItem.isError && (
         <div className="error">
-          Error: {createItem.error.message}
+          Error: {JSON.stringify(createItem.error.error)}
         </div>
       )}
     </form>
@@ -370,12 +372,12 @@ function ItemList() {
       }),
   });
 
-  if (items.isLoading) {
+  if (items.isPending) {
     return <LoadingSpinner />;
   }
 
   if (items.isError) {
-    return <ErrorMessage message={items.error.message} />;
+    return <ErrorMessage message={JSON.stringify(items.error.error)} />;
   }
 
   return (

--- a/docs/src/content/docs/pt/guides/connection/react-py-agent.mdx
+++ b/docs/src/content/docs/pt/guides/connection/react-py-agent.mdx
@@ -183,6 +183,10 @@ O gerador de conexão configura automaticamente a integração `dev`:
 O site e o agente conectado farão hot-reload, permitindo que você itere rapidamente em ambos juntos sem implantar na AWS.
 :::
 
+:::note[O target dev requer o Nx Daemon]
+O target `dev` faz hot-reload de servidores de desenvolvimento locais. Muitos deles dependem de [`nx watch`](https://nx.dev/docs/guides/tasks--caching/workspace-watching) para conseguir isso, o que requer que o [Nx Daemon](https://nx.dev/docs/concepts/nx-daemon) esteja habilitado.
+:::
+
 ## Mais Informações
 
 Para mais informações, consulte:

--- a/docs/src/content/docs/pt/guides/connection/react-smithy.mdx
+++ b/docs/src/content/docs/pt/guides/connection/react-smithy.mdx
@@ -126,6 +126,10 @@ Para controle mais refinado, você pode usar o target `watch-generate:<ApiName>-
 />
 :::
 
+:::note[O target dev requer o Nx Daemon]
+O target `dev` faz hot-reload de servidores de desenvolvimento locais. Muitos deles dependem de [`nx watch`](https://nx.dev/docs/guides/tasks--caching/workspace-watching) para conseguir isso, o que requer que o [Nx Daemon](https://nx.dev/docs/concepts/nx-daemon) esteja habilitado.
+:::
+
 ### Usando o Hook da API
 
 O gerador fornece um hook `use<ApiName>` que você pode usar para chamar sua API com TanStack Query.
@@ -143,12 +147,14 @@ function MyComponent() {
   const api = useMyApi();
   const item = useQuery(api.getItem.queryOptions({ itemId: 'some-id' }));
 
-  if (item.isLoading) return <div>Loading...</div>;
-  if (item.isError) return <div>Error: {item.error.message}</div>;
+  if (item.isPending) return <div>Loading...</div>;
+  if (item.isError) return <div>Error: {JSON.stringify(item.error.error)}</div>;
 
   return <div>Item: {item.data.name}</div>;
 }
 ```
+
+O erro é uma união discriminada de objetos `{ status, error }` em vez de um `Error`, então não há `message` de nível superior para renderizar. Restrinja em `status` para ler um corpo de resposta específico — veja [Tratamento de Erros](#tratamento-de-erros) abaixo.
 
 <Drawer title="Usando o cliente de API diretamente" trigger="Clique aqui para um exemplo usando o cliente vanilla diretamente.">
 ```tsx {5,13}
@@ -219,7 +225,7 @@ function CreateItemForm() {
 
       {createItem.isError && (
         <div className="error">
-          Error: {createItem.error.message}
+          Error: {JSON.stringify(createItem.error.error)}
         </div>
       )}
     </form>
@@ -331,12 +337,12 @@ function ItemList() {
       }),
   });
 
-  if (items.isLoading) {
+  if (items.isPending) {
     return <LoadingSpinner />;
   }
 
   if (items.isError) {
-    return <ErrorMessage message={items.error.message} />;
+    return <ErrorMessage message={JSON.stringify(items.error.error)} />;
   }
 
   return (

--- a/docs/src/content/docs/pt/guides/connection/react-trpc.mdx
+++ b/docs/src/content/docs/pt/guides/connection/react-trpc.mdx
@@ -63,8 +63,7 @@ O gerador cria a seguinte estrutura em sua aplicação React:
     - QueryClientProvider.tsx Provedor de cliente TanStack React Query
   - hooks
     - useSigV4.tsx Hook para assinar requisições HTTP com SigV4 (somente IAM)
-    - use\<ApiName>.tsx Um hook retornando o proxy de opções tRPC para integração com TanStack Query
-    - use\<ApiName>Client.tsx Um hook retornando o cliente tRPC vanilla para chamadas diretas à API
+    - use\<ApiName>.tsx Exporta tanto `use<ApiName>`, retornando o proxy de opções tRPC para integração com TanStack Query, quanto `use<ApiName>Client`, retornando o cliente tRPC vanilla para chamadas diretas à API
 
 </FileTree>
 
@@ -103,6 +102,8 @@ function MyComponent() {
   };
 
   if (isLoading) return <div>Loading...</div>;
+  if (error) return <div>Error: {error.message}</div>;
+  if (!data) return null;
 
   return (
     <ul>
@@ -113,6 +114,8 @@ function MyComponent() {
   );
 }
 ```
+
+`data` é `undefined` até que a consulta seja resolvida, então proteja-a antes de desreferenciar.
 
 ### Usando o Cliente tRPC Vanilla
 
@@ -156,6 +159,8 @@ function MyComponent() {
       </div>
     );
   }
+
+  if (!data) return null;
 
   return (
     <ul>
@@ -278,7 +283,7 @@ function UserList() {
 
   const users = useQuery(trpc.users.list.queryOptions());
 
-  if (users.isLoading) {
+  if (users.isPending) {
     return <LoadingSpinner />;
   }
 
@@ -338,7 +343,7 @@ function UserList() {
 
   return (
     <ul>
-      {users.map((user) => (
+      {users.data?.map((user) => (
         <li key={user.id}>
           {user.name}
           <button onClick={() => deleteMutation.mutate(user.id)}>Delete</button>
@@ -366,7 +371,7 @@ function UserList() {
 
   return (
     <ul>
-      {users.map((user) => (
+      {users.data?.map((user) => (
         <li key={user.id} onMouseEnter={() => prefetchUser(user.id)}>
           <Link to={`/users/${user.id}`}>{user.name}</Link>
         </li>

--- a/docs/src/content/docs/pt/guides/connection/ts-agent-rdb.mdx
+++ b/docs/src/content/docs/pt/guides/connection/ts-agent-rdb.mdx
@@ -36,13 +36,13 @@ Selecione seu projeto Agent como origem e seu projeto de banco de dados relacion
 
 ## Saída do Gerador
 
-O gerador modifica dois arquivos no diretório de origem do seu agente:
+O gerador modifica os seguintes arquivos no diretório de origem do seu agente:
 
 <FileTree>
 
 - packages/my-service/src/my-agent
   - agent.ts Cliente Prisma obtido dentro de `getAgent` e disponível para ferramentas
-  - Dockerfile Pacote CA do RDS instalado para conexões SSL com Aurora
+  - Dockerfile Pacote CA do RDS instalado para conexões SSL com Aurora (somente quando o `infra` do agente é `agentcore-ecr`)
 
 </FileTree>
 

--- a/docs/src/content/docs/pt/guides/connection/ts-mcp-server-rdb.mdx
+++ b/docs/src/content/docs/pt/guides/connection/ts-mcp-server-rdb.mdx
@@ -36,13 +36,13 @@ Selecione seu projeto de servidor MCP como origem e seu projeto de banco de dado
 
 ## Saída do Gerador
 
-O gerador modifica dois arquivos no diretório de origem do seu servidor MCP:
+O gerador modifica os seguintes arquivos no diretório de origem do seu servidor MCP:
 
 <FileTree>
 
 - packages/my-service/src/my-mcp
   - server.ts Cliente Prisma obtido e disponível para todas as ferramentas registradas dentro de `createServer`
-  - Dockerfile Pacote CA do RDS instalado para conexões SSL com Aurora
+  - Dockerfile Pacote CA do RDS instalado para conexões SSL com Aurora (somente quando o `infra` do servidor MCP é `agentcore-ecr`)
 
 </FileTree>
 
@@ -52,11 +52,12 @@ Além disso, o target `<mcp-server-name>-dev` é atualizado para depender do tar
 
 O cliente Prisma é obtido dentro de `createServer` e está disponível para todas as ferramentas e recursos registrados lá:
 
-```ts title="packages/my-service/src/my-mcp/server.ts" {1,4}
+```ts title="packages/my-service/src/my-mcp/server.ts" {1,4,5}
 import { getPrisma as getMyDb } from '@my-scope/my-db';
 
 export const createServer = async () => {
   const myDb = await getMyDb();
+  myDb.$on('error', console.error);
   const server = new McpServer({ name: 'my-service', version: '1.0.0' });
   // register tools/resources that use myDb
   return server;

--- a/docs/src/content/docs/pt/guides/ts-rdb.mdx
+++ b/docs/src/content/docs/pt/guides/ts-rdb.mdx
@@ -45,11 +45,18 @@ O gerador criará a seguinte estrutura de projeto no diretório `<directory>/<na
     - create-db-user-handler.ts Lambda handler used to create the application database user during deployment
     - migration-handler.ts Lambda handler used to run database migrations during deployment
   - .gitignore Git ignore entries including generated Prisma client output
+  - .trivyignore Vulnerability IDs to suppress when scanning the migration image
   - config.json Local development connection details and runtime config key
   - Dockerfile Container image definition for the migration handler
   - package.json Project manifest defining the project's package name and dependencies
   - project.json Project configuration and build targets
   - prisma.config.ts Configuration for Prisma CLI
+  - README.md Project readme
+  - rolldown.config.ts Bundler configuration invoked by the `bundle` target
+  - tsconfig.json TypeScript project references
+  - tsconfig.lib.json TypeScript configuration for the library build
+  - tsconfig.spec.json TypeScript configuration for tests
+  - vitest.config.mts Vitest configuration
 </FileTree>
 
 Scripts de desenvolvimento local são compartilhados entre todos os projetos de banco de dados e gerados em `packages/common/scripts/`:
@@ -342,7 +349,7 @@ export const listExampleTable = publicProcedure
 
 **Opção 2: middleware tRPC**
 
-Se você estiver usando o [padrão de middleware](#injecting-the-prisma-client-via-middleware), adicione a chamada `$disconnect()` ao middleware para que todos os procedimentos construídos sobre ele sejam cobertos automaticamente:
+Se você estiver usando o <Link path="guides/connection/trpc-rdb#using-the-middleware">padrão de middleware</Link>, adicione a chamada `$disconnect()` ao middleware para que todos os procedimentos construídos sobre ele sejam cobertos automaticamente:
 
 ```ts title="packages/api/src/middleware/db.ts"
 import { getPrisma } from '@my-scope/db';

--- a/docs/src/content/docs/pt/troubleshooting/nx.mdx
+++ b/docs/src/content/docs/pt/troubleshooting/nx.mdx
@@ -24,6 +24,6 @@ Para este e qualquer outro erro inesperado, sempre vale a pena redefinir o Nx e 
 
 Se isso falhar, você pode tentar [desabilitar o daemon completamente](https://nx.dev/docs/concepts/nx-daemon#turning-it-off).
 
-:::warning[Daemon Necessário]
-O comando `nx watch` requer o daemon e, portanto, alguns dos seus alvos de hot-reloading podem não funcionar se você desabilitá-lo.
+:::note[Daemon Necessário]
+O comando `nx watch` requer o daemon, então os alvos `dev` que dependem dele para fazer hot-reload dos seus servidores de desenvolvimento locais precisam que o daemon esteja habilitado.
 :::

--- a/docs/src/content/docs/vi/guides/connection/py-agent-rdb.mdx
+++ b/docs/src/content/docs/vi/guides/connection/py-agent-rdb.mdx
@@ -42,7 +42,7 @@ Chọn dự án Agent của bạn làm nguồn và dự án cơ sở dữ liệu
   - pyproject.toml Thêm database package như một workspace dependency
   - my\_service
     - my\_agent
-      - Dockerfile Thêm RDS CA bundle được sử dụng cho các kết nối Aurora trực tiếp
+      - Dockerfile Thêm RDS CA bundle được sử dụng cho các kết nối Aurora trực tiếp (chỉ khi `infra` của agent là `agentcore-ecr`)
 
 </FileTree>
 

--- a/docs/src/content/docs/vi/guides/connection/py-fast-api-rdb.mdx
+++ b/docs/src/content/docs/vi/guides/connection/py-fast-api-rdb.mdx
@@ -11,6 +11,7 @@ import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Infrastructure from '@components/infrastructure.astro';
+import Snippet from '@components/snippet.astro';
 
 Generator `connection` kết nối một <Link path="guides/fastapi">FastAPI</Link> với dự án <Link path="guides/py-rdb">Python Relational Database</Link>, tiêm một session SQLModel có kiểu vào các route handler của bạn thông qua một dependency của FastAPI.
 
@@ -167,6 +168,10 @@ Triển khai các hàm Lambda API vào **private subnet với egress**, không p
 
 </Fragment>
 </Infrastructure>
+
+### Yêu cầu SSL Khi Kết nối Không Sử dụng RDS Proxy
+
+<Snippet name="connection/py-lambda-rdb-ssl-requirements" parentHeading="Yêu cầu SSL Khi Kết nối Không Sử dụng RDS Proxy" />
 
 ## Phát triển Cục bộ
 

--- a/docs/src/content/docs/vi/guides/connection/py-mcp-server-rdb.mdx
+++ b/docs/src/content/docs/vi/guides/connection/py-mcp-server-rdb.mdx
@@ -42,7 +42,7 @@ Chọn dự án MCP server của bạn làm nguồn và dự án cơ sở dữ l
   - pyproject.toml Thêm package database như một workspace dependency
   - my\_service
     - my\_mcp\_server
-      - Dockerfile Thêm RDS CA bundle được sử dụng cho các kết nối Aurora trực tiếp
+      - Dockerfile Thêm RDS CA bundle được sử dụng cho các kết nối Aurora trực tiếp (chỉ khi `infra` của MCP server là `agentcore-ecr`)
 
 </FileTree>
 

--- a/docs/src/content/docs/vi/guides/connection/react-agui.mdx
+++ b/docs/src/content/docs/vi/guides/connection/react-agui.mdx
@@ -205,12 +205,14 @@ Các ghi đè theo từng chat vẫn hoạt động cùng với theme — bất 
 
 ### Thay thế slot bằng component tùy chỉnh
 
-Bất kỳ slot nào cũng có thể nhận một component React thay vì className, vì vậy bạn có thể thay thế hoàn toàn mặc định:
+Bất kỳ slot nào cũng có thể nhận một component React thay vì className, vì vậy bạn có thể thay thế hoàn toàn mặc định. Định kiểu component của bạn theo các props mà slot khai báo — `sendButton` render một `<button>`, vì vậy nó nhận `ButtonHTMLAttributes`:
 
 ```tsx
 import { CopilotChat } from './components/copilot';
 
-const MySendButton: React.FC<{ onClick: () => void }> = ({ onClick }) => (
+const MySendButton: React.FC<React.ButtonHTMLAttributes<HTMLButtonElement>> = ({
+  onClick,
+}) => (
   <button onClick={onClick} className="my-send-btn">
     Send
   </button>
@@ -247,6 +249,10 @@ Generator connection tự động cấu hình tích hợp `dev`:
 
 :::tip[Hot Reloading]
 Trang web và agent được kết nối hot-reload cùng nhau, cho phép bạn nhanh chóng lặp lại trên cả hai phía mà không cần triển khai lên AWS.
+:::
+
+:::note[Target dev yêu cầu Nx Daemon]
+Target `dev` hot-reload các server dev cục bộ. Nhiều trong số này dựa vào [`nx watch`](https://nx.dev/docs/guides/tasks--caching/workspace-watching) để đạt được điều này, yêu cầu [Nx Daemon](https://nx.dev/docs/concepts/nx-daemon) phải được bật.
 :::
 
 ## Thông tin thêm

--- a/docs/src/content/docs/vi/guides/connection/react-fastapi.mdx
+++ b/docs/src/content/docs/vi/guides/connection/react-fastapi.mdx
@@ -125,8 +125,8 @@ Nếu bạn đang làm việc tích cực với cả ứng dụng React và Fast
 />
 :::
 
-:::warning[Phụ thuộc file watcher]
-`watch-generate:<ApiName>-client` dựa vào lệnh [`nx watch`](https://nx.dev/docs/guides/tasks--caching/workspace-watching), yêu cầu [Nx Daemon](https://nx.dev/docs/concepts/nx-daemon) đang chạy. Do đó nếu bạn đã tắt daemon, client sẽ không tự động sinh lại khi thay đổi FastAPI của bạn.
+:::note[Target dev yêu cầu Nx Daemon]
+Target `dev` hot-reload các local dev servers. Nhiều trong số này dựa vào [`nx watch`](https://nx.dev/docs/guides/tasks--caching/workspace-watching) để đạt được điều này, yêu cầu [Nx Daemon](https://nx.dev/docs/concepts/nx-daemon) được bật.
 :::
 
 ### Sử dụng API Hook
@@ -146,12 +146,14 @@ function MyComponent() {
   const api = useMyApi();
   const item = useQuery(api.getItem.queryOptions({ itemId: 'some-id' }));
 
-  if (item.isLoading) return <div>Loading...</div>;
-  if (item.isError) return <div>Error: {item.error.message}</div>;
+  if (item.isPending) return <div>Loading...</div>;
+  if (item.isError) return <div>Error: {JSON.stringify(item.error.error)}</div>;
 
   return <div>Item: {item.data.name}</div>;
 }
 ```
+
+Lỗi là một discriminated union của các đối tượng `{ status, error }` thay vì một `Error`, vì vậy không có `message` cấp cao nhất để render. Thu hẹp trên `status` để đọc một response body cụ thể — xem [Xử lý Lỗi](#xử-lý-lỗi) bên dưới.
 
 <Drawer title="Sử dụng API client trực tiếp" trigger="Nhấn vào đây để xem ví dụ sử dụng vanilla client trực tiếp.">
 ```tsx {5,13}
@@ -222,7 +224,7 @@ function CreateItemForm() {
 
       {createItem.isError && (
         <div className="error">
-          Error: {createItem.error.message}
+          Error: {JSON.stringify(createItem.error.error)}
         </div>
       )}
     </form>
@@ -370,12 +372,12 @@ function ItemList() {
       }),
   });
 
-  if (items.isLoading) {
+  if (items.isPending) {
     return <LoadingSpinner />;
   }
 
   if (items.isError) {
-    return <ErrorMessage message={items.error.message} />;
+    return <ErrorMessage message={JSON.stringify(items.error.error)} />;
   }
 
   return (

--- a/docs/src/content/docs/vi/guides/connection/react-py-agent.mdx
+++ b/docs/src/content/docs/vi/guides/connection/react-py-agent.mdx
@@ -183,6 +183,10 @@ Connection generator tự động cấu hình tích hợp `dev`:
 Website và agent được kết nối sẽ hot-reload, cho phép bạn nhanh chóng lặp lại trên cả hai cùng nhau mà không cần deploy lên AWS.
 :::
 
+:::note[Target dev yêu cầu Nx Daemon]
+Target `dev` hot-reload các local dev server. Nhiều trong số này dựa vào [`nx watch`](https://nx.dev/docs/guides/tasks--caching/workspace-watching) để đạt được điều này, điều này yêu cầu [Nx Daemon](https://nx.dev/docs/concepts/nx-daemon) phải được bật.
+:::
+
 ## Thông tin thêm
 
 Để biết thêm thông tin, vui lòng tham khảo:

--- a/docs/src/content/docs/vi/guides/connection/react-smithy.mdx
+++ b/docs/src/content/docs/vi/guides/connection/react-smithy.mdx
@@ -126,6 +126,10 @@ Nếu bạn đang tích cực làm việc trên cả ứng dụng React và Smit
 />
 :::
 
+:::note[Target dev yêu cầu Nx Daemon]
+Target `dev` hot-reload các local dev server. Nhiều trong số này dựa vào [`nx watch`](https://nx.dev/docs/guides/tasks--caching/workspace-watching) để đạt được điều này, yêu cầu [Nx Daemon](https://nx.dev/docs/concepts/nx-daemon) phải được bật.
+:::
+
 ### Sử dụng API Hook
 
 Generator cung cấp hook `use<ApiName>` mà bạn có thể sử dụng để gọi API của mình với TanStack Query.
@@ -143,12 +147,14 @@ function MyComponent() {
   const api = useMyApi();
   const item = useQuery(api.getItem.queryOptions({ itemId: 'some-id' }));
 
-  if (item.isLoading) return <div>Loading...</div>;
-  if (item.isError) return <div>Error: {item.error.message}</div>;
+  if (item.isPending) return <div>Loading...</div>;
+  if (item.isError) return <div>Error: {JSON.stringify(item.error.error)}</div>;
 
   return <div>Item: {item.data.name}</div>;
 }
 ```
+
+Lỗi là một discriminated union của các đối tượng `{ status, error }` thay vì một `Error`, vì vậy không có `message` cấp cao nhất để render. Thu hẹp trên `status` để đọc một response body cụ thể — xem [Xử lý lỗi](#xử-lý-lỗi) bên dưới.
 
 <Drawer title="Sử dụng API client trực tiếp" trigger="Nhấp vào đây để xem ví dụ sử dụng vanilla client trực tiếp.">
 ```tsx {5,13}
@@ -219,7 +225,7 @@ function CreateItemForm() {
 
       {createItem.isError && (
         <div className="error">
-          Error: {createItem.error.message}
+          Error: {JSON.stringify(createItem.error.error)}
         </div>
       )}
     </form>
@@ -331,12 +337,12 @@ function ItemList() {
       }),
   });
 
-  if (items.isLoading) {
+  if (items.isPending) {
     return <LoadingSpinner />;
   }
 
   if (items.isError) {
-    return <ErrorMessage message={items.error.message} />;
+    return <ErrorMessage message={JSON.stringify(items.error.error)} />;
   }
 
   return (

--- a/docs/src/content/docs/vi/guides/connection/react-trpc.mdx
+++ b/docs/src/content/docs/vi/guides/connection/react-trpc.mdx
@@ -63,8 +63,7 @@ Generator tạo ra cấu trúc sau trong ứng dụng React của bạn:
     - QueryClientProvider.tsx TanStack React Query client provider
   - hooks
     - useSigV4.tsx Hook để ký các HTTP request với SigV4 (chỉ IAM)
-    - use\<ApiName>.tsx Một hook trả về tRPC options proxy cho tích hợp TanStack Query
-    - use\<ApiName>Client.tsx Một hook trả về vanilla tRPC client cho các lời gọi API trực tiếp
+    - use\<ApiName>.tsx Exports both `use<ApiName>`, returning the tRPC options proxy for TanStack Query integration, and `use<ApiName>Client`, returning the vanilla tRPC client for direct API calls
 
 </FileTree>
 
@@ -103,6 +102,8 @@ function MyComponent() {
   };
 
   if (isLoading) return <div>Loading...</div>;
+  if (error) return <div>Error: {error.message}</div>;
+  if (!data) return null;
 
   return (
     <ul>
@@ -113,6 +114,8 @@ function MyComponent() {
   );
 }
 ```
+
+`data` là `undefined` cho đến khi query được giải quyết, vì vậy hãy bảo vệ nó trước khi tham chiếu.
 
 ### Sử dụng Vanilla tRPC Client
 
@@ -156,6 +159,8 @@ function MyComponent() {
       </div>
     );
   }
+
+  if (!data) return null;
 
   return (
     <ul>
@@ -278,7 +283,7 @@ function UserList() {
 
   const users = useQuery(trpc.users.list.queryOptions());
 
-  if (users.isLoading) {
+  if (users.isPending) {
     return <LoadingSpinner />;
   }
 
@@ -338,7 +343,7 @@ function UserList() {
 
   return (
     <ul>
-      {users.map((user) => (
+      {users.data?.map((user) => (
         <li key={user.id}>
           {user.name}
           <button onClick={() => deleteMutation.mutate(user.id)}>Delete</button>
@@ -366,7 +371,7 @@ function UserList() {
 
   return (
     <ul>
-      {users.map((user) => (
+      {users.data?.map((user) => (
         <li key={user.id} onMouseEnter={() => prefetchUser(user.id)}>
           <Link to={`/users/${user.id}`}>{user.name}</Link>
         </li>

--- a/docs/src/content/docs/vi/guides/connection/ts-agent-rdb.mdx
+++ b/docs/src/content/docs/vi/guides/connection/ts-agent-rdb.mdx
@@ -36,13 +36,13 @@ Chọn dự án Agent của bạn làm nguồn và dự án cơ sở dữ liệu
 
 ## Kết quả của Generator
 
-Generator sửa đổi hai file trong thư mục nguồn của agent:
+Generator sửa đổi các file sau trong thư mục nguồn của agent:
 
 <FileTree>
 
 - packages/my-service/src/my-agent
   - agent.ts Prisma client được lấy bên trong `getAgent` và có sẵn cho các tool
-  - Dockerfile RDS CA bundle được cài đặt cho kết nối SSL đến Aurora
+  - Dockerfile RDS CA bundle được cài đặt cho kết nối SSL đến Aurora (chỉ khi `infra` của agent là `agentcore-ecr`)
 
 </FileTree>
 

--- a/docs/src/content/docs/vi/guides/connection/ts-mcp-server-rdb.mdx
+++ b/docs/src/content/docs/vi/guides/connection/ts-mcp-server-rdb.mdx
@@ -36,13 +36,13 @@ Chọn dự án MCP server của bạn làm nguồn và dự án cơ sở dữ l
 
 ## Kết quả của Generator
 
-Generator sửa đổi hai tệp trong thư mục nguồn của MCP server của bạn:
+Generator sửa đổi các tệp sau trong thư mục nguồn của MCP server của bạn:
 
 <FileTree>
 
 - packages/my-service/src/my-mcp
   - server.ts Prisma client được lấy và có sẵn cho tất cả các công cụ được đăng ký bên trong `createServer`
-  - Dockerfile RDS CA bundle được cài đặt cho các kết nối SSL đến Aurora
+  - Dockerfile RDS CA bundle được cài đặt cho các kết nối SSL đến Aurora (chỉ khi `infra` của MCP server là `agentcore-ecr`)
 
 </FileTree>
 
@@ -52,11 +52,12 @@ Ngoài ra, target `<mcp-server-name>-dev` được cập nhật để phụ thu�
 
 Prisma client được lấy bên trong `createServer` và có sẵn cho tất cả các công cụ và tài nguyên được đăng ký ở đó:
 
-```ts title="packages/my-service/src/my-mcp/server.ts" {1,4}
+```ts title="packages/my-service/src/my-mcp/server.ts" {1,4,5}
 import { getPrisma as getMyDb } from '@my-scope/my-db';
 
 export const createServer = async () => {
   const myDb = await getMyDb();
+  myDb.$on('error', console.error);
   const server = new McpServer({ name: 'my-service', version: '1.0.0' });
   // register tools/resources that use myDb
   return server;

--- a/docs/src/content/docs/vi/guides/ts-rdb.mdx
+++ b/docs/src/content/docs/vi/guides/ts-rdb.mdx
@@ -45,11 +45,18 @@ Generator sẽ tạo cấu trúc dự án sau trong thư mục `<directory>/<nam
     - create-db-user-handler.ts Lambda handler used to create the application database user during deployment
     - migration-handler.ts Lambda handler used to run database migrations during deployment
   - .gitignore Git ignore entries including generated Prisma client output
+  - .trivyignore Vulnerability IDs to suppress when scanning the migration image
   - config.json Local development connection details and runtime config key
   - Dockerfile Container image definition for the migration handler
   - package.json Project manifest defining the project's package name and dependencies
   - project.json Project configuration and build targets
   - prisma.config.ts Configuration for Prisma CLI
+  - README.md Project readme
+  - rolldown.config.ts Bundler configuration invoked by the `bundle` target
+  - tsconfig.json TypeScript project references
+  - tsconfig.lib.json TypeScript configuration for the library build
+  - tsconfig.spec.json TypeScript configuration for tests
+  - vitest.config.mts Vitest configuration
 </FileTree>
 
 Các script phát triển cục bộ được chia sẻ trên tất cả các dự án cơ sở dữ liệu và được tạo vào `packages/common/scripts/`:
@@ -342,7 +349,7 @@ export const listExampleTable = publicProcedure
 
 **Tùy chọn 2: tRPC middleware**
 
-Nếu bạn đang sử dụng [mẫu middleware](#injecting-the-prisma-client-via-middleware), thêm lời gọi `$disconnect()` vào middleware để tất cả các procedure được xây dựng trên nó được bao phủ tự động:
+Nếu bạn đang sử dụng <Link path="guides/connection/trpc-rdb#using-the-middleware">mẫu middleware</Link>, thêm lời gọi `$disconnect()` vào middleware để tất cả các procedure được xây dựng trên nó được bao phủ tự động:
 
 ```ts title="packages/api/src/middleware/db.ts"
 import { getPrisma } from '@my-scope/db';

--- a/docs/src/content/docs/vi/troubleshooting/nx.mdx
+++ b/docs/src/content/docs/vi/troubleshooting/nx.mdx
@@ -25,6 +25,6 @@ Pass --verbose to see the stacktrace.
 
 Nếu không được, bạn có thể thử [vô hiệu hóa daemon hoàn toàn](https://nx.dev/docs/concepts/nx-daemon#turning-it-off).
 
-:::warning[Yêu cầu Daemon]
-Lệnh `nx watch` yêu cầu daemon, và do đó một số target hot-reloading của bạn có thể không hoạt động nếu bạn vô hiệu hóa nó.
+:::note[Yêu cầu Daemon]
+Lệnh `nx watch` yêu cầu daemon, do đó các target `dev` dựa vào nó để hot-reload các dev server cục bộ của bạn cần daemon được bật.
 :::

--- a/docs/src/content/docs/zh/guides/connection/py-agent-rdb.mdx
+++ b/docs/src/content/docs/zh/guides/connection/py-agent-rdb.mdx
@@ -42,7 +42,7 @@ import Infrastructure from '@components/infrastructure.astro';
   - pyproject.toml 将数据库包添加为工作区依赖
   - my\_service
     - my\_agent
-      - Dockerfile 添加用于直接 Aurora 连接的 RDS CA 证书包
+      - Dockerfile 添加用于直接 Aurora 连接的 RDS CA 证书包（仅当 agent 的 `infra` 为 `agentcore-ecr` 时）
 
 </FileTree>
 

--- a/docs/src/content/docs/zh/guides/connection/py-fast-api-rdb.mdx
+++ b/docs/src/content/docs/zh/guides/connection/py-fast-api-rdb.mdx
@@ -11,6 +11,7 @@ import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Infrastructure from '@components/infrastructure.astro';
+import Snippet from '@components/snippet.astro';
 
 `connection` 生成器将 <Link path="guides/fastapi">FastAPI</Link> 连接到 <Link path="guides/py-rdb">Python 关系数据库</Link>项目，通过 FastAPI 依赖项将类型化的 SQLModel 会话注入到您的路由处理程序中。
 
@@ -167,6 +168,10 @@ AppConfig 应用程序默认公开 `database` 命名空间，因此数据库模�
 
 </Fragment>
 </Infrastructure>
+
+### 在不使用 RDS Proxy 的情况下连接时的 SSL 要求
+
+<Snippet name="connection/py-lambda-rdb-ssl-requirements" parentHeading="在不使用 RDS Proxy 的情况下连接时的 SSL 要求" />
 
 ## 本地开发
 

--- a/docs/src/content/docs/zh/guides/connection/py-mcp-server-rdb.mdx
+++ b/docs/src/content/docs/zh/guides/connection/py-mcp-server-rdb.mdx
@@ -42,7 +42,7 @@ import Infrastructure from '@components/infrastructure.astro';
   - pyproject.toml 将数据库包添加为工作区依赖
   - my\_service
     - my\_mcp\_server
-      - Dockerfile 添加用于直接 Aurora 连接的 RDS CA 证书包
+      - Dockerfile 添加用于直接 Aurora 连接的 RDS CA 证书包（仅当 MCP 服务器的 `infra` 为 `agentcore-ecr` 时）
 
 </FileTree>
 

--- a/docs/src/content/docs/zh/guides/connection/react-agui.mdx
+++ b/docs/src/content/docs/zh/guides/connection/react-agui.mdx
@@ -205,12 +205,14 @@ import { CopilotChat } from './components/copilot';
 
 ### 用自定义组件替换插槽
 
-任何插槽都可以接受 React 组件而不是 className，因此您可以完全替换默认值：
+任何插槽都可以接受 React 组件而不是 className，因此您可以完全替换默认值。根据插槽声明的 props 为您的组件设置类型——`sendButton` 渲染一个 `<button>`，因此它接收 `ButtonHTMLAttributes`：
 
 ```tsx
 import { CopilotChat } from './components/copilot';
 
-const MySendButton: React.FC<{ onClick: () => void }> = ({ onClick }) => (
+const MySendButton: React.FC<React.ButtonHTMLAttributes<HTMLButtonElement>> = ({
+  onClick,
+}) => (
   <button onClick={onClick} className="my-send-btn">
     Send
   </button>
@@ -247,6 +249,10 @@ const MySendButton: React.FC<{ onClick: () => void }> = ({ onClick }) => (
 
 :::tip[热重载]
 网站和连接的 agent 一起热重载，使您能够快速迭代双方，而无需部署到 AWS。
+:::
+
+:::note[dev 目标需要 Nx Daemon]
+`dev` 目标会热重载本地开发服务器。其中许多依赖于 [`nx watch`](https://nx.dev/docs/guides/tasks--caching/workspace-watching) 来实现这一点，这需要启用 [Nx Daemon](https://nx.dev/docs/concepts/nx-daemon)。
 :::
 
 ## 更多信息

--- a/docs/src/content/docs/zh/guides/connection/react-fastapi.mdx
+++ b/docs/src/content/docs/zh/guides/connection/react-fastapi.mdx
@@ -125,8 +125,8 @@ root.render(
 />
 :::
 
-:::warning[文件监视器依赖]
-`watch-generate:<ApiName>-client` 依赖于 [`nx watch`](https://nx.dev/docs/guides/tasks--caching/workspace-watching) 命令，该命令需要 [Nx Daemon](https://nx.dev/docs/concepts/nx-daemon) 运行。因此，如果您禁用了守护进程，客户端将不会在对 FastAPI 进行更改时自动重新生成。
+:::note[dev 目标需要 Nx Daemon]
+`dev` 目标会热重载本地开发服务器。其中许多依赖于 [`nx watch`](https://nx.dev/docs/guides/tasks--caching/workspace-watching) 来实现这一点，这需要启用 [Nx Daemon](https://nx.dev/docs/concepts/nx-daemon)。
 :::
 
 ### 使用 API 钩子
@@ -146,12 +146,14 @@ function MyComponent() {
   const api = useMyApi();
   const item = useQuery(api.getItem.queryOptions({ itemId: 'some-id' }));
 
-  if (item.isLoading) return <div>Loading...</div>;
-  if (item.isError) return <div>Error: {item.error.message}</div>;
+  if (item.isPending) return <div>Loading...</div>;
+  if (item.isError) return <div>Error: {JSON.stringify(item.error.error)}</div>;
 
   return <div>Item: {item.data.name}</div>;
 }
 ```
+
+错误是 `{ status, error }` 对象的可区分联合，而不是 `Error`，因此没有顶级 `message` 可供渲染。通过 `status` 缩小范围以读取特定的响应主体 — 请参阅下面的[错误处理](#错误处理)。
 
 <Drawer title="直接使用 API 客户端" trigger="点击此处查看直接使用原生客户端的示例。">
 ```tsx {5,13}
@@ -222,7 +224,7 @@ function CreateItemForm() {
 
       {createItem.isError && (
         <div className="error">
-          Error: {createItem.error.message}
+          Error: {JSON.stringify(createItem.error.error)}
         </div>
       )}
     </form>
@@ -370,12 +372,12 @@ function ItemList() {
       }),
   });
 
-  if (items.isLoading) {
+  if (items.isPending) {
     return <LoadingSpinner />;
   }
 
   if (items.isError) {
-    return <ErrorMessage message={items.error.message} />;
+    return <ErrorMessage message={JSON.stringify(items.error.error)} />;
   }
 
   return (

--- a/docs/src/content/docs/zh/guides/connection/react-py-agent.mdx
+++ b/docs/src/content/docs/zh/guides/connection/react-py-agent.mdx
@@ -183,6 +183,10 @@ function ChatComponent() {
 网站和连接的 agent 将热重载，使您能够快速迭代两者而无需部署到 AWS。
 :::
 
+:::note[dev 目标需要 Nx Daemon]
+`dev` 目标会热重载本地开发服务器。其中许多依赖于 [`nx watch`](https://nx.dev/docs/guides/tasks--caching/workspace-watching) 来实现此功能，这需要启用 [Nx Daemon](https://nx.dev/docs/concepts/nx-daemon)。
+:::
+
 ## 更多信息
 
 有关更多信息，请参阅：

--- a/docs/src/content/docs/zh/guides/connection/react-smithy.mdx
+++ b/docs/src/content/docs/zh/guides/connection/react-smithy.mdx
@@ -126,6 +126,10 @@ root.render(
 />
 :::
 
+:::note[dev 目标需要 Nx Daemon]
+`dev` 目标会热重载本地开发服务器。其中许多依赖于 [`nx watch`](https://nx.dev/docs/guides/tasks--caching/workspace-watching) 来实现这一点，这需要启用 [Nx Daemon](https://nx.dev/docs/concepts/nx-daemon)。
+:::
+
 ### 使用 API Hook
 
 生成器提供了一个 `use<ApiName>` hook，您可以使用它通过 TanStack Query 调用 API。
@@ -143,12 +147,14 @@ function MyComponent() {
   const api = useMyApi();
   const item = useQuery(api.getItem.queryOptions({ itemId: 'some-id' }));
 
-  if (item.isLoading) return <div>Loading...</div>;
-  if (item.isError) return <div>Error: {item.error.message}</div>;
+  if (item.isPending) return <div>Loading...</div>;
+  if (item.isError) return <div>Error: {JSON.stringify(item.error.error)}</div>;
 
   return <div>Item: {item.data.name}</div>;
 }
 ```
+
+错误是 `{ status, error }` 对象的可辨识联合，而不是 `Error`，因此没有顶级 `message` 可以渲染。通过 `status` 进行收窄以读取特定的响应体 — 请参阅下面的[错误处理](#错误处理)。
 
 <Drawer title="直接使用 API 客户端" trigger="点击此处查看直接使用原生客户端的示例。">
 ```tsx {5,13}
@@ -219,7 +225,7 @@ function CreateItemForm() {
 
       {createItem.isError && (
         <div className="error">
-          Error: {createItem.error.message}
+          Error: {JSON.stringify(createItem.error.error)}
         </div>
       )}
     </form>
@@ -331,12 +337,12 @@ function ItemList() {
       }),
   });
 
-  if (items.isLoading) {
+  if (items.isPending) {
     return <LoadingSpinner />;
   }
 
   if (items.isError) {
-    return <ErrorMessage message={items.error.message} />;
+    return <ErrorMessage message={JSON.stringify(items.error.error)} />;
   }
 
   return (

--- a/docs/src/content/docs/zh/guides/connection/react-trpc.mdx
+++ b/docs/src/content/docs/zh/guides/connection/react-trpc.mdx
@@ -63,8 +63,7 @@ root.render(
     - QueryClientProvider.tsx TanStack React Query 客户端提供程序
   - hooks
     - useSigV4.tsx 用于使用 SigV4 签名 HTTP 请求的钩子（仅限 IAM）
-    - use\<ApiName>.tsx 返回 tRPC 选项代理以集成 TanStack Query 的钩子
-    - use\<ApiName>Client.tsx 返回原生 tRPC 客户端以直接调用 API 的钩子
+    - use\<ApiName>.tsx 导出 `use<ApiName>`（返回 tRPC 选项代理以集成 TanStack Query）和 `use<ApiName>Client`（返回原生 tRPC 客户端以直接调用 API）
 
 </FileTree>
 
@@ -103,6 +102,8 @@ function MyComponent() {
   };
 
   if (isLoading) return <div>Loading...</div>;
+  if (error) return <div>Error: {error.message}</div>;
+  if (!data) return null;
 
   return (
     <ul>
@@ -113,6 +114,8 @@ function MyComponent() {
   );
 }
 ```
+
+`data` 在查询解析之前是 `undefined`，因此在解引用之前要对其进行保护。
 
 ### 使用原生 tRPC 客户端
 
@@ -156,6 +159,8 @@ function MyComponent() {
       </div>
     );
   }
+
+  if (!data) return null;
 
   return (
     <ul>
@@ -278,7 +283,7 @@ function UserList() {
 
   const users = useQuery(trpc.users.list.queryOptions());
 
-  if (users.isLoading) {
+  if (users.isPending) {
     return <LoadingSpinner />;
   }
 
@@ -338,7 +343,7 @@ function UserList() {
 
   return (
     <ul>
-      {users.map((user) => (
+      {users.data?.map((user) => (
         <li key={user.id}>
           {user.name}
           <button onClick={() => deleteMutation.mutate(user.id)}>Delete</button>
@@ -366,7 +371,7 @@ function UserList() {
 
   return (
     <ul>
-      {users.map((user) => (
+      {users.data?.map((user) => (
         <li key={user.id} onMouseEnter={() => prefetchUser(user.id)}>
           <Link to={`/users/${user.id}`}>{user.name}</Link>
         </li>

--- a/docs/src/content/docs/zh/guides/connection/ts-agent-rdb.mdx
+++ b/docs/src/content/docs/zh/guides/connection/ts-agent-rdb.mdx
@@ -36,13 +36,13 @@ import Snippet from '@components/snippet.astro';
 
 ## 生成器输出
 
-生成器会修改您的 agent 源目录中的两个文件：
+生成器会修改您的 agent 源目录中的以下文件：
 
 <FileTree>
 
 - packages/my-service/src/my-agent
   - agent.ts 在 `getAgent` 中获取 Prisma 客户端并可供工具使用
-  - Dockerfile 安装 RDS CA 证书包以实现与 Aurora 的 SSL 连接
+  - Dockerfile 安装 RDS CA 证书包以实现与 Aurora 的 SSL 连接(仅当 agent 的 `infra` 为 `agentcore-ecr` 时)
 
 </FileTree>
 

--- a/docs/src/content/docs/zh/guides/connection/ts-mcp-server-rdb.mdx
+++ b/docs/src/content/docs/zh/guides/connection/ts-mcp-server-rdb.mdx
@@ -36,13 +36,13 @@ import Snippet from '@components/snippet.astro';
 
 ## 生成器输出
 
-生成器会修改 MCP server 源目录中的两个文件：
+生成器会修改 MCP server 源目录中的以下文件：
 
 <FileTree>
 
 - packages/my-service/src/my-mcp
   - server.ts Prisma 客户端已获取并可供 `createServer` 内注册的所有工具使用
-  - Dockerfile 已安装 RDS CA 证书包以便通过 SSL 连接到 Aurora
+  - Dockerfile 已安装 RDS CA 证书包以便通过 SSL 连接到 Aurora（仅当 MCP server 的 `infra` 为 `agentcore-ecr` 时）
 
 </FileTree>
 
@@ -52,11 +52,12 @@ import Snippet from '@components/snippet.astro';
 
 Prisma 客户端在 `createServer` 内获取，并可供在其中注册的所有工具和资源使用：
 
-```ts title="packages/my-service/src/my-mcp/server.ts" {1,4}
+```ts title="packages/my-service/src/my-mcp/server.ts" {1,4,5}
 import { getPrisma as getMyDb } from '@my-scope/my-db';
 
 export const createServer = async () => {
   const myDb = await getMyDb();
+  myDb.$on('error', console.error);
   const server = new McpServer({ name: 'my-service', version: '1.0.0' });
   // register tools/resources that use myDb
   return server;

--- a/docs/src/content/docs/zh/guides/ts-rdb.mdx
+++ b/docs/src/content/docs/zh/guides/ts-rdb.mdx
@@ -45,11 +45,18 @@ import OptionFilter from '@components/option-filter.astro';
     - create-db-user-handler.ts Lambda handler used to create the application database user during deployment
     - migration-handler.ts Lambda handler used to run database migrations during deployment
   - .gitignore Git ignore entries including generated Prisma client output
+  - .trivyignore Vulnerability IDs to suppress when scanning the migration image
   - config.json Local development connection details and runtime config key
   - Dockerfile Container image definition for the migration handler
   - package.json Project manifest defining the project's package name and dependencies
   - project.json Project configuration and build targets
   - prisma.config.ts Configuration for Prisma CLI
+  - README.md Project readme
+  - rolldown.config.ts Bundler configuration invoked by the `bundle` target
+  - tsconfig.json TypeScript project references
+  - tsconfig.lib.json TypeScript configuration for the library build
+  - tsconfig.spec.json TypeScript configuration for tests
+  - vitest.config.mts Vitest configuration
 </FileTree>
 
 本地开发脚本在所有数据库项目之间共享，并生成到 `packages/common/scripts/` 中：
@@ -342,7 +349,7 @@ export const listExampleTable = publicProcedure
 
 **选项 2：tRPC 中间件**
 
-如果您使用的是[中间件模式](#injecting-the-prisma-client-via-middleware)，请将 `$disconnect()` 调用添加到中间件，以便基于它构建的所有过程都会自动覆盖：
+如果您使用的是<Link path="guides/connection/trpc-rdb#using-the-middleware">中间件模式</Link>，请将 `$disconnect()` 调用添加到中间件，以便基于它构建的所有过程都会自动覆盖：
 
 ```ts title="packages/api/src/middleware/db.ts"
 import { getPrisma } from '@my-scope/db';

--- a/docs/src/content/docs/zh/troubleshooting/nx.mdx
+++ b/docs/src/content/docs/zh/troubleshooting/nx.mdx
@@ -24,6 +24,6 @@ Pass --verbose to see the stacktrace.
 
 如果这样做无效，您可以尝试[完全禁用守护进程](https://nx.dev/docs/concepts/nx-daemon#turning-it-off)。
 
-:::warning[需要守护进程]
-`nx watch` 命令需要守护进程，因此如果您禁用它，某些热重载目标可能无法正常工作。
+:::note[需要守护进程]
+`nx watch` 命令需要守护进程，因此依赖它来热重载本地开发服务器的 `dev` 目标需要启用守护进程。
 :::

--- a/packages/nx-plugin/src/py/rdb/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/py/rdb/__snapshots__/generator.spec.ts.snap
@@ -170,9 +170,13 @@ def handler(event: dict[str, Any], _context: Any) -> dict[str, Any]:
 exports[`py#rdb generator > should generate MySQL dependencies and templates 4`] = `
 "FROM public.ecr.aws/lambda/python:3.14
 
-# Patch OS packages beyond the base image's pinned release so the image is
-# free of known HIGH/CRITICAL vulnerabilities
-RUN microdnf upgrade -y --releasever latest && microdnf clean all
+# Patch OS packages beyond the base image's pinned release, and drop pip, whose
+# vendored copies of msgpack and setuptools carry known HIGH vulnerabilities.
+# The handler's dependencies are already installed in the image, so nothing
+# installs packages at runtime.
+RUN microdnf upgrade -y --releasever latest && microdnf clean all \\
+    && rm -rf /var/lang/lib/python*/site-packages/pip \\
+    /var/lang/lib/python*/site-packages/pip-*.dist-info
 
 WORKDIR \${LAMBDA_TASK_ROOT}
 
@@ -188,9 +192,13 @@ CMD ["proj_db.migration_handler.handler"]
 exports[`py#rdb generator > should generate MySQL dependencies and templates 5`] = `
 "FROM public.ecr.aws/lambda/python:3.14
 
-# Patch OS packages beyond the base image's pinned release so the image is
-# free of known HIGH/CRITICAL vulnerabilities
-RUN microdnf upgrade -y --releasever latest && microdnf clean all
+# Patch OS packages beyond the base image's pinned release, and drop pip, whose
+# vendored copies of msgpack and setuptools carry known HIGH vulnerabilities.
+# The handler's dependencies are already installed in the image, so nothing
+# installs packages at runtime.
+RUN microdnf upgrade -y --releasever latest && microdnf clean all \\
+    && rm -rf /var/lang/lib/python*/site-packages/pip \\
+    /var/lang/lib/python*/site-packages/pip-*.dist-info
 
 WORKDIR \${LAMBDA_TASK_ROOT}
 
@@ -1382,9 +1390,13 @@ datefmt = %H:%M:%S
 exports[`py#rdb generator > should generate a PostgreSQL SQLModel project with Alembic 2`] = `
 "FROM public.ecr.aws/lambda/python:3.14
 
-# Patch OS packages beyond the base image's pinned release so the image is
-# free of known HIGH/CRITICAL vulnerabilities
-RUN microdnf upgrade -y --releasever latest && microdnf clean all
+# Patch OS packages beyond the base image's pinned release, and drop pip, whose
+# vendored copies of msgpack and setuptools carry known HIGH vulnerabilities.
+# The handler's dependencies are already installed in the image, so nothing
+# installs packages at runtime.
+RUN microdnf upgrade -y --releasever latest && microdnf clean all \\
+    && rm -rf /var/lang/lib/python*/site-packages/pip \\
+    /var/lang/lib/python*/site-packages/pip-*.dist-info
 
 WORKDIR \${LAMBDA_TASK_ROOT}
 
@@ -1400,9 +1412,13 @@ CMD ["proj_db.migration_handler.handler"]
 exports[`py#rdb generator > should generate a PostgreSQL SQLModel project with Alembic 3`] = `
 "FROM public.ecr.aws/lambda/python:3.14
 
-# Patch OS packages beyond the base image's pinned release so the image is
-# free of known HIGH/CRITICAL vulnerabilities
-RUN microdnf upgrade -y --releasever latest && microdnf clean all
+# Patch OS packages beyond the base image's pinned release, and drop pip, whose
+# vendored copies of msgpack and setuptools carry known HIGH vulnerabilities.
+# The handler's dependencies are already installed in the image, so nothing
+# installs packages at runtime.
+RUN microdnf upgrade -y --releasever latest && microdnf clean all \\
+    && rm -rf /var/lang/lib/python*/site-packages/pip \\
+    /var/lang/lib/python*/site-packages/pip-*.dist-info
 
 WORKDIR \${LAMBDA_TASK_ROOT}
 

--- a/packages/nx-plugin/src/py/rdb/files/Dockerfile.create-db-user.template
+++ b/packages/nx-plugin/src/py/rdb/files/Dockerfile.create-db-user.template
@@ -1,8 +1,12 @@
 FROM public.ecr.aws/lambda/python:3.14
 
-# Patch OS packages beyond the base image's pinned release so the image is
-# free of known HIGH/CRITICAL vulnerabilities
-RUN microdnf upgrade -y --releasever latest && microdnf clean all
+# Patch OS packages beyond the base image's pinned release, and drop pip, whose
+# vendored copies of msgpack and setuptools carry known HIGH vulnerabilities.
+# The handler's dependencies are already installed in the image, so nothing
+# installs packages at runtime.
+RUN microdnf upgrade -y --releasever latest && microdnf clean all \
+    && rm -rf /var/lang/lib/python*/site-packages/pip \
+    /var/lang/lib/python*/site-packages/pip-*.dist-info
 
 WORKDIR ${LAMBDA_TASK_ROOT}
 

--- a/packages/nx-plugin/src/py/rdb/files/Dockerfile.migration.template
+++ b/packages/nx-plugin/src/py/rdb/files/Dockerfile.migration.template
@@ -1,8 +1,12 @@
 FROM public.ecr.aws/lambda/python:3.14
 
-# Patch OS packages beyond the base image's pinned release so the image is
-# free of known HIGH/CRITICAL vulnerabilities
-RUN microdnf upgrade -y --releasever latest && microdnf clean all
+# Patch OS packages beyond the base image's pinned release, and drop pip, whose
+# vendored copies of msgpack and setuptools carry known HIGH vulnerabilities.
+# The handler's dependencies are already installed in the image, so nothing
+# installs packages at runtime.
+RUN microdnf upgrade -y --releasever latest && microdnf clean all \
+    && rm -rf /var/lang/lib/python*/site-packages/pip \
+    /var/lang/lib/python*/site-packages/pip-*.dist-info
 
 WORKDIR ${LAMBDA_TASK_ROOT}
 

--- a/packages/nx-plugin/src/py/rdb/generator.spec.ts
+++ b/packages/nx-plugin/src/py/rdb/generator.spec.ts
@@ -266,12 +266,46 @@ describe('py#rdb generator', () => {
     );
   });
 
+  it.each(['cdk', 'terraform'] as const)(
+    'should build and scan both images when iac is %s',
+    async (iac) => {
+      await pyRdbGenerator(tree, { ...defaultOptions, iac });
+
+      const projectConfig = readProjectConfigurationUnqualified(
+        tree,
+        'proj.db',
+      );
+
+      expect(projectConfig.targets['docker'].options.commands).toEqual([
+        expect.stringContaining('-t proj-db-migration:latest'),
+        expect.stringContaining('-t proj-db-create-db-user:latest'),
+      ]);
+      expect(projectConfig.targets['trivy'].dependsOn).toEqual(['docker']);
+      expect(tree.exists('packages/db/.trivyignore')).toBe(true);
+
+      // pip's vendored msgpack and setuptools carry HIGH findings, and nothing
+      // installs packages at runtime, so both images drop pip rather than
+      // suppressing the findings.
+      for (const dockerfile of [
+        'Dockerfile.migration',
+        'Dockerfile.create-db-user',
+      ]) {
+        expect(tree.read(`packages/db/${dockerfile}`, 'utf-8')).toContain(
+          'rm -rf /var/lang/lib/python*/site-packages/pip',
+        );
+      }
+    },
+  );
+
   it('should generate local database support without infrastructure', async () => {
     await pyRdbGenerator(tree, { ...defaultOptions, infra: 'none' });
 
     const projectConfig = readProjectConfigurationUnqualified(tree, 'proj.db');
     expect(projectConfig.targets['bundle-migration']).toBeUndefined();
     expect(projectConfig.targets['bundle-create-db-user']).toBeUndefined();
+    expect(projectConfig.targets['docker']).toBeUndefined();
+    expect(projectConfig.targets['trivy']).toBeUndefined();
+    expect(tree.exists('packages/db/.trivyignore')).toBe(false);
     expect(projectConfig.targets.dev).toBeDefined();
     expect(projectConfig.targets.migrate).toBeDefined();
     expect(tree.exists('packages/common/constructs')).toBe(false);

--- a/packages/nx-plugin/src/py/rdb/generator.ts
+++ b/packages/nx-plugin/src/py/rdb/generator.ts
@@ -355,33 +355,34 @@ export const pyRdbGenerator = async (
   };
 
   if (options.infra !== 'none') {
-    if (iac === 'terraform') {
-      projectConfig.targets.docker = {
-        cache: IMAGE_BUILD_CACHE,
-        executor: 'nx:run-commands',
-        options: {
-          commands: [
-            `${containerEngine} build --platform linux/arm64 --provenance=false -t ${migrationDockerImageTag} ${migrationBundleDir}`,
-            `${containerEngine} build --platform linux/arm64 --provenance=false -t ${createDbUserDockerImageTag} ${createDbUserBundleDir}`,
-          ],
-          parallel: false,
-        },
-        dependsOn: ['bundle-migration', 'bundle-create-db-user'],
-      };
-      addArtifactDependencyToTargets(projectConfig, 'docker');
+    // Both images ship under either provider — Terraform pushes the locally
+    // built tags, CDK builds the same contexts as image assets — so the build
+    // and its scan are wired up for either.
+    projectConfig.targets.docker = {
+      cache: IMAGE_BUILD_CACHE,
+      executor: 'nx:run-commands',
+      options: {
+        commands: [
+          `${containerEngine} build --platform linux/arm64 --provenance=false -t ${migrationDockerImageTag} ${migrationBundleDir}`,
+          `${containerEngine} build --platform linux/arm64 --provenance=false -t ${createDbUserDockerImageTag} ${createDbUserBundleDir}`,
+        ],
+        parallel: false,
+      },
+      dependsOn: ['bundle-migration', 'bundle-create-db-user'],
+    };
+    addArtifactDependencyToTargets(projectConfig, 'docker');
 
-      addDockerScanTarget(
-        tree,
-        {
-          project: projectConfig,
-          containerEngine,
-          trivyTargetName: 'trivy',
-          dockerTargetName: 'docker',
-          imageTags: [migrationDockerImageTag, createDbUserDockerImageTag],
-        },
-        DEPENDENCIES,
-      );
-    }
+    addDockerScanTarget(
+      tree,
+      {
+        project: projectConfig,
+        containerEngine,
+        trivyTargetName: 'trivy',
+        dockerTargetName: 'docker',
+        imageTags: [migrationDockerImageTag, createDbUserDockerImageTag],
+      },
+      DEPENDENCIES,
+    );
     addDependencyToTargetIfNotPresent(
       projectConfig,
       'build',

--- a/packages/nx-plugin/src/ts/rdb/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/ts/rdb/__snapshots__/generator.spec.ts.snap
@@ -4533,10 +4533,15 @@ WORKDIR \${LAMBDA_TASK_ROOT}
 
 # npm blocks dependency install scripts by default; allow prisma's so its
 # postinstall downloads the schema-engine binary needed to run migrations.
+# The overrides pin transitive dependencies of the CLI with known HIGH/CRITICAL
+# vulnerabilities to fixed versions, which its own ranges resolve below.
 # npm is removed once prisma is installed — the handler runs prisma's own
 # binary directly, and npm's bundled dependencies would otherwise carry known
 # HIGH/CRITICAL vulnerabilities into the image.
 RUN printf 'allow-scripts[]=prisma\\nallow-scripts[]=@prisma/engines\\n' > .npmrc \\
+    && npm init -y \\
+    && npm pkg set "overrides.deepmerge-ts=8.0.0" \\
+    && npm pkg set "overrides.mysql2=3.22.0" \\
     && npm install prisma@7.10.0 \\
     && rm .npmrc \\
     && npm uninstall -g npm

--- a/packages/nx-plugin/src/ts/rdb/files/Dockerfile.template
+++ b/packages/nx-plugin/src/ts/rdb/files/Dockerfile.template
@@ -14,10 +14,15 @@ WORKDIR ${LAMBDA_TASK_ROOT}
 
 # npm blocks dependency install scripts by default; allow prisma's so its
 # postinstall downloads the schema-engine binary needed to run migrations.
+# The overrides pin transitive dependencies of the CLI with known HIGH/CRITICAL
+# vulnerabilities to fixed versions, which its own ranges resolve below.
 # npm is removed once prisma is installed — the handler runs prisma's own
 # binary directly, and npm's bundled dependencies would otherwise carry known
 # HIGH/CRITICAL vulnerabilities into the image.
 RUN printf 'allow-scripts[]=prisma\nallow-scripts[]=@prisma/engines\n' > .npmrc \
+    && npm init -y \
+    && npm pkg set "overrides.deepmerge-ts=<%- deepmergeTsVersion %>" \
+    && npm pkg set "overrides.mysql2=<%- mysql2Version %>" \
     && npm install prisma@<%= prismaVersion %> \
     && rm .npmrc \
     && npm uninstall -g npm

--- a/packages/nx-plugin/src/ts/rdb/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/rdb/generator.spec.ts
@@ -550,6 +550,45 @@ describe('ts#rdb generator', () => {
     expect(updatedProjectJson.targets['bundle']).toBeDefined();
   });
 
+  it.each(['cdk', 'terraform'] as const)(
+    'should build and scan the migration image when iac is %s',
+    async (iac) => {
+      await tsRdbGenerator(tree, { ...defaultOptions, iac });
+
+      const projectConfig = readProjectConfigurationUnqualified(
+        tree,
+        '@proj/db',
+      );
+
+      expect(projectConfig.targets['docker'].options.command).toContain(
+        '-t proj-db-migration:latest',
+      );
+      expect(projectConfig.targets['trivy'].dependsOn).toEqual(['docker']);
+      expect(tree.exists('packages/db/.trivyignore')).toBe(true);
+
+      // The prisma CLI the image installs to run migrations resolves two of its
+      // own dependencies below their fixes, so the build overrides them rather
+      // than suppressing the findings.
+      const dockerfile = tree.read('packages/db/Dockerfile', 'utf-8');
+      expect(dockerfile).toContain(
+        `npm pkg set "overrides.deepmerge-ts=${TS_VERSIONS['deepmerge-ts']}"`,
+      );
+      expect(dockerfile).toContain(
+        `npm pkg set "overrides.mysql2=${TS_VERSIONS.mysql2}"`,
+      );
+    },
+  );
+
+  it('should not add image targets when no infrastructure is generated', async () => {
+    await tsRdbGenerator(tree, { ...defaultOptions, infra: 'none' });
+
+    const projectConfig = readProjectConfigurationUnqualified(tree, '@proj/db');
+
+    expect(projectConfig.targets['docker']).toBeUndefined();
+    expect(projectConfig.targets['trivy']).toBeUndefined();
+    expect(tree.exists('packages/db/.trivyignore')).toBe(false);
+  });
+
   it('should place the project in a subDirectory when provided', async () => {
     await tsRdbGenerator(tree, { ...defaultOptions, subDirectory: 'nested' });
 

--- a/packages/nx-plugin/src/ts/rdb/generator.ts
+++ b/packages/nx-plugin/src/ts/rdb/generator.ts
@@ -32,6 +32,7 @@ import {
   IMAGE_BUILD_CACHE,
   NODE_IMAGE_DEPENDENCIES,
   nodeImageVersions,
+  PRISMA_IMAGE_DEPENDENCIES,
 } from '../../utils/docker.js';
 import { formatFilesInSubtree } from '../../utils/format.js';
 import { FS_DEPENDENCIES, FsCommands } from '../../utils/fs.js';
@@ -99,6 +100,7 @@ export const DEPENDENCIES = declareDependencies<TsRdbMetadata>()({
     ...ownedElsewhere(SHARED_CONSTRUCTS_DEPENDENCIES),
     ...ownedElsewhere(SHARED_RDB_SCRIPTS_DEPENDENCIES),
     ...ownedElsewhere(NODE_IMAGE_DEPENDENCIES),
+    ...ownedElsewhere(PRISMA_IMAGE_DEPENDENCIES),
   ],
 });
 
@@ -164,6 +166,8 @@ export const tsRdbGenerator = async (
     databasePackageAlias: fullyQualifiedName,
     databaseProvider: options.engine === 'mysql' ? 'mysql' : 'postgresql',
     prismaVersion: TS_VERSIONS.prisma,
+    deepmergeTsVersion: TS_VERSIONS['deepmerge-ts'],
+    mysql2Version: TS_VERSIONS.mysql2,
     ...nodeImageVersions(),
     prismaAdapterPackage:
       options.engine === 'mysql'
@@ -341,29 +345,30 @@ export const tsRdbGenerator = async (
     options.infra !== 'none' ? await resolveIac(tree, options.iac) : undefined;
 
   if (options.infra !== 'none') {
-    if (iac === 'terraform') {
-      projectConfig.targets['docker'] = {
-        cache: IMAGE_BUILD_CACHE,
-        executor: 'nx:run-commands',
-        options: {
-          command: `${containerEngine} build --platform linux/arm64 --provenance=false -t ${migrationDockerImageTag} ${migrationBundleDir}`,
-        },
-        dependsOn: ['bundle'],
-      };
-      addArtifactDependencyToTargets(projectConfig, 'docker');
+    // The migration image ships under both providers — Terraform pushes the
+    // locally built tag, CDK builds the same context as an image asset — so the
+    // build and its scan are wired up for either.
+    projectConfig.targets['docker'] = {
+      cache: IMAGE_BUILD_CACHE,
+      executor: 'nx:run-commands',
+      options: {
+        command: `${containerEngine} build --platform linux/arm64 --provenance=false -t ${migrationDockerImageTag} ${migrationBundleDir}`,
+      },
+      dependsOn: ['bundle'],
+    };
+    addArtifactDependencyToTargets(projectConfig, 'docker');
 
-      addDockerScanTarget(
-        tree,
-        {
-          project: projectConfig,
-          containerEngine,
-          trivyTargetName: 'trivy',
-          dockerTargetName: 'docker',
-          imageTags: [migrationDockerImageTag],
-        },
-        DEPENDENCIES,
-      );
-    }
+    addDockerScanTarget(
+      tree,
+      {
+        project: projectConfig,
+        containerEngine,
+        trivyTargetName: 'trivy',
+        dockerTargetName: 'docker',
+        imageTags: [migrationDockerImageTag],
+      },
+      DEPENDENCIES,
+    );
     addArtifactDependencyToTargets(projectConfig, 'bundle');
   }
   addDependencyToTargetIfNotPresent(projectConfig, 'compile', 'generate');

--- a/packages/nx-plugin/src/utils/docker.ts
+++ b/packages/nx-plugin/src/utils/docker.ts
@@ -64,6 +64,17 @@ export const NODE_IMAGE_DEPENDENCIES = [
 ] as const satisfies readonly { name: ITsDepVersion }[];
 
 /**
+ * Packages the prisma CLI install in a vended RDB migration `Dockerfile` pins.
+ * The CLI's own ranges resolve both below a known HIGH vulnerability's fix, so
+ * the image overrides them. Spread through `ownedElsewhere` for the same reason
+ * as {@link NODE_IMAGE_DEPENDENCIES}.
+ */
+export const PRISMA_IMAGE_DEPENDENCIES = [
+  { name: 'deepmerge-ts' },
+  { name: 'mysql2' },
+] as const satisfies readonly { name: ITsDepVersion }[];
+
+/**
  * Packages the AWS Distro for OpenTelemetry install in a vended `Dockerfile`
  * pins, for the images that auto-instrument with it. Spread through
  * `ownedElsewhere` for the same reason as {@link NODE_IMAGE_DEPENDENCIES}.

--- a/packages/nx-plugin/src/utils/version-upgrade-migration/real-templates.spec.ts
+++ b/packages/nx-plugin/src/utils/version-upgrade-migration/real-templates.spec.ts
@@ -317,6 +317,8 @@ const VENDED_TEMPLATE_VARS = new Set([
   'jaegerVersion',
   'adotVersion',
   'prismaVersion',
+  'deepmergeTsVersion',
+  'mysql2Version',
   'rolldownVersion',
   'rolldownDtsVersion',
   'esmShimVersion',

--- a/packages/nx-plugin/src/utils/versions.ts
+++ b/packages/nx-plugin/src/utils/versions.ts
@@ -24,6 +24,12 @@ export const TS_VERSIONS = {
   // as fixed. Overriding brace-expansion directly is not viable — 5.x drops the
   // CommonJS default export that minimatch 9 calls.
   minimatch: '10.2.6',
+  // Both overridden in the vended RDB migration image build, which installs the
+  // prisma CLI to run migrations: its own ranges resolve deepmerge-ts below the
+  // CVE-2026-40345 fix (HIGH) and mysql2 below the GHSA-3f6p-5ww8-9rcr fix
+  // (HIGH). Neither is imported by the handler, which drives the schema engine.
+  'deepmerge-ts': '8.0.0',
+  mysql2: '3.22.0',
   '@aws-sdk/client-dynamodb': '3.1121.0',
   '@aws-sdk/client-api-gateway': '3.1121.0',
   '@aws-sdk/client-iam': '3.1121.0',


### PR DESCRIPTION
### Reason for this change

Bug-bash findings across the RDB guides and the React/RDB connection pages. The one change to generated output:

**`databases-03` — the Image Scanning section was unreachable for CDK users.** Both RDB guides render the shared trivy snippet, promising a `trivy` target and a `.trivyignore`. In a CDK workspace neither existed for any RDB project (nor a `docker` target), despite all of them shipping Dockerfiles: `addDockerScanTarget` sat inside `if (iac === 'terraform')`. `pnpm trivy` reported "No tasks were run", so the migration image a CDK workspace deploys was never scanned.

The rest are documentation-only: the `dev` target's dependency on the Nx Daemon was undocumented on three of the four connection guides (`conn-web-05`), examples that do not typecheck (`conn-web-08`, `conn-web-09`, `conn-web-10`), a dead in-page anchor (`databases-04`), FileTrees that do not match generator output (`conn-web-11`, `conn-data-06`, `databases-07`), an undocumented generated line (`conn-data-07`), and an orphaned snippet (`conn-data-10`).

### Description of changes

**Image scanning for CDK RDB projects.** The RDB generators were the outlier: `ts#agent` and `ts#mcp-server` already add `docker` + `trivy` under both providers, and CDK builds the very same context (`DockerImageCode.fromImageAsset`). Both `ts#rdb` and `py#rdb` now wire up the build and its scan regardless of provider.

Turning the scan on surfaced two HIGH findings per RDB image. Both are **fixed at the source rather than suppressed** — the ignore list I first proposed is gone:

- **TypeScript:** the image installs the prisma CLI to run migrations, and the CLI's own ranges resolve `deepmerge-ts` below the CVE-2026-40345 fix and `mysql2` below the GHSA-3f6p-5ww8-9rcr fix. The install now overrides both via `npm pkg set`, exactly as the agent and MCP image builds already do for `minimatch`. The versions live in `TS_VERSIONS` and are declared through `PRISMA_IMAGE_DEPENDENCIES`, so the weekly sync keeps them current.
- **Python:** the findings were pip's *vendored* copies of `msgpack` and `setuptools` (under `site-packages/pip/_vendor/`) — not OS packages, so `microdnf upgrade` correctly never touched them, and pip is already at its latest so upgrading it does not help. Nothing installs packages at runtime, so both images drop pip.

**`conn-web-05` is documented, not worked around.** `nx watch` needs the daemon, so the `dev` targets built on it do too. Previously only the FastAPI guide mentioned this, and it framed the consequence as merely losing auto-regeneration; the Smithy, py-agent and AG-UI guides said nothing. All four now carry the same note stating the `dev` target requires the daemon (wording per review), and the Nx troubleshooting page matches.

Other doc fixes: guarded `data`/`isPending` and `users.data` in react-trpc; replaced `item.error.message` with `JSON.stringify(item.error.error)` in react-fastapi/react-smithy (the error is a `{ status, error }` union, which those guides document further down); typed the AG-UI slot component as `ButtonHTMLAttributes<HTMLButtonElement>`; pointed the ts-rdb anchor at `connection/trpc-rdb#using-the-middleware`; corrected the tRPC hooks FileTree (one file exporting both hooks) and the ts-rdb FileTree; annotated the conditional Dockerfile in four connection guides. For `conn-data-10` the orphaned `py-lambda-rdb-ssl-requirements` snippet is wired into `py-fast-api-rdb.mdx` rather than deleted — its content is accurate and its TypeScript counterparts are already rendered from the equivalent pages, so FastAPI readers connecting without RDS Proxy were the only ones left without guidance.

**No migration**, per review. Existing workspaces keep the shape they already deploy; new ones get the scan from today's generators.

### Description of how you validated changes

`pnpm nx run @aws/nx-plugin:test -u`, `pnpm nx run-many --target lint --all --fix` and `pnpm nx run-many --target build --projects=@aws/nx-plugin` all pass. Snapshot changes are limited to the two RDB Dockerfiles. Added cases parameterise the RDB generator specs over both IaC providers to assert the image targets exist for each, assert they are absent with `--infra none`, and assert each Dockerfile carries its fix.

End-to-end in a scratch CDK workspace (`pnpm create @aws/nx-workspace`, linked to the local build) with `ts#rdb`, `py#rdb`, `ts#react-website`, `py#fast-api`, `ts#trpc-api` and an AG-UI `ts#agent`, all connected:

- **Image scanning, with real containers:** both RDB projects now get `docker`, `trivy` and `.trivyignore` under CDK. Built the TypeScript and Python migration images and ran the pinned Trivy image against each. Before the fixes Trivy **exits 1** (two HIGH findings per image — which is how I found them); after, it **exits 0** with an empty ignore file. Confirmed the overridden `deepmerge-ts@8.0.0` and `mysql2@3.22.0` actually land with the schema engine intact and `prisma --version` working, and that the Python migration handler still imports and runs without pip (`alembic`, `sqlalchemy`, `asyncpg`, `boto3` and `migration_handler.handler` all load). This also matters because the `Smoke Tests - trivy` lane scans every image the generator matrix produces.
- **Local database workflow:** started the Postgres container via `nx run <db>:dev` and applied a migration with `nx run <db>:prisma migrate dev`, which succeeded against the live container.
- **Examples:** pasted every corrected example into the workspace and confirmed `typecheck` passes. Each was first confirmed to fail with exactly the error the finding reported (TS18048, TS2339 on `UseQueryResult`/`message`, TS2322 on the slot) before the fix.
- **`conn-web-05`:** confirmed with `NX_DAEMON=false` that the watch task exits non-zero and takes `dev` down with it, i.e. the daemon really is required — which is what the note now states.

Not deployed to AWS. Ports in 14670-14699 and distinct container names were used to avoid collisions with other scratch workspaces on this box.

### Issue # (if applicable)

N/A — from a v1.0 bug bash.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
