### PR TITLE
ci: right-size Linux runner compute across several instance sizes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ permissions:
 jobs:
   package:
     name: Package
-    runs-on: codebuild-nx-plugin-for-aws-runner-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: codebuild-nx-plugin-for-aws-runner-${{ github.run_id }}-${{ github.run_attempt }}-large
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -49,7 +49,7 @@ jobs:
           path: dist
   build:
     name: Build
-    runs-on: codebuild-nx-plugin-for-aws-runner-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: codebuild-nx-plugin-for-aws-runner-${{ github.run_id }}-${{ github.run_attempt }}-xlarge
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -75,7 +75,7 @@ jobs:
           path: docs/dist
   unit_tests:
     name: Unit Tests - ${{ matrix.shard }}
-    runs-on: codebuild-nx-plugin-for-aws-runner-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: codebuild-nx-plugin-for-aws-runner-${{ github.run_id }}-${{ github.run_attempt }}-large
     strategy:
       fail-fast: false
       matrix:
@@ -98,44 +98,76 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
   smoke_tests:
     name: Smoke Tests - ${{matrix.smoke_test}}
-    runs-on: codebuild-nx-plugin-for-aws-runner-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: codebuild-nx-plugin-for-aws-runner-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.size }}
     needs: package
     strategy:
       fail-fast: false
       matrix:
-        smoke_test:
-          - npm
-          - yarn-classic
-          - yarn-4
-          - pnpm-10
-          - pnpm-11
-          - pnpm-12
-          - bun
-          - create-workspace
-          - dungeon-adventure
-          - terraform
-          - rdb
-          - trpc-api
-          - fast-api
-          - smithy-api
-          - react-website
-          - infra-none
-          - existing-workspace
-          - idempotency
-          - cdk-deploy
-          - cdk-deploy-rdb
-          - terraform-deploy
-          - terraform-deploy-rdb
-          - license-sync
-          - mcp-server
-          - nx-plugin
-          - test-matrix
-          - local-dev
-          - git-secrets
-          - audit
-          - finch
-          - trivy
-          - release
+        include:
+          - smoke_test: npm
+            size: xlarge
+          - smoke_test: yarn-classic
+            size: xlarge
+          - smoke_test: yarn-4
+            size: xlarge
+          - smoke_test: pnpm-10
+            size: xlarge
+          - smoke_test: pnpm-11
+            size: xlarge
+          - smoke_test: pnpm-12
+            size: xlarge
+          - smoke_test: bun
+            size: xlarge
+          - smoke_test: create-workspace
+            size: large
+          - smoke_test: dungeon-adventure
+            size: large
+          - smoke_test: terraform
+            size: xlarge
+          - smoke_test: rdb
+            size: xlarge
+          - smoke_test: trpc-api
+            size: large
+          - smoke_test: fast-api
+            size: large
+          - smoke_test: smithy-api
+            size: medium
+          - smoke_test: react-website
+            size: large
+          - smoke_test: infra-none
+            size: large
+          - smoke_test: existing-workspace
+            size: medium
+          - smoke_test: idempotency
+            size: xlarge
+          - smoke_test: cdk-deploy
+            size: xlarge
+          - smoke_test: cdk-deploy-rdb
+            size: xlarge
+          - smoke_test: terraform-deploy
+            size: xlarge
+          - smoke_test: terraform-deploy-rdb
+            size: xlarge
+          - smoke_test: license-sync
+            size: medium
+          - smoke_test: mcp-server
+            size: medium
+          - smoke_test: nx-plugin
+            size: medium
+          - smoke_test: test-matrix
+            size: large
+          - smoke_test: local-dev
+            size: large
+          - smoke_test: git-secrets
+            size: medium
+          - smoke_test: audit
+            size: medium
+          - smoke_test: finch
+            size: xlarge
+          - smoke_test: trivy
+            size: xlarge
+          - smoke_test: release
+            size: medium
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -164,7 +196,7 @@ jobs:
   # (NX_E2E_SHARD=<index>/<total>). Nothing here deploys, so no AWS credentials.
   smoke_tests_migrate:
     name: Smoke Tests - migrate (${{matrix.shard}}/5)
-    runs-on: codebuild-nx-plugin-for-aws-runner-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: codebuild-nx-plugin-for-aws-runner-${{ github.run_id }}-${{ github.run_attempt }}-xlarge
     needs: package
     strategy:
       fail-fast: false
@@ -193,7 +225,7 @@ jobs:
   # comes from sharding across machines (NX_E2E_SHARD=<index>/<total>).
   smoke_tests_standalone:
     name: Smoke Tests - standalone (${{matrix.shard}}/6)
-    runs-on: codebuild-nx-plugin-for-aws-runner-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: codebuild-nx-plugin-for-aws-runner-${{ github.run_id }}-${{ github.run_attempt }}-2xlarge
     needs: package
     strategy:
       fail-fast: false

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -30,7 +30,7 @@ permissions:
 jobs:
   package:
     name: Package
-    runs-on: codebuild-nx-plugin-for-aws-runner-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: codebuild-nx-plugin-for-aws-runner-${{ github.run_id }}-${{ github.run_attempt }}-large
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -49,7 +49,7 @@ jobs:
           path: dist
   build:
     name: Build
-    runs-on: codebuild-nx-plugin-for-aws-runner-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: codebuild-nx-plugin-for-aws-runner-${{ github.run_id }}-${{ github.run_attempt }}-xlarge
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -70,7 +70,7 @@ jobs:
         run: git diff --ignore-space-at-eol --exit-code -- ':!**/LICENSE-THIRD-PARTY'
   unit_tests:
     name: Unit Tests - ${{ matrix.shard }}
-    runs-on: codebuild-nx-plugin-for-aws-runner-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: codebuild-nx-plugin-for-aws-runner-${{ github.run_id }}-${{ github.run_attempt }}-large
     strategy:
       fail-fast: false
       matrix:
@@ -93,41 +93,70 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
   smoke_tests:
     name: Smoke Tests - ${{matrix.smoke_test}}
-    runs-on: codebuild-nx-plugin-for-aws-runner-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: codebuild-nx-plugin-for-aws-runner-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.size }}
     needs: package
     strategy:
       fail-fast: false
       matrix:
-        smoke_test:
-          - npm
-          - yarn-classic
-          - yarn-4
-          - pnpm-10
-          - pnpm-11
-          - pnpm-12
-          - bun
-          - create-workspace
-          - dungeon-adventure
-          - terraform
-          - rdb
-          - trpc-api
-          - fast-api
-          - smithy-api
-          - react-website
-          - infra-none
-          - existing-workspace
-          - idempotency
-          - license-sync
-          - license-check
-          - mcp-server
-          - nx-plugin
-          - test-matrix
-          - local-dev
-          - git-secrets
-          - audit
-          - finch
-          - trivy
-          - release
+        include:
+          - smoke_test: npm
+            size: xlarge
+          - smoke_test: yarn-classic
+            size: xlarge
+          - smoke_test: yarn-4
+            size: xlarge
+          - smoke_test: pnpm-10
+            size: xlarge
+          - smoke_test: pnpm-11
+            size: xlarge
+          - smoke_test: pnpm-12
+            size: xlarge
+          - smoke_test: bun
+            size: xlarge
+          - smoke_test: create-workspace
+            size: large
+          - smoke_test: dungeon-adventure
+            size: large
+          - smoke_test: terraform
+            size: xlarge
+          - smoke_test: rdb
+            size: xlarge
+          - smoke_test: trpc-api
+            size: large
+          - smoke_test: fast-api
+            size: large
+          - smoke_test: smithy-api
+            size: medium
+          - smoke_test: react-website
+            size: large
+          - smoke_test: infra-none
+            size: large
+          - smoke_test: existing-workspace
+            size: medium
+          - smoke_test: idempotency
+            size: xlarge
+          - smoke_test: license-sync
+            size: medium
+          - smoke_test: license-check
+            size: medium
+          - smoke_test: mcp-server
+            size: medium
+          - smoke_test: nx-plugin
+            size: medium
+          - smoke_test: test-matrix
+            size: large
+          - smoke_test: local-dev
+            size: large
+          - smoke_test: git-secrets
+            size: medium
+          - smoke_test: audit
+            size: medium
+          - smoke_test: finch
+            size: xlarge
+          - smoke_test: trivy
+            size: xlarge
+          - smoke_test: release
+            size: medium
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -150,7 +179,7 @@ jobs:
   # (NX_E2E_SHARD=<index>/<total>).
   smoke_tests_migrate:
     name: Smoke Tests - migrate (${{matrix.shard}}/5)
-    runs-on: codebuild-nx-plugin-for-aws-runner-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: codebuild-nx-plugin-for-aws-runner-${{ github.run_id }}-${{ github.run_attempt }}-xlarge
     needs: package
     strategy:
       fail-fast: false
@@ -179,7 +208,7 @@ jobs:
   # comes from sharding across machines (NX_E2E_SHARD=<index>/<total>).
   smoke_tests_standalone:
     name: Smoke Tests - standalone (${{matrix.shard}}/6)
-    runs-on: codebuild-nx-plugin-for-aws-runner-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: codebuild-nx-plugin-for-aws-runner-${{ github.run_id }}-${{ github.run_attempt }}-2xlarge
     needs: package
     strategy:
       fail-fast: false


### PR DESCRIPTION
Every Linux CI job ran on the runner project's default `BUILD_GENERAL1_2XLARGE`, so all ~52 jobs competed for one quota (`Linux/2XLarge`, 100 in us-west-2). Measured occupancy peaked at **95/100**, queue waits hit p99 1018s (CloudWatch max 1797s), and runs that never got a runner were cancelled by `cancel-in-progress` on the next push — which is why PRs looked like CI never started.

Each size has its **own** quota, so spreading across sizes draws from several independent pools.

| size | jobs | quota | concurrent runs |
|---|---|---|---|
| medium | 9 | 300 | 33 |
| large | 19 | 300 | 15 |
| xlarge | 18 | 100 | **5** ← binding |
| 2xlarge | 6 | 100 | 16 |

Previously the binding pool supported **1** concurrent run. Measured on this branch against the mean of 4 pre-change runs:

| metric | before | after |
|---|---|---|
| linux wall clock | 52.5 min | **40.5 min** (−23%) |
| wait for first runner | 3.0 min | **0.4 min** |
| machine-minutes | 610 | 603 (−1%) |
| vCPU-minutes (cost proxy) | 43,912 | **20,943** (−52%) |
| 2XLarge slot-minutes | 610 | **101** (−83%) |

Per-size timing: medium +18%, large +9%, xlarge −5%, 2xlarge −2%. Throughput is flat while vCPU consumption halves, and jobs stop queueing.

Sizes are calibrated from real runs of this change, not estimated. `standalone` shards stay on 2xlarge — they deliberately saturate every core. Unit shards are on large because medium made them 2.5–3× slower. The package-manager and container legs are on xlarge because large failed 5 of them while xlarge passed 9/9. All 52 Linux jobs pass on the current revision.

No new CodeBuild projects or webhooks are needed — AWS documents the instance-size label override for exactly this. The override omits an image identifier on purpose so `standard:8.0` is preserved (the label's `ubuntu` identifiers stop at 7.0).

**Worth knowing:** `xlarge` is now the binding pool, so the open Service Quotas case for `Linux/XLarge → 1000` is the right lever to finish this off. The four `*-deploy` legs in `ci.yml` are the least-calibrated group (one recent sample, dominated by CloudFormation wait) and are parked on xlarge.
