### PR TITLE
fix(ts#api): stop a project name colliding with the core construct it extends

### DIFF
--- a/packages/nx-plugin/src/py/fast-api/generator.spec.ts
+++ b/packages/nx-plugin/src/py/fast-api/generator.spec.ts
@@ -573,4 +573,54 @@ describe('fastapi project generator', () => {
 
     expect(tree.exists('packages/common/constructs')).toBeTruthy();
   });
+
+  // The reserved name follows the infrastructure, not the framework: a REST API
+  // named `rest-api` collides where an HTTP one named `http-api` does.
+  describe.each([
+    { name: 'http-api', infra: 'http-lambda' as const, coreClass: 'HttpApi' },
+    { name: 'rest-api', infra: 'rest-lambda' as const, coreClass: 'RestApi' },
+  ])(
+    'a project named $name, colliding with the core $coreClass',
+    ({ name, infra, coreClass }) => {
+      it('extends the aliased core construct rather than itself', async () => {
+        await pyFastApiProjectGenerator(tree, {
+          name,
+          directory: 'apps',
+          infra,
+          auth: 'iam',
+          iac: 'cdk',
+        });
+
+        const construct =
+          tree.read(
+            `packages/common/constructs/src/app/apis/${name}.ts`,
+            'utf-8',
+          ) ?? '';
+
+        expect(construct).toContain(`${coreClass} as Core${coreClass}`);
+        expect(construct).toContain(`extends Core${coreClass}<`);
+        expect(construct).toContain(`export class ${coreClass}<`);
+        expect(construct).not.toContain(`extends ${coreClass}<`);
+      });
+
+      it('leaves the import unaliased for a name that does not collide', async () => {
+        await pyFastApiProjectGenerator(tree, {
+          name: 'test-api',
+          directory: 'apps',
+          infra,
+          auth: 'iam',
+          iac: 'cdk',
+        });
+
+        const construct =
+          tree.read(
+            'packages/common/constructs/src/app/apis/test-api.ts',
+            'utf-8',
+          ) ?? '';
+
+        expect(construct).toContain(`extends ${coreClass}<`);
+        expect(construct).not.toContain(`Core${coreClass}`);
+      });
+    },
+  );
 });

--- a/packages/nx-plugin/src/trpc/backend/generator.spec.ts
+++ b/packages/nx-plugin/src/trpc/backend/generator.spec.ts
@@ -1271,4 +1271,74 @@ describe('trpc backend generator', () => {
     const projectConfig = JSON.parse(secondProjectJson);
     expect(projectConfig.metadata.ports).toEqual([2022]);
   });
+
+  // A project named after the core construct its infrastructure extends used to
+  // emit `export class HttpApi ... extends HttpApi` with `HttpApi` imported too.
+  describe.each([
+    {
+      name: 'http-api',
+      infra: 'http-lambda' as const,
+      coreClass: 'HttpApi',
+      corePath: '../../core/api/http-api.js',
+    },
+    {
+      name: 'rest-api',
+      infra: 'rest-lambda' as const,
+      coreClass: 'RestApi',
+      corePath: '../../core/api/rest-api.js',
+    },
+  ])(
+    'a project named $name, colliding with the core $coreClass',
+    ({ name, infra, coreClass, corePath }) => {
+      it('extends the aliased core construct rather than itself', async () => {
+        await tsTrpcApiGenerator(tree, {
+          name,
+          directory: 'apps',
+          infra,
+          integrationPattern: 'isolated',
+          auth: 'iam',
+          iac: 'cdk',
+        });
+
+        const construct =
+          tree.read(
+            `packages/common/constructs/src/app/apis/${name}.ts`,
+            'utf-8',
+          ) ?? '';
+
+        // The core class is imported under an alias, so the app class of the
+        // same name neither collides with nor extends itself.
+        expect(construct).toContain(`${coreClass} as Core${coreClass}`);
+        expect(construct).toContain(`from '${corePath}'`);
+        expect(construct).toContain(`extends Core${coreClass}<`);
+        expect(construct).toContain(`export class ${coreClass}<`);
+        expect(construct).not.toMatch(
+          new RegExp(`import \\{[^}]*\\b${coreClass}\\s*\\}`),
+        );
+        expect(construct).not.toContain(`extends ${coreClass}<`);
+      });
+
+      it('leaves the import unaliased for a name that does not collide', async () => {
+        await tsTrpcApiGenerator(tree, {
+          name: 'test-api',
+          directory: 'apps',
+          infra,
+          integrationPattern: 'isolated',
+          auth: 'iam',
+          iac: 'cdk',
+        });
+
+        const construct =
+          tree.read(
+            'packages/common/constructs/src/app/apis/test-api.ts',
+            'utf-8',
+          ) ?? '';
+
+        // Aliasing is applied only where it is needed, so the vended code for an
+        // ordinary name is unchanged.
+        expect(construct).toContain(`extends ${coreClass}<`);
+        expect(construct).not.toContain(`Core${coreClass}`);
+      });
+    },
+  );
 });

--- a/packages/nx-plugin/src/ts/react-website/app/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/react-website/app/generator.spec.ts
@@ -217,6 +217,44 @@ describe('react-website generator', () => {
     ).toMatchSnapshot('common/constructs-core-static-website.ts');
   });
 
+  // A website named after the core construct it extends used to emit
+  // `export class StaticWebsite ... extends StaticWebsite` with the core
+  // `StaticWebsite` imported unaliased.
+  it('extends the aliased core construct when named static-website', async () => {
+    await tsReactWebsiteGenerator(tree, { ...options, name: 'static-website' });
+
+    const construct =
+      tree.read(
+        'packages/common/constructs/src/app/static-websites/static-website.ts',
+        'utf-8',
+      ) ?? '';
+
+    expect(construct).toContain('StaticWebsite as CoreStaticWebsite');
+    expect(construct).toContain('StaticWebsiteProps as CoreStaticWebsiteProps');
+    expect(construct).toContain('extends CoreStaticWebsite');
+    expect(construct).toContain('export class StaticWebsite');
+    expect(construct).not.toMatch(/import \{[^}]*\bStaticWebsite\s*,/);
+    expect(construct).not.toContain('extends StaticWebsite');
+  });
+
+  it('leaves the core import unaliased for a name that does not collide', async () => {
+    await tsReactWebsiteGenerator(tree, options);
+
+    const construct =
+      tree.read(
+        'packages/common/constructs/src/app/static-websites/test-app.ts',
+        'utf-8',
+      ) ?? '';
+
+    // Aliasing is applied only where it is needed, so the vended code for an
+    // ordinary name is unchanged.
+    expect(construct).toContain(
+      "import { StaticWebsite, StaticWebsiteProps } from '../../core/index.js'",
+    );
+    expect(construct).toContain('extends StaticWebsite');
+    expect(construct).not.toContain('CoreStaticWebsite');
+  });
+
   it('should update package.json with required dependencies', async () => {
     await tsReactWebsiteGenerator(tree, options);
     // The website's runtime dependencies live in its own project manifest

--- a/packages/nx-plugin/src/utils/agent-core-constructs/files/cdk/app/agentcore-gateway/__nameKebabCase__/__nameKebabCase__.ts.template
+++ b/packages/nx-plugin/src/utils/agent-core-constructs/files/cdk/app/agentcore-gateway/__nameKebabCase__/__nameKebabCase__.ts.template
@@ -7,9 +7,13 @@ import * as url from 'node:url';
 import { GatewayAuthorizer } from 'aws-cdk-lib/aws-bedrockagentcore';
 import { IUserPool, IUserPoolClient } from 'aws-cdk-lib/aws-cognito';
 <%_ } _%>
+<%_ /* Alias the core imports only when this gateway's name would shadow them. */ _%>
+<%_ const collides = ['AgentCoreGateway', 'AgentCoreGatewayProps'].includes(nameClassName); _%>
+<%_ const coreGateway = collides ? 'CoreAgentCoreGateway' : 'AgentCoreGateway'; _%>
+<%_ const coreGatewayProps = collides ? 'CoreAgentCoreGatewayProps' : 'AgentCoreGatewayProps'; _%>
 import {
-  AgentCoreGateway,
-  AgentCoreGatewayProps,
+  AgentCoreGateway<% if (collides) { %> as <%= coreGateway %><% } %>,
+  AgentCoreGatewayProps<% if (collides) { %> as <%= coreGatewayProps %><% } %>,
 } from '../../../core/agentcore-gateway/agentcore-gateway<% if (esm) { %>.js<% } %>';
 import { RuntimeConfig } from '../../../core/runtime-config<% if (esm) { %>.js<% } %>';
 <%_ if (cedarPolicy) { _%>
@@ -18,7 +22,7 @@ import { findWorkspaceRoot } from '../../../core/workspace<% if (esm) { %>.js<% 
 
 <%_ if (auth === 'cognito') { _%>
 export type <%- nameClassName %>Props = Omit<
-  AgentCoreGatewayProps,
+  <%= coreGatewayProps %>,
   <%_ if (cedarPolicy) { _%>'cedarPolicyPath' | <%_ } _%>'authorizer' | 'protocol'
 > & {
   /**
@@ -31,9 +35,9 @@ export type <%- nameClassName %>Props = Omit<
   };
 };
 <%_ } else if (cedarPolicy) { _%>
-export type <%- nameClassName %>Props = Omit<AgentCoreGatewayProps, 'cedarPolicyPath' | 'protocol'>;
+export type <%- nameClassName %>Props = Omit<<%= coreGatewayProps %>, 'cedarPolicyPath' | 'protocol'>;
 <%_ } else { _%>
-export type <%- nameClassName %>Props = Omit<AgentCoreGatewayProps, 'protocol'>;
+export type <%- nameClassName %>Props = Omit<<%= coreGatewayProps %>, 'protocol'>;
 <%_ } _%>
 
 /**
@@ -44,7 +48,7 @@ export type <%- nameClassName %>Props = Omit<AgentCoreGatewayProps, 'protocol'>;
  * at synth time and attached to a PolicyEngine running in ENFORCE mode.
 <%_ } _%>
  */
-export class <%- nameClassName %> extends AgentCoreGateway {
+export class <%- nameClassName %> extends <%= coreGateway %> {
   /** Default Gateway target name when added to another Gateway. */
   public readonly gatewayName = '<%- nameKebabCase %>';
 

--- a/packages/nx-plugin/src/utils/api-constructs/files/cdk/app/apis/http/__apiNameKebabCase__.ts.template
+++ b/packages/nx-plugin/src/utils/api-constructs/files/cdk/app/apis/http/__apiNameKebabCase__.ts.template
@@ -43,7 +43,9 @@ import {
   IntegrationBuilder,
 } from '../../core/api/utils<% if (esm) { %>.js<% } %>';
 import { findCloudFrontDomainNames } from '../../core/cloudfront<% if (esm) { %>.js<% } %>';
-import { HttpApi } from '../../core/api/http-api<% if (esm) { %>.js<% } %>';
+<%_ /* Alias the core class only when this API's name would shadow it. */ _%>
+<%_ const coreHttpApi = apiNameClassName === 'HttpApi' ? 'CoreHttpApi' : 'HttpApi'; _%>
+import { HttpApi<% if (coreHttpApi !== 'HttpApi') { %> as <%= coreHttpApi %><% } %> } from '../../core/api/http-api<% if (esm) { %>.js<% } %>';
 <%_ if (backend.type === 'trpc') { _%>
 import { Procedures, routerToOperations } from '../../core/api/trpc-utils<% if (esm) { %>.js<% } %>';
 import { AppRouter, appRouter } from '<%= backend.projectAlias %>';
@@ -87,7 +89,7 @@ export interface <%= apiNameClassName %>Props<
  */
 export class <%= apiNameClassName %><
   TIntegrations extends ApiIntegrations<Operations, HttpApiIntegration>,
-> extends HttpApi<Operations, TIntegrations> {
+> extends <%= coreHttpApi %><Operations, TIntegrations> {
   /**
    <%_ if (backend.integrationPattern === 'shared') { _%>
    * Creates default integrations for all operations using a single shared

--- a/packages/nx-plugin/src/utils/api-constructs/files/cdk/app/apis/rest/__apiNameKebabCase__.ts.template
+++ b/packages/nx-plugin/src/utils/api-constructs/files/cdk/app/apis/rest/__apiNameKebabCase__.ts.template
@@ -46,7 +46,9 @@ import {
   RestApiIntegration,
 } from '../../core/api/utils<% if (esm) { %>.js<% } %>';
 import { findCloudFrontDomainNames } from '../../core/cloudfront<% if (esm) { %>.js<% } %>';
-import { AddCorsPreflightAspect, RestApi } from '../../core/api/rest-api<% if (esm) { %>.js<% } %>';
+<%_ /* Alias the core class only when this API's name would shadow it. */ _%>
+<%_ const coreRestApi = apiNameClassName === 'RestApi' ? 'CoreRestApi' : 'RestApi'; _%>
+import { AddCorsPreflightAspect, RestApi<% if (coreRestApi !== 'RestApi') { %> as <%= coreRestApi %><% } %> } from '../../core/api/rest-api<% if (esm) { %>.js<% } %>';
 <%_ if (backend.type === 'trpc') { _%>
 import { Procedures, routerToOperations } from '../../core/api/trpc-utils<% if (esm) { %>.js<% } %>';
 import { AppRouter, appRouter } from '<%= backend.projectAlias %>';
@@ -95,7 +97,7 @@ export interface <%= apiNameClassName %>Props<
  */
 export class <%= apiNameClassName %><
   TIntegrations extends ApiIntegrations<Operations, RestApiIntegration>,
-> extends RestApi<Operations, TIntegrations> {
+> extends <%= coreRestApi %><Operations, TIntegrations> {
   private allowedOrigins: readonly string[] = ['*'];
 
   /**

--- a/packages/nx-plugin/src/utils/dynamodb-constructs/files/cdk/app/dynamodb/__nameKebabCase__.ts.template
+++ b/packages/nx-plugin/src/utils/dynamodb-constructs/files/cdk/app/dynamodb/__nameKebabCase__.ts.template
@@ -1,8 +1,12 @@
 import { Construct } from 'constructs';
 import { AttributeType, ProjectionType } from 'aws-cdk-lib/aws-dynamodb';
+<%_ /* Alias the core imports only when this table's name would shadow them. */ _%>
+<%_ const collides = nameClassName === 'DynamoDBTable'; _%>
+<%_ const coreTable = collides ? 'CoreDynamoDBTable' : 'DynamoDBTable'; _%>
+<%_ const coreTableProps = collides ? 'CoreDynamoDBTableProps' : 'DynamoDBTableProps'; _%>
 import {
-  DynamoDBTable,
-  DynamoDBTableProps,
+  DynamoDBTable<% if (collides) { %> as <%= coreTable %><% } %>,
+  DynamoDBTableProps<% if (collides) { %> as <%= coreTableProps %><% } %>,
 } from '../../core/dynamodb<% if (esm) { %>.js<% } %>';
 import { findWorkspaceRoot } from '../../core/workspace<% if (esm) { %>.js<% } %>';
 import { readFileSync } from 'fs';
@@ -20,11 +24,11 @@ const { runtimeConfigKey, tableConfig } = JSON.parse(
 ) as { runtimeConfigKey: string; tableConfig: { globalSecondaryIndexes: { indexName: string; partitionKey: string; sortKey?: string }[] } };
 
 export type <%= nameClassName %>Props = Omit<
-  DynamoDBTableProps,
+  <%= coreTableProps %>,
   'runtimeConfigKey'
 >;
 
-export class <%= nameClassName %> extends DynamoDBTable {
+export class <%= nameClassName %> extends <%= coreTable %> {
   constructor(scope: Construct, id: string, props?: <%= nameClassName %>Props) {
     super(scope, id, {
       ...props,

--- a/packages/nx-plugin/src/utils/rdb-constructs/files/cdk/app/dbs/__nameKebabCase__.ts.template
+++ b/packages/nx-plugin/src/utils/rdb-constructs/files/cdk/app/dbs/__nameKebabCase__.ts.template
@@ -15,10 +15,15 @@ import {
   Runtime,
 <%_ } _%>
 } from 'aws-cdk-lib/aws-lambda';
+<%_ /* Alias the core imports only when this database's name would shadow them. */ _%>
+<%_ const collides = ['AuroraDatabase', 'AuroraDatabaseEngines', 'AuroraDatabaseProps'].includes(nameClassName); _%>
+<%_ const coreDb = collides ? 'CoreAuroraDatabase' : 'AuroraDatabase'; _%>
+<%_ const coreDbEngines = collides ? 'CoreAuroraDatabaseEngines' : 'AuroraDatabaseEngines'; _%>
+<%_ const coreDbProps = collides ? 'CoreAuroraDatabaseProps' : 'AuroraDatabaseProps'; _%>
 import {
-  AuroraDatabase,
-  AuroraDatabaseEngines,
-  AuroraDatabaseProps,
+  AuroraDatabase<% if (collides) { %> as <%= coreDb %><% } %>,
+  AuroraDatabaseEngines<% if (collides) { %> as <%= coreDbEngines %><% } %>,
+  AuroraDatabaseProps<% if (collides) { %> as <%= coreDbProps %><% } %>,
 } from '../../core/rdb/aurora<% if (esm) { %>.js<% } %>';
 import { findWorkspaceRoot } from '../../core/workspace<% if (esm) { %>.js<% } %>';
 
@@ -43,21 +48,21 @@ const createDbUserBundleDir = path.join(
 );
 
 export type <%= nameClassName %>Props = Omit<
-  AuroraDatabaseProps,
+  <%= coreDbProps %>,
   'databaseName' | 'adminUser' | 'runtimeConfigKey' | 'engine'
 >;
 
 /**
  * CDK construct that provisions an Aurora Serverless v2 cluster.
  */
-export class <%= nameClassName %> extends AuroraDatabase {
+export class <%= nameClassName %> extends <%= coreDb %> {
   constructor(scope: Construct, id: string, props: <%= nameClassName %>Props) {
     super(scope, id, {
       ...props,
       databaseName: '<%= databaseName %>',
       adminUser: '<%= adminUser %>',
       runtimeConfigKey,
-      engine: AuroraDatabaseEngines.<%= engine %>({}),
+      engine: <%= coreDbEngines %>.<%= engine %>({}),
     });
   }
 

--- a/packages/nx-plugin/src/utils/website-constructs/files/cdk/app/static-websites/__websiteNameKebabCase__.ts.template
+++ b/packages/nx-plugin/src/utils/website-constructs/files/cdk/app/static-websites/__websiteNameKebabCase__.ts.template
@@ -1,16 +1,20 @@
 import * as url from 'url';
 import { Construct } from 'constructs';
+<%_ /* Alias the core imports only when this website's name would shadow them. */ _%>
+<%_ const collides = websiteNameClassName === 'StaticWebsite'; _%>
+<%_ const coreWebsite = collides ? 'CoreStaticWebsite' : 'StaticWebsite'; _%>
+<%_ const coreWebsiteProps = collides ? 'CoreStaticWebsiteProps' : 'StaticWebsiteProps'; _%>
 import {
-  StaticWebsite,
-  StaticWebsiteProps,
+  StaticWebsite<% if (collides) { %> as <%= coreWebsite %><% } %>,
+  StaticWebsiteProps<% if (collides) { %> as <%= coreWebsiteProps %><% } %>,
 } from '../../core/index<% if (esm) { %>.js<% } %>';
 
 export type <%= websiteNameClassName %>Props = Omit<
-  StaticWebsiteProps,
+  <%= coreWebsiteProps %>,
   'websiteName' | 'websiteFilePath'
 >;
 
-export class <%= websiteNameClassName %> extends StaticWebsite {
+export class <%= websiteNameClassName %> extends <%= coreWebsite %> {
   constructor(scope: Construct, id: string, props?: <%= websiteNameClassName %>Props) {
     super(scope, id, {
       ...props,


### PR DESCRIPTION
### Reason for this change

Closes bug bash finding **`ts-api-01`** (blocker, verified).

Naming a project after the core CDK construct its infrastructure extends generated a **self-referencing class that cannot compile**. `ts#api --name=http-api --framework=trpc --infra=http-lambda` emitted `packages/common/constructs/src/app/apis/http-api.ts` containing:

```ts
import { HttpApi } from '../../core/api/http-api.js';

export class HttpApi<
  TIntegrations extends ApiIntegrations<Operations, HttpApiIntegration>,
> extends HttpApi<Operations, TIntegrations> {
```

That is 5 TS errors (`TS2395`, `TS2440`, `TS2506`, `TS2339`), which fails `@ws/common-constructs:compile` and with it `build` for the **whole workspace** — `common-constructs` is a dependency of every API project's build. There is no warning at generate time, and recovering by hand means unpicking the project from `apis/index.ts`, `package.json`, `project.json`, `tsconfig.base.json` and `tsconfig.json`.

### Description of changes

Each app-level CDK construct template aliases its core import to `Core<Symbol>` **only when the chosen name would actually shadow it**. In the ordinary case the generated code keeps the plain import and is byte-identical to today, so the blast radius is limited to the workspaces that were broken.

The collision check is computed in the template from the same class the template extends (`apiNameClassName === 'HttpApi'`, `nameClassName === 'DynamoDBTable'`, …), so it needs no generator changes, no new shared helper and no additions to `templateOptions`.

**Why a check rather than a reserved-name denylist.** The reserved name isn't a property of the generator — it depends on which core construct the chosen *infrastructure* extends:

- `ts#api --name=http-api --infra=http-lambda` → collides (extends `HttpApi`)
- `ts#api --name=rest-api --infra=rest-lambda` → collides (extends `RestApi`)
- `py#api --name=rest-api --framework=fastapi` → **collides** (9 errors), because py#api defaults to REST
- `py#api --name=http-api` → **compiles fine**, same generator, same name, different infra

So `http-api` is fatal in one configuration and perfectly legal in another. A denylist would have to be keyed on (generator × framework × infra) and kept in sync with every new core construct, and would reject names that are fine. Deriving the reserved name from the class the template extends handles that variability by construction.

Templates covered — the same latent shape existed beyond the two API cases, so all of them now check:

| Template | Colliding name |
| --- | --- |
| `api-constructs` http | `HttpApi` |
| `api-constructs` rest | `RestApi` |
| `website-constructs` | `StaticWebsite` / `StaticWebsiteProps` |
| `dynamodb-constructs` | `DynamoDBTable` / `DynamoDBTableProps` |
| `rdb-constructs` | `AuroraDatabase` / `…Engines` / `…Props` |
| `agent-core-constructs` gateway | `AgentCoreGateway` / `…Props` |

`lambda-functions` needed no change — it extends CDK's own `Function`, not a vended core construct. **Terraform is not affected**: the HCL templates interpolate the project name only into strings and paths (`website_name`, S3 keys, `name_prefix`), and the `module` labels are fixed literals (`module "http_api"`), so no user-chosen name can shadow a module reference.

No migration. With conditional aliasing there is nothing to carry: a workspace whose name doesn't collide is unchanged by this PR, and one that does collide never compiled in the first place.

**Diff size:** 9 files, +203/-24, and **no snapshots move** — the earlier revision of this PR aliased unconditionally, which was 23 files / +867/-81 with 12 snapshot files churning. That churn was the blast radius @cogwirrel objected to, and conditional aliasing removes all of it.

### Description of how you validated changes

Each affected generator has a **pair** of tests, and the second of each pair is what demonstrates the small blast radius:

- **colliding name → aliased**: `expect(construct).toContain('HttpApi as CoreHttpApi')`, `toContain('extends CoreHttpApi<')`, plus `not.toContain('extends HttpApi<')` and no unaliased core import left.
- **ordinary name → untouched**: `expect(construct).toContain('extends HttpApi<')` and `expect(construct).not.toContain('CoreHttpApi')` — i.e. the vended output for a normal project is exactly as before.

Applied to `http-api`/`http-lambda` and `rest-api`/`rest-lambda` in `trpc/backend` and again in `py/fast-api` (covering the infra-dependent variability above), and to the non-API case in `ts/react-website` with a website named `static-website`.

```
pnpm exec vitest run src/trpc/backend/generator.spec.ts src/py/fast-api/generator.spec.ts \
  src/ts/react-website/app/generator.spec.ts src/agentcore-gateway/generator.spec.ts
# 230 passed, 0 snapshots written
```

That no snapshot needed updating — and that `agentcore-gateway/generator.spec.ts` needed no assertion changes — is itself the evidence that ordinary output is unchanged.

End-to-end in a scratch workspace against the locally compiled plugin, both directions in the same workspace:

```
pnpm nx g @aws/nx-plugin:ts#api --name=http-api --framework=trpc --infra=http-lambda --auth=cognito
#   -> import { HttpApi as CoreHttpApi } ... extends CoreHttpApi<Operations, TIntegrations>
pnpm nx g @aws/nx-plugin:ts#api --name=orders   --framework=trpc --infra=http-lambda --auth=cognito
#   -> import { HttpApi } ...              extends HttpApi<Operations, TIntegrations>
pnpm nx sync && pnpm install
pnpm nx run @ws/common-constructs:compile   # was 5 errors on http-api -> now clean
```

Nothing was deployed to AWS.

### Known limitation (pre-existing, not introduced here)

For a website named `static-website` specifically, one *separate* pre-existing error remains after aliasing: `common/constructs/src/index.ts` star-re-exports both `./app/index.js` and `./core/index.js`, so an app class sharing a core class's name is an ambiguous re-export (`TS2308` on `StaticWebsite` and `StaticWebsiteProps`). I confirmed this error is present before this change too, so it's a distinct barrel-shadowing issue in the `common/constructs` export surface rather than a regression, and fixing it means changing how those barrels re-export. Left out of scope here and flagged for follow-up. The API cases are unaffected, since `core/api/*` isn't re-exported through `core/index.ts` — which is why `http-api`/`rest-api` compile cleanly end to end.

### Issue # (if applicable)

N/A — from the v1.0 bug bash (`ts-api-01`).

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
