### PR TITLE
fix(ts#api): preserve user API code when the generator is re-run

### DIFF
--- a/docs/src/components/install-command.astro
+++ b/docs/src/components/install-command.astro
@@ -1,8 +1,9 @@
 ---
 import PackageManagerCommand from './package-manager-command.astro';
 import { buildInstallCommand } from '../../../packages/nx-plugin/src/utils/commands';
-const { pkg, dev, project } = Astro.props;
+const { pkg, dev, project, projectDir } = Astro.props;
 
-const buildCommand = (pm) => buildInstallCommand(pm, pkg, dev, project);
+const buildCommand = (pm) =>
+  buildInstallCommand(pm, pkg, dev, project, projectDir);
 ---
 <PackageManagerCommand buildCommand={buildCommand} />

--- a/docs/src/content/docs/en/guides/trpc.mdx
+++ b/docs/src/content/docs/en/guides/trpc.mdx
@@ -16,6 +16,8 @@ import NxCommands from '@components/nx-commands.astro';
 import Infrastructure from '@components/infrastructure.astro';
 import Snippet from '@components/snippet.astro';
 import OptionFilter from '@components/option-filter.astro';
+import InstallCommand from '@components/install-command.astro';
+import { TS_VERSIONS } from '../../../../../../packages/nx-plugin/src/utils/versions';
 
 [tRPC](https://trpc.io/) is a framework for building APIs in TypeScript with end-to-end type safety. Using tRPC, updates to API operation inputs and outputs are immediately reflected in client code and are visible in your IDE without the need to rebuild your project.
 
@@ -49,15 +51,18 @@ The generator will create the following project structure in the `<directory>/<a
 
 <FileTree>
   - src
+    - index.ts Package entrypoint re-exporting the router, context, client and schema
     - init.ts Backend tRPC initialisation
     - handler.ts Lambda handler entrypoint
     - router.ts tRPC router definition
     - schema Schema definitions using Zod
+      - index.ts Barrel re-exporting every schema
       - echo.ts Example definitions for the input and output of the "echo" procedure
       - z-async-iterable.ts Zod helper for subscriptions (REST API only)
     - procedures Procedures (or operations) exposed by your API
       - echo.ts Example procedure
     - middleware
+      - index.ts Barrel re-exporting the middleware, and the procedure context type
       - error.ts Middleware for error handling
       - logger.ts middleware for configuring AWS Powertools for Lambda logging
       - tracer.ts middleware for configuring AWS Powertools for Lambda tracing
@@ -65,9 +70,15 @@ The generator will create the following project structure in the `<directory>/<a
     - local-server.ts tRPC standalone adapter entrypoint for local development server
     - client
       - index.ts Type-safe client for machine-to-machine API calls
+  - rolldown.config.ts Bundle configuration for the Lambda deployment package
   - tsconfig.json TypeScript configuration
+  - tsconfig.lib.json TypeScript configuration for the library sources
+  - tsconfig.spec.json TypeScript configuration for the tests
+  - vitest.config.mts Vitest configuration
   - package.json Project manifest defining the project's package name and dependencies
   - project.json Project configuration and build targets
+  - README.md Project readme
+  - .gitignore Ignores the project's build output
 
 </FileTree>
 
@@ -297,6 +308,10 @@ As an example, let's implement some middlware to extract some details about the 
 <OptionFilter when={{ auth: 'iam' }} description="Identity middleware example for IAM-authenticated APIs">
 This example walks through identity middleware for `IAM` authentication. We look up the caller in Cognito using the sub extracted from the API Gateway event.
 
+The lookup uses the Cognito Identity Provider client, which is not a dependency of a generated tRPC API. Install it into your API project first:
+
+<InstallCommand pkg={`@aws-sdk/client-cognito-identity-provider@${TS_VERSIONS['@aws-sdk/client-cognito-identity-provider']}`} project="@my-scope/my-api" />
+
 First, we define what we'll add to the context:
 
 ```ts
@@ -334,8 +349,8 @@ In our case, we want to extract details about the calling Cognito user. We'll do
 ```ts
 import { CognitoIdentityProvider } from '@aws-sdk/client-cognito-identity-provider';
 import { initTRPC, TRPCError } from '@trpc/server';
-import { CreateAWSLambdaContextOptions } from '@trpc/server/adapters/aws-lambda';
-import { APIGatewayProxyEvent } from 'aws-lambda';
+import type { CreateAWSLambdaContextOptions } from '@trpc/server/adapters/aws-lambda';
+import type { APIGatewayProxyEvent } from 'aws-lambda';
 
 export interface IIdentityContext {
   identity?: {
@@ -345,12 +360,17 @@ export interface IIdentityContext {
 }
 
 export const createIdentityPlugin = () => {
-  const t = initTRPC.context<IIdentityContext & CreateAWSLambdaContextOptions<APIGatewayProxyEvent>>().create();
+  const t = initTRPC
+    .context<
+      IIdentityContext & CreateAWSLambdaContextOptions<APIGatewayProxyEvent>
+    >()
+    .create();
 
   const cognito = new CognitoIdentityProvider();
 
   return t.procedure.use(async (opts) => {
-    const cognitoAuthenticationProvider = opts.ctx.event.requestContext?.identity?.cognitoAuthenticationProvider;
+    const cognitoAuthenticationProvider =
+      opts.ctx.event.requestContext?.identity?.cognitoAuthenticationProvider;
 
     let sub: string | undefined = undefined;
     if (cognitoAuthenticationProvider) {
@@ -397,8 +417,8 @@ export const createIdentityPlugin = () => {
 ```ts
 import { CognitoIdentityProvider } from '@aws-sdk/client-cognito-identity-provider';
 import { initTRPC, TRPCError } from '@trpc/server';
-import { CreateAWSLambdaContextOptions } from '@trpc/server/adapters/aws-lambda';
-import { APIGatewayProxyEventV2WithIAMAuthorizer } from 'aws-lambda';
+import type { CreateAWSLambdaContextOptions } from '@trpc/server/adapters/aws-lambda';
+import type { APIGatewayProxyEventV2WithIAMAuthorizer } from 'aws-lambda';
 
 export interface IIdentityContext {
   identity?: {
@@ -408,7 +428,12 @@ export interface IIdentityContext {
 }
 
 export const createIdentityPlugin = () => {
-  const t = initTRPC.context<IIdentityContext & CreateAWSLambdaContextOptions<APIGatewayProxyEventV2WithIAMAuthorizer>>().create();
+  const t = initTRPC
+    .context<
+      IIdentityContext &
+        CreateAWSLambdaContextOptions<APIGatewayProxyEventV2WithIAMAuthorizer>
+    >()
+    .create();
 
   const cognito = new CognitoIdentityProvider();
 
@@ -481,12 +506,16 @@ export interface IIdentityContext {
 
 Note that we define an additional _optional_ property on the context. tRPC manages ensuring that this is defined in procedures which have correctly configured this middleware.
 
-Next, the middleware itself:
+Next, the middleware itself. The event type and the location of the claims differ between a REST API and an HTTP API, so the implementation depends on your selected `infra`:
+
+<Tabs syncKey="http-rest">
+<TabItem label="REST API" _filter={{ infra: 'rest-lambda' }}>
+A REST API's Cognito User Pools authorizer places the claims at `event.requestContext.authorizer.claims`:
 
 ```ts
 import { initTRPC, TRPCError } from '@trpc/server';
-import { CreateAWSLambdaContextOptions } from '@trpc/server/adapters/aws-lambda';
-import { APIGatewayProxyEvent } from 'aws-lambda';
+import type { CreateAWSLambdaContextOptions } from '@trpc/server/adapters/aws-lambda';
+import type { APIGatewayProxyEvent } from 'aws-lambda';
 
 export interface IIdentityContext {
   identity?: {
@@ -497,7 +526,9 @@ export interface IIdentityContext {
 
 export const createIdentityPlugin = () => {
   const t = initTRPC
-    .context<IIdentityContext & CreateAWSLambdaContextOptions<APIGatewayProxyEvent>>()
+    .context<
+      IIdentityContext & CreateAWSLambdaContextOptions<APIGatewayProxyEvent>
+    >()
     .create();
 
   return t.procedure.use(async (opts) => {
@@ -506,7 +537,7 @@ export const createIdentityPlugin = () => {
       | undefined;
 
     const sub = claims?.sub;
-    const username = claims?.username;
+    const username = claims?.username ?? claims?.['cognito:username'];
 
     if (!sub || !username) {
       throw new TRPCError({
@@ -527,6 +558,59 @@ export const createIdentityPlugin = () => {
   });
 };
 ```
+</TabItem>
+<TabItem label="HTTP API" _filter={{ infra: 'http-lambda' }}>
+An HTTP API's JWT authorizer delivers a payload-v2 event whose claims sit one level deeper, at `event.requestContext.authorizer.jwt.claims`. The context must be typed on `APIGatewayProxyEventV2WithJWTAuthorizer` to match the one the generated `publicProcedure` uses — otherwise `.concat()` fails with tRPC's `Context mismatch` error:
+
+```ts
+import { initTRPC, TRPCError } from '@trpc/server';
+import type { CreateAWSLambdaContextOptions } from '@trpc/server/adapters/aws-lambda';
+import type { APIGatewayProxyEventV2WithJWTAuthorizer } from 'aws-lambda';
+
+export interface IIdentityContext {
+  identity?: {
+    sub: string;
+    username: string;
+  };
+}
+
+export const createIdentityPlugin = () => {
+  const t = initTRPC
+    .context<
+      IIdentityContext &
+        CreateAWSLambdaContextOptions<APIGatewayProxyEventV2WithJWTAuthorizer>
+    >()
+    .create();
+
+  return t.procedure.use(async (opts) => {
+    const claims = opts.ctx.event.requestContext?.authorizer?.jwt?.claims as
+      | Record<string, string>
+      | undefined;
+
+    const sub = claims?.sub;
+    const username = claims?.username ?? claims?.['cognito:username'];
+
+    if (!sub || !username) {
+      throw new TRPCError({
+        code: 'FORBIDDEN',
+        message: 'Unable to determine calling user',
+      });
+    }
+
+    return await opts.next({
+      ctx: {
+        ...opts.ctx,
+        identity: {
+          sub,
+          username,
+        },
+      },
+    });
+  });
+};
+```
+</TabItem>
+</Tabs>
 
 You can then mix the plugin into any procedure that needs the caller's identity:
 

--- a/docs/src/content/docs/en/guides/ts-smithy-api.mdx
+++ b/docs/src/content/docs/en/guides/ts-smithy-api.mdx
@@ -18,6 +18,8 @@ import PackageManagerShortCommand from '@components/package-manager-short-comman
 import Infrastructure from '@components/infrastructure.astro';
 import Snippet from '@components/snippet.astro';
 import OptionFilter from '@components/option-filter.astro';
+import InstallCommand from '@components/install-command.astro';
+import { TS_VERSIONS } from '../../../../../../packages/nx-plugin/src/utils/versions';
 
 [Smithy](https://smithy.io/) is a protocol-agnostic interface definition language for authoring APIs in a model driven fashion.
 
@@ -46,7 +48,6 @@ The generator creates two related projects in the `<directory>/<api-name>` direc
 <FileTree>
 
 - **model/** Smithy model project
-  - package.json Project manifest defining the project's package name and dependencies
   - project.json Project configuration and build targets
   - smithy-build.json Smithy build configuration
   - ssdk.rolldown.config.mjs Bundles the generated TypeScript Server SDK
@@ -55,9 +56,15 @@ The generator creates two related projects in the `<directory>/<api-name>` direc
     - operations/
       - echo.smithy Example operation definition
 - **backend/** TypeScript backend implementation
+  - package.json Project manifest defining the project's package name and dependencies
   - project.json Project configuration and build targets
   - rolldown.config.ts Bundle configuration
+  - tsconfig.json TypeScript configuration
+  - tsconfig.lib.json TypeScript configuration for the library sources
+  - tsconfig.spec.json TypeScript configuration for the tests
+  - vitest.config.mts Vitest configuration
   - src/
+    - index.ts Package entrypoint
     - handler.ts AWS Lambda handler
     - local-server.ts Local development server
     - service.ts Service implementation
@@ -91,7 +98,7 @@ The common infrastructure as code project is structured as follows:
 </FileTree>
 
 :::note[Generated Project]
-This project is generated using the [`ts#project`](guides/typescript-project) generator and therefore configures the same build targets.
+This project is generated using the <Link path="/guides/typescript-project">`ts#project`</Link> generator and therefore configures the same build targets.
 :::
 </Fragment>
 <Fragment slot="terraform">
@@ -110,7 +117,7 @@ This project is generated using the [`ts#project`](guides/typescript-project) ge
 </FileTree>
 
 :::note[Generated Project]
-This project is generated using the [`terraform#project`](guides/terraform-project) generator and therefore configures the same build targets.
+This project is generated using the <Link path="/guides/terraform-project">`terraform#project`</Link> generator and therefore configures the same build targets.
 :::
 </Fragment>
 </Infrastructure>
@@ -475,7 +482,9 @@ export interface ServiceContext {
 Next, write the resolver in `src/identity.ts`. It throws `UnauthorizedError` when the caller cannot be determined. The implementation depends on your selected `auth` method:
 
 <OptionFilter when={{ auth: 'iam' }} description="Identity resolution for IAM-authenticated APIs">
-For `IAM` authentication, we look up the caller in Cognito using the sub extracted from the API Gateway event:
+For `IAM` authentication, we look up the caller in Cognito using the sub extracted from the API Gateway event. The lookup uses the Cognito Identity Provider client, which is not a dependency of a generated Smithy backend, so install it into the backend project first:
+
+<InstallCommand pkg={`@aws-sdk/client-cognito-identity-provider@${TS_VERSIONS['@aws-sdk/client-cognito-identity-provider']}`} project="@my-scope/my-api" projectDir="packages/my-api/backend" />
 
 ```ts
 import { CognitoIdentityProvider } from '@aws-sdk/client-cognito-identity-provider';
@@ -498,7 +507,9 @@ export const getIdentity = async (
   }
 
   if (!sub) {
-    throw new UnauthorizedError({ message: 'Unable to determine calling user' });
+    throw new UnauthorizedError({
+      message: 'Unable to determine calling user',
+    });
   }
 
   const { Users } = await cognito.listUsers({
@@ -509,7 +520,9 @@ export const getIdentity = async (
   });
 
   if (!Users || Users.length !== 1) {
-    throw new UnauthorizedError({ message: `No user found with subjectId ${sub}` });
+    throw new UnauthorizedError({
+      message: `No user found with subjectId ${sub}`,
+    });
   }
 
   return { sub, username: Users[0].Username! };
@@ -536,7 +549,9 @@ export const getIdentity = async (
   const username = claims?.username;
 
   if (!sub || !username) {
-    throw new UnauthorizedError({ message: 'Unable to determine calling user' });
+    throw new UnauthorizedError({
+      message: 'Unable to determine calling user',
+    });
   }
 
   return { sub, username };
@@ -559,6 +574,17 @@ const httpResponse = await serviceHandler.handle(httpRequest, {
   logger,
   metrics,
   getIdentity: () => getIdentity(event),
+});
+```
+
+`getIdentity` is a required field on `ServiceContext`, and as the [caution above](#service-context) notes the context is constructed in **both** entrypoints — so `src/local-server.ts` needs it too. There is no API Gateway authorizer in front of the local server, so supply a stub identity for local development:
+
+```ts {5} ins={5}
+const httpResponse = await serviceHandler.handle(httpRequest, {
+  tracer,
+  logger,
+  metrics,
+  getIdentity: async () => ({ sub: 'local', username: 'local' }),
 });
 ```
 
@@ -800,6 +826,49 @@ output "lambda_function_name" {
 <Snippet name="api/access-logging" parentHeading="Access logging" />
 
 ### Integrations
+
+<Infrastructure>
+<Fragment slot="cdk">
+:::caution[Operation names are camelCase in CDK]
+Smithy operations are declared in PascalCase (`Echo`), and your backend exports them under that name. The CDK integration keys are the **camelCase** form of the same name, so an operation `Echo` is `echo` everywhere in your stack:
+
+```ts
+const api = new MyApi(this, 'MyApi', {
+  integrations: MyApi.defaultIntegrations(this)
+    // `Echo` in the model, `echo` here
+    .withOperationOptions({ echo: { timeout: Duration.seconds(60) } })
+    .build(),
+});
+
+api.integrations.echo.handler.addToRolePolicy(...);
+```
+:::
+</Fragment>
+<Fragment slot="terraform">
+:::note[Operation names are camelCase in Terraform]
+The generated module's operation-keyed outputs and its `operations.json` use the **camelCase** form of the Smithy operation name, so a Smithy operation `Echo` is keyed `echo`:
+
+```hcl
+# `Echo` in the model, `echo` here
+resource "aws_iam_role_policy" "echo_permissions" {
+  name = "echo-additional-permissions"
+  role = module.my_api.lambda_execution_role_names["echo"]
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["s3:GetObject"]
+        Resource = "arn:aws:s3:::my-bucket/*"
+      }
+    ]
+  })
+}
+```
+:::
+</Fragment>
+</Infrastructure>
 
 <Snippet name="api/type-safe-api-integrations" parentHeading="Integrations" />
 

--- a/docs/src/content/docs/en/snippets/api/type-safe-api-integrations.mdx
+++ b/docs/src/content/docs/en/snippets/api/type-safe-api-integrations.mdx
@@ -66,6 +66,8 @@ const api = new MyApi(this, 'MyApi', {
 
 api.integrations.$router.handler.addEnvironment('LOG_LEVEL', 'DEBUG');
 ```
+
+Note that `$router` is no longer available if you override every operation via `withOverrides`, since no operation is left using the default router integration.
 </Fragment>
 <Fragment slot="terraform">
 With the `isolated` pattern, the module's outputs are maps keyed by operation name, so you can reach a single operation's resources. For example, to grant one operation's Lambda function extra permissions:

--- a/docs/src/content/docs/es/guides/trpc.mdx
+++ b/docs/src/content/docs/es/guides/trpc.mdx
@@ -16,6 +16,8 @@ import NxCommands from '@components/nx-commands.astro';
 import Infrastructure from '@components/infrastructure.astro';
 import Snippet from '@components/snippet.astro';
 import OptionFilter from '@components/option-filter.astro';
+import InstallCommand from '@components/install-command.astro';
+import { TS_VERSIONS } from '../../../../../../packages/nx-plugin/src/utils/versions';
 
 [tRPC](https://trpc.io/) es un framework para construir APIs en TypeScript con seguridad de tipos de extremo a extremo. Usando tRPC, las actualizaciones a las entradas y salidas de las operaciones de la API se reflejan inmediatamente en el código del cliente y son visibles en tu IDE sin necesidad de reconstruir tu proyecto.
 
@@ -49,15 +51,18 @@ El generador creará la siguiente estructura de proyecto en el directorio `<dire
 
 <FileTree>
   - src
+    - index.ts Package entrypoint re-exporting the router, context, client and schema
     - init.ts Backend tRPC initialisation
     - handler.ts Lambda handler entrypoint
     - router.ts tRPC router definition
     - schema Schema definitions using Zod
+      - index.ts Barrel re-exporting every schema
       - echo.ts Example definitions for the input and output of the "echo" procedure
       - z-async-iterable.ts Zod helper for subscriptions (REST API only)
     - procedures Procedures (or operations) exposed by your API
       - echo.ts Example procedure
     - middleware
+      - index.ts Barrel re-exporting the middleware, and the procedure context type
       - error.ts Middleware for error handling
       - logger.ts middleware for configuring AWS Powertools for Lambda logging
       - tracer.ts middleware for configuring AWS Powertools for Lambda tracing
@@ -65,9 +70,15 @@ El generador creará la siguiente estructura de proyecto en el directorio `<dire
     - local-server.ts tRPC standalone adapter entrypoint for local development server
     - client
       - index.ts Type-safe client for machine-to-machine API calls
+  - rolldown.config.ts Bundle configuration for the Lambda deployment package
   - tsconfig.json TypeScript configuration
+  - tsconfig.lib.json TypeScript configuration for the library sources
+  - tsconfig.spec.json TypeScript configuration for the tests
+  - vitest.config.mts Vitest configuration
   - package.json Project manifest defining the project's package name and dependencies
   - project.json Project configuration and build targets
+  - README.md Project readme
+  - .gitignore Ignores the project's build output
 
 </FileTree>
 
@@ -297,6 +308,10 @@ Como ejemplo, implementemos un middleware para extraer algunos detalles sobre el
 <OptionFilter when={{ auth: 'iam' }} description="Identity middleware example for IAM-authenticated APIs">
 Este ejemplo recorre el middleware de identidad para autenticación `IAM`. Buscamos al llamador en Cognito usando el sub extraído del evento de API Gateway.
 
+La búsqueda utiliza el cliente Cognito Identity Provider, que no es una dependencia de una API tRPC generada. Instálalo primero en tu proyecto de API:
+
+<InstallCommand pkg={`@aws-sdk/client-cognito-identity-provider@${TS_VERSIONS['@aws-sdk/client-cognito-identity-provider']}`} project="@my-scope/my-api" />
+
 Primero, definimos lo que agregaremos al contexto:
 
 ```ts
@@ -334,8 +349,8 @@ En nuestro caso, queremos extraer detalles sobre el usuario de Cognito que llama
 ```ts
 import { CognitoIdentityProvider } from '@aws-sdk/client-cognito-identity-provider';
 import { initTRPC, TRPCError } from '@trpc/server';
-import { CreateAWSLambdaContextOptions } from '@trpc/server/adapters/aws-lambda';
-import { APIGatewayProxyEvent } from 'aws-lambda';
+import type { CreateAWSLambdaContextOptions } from '@trpc/server/adapters/aws-lambda';
+import type { APIGatewayProxyEvent } from 'aws-lambda';
 
 export interface IIdentityContext {
   identity?: {
@@ -345,12 +360,17 @@ export interface IIdentityContext {
 }
 
 export const createIdentityPlugin = () => {
-  const t = initTRPC.context<IIdentityContext & CreateAWSLambdaContextOptions<APIGatewayProxyEvent>>().create();
+  const t = initTRPC
+    .context<
+      IIdentityContext & CreateAWSLambdaContextOptions<APIGatewayProxyEvent>
+    >()
+    .create();
 
   const cognito = new CognitoIdentityProvider();
 
   return t.procedure.use(async (opts) => {
-    const cognitoAuthenticationProvider = opts.ctx.event.requestContext?.identity?.cognitoAuthenticationProvider;
+    const cognitoAuthenticationProvider =
+      opts.ctx.event.requestContext?.identity?.cognitoAuthenticationProvider;
 
     let sub: string | undefined = undefined;
     if (cognitoAuthenticationProvider) {
@@ -397,8 +417,8 @@ export const createIdentityPlugin = () => {
 ```ts
 import { CognitoIdentityProvider } from '@aws-sdk/client-cognito-identity-provider';
 import { initTRPC, TRPCError } from '@trpc/server';
-import { CreateAWSLambdaContextOptions } from '@trpc/server/adapters/aws-lambda';
-import { APIGatewayProxyEventV2WithIAMAuthorizer } from 'aws-lambda';
+import type { CreateAWSLambdaContextOptions } from '@trpc/server/adapters/aws-lambda';
+import type { APIGatewayProxyEventV2WithIAMAuthorizer } from 'aws-lambda';
 
 export interface IIdentityContext {
   identity?: {
@@ -408,7 +428,12 @@ export interface IIdentityContext {
 }
 
 export const createIdentityPlugin = () => {
-  const t = initTRPC.context<IIdentityContext & CreateAWSLambdaContextOptions<APIGatewayProxyEventV2WithIAMAuthorizer>>().create();
+  const t = initTRPC
+    .context<
+      IIdentityContext &
+        CreateAWSLambdaContextOptions<APIGatewayProxyEventV2WithIAMAuthorizer>
+    >()
+    .create();
 
   const cognito = new CognitoIdentityProvider();
 
@@ -481,12 +506,16 @@ export interface IIdentityContext {
 
 Ten en cuenta que definimos una propiedad adicional _opcional_ en el contexto. tRPC se encarga de asegurar que esto esté definido en los procedimientos que han configurado correctamente este middleware.
 
-A continuación, el middleware en sí:
+A continuación, el middleware en sí. El tipo de evento y la ubicación de las reclamaciones difieren entre una API REST y una API HTTP, por lo que la implementación depende de tu `infra` seleccionado:
+
+<Tabs syncKey="http-rest">
+<TabItem label="REST API" _filter={{ infra: 'rest-lambda' }}>
+El autorizador de Cognito User Pools de una API REST coloca las reclamaciones en `event.requestContext.authorizer.claims`:
 
 ```ts
 import { initTRPC, TRPCError } from '@trpc/server';
-import { CreateAWSLambdaContextOptions } from '@trpc/server/adapters/aws-lambda';
-import { APIGatewayProxyEvent } from 'aws-lambda';
+import type { CreateAWSLambdaContextOptions } from '@trpc/server/adapters/aws-lambda';
+import type { APIGatewayProxyEvent } from 'aws-lambda';
 
 export interface IIdentityContext {
   identity?: {
@@ -497,7 +526,9 @@ export interface IIdentityContext {
 
 export const createIdentityPlugin = () => {
   const t = initTRPC
-    .context<IIdentityContext & CreateAWSLambdaContextOptions<APIGatewayProxyEvent>>()
+    .context<
+      IIdentityContext & CreateAWSLambdaContextOptions<APIGatewayProxyEvent>
+    >()
     .create();
 
   return t.procedure.use(async (opts) => {
@@ -506,7 +537,7 @@ export const createIdentityPlugin = () => {
       | undefined;
 
     const sub = claims?.sub;
-    const username = claims?.username;
+    const username = claims?.username ?? claims?.['cognito:username'];
 
     if (!sub || !username) {
       throw new TRPCError({
@@ -527,6 +558,59 @@ export const createIdentityPlugin = () => {
   });
 };
 ```
+</TabItem>
+<TabItem label="HTTP API" _filter={{ infra: 'http-lambda' }}>
+El autorizador JWT de una API HTTP entrega un evento payload-v2 cuyas reclamaciones se encuentran un nivel más profundo, en `event.requestContext.authorizer.jwt.claims`. El contexto debe estar tipado en `APIGatewayProxyEventV2WithJWTAuthorizer` para coincidir con el que usa el `publicProcedure` generado; de lo contrario, `.concat()` falla con el error `Context mismatch` de tRPC:
+
+```ts
+import { initTRPC, TRPCError } from '@trpc/server';
+import type { CreateAWSLambdaContextOptions } from '@trpc/server/adapters/aws-lambda';
+import type { APIGatewayProxyEventV2WithJWTAuthorizer } from 'aws-lambda';
+
+export interface IIdentityContext {
+  identity?: {
+    sub: string;
+    username: string;
+  };
+}
+
+export const createIdentityPlugin = () => {
+  const t = initTRPC
+    .context<
+      IIdentityContext &
+        CreateAWSLambdaContextOptions<APIGatewayProxyEventV2WithJWTAuthorizer>
+    >()
+    .create();
+
+  return t.procedure.use(async (opts) => {
+    const claims = opts.ctx.event.requestContext?.authorizer?.jwt?.claims as
+      | Record<string, string>
+      | undefined;
+
+    const sub = claims?.sub;
+    const username = claims?.username ?? claims?.['cognito:username'];
+
+    if (!sub || !username) {
+      throw new TRPCError({
+        code: 'FORBIDDEN',
+        message: 'Unable to determine calling user',
+      });
+    }
+
+    return await opts.next({
+      ctx: {
+        ...opts.ctx,
+        identity: {
+          sub,
+          username,
+        },
+      },
+    });
+  });
+};
+```
+</TabItem>
+</Tabs>
 
 Luego puedes mezclar el plugin en cualquier procedimiento que necesite la identidad del llamador:
 

--- a/docs/src/content/docs/es/guides/ts-smithy-api.mdx
+++ b/docs/src/content/docs/es/guides/ts-smithy-api.mdx
@@ -18,6 +18,8 @@ import PackageManagerShortCommand from '@components/package-manager-short-comman
 import Infrastructure from '@components/infrastructure.astro';
 import Snippet from '@components/snippet.astro';
 import OptionFilter from '@components/option-filter.astro';
+import InstallCommand from '@components/install-command.astro';
+import { TS_VERSIONS } from '../../../../../../packages/nx-plugin/src/utils/versions';
 
 [Smithy](https://smithy.io/) es un lenguaje de definición de interfaz independiente del protocolo para crear APIs de manera orientada a modelos.
 
@@ -46,7 +48,6 @@ El generador crea dos proyectos relacionados en el directorio `<directory>/<api-
 <FileTree>
 
 - **model/** Proyecto del modelo Smithy
-  - package.json Manifiesto del proyecto que define el nombre del paquete y las dependencias
   - project.json Configuración del proyecto y objetivos de compilación
   - smithy-build.json Configuración de compilación de Smithy
   - ssdk.rolldown.config.mjs Empaqueta el TypeScript Server SDK generado
@@ -55,9 +56,15 @@ El generador crea dos proyectos relacionados en el directorio `<directory>/<api-
     - operations/
       - echo.smithy Definición de operación de ejemplo
 - **backend/** Implementación del backend en TypeScript
+  - package.json Manifiesto del proyecto que define el nombre del paquete y las dependencias
   - project.json Configuración del proyecto y objetivos de compilación
   - rolldown.config.ts Configuración del empaquetado
+  - tsconfig.json Configuración de TypeScript
+  - tsconfig.lib.json Configuración de TypeScript para las fuentes de la biblioteca
+  - tsconfig.spec.json Configuración de TypeScript para las pruebas
+  - vitest.config.mts Configuración de Vitest
   - src/
+    - index.ts Punto de entrada del paquete
     - handler.ts Handler de AWS Lambda
     - local-server.ts Servidor de desarrollo local
     - service.ts Implementación del servicio
@@ -91,7 +98,7 @@ El proyecto común de infraestructura como código está estructurado de la sigu
 </FileTree>
 
 :::note[Proyecto Generado]
-Este proyecto se genera usando el generador [`ts#project`](guides/typescript-project) y por lo tanto configura los mismos objetivos de compilación.
+Este proyecto se genera usando el generador <Link path="/guides/typescript-project">`ts#project`</Link> y por lo tanto configura los mismos objetivos de compilación.
 :::
 </Fragment>
 <Fragment slot="terraform">
@@ -110,7 +117,7 @@ Este proyecto se genera usando el generador [`ts#project`](guides/typescript-pro
 </FileTree>
 
 :::note[Proyecto Generado]
-Este proyecto se genera usando el generador [`terraform#project`](guides/terraform-project) y por lo tanto configura los mismos objetivos de compilación.
+Este proyecto se genera usando el generador <Link path="/guides/terraform-project">`terraform#project`</Link> y por lo tanto configura los mismos objetivos de compilación.
 :::
 </Fragment>
 </Infrastructure>
@@ -475,7 +482,9 @@ export interface ServiceContext {
 A continuación, escribe el resolvedor en `src/identity.ts`. Lanza `UnauthorizedError` cuando no se puede determinar el llamador. La implementación depende de tu método `auth` seleccionado:
 
 <OptionFilter when={{ auth: 'iam' }} description="Resolución de identidad para APIs autenticadas con IAM">
-Para autenticación `IAM`, buscamos el llamador en Cognito usando el sub extraído del evento de API Gateway:
+Para autenticación `IAM`, buscamos el llamador en Cognito usando el sub extraído del evento de API Gateway. La búsqueda utiliza el cliente Cognito Identity Provider, que no es una dependencia de un backend Smithy generado, así que instálalo primero en el proyecto backend:
+
+<InstallCommand pkg={`@aws-sdk/client-cognito-identity-provider@${TS_VERSIONS['@aws-sdk/client-cognito-identity-provider']}`} project="@my-scope/my-api" projectDir="packages/my-api/backend" />
 
 ```ts
 import { CognitoIdentityProvider } from '@aws-sdk/client-cognito-identity-provider';
@@ -498,7 +507,9 @@ export const getIdentity = async (
   }
 
   if (!sub) {
-    throw new UnauthorizedError({ message: 'Unable to determine calling user' });
+    throw new UnauthorizedError({
+      message: 'Unable to determine calling user',
+    });
   }
 
   const { Users } = await cognito.listUsers({
@@ -509,7 +520,9 @@ export const getIdentity = async (
   });
 
   if (!Users || Users.length !== 1) {
-    throw new UnauthorizedError({ message: `No user found with subjectId ${sub}` });
+    throw new UnauthorizedError({
+      message: `No user found with subjectId ${sub}`,
+    });
   }
 
   return { sub, username: Users[0].Username! };
@@ -536,7 +549,9 @@ export const getIdentity = async (
   const username = claims?.username;
 
   if (!sub || !username) {
-    throw new UnauthorizedError({ message: 'Unable to determine calling user' });
+    throw new UnauthorizedError({
+      message: 'Unable to determine calling user',
+    });
   }
 
   return { sub, username };
@@ -559,6 +574,17 @@ const httpResponse = await serviceHandler.handle(httpRequest, {
   logger,
   metrics,
   getIdentity: () => getIdentity(event),
+});
+```
+
+`getIdentity` es un campo requerido en `ServiceContext`, y como la [advertencia anterior](#contexto-del-servicio) señala, el contexto se construye en **ambos** puntos de entrada — por lo que `src/local-server.ts` también lo necesita. No hay un autorizador de API Gateway frente al servidor local, así que proporciona una identidad stub para el desarrollo local:
+
+```ts {5} ins={5}
+const httpResponse = await serviceHandler.handle(httpRequest, {
+  tracer,
+  logger,
+  metrics,
+  getIdentity: async () => ({ sub: 'local', username: 'local' }),
 });
 ```
 
@@ -800,6 +826,49 @@ output "lambda_function_name" {
 <Snippet name="api/access-logging" parentHeading="Registro de acceso" />
 
 ### Integraciones
+
+<Infrastructure>
+<Fragment slot="cdk">
+:::caution[Los nombres de operación están en camelCase en CDK]
+Las operaciones de Smithy se declaran en PascalCase (`Echo`), y tu backend las exporta bajo ese nombre. Las claves de integración de CDK están en la forma **camelCase** del mismo nombre, por lo que una operación `Echo` es `echo` en todas partes de tu stack:
+
+```ts
+const api = new MyApi(this, 'MyApi', {
+  integrations: MyApi.defaultIntegrations(this)
+    // `Echo` in the model, `echo` here
+    .withOperationOptions({ echo: { timeout: Duration.seconds(60) } })
+    .build(),
+});
+
+api.integrations.echo.handler.addToRolePolicy(...);
+```
+:::
+</Fragment>
+<Fragment slot="terraform">
+:::note[Los nombres de operación están en camelCase en Terraform]
+Las salidas con clave de operación del módulo generado y su `operations.json` usan la forma **camelCase** del nombre de operación de Smithy, por lo que una operación de Smithy `Echo` tiene la clave `echo`:
+
+```hcl
+# `Echo` in the model, `echo` here
+resource "aws_iam_role_policy" "echo_permissions" {
+  name = "echo-additional-permissions"
+  role = module.my_api.lambda_execution_role_names["echo"]
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["s3:GetObject"]
+        Resource = "arn:aws:s3:::my-bucket/*"
+      }
+    ]
+  })
+}
+```
+:::
+</Fragment>
+</Infrastructure>
 
 <Snippet name="api/type-safe-api-integrations" parentHeading="Integraciones" />
 

--- a/docs/src/content/docs/es/snippets/api/type-safe-api-integrations.mdx
+++ b/docs/src/content/docs/es/snippets/api/type-safe-api-integrations.mdx
@@ -66,6 +66,8 @@ const api = new MyApi(this, 'MyApi', {
 
 api.integrations.$router.handler.addEnvironment('LOG_LEVEL', 'DEBUG');
 ```
+
+Tenga en cuenta que `$router` ya no está disponible si anula todas las operaciones a través de `withOverrides`, ya que ninguna operación queda usando la integración de enrutador predeterminada.
 </Fragment>
 <Fragment slot="terraform">
 Con el patrón `isolated`, las salidas del módulo son mapas indexados por nombre de operación, por lo que puede acceder a los recursos de una sola operación. Por ejemplo, para otorgar permisos adicionales a la función Lambda de una operación:

--- a/docs/src/content/docs/fr/guides/trpc.mdx
+++ b/docs/src/content/docs/fr/guides/trpc.mdx
@@ -16,6 +16,8 @@ import NxCommands from '@components/nx-commands.astro';
 import Infrastructure from '@components/infrastructure.astro';
 import Snippet from '@components/snippet.astro';
 import OptionFilter from '@components/option-filter.astro';
+import InstallCommand from '@components/install-command.astro';
+import { TS_VERSIONS } from '../../../../../../packages/nx-plugin/src/utils/versions';
 
 [tRPC](https://trpc.io/) est un framework pour créer des API en TypeScript avec une sécurité de type de bout en bout. Avec tRPC, les mises à jour des entrées et sorties des opérations d'API sont immédiatement reflétées dans le code client et sont visibles dans votre IDE sans avoir besoin de reconstruire votre projet.
 
@@ -49,15 +51,18 @@ Le générateur créera la structure de projet suivante dans le répertoire `<di
 
 <FileTree>
   - src
+    - index.ts Package entrypoint re-exporting the router, context, client and schema
     - init.ts Backend tRPC initialisation
     - handler.ts Lambda handler entrypoint
     - router.ts tRPC router definition
     - schema Schema definitions using Zod
+      - index.ts Barrel re-exporting every schema
       - echo.ts Example definitions for the input and output of the "echo" procedure
       - z-async-iterable.ts Zod helper for subscriptions (REST API only)
     - procedures Procedures (or operations) exposed by your API
       - echo.ts Example procedure
     - middleware
+      - index.ts Barrel re-exporting the middleware, and the procedure context type
       - error.ts Middleware for error handling
       - logger.ts middleware for configuring AWS Powertools for Lambda logging
       - tracer.ts middleware for configuring AWS Powertools for Lambda tracing
@@ -65,9 +70,15 @@ Le générateur créera la structure de projet suivante dans le répertoire `<di
     - local-server.ts tRPC standalone adapter entrypoint for local development server
     - client
       - index.ts Type-safe client for machine-to-machine API calls
+  - rolldown.config.ts Bundle configuration for the Lambda deployment package
   - tsconfig.json TypeScript configuration
+  - tsconfig.lib.json TypeScript configuration for the library sources
+  - tsconfig.spec.json TypeScript configuration for the tests
+  - vitest.config.mts Vitest configuration
   - package.json Project manifest defining the project's package name and dependencies
   - project.json Project configuration and build targets
+  - README.md Project readme
+  - .gitignore Ignores the project's build output
 
 </FileTree>
 
@@ -297,6 +308,10 @@ Vous pouvez ajouter des valeurs supplémentaires au contexte fourni aux procédu
 <OptionFilter when={{ auth: 'iam' }} description="Identity middleware example for IAM-authenticated APIs">
 Cet exemple présente un middleware d'identité pour l'authentification `IAM`. Nous recherchons l'appelant dans Cognito en utilisant le sub extrait de l'événement API Gateway.
 
+La recherche utilise le client Cognito Identity Provider, qui n'est pas une dépendance d'une API tRPC générée. Installez-le d'abord dans votre projet d'API :
+
+<InstallCommand pkg={`@aws-sdk/client-cognito-identity-provider@${TS_VERSIONS['@aws-sdk/client-cognito-identity-provider']}`} project="@my-scope/my-api" />
+
 Tout d'abord, nous définissons ce que nous ajouterons au contexte :
 
 ```ts
@@ -334,8 +349,8 @@ Dans notre cas, nous voulons extraire des détails sur l'utilisateur Cognito app
 ```ts
 import { CognitoIdentityProvider } from '@aws-sdk/client-cognito-identity-provider';
 import { initTRPC, TRPCError } from '@trpc/server';
-import { CreateAWSLambdaContextOptions } from '@trpc/server/adapters/aws-lambda';
-import { APIGatewayProxyEvent } from 'aws-lambda';
+import type { CreateAWSLambdaContextOptions } from '@trpc/server/adapters/aws-lambda';
+import type { APIGatewayProxyEvent } from 'aws-lambda';
 
 export interface IIdentityContext {
   identity?: {
@@ -345,12 +360,17 @@ export interface IIdentityContext {
 }
 
 export const createIdentityPlugin = () => {
-  const t = initTRPC.context<IIdentityContext & CreateAWSLambdaContextOptions<APIGatewayProxyEvent>>().create();
+  const t = initTRPC
+    .context<
+      IIdentityContext & CreateAWSLambdaContextOptions<APIGatewayProxyEvent>
+    >()
+    .create();
 
   const cognito = new CognitoIdentityProvider();
 
   return t.procedure.use(async (opts) => {
-    const cognitoAuthenticationProvider = opts.ctx.event.requestContext?.identity?.cognitoAuthenticationProvider;
+    const cognitoAuthenticationProvider =
+      opts.ctx.event.requestContext?.identity?.cognitoAuthenticationProvider;
 
     let sub: string | undefined = undefined;
     if (cognitoAuthenticationProvider) {
@@ -397,8 +417,8 @@ export const createIdentityPlugin = () => {
 ```ts
 import { CognitoIdentityProvider } from '@aws-sdk/client-cognito-identity-provider';
 import { initTRPC, TRPCError } from '@trpc/server';
-import { CreateAWSLambdaContextOptions } from '@trpc/server/adapters/aws-lambda';
-import { APIGatewayProxyEventV2WithIAMAuthorizer } from 'aws-lambda';
+import type { CreateAWSLambdaContextOptions } from '@trpc/server/adapters/aws-lambda';
+import type { APIGatewayProxyEventV2WithIAMAuthorizer } from 'aws-lambda';
 
 export interface IIdentityContext {
   identity?: {
@@ -408,7 +428,12 @@ export interface IIdentityContext {
 }
 
 export const createIdentityPlugin = () => {
-  const t = initTRPC.context<IIdentityContext & CreateAWSLambdaContextOptions<APIGatewayProxyEventV2WithIAMAuthorizer>>().create();
+  const t = initTRPC
+    .context<
+      IIdentityContext &
+        CreateAWSLambdaContextOptions<APIGatewayProxyEventV2WithIAMAuthorizer>
+    >()
+    .create();
 
   const cognito = new CognitoIdentityProvider();
 
@@ -481,12 +506,16 @@ export interface IIdentityContext {
 
 Notez que nous définissons une propriété supplémentaire _optionnelle_ sur le contexte. tRPC gère la garantie que cela est défini dans les procédures qui ont correctement configuré ce middleware.
 
-Ensuite, le middleware lui-même :
+Ensuite, le middleware lui-même. Le type d'événement et l'emplacement des revendications diffèrent entre une API REST et une API HTTP, donc l'implémentation dépend de votre `infra` sélectionné :
+
+<Tabs syncKey="http-rest">
+<TabItem label="REST API" _filter={{ infra: 'rest-lambda' }}>
+L'autorisateur Cognito User Pools d'une API REST place les revendications à `event.requestContext.authorizer.claims` :
 
 ```ts
 import { initTRPC, TRPCError } from '@trpc/server';
-import { CreateAWSLambdaContextOptions } from '@trpc/server/adapters/aws-lambda';
-import { APIGatewayProxyEvent } from 'aws-lambda';
+import type { CreateAWSLambdaContextOptions } from '@trpc/server/adapters/aws-lambda';
+import type { APIGatewayProxyEvent } from 'aws-lambda';
 
 export interface IIdentityContext {
   identity?: {
@@ -497,7 +526,9 @@ export interface IIdentityContext {
 
 export const createIdentityPlugin = () => {
   const t = initTRPC
-    .context<IIdentityContext & CreateAWSLambdaContextOptions<APIGatewayProxyEvent>>()
+    .context<
+      IIdentityContext & CreateAWSLambdaContextOptions<APIGatewayProxyEvent>
+    >()
     .create();
 
   return t.procedure.use(async (opts) => {
@@ -506,7 +537,7 @@ export const createIdentityPlugin = () => {
       | undefined;
 
     const sub = claims?.sub;
-    const username = claims?.username;
+    const username = claims?.username ?? claims?.['cognito:username'];
 
     if (!sub || !username) {
       throw new TRPCError({
@@ -527,6 +558,59 @@ export const createIdentityPlugin = () => {
   });
 };
 ```
+</TabItem>
+<TabItem label="HTTP API" _filter={{ infra: 'http-lambda' }}>
+L'autorisateur JWT d'une API HTTP fournit un événement payload-v2 dont les revendications se trouvent un niveau plus profond, à `event.requestContext.authorizer.jwt.claims`. Le contexte doit être typé sur `APIGatewayProxyEventV2WithJWTAuthorizer` pour correspondre à celui que le `publicProcedure` généré utilise — sinon `.concat()` échoue avec l'erreur `Context mismatch` de tRPC :
+
+```ts
+import { initTRPC, TRPCError } from '@trpc/server';
+import type { CreateAWSLambdaContextOptions } from '@trpc/server/adapters/aws-lambda';
+import type { APIGatewayProxyEventV2WithJWTAuthorizer } from 'aws-lambda';
+
+export interface IIdentityContext {
+  identity?: {
+    sub: string;
+    username: string;
+  };
+}
+
+export const createIdentityPlugin = () => {
+  const t = initTRPC
+    .context<
+      IIdentityContext &
+        CreateAWSLambdaContextOptions<APIGatewayProxyEventV2WithJWTAuthorizer>
+    >()
+    .create();
+
+  return t.procedure.use(async (opts) => {
+    const claims = opts.ctx.event.requestContext?.authorizer?.jwt?.claims as
+      | Record<string, string>
+      | undefined;
+
+    const sub = claims?.sub;
+    const username = claims?.username ?? claims?.['cognito:username'];
+
+    if (!sub || !username) {
+      throw new TRPCError({
+        code: 'FORBIDDEN',
+        message: 'Unable to determine calling user',
+      });
+    }
+
+    return await opts.next({
+      ctx: {
+        ...opts.ctx,
+        identity: {
+          sub,
+          username,
+        },
+      },
+    });
+  });
+};
+```
+</TabItem>
+</Tabs>
 
 Vous pouvez ensuite mélanger le plugin dans n'importe quelle procédure qui a besoin de l'identité de l'appelant :
 

--- a/docs/src/content/docs/fr/guides/ts-smithy-api.mdx
+++ b/docs/src/content/docs/fr/guides/ts-smithy-api.mdx
@@ -18,6 +18,8 @@ import PackageManagerShortCommand from '@components/package-manager-short-comman
 import Infrastructure from '@components/infrastructure.astro';
 import Snippet from '@components/snippet.astro';
 import OptionFilter from '@components/option-filter.astro';
+import InstallCommand from '@components/install-command.astro';
+import { TS_VERSIONS } from '../../../../../../packages/nx-plugin/src/utils/versions';
 
 [Smithy](https://smithy.io/) est un langage de définition d'interface indépendant du protocole pour créer des API de manière pilotée par modèle.
 
@@ -46,7 +48,6 @@ Le générateur crée deux projets liés dans le répertoire `<directory>/<api-n
 <FileTree>
 
 - **model/** Projet de modèle Smithy
-  - package.json Manifeste du projet définissant le nom du package et les dépendances
   - project.json Configuration du projet et cibles de build
   - smithy-build.json Configuration de build Smithy
   - ssdk.rolldown.config.mjs Bundle le TypeScript Server SDK généré
@@ -55,9 +56,15 @@ Le générateur crée deux projets liés dans le répertoire `<directory>/<api-n
     - operations/
       - echo.smithy Exemple de définition d'opération
 - **backend/** Implémentation backend TypeScript
+  - package.json Manifeste du projet définissant le nom du package et les dépendances
   - project.json Configuration du projet et cibles de build
   - rolldown.config.ts Configuration du bundle
+  - tsconfig.json Configuration TypeScript
+  - tsconfig.lib.json Configuration TypeScript pour les sources de la bibliothèque
+  - tsconfig.spec.json Configuration TypeScript pour les tests
+  - vitest.config.mts Configuration Vitest
   - src/
+    - index.ts Point d'entrée du package
     - handler.ts Gestionnaire AWS Lambda
     - local-server.ts Serveur de développement local
     - service.ts Implémentation du service
@@ -91,7 +98,7 @@ Le projet d'infrastructure en tant que code commun est structuré comme suit :
 </FileTree>
 
 :::note[Projet généré]
-Ce projet est généré en utilisant le générateur [`ts#project`](guides/typescript-project) et configure donc les mêmes cibles de build.
+Ce projet est généré en utilisant le générateur <Link path="/guides/typescript-project">`ts#project`</Link> et configure donc les mêmes cibles de build.
 :::
 </Fragment>
 <Fragment slot="terraform">
@@ -110,7 +117,7 @@ Ce projet est généré en utilisant le générateur [`ts#project`](guides/types
 </FileTree>
 
 :::note[Projet généré]
-Ce projet est généré en utilisant le générateur [`terraform#project`](guides/terraform-project) et configure donc les mêmes cibles de build.
+Ce projet est généré en utilisant le générateur <Link path="/guides/terraform-project">`terraform#project`</Link> et configure donc les mêmes cibles de build.
 :::
 </Fragment>
 </Infrastructure>
@@ -475,7 +482,9 @@ export interface ServiceContext {
 Ensuite, écrivez le résolveur dans `src/identity.ts`. Il lève `UnauthorizedError` lorsque l'appelant ne peut pas être déterminé. L'implémentation dépend de votre méthode `auth` sélectionnée :
 
 <OptionFilter when={{ auth: 'iam' }} description="Résolution d'identité pour les API authentifiées par IAM">
-Pour l'authentification `IAM`, nous recherchons l'appelant dans Cognito en utilisant le sub extrait de l'événement API Gateway :
+Pour l'authentification `IAM`, nous recherchons l'appelant dans Cognito en utilisant le sub extrait de l'événement API Gateway. La recherche utilise le client Cognito Identity Provider, qui n'est pas une dépendance d'un backend Smithy généré, donc installez-le d'abord dans le projet backend :
+
+<InstallCommand pkg={`@aws-sdk/client-cognito-identity-provider@${TS_VERSIONS['@aws-sdk/client-cognito-identity-provider']}`} project="@my-scope/my-api" projectDir="packages/my-api/backend" />
 
 ```ts
 import { CognitoIdentityProvider } from '@aws-sdk/client-cognito-identity-provider';
@@ -498,7 +507,9 @@ export const getIdentity = async (
   }
 
   if (!sub) {
-    throw new UnauthorizedError({ message: 'Unable to determine calling user' });
+    throw new UnauthorizedError({
+      message: 'Unable to determine calling user',
+    });
   }
 
   const { Users } = await cognito.listUsers({
@@ -509,7 +520,9 @@ export const getIdentity = async (
   });
 
   if (!Users || Users.length !== 1) {
-    throw new UnauthorizedError({ message: `No user found with subjectId ${sub}` });
+    throw new UnauthorizedError({
+      message: `No user found with subjectId ${sub}`,
+    });
   }
 
   return { sub, username: Users[0].Username! };
@@ -536,7 +549,9 @@ export const getIdentity = async (
   const username = claims?.username;
 
   if (!sub || !username) {
-    throw new UnauthorizedError({ message: 'Unable to determine calling user' });
+    throw new UnauthorizedError({
+      message: 'Unable to determine calling user',
+    });
   }
 
   return { sub, username };
@@ -559,6 +574,17 @@ const httpResponse = await serviceHandler.handle(httpRequest, {
   logger,
   metrics,
   getIdentity: () => getIdentity(event),
+});
+```
+
+`getIdentity` est un champ requis sur `ServiceContext`, et comme la [mise en garde ci-dessus](#contexte-du-service) le note, le contexte est construit dans **les deux** points d'entrée — donc `src/local-server.ts` en a également besoin. Il n'y a pas d'autorisateur API Gateway devant le serveur local, donc fournissez une identité factice pour le développement local :
+
+```ts {5} ins={5}
+const httpResponse = await serviceHandler.handle(httpRequest, {
+  tracer,
+  logger,
+  metrics,
+  getIdentity: async () => ({ sub: 'local', username: 'local' }),
 });
 ```
 
@@ -800,6 +826,49 @@ output "lambda_function_name" {
 <Snippet name="api/access-logging" parentHeading="Journalisation des accès" />
 
 ### Intégrations
+
+<Infrastructure>
+<Fragment slot="cdk">
+:::caution[Les noms d'opération sont en camelCase dans CDK]
+Les opérations Smithy sont déclarées en PascalCase (`Echo`), et votre backend les exporte sous ce nom. Les clés d'intégration CDK sont la forme **camelCase** du même nom, donc une opération `Echo` est `echo` partout dans votre stack :
+
+```ts
+const api = new MyApi(this, 'MyApi', {
+  integrations: MyApi.defaultIntegrations(this)
+    // `Echo` in the model, `echo` here
+    .withOperationOptions({ echo: { timeout: Duration.seconds(60) } })
+    .build(),
+});
+
+api.integrations.echo.handler.addToRolePolicy(...);
+```
+:::
+</Fragment>
+<Fragment slot="terraform">
+:::note[Les noms d'opération sont en camelCase dans Terraform]
+Les sorties indexées par opération du module généré et son `operations.json` utilisent la forme **camelCase** du nom d'opération Smithy, donc une opération Smithy `Echo` est indexée `echo` :
+
+```hcl
+# `Echo` in the model, `echo` here
+resource "aws_iam_role_policy" "echo_permissions" {
+  name = "echo-additional-permissions"
+  role = module.my_api.lambda_execution_role_names["echo"]
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["s3:GetObject"]
+        Resource = "arn:aws:s3:::my-bucket/*"
+      }
+    ]
+  })
+}
+```
+:::
+</Fragment>
+</Infrastructure>
 
 <Snippet name="api/type-safe-api-integrations" parentHeading="Intégrations" />
 

--- a/docs/src/content/docs/fr/snippets/api/type-safe-api-integrations.mdx
+++ b/docs/src/content/docs/fr/snippets/api/type-safe-api-integrations.mdx
@@ -66,6 +66,8 @@ const api = new MyApi(this, 'MyApi', {
 
 api.integrations.$router.handler.addEnvironment('LOG_LEVEL', 'DEBUG');
 ```
+
+Notez que `$router` n'est plus disponible si vous remplacez chaque opération via `withOverrides`, puisqu'aucune opération n'utilise plus l'intégration de routeur par défaut.
 </Fragment>
 <Fragment slot="terraform">
 Avec le modèle `isolated`, les sorties du module sont des maps indexées par nom d'opération, vous pouvez donc accéder aux ressources d'une seule opération. Par exemple, pour accorder des permissions supplémentaires à la fonction Lambda d'une opération :

--- a/docs/src/content/docs/it/guides/trpc.mdx
+++ b/docs/src/content/docs/it/guides/trpc.mdx
@@ -16,6 +16,8 @@ import NxCommands from '@components/nx-commands.astro';
 import Infrastructure from '@components/infrastructure.astro';
 import Snippet from '@components/snippet.astro';
 import OptionFilter from '@components/option-filter.astro';
+import InstallCommand from '@components/install-command.astro';
+import { TS_VERSIONS } from '../../../../../../packages/nx-plugin/src/utils/versions';
 
 [tRPC](https://trpc.io/) è un framework per la creazione di API in TypeScript con type safety end-to-end. Utilizzando tRPC, gli aggiornamenti agli input e output delle operazioni API si riflettono immediatamente nel codice client e sono visibili nel tuo IDE senza la necessità di ricostruire il progetto.
 
@@ -49,15 +51,18 @@ Il generatore creerà la seguente struttura di progetto nella directory `<direct
 
 <FileTree>
   - src
+    - index.ts Package entrypoint re-exporting the router, context, client and schema
     - init.ts Backend tRPC initialisation
     - handler.ts Lambda handler entrypoint
     - router.ts tRPC router definition
     - schema Schema definitions using Zod
+      - index.ts Barrel re-exporting every schema
       - echo.ts Example definitions for the input and output of the "echo" procedure
       - z-async-iterable.ts Zod helper for subscriptions (REST API only)
     - procedures Procedures (or operations) exposed by your API
       - echo.ts Example procedure
     - middleware
+      - index.ts Barrel re-exporting the middleware, and the procedure context type
       - error.ts Middleware for error handling
       - logger.ts middleware for configuring AWS Powertools for Lambda logging
       - tracer.ts middleware for configuring AWS Powertools for Lambda tracing
@@ -65,9 +70,15 @@ Il generatore creerà la seguente struttura di progetto nella directory `<direct
     - local-server.ts tRPC standalone adapter entrypoint for local development server
     - client
       - index.ts Type-safe client for machine-to-machine API calls
+  - rolldown.config.ts Bundle configuration for the Lambda deployment package
   - tsconfig.json TypeScript configuration
+  - tsconfig.lib.json TypeScript configuration for the library sources
+  - tsconfig.spec.json TypeScript configuration for the tests
+  - vitest.config.mts Vitest configuration
   - package.json Project manifest defining the project's package name and dependencies
   - project.json Project configuration and build targets
+  - README.md Project readme
+  - .gitignore Ignores the project's build output
 
 </FileTree>
 
@@ -297,6 +308,10 @@ Come esempio, implementiamo un middleware per estrarre alcuni dettagli sull'uten
 <OptionFilter when={{ auth: 'iam' }} description="Identity middleware example for IAM-authenticated APIs">
 Questo esempio illustra il middleware di identità per l'autenticazione `IAM`. Cerchiamo il chiamante in Cognito utilizzando il sub estratto dall'evento API Gateway.
 
+La ricerca utilizza il client Cognito Identity Provider, che non è una dipendenza di un'API tRPC generata. Installalo prima nel tuo progetto API:
+
+<InstallCommand pkg={`@aws-sdk/client-cognito-identity-provider@${TS_VERSIONS['@aws-sdk/client-cognito-identity-provider']}`} project="@my-scope/my-api" />
+
 Prima, definiamo cosa aggiungeremo al contesto:
 
 ```ts
@@ -334,8 +349,8 @@ Nel nostro caso, vogliamo estrarre dettagli sull'utente Cognito chiamante. Lo fa
 ```ts
 import { CognitoIdentityProvider } from '@aws-sdk/client-cognito-identity-provider';
 import { initTRPC, TRPCError } from '@trpc/server';
-import { CreateAWSLambdaContextOptions } from '@trpc/server/adapters/aws-lambda';
-import { APIGatewayProxyEvent } from 'aws-lambda';
+import type { CreateAWSLambdaContextOptions } from '@trpc/server/adapters/aws-lambda';
+import type { APIGatewayProxyEvent } from 'aws-lambda';
 
 export interface IIdentityContext {
   identity?: {
@@ -345,12 +360,17 @@ export interface IIdentityContext {
 }
 
 export const createIdentityPlugin = () => {
-  const t = initTRPC.context<IIdentityContext & CreateAWSLambdaContextOptions<APIGatewayProxyEvent>>().create();
+  const t = initTRPC
+    .context<
+      IIdentityContext & CreateAWSLambdaContextOptions<APIGatewayProxyEvent>
+    >()
+    .create();
 
   const cognito = new CognitoIdentityProvider();
 
   return t.procedure.use(async (opts) => {
-    const cognitoAuthenticationProvider = opts.ctx.event.requestContext?.identity?.cognitoAuthenticationProvider;
+    const cognitoAuthenticationProvider =
+      opts.ctx.event.requestContext?.identity?.cognitoAuthenticationProvider;
 
     let sub: string | undefined = undefined;
     if (cognitoAuthenticationProvider) {
@@ -397,8 +417,8 @@ export const createIdentityPlugin = () => {
 ```ts
 import { CognitoIdentityProvider } from '@aws-sdk/client-cognito-identity-provider';
 import { initTRPC, TRPCError } from '@trpc/server';
-import { CreateAWSLambdaContextOptions } from '@trpc/server/adapters/aws-lambda';
-import { APIGatewayProxyEventV2WithIAMAuthorizer } from 'aws-lambda';
+import type { CreateAWSLambdaContextOptions } from '@trpc/server/adapters/aws-lambda';
+import type { APIGatewayProxyEventV2WithIAMAuthorizer } from 'aws-lambda';
 
 export interface IIdentityContext {
   identity?: {
@@ -408,7 +428,12 @@ export interface IIdentityContext {
 }
 
 export const createIdentityPlugin = () => {
-  const t = initTRPC.context<IIdentityContext & CreateAWSLambdaContextOptions<APIGatewayProxyEventV2WithIAMAuthorizer>>().create();
+  const t = initTRPC
+    .context<
+      IIdentityContext &
+        CreateAWSLambdaContextOptions<APIGatewayProxyEventV2WithIAMAuthorizer>
+    >()
+    .create();
 
   const cognito = new CognitoIdentityProvider();
 
@@ -481,12 +506,16 @@ export interface IIdentityContext {
 
 Nota che definiamo una proprietà aggiuntiva _opzionale_ sul contesto. tRPC gestisce l'assicurazione che questa sia definita nelle procedure che hanno configurato correttamente questo middleware.
 
-Successivamente, il middleware stesso:
+Successivamente, il middleware stesso. Il tipo di evento e la posizione dei claim differiscono tra una REST API e un'HTTP API, quindi l'implementazione dipende dal tuo `infra` selezionato:
+
+<Tabs syncKey="http-rest">
+<TabItem label="REST API" _filter={{ infra: 'rest-lambda' }}>
+L'autorizzatore Cognito User Pools di una REST API posiziona i claim in `event.requestContext.authorizer.claims`:
 
 ```ts
 import { initTRPC, TRPCError } from '@trpc/server';
-import { CreateAWSLambdaContextOptions } from '@trpc/server/adapters/aws-lambda';
-import { APIGatewayProxyEvent } from 'aws-lambda';
+import type { CreateAWSLambdaContextOptions } from '@trpc/server/adapters/aws-lambda';
+import type { APIGatewayProxyEvent } from 'aws-lambda';
 
 export interface IIdentityContext {
   identity?: {
@@ -497,7 +526,9 @@ export interface IIdentityContext {
 
 export const createIdentityPlugin = () => {
   const t = initTRPC
-    .context<IIdentityContext & CreateAWSLambdaContextOptions<APIGatewayProxyEvent>>()
+    .context<
+      IIdentityContext & CreateAWSLambdaContextOptions<APIGatewayProxyEvent>
+    >()
     .create();
 
   return t.procedure.use(async (opts) => {
@@ -506,7 +537,7 @@ export const createIdentityPlugin = () => {
       | undefined;
 
     const sub = claims?.sub;
-    const username = claims?.username;
+    const username = claims?.username ?? claims?.['cognito:username'];
 
     if (!sub || !username) {
       throw new TRPCError({
@@ -527,6 +558,59 @@ export const createIdentityPlugin = () => {
   });
 };
 ```
+</TabItem>
+<TabItem label="HTTP API" _filter={{ infra: 'http-lambda' }}>
+L'autorizzatore JWT di un'HTTP API fornisce un evento payload-v2 i cui claim si trovano un livello più in profondità, in `event.requestContext.authorizer.jwt.claims`. Il contesto deve essere tipizzato su `APIGatewayProxyEventV2WithJWTAuthorizer` per corrispondere a quello utilizzato dal `publicProcedure` generato — altrimenti `.concat()` fallisce con l'errore `Context mismatch` di tRPC:
+
+```ts
+import { initTRPC, TRPCError } from '@trpc/server';
+import type { CreateAWSLambdaContextOptions } from '@trpc/server/adapters/aws-lambda';
+import type { APIGatewayProxyEventV2WithJWTAuthorizer } from 'aws-lambda';
+
+export interface IIdentityContext {
+  identity?: {
+    sub: string;
+    username: string;
+  };
+}
+
+export const createIdentityPlugin = () => {
+  const t = initTRPC
+    .context<
+      IIdentityContext &
+        CreateAWSLambdaContextOptions<APIGatewayProxyEventV2WithJWTAuthorizer>
+    >()
+    .create();
+
+  return t.procedure.use(async (opts) => {
+    const claims = opts.ctx.event.requestContext?.authorizer?.jwt?.claims as
+      | Record<string, string>
+      | undefined;
+
+    const sub = claims?.sub;
+    const username = claims?.username ?? claims?.['cognito:username'];
+
+    if (!sub || !username) {
+      throw new TRPCError({
+        code: 'FORBIDDEN',
+        message: 'Unable to determine calling user',
+      });
+    }
+
+    return await opts.next({
+      ctx: {
+        ...opts.ctx,
+        identity: {
+          sub,
+          username,
+        },
+      },
+    });
+  });
+};
+```
+</TabItem>
+</Tabs>
 
 Puoi quindi mescolare il plugin in qualsiasi procedura che necessita dell'identità del chiamante:
 
@@ -595,7 +679,7 @@ export class ExampleStack extends Stack {
 }
 ```
 
-Il costrutto `UserIdentity` può essere generato utilizzando il <Link path="/guides/react-website-auth">generatore `ts#website#auth`</Link>.
+Il costrutto `UserIdentity` può essere generato utilizzando il <Link path="/it/guides/react-website-auth">generatore `ts#website#auth`</Link>.
 </OptionFilter>
 
 Questo configura l'infrastruttura della tua API, inclusa un'API AWS API Gateway REST o HTTP, funzioni AWS Lambda per la logica di business e autenticazione basata sul tuo metodo `auth` scelto.
@@ -605,7 +689,7 @@ Questo configura l'infrastruttura della tua API, inclusa un'API AWS API Gateway 
 <Fragment slot="terraform">
 I moduli Terraform per il deploy della tua API sono in the `common/terraform` folder. Puoi usare questo in una configurazione Terraform.
 
-Il modulo API prepara il suo zip di deployment Lambda in un bucket S3 di asset condiviso — vedi la <Link path="/guides/terraform-project">guida all'infrastruttura Terraform</Link> per i dettagli. Istanzia il modulo `core/asset-bucket` una volta per deployment e passa il suo output `bucket_name` in ogni modulo API / Lambda tramite l'input `asset_bucket_name`:
+Il modulo API prepara il suo zip di deployment Lambda in un bucket S3 di asset condiviso — vedi la <Link path="/it/guides/terraform-project">guida all'infrastruttura Terraform</Link> per i dettagli. Istanzia il modulo `core/asset-bucket` una volta per deployment e passa il suo output `bucket_name` in ogni modulo API / Lambda tramite l'input `asset_bucket_name`:
 
 <OptionFilter when={{ auth: ['iam', 'custom'] }} description="Terraform usage for IAM or Custom authentication">
 ```hcl {1-3, 8}

--- a/docs/src/content/docs/it/guides/ts-smithy-api.mdx
+++ b/docs/src/content/docs/it/guides/ts-smithy-api.mdx
@@ -18,6 +18,8 @@ import PackageManagerShortCommand from '@components/package-manager-short-comman
 import Infrastructure from '@components/infrastructure.astro';
 import Snippet from '@components/snippet.astro';
 import OptionFilter from '@components/option-filter.astro';
+import InstallCommand from '@components/install-command.astro';
+import { TS_VERSIONS } from '../../../../../../packages/nx-plugin/src/utils/versions';
 
 [Smithy](https://smithy.io/) è un linguaggio di definizione di interfacce indipendente dal protocollo per la creazione di API in modo model-driven.
 
@@ -46,7 +48,6 @@ Il generatore crea due progetti correlati nella directory `<directory>/<api-name
 <FileTree>
 
 - **model/** Progetto del modello Smithy
-  - package.json Manifest del progetto che definisce il nome del pacchetto e le dipendenze
   - project.json Configurazione del progetto e target di build
   - smithy-build.json Configurazione di build Smithy
   - ssdk.rolldown.config.mjs Raggruppa il TypeScript Server SDK generato
@@ -55,9 +56,15 @@ Il generatore crea due progetti correlati nella directory `<directory>/<api-name
     - operations/
       - echo.smithy Definizione di operazione di esempio
 - **backend/** Implementazione backend TypeScript
+  - package.json Manifest del progetto che definisce il nome del pacchetto e le dipendenze
   - project.json Configurazione del progetto e target di build
   - rolldown.config.ts Configurazione del bundle
+  - tsconfig.json Configurazione TypeScript
+  - tsconfig.lib.json Configurazione TypeScript per i sorgenti della libreria
+  - tsconfig.spec.json Configurazione TypeScript per i test
+  - vitest.config.mts Configurazione Vitest
   - src/
+    - index.ts Punto di ingresso del pacchetto
     - handler.ts Handler AWS Lambda
     - local-server.ts Server di sviluppo locale
     - service.ts Implementazione del servizio
@@ -91,7 +98,7 @@ Il progetto comune di infrastruttura come codice è strutturato come segue:
 </FileTree>
 
 :::note[Progetto Generato]
-Questo progetto è generato utilizzando il generatore [`ts#project`](guides/typescript-project) e quindi configura gli stessi target di build.
+Questo progetto è generato utilizzando il generatore <Link path="/it/guides/typescript-project">`ts#project`</Link> e quindi configura gli stessi target di build.
 :::
 </Fragment>
 <Fragment slot="terraform">
@@ -110,7 +117,7 @@ Questo progetto è generato utilizzando il generatore [`ts#project`](guides/type
 </FileTree>
 
 :::note[Progetto Generato]
-Questo progetto è generato utilizzando il generatore [`terraform#project`](guides/terraform-project) e quindi configura gli stessi target di build.
+Questo progetto è generato utilizzando il generatore <Link path="/it/guides/terraform-project">`terraform#project`</Link> e quindi configura gli stessi target di build.
 :::
 </Fragment>
 </Infrastructure>
@@ -475,7 +482,9 @@ export interface ServiceContext {
 Successivamente, scrivi il resolver in `src/identity.ts`. Lancia `UnauthorizedError` quando il chiamante non può essere determinato. L'implementazione dipende dal tuo metodo `auth` selezionato:
 
 <OptionFilter when={{ auth: 'iam' }} description="Identity resolution for IAM-authenticated APIs">
-Per l'autenticazione `IAM`, cerchiamo il chiamante in Cognito utilizzando il sub estratto dall'evento API Gateway:
+Per l'autenticazione `IAM`, cerchiamo il chiamante in Cognito utilizzando il sub estratto dall'evento API Gateway. La ricerca utilizza il client Cognito Identity Provider, che non è una dipendenza di un backend Smithy generato, quindi installalo prima nel progetto backend:
+
+<InstallCommand pkg={`@aws-sdk/client-cognito-identity-provider@${TS_VERSIONS['@aws-sdk/client-cognito-identity-provider']}`} project="@my-scope/my-api" projectDir="packages/my-api/backend" />
 
 ```ts
 import { CognitoIdentityProvider } from '@aws-sdk/client-cognito-identity-provider';
@@ -498,7 +507,9 @@ export const getIdentity = async (
   }
 
   if (!sub) {
-    throw new UnauthorizedError({ message: 'Unable to determine calling user' });
+    throw new UnauthorizedError({
+      message: 'Unable to determine calling user',
+    });
   }
 
   const { Users } = await cognito.listUsers({
@@ -509,7 +520,9 @@ export const getIdentity = async (
   });
 
   if (!Users || Users.length !== 1) {
-    throw new UnauthorizedError({ message: `No user found with subjectId ${sub}` });
+    throw new UnauthorizedError({
+      message: `No user found with subjectId ${sub}`,
+    });
   }
 
   return { sub, username: Users[0].Username! };
@@ -536,7 +549,9 @@ export const getIdentity = async (
   const username = claims?.username;
 
   if (!sub || !username) {
-    throw new UnauthorizedError({ message: 'Unable to determine calling user' });
+    throw new UnauthorizedError({
+      message: 'Unable to determine calling user',
+    });
   }
 
   return { sub, username };
@@ -559,6 +574,17 @@ const httpResponse = await serviceHandler.handle(httpRequest, {
   logger,
   metrics,
   getIdentity: () => getIdentity(event),
+});
+```
+
+`getIdentity` è un campo obbligatorio su `ServiceContext`, e come nota la [cautela sopra](#contesto-del-servizio) il contesto è costruito in **entrambi** i punti di ingresso — quindi anche `src/local-server.ts` ne ha bisogno. Non c'è alcun authorizer API Gateway davanti al server locale, quindi fornisci un'identità stub per lo sviluppo locale:
+
+```ts {5} ins={5}
+const httpResponse = await serviceHandler.handle(httpRequest, {
+  tracer,
+  logger,
+  metrics,
+  getIdentity: async () => ({ sub: 'local', username: 'local' }),
 });
 ```
 
@@ -800,6 +826,49 @@ output "lambda_function_name" {
 <Snippet name="api/access-logging" parentHeading="Logging degli accessi" />
 
 ### Integrazioni
+
+<Infrastructure>
+<Fragment slot="cdk">
+:::caution[I nomi delle operazioni sono camelCase in CDK]
+Le operazioni Smithy sono dichiarate in PascalCase (`Echo`), e il tuo backend le esporta con quel nome. Le chiavi di integrazione CDK sono nella forma **camelCase** dello stesso nome, quindi un'operazione `Echo` è `echo` ovunque nel tuo stack:
+
+```ts
+const api = new MyApi(this, 'MyApi', {
+  integrations: MyApi.defaultIntegrations(this)
+    // `Echo` in the model, `echo` here
+    .withOperationOptions({ echo: { timeout: Duration.seconds(60) } })
+    .build(),
+});
+
+api.integrations.echo.handler.addToRolePolicy(...);
+```
+:::
+</Fragment>
+<Fragment slot="terraform">
+:::note[I nomi delle operazioni sono camelCase in Terraform]
+Gli output con chiave operazione del modulo generato e il suo `operations.json` usano la forma **camelCase** del nome dell'operazione Smithy, quindi un'operazione Smithy `Echo` ha chiave `echo`:
+
+```hcl
+# `Echo` in the model, `echo` here
+resource "aws_iam_role_policy" "echo_permissions" {
+  name = "echo-additional-permissions"
+  role = module.my_api.lambda_execution_role_names["echo"]
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["s3:GetObject"]
+        Resource = "arn:aws:s3:::my-bucket/*"
+      }
+    ]
+  })
+}
+```
+:::
+</Fragment>
+</Infrastructure>
 
 <Snippet name="api/type-safe-api-integrations" parentHeading="Integrazioni" />
 

--- a/docs/src/content/docs/it/snippets/api/type-safe-api-integrations.mdx
+++ b/docs/src/content/docs/it/snippets/api/type-safe-api-integrations.mdx
@@ -66,6 +66,8 @@ const api = new MyApi(this, 'MyApi', {
 
 api.integrations.$router.handler.addEnvironment('LOG_LEVEL', 'DEBUG');
 ```
+
+Nota che `$router` non è più disponibile se sovrascrivi ogni operazione tramite `withOverrides`, poiché nessuna operazione rimane ad utilizzare l'integrazione router predefinita.
 </Fragment>
 <Fragment slot="terraform">
 Con il pattern `isolated`, gli output del modulo sono mappe indicizzate per nome di operazione, quindi puoi raggiungere le risorse di una singola operazione. Ad esempio, per concedere autorizzazioni extra alla funzione Lambda di un'operazione:

--- a/docs/src/content/docs/jp/guides/trpc.mdx
+++ b/docs/src/content/docs/jp/guides/trpc.mdx
@@ -16,6 +16,8 @@ import NxCommands from '@components/nx-commands.astro';
 import Infrastructure from '@components/infrastructure.astro';
 import Snippet from '@components/snippet.astro';
 import OptionFilter from '@components/option-filter.astro';
+import InstallCommand from '@components/install-command.astro';
+import { TS_VERSIONS } from '../../../../../../packages/nx-plugin/src/utils/versions';
 
 [tRPC](https://trpc.io/)は、TypeScriptでエンドツーエンドの型安全性を備えたAPIを構築するためのフレームワークです。tRPCを使用すると、API操作の入力と出力の更新がクライアントコードに即座に反映され、プロジェクトを再ビルドする必要なくIDEで確認できます。
 
@@ -49,15 +51,18 @@ tRPC APIジェネレーターは、AWS CDKまたはTerraformインフラスト�
 
 <FileTree>
   - src
+    - index.ts Package entrypoint re-exporting the router, context, client and schema
     - init.ts Backend tRPC initialisation
     - handler.ts Lambda handler entrypoint
     - router.ts tRPC router definition
     - schema Schema definitions using Zod
+      - index.ts Barrel re-exporting every schema
       - echo.ts Example definitions for the input and output of the "echo" procedure
       - z-async-iterable.ts Zod helper for subscriptions (REST API only)
     - procedures Procedures (or operations) exposed by your API
       - echo.ts Example procedure
     - middleware
+      - index.ts Barrel re-exporting the middleware, and the procedure context type
       - error.ts Middleware for error handling
       - logger.ts middleware for configuring AWS Powertools for Lambda logging
       - tracer.ts middleware for configuring AWS Powertools for Lambda tracing
@@ -65,9 +70,15 @@ tRPC APIジェネレーターは、AWS CDKまたはTerraformインフラスト�
     - local-server.ts tRPC standalone adapter entrypoint for local development server
     - client
       - index.ts Type-safe client for machine-to-machine API calls
+  - rolldown.config.ts Bundle configuration for the Lambda deployment package
   - tsconfig.json TypeScript configuration
+  - tsconfig.lib.json TypeScript configuration for the library sources
+  - tsconfig.spec.json TypeScript configuration for the tests
+  - vitest.config.mts Vitest configuration
   - package.json Project manifest defining the project's package name and dependencies
   - project.json Project configuration and build targets
+  - README.md Project readme
+  - .gitignore Ignores the project's build output
 
 </FileTree>
 
@@ -297,6 +308,10 @@ export const echo = publicProcedure
 <OptionFilter when={{ auth: 'iam' }} description="Identity middleware example for IAM-authenticated APIs">
 この例では、`IAM`認証のIDミドルウェアについて説明します。API Gatewayイベントから抽出されたsubを使用して、Cognitoで呼び出し元を検索します。
 
+検索にはCognito Identity Providerクライアントを使用しますが、これは生成されたtRPC APIの依存関係ではありません。まず、APIプロジェクトにインストールしてください：
+
+<InstallCommand pkg={`@aws-sdk/client-cognito-identity-provider@${TS_VERSIONS['@aws-sdk/client-cognito-identity-provider']}`} project="@my-scope/my-api" />
+
 まず、コンテキストに追加する内容を定義します：
 
 ```ts
@@ -334,8 +349,8 @@ export const createIdentityPlugin = () => {
 ```ts
 import { CognitoIdentityProvider } from '@aws-sdk/client-cognito-identity-provider';
 import { initTRPC, TRPCError } from '@trpc/server';
-import { CreateAWSLambdaContextOptions } from '@trpc/server/adapters/aws-lambda';
-import { APIGatewayProxyEvent } from 'aws-lambda';
+import type { CreateAWSLambdaContextOptions } from '@trpc/server/adapters/aws-lambda';
+import type { APIGatewayProxyEvent } from 'aws-lambda';
 
 export interface IIdentityContext {
   identity?: {
@@ -345,12 +360,17 @@ export interface IIdentityContext {
 }
 
 export const createIdentityPlugin = () => {
-  const t = initTRPC.context<IIdentityContext & CreateAWSLambdaContextOptions<APIGatewayProxyEvent>>().create();
+  const t = initTRPC
+    .context<
+      IIdentityContext & CreateAWSLambdaContextOptions<APIGatewayProxyEvent>
+    >()
+    .create();
 
   const cognito = new CognitoIdentityProvider();
 
   return t.procedure.use(async (opts) => {
-    const cognitoAuthenticationProvider = opts.ctx.event.requestContext?.identity?.cognitoAuthenticationProvider;
+    const cognitoAuthenticationProvider =
+      opts.ctx.event.requestContext?.identity?.cognitoAuthenticationProvider;
 
     let sub: string | undefined = undefined;
     if (cognitoAuthenticationProvider) {
@@ -397,8 +417,8 @@ export const createIdentityPlugin = () => {
 ```ts
 import { CognitoIdentityProvider } from '@aws-sdk/client-cognito-identity-provider';
 import { initTRPC, TRPCError } from '@trpc/server';
-import { CreateAWSLambdaContextOptions } from '@trpc/server/adapters/aws-lambda';
-import { APIGatewayProxyEventV2WithIAMAuthorizer } from 'aws-lambda';
+import type { CreateAWSLambdaContextOptions } from '@trpc/server/adapters/aws-lambda';
+import type { APIGatewayProxyEventV2WithIAMAuthorizer } from 'aws-lambda';
 
 export interface IIdentityContext {
   identity?: {
@@ -408,7 +428,12 @@ export interface IIdentityContext {
 }
 
 export const createIdentityPlugin = () => {
-  const t = initTRPC.context<IIdentityContext & CreateAWSLambdaContextOptions<APIGatewayProxyEventV2WithIAMAuthorizer>>().create();
+  const t = initTRPC
+    .context<
+      IIdentityContext &
+        CreateAWSLambdaContextOptions<APIGatewayProxyEventV2WithIAMAuthorizer>
+    >()
+    .create();
 
   const cognito = new CognitoIdentityProvider();
 
@@ -481,12 +506,16 @@ export interface IIdentityContext {
 
 コンテキストに追加の_オプション_プロパティを定義することに注意してください。tRPCは、このミドルウェアを正しく構成したプロシージャでこれが定義されていることを保証します。
 
-次に、ミドルウェア自体：
+次に、ミドルウェア自体です。イベントタイプとクレームの場所はREST APIとHTTP APIで異なるため、実装は選択した`infra`によって異なります：
+
+<Tabs syncKey="http-rest">
+<TabItem label="REST API" _filter={{ infra: 'rest-lambda' }}>
+REST APIのCognito User Poolsオーソライザーは、クレームを`event.requestContext.authorizer.claims`に配置します：
 
 ```ts
 import { initTRPC, TRPCError } from '@trpc/server';
-import { CreateAWSLambdaContextOptions } from '@trpc/server/adapters/aws-lambda';
-import { APIGatewayProxyEvent } from 'aws-lambda';
+import type { CreateAWSLambdaContextOptions } from '@trpc/server/adapters/aws-lambda';
+import type { APIGatewayProxyEvent } from 'aws-lambda';
 
 export interface IIdentityContext {
   identity?: {
@@ -497,7 +526,9 @@ export interface IIdentityContext {
 
 export const createIdentityPlugin = () => {
   const t = initTRPC
-    .context<IIdentityContext & CreateAWSLambdaContextOptions<APIGatewayProxyEvent>>()
+    .context<
+      IIdentityContext & CreateAWSLambdaContextOptions<APIGatewayProxyEvent>
+    >()
     .create();
 
   return t.procedure.use(async (opts) => {
@@ -506,7 +537,7 @@ export const createIdentityPlugin = () => {
       | undefined;
 
     const sub = claims?.sub;
-    const username = claims?.username;
+    const username = claims?.username ?? claims?.['cognito:username'];
 
     if (!sub || !username) {
       throw new TRPCError({
@@ -527,6 +558,59 @@ export const createIdentityPlugin = () => {
   });
 };
 ```
+</TabItem>
+<TabItem label="HTTP API" _filter={{ infra: 'http-lambda' }}>
+HTTP APIのJWTオーソライザーは、クレームが1レベル深い`event.requestContext.authorizer.jwt.claims`にあるpayload-v2イベントを配信します。コンテキストは、生成された`publicProcedure`が使用するものと一致するように`APIGatewayProxyEventV2WithJWTAuthorizer`で型付けする必要があります。そうしないと、`.concat()`がtRPCの`Context mismatch`エラーで失敗します：
+
+```ts
+import { initTRPC, TRPCError } from '@trpc/server';
+import type { CreateAWSLambdaContextOptions } from '@trpc/server/adapters/aws-lambda';
+import type { APIGatewayProxyEventV2WithJWTAuthorizer } from 'aws-lambda';
+
+export interface IIdentityContext {
+  identity?: {
+    sub: string;
+    username: string;
+  };
+}
+
+export const createIdentityPlugin = () => {
+  const t = initTRPC
+    .context<
+      IIdentityContext &
+        CreateAWSLambdaContextOptions<APIGatewayProxyEventV2WithJWTAuthorizer>
+    >()
+    .create();
+
+  return t.procedure.use(async (opts) => {
+    const claims = opts.ctx.event.requestContext?.authorizer?.jwt?.claims as
+      | Record<string, string>
+      | undefined;
+
+    const sub = claims?.sub;
+    const username = claims?.username ?? claims?.['cognito:username'];
+
+    if (!sub || !username) {
+      throw new TRPCError({
+        code: 'FORBIDDEN',
+        message: 'Unable to determine calling user',
+      });
+    }
+
+    return await opts.next({
+      ctx: {
+        ...opts.ctx,
+        identity: {
+          sub,
+          username,
+        },
+      },
+    });
+  });
+};
+```
+</TabItem>
+</Tabs>
 
 その後、呼び出し元のIDが必要なプロシージャにプラグインをミックスできます：
 

--- a/docs/src/content/docs/jp/guides/ts-smithy-api.mdx
+++ b/docs/src/content/docs/jp/guides/ts-smithy-api.mdx
@@ -18,6 +18,8 @@ import PackageManagerShortCommand from '@components/package-manager-short-comman
 import Infrastructure from '@components/infrastructure.astro';
 import Snippet from '@components/snippet.astro';
 import OptionFilter from '@components/option-filter.astro';
+import InstallCommand from '@components/install-command.astro';
+import { TS_VERSIONS } from '../../../../../../packages/nx-plugin/src/utils/versions';
 
 [Smithy](https://smithy.io/) は、モデル駆動型の方法で API を作成するためのプロトコルに依存しないインターフェース定義言語です。
 
@@ -46,7 +48,6 @@ Smithy TypeScript API ジェネレーターは、サービス定義に Smithy �
 <FileTree>
 
 - **model/** Smithy モデルプロジェクト
-  - package.json プロジェクトのパッケージ名と依存関係を定義するプロジェクトマニフェスト
   - project.json プロジェクト設定とビルドターゲット
   - smithy-build.json Smithy ビルド設定
   - ssdk.rolldown.config.mjs 生成された TypeScript Server SDK をバンドル
@@ -55,9 +56,15 @@ Smithy TypeScript API ジェネレーターは、サービス定義に Smithy �
     - operations/
       - echo.smithy サンプルオペレーション定義
 - **backend/** TypeScript バックエンド実装
+  - package.json プロジェクトのパッケージ名と依存関係を定義するプロジェクトマニフェスト
   - project.json プロジェクト設定とビルドターゲット
   - rolldown.config.ts バンドル設定
+  - tsconfig.json TypeScript 設定
+  - tsconfig.lib.json ライブラリソース用の TypeScript 設定
+  - tsconfig.spec.json テスト用の TypeScript 設定
+  - vitest.config.mts Vitest 設定
   - src/
+    - index.ts パッケージエントリーポイント
     - handler.ts AWS Lambda ハンドラー
     - local-server.ts ローカル開発サーバー
     - service.ts サービス実装
@@ -91,7 +98,7 @@ Smithy TypeScript API ジェネレーターは、サービス定義に Smithy �
 </FileTree>
 
 :::note[生成されたプロジェクト]
-このプロジェクトは[`ts#project`](guides/typescript-project)ジェネレータで生成されるため、同じビルドターゲットを設定します。
+このプロジェクトは <Link path="/guides/typescript-project">`ts#project`</Link> ジェネレーターで生成されるため、同じビルドターゲットを設定します。
 :::
 </Fragment>
 <Fragment slot="terraform">
@@ -110,7 +117,7 @@ Smithy TypeScript API ジェネレーターは、サービス定義に Smithy �
 </FileTree>
 
 :::note[生成されたプロジェクト]
-このプロジェクトは[`terraform#project`](guides/terraform-project)ジェネレータで生成されるため、同じビルドターゲットを設定します。
+このプロジェクトは <Link path="/guides/terraform-project">`terraform#project`</Link> ジェネレーターで生成されるため、同じビルドターゲットを設定します。
 :::
 </Fragment>
 </Infrastructure>
@@ -475,7 +482,9 @@ export interface ServiceContext {
 次に、`src/identity.ts` にリゾルバーを記述します。呼び出し元を判別できない場合は `UnauthorizedError` をスローします。実装は選択した `auth` メソッドによって異なります：
 
 <OptionFilter when={{ auth: 'iam' }} description="IAM 認証 API の ID 解決">
-`IAM` 認証の場合、API Gateway イベントから抽出された sub を使用して Cognito で呼び出し元を検索します：
+`IAM` 認証の場合、API Gateway イベントから抽出された sub を使用して Cognito で呼び出し元を検索します。検索には Cognito Identity Provider クライアントを使用しますが、これは生成された Smithy バックエンドの依存関係ではないため、最初にバックエンドプロジェクトにインストールします：
+
+<InstallCommand pkg={`@aws-sdk/client-cognito-identity-provider@${TS_VERSIONS['@aws-sdk/client-cognito-identity-provider']}`} project="@my-scope/my-api" projectDir="packages/my-api/backend" />
 
 ```ts
 import { CognitoIdentityProvider } from '@aws-sdk/client-cognito-identity-provider';
@@ -498,7 +507,9 @@ export const getIdentity = async (
   }
 
   if (!sub) {
-    throw new UnauthorizedError({ message: 'Unable to determine calling user' });
+    throw new UnauthorizedError({
+      message: 'Unable to determine calling user',
+    });
   }
 
   const { Users } = await cognito.listUsers({
@@ -509,7 +520,9 @@ export const getIdentity = async (
   });
 
   if (!Users || Users.length !== 1) {
-    throw new UnauthorizedError({ message: `No user found with subjectId ${sub}` });
+    throw new UnauthorizedError({
+      message: `No user found with subjectId ${sub}`,
+    });
   }
 
   return { sub, username: Users[0].Username! };
@@ -536,7 +549,9 @@ export const getIdentity = async (
   const username = claims?.username;
 
   if (!sub || !username) {
-    throw new UnauthorizedError({ message: 'Unable to determine calling user' });
+    throw new UnauthorizedError({
+      message: 'Unable to determine calling user',
+    });
   }
 
   return { sub, username };
@@ -559,6 +574,17 @@ const httpResponse = await serviceHandler.handle(httpRequest, {
   logger,
   metrics,
   getIdentity: () => getIdentity(event),
+});
+```
+
+`getIdentity` は `ServiceContext` の必須フィールドであり、[上記の注意](#サービスコンテキスト)で述べたように、コンテキストは**両方**のエントリーポイントで構築されます — したがって `src/local-server.ts` にも必要です。ローカルサーバーの前には API Gateway オーソライザーがないため、ローカル開発用のスタブ ID を提供します：
+
+```ts {5} ins={5}
+const httpResponse = await serviceHandler.handle(httpRequest, {
+  tracer,
+  logger,
+  metrics,
+  getIdentity: async () => ({ sub: 'local', username: 'local' }),
 });
 ```
 
@@ -800,6 +826,49 @@ output "lambda_function_name" {
 <Snippet name="api/access-logging" parentHeading="アクセスログ" />
 
 ### 統合
+
+<Infrastructure>
+<Fragment slot="cdk">
+:::caution[CDK ではオペレーション名は camelCase]
+Smithy オペレーションは PascalCase（`Echo`）で宣言され、バックエンドはその名前でエクスポートします。CDK 統合キーは同じ名前の **camelCase** 形式であるため、オペレーション `Echo` はスタック内のすべての場所で `echo` になります：
+
+```ts
+const api = new MyApi(this, 'MyApi', {
+  integrations: MyApi.defaultIntegrations(this)
+    // `Echo` in the model, `echo` here
+    .withOperationOptions({ echo: { timeout: Duration.seconds(60) } })
+    .build(),
+});
+
+api.integrations.echo.handler.addToRolePolicy(...);
+```
+:::
+</Fragment>
+<Fragment slot="terraform">
+:::note[Terraform ではオペレーション名は camelCase]
+生成されたモジュールのオペレーションをキーとする出力とその `operations.json` は、Smithy オペレーション名の **camelCase** 形式を使用するため、Smithy オペレーション `Echo` はキー `echo` になります：
+
+```hcl
+# `Echo` in the model, `echo` here
+resource "aws_iam_role_policy" "echo_permissions" {
+  name = "echo-additional-permissions"
+  role = module.my_api.lambda_execution_role_names["echo"]
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["s3:GetObject"]
+        Resource = "arn:aws:s3:::my-bucket/*"
+      }
+    ]
+  })
+}
+```
+:::
+</Fragment>
+</Infrastructure>
 
 <Snippet name="api/type-safe-api-integrations" parentHeading="統合" />
 

--- a/docs/src/content/docs/jp/guides/ts-smithy-api.mdx
+++ b/docs/src/content/docs/jp/guides/ts-smithy-api.mdx
@@ -98,7 +98,7 @@ Smithy TypeScript API ジェネレーターは、サービス定義に Smithy �
 </FileTree>
 
 :::note[生成されたプロジェクト]
-このプロジェクトは <Link path="/guides/typescript-project">`ts#project`</Link> ジェネレーターで生成されるため、同じビルドターゲットを設定します。
+このプロジェクトは <Link path="/jp/guides/typescript-project">`ts#project`</Link> ジェネレーターで生成されるため、同じビルドターゲットを設定します。
 :::
 </Fragment>
 <Fragment slot="terraform">
@@ -117,7 +117,7 @@ Smithy TypeScript API ジェネレーターは、サービス定義に Smithy �
 </FileTree>
 
 :::note[生成されたプロジェクト]
-このプロジェクトは <Link path="/guides/terraform-project">`terraform#project`</Link> ジェネレーターで生成されるため、同じビルドターゲットを設定します。
+このプロジェクトは <Link path="/jp/guides/terraform-project">`terraform#project`</Link> ジェネレーターで生成されるため、同じビルドターゲットを設定します。
 :::
 </Fragment>
 </Infrastructure>

--- a/docs/src/content/docs/jp/snippets/api/type-safe-api-integrations.mdx
+++ b/docs/src/content/docs/jp/snippets/api/type-safe-api-integrations.mdx
@@ -66,6 +66,8 @@ const api = new MyApi(this, 'MyApi', {
 
 api.integrations.$router.handler.addEnvironment('LOG_LEVEL', 'DEBUG');
 ```
+
+`withOverrides` を介してすべてのオペレーションをオーバーライドした場合、デフォルトのルーターインテグレーションを使用するオペレーションが残っていないため、`$router` は使用できなくなることに注意してください。
 </Fragment>
 <Fragment slot="terraform">
 `isolated` パターンでは、モジュールの出力はオペレーション名でキー付けされたマップであるため、単一のオペレーションのリソースにアクセスできます。例えば、1 つのオペレーションの Lambda 関数に追加の権限を付与するには：

--- a/docs/src/content/docs/ko/guides/trpc.mdx
+++ b/docs/src/content/docs/ko/guides/trpc.mdx
@@ -16,6 +16,8 @@ import NxCommands from '@components/nx-commands.astro';
 import Infrastructure from '@components/infrastructure.astro';
 import Snippet from '@components/snippet.astro';
 import OptionFilter from '@components/option-filter.astro';
+import InstallCommand from '@components/install-command.astro';
+import { TS_VERSIONS } from '../../../../../../packages/nx-plugin/src/utils/versions';
 
 [tRPC](https://trpc.io/)는 엔드투엔드 타입 안전성을 갖춘 TypeScript API를 구축하기 위한 프레임워크입니다. tRPC를 사용하면 API 작업 입력 및 출력에 대한 업데이트가 프로젝트를 다시 빌드할 필요 없이 클라이언트 코드에 즉시 반영되고 IDE에서 확인할 수 있습니다.
 
@@ -49,15 +51,18 @@ tRPC API 생성기는 AWS CDK 또는 Terraform 인프라 설정과 함께 새로
 
 <FileTree>
   - src
+    - index.ts Package entrypoint re-exporting the router, context, client and schema
     - init.ts Backend tRPC initialisation
     - handler.ts Lambda handler entrypoint
     - router.ts tRPC router definition
     - schema Schema definitions using Zod
+      - index.ts Barrel re-exporting every schema
       - echo.ts Example definitions for the input and output of the "echo" procedure
       - z-async-iterable.ts Zod helper for subscriptions (REST API only)
     - procedures Procedures (or operations) exposed by your API
       - echo.ts Example procedure
     - middleware
+      - index.ts Barrel re-exporting the middleware, and the procedure context type
       - error.ts Middleware for error handling
       - logger.ts middleware for configuring AWS Powertools for Lambda logging
       - tracer.ts middleware for configuring AWS Powertools for Lambda tracing
@@ -65,9 +70,15 @@ tRPC API 생성기는 AWS CDK 또는 Terraform 인프라 설정과 함께 새로
     - local-server.ts tRPC standalone adapter entrypoint for local development server
     - client
       - index.ts Type-safe client for machine-to-machine API calls
+  - rolldown.config.ts Bundle configuration for the Lambda deployment package
   - tsconfig.json TypeScript configuration
+  - tsconfig.lib.json TypeScript configuration for the library sources
+  - tsconfig.spec.json TypeScript configuration for the tests
+  - vitest.config.mts Vitest configuration
   - package.json Project manifest defining the project's package name and dependencies
   - project.json Project configuration and build targets
+  - README.md Project readme
+  - .gitignore Ignores the project's build output
 
 </FileTree>
 
@@ -297,6 +308,10 @@ export const echo = publicProcedure
 <OptionFilter when={{ auth: 'iam' }} description="Identity middleware example for IAM-authenticated APIs">
 이 예제는 `IAM` 인증을 위한 ID 미들웨어를 안내합니다. API Gateway 이벤트에서 추출한 sub를 사용하여 Cognito에서 호출자를 조회합니다.
 
+조회는 생성된 tRPC API의 종속성이 아닌 Cognito Identity Provider 클라이언트를 사용합니다. 먼저 API 프로젝트에 설치하세요:
+
+<InstallCommand pkg={`@aws-sdk/client-cognito-identity-provider@${TS_VERSIONS['@aws-sdk/client-cognito-identity-provider']}`} project="@my-scope/my-api" />
+
 먼저 컨텍스트에 추가할 내용을 정의합니다:
 
 ```ts
@@ -334,8 +349,8 @@ export const createIdentityPlugin = () => {
 ```ts
 import { CognitoIdentityProvider } from '@aws-sdk/client-cognito-identity-provider';
 import { initTRPC, TRPCError } from '@trpc/server';
-import { CreateAWSLambdaContextOptions } from '@trpc/server/adapters/aws-lambda';
-import { APIGatewayProxyEvent } from 'aws-lambda';
+import type { CreateAWSLambdaContextOptions } from '@trpc/server/adapters/aws-lambda';
+import type { APIGatewayProxyEvent } from 'aws-lambda';
 
 export interface IIdentityContext {
   identity?: {
@@ -345,12 +360,17 @@ export interface IIdentityContext {
 }
 
 export const createIdentityPlugin = () => {
-  const t = initTRPC.context<IIdentityContext & CreateAWSLambdaContextOptions<APIGatewayProxyEvent>>().create();
+  const t = initTRPC
+    .context<
+      IIdentityContext & CreateAWSLambdaContextOptions<APIGatewayProxyEvent>
+    >()
+    .create();
 
   const cognito = new CognitoIdentityProvider();
 
   return t.procedure.use(async (opts) => {
-    const cognitoAuthenticationProvider = opts.ctx.event.requestContext?.identity?.cognitoAuthenticationProvider;
+    const cognitoAuthenticationProvider =
+      opts.ctx.event.requestContext?.identity?.cognitoAuthenticationProvider;
 
     let sub: string | undefined = undefined;
     if (cognitoAuthenticationProvider) {
@@ -397,8 +417,8 @@ export const createIdentityPlugin = () => {
 ```ts
 import { CognitoIdentityProvider } from '@aws-sdk/client-cognito-identity-provider';
 import { initTRPC, TRPCError } from '@trpc/server';
-import { CreateAWSLambdaContextOptions } from '@trpc/server/adapters/aws-lambda';
-import { APIGatewayProxyEventV2WithIAMAuthorizer } from 'aws-lambda';
+import type { CreateAWSLambdaContextOptions } from '@trpc/server/adapters/aws-lambda';
+import type { APIGatewayProxyEventV2WithIAMAuthorizer } from 'aws-lambda';
 
 export interface IIdentityContext {
   identity?: {
@@ -408,7 +428,12 @@ export interface IIdentityContext {
 }
 
 export const createIdentityPlugin = () => {
-  const t = initTRPC.context<IIdentityContext & CreateAWSLambdaContextOptions<APIGatewayProxyEventV2WithIAMAuthorizer>>().create();
+  const t = initTRPC
+    .context<
+      IIdentityContext &
+        CreateAWSLambdaContextOptions<APIGatewayProxyEventV2WithIAMAuthorizer>
+    >()
+    .create();
 
   const cognito = new CognitoIdentityProvider();
 
@@ -481,12 +506,16 @@ export interface IIdentityContext {
 
 컨텍스트에 추가 _선택적_ 속성을 정의합니다. tRPC는 이 미들웨어를 올바르게 구성한 프로시저에서 이것이 정의되도록 관리합니다.
 
-다음으로 미들웨어 자체입니다:
+다음으로 미들웨어 자체입니다. 이벤트 타입과 클레임의 위치는 REST API와 HTTP API 간에 다르므로 구현은 선택한 `infra`에 따라 달라집니다:
+
+<Tabs syncKey="http-rest">
+<TabItem label="REST API" _filter={{ infra: 'rest-lambda' }}>
+REST API의 Cognito User Pools 권한 부여자는 클레임을 `event.requestContext.authorizer.claims`에 배치합니다:
 
 ```ts
 import { initTRPC, TRPCError } from '@trpc/server';
-import { CreateAWSLambdaContextOptions } from '@trpc/server/adapters/aws-lambda';
-import { APIGatewayProxyEvent } from 'aws-lambda';
+import type { CreateAWSLambdaContextOptions } from '@trpc/server/adapters/aws-lambda';
+import type { APIGatewayProxyEvent } from 'aws-lambda';
 
 export interface IIdentityContext {
   identity?: {
@@ -497,7 +526,9 @@ export interface IIdentityContext {
 
 export const createIdentityPlugin = () => {
   const t = initTRPC
-    .context<IIdentityContext & CreateAWSLambdaContextOptions<APIGatewayProxyEvent>>()
+    .context<
+      IIdentityContext & CreateAWSLambdaContextOptions<APIGatewayProxyEvent>
+    >()
     .create();
 
   return t.procedure.use(async (opts) => {
@@ -506,7 +537,7 @@ export const createIdentityPlugin = () => {
       | undefined;
 
     const sub = claims?.sub;
-    const username = claims?.username;
+    const username = claims?.username ?? claims?.['cognito:username'];
 
     if (!sub || !username) {
       throw new TRPCError({
@@ -527,6 +558,59 @@ export const createIdentityPlugin = () => {
   });
 };
 ```
+</TabItem>
+<TabItem label="HTTP API" _filter={{ infra: 'http-lambda' }}>
+HTTP API의 JWT 권한 부여자는 클레임이 한 단계 더 깊은 `event.requestContext.authorizer.jwt.claims`에 있는 payload-v2 이벤트를 전달합니다. 컨텍스트는 생성된 `publicProcedure`가 사용하는 것과 일치하도록 `APIGatewayProxyEventV2WithJWTAuthorizer`로 타입이 지정되어야 합니다 — 그렇지 않으면 `.concat()`이 tRPC의 `Context mismatch` 오류와 함께 실패합니다:
+
+```ts
+import { initTRPC, TRPCError } from '@trpc/server';
+import type { CreateAWSLambdaContextOptions } from '@trpc/server/adapters/aws-lambda';
+import type { APIGatewayProxyEventV2WithJWTAuthorizer } from 'aws-lambda';
+
+export interface IIdentityContext {
+  identity?: {
+    sub: string;
+    username: string;
+  };
+}
+
+export const createIdentityPlugin = () => {
+  const t = initTRPC
+    .context<
+      IIdentityContext &
+        CreateAWSLambdaContextOptions<APIGatewayProxyEventV2WithJWTAuthorizer>
+    >()
+    .create();
+
+  return t.procedure.use(async (opts) => {
+    const claims = opts.ctx.event.requestContext?.authorizer?.jwt?.claims as
+      | Record<string, string>
+      | undefined;
+
+    const sub = claims?.sub;
+    const username = claims?.username ?? claims?.['cognito:username'];
+
+    if (!sub || !username) {
+      throw new TRPCError({
+        code: 'FORBIDDEN',
+        message: 'Unable to determine calling user',
+      });
+    }
+
+    return await opts.next({
+      ctx: {
+        ...opts.ctx,
+        identity: {
+          sub,
+          username,
+        },
+      },
+    });
+  });
+};
+```
+</TabItem>
+</Tabs>
 
 그런 다음 호출자의 ID가 필요한 모든 프로시저에 플러그인을 혼합할 수 있습니다:
 

--- a/docs/src/content/docs/ko/guides/ts-smithy-api.mdx
+++ b/docs/src/content/docs/ko/guides/ts-smithy-api.mdx
@@ -98,7 +98,7 @@ Smithy TypeScript API 생성기는 서비스 정의를 위해 Smithy를 사용�
 </FileTree>
 
 :::note[생성된 프로젝트]
-이 프로젝트는 <Link path="/guides/typescript-project">`ts#project`</Link> 생성기를 사용하여 생성되므로 동일한 빌드 타겟을 구성합니다.
+이 프로젝트는 <Link path="/ko/guides/typescript-project">`ts#project`</Link> 생성기를 사용하여 생성되므로 동일한 빌드 타겟을 구성합니다.
 :::
 </Fragment>
 <Fragment slot="terraform">
@@ -117,7 +117,7 @@ Smithy TypeScript API 생성기는 서비스 정의를 위해 Smithy를 사용�
 </FileTree>
 
 :::note[생성된 프로젝트]
-이 프로젝트는 <Link path="/guides/terraform-project">`terraform#project`</Link> 생성기를 사용하여 생성되므로 동일한 빌드 타겟을 구성합니다.
+이 프로젝트는 <Link path="/ko/guides/terraform-project">`terraform#project`</Link> 생성기를 사용하여 생성되므로 동일한 빌드 타겟을 구성합니다.
 :::
 </Fragment>
 </Infrastructure>
@@ -235,7 +235,7 @@ Smithy 및 구문에 대한 자세한 내용은 [Smithy 사양](https://smithy.i
 
 동일한 데이터 타입을 공유하는 여러 Smithy API가 있는 경우, 각 모델에서 중복하는 대신 shape 라이브러리에서 해당 타입을 한 번 정의할 수 있습니다. shape 라이브러리는 서비스가 없는 Smithy 프로젝트로, 재사용 가능한 shape만 있으며 여러 Smithy 프로젝트가 의존할 수 있습니다.
 
-<Link path="guides/smithy-project">`smithy#project`</Link> 생성기로 하나를 생성하세요:
+<Link path="/ko/guides/smithy-project">`smithy#project`</Link> 생성기로 하나를 생성하세요:
 
 <RunGenerator generator="smithy#project" requiredParameters={{ name: 'my-shapes', type: 'shapes' }} />
 
@@ -254,7 +254,7 @@ structure GetCustomerOutput {
 }
 ```
 
-shape 라이브러리를 생성하고 API 모델의 의존성으로 연결하는 방법은 <Link path="guides/smithy-project">Smithy 프로젝트 가이드</Link>를 참조하세요.
+shape 라이브러리를 생성하고 API 모델의 의존성으로 연결하는 방법은 <Link path="/ko/guides/smithy-project">Smithy 프로젝트 가이드</Link>를 참조하세요.
 
 ### TypeScript에서 작업 구현
 
@@ -946,11 +946,11 @@ resource "aws_iam_role_policy_attachment" "api_invoke_access" {
 
 ## Smithy API 호출
 
-React 웹사이트에서 API를 호출하려면 Smithy 모델에서 타입 안전한 클라이언트 생성을 제공하는 <Link path="guides/connection/react-smithy">`connection`</Link> 생성기를 사용할 수 있습니다.
+React 웹사이트에서 API를 호출하려면 Smithy 모델에서 타입 안전한 클라이언트 생성을 제공하는 <Link path="/ko/guides/connection/react-smithy">`connection`</Link> 생성기를 사용할 수 있습니다.
 
 ## 연결
 
-<Link path="guides/connection">`connection`</Link> 생성기를 사용하여 이 프로젝트를 워크스페이스의 다른 프로젝트와 통합하세요. 다음 연결에는 이 프로젝트가 포함됩니다:
+<Link path="/ko/guides/connection">`connection`</Link> 생성기를 사용하여 이 프로젝트를 워크스페이스의 다른 프로젝트와 통합하세요. 다음 연결에는 이 프로젝트가 포함됩니다:
 
 <CardGrid>
   <ConnectionCard

--- a/docs/src/content/docs/ko/guides/ts-smithy-api.mdx
+++ b/docs/src/content/docs/ko/guides/ts-smithy-api.mdx
@@ -18,6 +18,8 @@ import PackageManagerShortCommand from '@components/package-manager-short-comman
 import Infrastructure from '@components/infrastructure.astro';
 import Snippet from '@components/snippet.astro';
 import OptionFilter from '@components/option-filter.astro';
+import InstallCommand from '@components/install-command.astro';
+import { TS_VERSIONS } from '../../../../../../packages/nx-plugin/src/utils/versions';
 
 [Smithy](https://smithy.io/)는 모델 기반 방식으로 API를 작성하기 위한 프로토콜 독립적 인터페이스 정의 언어입니다.
 
@@ -46,7 +48,6 @@ Smithy TypeScript API 생성기는 서비스 정의를 위해 Smithy를 사용�
 <FileTree>
 
 - **model/** Smithy 모델 프로젝트
-  - package.json 프로젝트의 패키지 이름과 의존성을 정의하는 프로젝트 매니페스트
   - project.json 프로젝트 구성 및 빌드 타겟
   - smithy-build.json Smithy 빌드 구성
   - ssdk.rolldown.config.mjs 생성된 TypeScript Server SDK를 번들링
@@ -55,9 +56,15 @@ Smithy TypeScript API 생성기는 서비스 정의를 위해 Smithy를 사용�
     - operations/
       - echo.smithy 예제 작업 정의
 - **backend/** TypeScript 백엔드 구현
+  - package.json 프로젝트의 패키지 이름과 의존성을 정의하는 프로젝트 매니페스트
   - project.json 프로젝트 구성 및 빌드 타겟
   - rolldown.config.ts 번들 구성
+  - tsconfig.json TypeScript 구성
+  - tsconfig.lib.json TypeScript 구성 (라이브러리 소스용)
+  - tsconfig.spec.json TypeScript 구성 (테스트용)
+  - vitest.config.mts Vitest 구성
   - src/
+    - index.ts 패키지 진입점
     - handler.ts AWS Lambda 핸들러
     - local-server.ts 로컬 개발 서버
     - service.ts 서비스 구현
@@ -91,7 +98,7 @@ Smithy TypeScript API 생성기는 서비스 정의를 위해 Smithy를 사용�
 </FileTree>
 
 :::note[생성된 프로젝트]
-이 프로젝트는 [`ts#project`](guides/typescript-project) 생성기를 사용하여 생성되므로 동일한 빌드 타겟을 구성합니다.
+이 프로젝트는 <Link path="/guides/typescript-project">`ts#project`</Link> 생성기를 사용하여 생성되므로 동일한 빌드 타겟을 구성합니다.
 :::
 </Fragment>
 <Fragment slot="terraform">
@@ -110,7 +117,7 @@ Smithy TypeScript API 생성기는 서비스 정의를 위해 Smithy를 사용�
 </FileTree>
 
 :::note[생성된 프로젝트]
-이 프로젝트는 [`terraform#project`](guides/terraform-project) 생성기를 사용하여 생성되므로 동일한 빌드 타겟을 구성합니다.
+이 프로젝트는 <Link path="/guides/terraform-project">`terraform#project`</Link> 생성기를 사용하여 생성되므로 동일한 빌드 타겟을 구성합니다.
 :::
 </Fragment>
 </Infrastructure>
@@ -475,7 +482,9 @@ export interface ServiceContext {
 다음으로, `src/identity.ts`에 리졸버를 작성합니다. 호출자를 확인할 수 없을 때 `UnauthorizedError`를 던집니다. 구현은 선택한 `auth` 방법에 따라 다릅니다:
 
 <OptionFilter when={{ auth: 'iam' }} description="IAM 인증 API에 대한 신원 확인">
-`IAM` 인증의 경우, API Gateway 이벤트에서 추출한 sub를 사용하여 Cognito에서 호출자를 조회합니다:
+`IAM` 인증의 경우, API Gateway 이벤트에서 추출한 sub를 사용하여 Cognito에서 호출자를 조회합니다. 조회는 Cognito Identity Provider 클라이언트를 사용하는데, 이는 생성된 Smithy 백엔드의 의존성이 아니므로 먼저 백엔드 프로젝트에 설치하세요:
+
+<InstallCommand pkg={`@aws-sdk/client-cognito-identity-provider@${TS_VERSIONS['@aws-sdk/client-cognito-identity-provider']}`} project="@my-scope/my-api" projectDir="packages/my-api/backend" />
 
 ```ts
 import { CognitoIdentityProvider } from '@aws-sdk/client-cognito-identity-provider';
@@ -498,7 +507,9 @@ export const getIdentity = async (
   }
 
   if (!sub) {
-    throw new UnauthorizedError({ message: 'Unable to determine calling user' });
+    throw new UnauthorizedError({
+      message: 'Unable to determine calling user',
+    });
   }
 
   const { Users } = await cognito.listUsers({
@@ -509,7 +520,9 @@ export const getIdentity = async (
   });
 
   if (!Users || Users.length !== 1) {
-    throw new UnauthorizedError({ message: `No user found with subjectId ${sub}` });
+    throw new UnauthorizedError({
+      message: `No user found with subjectId ${sub}`,
+    });
   }
 
   return { sub, username: Users[0].Username! };
@@ -536,7 +549,9 @@ export const getIdentity = async (
   const username = claims?.username;
 
   if (!sub || !username) {
-    throw new UnauthorizedError({ message: 'Unable to determine calling user' });
+    throw new UnauthorizedError({
+      message: 'Unable to determine calling user',
+    });
   }
 
   return { sub, username };
@@ -559,6 +574,17 @@ const httpResponse = await serviceHandler.handle(httpRequest, {
   logger,
   metrics,
   getIdentity: () => getIdentity(event),
+});
+```
+
+`getIdentity`는 `ServiceContext`의 필수 필드이며, [위의 주의사항](#서비스-컨텍스트)에서 언급한 것처럼 컨텍스트는 **두** 진입점 모두에서 구성됩니다 — 따라서 `src/local-server.ts`에도 필요합니다. 로컬 서버 앞에는 API Gateway 권한 부여자가 없으므로 로컬 개발을 위한 스텁 신원을 제공하세요:
+
+```ts {5} ins={5}
+const httpResponse = await serviceHandler.handle(httpRequest, {
+  tracer,
+  logger,
+  metrics,
+  getIdentity: async () => ({ sub: 'local', username: 'local' }),
 });
 ```
 
@@ -800,6 +826,49 @@ output "lambda_function_name" {
 <Snippet name="api/access-logging" parentHeading="액세스 로깅" />
 
 ### 통합
+
+<Infrastructure>
+<Fragment slot="cdk">
+:::caution[CDK에서 작업 이름은 camelCase입니다]
+Smithy 작업은 PascalCase(`Echo`)로 선언되며, 백엔드는 해당 이름으로 내보냅니다. CDK 통합 키는 동일한 이름의 **camelCase** 형식이므로 작업 `Echo`는 스택의 모든 곳에서 `echo`입니다:
+
+```ts
+const api = new MyApi(this, 'MyApi', {
+  integrations: MyApi.defaultIntegrations(this)
+    // `Echo` in the model, `echo` here
+    .withOperationOptions({ echo: { timeout: Duration.seconds(60) } })
+    .build(),
+});
+
+api.integrations.echo.handler.addToRolePolicy(...);
+```
+:::
+</Fragment>
+<Fragment slot="terraform">
+:::note[Terraform에서 작업 이름은 camelCase입니다]
+생성된 모듈의 작업 키 출력과 `operations.json`은 Smithy 작업 이름의 **camelCase** 형식을 사용하므로 Smithy 작업 `Echo`는 `echo`로 키가 지정됩니다:
+
+```hcl
+# `Echo` in the model, `echo` here
+resource "aws_iam_role_policy" "echo_permissions" {
+  name = "echo-additional-permissions"
+  role = module.my_api.lambda_execution_role_names["echo"]
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["s3:GetObject"]
+        Resource = "arn:aws:s3:::my-bucket/*"
+      }
+    ]
+  })
+}
+```
+:::
+</Fragment>
+</Infrastructure>
 
 <Snippet name="api/type-safe-api-integrations" parentHeading="통합" />
 

--- a/docs/src/content/docs/ko/snippets/api/type-safe-api-integrations.mdx
+++ b/docs/src/content/docs/ko/snippets/api/type-safe-api-integrations.mdx
@@ -66,6 +66,8 @@ const api = new MyApi(this, 'MyApi', {
 
 api.integrations.$router.handler.addEnvironment('LOG_LEVEL', 'DEBUG');
 ```
+
+`withOverrides`를 통해 모든 작업을 재정의하면 기본 라우터 통합을 사용하는 작업이 남아 있지 않으므로 `$router`를 더 이상 사용할 수 없습니다.
 </Fragment>
 <Fragment slot="terraform">
 `isolated` 패턴을 사용하면 모듈의 출력은 작업 이름으로 키가 지정된 맵이므로 단일 작업의 리소스에 접근할 수 있습니다. 예를 들어, 하나의 작업의 Lambda 함수에 추가 권한을 부여하려면:

--- a/docs/src/content/docs/pt/guides/trpc.mdx
+++ b/docs/src/content/docs/pt/guides/trpc.mdx
@@ -16,6 +16,8 @@ import NxCommands from '@components/nx-commands.astro';
 import Infrastructure from '@components/infrastructure.astro';
 import Snippet from '@components/snippet.astro';
 import OptionFilter from '@components/option-filter.astro';
+import InstallCommand from '@components/install-command.astro';
+import { TS_VERSIONS } from '../../../../../../packages/nx-plugin/src/utils/versions';
 
 [tRPC](https://trpc.io/) é um framework para construir APIs em TypeScript com segurança de tipo de ponta a ponta. Usando tRPC, atualizações nas entradas e saídas de operações da API são imediatamente refletidas no código do cliente e são visíveis no seu IDE sem a necessidade de reconstruir seu projeto.
 
@@ -49,15 +51,18 @@ O gerador criará a seguinte estrutura de projeto no diretório `<directory>/<ap
 
 <FileTree>
   - src
+    - index.ts Package entrypoint re-exporting the router, context, client and schema
     - init.ts Backend tRPC initialisation
     - handler.ts Lambda handler entrypoint
     - router.ts tRPC router definition
     - schema Schema definitions using Zod
+      - index.ts Barrel re-exporting every schema
       - echo.ts Example definitions for the input and output of the "echo" procedure
       - z-async-iterable.ts Zod helper for subscriptions (REST API only)
     - procedures Procedures (or operations) exposed by your API
       - echo.ts Example procedure
     - middleware
+      - index.ts Barrel re-exporting the middleware, and the procedure context type
       - error.ts Middleware for error handling
       - logger.ts middleware for configuring AWS Powertools for Lambda logging
       - tracer.ts middleware for configuring AWS Powertools for Lambda tracing
@@ -65,9 +70,15 @@ O gerador criará a seguinte estrutura de projeto no diretório `<directory>/<ap
     - local-server.ts tRPC standalone adapter entrypoint for local development server
     - client
       - index.ts Type-safe client for machine-to-machine API calls
+  - rolldown.config.ts Bundle configuration for the Lambda deployment package
   - tsconfig.json TypeScript configuration
+  - tsconfig.lib.json TypeScript configuration for the library sources
+  - tsconfig.spec.json TypeScript configuration for the tests
+  - vitest.config.mts Vitest configuration
   - package.json Project manifest defining the project's package name and dependencies
   - project.json Project configuration and build targets
+  - README.md Project readme
+  - .gitignore Ignores the project's build output
 
 </FileTree>
 
@@ -297,6 +308,10 @@ Como exemplo, vamos implementar algum middleware para extrair alguns detalhes so
 <OptionFilter when={{ auth: 'iam' }} description="Identity middleware example for IAM-authenticated APIs">
 Este exemplo percorre o middleware de identidade para autenticação `IAM`. Procuramos o chamador no Cognito usando o sub extraído do evento API Gateway.
 
+A pesquisa usa o cliente Cognito Identity Provider, que não é uma dependência de uma API tRPC gerada. Instale-o em seu projeto de API primeiro:
+
+<InstallCommand pkg={`@aws-sdk/client-cognito-identity-provider@${TS_VERSIONS['@aws-sdk/client-cognito-identity-provider']}`} project="@my-scope/my-api" />
+
 Primeiro, definimos o que adicionaremos ao contexto:
 
 ```ts
@@ -334,8 +349,8 @@ No nosso caso, queremos extrair detalhes sobre o usuário Cognito chamador. Fare
 ```ts
 import { CognitoIdentityProvider } from '@aws-sdk/client-cognito-identity-provider';
 import { initTRPC, TRPCError } from '@trpc/server';
-import { CreateAWSLambdaContextOptions } from '@trpc/server/adapters/aws-lambda';
-import { APIGatewayProxyEvent } from 'aws-lambda';
+import type { CreateAWSLambdaContextOptions } from '@trpc/server/adapters/aws-lambda';
+import type { APIGatewayProxyEvent } from 'aws-lambda';
 
 export interface IIdentityContext {
   identity?: {
@@ -345,12 +360,17 @@ export interface IIdentityContext {
 }
 
 export const createIdentityPlugin = () => {
-  const t = initTRPC.context<IIdentityContext & CreateAWSLambdaContextOptions<APIGatewayProxyEvent>>().create();
+  const t = initTRPC
+    .context<
+      IIdentityContext & CreateAWSLambdaContextOptions<APIGatewayProxyEvent>
+    >()
+    .create();
 
   const cognito = new CognitoIdentityProvider();
 
   return t.procedure.use(async (opts) => {
-    const cognitoAuthenticationProvider = opts.ctx.event.requestContext?.identity?.cognitoAuthenticationProvider;
+    const cognitoAuthenticationProvider =
+      opts.ctx.event.requestContext?.identity?.cognitoAuthenticationProvider;
 
     let sub: string | undefined = undefined;
     if (cognitoAuthenticationProvider) {
@@ -397,8 +417,8 @@ export const createIdentityPlugin = () => {
 ```ts
 import { CognitoIdentityProvider } from '@aws-sdk/client-cognito-identity-provider';
 import { initTRPC, TRPCError } from '@trpc/server';
-import { CreateAWSLambdaContextOptions } from '@trpc/server/adapters/aws-lambda';
-import { APIGatewayProxyEventV2WithIAMAuthorizer } from 'aws-lambda';
+import type { CreateAWSLambdaContextOptions } from '@trpc/server/adapters/aws-lambda';
+import type { APIGatewayProxyEventV2WithIAMAuthorizer } from 'aws-lambda';
 
 export interface IIdentityContext {
   identity?: {
@@ -408,7 +428,12 @@ export interface IIdentityContext {
 }
 
 export const createIdentityPlugin = () => {
-  const t = initTRPC.context<IIdentityContext & CreateAWSLambdaContextOptions<APIGatewayProxyEventV2WithIAMAuthorizer>>().create();
+  const t = initTRPC
+    .context<
+      IIdentityContext &
+        CreateAWSLambdaContextOptions<APIGatewayProxyEventV2WithIAMAuthorizer>
+    >()
+    .create();
 
   const cognito = new CognitoIdentityProvider();
 
@@ -481,12 +506,16 @@ export interface IIdentityContext {
 
 Note que definimos uma propriedade adicional _opcional_ no contexto. tRPC gerencia garantir que isso seja definido em procedimentos que configuraram corretamente este middleware.
 
-Em seguida, o middleware em si:
+Em seguida, o middleware em si. O tipo de evento e a localização das reivindicações diferem entre uma API REST e uma API HTTP, portanto a implementação depende do seu `infra` selecionado:
+
+<Tabs syncKey="http-rest">
+<TabItem label="REST API" _filter={{ infra: 'rest-lambda' }}>
+O autorizador Cognito User Pools de uma API REST coloca as reivindicações em `event.requestContext.authorizer.claims`:
 
 ```ts
 import { initTRPC, TRPCError } from '@trpc/server';
-import { CreateAWSLambdaContextOptions } from '@trpc/server/adapters/aws-lambda';
-import { APIGatewayProxyEvent } from 'aws-lambda';
+import type { CreateAWSLambdaContextOptions } from '@trpc/server/adapters/aws-lambda';
+import type { APIGatewayProxyEvent } from 'aws-lambda';
 
 export interface IIdentityContext {
   identity?: {
@@ -497,7 +526,9 @@ export interface IIdentityContext {
 
 export const createIdentityPlugin = () => {
   const t = initTRPC
-    .context<IIdentityContext & CreateAWSLambdaContextOptions<APIGatewayProxyEvent>>()
+    .context<
+      IIdentityContext & CreateAWSLambdaContextOptions<APIGatewayProxyEvent>
+    >()
     .create();
 
   return t.procedure.use(async (opts) => {
@@ -506,7 +537,7 @@ export const createIdentityPlugin = () => {
       | undefined;
 
     const sub = claims?.sub;
-    const username = claims?.username;
+    const username = claims?.username ?? claims?.['cognito:username'];
 
     if (!sub || !username) {
       throw new TRPCError({
@@ -527,6 +558,59 @@ export const createIdentityPlugin = () => {
   });
 };
 ```
+</TabItem>
+<TabItem label="HTTP API" _filter={{ infra: 'http-lambda' }}>
+O autorizador JWT de uma API HTTP entrega um evento payload-v2 cujas reivindicações ficam um nível mais profundo, em `event.requestContext.authorizer.jwt.claims`. O contexto deve ser tipado em `APIGatewayProxyEventV2WithJWTAuthorizer` para corresponder ao que o `publicProcedure` gerado usa — caso contrário, `.concat()` falha com o erro `Context mismatch` do tRPC:
+
+```ts
+import { initTRPC, TRPCError } from '@trpc/server';
+import type { CreateAWSLambdaContextOptions } from '@trpc/server/adapters/aws-lambda';
+import type { APIGatewayProxyEventV2WithJWTAuthorizer } from 'aws-lambda';
+
+export interface IIdentityContext {
+  identity?: {
+    sub: string;
+    username: string;
+  };
+}
+
+export const createIdentityPlugin = () => {
+  const t = initTRPC
+    .context<
+      IIdentityContext &
+        CreateAWSLambdaContextOptions<APIGatewayProxyEventV2WithJWTAuthorizer>
+    >()
+    .create();
+
+  return t.procedure.use(async (opts) => {
+    const claims = opts.ctx.event.requestContext?.authorizer?.jwt?.claims as
+      | Record<string, string>
+      | undefined;
+
+    const sub = claims?.sub;
+    const username = claims?.username ?? claims?.['cognito:username'];
+
+    if (!sub || !username) {
+      throw new TRPCError({
+        code: 'FORBIDDEN',
+        message: 'Unable to determine calling user',
+      });
+    }
+
+    return await opts.next({
+      ctx: {
+        ...opts.ctx,
+        identity: {
+          sub,
+          username,
+        },
+      },
+    });
+  });
+};
+```
+</TabItem>
+</Tabs>
 
 Você pode então misturar o plugin em qualquer procedimento que precise da identidade do chamador:
 
@@ -595,7 +679,7 @@ export class ExampleStack extends Stack {
 }
 ```
 
-O construto `UserIdentity` pode ser gerado usando o <Link path="/guides/react-website-auth">gerador `ts#website#auth`</Link>.
+O construto `UserIdentity` pode ser gerado usando o <Link path="/pt/guides/react-website-auth">gerador `ts#website#auth`</Link>.
 </OptionFilter>
 
 Isso configura sua infraestrutura de API, incluindo uma API AWS API Gateway REST ou HTTP, funções AWS Lambda para lógica de negócios e autenticação baseada no seu método `auth` escolhido.
@@ -605,7 +689,7 @@ Isso configura sua infraestrutura de API, incluindo uma API AWS API Gateway REST
 <Fragment slot="terraform">
 Os módulos Terraform para implantar sua API estão na pasta `common/terraform`. Você pode usar isso em uma configuração Terraform.
 
-O módulo de API prepara seu zip de implantação Lambda em um bucket S3 de ativos compartilhado — veja o <Link path="/guides/terraform-project">guia de infraestrutura Terraform</Link> para detalhes. Instancie o módulo `core/asset-bucket` uma vez por implantação e passe sua saída `bucket_name` para cada módulo de API / Lambda via a entrada `asset_bucket_name`:
+O módulo de API prepara seu zip de implantação Lambda em um bucket S3 de ativos compartilhado — veja o <Link path="/pt/guides/terraform-project">guia de infraestrutura Terraform</Link> para detalhes. Instancie o módulo `core/asset-bucket` uma vez por implantação e passe sua saída `bucket_name` para cada módulo de API / Lambda via a entrada `asset_bucket_name`:
 
 <OptionFilter when={{ auth: ['iam', 'custom'] }} description="Terraform usage for IAM or Custom authentication">
 ```hcl {1-3, 8}
@@ -825,7 +909,7 @@ const client = createMyApiClient({ url: 'https://my-api-url.example.com/' });
 await client.echo.query({ message: 'Hello world!' });
 ```
 
-Se você estiver chamando sua API de um site React, considere usar o gerador <Link path="guides/connection/react-trpc">Connection</Link> para configurar o cliente.
+Se você estiver chamando sua API de um site React, considere usar o gerador <Link path="/pt/guides/connection/react-trpc">Connection</Link> para configurar o cliente.
 
 ## Mais Informações
 
@@ -833,7 +917,7 @@ Para mais informações sobre tRPC, consulte a [documentação do tRPC](https://
 
 ## Conexões
 
-Use o gerador <Link path="guides/connection">`connection`</Link> para integrar este projeto com outros em seu workspace. As seguintes conexões envolvem este projeto:
+Use o gerador <Link path="/pt/guides/connection">`connection`</Link> para integrar este projeto com outros em seu workspace. As seguintes conexões envolvem este projeto:
 
 <CardGrid>
   <ConnectionCard

--- a/docs/src/content/docs/pt/guides/ts-smithy-api.mdx
+++ b/docs/src/content/docs/pt/guides/ts-smithy-api.mdx
@@ -18,6 +18,8 @@ import PackageManagerShortCommand from '@components/package-manager-short-comman
 import Infrastructure from '@components/infrastructure.astro';
 import Snippet from '@components/snippet.astro';
 import OptionFilter from '@components/option-filter.astro';
+import InstallCommand from '@components/install-command.astro';
+import { TS_VERSIONS } from '../../../../../../packages/nx-plugin/src/utils/versions';
 
 [Smithy](https://smithy.io/) é uma linguagem de definição de interface independente de protocolo para criar APIs de forma orientada a modelos.
 
@@ -46,7 +48,6 @@ O gerador cria dois projetos relacionados no diretório `<directory>/<api-name>`
 <FileTree>
 
 - **model/** Projeto de modelo Smithy
-  - package.json Manifesto do projeto definindo o nome do pacote e dependências
   - project.json Configuração do projeto e alvos de build
   - smithy-build.json Configuração de build do Smithy
   - ssdk.rolldown.config.mjs Empacota o TypeScript Server SDK gerado
@@ -55,9 +56,15 @@ O gerador cria dois projetos relacionados no diretório `<directory>/<api-name>`
     - operations/
       - echo.smithy Definição de operação de exemplo
 - **backend/** Implementação backend TypeScript
+  - package.json Manifesto do projeto definindo o nome do pacote e dependências
   - project.json Configuração do projeto e alvos de build
   - rolldown.config.ts Configuração de empacotamento
+  - tsconfig.json Configuração TypeScript
+  - tsconfig.lib.json Configuração TypeScript para as fontes da biblioteca
+  - tsconfig.spec.json Configuração TypeScript para os testes
+  - vitest.config.mts Configuração Vitest
   - src/
+    - index.ts Ponto de entrada do pacote
     - handler.ts Handler do AWS Lambda
     - local-server.ts Servidor de desenvolvimento local
     - service.ts Implementação do serviço
@@ -91,7 +98,7 @@ O projeto comum de infraestrutura como código é estruturado da seguinte forma:
 </FileTree>
 
 :::note[Projeto Gerado]
-Este projeto é gerado usando o gerador [`ts#project`](guides/typescript-project) e, portanto, configura os mesmos alvos de build.
+Este projeto é gerado usando o gerador <Link path="/guides/typescript-project">`ts#project`</Link> e, portanto, configura os mesmos alvos de build.
 :::
 </Fragment>
 <Fragment slot="terraform">
@@ -110,7 +117,7 @@ Este projeto é gerado usando o gerador [`ts#project`](guides/typescript-project
 </FileTree>
 
 :::note[Projeto Gerado]
-Este projeto é gerado usando o gerador [`terraform#project`](guides/terraform-project) e, portanto, configura os mesmos alvos de build.
+Este projeto é gerado usando o gerador <Link path="/guides/terraform-project">`terraform#project`</Link> e, portanto, configura os mesmos alvos de build.
 :::
 </Fragment>
 </Infrastructure>
@@ -475,7 +482,9 @@ export interface ServiceContext {
 Em seguida, escreva o resolvedor em `src/identity.ts`. Ele lança `UnauthorizedError` quando o chamador não pode ser determinado. A implementação depende do seu método `auth` selecionado:
 
 <OptionFilter when={{ auth: 'iam' }} description="Resolução de identidade para APIs autenticadas por IAM">
-Para autenticação `IAM`, procuramos o chamador no Cognito usando o sub extraído do evento do API Gateway:
+Para autenticação `IAM`, procuramos o chamador no Cognito usando o sub extraído do evento do API Gateway. A busca usa o cliente Cognito Identity Provider, que não é uma dependência de um backend Smithy gerado, então instale-o no projeto backend primeiro:
+
+<InstallCommand pkg={`@aws-sdk/client-cognito-identity-provider@${TS_VERSIONS['@aws-sdk/client-cognito-identity-provider']}`} project="@my-scope/my-api" projectDir="packages/my-api/backend" />
 
 ```ts
 import { CognitoIdentityProvider } from '@aws-sdk/client-cognito-identity-provider';
@@ -498,7 +507,9 @@ export const getIdentity = async (
   }
 
   if (!sub) {
-    throw new UnauthorizedError({ message: 'Unable to determine calling user' });
+    throw new UnauthorizedError({
+      message: 'Unable to determine calling user',
+    });
   }
 
   const { Users } = await cognito.listUsers({
@@ -509,7 +520,9 @@ export const getIdentity = async (
   });
 
   if (!Users || Users.length !== 1) {
-    throw new UnauthorizedError({ message: `No user found with subjectId ${sub}` });
+    throw new UnauthorizedError({
+      message: `No user found with subjectId ${sub}`,
+    });
   }
 
   return { sub, username: Users[0].Username! };
@@ -536,7 +549,9 @@ export const getIdentity = async (
   const username = claims?.username;
 
   if (!sub || !username) {
-    throw new UnauthorizedError({ message: 'Unable to determine calling user' });
+    throw new UnauthorizedError({
+      message: 'Unable to determine calling user',
+    });
   }
 
   return { sub, username };
@@ -559,6 +574,17 @@ const httpResponse = await serviceHandler.handle(httpRequest, {
   logger,
   metrics,
   getIdentity: () => getIdentity(event),
+});
+```
+
+`getIdentity` é um campo obrigatório em `ServiceContext`, e como a [observação acima](#contexto-do-serviço) nota, o contexto é construído em **ambos** os pontos de entrada — então `src/local-server.ts` também precisa dele. Não há autorizador do API Gateway na frente do servidor local, então forneça uma identidade stub para desenvolvimento local:
+
+```ts {5} ins={5}
+const httpResponse = await serviceHandler.handle(httpRequest, {
+  tracer,
+  logger,
+  metrics,
+  getIdentity: async () => ({ sub: 'local', username: 'local' }),
 });
 ```
 
@@ -800,6 +826,49 @@ output "lambda_function_name" {
 <Snippet name="api/access-logging" parentHeading="Logging de acesso" />
 
 ### Integrações
+
+<Infrastructure>
+<Fragment slot="cdk">
+:::caution[Nomes de operações são camelCase no CDK]
+As operações Smithy são declaradas em PascalCase (`Echo`), e seu backend as exporta sob esse nome. As chaves de integração CDK são a forma **camelCase** do mesmo nome, então uma operação `Echo` é `echo` em todos os lugares na sua stack:
+
+```ts
+const api = new MyApi(this, 'MyApi', {
+  integrations: MyApi.defaultIntegrations(this)
+    // `Echo` in the model, `echo` here
+    .withOperationOptions({ echo: { timeout: Duration.seconds(60) } })
+    .build(),
+});
+
+api.integrations.echo.handler.addToRolePolicy(...);
+```
+:::
+</Fragment>
+<Fragment slot="terraform">
+:::note[Nomes de operações são camelCase no Terraform]
+As saídas com chave de operação do módulo gerado e seu `operations.json` usam a forma **camelCase** do nome da operação Smithy, então uma operação Smithy `Echo` tem a chave `echo`:
+
+```hcl
+# `Echo` in the model, `echo` here
+resource "aws_iam_role_policy" "echo_permissions" {
+  name = "echo-additional-permissions"
+  role = module.my_api.lambda_execution_role_names["echo"]
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["s3:GetObject"]
+        Resource = "arn:aws:s3:::my-bucket/*"
+      }
+    ]
+  })
+}
+```
+:::
+</Fragment>
+</Infrastructure>
 
 <Snippet name="api/type-safe-api-integrations" parentHeading="Integrações" />
 

--- a/docs/src/content/docs/pt/snippets/api/type-safe-api-integrations.mdx
+++ b/docs/src/content/docs/pt/snippets/api/type-safe-api-integrations.mdx
@@ -66,6 +66,8 @@ const api = new MyApi(this, 'MyApi', {
 
 api.integrations.$router.handler.addEnvironment('LOG_LEVEL', 'DEBUG');
 ```
+
+Observe que `$router` não está mais disponível se você substituir todas as operações via `withOverrides`, já que nenhuma operação resta usando a integração de router padrão.
 </Fragment>
 <Fragment slot="terraform">
 Com o padrão `isolated`, as saídas do módulo são mapas indexados por nome de operação, então você pode acessar os recursos de uma única operação. Por exemplo, para conceder permissões extras à função Lambda de uma operação:

--- a/docs/src/content/docs/vi/guides/trpc.mdx
+++ b/docs/src/content/docs/vi/guides/trpc.mdx
@@ -16,6 +16,8 @@ import NxCommands from '@components/nx-commands.astro';
 import Infrastructure from '@components/infrastructure.astro';
 import Snippet from '@components/snippet.astro';
 import OptionFilter from '@components/option-filter.astro';
+import InstallCommand from '@components/install-command.astro';
+import { TS_VERSIONS } from '../../../../../../packages/nx-plugin/src/utils/versions';
 
 [tRPC](https://trpc.io/) là một framework để xây dựng API trong TypeScript với tính an toàn kiểu từ đầu đến cuối. Sử dụng tRPC, các cập nhật đối với đầu vào và đầu ra của các thao tác API được phản ánh ngay lập tức trong mã client và hiển thị trong IDE của bạn mà không cần rebuild dự án.
 
@@ -49,15 +51,18 @@ Generator sẽ tạo cấu trúc dự án sau trong thư mục `<directory>/<api
 
 <FileTree>
   - src
+    - index.ts Package entrypoint re-exporting the router, context, client and schema
     - init.ts Backend tRPC initialisation
     - handler.ts Lambda handler entrypoint
     - router.ts tRPC router definition
     - schema Schema definitions using Zod
+      - index.ts Barrel re-exporting every schema
       - echo.ts Example definitions for the input and output of the "echo" procedure
       - z-async-iterable.ts Zod helper for subscriptions (REST API only)
     - procedures Procedures (or operations) exposed by your API
       - echo.ts Example procedure
     - middleware
+      - index.ts Barrel re-exporting the middleware, and the procedure context type
       - error.ts Middleware for error handling
       - logger.ts middleware for configuring AWS Powertools for Lambda logging
       - tracer.ts middleware for configuring AWS Powertools for Lambda tracing
@@ -65,9 +70,15 @@ Generator sẽ tạo cấu trúc dự án sau trong thư mục `<directory>/<api
     - local-server.ts tRPC standalone adapter entrypoint for local development server
     - client
       - index.ts Type-safe client for machine-to-machine API calls
+  - rolldown.config.ts Bundle configuration for the Lambda deployment package
   - tsconfig.json TypeScript configuration
+  - tsconfig.lib.json TypeScript configuration for the library sources
+  - tsconfig.spec.json TypeScript configuration for the tests
+  - vitest.config.mts Vitest configuration
   - package.json Project manifest defining the project's package name and dependencies
   - project.json Project configuration and build targets
+  - README.md Project readme
+  - .gitignore Ignores the project's build output
 
 </FileTree>
 
@@ -297,6 +308,10 @@ Ví dụ, hãy triển khai một số middleware để trích xuất một số
 <OptionFilter when={{ auth: 'iam' }} description="Identity middleware example for IAM-authenticated APIs">
 Ví dụ này hướng dẫn về identity middleware cho xác thực `IAM`. Chúng ta tra cứu người gọi trong Cognito bằng cách sử dụng sub được trích xuất từ sự kiện API Gateway.
 
+Việc tra cứu sử dụng Cognito Identity Provider client, không phải là dependency của một API tRPC được tạo. Cài đặt nó vào dự án API của bạn trước:
+
+<InstallCommand pkg={`@aws-sdk/client-cognito-identity-provider@${TS_VERSIONS['@aws-sdk/client-cognito-identity-provider']}`} project="@my-scope/my-api" />
+
 Đầu tiên, chúng ta định nghĩa những gì chúng ta sẽ thêm vào ngữ cảnh:
 
 ```ts
@@ -334,8 +349,8 @@ Trong trường hợp của chúng ta, chúng ta muốn trích xuất chi tiết
 ```ts
 import { CognitoIdentityProvider } from '@aws-sdk/client-cognito-identity-provider';
 import { initTRPC, TRPCError } from '@trpc/server';
-import { CreateAWSLambdaContextOptions } from '@trpc/server/adapters/aws-lambda';
-import { APIGatewayProxyEvent } from 'aws-lambda';
+import type { CreateAWSLambdaContextOptions } from '@trpc/server/adapters/aws-lambda';
+import type { APIGatewayProxyEvent } from 'aws-lambda';
 
 export interface IIdentityContext {
   identity?: {
@@ -345,12 +360,17 @@ export interface IIdentityContext {
 }
 
 export const createIdentityPlugin = () => {
-  const t = initTRPC.context<IIdentityContext & CreateAWSLambdaContextOptions<APIGatewayProxyEvent>>().create();
+  const t = initTRPC
+    .context<
+      IIdentityContext & CreateAWSLambdaContextOptions<APIGatewayProxyEvent>
+    >()
+    .create();
 
   const cognito = new CognitoIdentityProvider();
 
   return t.procedure.use(async (opts) => {
-    const cognitoAuthenticationProvider = opts.ctx.event.requestContext?.identity?.cognitoAuthenticationProvider;
+    const cognitoAuthenticationProvider =
+      opts.ctx.event.requestContext?.identity?.cognitoAuthenticationProvider;
 
     let sub: string | undefined = undefined;
     if (cognitoAuthenticationProvider) {
@@ -397,8 +417,8 @@ export const createIdentityPlugin = () => {
 ```ts
 import { CognitoIdentityProvider } from '@aws-sdk/client-cognito-identity-provider';
 import { initTRPC, TRPCError } from '@trpc/server';
-import { CreateAWSLambdaContextOptions } from '@trpc/server/adapters/aws-lambda';
-import { APIGatewayProxyEventV2WithIAMAuthorizer } from 'aws-lambda';
+import type { CreateAWSLambdaContextOptions } from '@trpc/server/adapters/aws-lambda';
+import type { APIGatewayProxyEventV2WithIAMAuthorizer } from 'aws-lambda';
 
 export interface IIdentityContext {
   identity?: {
@@ -408,7 +428,12 @@ export interface IIdentityContext {
 }
 
 export const createIdentityPlugin = () => {
-  const t = initTRPC.context<IIdentityContext & CreateAWSLambdaContextOptions<APIGatewayProxyEventV2WithIAMAuthorizer>>().create();
+  const t = initTRPC
+    .context<
+      IIdentityContext &
+        CreateAWSLambdaContextOptions<APIGatewayProxyEventV2WithIAMAuthorizer>
+    >()
+    .create();
 
   const cognito = new CognitoIdentityProvider();
 
@@ -481,12 +506,16 @@ export interface IIdentityContext {
 
 Lưu ý rằng chúng ta định nghĩa một thuộc tính _tùy chọn_ bổ sung cho context. tRPC quản lý đảm bảo rằng điều này được định nghĩa trong các procedure đã cấu hình middleware này một cách chính xác.
 
-Tiếp theo, chính middleware đó:
+Tiếp theo, chính middleware đó. Loại event và vị trí của các claim khác nhau giữa REST API và HTTP API, vì vậy triển khai phụ thuộc vào `infra` đã chọn của bạn:
+
+<Tabs syncKey="http-rest">
+<TabItem label="REST API" _filter={{ infra: 'rest-lambda' }}>
+Cognito User Pools authorizer của REST API đặt các claim tại `event.requestContext.authorizer.claims`:
 
 ```ts
 import { initTRPC, TRPCError } from '@trpc/server';
-import { CreateAWSLambdaContextOptions } from '@trpc/server/adapters/aws-lambda';
-import { APIGatewayProxyEvent } from 'aws-lambda';
+import type { CreateAWSLambdaContextOptions } from '@trpc/server/adapters/aws-lambda';
+import type { APIGatewayProxyEvent } from 'aws-lambda';
 
 export interface IIdentityContext {
   identity?: {
@@ -497,7 +526,9 @@ export interface IIdentityContext {
 
 export const createIdentityPlugin = () => {
   const t = initTRPC
-    .context<IIdentityContext & CreateAWSLambdaContextOptions<APIGatewayProxyEvent>>()
+    .context<
+      IIdentityContext & CreateAWSLambdaContextOptions<APIGatewayProxyEvent>
+    >()
     .create();
 
   return t.procedure.use(async (opts) => {
@@ -506,7 +537,7 @@ export const createIdentityPlugin = () => {
       | undefined;
 
     const sub = claims?.sub;
-    const username = claims?.username;
+    const username = claims?.username ?? claims?.['cognito:username'];
 
     if (!sub || !username) {
       throw new TRPCError({
@@ -527,6 +558,59 @@ export const createIdentityPlugin = () => {
   });
 };
 ```
+</TabItem>
+<TabItem label="HTTP API" _filter={{ infra: 'http-lambda' }}>
+JWT authorizer của HTTP API cung cấp một payload-v2 event có các claim nằm sâu hơn một cấp, tại `event.requestContext.authorizer.jwt.claims`. Context phải được định kiểu trên `APIGatewayProxyEventV2WithJWTAuthorizer` để khớp với cái mà `publicProcedure` được tạo sử dụng — nếu không `.concat()` sẽ thất bại với lỗi `Context mismatch` của tRPC:
+
+```ts
+import { initTRPC, TRPCError } from '@trpc/server';
+import type { CreateAWSLambdaContextOptions } from '@trpc/server/adapters/aws-lambda';
+import type { APIGatewayProxyEventV2WithJWTAuthorizer } from 'aws-lambda';
+
+export interface IIdentityContext {
+  identity?: {
+    sub: string;
+    username: string;
+  };
+}
+
+export const createIdentityPlugin = () => {
+  const t = initTRPC
+    .context<
+      IIdentityContext &
+        CreateAWSLambdaContextOptions<APIGatewayProxyEventV2WithJWTAuthorizer>
+    >()
+    .create();
+
+  return t.procedure.use(async (opts) => {
+    const claims = opts.ctx.event.requestContext?.authorizer?.jwt?.claims as
+      | Record<string, string>
+      | undefined;
+
+    const sub = claims?.sub;
+    const username = claims?.username ?? claims?.['cognito:username'];
+
+    if (!sub || !username) {
+      throw new TRPCError({
+        code: 'FORBIDDEN',
+        message: 'Unable to determine calling user',
+      });
+    }
+
+    return await opts.next({
+      ctx: {
+        ...opts.ctx,
+        identity: {
+          sub,
+          username,
+        },
+      },
+    });
+  });
+};
+```
+</TabItem>
+</Tabs>
 
 Sau đó bạn có thể kết hợp plugin vào bất kỳ procedure nào cần identity của người gọi:
 

--- a/docs/src/content/docs/vi/guides/ts-smithy-api.mdx
+++ b/docs/src/content/docs/vi/guides/ts-smithy-api.mdx
@@ -18,6 +18,8 @@ import PackageManagerShortCommand from '@components/package-manager-short-comman
 import Infrastructure from '@components/infrastructure.astro';
 import Snippet from '@components/snippet.astro';
 import OptionFilter from '@components/option-filter.astro';
+import InstallCommand from '@components/install-command.astro';
+import { TS_VERSIONS } from '../../../../../../packages/nx-plugin/src/utils/versions';
 
 [Smithy](https://smithy.io/) là một ngôn ngữ định nghĩa giao diện độc lập với giao thức để tạo API theo cách hướng mô hình.
 
@@ -46,7 +48,6 @@ Trình tạo tạo hai dự án liên quan trong thư mục `<directory>/<api-na
 <FileTree>
 
 - **model/** Dự án mô hình Smithy
-  - package.json Tệp kê khai dự án định nghĩa tên gói và các phụ thuộc của dự án
   - project.json Cấu hình dự án và các target build
   - smithy-build.json Cấu hình build Smithy
   - ssdk.rolldown.config.mjs Đóng gói TypeScript Server SDK được tạo
@@ -55,9 +56,15 @@ Trình tạo tạo hai dự án liên quan trong thư mục `<directory>/<api-na
     - operations/
       - echo.smithy Định nghĩa thao tác ví dụ
 - **backend/** Triển khai backend TypeScript
+  - package.json Tệp kê khai dự án định nghĩa tên gói và các phụ thuộc của dự án
   - project.json Cấu hình dự án và các target build
   - rolldown.config.ts Cấu hình bundle
+  - tsconfig.json TypeScript configuration
+  - tsconfig.lib.json TypeScript configuration for the library sources
+  - tsconfig.spec.json TypeScript configuration for the tests
+  - vitest.config.mts Vitest configuration
   - src/
+    - index.ts Package entrypoint
     - handler.ts AWS Lambda handler
     - local-server.ts Server phát triển cục bộ
     - service.ts Triển khai dịch vụ
@@ -91,7 +98,7 @@ Dự án mã cơ sở hạ tầng chung được cấu trúc như sau:
 </FileTree>
 
 :::note[Dự án được tạo]
-Dự án này được tạo bằng trình tạo [`ts#project`](guides/typescript-project) và do đó cấu hình các build targets giống nhau.
+Dự án này được tạo bằng trình tạo <Link path="/guides/typescript-project">`ts#project`</Link> và do đó cấu hình các build targets giống nhau.
 :::
 </Fragment>
 <Fragment slot="terraform">
@@ -110,7 +117,7 @@ Dự án này được tạo bằng trình tạo [`ts#project`](guides/typescrip
 </FileTree>
 
 :::note[Dự án được tạo]
-Dự án này được tạo bằng trình tạo [`terraform#project`](guides/terraform-project) và do đó cấu hình các build targets giống nhau.
+Dự án này được tạo bằng trình tạo <Link path="/guides/terraform-project">`terraform#project`</Link> và do đó cấu hình các build targets giống nhau.
 :::
 </Fragment>
 </Infrastructure>
@@ -475,7 +482,9 @@ export interface ServiceContext {
 Tiếp theo, viết resolver trong `src/identity.ts`. Nó ném `UnauthorizedError` khi không thể xác định người gọi. Việc triển khai phụ thuộc vào phương thức `auth` bạn đã chọn:
 
 <OptionFilter when={{ auth: 'iam' }} description="Giải quyết danh tính cho các API được xác thực IAM">
-Đối với xác thực `IAM`, chúng ta tra cứu người gọi trong Cognito bằng sub được trích xuất từ sự kiện API Gateway:
+Đối với xác thực `IAM`, chúng ta tra cứu người gọi trong Cognito bằng sub được trích xuất từ sự kiện API Gateway. Việc tra cứu sử dụng Cognito Identity Provider client, không phải là một phụ thuộc của backend Smithy được tạo, vì vậy hãy cài đặt nó vào dự án backend trước:
+
+<InstallCommand pkg={`@aws-sdk/client-cognito-identity-provider@${TS_VERSIONS['@aws-sdk/client-cognito-identity-provider']}`} project="@my-scope/my-api" projectDir="packages/my-api/backend" />
 
 ```ts
 import { CognitoIdentityProvider } from '@aws-sdk/client-cognito-identity-provider';
@@ -498,7 +507,9 @@ export const getIdentity = async (
   }
 
   if (!sub) {
-    throw new UnauthorizedError({ message: 'Unable to determine calling user' });
+    throw new UnauthorizedError({
+      message: 'Unable to determine calling user',
+    });
   }
 
   const { Users } = await cognito.listUsers({
@@ -509,7 +520,9 @@ export const getIdentity = async (
   });
 
   if (!Users || Users.length !== 1) {
-    throw new UnauthorizedError({ message: `No user found with subjectId ${sub}` });
+    throw new UnauthorizedError({
+      message: `No user found with subjectId ${sub}`,
+    });
   }
 
   return { sub, username: Users[0].Username! };
@@ -536,7 +549,9 @@ export const getIdentity = async (
   const username = claims?.username;
 
   if (!sub || !username) {
-    throw new UnauthorizedError({ message: 'Unable to determine calling user' });
+    throw new UnauthorizedError({
+      message: 'Unable to determine calling user',
+    });
   }
 
   return { sub, username };
@@ -559,6 +574,17 @@ const httpResponse = await serviceHandler.handle(httpRequest, {
   logger,
   metrics,
   getIdentity: () => getIdentity(event),
+});
+```
+
+`getIdentity` là một trường bắt buộc trên `ServiceContext`, và như [cảnh báo ở trên](#ngữ-cảnh-dịch-vụ) lưu ý, ngữ cảnh được xây dựng trong **cả hai** điểm vào — vì vậy `src/local-server.ts` cũng cần nó. Không có API Gateway authorizer ở phía trước local server, vì vậy hãy cung cấp một danh tính stub cho phát triển cục bộ:
+
+```ts {5} ins={5}
+const httpResponse = await serviceHandler.handle(httpRequest, {
+  tracer,
+  logger,
+  metrics,
+  getIdentity: async () => ({ sub: 'local', username: 'local' }),
 });
 ```
 
@@ -800,6 +826,49 @@ output "lambda_function_name" {
 <Snippet name="api/access-logging" parentHeading="Ghi log truy cập" />
 
 ### Tích hợp
+
+<Infrastructure>
+<Fragment slot="cdk">
+:::caution[Tên operation là camelCase trong CDK]
+Các operation Smithy được khai báo ở dạng PascalCase (`Echo`), và backend của bạn xuất chúng dưới tên đó. Các khóa tích hợp CDK là dạng **camelCase** của cùng một tên, vì vậy một operation `Echo` là `echo` ở mọi nơi trong stack của bạn:
+
+```ts
+const api = new MyApi(this, 'MyApi', {
+  integrations: MyApi.defaultIntegrations(this)
+    // `Echo` in the model, `echo` here
+    .withOperationOptions({ echo: { timeout: Duration.seconds(60) } })
+    .build(),
+});
+
+api.integrations.echo.handler.addToRolePolicy(...);
+```
+:::
+</Fragment>
+<Fragment slot="terraform">
+:::note[Tên operation là camelCase trong Terraform]
+Các đầu ra được khóa theo operation của module được tạo và `operations.json` của nó sử dụng dạng **camelCase** của tên operation Smithy, vì vậy một operation Smithy `Echo` được khóa là `echo`:
+
+```hcl
+# `Echo` in the model, `echo` here
+resource "aws_iam_role_policy" "echo_permissions" {
+  name = "echo-additional-permissions"
+  role = module.my_api.lambda_execution_role_names["echo"]
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["s3:GetObject"]
+        Resource = "arn:aws:s3:::my-bucket/*"
+      }
+    ]
+  })
+}
+```
+:::
+</Fragment>
+</Infrastructure>
 
 <Snippet name="api/type-safe-api-integrations" parentHeading="Tích hợp" />
 

--- a/docs/src/content/docs/vi/guides/ts-smithy-api.mdx
+++ b/docs/src/content/docs/vi/guides/ts-smithy-api.mdx
@@ -98,7 +98,7 @@ Dự án mã cơ sở hạ tầng chung được cấu trúc như sau:
 </FileTree>
 
 :::note[Dự án được tạo]
-Dự án này được tạo bằng trình tạo <Link path="/guides/typescript-project">`ts#project`</Link> và do đó cấu hình các build targets giống nhau.
+Dự án này được tạo bằng trình tạo <Link path="/vi/guides/typescript-project">`ts#project`</Link> và do đó cấu hình các build targets giống nhau.
 :::
 </Fragment>
 <Fragment slot="terraform">
@@ -117,7 +117,7 @@ Dự án này được tạo bằng trình tạo <Link path="/guides/typescript-
 </FileTree>
 
 :::note[Dự án được tạo]
-Dự án này được tạo bằng trình tạo <Link path="/guides/terraform-project">`terraform#project`</Link> và do đó cấu hình các build targets giống nhau.
+Dự án này được tạo bằng trình tạo <Link path="/vi/guides/terraform-project">`terraform#project`</Link> và do đó cấu hình các build targets giống nhau.
 :::
 </Fragment>
 </Infrastructure>

--- a/docs/src/content/docs/vi/snippets/api/type-safe-api-integrations.mdx
+++ b/docs/src/content/docs/vi/snippets/api/type-safe-api-integrations.mdx
@@ -66,6 +66,8 @@ const api = new MyApi(this, 'MyApi', {
 
 api.integrations.$router.handler.addEnvironment('LOG_LEVEL', 'DEBUG');
 ```
+
+Lưu ý rằng `$router` không còn khả dụng nếu bạn ghi đè mọi hoạt động thông qua `withOverrides`, vì không còn hoạt động nào sử dụng tích hợp router mặc định.
 </Fragment>
 <Fragment slot="terraform">
 Với mẫu `isolated`, các đầu ra của module là các map được khóa theo tên hoạt động, vì vậy bạn có thể truy cập tài nguyên của một hoạt động duy nhất. Ví dụ, để cấp quyền bổ sung cho hàm Lambda của một hoạt động:

--- a/docs/src/content/docs/zh/guides/trpc.mdx
+++ b/docs/src/content/docs/zh/guides/trpc.mdx
@@ -16,6 +16,8 @@ import NxCommands from '@components/nx-commands.astro';
 import Infrastructure from '@components/infrastructure.astro';
 import Snippet from '@components/snippet.astro';
 import OptionFilter from '@components/option-filter.astro';
+import InstallCommand from '@components/install-command.astro';
+import { TS_VERSIONS } from '../../../../../../packages/nx-plugin/src/utils/versions';
 
 [tRPC](https://trpc.io/) 是一个用于在 TypeScript 中构建 API 的框架,具有端到端的类型安全性。使用 tRPC,对 API 操作输入和输出的更新会立即反映在客户端代码中,并在 IDE 中可见,无需重新构建项目。
 
@@ -49,15 +51,18 @@ tRPC API 生成器创建一个新的 tRPC API,并配置 AWS CDK 或 Terraform �
 
 <FileTree>
   - src
+    - index.ts Package entrypoint re-exporting the router, context, client and schema
     - init.ts 后端 tRPC 初始化
     - handler.ts Lambda 处理程序入口点
     - router.ts tRPC 路由器定义
     - schema 使用 Zod 的模式定义
+      - index.ts Barrel re-exporting every schema
       - echo.ts "echo" 过程的输入和输出示例定义
-      - z-async-iterable.ts 用于订阅的 Zod 辅助工具（仅限 REST API）
-    - procedures API 公开的过程（或操作）
+      - z-async-iterable.ts 用于订阅的 Zod 辅助工具(仅限 REST API)
+    - procedures API 公开的过程(或操作)
       - echo.ts 示例过程
     - middleware
+      - index.ts Barrel re-exporting the middleware, and the procedure context type
       - error.ts 用于错误处理的中间件
       - logger.ts 用于配置 AWS Powertools for Lambda 日志记录的中间件
       - tracer.ts 用于配置 AWS Powertools for Lambda 跟踪的中间件
@@ -65,9 +70,15 @@ tRPC API 生成器创建一个新的 tRPC API,并配置 AWS CDK 或 Terraform �
     - local-server.ts 用于本地开发服务器的 tRPC 独立适配器入口点
     - client
       - index.ts 用于机器对机器 API 调用的类型安全客户端
+  - rolldown.config.ts Bundle configuration for the Lambda deployment package
   - tsconfig.json TypeScript 配置
+  - tsconfig.lib.json TypeScript configuration for the library sources
+  - tsconfig.spec.json TypeScript configuration for the tests
+  - vitest.config.mts Vitest configuration
   - package.json 定义项目包名称和依赖项的项目清单
   - project.json 项目配置和构建目标
+  - README.md Project readme
+  - .gitignore Ignores the project's build output
 
 </FileTree>
 
@@ -297,6 +308,10 @@ export const echo = publicProcedure
 <OptionFilter when={{ auth: 'iam' }} description="IAM 身份验证 API 的身份中间件示例">
 此示例演示了 `IAM` 身份验证的身份中间件。我们使用从 API Gateway 事件中提取的 sub 在 Cognito 中查找调用者。
 
+查找使用 Cognito Identity Provider 客户端,它不是生成的 tRPC API 的依赖项。首先将其安装到您的 API 项目中:
+
+<InstallCommand pkg={`@aws-sdk/client-cognito-identity-provider@${TS_VERSIONS['@aws-sdk/client-cognito-identity-provider']}`} project="@my-scope/my-api" />
+
 首先,我们定义要添加到上下文的内容:
 
 ```ts
@@ -334,8 +349,8 @@ export const createIdentityPlugin = () => {
 ```ts
 import { CognitoIdentityProvider } from '@aws-sdk/client-cognito-identity-provider';
 import { initTRPC, TRPCError } from '@trpc/server';
-import { CreateAWSLambdaContextOptions } from '@trpc/server/adapters/aws-lambda';
-import { APIGatewayProxyEvent } from 'aws-lambda';
+import type { CreateAWSLambdaContextOptions } from '@trpc/server/adapters/aws-lambda';
+import type { APIGatewayProxyEvent } from 'aws-lambda';
 
 export interface IIdentityContext {
   identity?: {
@@ -345,12 +360,17 @@ export interface IIdentityContext {
 }
 
 export const createIdentityPlugin = () => {
-  const t = initTRPC.context<IIdentityContext & CreateAWSLambdaContextOptions<APIGatewayProxyEvent>>().create();
+  const t = initTRPC
+    .context<
+      IIdentityContext & CreateAWSLambdaContextOptions<APIGatewayProxyEvent>
+    >()
+    .create();
 
   const cognito = new CognitoIdentityProvider();
 
   return t.procedure.use(async (opts) => {
-    const cognitoAuthenticationProvider = opts.ctx.event.requestContext?.identity?.cognitoAuthenticationProvider;
+    const cognitoAuthenticationProvider =
+      opts.ctx.event.requestContext?.identity?.cognitoAuthenticationProvider;
 
     let sub: string | undefined = undefined;
     if (cognitoAuthenticationProvider) {
@@ -397,8 +417,8 @@ export const createIdentityPlugin = () => {
 ```ts
 import { CognitoIdentityProvider } from '@aws-sdk/client-cognito-identity-provider';
 import { initTRPC, TRPCError } from '@trpc/server';
-import { CreateAWSLambdaContextOptions } from '@trpc/server/adapters/aws-lambda';
-import { APIGatewayProxyEventV2WithIAMAuthorizer } from 'aws-lambda';
+import type { CreateAWSLambdaContextOptions } from '@trpc/server/adapters/aws-lambda';
+import type { APIGatewayProxyEventV2WithIAMAuthorizer } from 'aws-lambda';
 
 export interface IIdentityContext {
   identity?: {
@@ -408,7 +428,12 @@ export interface IIdentityContext {
 }
 
 export const createIdentityPlugin = () => {
-  const t = initTRPC.context<IIdentityContext & CreateAWSLambdaContextOptions<APIGatewayProxyEventV2WithIAMAuthorizer>>().create();
+  const t = initTRPC
+    .context<
+      IIdentityContext &
+        CreateAWSLambdaContextOptions<APIGatewayProxyEventV2WithIAMAuthorizer>
+    >()
+    .create();
 
   const cognito = new CognitoIdentityProvider();
 
@@ -479,14 +504,18 @@ export interface IIdentityContext {
 }
 ```
 
-请注意，我们在上下文上定义了一个额外的_可选_属性。tRPC 管理确保在正确配置了此中间件的过程中定义此属性。
+请注意,我们在上下文上定义了一个额外的_可选_属性。tRPC 管理确保在正确配置了此中间件的过程中定义此属性。
 
-接下来是中间件本身：
+接下来是中间件本身。事件类型和声明的位置在 REST API 和 HTTP API 之间有所不同,因此实现取决于您选择的 `infra`:
+
+<Tabs syncKey="http-rest">
+<TabItem label="REST API" _filter={{ infra: 'rest-lambda' }}>
+REST API 的 Cognito User Pools 授权器将声明放在 `event.requestContext.authorizer.claims`:
 
 ```ts
 import { initTRPC, TRPCError } from '@trpc/server';
-import { CreateAWSLambdaContextOptions } from '@trpc/server/adapters/aws-lambda';
-import { APIGatewayProxyEvent } from 'aws-lambda';
+import type { CreateAWSLambdaContextOptions } from '@trpc/server/adapters/aws-lambda';
+import type { APIGatewayProxyEvent } from 'aws-lambda';
 
 export interface IIdentityContext {
   identity?: {
@@ -497,7 +526,9 @@ export interface IIdentityContext {
 
 export const createIdentityPlugin = () => {
   const t = initTRPC
-    .context<IIdentityContext & CreateAWSLambdaContextOptions<APIGatewayProxyEvent>>()
+    .context<
+      IIdentityContext & CreateAWSLambdaContextOptions<APIGatewayProxyEvent>
+    >()
     .create();
 
   return t.procedure.use(async (opts) => {
@@ -506,7 +537,7 @@ export const createIdentityPlugin = () => {
       | undefined;
 
     const sub = claims?.sub;
-    const username = claims?.username;
+    const username = claims?.username ?? claims?.['cognito:username'];
 
     if (!sub || !username) {
       throw new TRPCError({
@@ -527,8 +558,61 @@ export const createIdentityPlugin = () => {
   });
 };
 ```
+</TabItem>
+<TabItem label="HTTP API" _filter={{ infra: 'http-lambda' }}>
+HTTP API 的 JWT 授权器提供 payload-v2 事件,其声明位于更深一层,在 `event.requestContext.authorizer.jwt.claims`。上下文必须在 `APIGatewayProxyEventV2WithJWTAuthorizer` 上进行类型化,以匹配生成的 `publicProcedure` 使用的上下文 — 否则 `.concat()` 会失败并出现 tRPC 的 `Context mismatch` 错误:
 
-然后，您可以将插件混合到任何需要调用者身份的过程中：
+```ts
+import { initTRPC, TRPCError } from '@trpc/server';
+import type { CreateAWSLambdaContextOptions } from '@trpc/server/adapters/aws-lambda';
+import type { APIGatewayProxyEventV2WithJWTAuthorizer } from 'aws-lambda';
+
+export interface IIdentityContext {
+  identity?: {
+    sub: string;
+    username: string;
+  };
+}
+
+export const createIdentityPlugin = () => {
+  const t = initTRPC
+    .context<
+      IIdentityContext &
+        CreateAWSLambdaContextOptions<APIGatewayProxyEventV2WithJWTAuthorizer>
+    >()
+    .create();
+
+  return t.procedure.use(async (opts) => {
+    const claims = opts.ctx.event.requestContext?.authorizer?.jwt?.claims as
+      | Record<string, string>
+      | undefined;
+
+    const sub = claims?.sub;
+    const username = claims?.username ?? claims?.['cognito:username'];
+
+    if (!sub || !username) {
+      throw new TRPCError({
+        code: 'FORBIDDEN',
+        message: 'Unable to determine calling user',
+      });
+    }
+
+    return await opts.next({
+      ctx: {
+        ...opts.ctx,
+        identity: {
+          sub,
+          username,
+        },
+      },
+    });
+  });
+};
+```
+</TabItem>
+</Tabs>
+
+然后,您可以将插件混合到任何需要调用者身份的过程中:
 
 ```ts
 import { publicProcedure } from '../init.js';

--- a/docs/src/content/docs/zh/guides/ts-smithy-api.mdx
+++ b/docs/src/content/docs/zh/guides/ts-smithy-api.mdx
@@ -18,6 +18,8 @@ import PackageManagerShortCommand from '@components/package-manager-short-comman
 import Infrastructure from '@components/infrastructure.astro';
 import Snippet from '@components/snippet.astro';
 import OptionFilter from '@components/option-filter.astro';
+import InstallCommand from '@components/install-command.astro';
+import { TS_VERSIONS } from '../../../../../../packages/nx-plugin/src/utils/versions';
 
 [Smithy](https://smithy.io/) 是一种与协议无关的接口定义语言，用于以模型驱动的方式编写 API。
 
@@ -46,7 +48,6 @@ Smithy TypeScript API 生成器使用 Smithy 进行服务定义，并使用 [Smi
 <FileTree>
 
 - **model/** Smithy 模型项目
-  - package.json 定义项目包名称和依赖项的项目清单
   - project.json 项目配置和构建目标
   - smithy-build.json Smithy 构建配置
   - ssdk.rolldown.config.mjs 打包生成的 TypeScript Server SDK
@@ -55,9 +56,15 @@ Smithy TypeScript API 生成器使用 Smithy 进行服务定义，并使用 [Smi
     - operations/
       - echo.smithy 示例操作定义
 - **backend/** TypeScript 后端实现
+  - package.json 定义项目包名称和依赖项的项目清单
   - project.json 项目配置和构建目标
   - rolldown.config.ts 打包配置
+  - tsconfig.json TypeScript 配置
+  - tsconfig.lib.json TypeScript 配置（用于库源代码）
+  - tsconfig.spec.json TypeScript 配置（用于测试）
+  - vitest.config.mts Vitest 配置
   - src/
+    - index.ts 包入口点
     - handler.ts AWS Lambda 处理程序
     - local-server.ts 本地开发服务器
     - service.ts 服务实现
@@ -91,7 +98,7 @@ Smithy TypeScript API 生成器使用 Smithy 进行服务定义，并使用 [Smi
 </FileTree>
 
 :::note[生成的项目]
-此项目使用 [`ts#project`](guides/typescript-project) 生成器生成，因此配置相同的构建目标。
+此项目使用 <Link path="/guides/typescript-project">`ts#project`</Link> 生成器生成，因此配置相同的构建目标。
 :::
 </Fragment>
 <Fragment slot="terraform">
@@ -110,7 +117,7 @@ Smithy TypeScript API 生成器使用 Smithy 进行服务定义，并使用 [Smi
 </FileTree>
 
 :::note[生成的项目]
-此项目使用 [`terraform#project`](guides/terraform-project) 生成器生成，因此配置相同的构建目标。
+此项目使用 <Link path="/guides/terraform-project">`terraform#project`</Link> 生成器生成，因此配置相同的构建目标。
 :::
 </Fragment>
 </Infrastructure>
@@ -475,7 +482,9 @@ export interface ServiceContext {
 接下来，在 `src/identity.ts` 中编写解析器。当无法确定调用者时，它会抛出 `UnauthorizedError`。实现取决于您选择的 `auth` 方法：
 
 <OptionFilter when={{ auth: 'iam' }} description="IAM 身份验证 API 的身份解析">
-对于 `IAM` 身份验证，我们使用从 API Gateway 事件中提取的 sub 在 Cognito 中查找调用者：
+对于 `IAM` 身份验证，我们使用从 API Gateway 事件中提取的 sub 在 Cognito 中查找调用者。查找使用 Cognito Identity Provider 客户端，它不是生成的 Smithy 后端的依赖项，因此首先将其安装到后端项目中：
+
+<InstallCommand pkg={`@aws-sdk/client-cognito-identity-provider@${TS_VERSIONS['@aws-sdk/client-cognito-identity-provider']}`} project="@my-scope/my-api" projectDir="packages/my-api/backend" />
 
 ```ts
 import { CognitoIdentityProvider } from '@aws-sdk/client-cognito-identity-provider';
@@ -498,7 +507,9 @@ export const getIdentity = async (
   }
 
   if (!sub) {
-    throw new UnauthorizedError({ message: 'Unable to determine calling user' });
+    throw new UnauthorizedError({
+      message: 'Unable to determine calling user',
+    });
   }
 
   const { Users } = await cognito.listUsers({
@@ -509,7 +520,9 @@ export const getIdentity = async (
   });
 
   if (!Users || Users.length !== 1) {
-    throw new UnauthorizedError({ message: `No user found with subjectId ${sub}` });
+    throw new UnauthorizedError({
+      message: `No user found with subjectId ${sub}`,
+    });
   }
 
   return { sub, username: Users[0].Username! };
@@ -536,7 +549,9 @@ export const getIdentity = async (
   const username = claims?.username;
 
   if (!sub || !username) {
-    throw new UnauthorizedError({ message: 'Unable to determine calling user' });
+    throw new UnauthorizedError({
+      message: 'Unable to determine calling user',
+    });
   }
 
   return { sub, username };
@@ -562,7 +577,18 @@ const httpResponse = await serviceHandler.handle(httpRequest, {
 });
 ```
 
-现在我们可以在操作中使用已解析的身份，例如在 `src/operations/echo.ts` 中：
+`getIdentity` 是 `ServiceContext` 上的必需字段，正如[上面的注意事项](#服务上下文)所述，上下文在**两个**入口点中构造 - 因此 `src/local-server.ts` 也需要它。本地服务器前面没有 API Gateway 授权器，因此为本地开发提供一个存根身份：
+
+```ts {5} ins={5}
+const httpResponse = await serviceHandler.handle(httpRequest, {
+  tracer,
+  logger,
+  metrics,
+  getIdentity: async () => ({ sub: 'local', username: 'local' }),
+});
+```
+
+我们现在可以在操作中使用已解析的身份，例如在 `src/operations/echo.ts` 中：
 
 ```ts
 import { ServiceContext } from '../context.js';
@@ -800,6 +826,49 @@ output "lambda_function_name" {
 <Snippet name="api/access-logging" parentHeading="访问日志记录" />
 
 ### 集成
+
+<Infrastructure>
+<Fragment slot="cdk">
+:::caution[CDK 中的操作名称为 camelCase]
+Smithy 操作以 PascalCase（`Echo`）声明，您的后端以该名称导出它们。CDK 集成键是相同名称的 **camelCase** 形式，因此操作 `Echo` 在您的堆栈中的任何地方都是 `echo`：
+
+```ts
+const api = new MyApi(this, 'MyApi', {
+  integrations: MyApi.defaultIntegrations(this)
+    // `Echo` in the model, `echo` here
+    .withOperationOptions({ echo: { timeout: Duration.seconds(60) } })
+    .build(),
+});
+
+api.integrations.echo.handler.addToRolePolicy(...);
+```
+:::
+</Fragment>
+<Fragment slot="terraform">
+:::note[Terraform 中的操作名称为 camelCase]
+生成的模块的操作键输出及其 `operations.json` 使用 Smithy 操作名称的 **camelCase** 形式，因此 Smithy 操作 `Echo` 的键为 `echo`：
+
+```hcl
+# `Echo` in the model, `echo` here
+resource "aws_iam_role_policy" "echo_permissions" {
+  name = "echo-additional-permissions"
+  role = module.my_api.lambda_execution_role_names["echo"]
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["s3:GetObject"]
+        Resource = "arn:aws:s3:::my-bucket/*"
+      }
+    ]
+  })
+}
+```
+:::
+</Fragment>
+</Infrastructure>
 
 <Snippet name="api/type-safe-api-integrations" parentHeading="集成" />
 

--- a/docs/src/content/docs/zh/snippets/api/type-safe-api-integrations.mdx
+++ b/docs/src/content/docs/zh/snippets/api/type-safe-api-integrations.mdx
@@ -66,6 +66,8 @@ const api = new MyApi(this, 'MyApi', {
 
 api.integrations.$router.handler.addEnvironment('LOG_LEVEL', 'DEBUG');
 ```
+
+请注意，如果您通过 `withOverrides` 覆盖了每个操作，`$router` 将不再可用，因为没有操作继续使用默认路由器集成。
 </Fragment>
 <Fragment slot="terraform">
 使用 `isolated` 模式，模块的输出是以操作名称为键的映射，因此您可以访问单个操作的资源。例如，要为一个操作的 Lambda 函数授予额外权限：

--- a/packages/nx-plugin/src/smithy/ts/api/generator.spec.ts
+++ b/packages/nx-plugin/src/smithy/ts/api/generator.spec.ts
@@ -551,6 +551,47 @@ describe('tsSmithyApiGenerator', () => {
     expect(secondBackendJson).toEqual(firstBackendJson);
   });
 
+  it('should preserve user-authored implementation files when re-run', async () => {
+    const options = {
+      name: 'test-api',
+      infra: 'rest-lambda' as const,
+      auth: 'custom' as const,
+      iac: 'cdk' as const,
+    };
+    await tsSmithyApiGenerator(tree, options);
+
+    // Stand in for what the guide has the reader write: a registered operation,
+    // a context carrying the caller's identity, and both entrypoints supplying it.
+    const userOwned = {
+      'test-api/backend/src/service.ts': `import { ServiceContext } from './context.js';
+import { TestApiService } from './generated/ssdk/index.js';
+import { Echo } from './operations/echo.js';
+import { GetUser } from './operations/get-user.js';
+
+export const Service: TestApiService<ServiceContext> = {
+  Echo,
+  GetUser,
+};
+`,
+      'test-api/backend/src/context.ts': '// MY CUSTOM CONTEXT\n',
+      'test-api/backend/src/operations/echo.ts': '// MY CUSTOM ECHO\n',
+      'test-api/backend/src/operations/get-user.ts':
+        'export const GetUser = 1;\n',
+      'test-api/backend/src/handler.ts': '// MY CUSTOM HANDLER\n',
+      'test-api/backend/src/local-server.ts': '// MY CUSTOM LOCAL SERVER\n',
+      'test-api/backend/src/index.ts': '// MY CUSTOM BARREL\n',
+    };
+    Object.entries(userOwned).forEach(([path, contents]) =>
+      tree.write(path, contents),
+    );
+
+    await tsSmithyApiGenerator(tree, options);
+
+    Object.entries(userOwned).forEach(([path, contents]) =>
+      expect(tree.read(path, 'utf-8')).toBe(contents),
+    );
+  });
+
   it('should configure OpenAPI metadata generation target', async () => {
     await tsSmithyApiGenerator(tree, {
       name: 'test-api',

--- a/packages/nx-plugin/src/smithy/ts/api/generator.ts
+++ b/packages/nx-plugin/src/smithy/ts/api/generator.ts
@@ -179,9 +179,12 @@ export const tsSmithyApiGenerator = async (
   );
   const port = assignPort(tree, backendProjectConfig, 3001);
 
-  // Delete default index.ts with "hello" function
-  tree.delete(joinPathFragments(backendProjectConfig.sourceRoot, 'index.ts'));
+  if (!projectExists) {
+    // Delete default index.ts with "hello" function
+    tree.delete(joinPathFragments(backendProjectConfig.sourceRoot, 'index.ts'));
+  }
 
+  // The API's source is user-owned, so a re-run leaves existing files alone.
   generateFiles(
     tree,
     joinPathFragments(import.meta.dirname, 'files'),
@@ -190,6 +193,9 @@ export const tsSmithyApiGenerator = async (
       apiNameClassName,
       port,
       ...esmVars(tree),
+    },
+    {
+      overwriteStrategy: OverwriteStrategy.KeepExisting,
     },
   );
 

--- a/packages/nx-plugin/src/trpc/backend/generator.spec.ts
+++ b/packages/nx-plugin/src/trpc/backend/generator.spec.ts
@@ -1341,4 +1341,74 @@ describe('trpc backend generator', () => {
       });
     },
   );
+  it('should preserve user-authored implementation files when re-run', async () => {
+    const options: TsTrpcApiGeneratorSchema = {
+      name: 'TestApi',
+      directory: 'apps',
+      infra: 'rest-lambda',
+      integrationPattern: 'isolated',
+      auth: 'iam',
+      iac: 'cdk',
+    };
+    await tsTrpcApiGenerator(tree, options);
+
+    // Stand in for what the guide has the reader write: a registered nested
+    // router, a new procedure, an edited schema and edited middleware.
+    const userOwned = {
+      'apps/test-api/src/router.ts': `import { echo } from './procedures/echo.js';
+import { listUsers } from './procedures/users/list.js';
+import { t } from './init.js';
+
+export const router = t.router;
+
+export const appRouter = router({
+  echo,
+  users: router({
+    list: listUsers,
+  }),
+});
+
+export type AppRouter = typeof appRouter;
+`,
+      'apps/test-api/src/procedures/echo.ts': `// MY CUSTOM CODE
+export const echo = publicProcedure.query(() => ({ message: 'hi' }));
+`,
+      'apps/test-api/src/procedures/users/list.ts':
+        'export const listUsers = 1;\n',
+      'apps/test-api/src/schema/index.ts': "export * from './users.js';\n",
+      'apps/test-api/src/schema/z-async-iterable.ts':
+        '// MY STREAMING HELPER\n',
+      'apps/test-api/src/init.ts': '// MY CUSTOM INIT\n',
+      'apps/test-api/src/index.ts': '// MY CUSTOM BARREL\n',
+      'apps/test-api/src/local-server.ts': '// MY CUSTOM LOCAL SERVER\n',
+      'apps/test-api/src/middleware/logger.ts': '// MY CUSTOM LOGGER\n',
+      'apps/test-api/src/middleware/metrics.ts': '// MY CUSTOM METRICS\n',
+      'apps/test-api/src/middleware/tracer.ts': '// MY CUSTOM TRACER\n',
+      'apps/test-api/src/middleware/error.ts': '// MY CUSTOM ERROR HANDLING\n',
+    };
+    Object.entries(userOwned).forEach(([path, contents]) =>
+      tree.write(path, contents),
+    );
+
+    await tsTrpcApiGenerator(tree, options);
+
+    Object.entries(userOwned).forEach(([path, contents]) =>
+      expect(tree.read(path, 'utf-8')).toBe(contents),
+    );
+  });
+
+  it('should vend its own entrypoint over the ts#project placeholder', async () => {
+    await tsTrpcApiGenerator(tree, {
+      name: 'TestApi',
+      directory: 'apps',
+      infra: 'rest-lambda',
+      integrationPattern: 'isolated',
+      auth: 'iam',
+      iac: 'cdk',
+    });
+
+    expect(tree.read('apps/test-api/src/index.ts', 'utf-8')).toContain(
+      "export { appRouter } from './router",
+    );
+  });
 });

--- a/packages/nx-plugin/src/trpc/backend/generator.ts
+++ b/packages/nx-plugin/src/trpc/backend/generator.ts
@@ -145,6 +145,11 @@ export async function tsTrpcApiGenerator(
   );
   const backendRoot = projectConfig.root;
 
+  if (!projectExists) {
+    // Clear the placeholder barrel from ts#project so the API's own is written.
+    tree.delete(joinPathFragments(backendRoot, 'src', 'index.ts'));
+  }
+
   const port = assignPort(tree, projectConfig, 2022);
 
   const enhancedOptions = {
@@ -274,13 +279,14 @@ export async function tsTrpcApiGenerator(
 
   updateProjectConfiguration(tree, projectConfig.name, projectConfig);
 
+  // The API's source is user-owned, so a re-run leaves existing files alone.
   generateFiles(
     tree,
     joinPathFragments(import.meta.dirname, 'files'),
     backendRoot,
     enhancedOptions,
     {
-      overwriteStrategy: OverwriteStrategy.Overwrite,
+      overwriteStrategy: OverwriteStrategy.KeepExisting,
     },
   );
 

--- a/packages/nx-plugin/src/utils/versions.ts
+++ b/packages/nx-plugin/src/utils/versions.ts
@@ -31,6 +31,7 @@ export const TS_VERSIONS = {
   '@aws-sdk/client-bedrock-runtime': '3.1121.0',
   '@aws-sdk/client-s3': '3.1121.0',
   '@aws-sdk/client-sts': '3.1121.0',
+  '@aws-sdk/client-cognito-identity-provider': '3.1121.0',
   '@aws-sdk/credential-providers': '3.1121.0',
   '@aws-sdk/credential-provider-cognito-identity': '3.972.69',
   '@aws-sdk/client-secrets-manager': '3.1121.0',


### PR DESCRIPTION
### Reason for this change

Closes the `ts-api` lane of the v1.0 bug bash. Findings addressed: **ts-api-02, 03, 04, 05, 06, 07, 08, 09, 10, 11**. (`ts-api-12` was dropped per review — see below.)

The headline issue (**ts-api-02**, major) is that `ts#api` is not idempotent. Re-running it for an existing API name reports `UPDATE .../src/router.ts` and `UPDATE .../src/procedures/echo.ts` and resets both to the scaffold — the exact two files the tRPC guide instructs the reader to edit ("If you add a new procedure, make sure you register it by adding it to the router in `src/router.ts`"). The reporting agent hit this for real mid-lane and lost a registered nested router, breaking `compile` of a downstream caller. This is the same family as the confirmed `ts#infra` / `terraform#project` blockers.

The rest are guide examples that don't work as written. A reader following them hits:

- **ts-api-03** (major) — the Cognito identity middleware isn't filtered by `infra`, so `http-lambda` readers get `APIGatewayProxyEvent` where the generator emits `APIGatewayProxyEventV2WithJWTAuthorizer` (tRPC `Context mismatch`, TS2345) *and* the wrong claims path (`authorizer.claims` vs `authorizer.jwt.claims`, so it would always throw `FORBIDDEN`). The IAM example directly above it *is* correctly tabbed.
- **ts-api-04** (major) — every identity example opens with `@aws-sdk/client-cognito-identity-provider`, which no generated API depends on and neither guide mentions. TS2307 on the first line.
- **ts-api-05** (minor) — the examples use a value import for `aws-lambda` types, failing biome's `noUndeclaredDependencies`. `lint --configuration=fix` does **not** repair it.
- **ts-api-06** (major) — the Smithy walkthrough adds a required `getIdentity` to `ServiceContext` but only patches `handler.ts`, breaking the generated `local-server.ts` — contradicting the guide's own "Manual Context Required" caution.
- **ts-api-07** (major) — `withOverrides` and `api.integrations.$router` are documented adjacently but are mutually exclusive on a scaffolded API.
- **ts-api-08** (docs) — Smithy operations are PascalCase but CDK integration keys are camelCase, undocumented.
- **ts-api-09 / 10 / 11** (docs) — a FileTree listing a `model/package.json` that is never generated, two bare relative links that 404, and a FileTree omitting `src/index.ts` (the entrypoint the guide's own client example imports from).

### Description of changes

**Idempotency (`ts-api-02`)** — `ts#api` now generates its source with `OverwriteStrategy.KeepExisting`, so a re-run leaves every existing file alone. That covers the two files the reported loss was in (`router.ts`, `procedures/echo.ts`) and everything else the guides instruct edits to. The same change is applied to the Smithy backend.

The placeholder barrel `ts#project` scaffolds is deleted only when the project did not already exist, so the API still vends its own `src/index.ts` on a first run; on a re-run nothing is deleted and `KeepExisting` preserves what is there. The Smithy generator had the same `tree.delete` unguarded, so it gets the same guard.

Only `ts#api` is touched here — the other generators in this family are a separate PR (#1211).

**Guides** — root cause was on the docs side for all of these; the generated output was right:

- `ts-api-03`: the Cognito example is now tabbed REST/HTTP like the IAM one, with `APIGatewayProxyEventV2WithJWTAuthorizer` and `authorizer.jwt.claims` on the HTTP tab. Username reads `claims.username ?? claims['cognito:username']`, since an ID token carries the latter.
- `ts-api-04`: `@aws-sdk/client-cognito-identity-provider` is documented as a prerequisite via `<InstallCommand>`, with the version rendered from `TS_VERSIONS` at build time so the documented pin can't go stale — the pattern `docker-bundling.mdx` uses for `CONTAINER_VERSIONS.trivy`. Neither generator declares the package: it only appears because a reader followed an optional walkthrough, so it's the user's dependency rather than something `ts#api` vends and owns. `<InstallCommand>` gained a `projectDir` passthrough (`buildInstallCommand` already accepted it) so the Smithy command targets `packages/<api>/backend` rather than npm/bun's wrong default.
- `ts-api-05`: `import type` throughout.
- `ts-api-06`: the walkthrough now includes the `local-server.ts` edit with a stub identity for local dev.
- `ts-api-07`: one sentence noting `$router` is unavailable once every operation is overridden. The types are correct — this is deliberate, since an all-overridden API routes nothing to the router — so the fix is documentation, not a type change.
- `ts-api-08`: a note in the Smithy guide's Integrations section with an example on each of the CDK and Terraform tabs (both metadata generators key off the same `dotNotationName`).
- `ts-api-09` / `ts-api-11`: FileTrees corrected against `find` output on real generated projects.
- `ts-api-10`: `<Link path="/guides/...">` as the rest of the docs use.

**Migration** — none added. The generated output is unchanged (the snapshots are untouched); the only behaviour change is what a *re-run* overwrites, which no existing workspace's on-disk state depends on. The `TS_VERSIONS` addition is read only by the guides to render the install command. Everything else is docs.

**`ts-api-12` intentionally not addressed** — the `auth`-has-no-`none` caution was removed per review, so that finding is left open.

### Description of how you validated changes

**Unit tests** — `pnpm nx run @aws/nx-plugin:test`: **4324 passed / 245 files, no failures and no snapshot changes**. New tests, since per `CONTRIBUTING.md` the existing idempotency tests pass only because they compare generator output to generator output:

- `trpc` and `smithy`: `should preserve user-authored implementation files when re-run` — writes user content into every generated source file between the two runs (including a registered nested router and a new procedure, reproducing the reported loss) and asserts it survives byte-for-byte.
- `trpc`: `should vend its own entrypoint over the ts#project placeholder` — asserts the API's own `src/index.ts` is what lands.

**End-to-end**, in a scratch workspace on the locally compiled plugin, generating the permutations each example targets (`--framework=trpc|smithy`, `--infra=rest-lambda|http-lambda`, `--auth=iam|cognito`) plus a `shared`/`custom` API and `ts#infra`:

- **Idempotency reproduced and fixed**: wrote a nested `users` router, a new procedure and `// MY CUSTOM CODE` into a generated API, re-ran the generator, confirmed all survived. Re-ran the Smithy generator over the completed identity walkthrough and confirmed all eight user files unchanged by `md5sum -c`.
- **Every corrected example pasted in verbatim**, then `build` (which runs `compile`, `lint` and `format`) green on all six projects — so `cog-http` now compiles where `ts-api-03` blocked it, and lint passes where `ts-api-05` failed.
- **`local-server.ts` verified specifically**: reverting just the new `getIdentity` line reproduces the exact `TS2345` from the finding, confirming the edit is what closes `ts-api-06`. With it, `tsx src/local-server.ts` serves and `GET /echo?message=hello` returns `{"message":"local says hello"}`.
- **`ts-api-07`/`08` confirmed against the real types**: `integrations.echo` and `withOperationOptions({ echo })` compile for Smithy's `operation Echo` (and the generated `metadata.gen.ts` shows `echo`); `$router` resolves with no overrides, and a `@ts-expect-error` on the all-overridden case passes — proving `$router` really is dropped, as the snippet now says. `synth` and `checkov` both green.

Stopped at `synth` — nothing deployed to AWS.

Also: `pnpm nx run-many --target lint --all --fix` clean, `pnpm nx run-many --target build --all` green, and `pnpm nx run docs:test` 124 passed (covers link integrity, so the `ts-api-10` fix is checked). The docs site build is left to CI.

The end-to-end run above exercised the original template-split implementation; review simplified that to a single blanket `KeepExisting`, which the unit tests re-verify — both `preserve user-authored implementation files` tests still pass unchanged.

### Issue # (if applicable)

N/A — bug bash findings ts-api-02 … ts-api-12.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*


