### PR TITLE
feat(release): cut stable 1.0 releases

### DIFF
--- a/docs/src/content/docs/en/blog/migrating-from-aws-pdk.mdx
+++ b/docs/src/content/docs/en/blog/migrating-from-aws-pdk.mdx
@@ -36,7 +36,7 @@ Note also that some features of PDK don't have exact equivalents. Refer to the [
 :::
 
 :::caution[Point-in-Time Guide]
-This is written as a point-of-time guide and will most likely not be updated as the Nx Plugin for AWS evolves. To compensate for this, the guide pins the version of `@aws/nx-plugin` to `1.0.0-rc.47`. You can try with the latest version if following along, but there may be some deviations from the guide.
+This is written as a point-of-time guide and will most likely not be updated as the Nx Plugin for AWS evolves. To compensate for this, the guide pins the version of `@aws/nx-plugin` to `1.0.0`. You can try with the latest version if following along, but there may be some deviations from the guide.
 :::
 
 ## Example Migration: Shopping List Application
@@ -54,7 +54,7 @@ The shopping list application consists of the following PDK project types:
 
 To start, we'll create a new workspace for our new project. While more extreme than an in-place migration, this approach gives us the cleanest end result. Creating an Nx workspace is equivalent to using PDK's `MonorepoTsProject`:
 
-<CreateNxWorkspaceCommand workspace="shopping-list" iac="cdk" tag="1.0.0-rc.47" />
+<CreateNxWorkspaceCommand workspace="shopping-list" iac="cdk" tag="1.0.0" />
 
 Open up the `shopping-list` directory this command creates in your favourite IDE.
 

--- a/docs/src/content/docs/en/snippets/pdk-migration/example/01-migrate-api.mdx
+++ b/docs/src/content/docs/en/snippets/pdk-migration/example/01-migrate-api.mdx
@@ -119,7 +119,7 @@ At this point, let's run a build to check our model changes and ensure we have s
 :::note
 You may see a build failure due to lint issues. These can usually be automatically fixed:
 
-<NxCommands commands={["run-many --target lint --fix"]} />
+<NxCommands commands={["run-many --target lint --configuration=fix"]} />
 :::
 
 #### Migrate the Lambda Handlers
@@ -132,7 +132,7 @@ The shopping list application's lambda handlers rely on the `@aws-sdk/client-dyn
 
 <InstallCommand pkg="@aws-sdk/client-dynamodb" project="@shopping-list/api" />
 
-Then, let's copy the `handlers/src/dynamo-client.ts` file from the PDK project to `backend/src/operations` so it's available for our handlers.
+Then, let's copy the `handlers/typescript/src/dynamo-client.ts` file from the PDK project to `backend/src/operations` so it's available for our handlers.
 
 The `ts#smithy-api` generator scaffolds an example `Echo` operation. Since we removed this from our model, delete the corresponding handler in `backend/src/operations/echo.ts`. We'll register our migrated operations in `service.ts` further below.
 
@@ -587,6 +587,7 @@ Additionally, update `packages/api/backend/project.json` and update `metadata.ap
 +    "apiName": "my-api",
     "auth": "iam",
     "modelProject": "@shopping-list/api-model",
+    "iac": "cdk",
     "ports": [3001]
   },
 ```
@@ -600,5 +601,5 @@ We can now build the project to check that the migration has worked so far:
 :::note
 You may see a build failure due to lint issues. These can usually be automatically fixed:
 
-<NxCommands commands={["run-many --target lint --fix"]} />
+<NxCommands commands={["run-many --target lint --configuration=fix"]} />
 :::

--- a/docs/src/content/docs/en/snippets/pdk-migration/example/01-migrate-api.mdx
+++ b/docs/src/content/docs/en/snippets/pdk-migration/example/01-migrate-api.mdx
@@ -8,6 +8,7 @@ import Link from '@components/link.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Drawer from '@components/drawer.astro';
 import InstallCommand from '@components/install-command.astro';
+import PackageManagerShortCommand from '@components/package-manager-short-command.astro';
 
 The `TypeSafeApiProject` used in the shopping list application made use of:
 
@@ -114,12 +115,12 @@ Now that we have the basic structure for our Smithy API project, we can migrate 
 
 At this point, let's run a build to check our model changes and ensure we have some generated server code to work with. There will be some failures in the backend project (`@shopping-list/api`) but we'll address those next.
 
-<NxCommands commands={["run-many --target build"]} />
+<PackageManagerShortCommand commands={["build"]} />
 
 :::note
 You may see a build failure due to lint issues. These can usually be automatically fixed:
 
-<NxCommands commands={["run-many --target lint --configuration=fix"]} />
+<PackageManagerShortCommand commands={["lint"]} />
 :::
 
 #### Migrate the Lambda Handlers
@@ -596,10 +597,10 @@ Additionally, update `packages/api/backend/project.json` and update `metadata.ap
 
 We can now build the project to check that the migration has worked so far:
 
-<NxCommands commands={["run-many --target build"]} />
+<PackageManagerShortCommand commands={["build"]} />
 
 :::note
 You may see a build failure due to lint issues. These can usually be automatically fixed:
 
-<NxCommands commands={["run-many --target lint --configuration=fix"]} />
+<PackageManagerShortCommand commands={["lint"]} />
 :::

--- a/docs/src/content/docs/en/snippets/pdk-migration/example/02-migrate-website.mdx
+++ b/docs/src/content/docs/en/snippets/pdk-migration/example/02-migrate-website.mdx
@@ -8,6 +8,7 @@ import Link from '@components/link.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Drawer from '@components/drawer.astro';
 import InstallCommand from '@components/install-command.astro';
+import PackageManagerShortCommand from '@components/package-manager-short-command.astro';
 
 The `CloudscapeReactTsWebsiteProject` used in the shopping list application configured a React website with CloudScape and Cognito authentication built in.
 
@@ -100,7 +101,7 @@ Since we're using [file-based routing](https://tanstack.com/router/latest/docs/f
 
 Let's start the local website server:
 
-<NxCommands commands={["dev website"]} />
+<PackageManagerShortCommand commands={["dev"]} />
 
 :::tip
 We're using the `dev` target here, which also starts local servers for any APIs which have been connected with `connection`, and hot-reloads if your website, model, or backend changes! This allows us to test our API and website locally before we've even written any CDK code.

--- a/docs/src/content/docs/en/snippets/pdk-migration/example/03-migrate-infra.mdx
+++ b/docs/src/content/docs/en/snippets/pdk-migration/example/03-migrate-infra.mdx
@@ -8,6 +8,7 @@ import Link from '@components/link.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Drawer from '@components/drawer.astro';
 import InstallCommand from '@components/install-command.astro';
+import PackageManagerShortCommand from '@components/package-manager-short-command.astro';
 
 The last project we need to migrate for our shopping list application is the `InfrastructureTsProject`. This is a TypeScript CDK project, for which the Nx Plugin for AWS equivalent is the <Link path="/guides/typescript-infrastructure">`ts#infra` generator</Link>.
 
@@ -152,10 +153,10 @@ Notice that we don't pass the identity or API to the website - runtime config is
 
 Let's build the project now that we've migrated all the relevant parts of the codebase to our new project.
 
-<NxCommands commands={["run-many --target build"]} />
+<PackageManagerShortCommand commands={["build"]} />
 
 :::caution
 You may see a build failure due to lint issues. These can usually be automatically fixed:
 
-<NxCommands commands={["run-many --target lint --configuration=fix"]} />
+<PackageManagerShortCommand commands={["lint"]} />
 :::

--- a/docs/src/content/docs/en/snippets/pdk-migration/example/03-migrate-infra.mdx
+++ b/docs/src/content/docs/en/snippets/pdk-migration/example/03-migrate-infra.mdx
@@ -157,5 +157,5 @@ Let's build the project now that we've migrated all the relevant parts of the co
 :::caution
 You may see a build failure due to lint issues. These can usually be automatically fixed:
 
-<NxCommands commands={["run-many --target lint --fix"]} />
+<NxCommands commands={["run-many --target lint --configuration=fix"]} />
 :::

--- a/docs/src/content/docs/en/snippets/pdk-migration/example/04-deploy.mdx
+++ b/docs/src/content/docs/en/snippets/pdk-migration/example/04-deploy.mdx
@@ -8,6 +8,7 @@ import Link from '@components/link.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Drawer from '@components/drawer.astro';
 import InstallCommand from '@components/install-command.astro';
+import PackageManagerShortCommand from '@components/package-manager-short-command.astro';
 
 
 Now we've got our fully migrated codebase, we can look at deploying it. There are two paths we can take at this point.
@@ -22,7 +23,7 @@ The simplest approach is to treat this as a completely new application, meaning 
 
 1. Deploy the new application:
 
-    <NxCommands commands={["deploy infra shopping-list-infra-sandbox/*"]} />
+    <NxCommands commands={['deploy-sandbox infra']} />
 
 </Steps>
 
@@ -73,9 +74,9 @@ For our shopping list application, the stateful resources we care about are the 
 
 1. Build and deploy the new application:
 
-    <NxCommands commands={["run-many --target build"]} />
+    <PackageManagerShortCommand commands={["build"]} />
 
-    <NxCommands commands={["deploy infra shopping-list-infra-sandbox/*"]} />
+    <NxCommands commands={['deploy-sandbox infra']} />
 
     Now we have our new application stood up referencing the existing resources, not yet taking any traffic.
 
@@ -108,7 +109,7 @@ For our shopping list application, the stateful resources we care about are the 
 
     And then run a build
 
-    <NxCommands commands={["run-many --target build"]} />
+    <PackageManagerShortCommand commands={["build"]} />
 
 1. Use `cdk import` in your new application's `packages/infra` folder to see which resources we'll be prompted to import.
 
@@ -199,7 +200,7 @@ For our shopping list application, the stateful resources we care about are the 
 
 1. Deploy the new application again to make sure that any changes to these existing resources (now managed by your new stack) are made:
 
-    <NxCommands commands={["deploy infra shopping-list-infra-sandbox/*"]} />
+    <NxCommands commands={['deploy-sandbox infra']} />
 
 1. Perform a full test of your new application again
 

--- a/docs/src/content/docs/en/snippets/pdk-migration/example/04-deploy.mdx
+++ b/docs/src/content/docs/en/snippets/pdk-migration/example/04-deploy.mdx
@@ -63,7 +63,7 @@ For our shopping list application, the stateful resources we care about are the 
 
     ```diff lang="ts"
     // packages/common/constructs/src/core/user-identity.ts
-    -this.userPool = this.createUserPool();
+    -this.userPool = this.createUserPool(mfa, mfaSecondFactor);
     +this.userPool = UserPool.fromUserPoolId(
     +  this,
     +  'UserPool',
@@ -98,7 +98,7 @@ For our shopping list application, the stateful resources we care about are the 
 
     ```diff lang="ts"
     // packages/common/constructs/src/core/user-identity.ts
-    +this.userPool = this.createUserPool();
+    +this.userPool = this.createUserPool(mfa, mfaSecondFactor);
     -this.userPool = UserPool.fromUserPoolId(
     -  this,
     -  'UserPool',

--- a/docs/src/content/docs/en/snippets/pdk-migration/faq/type-safe-api.mdx
+++ b/docs/src/content/docs/en/snippets/pdk-migration/faq/type-safe-api.mdx
@@ -14,7 +14,7 @@ The most commonly used components from Type Safe API are covered in the example 
 
 #### APIs Modelled with OpenAPI
 
-The Nx Plugin for AWS supports APIs modelled in Smithy, but not those modelled directly OpenAPI. The <Link path="/guides/ts-smithy-api">`ts#smithy-api` generator</Link> is a good starting point which you can then modify. You can define your OpenAPI specification in the `model` project's `src` folder instead of Smithy, and modify the `build.Dockerfile` to use your desired code generation tool for clients/servers if they aren't available on NPM. If your desired tools are on NPM, you can just install them as dev dependencies to your Nx workspace and call them directly as Nx build targets.
+The Nx Plugin for AWS supports APIs modelled in Smithy, but not those modelled directly OpenAPI. The <Link path="/guides/ts-smithy-api">`ts#smithy-api` generator</Link> is a good starting point which you can then modify. You can define your OpenAPI specification in the `model` project's `src` folder instead of Smithy, and update the `model` project's `compile` target to run your desired code generation tool for clients/servers. If your desired tools are on NPM, you can install them as dev dependencies to your Nx workspace and call them directly as Nx build targets.
 
 ##### Backend
 
@@ -153,7 +153,7 @@ const pythonLambdaHandler = new Function(this, 'PythonImplementation', {
   ...
 });
 
-new MyApi(this, 'MyApi', {
+new Api(this, 'MyApi', {
   integrations: Api.defaultIntegrations(this)
     .withOverrides({
       echo: {

--- a/docs/src/content/docs/es/blog/migrating-from-aws-pdk.mdx
+++ b/docs/src/content/docs/es/blog/migrating-from-aws-pdk.mdx
@@ -54,7 +54,7 @@ La aplicación de lista de compras consiste en los siguientes tipos de proyecto 
 
 Para comenzar, crearemos un nuevo espacio de trabajo para nuestro nuevo proyecto. Aunque es más extremo que una migración in situ, este enfoque nos da el resultado final más limpio. Crear un espacio de trabajo Nx es equivalente a usar el `MonorepoTsProject` de PDK:
 
-<CreateNxWorkspaceCommand workspace="shopping-list" iac="cdk" tag="1.0.0-rc.47" />
+<CreateNxWorkspaceCommand workspace="shopping-list" iac="cdk" tag="1.0.0" />
 
 Abre el directorio `shopping-list` que este comando crea en tu IDE favorito.
 

--- a/docs/src/content/docs/es/snippets/pdk-migration/example/01-migrate-api.mdx
+++ b/docs/src/content/docs/es/snippets/pdk-migration/example/01-migrate-api.mdx
@@ -587,6 +587,7 @@ Además, actualiza `packages/api/backend/project.json` y actualiza `metadata.api
 +    "apiName": "my-api",
     "auth": "iam",
     "modelProject": "@shopping-list/api-model",
+    "iac": "cdk",
     "ports": [3001]
   },
 ```
@@ -600,5 +601,5 @@ Ahora podemos compilar el proyecto para verificar que la migración ha funcionad
 :::note
 Puedes ver una falla de compilación debido a problemas de lint. Estos generalmente se pueden corregir automáticamente:
 
-<NxCommands commands={["run-many --target lint --fix"]} />
+<NxCommands commands={["run-many --target lint --configuration=fix"]} />
 :::

--- a/docs/src/content/docs/es/snippets/pdk-migration/example/01-migrate-api.mdx
+++ b/docs/src/content/docs/es/snippets/pdk-migration/example/01-migrate-api.mdx
@@ -8,6 +8,7 @@ import Link from '@components/link.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Drawer from '@components/drawer.astro';
 import InstallCommand from '@components/install-command.astro';
+import PackageManagerShortCommand from '@components/package-manager-short-command.astro';
 
 El `TypeSafeApiProject` utilizado en la aplicación de lista de compras hizo uso de:
 
@@ -114,12 +115,12 @@ Ahora que tenemos la estructura básica para nuestro proyecto de API Smithy, pod
 
 En este punto, ejecutemos una compilación para verificar los cambios de nuestro modelo y asegurarnos de tener algo de código de servidor generado con el que trabajar. Habrá algunas fallas en el proyecto backend (`@shopping-list/api`) pero las abordaremos a continuación.
 
-<NxCommands commands={["run-many --target build"]} />
+<PackageManagerShortCommand commands={["build"]} />
 
 :::note
 Puedes ver una falla de compilación debido a problemas de lint. Estos generalmente se pueden corregir automáticamente:
 
-<NxCommands commands={["run-many --target lint --fix"]} />
+<PackageManagerShortCommand commands={["lint"]} />
 :::
 
 #### Migrar los Manejadores Lambda
@@ -596,10 +597,10 @@ Además, actualiza `packages/api/backend/project.json` y actualiza `metadata.api
 
 Ahora podemos compilar el proyecto para verificar que la migración ha funcionado hasta ahora:
 
-<NxCommands commands={["run-many --target build"]} />
+<PackageManagerShortCommand commands={["build"]} />
 
 :::note
 Puedes ver una falla de compilación debido a problemas de lint. Estos generalmente se pueden corregir automáticamente:
 
-<NxCommands commands={["run-many --target lint --configuration=fix"]} />
+<PackageManagerShortCommand commands={["lint"]} />
 :::

--- a/docs/src/content/docs/es/snippets/pdk-migration/example/02-migrate-website.mdx
+++ b/docs/src/content/docs/es/snippets/pdk-migration/example/02-migrate-website.mdx
@@ -8,6 +8,7 @@ import Link from '@components/link.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Drawer from '@components/drawer.astro';
 import InstallCommand from '@components/install-command.astro';
+import PackageManagerShortCommand from '@components/package-manager-short-command.astro';
 
 El `CloudscapeReactTsWebsiteProject` utilizado en la aplicación de lista de compras configuró un sitio web React con CloudScape y autenticación Cognito integrada.
 
@@ -100,7 +101,7 @@ Dado que estamos usando [enrutamiento basado en archivos](https://tanstack.com/r
 
 Iniciemos el servidor del sitio web local:
 
-<NxCommands commands={["dev website"]} />
+<PackageManagerShortCommand commands={["dev"]} />
 
 :::tip
 Estamos usando el objetivo `dev` aquí, que también inicia servidores locales para cualquier API que se haya conectado con `connection`, y recarga en caliente si tu sitio web, modelo o backend cambia. Esto nos permite probar nuestra API y sitio web localmente antes de haber escrito cualquier código CDK.

--- a/docs/src/content/docs/es/snippets/pdk-migration/example/03-migrate-infra.mdx
+++ b/docs/src/content/docs/es/snippets/pdk-migration/example/03-migrate-infra.mdx
@@ -157,5 +157,5 @@ Construyamos el proyecto ahora que hemos migrado todas las partes relevantes de 
 :::caution
 Puedes ver un fallo de compilación debido a problemas de lint. Estos generalmente pueden corregirse automáticamente:
 
-<NxCommands commands={["run-many --target lint --fix"]} />
+<NxCommands commands={["run-many --target lint --configuration=fix"]} />
 :::

--- a/docs/src/content/docs/es/snippets/pdk-migration/example/03-migrate-infra.mdx
+++ b/docs/src/content/docs/es/snippets/pdk-migration/example/03-migrate-infra.mdx
@@ -8,6 +8,7 @@ import Link from '@components/link.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Drawer from '@components/drawer.astro';
 import InstallCommand from '@components/install-command.astro';
+import PackageManagerShortCommand from '@components/package-manager-short-command.astro';
 
 El último proyecto que necesitamos migrar para nuestra aplicación de lista de compras es el `InfrastructureTsProject`. Este es un proyecto TypeScript CDK, para el cual el equivalente en Nx Plugin for AWS es el <Link path="/guides/typescript-infrastructure">generador `ts#infra`</Link>.
 
@@ -152,10 +153,10 @@ Observa que no pasamos la identidad o la API al sitio web - la configuración en
 
 Construyamos el proyecto ahora que hemos migrado todas las partes relevantes de la base de código a nuestro nuevo proyecto.
 
-<NxCommands commands={["run-many --target build"]} />
+<PackageManagerShortCommand commands={["build"]} />
 
 :::caution
 Puedes ver un fallo de compilación debido a problemas de lint. Estos generalmente pueden corregirse automáticamente:
 
-<NxCommands commands={["run-many --target lint --configuration=fix"]} />
+<PackageManagerShortCommand commands={["lint"]} />
 :::

--- a/docs/src/content/docs/es/snippets/pdk-migration/example/04-deploy.mdx
+++ b/docs/src/content/docs/es/snippets/pdk-migration/example/04-deploy.mdx
@@ -8,6 +8,7 @@ import Link from '@components/link.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Drawer from '@components/drawer.astro';
 import InstallCommand from '@components/install-command.astro';
+import PackageManagerShortCommand from '@components/package-manager-short-command.astro';
 
 
 Ahora que tenemos nuestra base de código completamente migrada, podemos proceder a desplegarla. Hay dos caminos que podemos tomar en este punto.
@@ -22,7 +23,7 @@ El enfoque más simple es tratar esto como una aplicación completamente nueva, 
 
 1. Despliega la nueva aplicación:
 
-    <NxCommands commands={["deploy infra shopping-list-infra-sandbox/*"]} />
+    <NxCommands commands={['deploy-sandbox infra']} />
 
 </Steps>
 
@@ -73,9 +74,9 @@ Para nuestra aplicación de lista de compras, los recursos con estado que nos im
 
 1. Construye y despliega la nueva aplicación:
 
-    <NxCommands commands={["run-many --target build"]} />
+    <PackageManagerShortCommand commands={["build"]} />
 
-    <NxCommands commands={["deploy infra shopping-list-infra-sandbox/*"]} />
+    <NxCommands commands={['deploy-sandbox infra']} />
 
     Ahora tenemos nuestra nueva aplicación levantada haciendo referencia a los recursos existentes, aún sin recibir tráfico.
 
@@ -108,7 +109,7 @@ Para nuestra aplicación de lista de compras, los recursos con estado que nos im
 
     Y luego ejecuta una construcción
 
-    <NxCommands commands={["run-many --target build"]} />
+    <PackageManagerShortCommand commands={["build"]} />
 
 1. Usa `cdk import` en la carpeta `packages/infra` de tu nueva aplicación para ver qué recursos se nos solicitará importar.
 
@@ -199,7 +200,7 @@ Para nuestra aplicación de lista de compras, los recursos con estado que nos im
 
 1. Despliega la nueva aplicación nuevamente para asegurarte de que se realicen los cambios en estos recursos existentes (ahora administrados por tu nuevo stack):
 
-    <NxCommands commands={["deploy infra shopping-list-infra-sandbox/*"]} />
+    <NxCommands commands={['deploy-sandbox infra']} />
 
 1. Realiza una prueba completa de tu nueva aplicación nuevamente
 

--- a/docs/src/content/docs/es/snippets/pdk-migration/example/04-deploy.mdx
+++ b/docs/src/content/docs/es/snippets/pdk-migration/example/04-deploy.mdx
@@ -63,7 +63,7 @@ Para nuestra aplicación de lista de compras, los recursos con estado que nos im
 
     ```diff lang="ts"
     // packages/common/constructs/src/core/user-identity.ts
-    -this.userPool = this.createUserPool();
+    -this.userPool = this.createUserPool(mfa, mfaSecondFactor);
     +this.userPool = UserPool.fromUserPoolId(
     +  this,
     +  'UserPool',
@@ -98,7 +98,7 @@ Para nuestra aplicación de lista de compras, los recursos con estado que nos im
 
     ```diff lang="ts"
     // packages/common/constructs/src/core/user-identity.ts
-    +this.userPool = this.createUserPool();
+    +this.userPool = this.createUserPool(mfa, mfaSecondFactor);
     -this.userPool = UserPool.fromUserPoolId(
     -  this,
     -  'UserPool',

--- a/docs/src/content/docs/es/snippets/pdk-migration/faq/type-safe-api.mdx
+++ b/docs/src/content/docs/es/snippets/pdk-migration/faq/type-safe-api.mdx
@@ -14,7 +14,7 @@ Los componentes más comúnmente utilizados de Type Safe API están cubiertos en
 
 #### APIs Modeladas con OpenAPI
 
-El Nx Plugin for AWS admite APIs modeladas en Smithy, pero no aquellas modeladas directamente en OpenAPI. El <Link path="/guides/ts-smithy-api">generador `ts#smithy-api`</Link> es un buen punto de partida que luego puedes modificar. Puedes definir tu especificación OpenAPI en la carpeta `src` del proyecto `model` en lugar de Smithy, y modificar el `build.Dockerfile` para usar tu herramienta de generación de código deseada para clientes/servidores si no están disponibles en NPM. Si tus herramientas deseadas están en NPM, simplemente puedes instalarlas como dependencias de desarrollo en tu espacio de trabajo Nx y llamarlas directamente como objetivos de compilación de Nx.
+El Nx Plugin for AWS admite APIs modeladas en Smithy, pero no aquellas modeladas directamente en OpenAPI. El <Link path="/guides/ts-smithy-api">generador `ts#smithy-api`</Link> es un buen punto de partida que luego puedes modificar. Puedes definir tu especificación OpenAPI en la carpeta `src` del proyecto `model` en lugar de Smithy, y actualizar el objetivo `compile` del proyecto `model` para ejecutar tu herramienta de generación de código deseada para clientes/servidores. Si tus herramientas deseadas están en NPM, puedes instalarlas como dependencias de desarrollo en tu espacio de trabajo Nx y llamarlas directamente como objetivos de compilación de Nx.
 
 ##### Backend
 
@@ -153,7 +153,7 @@ const pythonLambdaHandler = new Function(this, 'PythonImplementation', {
   ...
 });
 
-new MyApi(this, 'MyApi', {
+new Api(this, 'MyApi', {
   integrations: Api.defaultIntegrations(this)
     .withOverrides({
       echo: {

--- a/docs/src/content/docs/fr/blog/migrating-from-aws-pdk.mdx
+++ b/docs/src/content/docs/fr/blog/migrating-from-aws-pdk.mdx
@@ -54,7 +54,7 @@ L'application de liste de courses se compose des types de projets PDK suivants :
 
 Pour commencer, nous allons créer un nouvel espace de travail pour notre nouveau projet. Bien que plus extrême qu'une migration sur place, cette approche nous donne le résultat final le plus propre. Créer un espace de travail Nx équivaut à utiliser le `MonorepoTsProject` de PDK :
 
-<CreateNxWorkspaceCommand workspace="shopping-list" iac="cdk" tag="1.0.0-rc.47" />
+<CreateNxWorkspaceCommand workspace="shopping-list" iac="cdk" tag="1.0.0" />
 
 Ouvrez le répertoire `shopping-list` créé par cette commande dans votre IDE préféré.
 

--- a/docs/src/content/docs/fr/snippets/pdk-migration/example/01-migrate-api.mdx
+++ b/docs/src/content/docs/fr/snippets/pdk-migration/example/01-migrate-api.mdx
@@ -8,6 +8,7 @@ import Link from '@components/link.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Drawer from '@components/drawer.astro';
 import InstallCommand from '@components/install-command.astro';
+import PackageManagerShortCommand from '@components/package-manager-short-command.astro';
 
 Le `TypeSafeApiProject` utilisé dans l'application de liste de courses a fait usage de :
 
@@ -114,12 +115,12 @@ Maintenant que nous avons la structure de base pour notre projet d'API Smithy, n
 
 À ce stade, exécutons une compilation pour vérifier nos modifications de modèle et nous assurer que nous avons du code serveur généré avec lequel travailler. Il y aura quelques échecs dans le projet backend (`@shopping-list/api`) mais nous les résoudrons ensuite.
 
-<NxCommands commands={["run-many --target build"]} />
+<PackageManagerShortCommand commands={["build"]} />
 
 :::note
 Vous pouvez voir un échec de compilation dû à des problèmes de lint. Ceux-ci peuvent généralement être corrigés automatiquement :
 
-<NxCommands commands={["run-many --target lint --configuration=fix"]} />
+<PackageManagerShortCommand commands={["lint"]} />
 :::
 
 #### Migrer les gestionnaires Lambda
@@ -596,10 +597,10 @@ De plus, mettez à jour `packages/api/backend/project.json` et modifiez `metadat
 
 Nous pouvons maintenant compiler le projet pour vérifier que la migration a fonctionné jusqu'à présent :
 
-<NxCommands commands={["run-many --target build"]} />
+<PackageManagerShortCommand commands={["build"]} />
 
 :::note
 Vous pouvez voir un échec de compilation dû à des problèmes de lint. Ceux-ci peuvent généralement être corrigés automatiquement :
 
-<NxCommands commands={["run-many --target lint --configuration=fix"]} />
+<PackageManagerShortCommand commands={["lint"]} />
 :::

--- a/docs/src/content/docs/fr/snippets/pdk-migration/example/01-migrate-api.mdx
+++ b/docs/src/content/docs/fr/snippets/pdk-migration/example/01-migrate-api.mdx
@@ -119,7 +119,7 @@ Maintenant que nous avons la structure de base pour notre projet d'API Smithy, n
 :::note
 Vous pouvez voir un échec de compilation dû à des problèmes de lint. Ceux-ci peuvent généralement être corrigés automatiquement :
 
-<NxCommands commands={["run-many --target lint --fix"]} />
+<NxCommands commands={["run-many --target lint --configuration=fix"]} />
 :::
 
 #### Migrer les gestionnaires Lambda
@@ -132,7 +132,7 @@ Les gestionnaires lambda de l'application de liste de courses dépendent du pack
 
 <InstallCommand pkg="@aws-sdk/client-dynamodb" project="@shopping-list/api" />
 
-Ensuite, copions le fichier `handlers/src/dynamo-client.ts` du projet PDK vers `backend/src/operations` afin qu'il soit disponible pour nos gestionnaires.
+Ensuite, copions le fichier `handlers/typescript/src/dynamo-client.ts` du projet PDK vers `backend/src/operations` afin qu'il soit disponible pour nos gestionnaires.
 
 Le générateur `ts#smithy-api` génère un exemple d'opération `Echo`. Puisque nous l'avons supprimée de notre modèle, supprimez le gestionnaire correspondant dans `backend/src/operations/echo.ts`. Nous enregistrerons nos opérations migrées dans `service.ts` plus bas.
 
@@ -587,6 +587,7 @@ De plus, mettez à jour `packages/api/backend/project.json` et modifiez `metadat
 +    "apiName": "my-api",
     "auth": "iam",
     "modelProject": "@shopping-list/api-model",
+    "iac": "cdk",
     "ports": [3001]
   },
 ```
@@ -600,5 +601,5 @@ Nous pouvons maintenant compiler le projet pour vérifier que la migration a fon
 :::note
 Vous pouvez voir un échec de compilation dû à des problèmes de lint. Ceux-ci peuvent généralement être corrigés automatiquement :
 
-<NxCommands commands={["run-many --target lint --fix"]} />
+<NxCommands commands={["run-many --target lint --configuration=fix"]} />
 :::

--- a/docs/src/content/docs/fr/snippets/pdk-migration/example/02-migrate-website.mdx
+++ b/docs/src/content/docs/fr/snippets/pdk-migration/example/02-migrate-website.mdx
@@ -8,6 +8,7 @@ import Link from '@components/link.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Drawer from '@components/drawer.astro';
 import InstallCommand from '@components/install-command.astro';
+import PackageManagerShortCommand from '@components/package-manager-short-command.astro';
 
 Le `CloudscapeReactTsWebsiteProject` utilisé dans l'application de liste de courses configurait un site web React avec CloudScape et l'authentification Cognito intégrée.
 
@@ -100,7 +101,7 @@ Puisque nous utilisons le [routage basé sur les fichiers](https://tanstack.com/
 
 Commençons par démarrer le serveur de site web local :
 
-<NxCommands commands={["dev website"]} />
+<PackageManagerShortCommand commands={["dev"]} />
 
 :::tip
 Nous utilisons la cible `dev` ici, qui démarre également des serveurs locaux pour toutes les API qui ont été connectées avec `connection`, et recharge à chaud si votre site web, modèle ou backend change ! Cela nous permet de tester notre API et notre site web localement avant même d'avoir écrit du code CDK.

--- a/docs/src/content/docs/fr/snippets/pdk-migration/example/03-migrate-infra.mdx
+++ b/docs/src/content/docs/fr/snippets/pdk-migration/example/03-migrate-infra.mdx
@@ -8,6 +8,7 @@ import Link from '@components/link.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Drawer from '@components/drawer.astro';
 import InstallCommand from '@components/install-command.astro';
+import PackageManagerShortCommand from '@components/package-manager-short-command.astro';
 
 Le dernier projet que nous devons migrer pour notre application de liste de courses est le `InfrastructureTsProject`. Il s'agit d'un projet TypeScript CDK, pour lequel l'équivalent dans le Nx Plugin for AWS est le <Link path="/guides/typescript-infrastructure">générateur `ts#infra`</Link>.
 
@@ -152,10 +153,10 @@ Notez que nous ne passons pas l'identité ou l'API au site Web - la configuratio
 
 Construisons maintenant le projet maintenant que nous avons migré toutes les parties pertinentes de la base de code vers notre nouveau projet.
 
-<NxCommands commands={["run-many --target build"]} />
+<PackageManagerShortCommand commands={["build"]} />
 
 :::caution
 Vous pouvez voir un échec de construction dû à des problèmes de lint. Ceux-ci peuvent généralement être corrigés automatiquement :
 
-<NxCommands commands={["run-many --target lint --configuration=fix"]} />
+<PackageManagerShortCommand commands={["lint"]} />
 :::

--- a/docs/src/content/docs/fr/snippets/pdk-migration/example/03-migrate-infra.mdx
+++ b/docs/src/content/docs/fr/snippets/pdk-migration/example/03-migrate-infra.mdx
@@ -157,5 +157,5 @@ Construisons maintenant le projet maintenant que nous avons migré toutes les pa
 :::caution
 Vous pouvez voir un échec de construction dû à des problèmes de lint. Ceux-ci peuvent généralement être corrigés automatiquement :
 
-<NxCommands commands={["run-many --target lint --fix"]} />
+<NxCommands commands={["run-many --target lint --configuration=fix"]} />
 :::

--- a/docs/src/content/docs/fr/snippets/pdk-migration/example/04-deploy.mdx
+++ b/docs/src/content/docs/fr/snippets/pdk-migration/example/04-deploy.mdx
@@ -8,6 +8,7 @@ import Link from '@components/link.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Drawer from '@components/drawer.astro';
 import InstallCommand from '@components/install-command.astro';
+import PackageManagerShortCommand from '@components/package-manager-short-command.astro';
 
 
 Maintenant que nous avons notre base de code entièrement migrée, nous pouvons envisager de la déployer. Il existe deux approches possibles à ce stade.
@@ -22,7 +23,7 @@ L'approche la plus simple consiste à traiter cela comme une application complè
 
 1. Déployer la nouvelle application :
 
-    <NxCommands commands={["deploy infra shopping-list-infra-sandbox/*"]} />
+    <NxCommands commands={['deploy-sandbox infra']} />
 
 </Steps>
 
@@ -73,9 +74,9 @@ Pour notre application de liste de courses, les ressources stateful qui nous int
 
 1. Construire et déployer la nouvelle application :
 
-    <NxCommands commands={["run-many --target build"]} />
+    <PackageManagerShortCommand commands={["build"]} />
 
-    <NxCommands commands={["deploy infra shopping-list-infra-sandbox/*"]} />
+    <NxCommands commands={['deploy-sandbox infra']} />
 
     Nous avons maintenant notre nouvelle application déployée référençant les ressources existantes, ne recevant pas encore de trafic.
 
@@ -108,7 +109,7 @@ Pour notre application de liste de courses, les ressources stateful qui nous int
 
     Et ensuite exécuter une construction
 
-    <NxCommands commands={["run-many --target build"]} />
+    <PackageManagerShortCommand commands={["build"]} />
 
 1. Utiliser `cdk import` dans le dossier `packages/infra` de votre nouvelle application pour voir quelles ressources nous serons invités à importer.
 
@@ -199,7 +200,7 @@ Pour notre application de liste de courses, les ressources stateful qui nous int
 
 1. Déployer à nouveau la nouvelle application pour s'assurer que toutes les modifications apportées à ces ressources existantes (maintenant gérées par votre nouvelle stack) sont effectuées :
 
-    <NxCommands commands={["deploy infra shopping-list-infra-sandbox/*"]} />
+    <NxCommands commands={['deploy-sandbox infra']} />
 
 1. Effectuer un test complet de votre nouvelle application à nouveau
 

--- a/docs/src/content/docs/fr/snippets/pdk-migration/example/04-deploy.mdx
+++ b/docs/src/content/docs/fr/snippets/pdk-migration/example/04-deploy.mdx
@@ -63,7 +63,7 @@ Pour notre application de liste de courses, les ressources stateful qui nous int
 
     ```diff lang="ts"
     // packages/common/constructs/src/core/user-identity.ts
-    -this.userPool = this.createUserPool();
+    -this.userPool = this.createUserPool(mfa, mfaSecondFactor);
     +this.userPool = UserPool.fromUserPoolId(
     +  this,
     +  'UserPool',
@@ -98,7 +98,7 @@ Pour notre application de liste de courses, les ressources stateful qui nous int
 
     ```diff lang="ts"
     // packages/common/constructs/src/core/user-identity.ts
-    +this.userPool = this.createUserPool();
+    +this.userPool = this.createUserPool(mfa, mfaSecondFactor);
     -this.userPool = UserPool.fromUserPoolId(
     -  this,
     -  'UserPool',

--- a/docs/src/content/docs/fr/snippets/pdk-migration/faq/type-safe-api.mdx
+++ b/docs/src/content/docs/fr/snippets/pdk-migration/faq/type-safe-api.mdx
@@ -14,7 +14,7 @@ Les composants les plus couramment utilisés de Type Safe API sont couverts dans
 
 #### APIs modélisées avec OpenAPI
 
-Le Nx Plugin for AWS prend en charge les APIs modélisées en Smithy, mais pas celles modélisées directement en OpenAPI. Le <Link path="/guides/ts-smithy-api">générateur `ts#smithy-api`</Link> est un bon point de départ que vous pouvez ensuite modifier. Vous pouvez définir votre spécification OpenAPI dans le dossier `src` du projet `model` au lieu de Smithy, et modifier le `build.Dockerfile` pour utiliser votre outil de génération de code souhaité pour les clients/serveurs s'ils ne sont pas disponibles sur NPM. Si vos outils souhaités sont sur NPM, vous pouvez simplement les installer en tant que dépendances de développement dans votre espace de travail Nx et les appeler directement en tant que cibles de build Nx.
+Le Nx Plugin for AWS prend en charge les APIs modélisées en Smithy, mais pas celles modélisées directement en OpenAPI. Le <Link path="/guides/ts-smithy-api">générateur `ts#smithy-api`</Link> est un bon point de départ que vous pouvez ensuite modifier. Vous pouvez définir votre spécification OpenAPI dans le dossier `src` du projet `model` au lieu de Smithy, et mettre à jour la cible `compile` du projet `model` pour exécuter votre outil de génération de code souhaité pour les clients/serveurs. Si vos outils souhaités sont sur NPM, vous pouvez les installer en tant que dépendances de développement dans votre espace de travail Nx et les appeler directement en tant que cibles de build Nx.
 
 ##### Backend
 
@@ -153,7 +153,7 @@ const pythonLambdaHandler = new Function(this, 'PythonImplementation', {
   ...
 });
 
-new MyApi(this, 'MyApi', {
+new Api(this, 'MyApi', {
   integrations: Api.defaultIntegrations(this)
     .withOverrides({
       echo: {
@@ -201,4 +201,4 @@ Vous pouvez également envisager de créer vos propres générateurs de code qui
 
 Vous pouvez également envisager de migrer pour utiliser le <Link path="/guides/trpc">générateur `ts#trpc-api`</Link> pour utiliser tRPC. Au moment de la rédaction, nous n'avons pas encore de support pour les subscriptions/streaming mais si c'est quelque chose dont vous avez besoin, ajoutez un +1 à notre [problème GitHub qui suit cela](https://github.com/awslabs/nx-plugin-for-aws/issues/194).
 
-Smithy est agnostique au protocole, mais n'a pas encore de support pour le protocole Websocket, référez-vous à [ce problème GitHub qui suit le support](https://github.com/smithy-lang/smithy/issues/1505).
+Smithy est agnostique au protocole, mais n'a pas encore de support pour le protocole Websocket, référez-vous à [ce problème GitHub qui suit le support](https://github.com/smithy-lang/smithy/issues/1505).lang/smithy/issues/1505).

--- a/docs/src/content/docs/it/blog/migrating-from-aws-pdk.mdx
+++ b/docs/src/content/docs/it/blog/migrating-from-aws-pdk.mdx
@@ -36,7 +36,7 @@ Nota anche che alcune funzionalità di PDK non hanno equivalenti esatti. Fai rif
 :::
 
 :::caution[Guida Temporale]
-Questa è scritta come una guida temporale e molto probabilmente non verrà aggiornata man mano che il Nx Plugin for AWS evolve. Per compensare questo, la guida fissa la versione di `@aws/nx-plugin` a `1.0.0-rc.47`. Puoi provare con l'ultima versione se segui la guida, ma potrebbero esserci alcune deviazioni dalla guida.
+Questa è scritta come una guida temporale e molto probabilmente non verrà aggiornata man mano che il Nx Plugin for AWS evolve. Per compensare questo, la guida fissa la versione di `@aws/nx-plugin` a `1.0.0`. Puoi provare con l'ultima versione se segui la guida, ma potrebbero esserci alcune deviazioni dalla guida.
 :::
 
 ## Esempio di Migrazione: Applicazione Shopping List
@@ -54,7 +54,7 @@ L'applicazione shopping list consiste nei seguenti tipi di progetto PDK:
 
 Per iniziare, creeremo un nuovo workspace per il nostro nuovo progetto. Sebbene più estremo di una migrazione in loco, questo approccio ci dà il risultato finale più pulito. Creare un workspace Nx è equivalente a usare il `MonorepoTsProject` di PDK:
 
-<CreateNxWorkspaceCommand workspace="shopping-list" iac="cdk" tag="1.0.0-rc.47" />
+<CreateNxWorkspaceCommand workspace="shopping-list" iac="cdk" tag="1.0.0" />
 
 Apri la directory `shopping-list` che questo comando crea nel tuo IDE preferito.
 

--- a/docs/src/content/docs/it/snippets/pdk-migration/example/01-migrate-api.mdx
+++ b/docs/src/content/docs/it/snippets/pdk-migration/example/01-migrate-api.mdx
@@ -8,6 +8,7 @@ import Link from '@components/link.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Drawer from '@components/drawer.astro';
 import InstallCommand from '@components/install-command.astro';
+import PackageManagerShortCommand from '@components/package-manager-short-command.astro';
 
 Il `TypeSafeApiProject` utilizzato nell'applicazione della lista della spesa faceva uso di:
 
@@ -114,12 +115,12 @@ Ora che abbiamo la struttura di base per il nostro progetto API Smithy, possiamo
 
 A questo punto, eseguiamo una build per verificare le modifiche al modello e assicurarci di avere del codice server generato con cui lavorare. Ci saranno alcuni errori nel progetto backend (`@shopping-list/api`) ma li risolveremo successivamente.
 
-<NxCommands commands={["run-many --target build"]} />
+<PackageManagerShortCommand commands={["build"]} />
 
 :::note
 Potresti vedere un errore di build dovuto a problemi di lint. Questi possono solitamente essere corretti automaticamente:
 
-<NxCommands commands={["run-many --target lint --configuration=fix"]} />
+<PackageManagerShortCommand commands={["lint"]} />
 :::
 
 #### Migrare i Lambda Handler
@@ -596,10 +597,10 @@ Inoltre, aggiorna `packages/api/backend/project.json` e modifica `metadata.apiNa
 
 Ora possiamo compilare il progetto per verificare che la migrazione abbia funzionato finora:
 
-<NxCommands commands={["run-many --target build"]} />
+<PackageManagerShortCommand commands={["build"]} />
 
 :::note
 Potresti vedere un errore di build dovuto a problemi di lint. Questi possono solitamente essere corretti automaticamente:
 
-<NxCommands commands={["run-many --target lint --configuration=fix"]} />
+<PackageManagerShortCommand commands={["lint"]} />
 :::

--- a/docs/src/content/docs/it/snippets/pdk-migration/example/01-migrate-api.mdx
+++ b/docs/src/content/docs/it/snippets/pdk-migration/example/01-migrate-api.mdx
@@ -119,7 +119,7 @@ A questo punto, eseguiamo una build per verificare le modifiche al modello e ass
 :::note
 Potresti vedere un errore di build dovuto a problemi di lint. Questi possono solitamente essere corretti automaticamente:
 
-<NxCommands commands={["run-many --target lint --fix"]} />
+<NxCommands commands={["run-many --target lint --configuration=fix"]} />
 :::
 
 #### Migrare i Lambda Handler
@@ -132,7 +132,7 @@ I lambda handler dell'applicazione della lista della spesa si basano sul pacchet
 
 <InstallCommand pkg="@aws-sdk/client-dynamodb" project="@shopping-list/api" />
 
-Quindi, copiamo il file `handlers/src/dynamo-client.ts` dal progetto PDK in `backend/src/operations` in modo che sia disponibile per i nostri handler.
+Quindi, copiamo il file `handlers/typescript/src/dynamo-client.ts` dal progetto PDK in `backend/src/operations` in modo che sia disponibile per i nostri handler.
 
 Il generatore `ts#smithy-api` crea uno scaffold di un'operazione `Echo` di esempio. Poiché l'abbiamo rimossa dal nostro modello, elimina l'handler corrispondente in `backend/src/operations/echo.ts`. Registreremo le nostre operazioni migrate in `service.ts` più avanti.
 
@@ -587,6 +587,7 @@ Inoltre, aggiorna `packages/api/backend/project.json` e modifica `metadata.apiNa
 +    "apiName": "my-api",
     "auth": "iam",
     "modelProject": "@shopping-list/api-model",
+    "iac": "cdk",
     "ports": [3001]
   },
 ```
@@ -600,5 +601,5 @@ Ora possiamo compilare il progetto per verificare che la migrazione abbia funzio
 :::note
 Potresti vedere un errore di build dovuto a problemi di lint. Questi possono solitamente essere corretti automaticamente:
 
-<NxCommands commands={["run-many --target lint --fix"]} />
+<NxCommands commands={["run-many --target lint --configuration=fix"]} />
 :::

--- a/docs/src/content/docs/it/snippets/pdk-migration/example/02-migrate-website.mdx
+++ b/docs/src/content/docs/it/snippets/pdk-migration/example/02-migrate-website.mdx
@@ -8,6 +8,7 @@ import Link from '@components/link.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Drawer from '@components/drawer.astro';
 import InstallCommand from '@components/install-command.astro';
+import PackageManagerShortCommand from '@components/package-manager-short-command.astro';
 
 Il `CloudscapeReactTsWebsiteProject` utilizzato nell'applicazione shopping list configurava un sito web React con CloudScape e autenticazione Cognito integrata.
 
@@ -100,7 +101,7 @@ Poiché stiamo utilizzando il [routing basato su file](https://tanstack.com/rout
 
 Avviamo il server del sito web locale:
 
-<NxCommands commands={["dev website"]} />
+<PackageManagerShortCommand commands={["dev"]} />
 
 :::tip
 Stiamo utilizzando il target `dev` qui, che avvia anche server locali per qualsiasi API che è stata connessa con `connection`, e ricarica automaticamente se il tuo sito web, modello o backend cambia! Questo ci consente di testare la nostra API e il sito web localmente prima ancora di aver scritto qualsiasi codice CDK.

--- a/docs/src/content/docs/it/snippets/pdk-migration/example/03-migrate-infra.mdx
+++ b/docs/src/content/docs/it/snippets/pdk-migration/example/03-migrate-infra.mdx
@@ -157,5 +157,5 @@ Costruiamo ora il progetto ora che abbiamo migrato tutte le parti rilevanti dell
 :::caution
 Potresti vedere un errore di build dovuto a problemi di lint. Questi possono solitamente essere corretti automaticamente:
 
-<NxCommands commands={["run-many --target lint --fix"]} />
+<NxCommands commands={["run-many --target lint --configuration=fix"]} />
 :::

--- a/docs/src/content/docs/it/snippets/pdk-migration/example/03-migrate-infra.mdx
+++ b/docs/src/content/docs/it/snippets/pdk-migration/example/03-migrate-infra.mdx
@@ -152,10 +152,13 @@ Nota che non passiamo l'identità o l'API al sito web - la configurazione runtim
 
 Costruiamo ora il progetto ora che abbiamo migrato tutte le parti rilevanti della codebase al nostro nuovo progetto.
 
-<NxCommands commands={["run-many --target build"]} />
+<PackageManagerShortCommand commands={["build"]} />
 
 :::caution
 Potresti vedere un errore di build dovuto a problemi di lint. Questi possono solitamente essere corretti automaticamente:
+
+<PackageManagerShortCommand commands={["lint"]} />
+:::nte essere corretti automaticamente:
 
 <NxCommands commands={["run-many --target lint --configuration=fix"]} />
 :::

--- a/docs/src/content/docs/it/snippets/pdk-migration/example/03-migrate-infra.mdx
+++ b/docs/src/content/docs/it/snippets/pdk-migration/example/03-migrate-infra.mdx
@@ -8,6 +8,7 @@ import Link from '@components/link.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Drawer from '@components/drawer.astro';
 import InstallCommand from '@components/install-command.astro';
+import PackageManagerShortCommand from '@components/package-manager-short-command.astro';
 
 L'ultimo progetto che dobbiamo migrare per la nostra applicazione shopping list è l'`InfrastructureTsProject`. Questo è un progetto TypeScript CDK, per il quale l'equivalente di Nx Plugin for AWS è il <Link path="/guides/typescript-infrastructure">generatore `ts#infra`</Link>.
 

--- a/docs/src/content/docs/it/snippets/pdk-migration/example/04-deploy.mdx
+++ b/docs/src/content/docs/it/snippets/pdk-migration/example/04-deploy.mdx
@@ -64,7 +64,7 @@ Per la nostra applicazione shopping list, le risorse stateful che ci interessano
 
     ```diff lang="ts"
     // packages/common/constructs/src/core/user-identity.ts
-    -this.userPool = this.createUserPool();
+    -this.userPool = this.createUserPool(mfa, mfaSecondFactor);
     +this.userPool = UserPool.fromUserPoolId(
     +  this,
     +  'UserPool',
@@ -99,7 +99,7 @@ Per la nostra applicazione shopping list, le risorse stateful che ci interessano
 
     ```diff lang="ts"
     // packages/common/constructs/src/core/user-identity.ts
-    +this.userPool = this.createUserPool();
+    +this.userPool = this.createUserPool(mfa, mfaSecondFactor);
     -this.userPool = UserPool.fromUserPoolId(
     -  this,
     -  'UserPool',

--- a/docs/src/content/docs/it/snippets/pdk-migration/example/04-deploy.mdx
+++ b/docs/src/content/docs/it/snippets/pdk-migration/example/04-deploy.mdx
@@ -9,6 +9,7 @@ import Link from '@components/link.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Drawer from '@components/drawer.astro';
 import InstallCommand from '@components/install-command.astro';
+import PackageManagerShortCommand from '@components/package-manager-short-command.astro';
 
 
 Ora che abbiamo la nostra codebase completamente migrata, possiamo occuparci del deploy. Ci sono due percorsi che possiamo seguire a questo punto.
@@ -23,7 +24,7 @@ L'approccio più semplice è trattare questa come un'applicazione completamente 
 
 1. Esegui il deploy della nuova applicazione:
 
-    <NxCommands commands={["deploy infra shopping-list-infra-sandbox/*"]} />
+    <NxCommands commands={['deploy-sandbox infra']} />
 
 </Steps>
 
@@ -74,9 +75,9 @@ Per la nostra applicazione shopping list, le risorse stateful che ci interessano
 
 1. Esegui il build e il deploy della nuova applicazione:
 
-    <NxCommands commands={["run-many --target build"]} />
+    <PackageManagerShortCommand commands={["build"]} />
 
-    <NxCommands commands={["deploy infra shopping-list-infra-sandbox/*"]} />
+    <NxCommands commands={['deploy-sandbox infra']} />
 
     Ora abbiamo la nostra nuova applicazione attiva che fa riferimento alle risorse esistenti, non ancora in ricezione di traffico.
 
@@ -109,7 +110,7 @@ Per la nostra applicazione shopping list, le risorse stateful che ci interessano
 
     E poi esegui un build
 
-    <NxCommands commands={["run-many --target build"]} />
+    <PackageManagerShortCommand commands={["build"]} />
 
 1. Usa `cdk import` nella cartella `packages/infra` della tua nuova applicazione per vedere quali risorse ci verrà richiesto di importare.
 
@@ -200,7 +201,7 @@ Per la nostra applicazione shopping list, le risorse stateful che ci interessano
 
 1. Esegui nuovamente il deploy della nuova applicazione per assicurarti che vengano apportate eventuali modifiche a queste risorse esistenti (ora gestite dal tuo nuovo stack):
 
-    <NxCommands commands={["deploy infra shopping-list-infra-sandbox/*"]} />
+    <NxCommands commands={['deploy-sandbox infra']} />
 
 1. Esegui un test completo della tua nuova applicazione ancora una volta
 

--- a/docs/src/content/docs/it/snippets/pdk-migration/faq/type-safe-api.mdx
+++ b/docs/src/content/docs/it/snippets/pdk-migration/faq/type-safe-api.mdx
@@ -14,7 +14,7 @@ I componenti più comunemente utilizzati di Type Safe API sono trattati nell'ese
 
 #### API modellate con OpenAPI
 
-Nx Plugin for AWS supporta API modellate in Smithy, ma non quelle modellate direttamente in OpenAPI. Il <Link path="/guides/ts-smithy-api">generatore `ts#smithy-api`</Link> è un buon punto di partenza che puoi poi modificare. Puoi definire la tua specifica OpenAPI nella cartella `src` del progetto `model` invece di Smithy, e modificare il `build.Dockerfile` per utilizzare il tuo strumento di generazione del codice desiderato per client/server se non sono disponibili su NPM. Se i tuoi strumenti desiderati sono su NPM, puoi semplicemente installarli come dipendenze di sviluppo nel tuo workspace Nx e chiamarli direttamente come target di build Nx.
+Nx Plugin for AWS supporta API modellate in Smithy, ma non quelle modellate direttamente in OpenAPI. Il <Link path="/guides/ts-smithy-api">generatore `ts#smithy-api`</Link> è un buon punto di partenza che puoi poi modificare. Puoi definire la tua specifica OpenAPI nella cartella `src` del progetto `model` invece di Smithy, e aggiornare il target `compile` del progetto `model` per eseguire il tuo strumento di generazione del codice desiderato per client/server. Se i tuoi strumenti desiderati sono su NPM, puoi installarli come dipendenze di sviluppo nel tuo workspace Nx e chiamarli direttamente come target di build Nx.
 
 ##### Backend
 
@@ -153,7 +153,7 @@ const pythonLambdaHandler = new Function(this, 'PythonImplementation', {
   ...
 });
 
-new MyApi(this, 'MyApi', {
+new Api(this, 'MyApi', {
   integrations: Api.defaultIntegrations(this)
     .withOverrides({
       echo: {

--- a/docs/src/content/docs/jp/blog/migrating-from-aws-pdk.mdx
+++ b/docs/src/content/docs/jp/blog/migrating-from-aws-pdk.mdx
@@ -36,7 +36,7 @@ Nx Plugin for AWSへの移行により、PDKと比較して以下のメリット
 :::
 
 :::caution[特定時点のガイド]
-これは特定時点のガイドとして書かれており、Nx Plugin for AWSの進化に伴って更新される可能性は低いです。これを補うため、このガイドでは`@aws/nx-plugin`のバージョンを`1.0.0-rc.47`に固定しています。最新バージョンで試すこともできますが、ガイドとの間にいくつかの相違がある可能性があります。
+これは特定時点のガイドとして書かれており、Nx Plugin for AWSの進化に伴って更新される可能性は低いです。これを補うため、このガイドでは`@aws/nx-plugin`のバージョンを`1.0.0`に固定しています。最新バージョンで試すこともできますが、ガイドとの間にいくつかの相違がある可能性があります。
 :::
 
 ## 移行例：ショッピングリストアプリケーション
@@ -54,7 +54,7 @@ Nx Plugin for AWSへの移行により、PDKと比較して以下のメリット
 
 まず、新しいプロジェクト用の新しいワークスペースを作成します。インプレース移行よりも極端ですが、このアプローチにより最もクリーンな最終結果が得られます。Nxワークスペースの作成は、PDKの`MonorepoTsProject`の使用と同等です：
 
-<CreateNxWorkspaceCommand workspace="shopping-list" iac="cdk" tag="1.0.0-rc.47" />
+<CreateNxWorkspaceCommand workspace="shopping-list" iac="cdk" tag="1.0.0" />
 
 このコマンドで作成された`shopping-list`ディレクトリをお気に入りのIDEで開きます。
 

--- a/docs/src/content/docs/jp/snippets/pdk-migration/example/01-migrate-api.mdx
+++ b/docs/src/content/docs/jp/snippets/pdk-migration/example/01-migrate-api.mdx
@@ -8,6 +8,7 @@ import Link from '@components/link.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Drawer from '@components/drawer.astro';
 import InstallCommand from '@components/install-command.astro';
+import PackageManagerShortCommand from '@components/package-manager-short-command.astro';
 
 ショッピングリストアプリケーションで使用されている `TypeSafeApiProject` は、以下を利用していました：
 
@@ -114,12 +115,12 @@ Smithy APIプロジェクトの基本構造ができたので、モデルを移�
 
 この時点で、ビルドを実行してモデルの変更を確認し、作業用の生成されたサーバーコードがあることを確認しましょう。バックエンドプロジェクト（`@shopping-list/api`）でいくつかの失敗が発生しますが、次にそれらに対処します。
 
-<NxCommands commands={["run-many --target build"]} />
+<PackageManagerShortCommand commands={["build"]} />
 
 :::note
 リントの問題によるビルド失敗が表示される場合があります。これらは通常、自動的に修正できます：
 
-<NxCommands commands={["run-many --target lint --configuration=fix"]} />
+<PackageManagerShortCommand commands={["lint"]} />
 :::
 
 #### Lambdaハンドラーの移行
@@ -596,10 +597,10 @@ const metrics = new Metrics();
 
 これで、プロジェクトをビルドして、これまでの移行が機能していることを確認できます：
 
-<NxCommands commands={["run-many --target build"]} />
+<PackageManagerShortCommand commands={["build"]} />
 
 :::note
 リントの問題によるビルド失敗が表示される場合があります。これらは通常、自動的に修正できます：
 
-<NxCommands commands={["run-many --target lint --configuration=fix"]} />
+<PackageManagerShortCommand commands={["lint"]} />
 :::

--- a/docs/src/content/docs/jp/snippets/pdk-migration/example/01-migrate-api.mdx
+++ b/docs/src/content/docs/jp/snippets/pdk-migration/example/01-migrate-api.mdx
@@ -119,7 +119,7 @@ Smithy APIプロジェクトの基本構造ができたので、モデルを移�
 :::note
 リントの問題によるビルド失敗が表示される場合があります。これらは通常、自動的に修正できます：
 
-<NxCommands commands={["run-many --target lint --fix"]} />
+<NxCommands commands={["run-many --target lint --configuration=fix"]} />
 :::
 
 #### Lambdaハンドラーの移行
@@ -132,7 +132,7 @@ Type Safe APIと `ts#smithy-api` ジェネレーターの主な違いの1つは�
 
 <InstallCommand pkg="@aws-sdk/client-dynamodb" project="@shopping-list/api" />
 
-次に、PDKプロジェクトから `handlers/src/dynamo-client.ts` ファイルを `backend/src/operations` にコピーして、ハンドラーで使用できるようにします。
+次に、PDKプロジェクトから `handlers/typescript/src/dynamo-client.ts` ファイルを `backend/src/operations` にコピーして、ハンドラーで使用できるようにします。
 
 `ts#smithy-api` ジェネレーターは、サンプルの `Echo` オペレーションをスキャフォールドします。モデルからこれを削除したので、`backend/src/operations/echo.ts` の対応するハンドラーを削除します。移行したオペレーションは、以下の `service.ts` で登録します。
 
@@ -587,6 +587,7 @@ const metrics = new Metrics();
 +    "apiName": "my-api",
     "auth": "iam",
     "modelProject": "@shopping-list/api-model",
+    "iac": "cdk",
     "ports": [3001]
   },
 ```
@@ -600,5 +601,5 @@ const metrics = new Metrics();
 :::note
 リントの問題によるビルド失敗が表示される場合があります。これらは通常、自動的に修正できます：
 
-<NxCommands commands={["run-many --target lint --fix"]} />
+<NxCommands commands={["run-many --target lint --configuration=fix"]} />
 :::

--- a/docs/src/content/docs/jp/snippets/pdk-migration/example/02-migrate-website.mdx
+++ b/docs/src/content/docs/jp/snippets/pdk-migration/example/02-migrate-website.mdx
@@ -8,6 +8,7 @@ import Link from '@components/link.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Drawer from '@components/drawer.astro';
 import InstallCommand from '@components/install-command.astro';
+import PackageManagerShortCommand from '@components/package-manager-short-command.astro';
 
 ショッピングリストアプリケーションで使用されている `CloudscapeReactTsWebsiteProject` は、CloudScape と Cognito 認証が組み込まれた React ウェブサイトを構成していました。
 
@@ -100,7 +101,7 @@ IDE でいくつかのビルドエラーが表示されるようになります�
 
 ローカルウェブサイトサーバーを起動しましょう：
 
-<NxCommands commands={["dev website"]} />
+<PackageManagerShortCommand commands={["dev"]} />
 
 :::tip
 ここでは `dev` ターゲットを使用しています。これは、`connection` で接続された API のローカルサーバーも起動し、ウェブサイト、モデル、またはバックエンドが変更された場合にホットリロードします！これにより、CDK コードを書く前に、API とウェブサイトをローカルでテストできます。

--- a/docs/src/content/docs/jp/snippets/pdk-migration/example/03-migrate-infra.mdx
+++ b/docs/src/content/docs/jp/snippets/pdk-migration/example/03-migrate-infra.mdx
@@ -8,6 +8,7 @@ import Link from '@components/link.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Drawer from '@components/drawer.astro';
 import InstallCommand from '@components/install-command.astro';
+import PackageManagerShortCommand from '@components/package-manager-short-command.astro';
 
 ショッピングリストアプリケーションで移行する必要がある最後のプロジェクトは `InfrastructureTsProject` です。これは TypeScript CDK プロジェクトであり、Nx Plugin for AWS の同等のものは <Link path="/guides/typescript-infrastructure">`ts#infra` ジェネレーター</Link>です。
 
@@ -152,10 +153,10 @@ ID や API を Website に渡していないことに注意してください - 
 
 コードベースの関連部分をすべて新しいプロジェクトに移行したので、プロジェクトをビルドしましょう。
 
-<NxCommands commands={["run-many --target build"]} />
+<PackageManagerShortCommand commands={["build"]} />
 
 :::caution
 lint の問題によりビルドが失敗する場合があります。これらは通常、自動的に修正できます：
 
-<NxCommands commands={["run-many --target lint --configuration=fix"]} />
+<PackageManagerShortCommand commands={["lint"]} />
 :::

--- a/docs/src/content/docs/jp/snippets/pdk-migration/example/03-migrate-infra.mdx
+++ b/docs/src/content/docs/jp/snippets/pdk-migration/example/03-migrate-infra.mdx
@@ -157,5 +157,5 @@ ID や API を Website に渡していないことに注意してください - 
 :::caution
 lint の問題によりビルドが失敗する場合があります。これらは通常、自動的に修正できます：
 
-<NxCommands commands={["run-many --target lint --fix"]} />
+<NxCommands commands={["run-many --target lint --configuration=fix"]} />
 :::

--- a/docs/src/content/docs/jp/snippets/pdk-migration/example/04-deploy.mdx
+++ b/docs/src/content/docs/jp/snippets/pdk-migration/example/04-deploy.mdx
@@ -63,7 +63,7 @@ PDKのショッピングリストアプリケーションでは、カスタム�
 
     ```diff lang="ts"
     // packages/common/constructs/src/core/user-identity.ts
-    -this.userPool = this.createUserPool();
+    -this.userPool = this.createUserPool(mfa, mfaSecondFactor);
     +this.userPool = UserPool.fromUserPoolId(
     +  this,
     +  'UserPool',
@@ -98,7 +98,7 @@ PDKのショッピングリストアプリケーションでは、カスタム�
 
     ```diff lang="ts"
     // packages/common/constructs/src/core/user-identity.ts
-    +this.userPool = this.createUserPool();
+    +this.userPool = this.createUserPool(mfa, mfaSecondFactor);
     -this.userPool = UserPool.fromUserPoolId(
     -  this,
     -  'UserPool',

--- a/docs/src/content/docs/jp/snippets/pdk-migration/example/04-deploy.mdx
+++ b/docs/src/content/docs/jp/snippets/pdk-migration/example/04-deploy.mdx
@@ -8,6 +8,7 @@ import Link from '@components/link.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Drawer from '@components/drawer.astro';
 import InstallCommand from '@components/install-command.astro';
+import PackageManagerShortCommand from '@components/package-manager-short-command.astro';
 
 
 完全に移行されたコードベースが完成したので、デプロイについて見ていきましょう。この時点で2つの方法があります。
@@ -22,7 +23,7 @@ import InstallCommand from '@components/install-command.astro';
 
 1. 新しいアプリケーションをデプロイします：
 
-    <NxCommands commands={["deploy infra shopping-list-infra-sandbox/*"]} />
+    <NxCommands commands={['deploy-sandbox infra']} />
 
 </Steps>
 
@@ -73,9 +74,9 @@ PDKのショッピングリストアプリケーションでは、カスタム�
 
 1. 新しいアプリケーションをビルドしてデプロイします：
 
-    <NxCommands commands={["run-many --target build"]} />
+    <PackageManagerShortCommand commands={["build"]} />
 
-    <NxCommands commands={["deploy infra shopping-list-infra-sandbox/*"]} />
+    <NxCommands commands={['deploy-sandbox infra']} />
 
     これで、既存のリソースを参照する新しいアプリケーションが立ち上がりましたが、まだトラフィックは受け取っていません。
 
@@ -108,7 +109,7 @@ PDKのショッピングリストアプリケーションでは、カスタム�
 
     そしてビルドを実行します
 
-    <NxCommands commands={["run-many --target build"]} />
+    <PackageManagerShortCommand commands={["build"]} />
 
 1. 新しいアプリケーションの`packages/infra`フォルダで`cdk import`を使用して、インポートするように促されるリソースを確認します。
 
@@ -199,7 +200,7 @@ PDKのショッピングリストアプリケーションでは、カスタム�
 
 1. 新しいアプリケーションを再度デプロイして、これらの既存のリソース（現在は新しいスタックによって管理されています）への変更が確実に行われるようにします：
 
-    <NxCommands commands={["deploy infra shopping-list-infra-sandbox/*"]} />
+    <NxCommands commands={['deploy-sandbox infra']} />
 
 1. 新しいアプリケーションの完全なテストを再度実行します
 

--- a/docs/src/content/docs/jp/snippets/pdk-migration/faq/type-safe-api.mdx
+++ b/docs/src/content/docs/jp/snippets/pdk-migration/faq/type-safe-api.mdx
@@ -14,7 +14,7 @@ Type Safe API で最もよく使用されるコンポーネントは上記の移
 
 #### OpenAPI でモデル化された API
 
-Nx Plugin for AWS は Smithy でモデル化された API をサポートしていますが、OpenAPI で直接モデル化された API はサポートしていません。<Link path="/guides/ts-smithy-api">`ts#smithy-api` ジェネレーター</Link>は良い出発点であり、その後変更することができます。`model` プロジェクトの `src` フォルダーに Smithy の代わりに OpenAPI 仕様を定義し、`build.Dockerfile` を変更して、NPM で利用できない場合は、クライアント/サーバー用の希望するコード生成ツールを使用できます。希望するツールが NPM にある場合は、Nx ワークスペースに開発依存関係としてインストールし、Nx ビルドターゲットとして直接呼び出すことができます。
+Nx Plugin for AWS は Smithy でモデル化された API をサポートしていますが、OpenAPI で直接モデル化された API はサポートしていません。<Link path="/guides/ts-smithy-api">`ts#smithy-api` ジェネレーター</Link>は良い出発点であり、その後変更することができます。`model` プロジェクトの `src` フォルダーに Smithy の代わりに OpenAPI 仕様を定義し、`model` プロジェクトの `compile` ターゲットを更新して、クライアント/サーバー用の希望するコード生成ツールを実行できます。希望するツールが NPM にある場合は、Nx ワークスペースに開発依存関係としてインストールし、Nx ビルドターゲットとして直接呼び出すことができます。
 
 ##### バックエンド
 
@@ -153,7 +153,7 @@ const pythonLambdaHandler = new Function(this, 'PythonImplementation', {
   ...
 });
 
-new MyApi(this, 'MyApi', {
+new Api(this, 'MyApi', {
   integrations: Api.defaultIntegrations(this)
     .withOverrides({
       echo: {

--- a/docs/src/content/docs/ko/blog/migrating-from-aws-pdk.mdx
+++ b/docs/src/content/docs/ko/blog/migrating-from-aws-pdk.mdx
@@ -36,7 +36,7 @@ Nx Plugin for AWS로 마이그레이션하면 PDK 대비 다음과 같은 이점
 :::
 
 :::caution[특정 시점 가이드]
-이 가이드는 특정 시점의 가이드로 작성되었으며 Nx Plugin for AWS가 발전함에 따라 업데이트되지 않을 가능성이 높습니다. 이를 보완하기 위해 가이드는 `@aws/nx-plugin` 버전을 `1.0.0-rc.47`로 고정합니다. 따라하실 때 최신 버전으로 시도할 수 있지만, 가이드와 약간의 차이가 있을 수 있습니다.
+이 가이드는 특정 시점의 가이드로 작성되었으며 Nx Plugin for AWS가 발전함에 따라 업데이트되지 않을 가능성이 높습니다. 이를 보완하기 위해 가이드는 `@aws/nx-plugin` 버전을 `1.0.0`로 고정합니다. 따라하실 때 최신 버전으로 시도할 수 있지만, 가이드와 약간의 차이가 있을 수 있습니다.
 :::
 
 ## 예제 마이그레이션: 쇼핑 목록 애플리케이션
@@ -54,7 +54,7 @@ Nx Plugin for AWS로 마이그레이션하면 PDK 대비 다음과 같은 이점
 
 시작하려면 새 프로젝트를 위한 새 워크스페이스를 생성합니다. 제자리 마이그레이션보다 더 극단적이지만, 이 접근 방식은 가장 깔끔한 최종 결과를 제공합니다. Nx 워크스페이스를 생성하는 것은 PDK의 `MonorepoTsProject`를 사용하는 것과 동등합니다:
 
-<CreateNxWorkspaceCommand workspace="shopping-list" iac="cdk" tag="1.0.0-rc.47" />
+<CreateNxWorkspaceCommand workspace="shopping-list" iac="cdk" tag="1.0.0" />
 
 이 명령이 생성하는 `shopping-list` 디렉토리를 선호하는 IDE에서 엽니다.
 

--- a/docs/src/content/docs/ko/snippets/pdk-migration/example/01-migrate-api.mdx
+++ b/docs/src/content/docs/ko/snippets/pdk-migration/example/01-migrate-api.mdx
@@ -119,7 +119,7 @@ import InstallCommand from '@components/install-command.astro';
 :::note
 린트 문제로 인한 빌드 실패가 발생할 수 있습니다. 이는 일반적으로 자동으로 수정할 수 있습니다:
 
-<NxCommands commands={["run-many --target lint --fix"]} />
+<NxCommands commands={["run-many --target lint --configuration=fix"]} />
 :::
 
 #### Lambda 핸들러 마이그레이션
@@ -132,7 +132,7 @@ Type Safe API와 `ts#smithy-api` 제너레이터의 주요 차이점 중 하나�
 
 <InstallCommand pkg="@aws-sdk/client-dynamodb" project="@shopping-list/api" />
 
-그런 다음 PDK 프로젝트의 `handlers/src/dynamo-client.ts` 파일을 `backend/src/operations`로 복사하여 핸들러에서 사용할 수 있도록 합니다.
+그런 다음 PDK 프로젝트의 `handlers/typescript/src/dynamo-client.ts` 파일을 `backend/src/operations`로 복사하여 핸들러에서 사용할 수 있도록 합니다.
 
 `ts#smithy-api` 제너레이터는 예제 `Echo` 작업을 스캐폴딩합니다. 모델에서 이를 제거했으므로 `backend/src/operations/echo.ts`의 해당 핸들러를 삭제합니다. 아래의 `service.ts`에서 마이그레이션된 작업을 등록하겠습니다.
 
@@ -587,6 +587,7 @@ const metrics = new Metrics();
 +    "apiName": "my-api",
     "auth": "iam",
     "modelProject": "@shopping-list/api-model",
+    "iac": "cdk",
     "ports": [3001]
   },
 ```
@@ -600,5 +601,5 @@ const metrics = new Metrics();
 :::note
 린트 문제로 인한 빌드 실패가 발생할 수 있습니다. 이는 일반적으로 자동으로 수정할 수 있습니다:
 
-<NxCommands commands={["run-many --target lint --fix"]} />
+<NxCommands commands={["run-many --target lint --configuration=fix"]} />
 :::

--- a/docs/src/content/docs/ko/snippets/pdk-migration/example/01-migrate-api.mdx
+++ b/docs/src/content/docs/ko/snippets/pdk-migration/example/01-migrate-api.mdx
@@ -8,6 +8,7 @@ import Link from '@components/link.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Drawer from '@components/drawer.astro';
 import InstallCommand from '@components/install-command.astro';
+import PackageManagerShortCommand from '@components/package-manager-short-command.astro';
 
 쇼핑 리스트 애플리케이션에서 사용된 `TypeSafeApiProject`는 다음을 활용했습니다:
 
@@ -114,12 +115,12 @@ import InstallCommand from '@components/install-command.astro';
 
 이 시점에서 빌드를 실행하여 모델 변경 사항을 확인하고 작업할 생성된 서버 코드가 있는지 확인해 보겠습니다. 백엔드 프로젝트(`@shopping-list/api`)에서 일부 실패가 발생할 수 있지만 다음에 해결하겠습니다.
 
-<NxCommands commands={["run-many --target build"]} />
+<PackageManagerShortCommand commands={["build"]} />
 
 :::note
 린트 문제로 인한 빌드 실패가 발생할 수 있습니다. 이는 일반적으로 자동으로 수정할 수 있습니다:
 
-<NxCommands commands={["run-many --target lint --configuration=fix"]} />
+<PackageManagerShortCommand commands={["lint"]} />
 :::
 
 #### Lambda 핸들러 마이그레이션
@@ -596,10 +597,10 @@ const metrics = new Metrics();
 
 이제 프로젝트를 빌드하여 지금까지의 마이그레이션이 제대로 작동하는지 확인할 수 있습니다:
 
-<NxCommands commands={["run-many --target build"]} />
+<PackageManagerShortCommand commands={["build"]} />
 
 :::note
 린트 문제로 인한 빌드 실패가 발생할 수 있습니다. 이는 일반적으로 자동으로 수정할 수 있습니다:
 
-<NxCommands commands={["run-many --target lint --configuration=fix"]} />
+<PackageManagerShortCommand commands={["lint"]} />
 :::

--- a/docs/src/content/docs/ko/snippets/pdk-migration/example/02-migrate-website.mdx
+++ b/docs/src/content/docs/ko/snippets/pdk-migration/example/02-migrate-website.mdx
@@ -8,6 +8,7 @@ import Link from '@components/link.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Drawer from '@components/drawer.astro';
 import InstallCommand from '@components/install-command.astro';
+import PackageManagerShortCommand from '@components/package-manager-short-command.astro';
 
 쇼핑 리스트 애플리케이션에서 사용된 `CloudscapeReactTsWebsiteProject`는 CloudScape와 Cognito 인증이 내장된 React 웹사이트를 구성했습니다.
 
@@ -100,7 +101,7 @@ Nx Plugin for AWS에서는 API 통합이 <Link path="/guides/connection">`connec
 
 로컬 웹사이트 서버를 시작해 봅시다:
 
-<NxCommands commands={["dev website"]} />
+<PackageManagerShortCommand commands={["dev"]} />
 
 :::tip
 여기서는 `dev` 타겟을 사용하고 있으며, 이는 `connection`으로 연결된 모든 API에 대한 로컬 서버도 시작하고, 웹사이트, 모델 또는 백엔드가 변경되면 핫 리로드됩니다! 이를 통해 CDK 코드를 작성하기 전에 API와 웹사이트를 로컬에서 테스트할 수 있습니다.

--- a/docs/src/content/docs/ko/snippets/pdk-migration/example/03-migrate-infra.mdx
+++ b/docs/src/content/docs/ko/snippets/pdk-migration/example/03-migrate-infra.mdx
@@ -8,6 +8,7 @@ import Link from '@components/link.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Drawer from '@components/drawer.astro';
 import InstallCommand from '@components/install-command.astro';
+import PackageManagerShortCommand from '@components/package-manager-short-command.astro';
 
 쇼핑 리스트 애플리케이션을 위해 마이그레이션해야 하는 마지막 프로젝트는 `InfrastructureTsProject`입니다. 이것은 TypeScript CDK 프로젝트이며, Nx Plugin for AWS에서 이에 해당하는 것은 <Link path="/guides/typescript-infrastructure">`ts#infra` 생성기</Link>입니다.
 
@@ -152,10 +153,10 @@ Type Safe API와 마찬가지로 Nx Plugin for AWS는 Smithy 모델을 기반으
 
 이제 코드베이스의 모든 관련 부분을 새 프로젝트로 마이그레이션했으므로 프로젝트를 빌드해 보겠습니다.
 
-<NxCommands commands={["run-many --target build"]} />
+<PackageManagerShortCommand commands={["build"]} />
 
 :::caution
 린트 문제로 인해 빌드 실패가 발생할 수 있습니다. 이는 일반적으로 자동으로 수정할 수 있습니다:
 
-<NxCommands commands={["run-many --target lint --configuration=fix"]} />
+<PackageManagerShortCommand commands={["lint"]} />
 :::

--- a/docs/src/content/docs/ko/snippets/pdk-migration/example/03-migrate-infra.mdx
+++ b/docs/src/content/docs/ko/snippets/pdk-migration/example/03-migrate-infra.mdx
@@ -157,5 +157,5 @@ Type Safe API와 마찬가지로 Nx Plugin for AWS는 Smithy 모델을 기반으
 :::caution
 린트 문제로 인해 빌드 실패가 발생할 수 있습니다. 이는 일반적으로 자동으로 수정할 수 있습니다:
 
-<NxCommands commands={["run-many --target lint --fix"]} />
+<NxCommands commands={["run-many --target lint --configuration=fix"]} />
 :::

--- a/docs/src/content/docs/ko/snippets/pdk-migration/example/04-deploy.mdx
+++ b/docs/src/content/docs/ko/snippets/pdk-migration/example/04-deploy.mdx
@@ -8,6 +8,7 @@ import Link from '@components/link.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Drawer from '@components/drawer.astro';
 import InstallCommand from '@components/install-command.astro';
+import PackageManagerShortCommand from '@components/package-manager-short-command.astro';
 
 
 이제 완전히 마이그레이션된 코드베이스를 얻었으므로 배포를 살펴볼 수 있습니다. 이 시점에서 두 가지 경로를 선택할 수 있습니다.
@@ -22,7 +23,7 @@ import InstallCommand from '@components/install-command.astro';
 
 1. 새 애플리케이션을 배포합니다:
 
-    <NxCommands commands={["deploy infra shopping-list-infra-sandbox/*"]} />
+    <NxCommands commands={['deploy-sandbox infra']} />
 
 </Steps>
 
@@ -73,9 +74,9 @@ PDK 쇼핑 목록 애플리케이션은 사용자 정의 도메인이나 DNS를 
 
 1. 새 애플리케이션을 빌드하고 배포합니다:
 
-    <NxCommands commands={["run-many --target build"]} />
+    <PackageManagerShortCommand commands={["build"]} />
 
-    <NxCommands commands={["deploy infra shopping-list-infra-sandbox/*"]} />
+    <NxCommands commands={['deploy-sandbox infra']} />
 
     이제 기존 리소스를 참조하는 새 애플리케이션이 구축되었지만 아직 트래픽을 받지 않습니다.
 
@@ -108,7 +109,7 @@ PDK 쇼핑 목록 애플리케이션은 사용자 정의 도메인이나 DNS를 
 
     그런 다음 빌드를 실행합니다
 
-    <NxCommands commands={["run-many --target build"]} />
+    <PackageManagerShortCommand commands={["build"]} />
 
 1. 새 애플리케이션의 `packages/infra` 폴더에서 `cdk import`를 사용하여 가져오라는 메시지가 표시될 리소스를 확인합니다.
 
@@ -199,7 +200,7 @@ PDK 쇼핑 목록 애플리케이션은 사용자 정의 도메인이나 DNS를 
 
 1. 이러한 기존 리소스(이제 새 스택에서 관리됨)에 대한 변경 사항이 적용되도록 새 애플리케이션을 다시 배포합니다:
 
-    <NxCommands commands={["deploy infra shopping-list-infra-sandbox/*"]} />
+    <NxCommands commands={['deploy-sandbox infra']} />
 
 1. 새 애플리케이션에 대한 전체 테스트를 다시 수행합니다
 

--- a/docs/src/content/docs/ko/snippets/pdk-migration/example/04-deploy.mdx
+++ b/docs/src/content/docs/ko/snippets/pdk-migration/example/04-deploy.mdx
@@ -63,7 +63,7 @@ PDK 쇼핑 목록 애플리케이션은 사용자 정의 도메인이나 DNS를 
 
     ```diff lang="ts"
     // packages/common/constructs/src/core/user-identity.ts
-    -this.userPool = this.createUserPool();
+    -this.userPool = this.createUserPool(mfa, mfaSecondFactor);
     +this.userPool = UserPool.fromUserPoolId(
     +  this,
     +  'UserPool',
@@ -98,7 +98,7 @@ PDK 쇼핑 목록 애플리케이션은 사용자 정의 도메인이나 DNS를 
 
     ```diff lang="ts"
     // packages/common/constructs/src/core/user-identity.ts
-    +this.userPool = this.createUserPool();
+    +this.userPool = this.createUserPool(mfa, mfaSecondFactor);
     -this.userPool = UserPool.fromUserPoolId(
     -  this,
     -  'UserPool',

--- a/docs/src/content/docs/ko/snippets/pdk-migration/faq/type-safe-api.mdx
+++ b/docs/src/content/docs/ko/snippets/pdk-migration/faq/type-safe-api.mdx
@@ -14,7 +14,7 @@ Type Safe API에서 가장 일반적으로 사용되는 컴포넌트는 위의 �
 
 #### OpenAPI로 모델링된 API
 
-Nx Plugin for AWS는 Smithy로 모델링된 API를 지원하지만 OpenAPI로 직접 모델링된 API는 지원하지 않습니다. <Link path="/guides/ts-smithy-api">`ts#smithy-api` 생성기</Link>가 좋은 시작점이며 이를 수정할 수 있습니다. Smithy 대신 `model` 프로젝트의 `src` 폴더에 OpenAPI 사양을 정의하고, NPM에서 사용할 수 없는 경우 클라이언트/서버용 원하는 코드 생성 도구를 사용하도록 `build.Dockerfile`을 수정할 수 있습니다. 원하는 도구가 NPM에 있는 경우 Nx 워크스페이스에 개발 의존성으로 설치하고 Nx 빌드 타겟으로 직접 호출할 수 있습니다.
+Nx Plugin for AWS는 Smithy로 모델링된 API를 지원하지만 OpenAPI로 직접 모델링된 API는 지원하지 않습니다. <Link path="/guides/ts-smithy-api">`ts#smithy-api` 생성기</Link>가 좋은 시작점이며 이를 수정할 수 있습니다. Smithy 대신 `model` 프로젝트의 `src` 폴더에 OpenAPI 사양을 정의하고, 클라이언트/서버용 원하는 코드 생성 도구를 실행하도록 `model` 프로젝트의 `compile` 타겟을 업데이트할 수 있습니다. 원하는 도구가 NPM에 있는 경우 Nx 워크스페이스에 개발 의존성으로 설치하고 Nx 빌드 타겟으로 직접 호출할 수 있습니다.
 
 ##### 백엔드
 
@@ -153,7 +153,7 @@ const pythonLambdaHandler = new Function(this, 'PythonImplementation', {
   ...
 });
 
-new MyApi(this, 'MyApi', {
+new Api(this, 'MyApi', {
   integrations: Api.defaultIntegrations(this)
     .withOverrides({
       echo: {

--- a/docs/src/content/docs/pt/blog/migrating-from-aws-pdk.mdx
+++ b/docs/src/content/docs/pt/blog/migrating-from-aws-pdk.mdx
@@ -54,7 +54,7 @@ A aplicação de lista de compras consiste nos seguintes tipos de projeto PDK:
 
 Para começar, criaremos um novo workspace para nosso novo projeto. Embora seja mais extremo do que uma migração no local, essa abordagem nos dá o resultado final mais limpo. Criar um workspace Nx é equivalente a usar o `MonorepoTsProject` do PDK:
 
-<CreateNxWorkspaceCommand workspace="shopping-list" iac="cdk" tag="1.0.0-rc.47" />
+<CreateNxWorkspaceCommand workspace="shopping-list" iac="cdk" tag="1.0.0" />
 
 Abra o diretório `shopping-list` que este comando cria no seu IDE favorito.
 

--- a/docs/src/content/docs/pt/snippets/pdk-migration/example/01-migrate-api.mdx
+++ b/docs/src/content/docs/pt/snippets/pdk-migration/example/01-migrate-api.mdx
@@ -119,7 +119,7 @@ Neste ponto, vamos executar uma compilação para verificar nossas alterações 
 :::note
 Você pode ver uma falha de compilação devido a problemas de lint. Estes geralmente podem ser corrigidos automaticamente:
 
-<NxCommands commands={["run-many --target lint --fix"]} />
+<NxCommands commands={["run-many --target lint --configuration=fix"]} />
 :::
 
 #### Migrar os Handlers Lambda
@@ -132,7 +132,7 @@ Os handlers lambda da aplicação de lista de compras dependem do pacote `@aws-s
 
 <InstallCommand pkg="@aws-sdk/client-dynamodb" project="@shopping-list/api" />
 
-Em seguida, vamos copiar o arquivo `handlers/src/dynamo-client.ts` do projeto PDK para `backend/src/operations` para que esteja disponível para nossos handlers.
+Em seguida, vamos copiar o arquivo `handlers/typescript/src/dynamo-client.ts` do projeto PDK para `backend/src/operations` para que esteja disponível para nossos handlers.
 
 O gerador `ts#smithy-api` cria um exemplo de operação `Echo`. Como removemos isso do nosso modelo, exclua o handler correspondente em `backend/src/operations/echo.ts`. Registraremos nossas operações migradas em `service.ts` mais adiante abaixo.
 
@@ -587,6 +587,7 @@ Além disso, atualize `packages/api/backend/project.json` e atualize `metadata.a
 +    "apiName": "my-api",
     "auth": "iam",
     "modelProject": "@shopping-list/api-model",
+    "iac": "cdk",
     "ports": [3001]
   },
 ```
@@ -600,5 +601,5 @@ Agora podemos compilar o projeto para verificar se a migração funcionou até a
 :::note
 Você pode ver uma falha de compilação devido a problemas de lint. Estes geralmente podem ser corrigidos automaticamente:
 
-<NxCommands commands={["run-many --target lint --fix"]} />
+<NxCommands commands={["run-many --target lint --configuration=fix"]} />
 :::

--- a/docs/src/content/docs/pt/snippets/pdk-migration/example/01-migrate-api.mdx
+++ b/docs/src/content/docs/pt/snippets/pdk-migration/example/01-migrate-api.mdx
@@ -8,6 +8,7 @@ import Link from '@components/link.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Drawer from '@components/drawer.astro';
 import InstallCommand from '@components/install-command.astro';
+import PackageManagerShortCommand from '@components/package-manager-short-command.astro';
 
 O `TypeSafeApiProject` usado na aplicação de lista de compras fez uso de:
 
@@ -114,12 +115,12 @@ Agora que temos a estrutura básica para nosso projeto de API Smithy, podemos mi
 
 Neste ponto, vamos executar uma compilação para verificar nossas alterações no modelo e garantir que temos algum código de servidor gerado para trabalhar. Haverá algumas falhas no projeto backend (`@shopping-list/api`), mas vamos resolver isso em seguida.
 
-<NxCommands commands={["run-many --target build"]} />
+<PackageManagerShortCommand commands={["build"]} />
 
 :::note
 Você pode ver uma falha de compilação devido a problemas de lint. Estes geralmente podem ser corrigidos automaticamente:
 
-<NxCommands commands={["run-many --target lint --configuration=fix"]} />
+<PackageManagerShortCommand commands={["lint"]} />
 :::
 
 #### Migrar os Handlers Lambda
@@ -596,10 +597,10 @@ Além disso, atualize `packages/api/backend/project.json` e atualize `metadata.a
 
 Agora podemos compilar o projeto para verificar se a migração funcionou até agora:
 
-<NxCommands commands={["run-many --target build"]} />
+<PackageManagerShortCommand commands={["build"]} />
 
 :::note
 Você pode ver uma falha de compilação devido a problemas de lint. Estes geralmente podem ser corrigidos automaticamente:
 
-<NxCommands commands={["run-many --target lint --configuration=fix"]} />
+<PackageManagerShortCommand commands={["lint"]} />
 :::

--- a/docs/src/content/docs/pt/snippets/pdk-migration/example/02-migrate-website.mdx
+++ b/docs/src/content/docs/pt/snippets/pdk-migration/example/02-migrate-website.mdx
@@ -8,6 +8,7 @@ import Link from '@components/link.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Drawer from '@components/drawer.astro';
 import InstallCommand from '@components/install-command.astro';
+import PackageManagerShortCommand from '@components/package-manager-short-command.astro';
 
 O `CloudscapeReactTsWebsiteProject` usado na aplicação de lista de compras configurou um website React com CloudScape e autenticação Cognito integrados.
 
@@ -100,7 +101,7 @@ Como estamos usando [roteamento baseado em arquivos](https://tanstack.com/router
 
 Vamos iniciar o servidor local do website:
 
-<NxCommands commands={["dev website"]} />
+<PackageManagerShortCommand commands={["dev"]} />
 
 :::tip
 Estamos usando o alvo `dev` aqui, que também inicia servidores locais para quaisquer APIs que foram conectadas com `connection`, e recarrega automaticamente se seu website, modelo ou backend mudar! Isso nos permite testar nossa API e website localmente antes mesmo de termos escrito qualquer código CDK.

--- a/docs/src/content/docs/pt/snippets/pdk-migration/example/03-migrate-infra.mdx
+++ b/docs/src/content/docs/pt/snippets/pdk-migration/example/03-migrate-infra.mdx
@@ -8,6 +8,7 @@ import Link from '@components/link.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Drawer from '@components/drawer.astro';
 import InstallCommand from '@components/install-command.astro';
+import PackageManagerShortCommand from '@components/package-manager-short-command.astro';
 
 O último projeto que precisamos migrar para nossa aplicação de lista de compras é o `InfrastructureTsProject`. Este é um projeto TypeScript CDK, para o qual o equivalente do Nx Plugin for AWS é o <Link path="/guides/typescript-infrastructure">gerador `ts#infra`</Link>.
 
@@ -152,10 +153,10 @@ Note que não passamos a identidade ou API para o website - a configuração de 
 
 Vamos construir o projeto agora que migramos todas as partes relevantes da base de código para nosso novo projeto.
 
-<NxCommands commands={["run-many --target build"]} />
+<PackageManagerShortCommand commands={["build"]} />
 
 :::caution
 Você pode ver uma falha de build devido a problemas de lint. Estes geralmente podem ser corrigidos automaticamente:
 
-<NxCommands commands={["run-many --target lint --configuration=fix"]} />
+<PackageManagerShortCommand commands={["lint"]} />
 :::

--- a/docs/src/content/docs/pt/snippets/pdk-migration/example/03-migrate-infra.mdx
+++ b/docs/src/content/docs/pt/snippets/pdk-migration/example/03-migrate-infra.mdx
@@ -157,5 +157,5 @@ Vamos construir o projeto agora que migramos todas as partes relevantes da base 
 :::caution
 Você pode ver uma falha de build devido a problemas de lint. Estes geralmente podem ser corrigidos automaticamente:
 
-<NxCommands commands={["run-many --target lint --fix"]} />
+<NxCommands commands={["run-many --target lint --configuration=fix"]} />
 :::

--- a/docs/src/content/docs/pt/snippets/pdk-migration/example/04-deploy.mdx
+++ b/docs/src/content/docs/pt/snippets/pdk-migration/example/04-deploy.mdx
@@ -63,7 +63,7 @@ Para nossa aplicação de lista de compras, os recursos com estado que nos impor
 
     ```diff lang="ts"
     // packages/common/constructs/src/core/user-identity.ts
-    -this.userPool = this.createUserPool();
+    -this.userPool = this.createUserPool(mfa, mfaSecondFactor);
     +this.userPool = UserPool.fromUserPoolId(
     +  this,
     +  'UserPool',
@@ -98,7 +98,7 @@ Para nossa aplicação de lista de compras, os recursos com estado que nos impor
 
     ```diff lang="ts"
     // packages/common/constructs/src/core/user-identity.ts
-    +this.userPool = this.createUserPool();
+    +this.userPool = this.createUserPool(mfa, mfaSecondFactor);
     -this.userPool = UserPool.fromUserPoolId(
     -  this,
     -  'UserPool',

--- a/docs/src/content/docs/pt/snippets/pdk-migration/example/04-deploy.mdx
+++ b/docs/src/content/docs/pt/snippets/pdk-migration/example/04-deploy.mdx
@@ -8,6 +8,7 @@ import Link from '@components/link.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Drawer from '@components/drawer.astro';
 import InstallCommand from '@components/install-command.astro';
+import PackageManagerShortCommand from '@components/package-manager-short-command.astro';
 
 
 Agora que temos nossa base de código totalmente migrada, podemos olhar para implantá-la. Existem dois caminhos que podemos seguir neste ponto.
@@ -22,7 +23,7 @@ A abordagem mais simples é tratar isso como uma aplicação completamente nova,
 
 1. Implante a nova aplicação:
 
-    <NxCommands commands={["deploy infra shopping-list-infra-sandbox/*"]} />
+    <NxCommands commands={['deploy-sandbox infra']} />
 
 </Steps>
 
@@ -73,9 +74,9 @@ Para nossa aplicação de lista de compras, os recursos com estado que nos impor
 
 1. Construa e implante a nova aplicação:
 
-    <NxCommands commands={["run-many --target build"]} />
+    <PackageManagerShortCommand commands={["build"]} />
 
-    <NxCommands commands={["deploy infra shopping-list-infra-sandbox/*"]} />
+    <NxCommands commands={['deploy-sandbox infra']} />
 
     Agora temos nossa nova aplicação configurada referenciando os recursos existentes, ainda não recebendo nenhum tráfego.
 
@@ -108,7 +109,7 @@ Para nossa aplicação de lista de compras, os recursos com estado que nos impor
 
     E então execute uma construção
 
-    <NxCommands commands={["run-many --target build"]} />
+    <PackageManagerShortCommand commands={["build"]} />
 
 1. Use `cdk import` na pasta `packages/infra` da sua nova aplicação para ver quais recursos seremos solicitados a importar.
 
@@ -199,7 +200,7 @@ Para nossa aplicação de lista de compras, os recursos com estado que nos impor
 
 1. Implante a nova aplicação novamente para garantir que quaisquer alterações nesses recursos existentes (agora gerenciados por sua nova pilha) sejam feitas:
 
-    <NxCommands commands={["deploy infra shopping-list-infra-sandbox/*"]} />
+    <NxCommands commands={['deploy-sandbox infra']} />
 
 1. Execute um teste completo de sua nova aplicação novamente
 

--- a/docs/src/content/docs/pt/snippets/pdk-migration/faq/type-safe-api.mdx
+++ b/docs/src/content/docs/pt/snippets/pdk-migration/faq/type-safe-api.mdx
@@ -14,7 +14,7 @@ Os componentes mais comumente usados do Type Safe API são cobertos no exemplo d
 
 #### APIs Modeladas com OpenAPI
 
-O Nx Plugin for AWS suporta APIs modeladas em Smithy, mas não aquelas modeladas diretamente em OpenAPI. O <Link path="/guides/ts-smithy-api">gerador `ts#smithy-api`</Link> é um bom ponto de partida que você pode então modificar. Você pode definir sua especificação OpenAPI na pasta `src` do projeto `model` em vez de Smithy, e modificar o `build.Dockerfile` para usar sua ferramenta de geração de código desejada para clientes/servidores se eles não estiverem disponíveis no NPM. Se suas ferramentas desejadas estiverem no NPM, você pode simplesmente instalá-las como dependências de desenvolvimento no seu workspace Nx e chamá-las diretamente como targets de build do Nx.
+O Nx Plugin for AWS suporta APIs modeladas em Smithy, mas não aquelas modeladas diretamente em OpenAPI. O <Link path="/guides/ts-smithy-api">gerador `ts#smithy-api`</Link> é um bom ponto de partida que você pode então modificar. Você pode definir sua especificação OpenAPI na pasta `src` do projeto `model` em vez de Smithy, e atualizar o target `compile` do projeto `model` para executar sua ferramenta de geração de código desejada para clientes/servidores. Se suas ferramentas desejadas estiverem no NPM, você pode instalá-las como dependências de desenvolvimento no seu workspace Nx e chamá-las diretamente como targets de build do Nx.
 
 ##### Backend
 
@@ -153,7 +153,7 @@ const pythonLambdaHandler = new Function(this, 'PythonImplementation', {
   ...
 });
 
-new MyApi(this, 'MyApi', {
+new Api(this, 'MyApi', {
   integrations: Api.defaultIntegrations(this)
     .withOverrides({
       echo: {

--- a/docs/src/content/docs/vi/blog/migrating-from-aws-pdk.mdx
+++ b/docs/src/content/docs/vi/blog/migrating-from-aws-pdk.mdx
@@ -36,7 +36,7 @@ Cũng lưu ý rằng một số tính năng của PDK không có tương đươn
 :::
 
 :::caution[Hướng dẫn Tại Thời điểm]
-Đây được viết như một hướng dẫn tại thời điểm và rất có thể sẽ không được cập nhật khi Nx Plugin for AWS phát triển. Để bù đắp cho điều này, hướng dẫn ghim phiên bản của `@aws/nx-plugin` ở `1.0.0-rc.47`. Bạn có thể thử với phiên bản mới nhất nếu làm theo, nhưng có thể có một số khác biệt so với hướng dẫn.
+Đây được viết như một hướng dẫn tại thời điểm và rất có thể sẽ không được cập nhật khi Nx Plugin for AWS phát triển. Để bù đắp cho điều này, hướng dẫn ghim phiên bản của `@aws/nx-plugin` ở `1.0.0`. Bạn có thể thử với phiên bản mới nhất nếu làm theo, nhưng có thể có một số khác biệt so với hướng dẫn.
 :::
 
 ## Ví dụ Di chuyển: Ứng dụng Danh sách Mua sắm
@@ -54,7 +54,7 @@ Trong hướng dẫn này, chúng ta sẽ sử dụng [Ứng dụng Danh sách M
 
 Để bắt đầu, chúng ta sẽ tạo một workspace mới cho dự án mới của chúng ta. Mặc dù cực đoan hơn so với di chuyển tại chỗ, cách tiếp cận này mang lại cho chúng ta kết quả cuối cùng sạch sẽ nhất. Tạo một Nx workspace tương đương với việc sử dụng `MonorepoTsProject` của PDK:
 
-<CreateNxWorkspaceCommand workspace="shopping-list" iac="cdk" tag="1.0.0-rc.47" />
+<CreateNxWorkspaceCommand workspace="shopping-list" iac="cdk" tag="1.0.0" />
 
 Mở thư mục `shopping-list` mà lệnh này tạo ra trong IDE yêu thích của bạn.
 

--- a/docs/src/content/docs/vi/snippets/pdk-migration/example/01-migrate-api.mdx
+++ b/docs/src/content/docs/vi/snippets/pdk-migration/example/01-migrate-api.mdx
@@ -8,6 +8,7 @@ import Link from '@components/link.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Drawer from '@components/drawer.astro';
 import InstallCommand from '@components/install-command.astro';
+import PackageManagerShortCommand from '@components/package-manager-short-command.astro';
 
 `TypeSafeApiProject` được sử dụng trong ứng dụng danh sách mua sắm đã sử dụng:
 
@@ -114,12 +115,12 @@ Bây giờ chúng ta đã có cấu trúc cơ bản cho dự án Smithy API, ch�
 
 Tại thời điểm này, hãy chạy một bản build để kiểm tra các thay đổi mô hình của chúng ta và đảm bảo chúng ta có một số mã máy chủ được tạo để làm việc. Sẽ có một số lỗi trong dự án backend (`@shopping-list/api`) nhưng chúng ta sẽ giải quyết chúng tiếp theo.
 
-<NxCommands commands={["run-many --target build"]} />
+<PackageManagerShortCommand commands={["build"]} />
 
 :::note
 Bạn có thể thấy lỗi build do các vấn đề lint. Những lỗi này thường có thể được tự động sửa:
 
-<NxCommands commands={["run-many --target lint --configuration=fix"]} />
+<PackageManagerShortCommand commands={["lint"]} />
 :::
 
 #### Di chuyển Lambda Handlers
@@ -596,10 +597,10 @@ Ngoài ra, cập nhật `packages/api/backend/project.json` và cập nhật `me
 
 Bây giờ chúng ta có thể build dự án để kiểm tra xem quá trình di chuyển đã hoạt động cho đến nay chưa:
 
-<NxCommands commands={["run-many --target build"]} />
+<PackageManagerShortCommand commands={["build"]} />
 
 :::note
 Bạn có thể thấy lỗi build do các vấn đề lint. Những lỗi này thường có thể được tự động sửa:
 
-<NxCommands commands={["run-many --target lint --configuration=fix"]} />
+<PackageManagerShortCommand commands={["lint"]} />
 :::

--- a/docs/src/content/docs/vi/snippets/pdk-migration/example/01-migrate-api.mdx
+++ b/docs/src/content/docs/vi/snippets/pdk-migration/example/01-migrate-api.mdx
@@ -119,7 +119,7 @@ Tại thời điểm này, hãy chạy một bản build để kiểm tra các t
 :::note
 Bạn có thể thấy lỗi build do các vấn đề lint. Những lỗi này thường có thể được tự động sửa:
 
-<NxCommands commands={["run-many --target lint --fix"]} />
+<NxCommands commands={["run-many --target lint --configuration=fix"]} />
 :::
 
 #### Di chuyển Lambda Handlers
@@ -132,7 +132,7 @@ Các lambda handler của ứng dụng danh sách mua sắm phụ thuộc vào g
 
 <InstallCommand pkg="@aws-sdk/client-dynamodb" project="@shopping-list/api" />
 
-Sau đó, hãy sao chép tệp `handlers/src/dynamo-client.ts` từ dự án PDK sang `backend/src/operations` để nó có sẵn cho các handler của chúng ta.
+Sau đó, hãy sao chép tệp `handlers/typescript/src/dynamo-client.ts` từ dự án PDK sang `backend/src/operations` để nó có sẵn cho các handler của chúng ta.
 
 Generator `ts#smithy-api` tạo ra một thao tác `Echo` ví dụ. Vì chúng ta đã xóa điều này khỏi mô hình của mình, hãy xóa handler tương ứng trong `backend/src/operations/echo.ts`. Chúng ta sẽ đăng ký các thao tác đã di chuyển của mình trong `service.ts` bên dưới.
 
@@ -587,6 +587,7 @@ Ngoài ra, cập nhật `packages/api/backend/project.json` và cập nhật `me
 +    "apiName": "my-api",
     "auth": "iam",
     "modelProject": "@shopping-list/api-model",
+    "iac": "cdk",
     "ports": [3001]
   },
 ```
@@ -600,5 +601,5 @@ Bây giờ chúng ta có thể build dự án để kiểm tra xem quá trình d
 :::note
 Bạn có thể thấy lỗi build do các vấn đề lint. Những lỗi này thường có thể được tự động sửa:
 
-<NxCommands commands={["run-many --target lint --fix"]} />
+<NxCommands commands={["run-many --target lint --configuration=fix"]} />
 :::

--- a/docs/src/content/docs/vi/snippets/pdk-migration/example/02-migrate-website.mdx
+++ b/docs/src/content/docs/vi/snippets/pdk-migration/example/02-migrate-website.mdx
@@ -8,6 +8,7 @@ import Link from '@components/link.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Drawer from '@components/drawer.astro';
 import InstallCommand from '@components/install-command.astro';
+import PackageManagerShortCommand from '@components/package-manager-short-command.astro';
 
 `CloudscapeReactTsWebsiteProject` được sử dụng trong ứng dụng danh sách mua sắm đã cấu hình một website React với CloudScape và xác thực Cognito được tích hợp sẵn.
 
@@ -100,7 +101,7 @@ Vì chúng ta đang sử dụng [file-based routing](https://tanstack.com/router
 
 Hãy khởi động máy chủ website cục bộ:
 
-<NxCommands commands={["dev website"]} />
+<PackageManagerShortCommand commands={["dev"]} />
 
 :::tip
 Chúng ta đang sử dụng target `dev` ở đây, cũng khởi động các máy chủ cục bộ cho bất kỳ API nào đã được kết nối với `connection`, và hot-reload nếu website, model hoặc backend của bạn thay đổi! Điều này cho phép chúng ta kiểm tra API và website của chúng ta cục bộ trước khi chúng ta thậm chí đã viết bất kỳ mã CDK nào.

--- a/docs/src/content/docs/vi/snippets/pdk-migration/example/03-migrate-infra.mdx
+++ b/docs/src/content/docs/vi/snippets/pdk-migration/example/03-migrate-infra.mdx
@@ -8,6 +8,7 @@ import Link from '@components/link.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Drawer from '@components/drawer.astro';
 import InstallCommand from '@components/install-command.astro';
+import PackageManagerShortCommand from '@components/package-manager-short-command.astro';
 
 Dự án cuối cùng chúng ta cần di chuyển cho ứng dụng danh sách mua sắm là `InfrastructureTsProject`. Đây là một dự án TypeScript CDK, mà tương đương trong Nx Plugin for AWS là <Link path="/guides/typescript-infrastructure">trình tạo `ts#infra`</Link>.
 
@@ -152,10 +153,10 @@ Lưu ý rằng chúng ta không truyền identity hoặc API cho website - cấu
 
 Hãy build dự án bây giờ sau khi chúng ta đã di chuyển tất cả các phần liên quan của codebase sang dự án mới.
 
-<NxCommands commands={["run-many --target build"]} />
+<PackageManagerShortCommand commands={["build"]} />
 
 :::caution
 Bạn có thể thấy lỗi build do các vấn đề lint. Những lỗi này thường có thể được tự động sửa:
 
-<NxCommands commands={["run-many --target lint --configuration=fix"]} />
+<PackageManagerShortCommand commands={["lint"]} />
 :::

--- a/docs/src/content/docs/vi/snippets/pdk-migration/example/03-migrate-infra.mdx
+++ b/docs/src/content/docs/vi/snippets/pdk-migration/example/03-migrate-infra.mdx
@@ -157,5 +157,5 @@ Hãy build dự án bây giờ sau khi chúng ta đã di chuyển tất cả cá
 :::caution
 Bạn có thể thấy lỗi build do các vấn đề lint. Những lỗi này thường có thể được tự động sửa:
 
-<NxCommands commands={["run-many --target lint --fix"]} />
+<NxCommands commands={["run-many --target lint --configuration=fix"]} />
 :::

--- a/docs/src/content/docs/vi/snippets/pdk-migration/example/04-deploy.mdx
+++ b/docs/src/content/docs/vi/snippets/pdk-migration/example/04-deploy.mdx
@@ -63,7 +63,7 @@ Cách tiếp cận này phức tạp và tinh tế hơn một chút, và đây c
 
     ```diff lang="ts"
     // packages/common/constructs/src/core/user-identity.ts
-    -this.userPool = this.createUserPool();
+    -this.userPool = this.createUserPool(mfa, mfaSecondFactor);
     +this.userPool = UserPool.fromUserPoolId(
     +  this,
     +  'UserPool',
@@ -98,7 +98,7 @@ Cách tiếp cận này phức tạp và tinh tế hơn một chút, và đây c
 
     ```diff lang="ts"
     // packages/common/constructs/src/core/user-identity.ts
-    +this.userPool = this.createUserPool();
+    +this.userPool = this.createUserPool(mfa, mfaSecondFactor);
     -this.userPool = UserPool.fromUserPoolId(
     -  this,
     -  'UserPool',

--- a/docs/src/content/docs/vi/snippets/pdk-migration/example/04-deploy.mdx
+++ b/docs/src/content/docs/vi/snippets/pdk-migration/example/04-deploy.mdx
@@ -8,6 +8,7 @@ import Link from '@components/link.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Drawer from '@components/drawer.astro';
 import InstallCommand from '@components/install-command.astro';
+import PackageManagerShortCommand from '@components/package-manager-short-command.astro';
 
 
 Bây giờ chúng ta đã có codebase đã được di chuyển hoàn toàn, chúng ta có thể xem xét việc triển khai nó. Có hai hướng đi mà chúng ta có thể thực hiện tại thời điểm này.
@@ -22,7 +23,7 @@ Cách tiếp cận đơn giản nhất là coi đây là một ứng dụng hoà
 
 1. Triển khai ứng dụng mới:
 
-    <NxCommands commands={["deploy infra shopping-list-infra-sandbox/*"]} />
+    <NxCommands commands={['deploy-sandbox infra']} />
 
 </Steps>
 
@@ -73,9 +74,9 @@ Cách tiếp cận này phức tạp và tinh tế hơn một chút, và đây c
 
 1. Build và triển khai ứng dụng mới:
 
-    <NxCommands commands={["run-many --target build"]} />
+    <PackageManagerShortCommand commands={["build"]} />
 
-    <NxCommands commands={["deploy infra shopping-list-infra-sandbox/*"]} />
+    <NxCommands commands={['deploy-sandbox infra']} />
 
     Bây giờ chúng ta có ứng dụng mới đã được thiết lập tham chiếu các tài nguyên hiện có, chưa nhận bất kỳ traffic nào.
 
@@ -108,7 +109,7 @@ Cách tiếp cận này phức tạp và tinh tế hơn một chút, và đây c
 
     Và sau đó chạy build
 
-    <NxCommands commands={["run-many --target build"]} />
+    <PackageManagerShortCommand commands={["build"]} />
 
 1. Sử dụng `cdk import` trong thư mục `packages/infra` của ứng dụng mới để xem các tài nguyên nào chúng ta sẽ được nhắc import.
 
@@ -199,7 +200,7 @@ Cách tiếp cận này phức tạp và tinh tế hơn một chút, và đây c
 
 1. Triển khai ứng dụng mới một lần nữa để đảm bảo rằng bất kỳ thay đổi nào đối với các tài nguyên hiện có này (hiện được quản lý bởi stack mới của bạn) được thực hiện:
 
-    <NxCommands commands={["deploy infra shopping-list-infra-sandbox/*"]} />
+    <NxCommands commands={['deploy-sandbox infra']} />
 
 1. Thực hiện kiểm thử đầy đủ ứng dụng mới của bạn một lần nữa
 

--- a/docs/src/content/docs/vi/snippets/pdk-migration/faq/type-safe-api.mdx
+++ b/docs/src/content/docs/vi/snippets/pdk-migration/faq/type-safe-api.mdx
@@ -14,7 +14,7 @@ Các thành phần được sử dụng phổ biến nhất từ Type Safe API �
 
 #### API được Mô hình hóa bằng OpenAPI
 
-Nx Plugin for AWS hỗ trợ các API được mô hình hóa trong Smithy, nhưng không hỗ trợ những API được mô hình hóa trực tiếp bằng OpenAPI. <Link path="/guides/ts-smithy-api">Generator `ts#smithy-api`</Link> là một điểm khởi đầu tốt mà bạn có thể sửa đổi sau đó. Bạn có thể định nghĩa đặc tả OpenAPI của mình trong thư mục `src` của dự án `model` thay vì Smithy, và sửa đổi `build.Dockerfile` để sử dụng công cụ tạo mã mong muốn cho clients/servers nếu chúng không có sẵn trên NPM. Nếu các công cụ mong muốn của bạn có trên NPM, bạn chỉ cần cài đặt chúng như dev dependencies vào Nx workspace của bạn và gọi chúng trực tiếp như các Nx build targets.
+Nx Plugin for AWS hỗ trợ các API được mô hình hóa trong Smithy, nhưng không hỗ trợ những API được mô hình hóa trực tiếp bằng OpenAPI. <Link path="/guides/ts-smithy-api">Generator `ts#smithy-api`</Link> là một điểm khởi đầu tốt mà bạn có thể sửa đổi sau đó. Bạn có thể định nghĩa đặc tả OpenAPI của mình trong thư mục `src` của dự án `model` thay vì Smithy, và cập nhật target `compile` của dự án `model` để chạy công cụ tạo mã mong muốn cho clients/servers. Nếu các công cụ mong muốn của bạn có trên NPM, bạn có thể cài đặt chúng như dev dependencies vào Nx workspace của bạn và gọi chúng trực tiếp như các Nx build targets.
 
 ##### Backend
 
@@ -153,7 +153,7 @@ const pythonLambdaHandler = new Function(this, 'PythonImplementation', {
   ...
 });
 
-new MyApi(this, 'MyApi', {
+new Api(this, 'MyApi', {
   integrations: Api.defaultIntegrations(this)
     .withOverrides({
       echo: {

--- a/docs/src/content/docs/zh/blog/migrating-from-aws-pdk.mdx
+++ b/docs/src/content/docs/zh/blog/migrating-from-aws-pdk.mdx
@@ -36,7 +36,7 @@ import InstallCommand from '@components/install-command.astro';
 :::
 
 :::caution[时间点指南]
-这是作为时间点指南编写的，很可能不会随着 Nx Plugin for AWS 的发展而更新。为了弥补这一点，本指南将 `@aws/nx-plugin` 的版本固定为 `1.0.0-rc.47`。如果您跟随操作，可以尝试使用最新版本，但可能会与指南有一些偏差。
+这是作为时间点指南编写的，很可能不会随着 Nx Plugin for AWS 的发展而更新。为了弥补这一点，本指南将 `@aws/nx-plugin` 的版本固定为 `1.0.0`。如果您跟随操作，可以尝试使用最新版本，但可能会与指南有一些偏差。
 :::
 
 ## 示例迁移：购物清单应用程序
@@ -54,7 +54,7 @@ import InstallCommand from '@components/install-command.astro';
 
 首先，我们将为新项目创建一个新的工作区。虽然这比就地迁移更极端，但这种方法为我们提供了最干净的最终结果。创建 Nx 工作区相当于使用 PDK 的 `MonorepoTsProject`：
 
-<CreateNxWorkspaceCommand workspace="shopping-list" iac="cdk" tag="1.0.0-rc.47" />
+<CreateNxWorkspaceCommand workspace="shopping-list" iac="cdk" tag="1.0.0" />
 
 在您喜欢的 IDE 中打开此命令创建的 `shopping-list` 目录。
 

--- a/docs/src/content/docs/zh/snippets/pdk-migration/example/01-migrate-api.mdx
+++ b/docs/src/content/docs/zh/snippets/pdk-migration/example/01-migrate-api.mdx
@@ -8,6 +8,7 @@ import Link from '@components/link.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Drawer from '@components/drawer.astro';
 import InstallCommand from '@components/install-command.astro';
+import PackageManagerShortCommand from '@components/package-manager-short-command.astro';
 
 购物清单应用程序中使用的 `TypeSafeApiProject` 利用了：
 
@@ -114,12 +115,12 @@ import InstallCommand from '@components/install-command.astro';
 
 此时，让我们运行构建以检查我们的模型更改并确保我们有一些生成的服务器代码可以使用。后端项目（`@shopping-list/api`）中会有一些失败，但我们接下来会解决这些问题。
 
-<NxCommands commands={["run-many --target build"]} />
+<PackageManagerShortCommand commands={["build"]} />
 
 :::note
 您可能会看到由于 lint 问题导致的构建失败。这些通常可以自动修复：
 
-<NxCommands commands={["run-many --target lint --configuration=fix"]} />
+<PackageManagerShortCommand commands={["lint"]} />
 :::
 
 #### 迁移 Lambda 处理程序
@@ -596,10 +597,10 @@ const metrics = new Metrics();
 
 我们现在可以构建项目以检查迁移到目前为止是否有效：
 
-<NxCommands commands={["run-many --target build"]} />
+<PackageManagerShortCommand commands={["build"]} />
 
 :::note
 您可能会看到由于 lint 问题导致的构建失败。这些通常可以自动修复：
 
-<NxCommands commands={["run-many --target lint --configuration=fix"]} />
+<PackageManagerShortCommand commands={["lint"]} />
 :::

--- a/docs/src/content/docs/zh/snippets/pdk-migration/example/01-migrate-api.mdx
+++ b/docs/src/content/docs/zh/snippets/pdk-migration/example/01-migrate-api.mdx
@@ -119,7 +119,7 @@ import InstallCommand from '@components/install-command.astro';
 :::note
 您可能会看到由于 lint 问题导致的构建失败。这些通常可以自动修复：
 
-<NxCommands commands={["run-many --target lint --fix"]} />
+<NxCommands commands={["run-many --target lint --configuration=fix"]} />
 :::
 
 #### 迁移 Lambda 处理程序
@@ -132,7 +132,7 @@ Type Safe API 和 `ts#smithy-api` 生成器之间的主要区别之一是处理�
 
 <InstallCommand pkg="@aws-sdk/client-dynamodb" project="@shopping-list/api" />
 
-然后，让我们将 PDK 项目中的 `handlers/src/dynamo-client.ts` 文件复制到 `backend/src/operations`，以便我们的处理程序可以使用它。
+然后，让我们将 PDK 项目中的 `handlers/typescript/src/dynamo-client.ts` 文件复制到 `backend/src/operations`，以便我们的处理程序可以使用它。
 
 `ts#smithy-api` 生成器搭建了一个示例 `Echo` 操作。由于我们从模型中删除了它，请删除 `backend/src/operations/echo.ts` 中的相应处理程序。我们将在下面的 `service.ts` 中注册我们迁移的操作。
 
@@ -587,6 +587,7 @@ const metrics = new Metrics();
 +    "apiName": "my-api",
     "auth": "iam",
     "modelProject": "@shopping-list/api-model",
+    "iac": "cdk",
     "ports": [3001]
   },
 ```
@@ -600,5 +601,5 @@ const metrics = new Metrics();
 :::note
 您可能会看到由于 lint 问题导致的构建失败。这些通常可以自动修复：
 
-<NxCommands commands={["run-many --target lint --fix"]} />
+<NxCommands commands={["run-many --target lint --configuration=fix"]} />
 :::

--- a/docs/src/content/docs/zh/snippets/pdk-migration/example/02-migrate-website.mdx
+++ b/docs/src/content/docs/zh/snippets/pdk-migration/example/02-migrate-website.mdx
@@ -8,6 +8,7 @@ import Link from '@components/link.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Drawer from '@components/drawer.astro';
 import InstallCommand from '@components/install-command.astro';
+import PackageManagerShortCommand from '@components/package-manager-short-command.astro';
 
 购物清单应用程序中使用的 `CloudscapeReactTsWebsiteProject` 配置了一个内置 CloudScape 和 Cognito 身份验证的 React 网站。
 
@@ -100,7 +101,7 @@ RuntimeConfig.ensure(this).config = {
 
 让我们启动本地网站服务器：
 
-<NxCommands commands={["dev website"]} />
+<PackageManagerShortCommand commands={["dev"]} />
 
 :::tip
 我们在这里使用 `dev` 目标，它还会为使用 `connection` 连接的任何 API 启动本地服务器，并在您的网站、模型或后端更改时热重载！这使我们能够在编写任何 CDK 代码之前在本地测试我们的 API 和网站。

--- a/docs/src/content/docs/zh/snippets/pdk-migration/example/03-migrate-infra.mdx
+++ b/docs/src/content/docs/zh/snippets/pdk-migration/example/03-migrate-infra.mdx
@@ -8,6 +8,7 @@ import Link from '@components/link.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Drawer from '@components/drawer.astro';
 import InstallCommand from '@components/install-command.astro';
+import PackageManagerShortCommand from '@components/package-manager-short-command.astro';
 
 我们需要为购物清单应用程序迁移的最后一个项目是 `InfrastructureTsProject`。这是一个 TypeScript CDK 项目，Nx Plugin for AWS 的等效项是 <Link path="/guides/typescript-infrastructure">`ts#infra` 生成器</Link>。
 
@@ -152,10 +153,10 @@ PDK 购物清单应用程序在 `constructs/apis/myapi.ts` 中有一个构造，
 
 现在我们已经将代码库的所有相关部分迁移到新项目中，让我们构建项目。
 
-<NxCommands commands={["run-many --target build"]} />
+<PackageManagerShortCommand commands={["build"]} />
 
 :::caution
 您可能会看到由于 lint 问题导致的构建失败。这些通常可以自动修复：
 
-<NxCommands commands={["run-many --target lint --configuration=fix"]} />
+<PackageManagerShortCommand commands={["lint"]} />
 :::

--- a/docs/src/content/docs/zh/snippets/pdk-migration/example/03-migrate-infra.mdx
+++ b/docs/src/content/docs/zh/snippets/pdk-migration/example/03-migrate-infra.mdx
@@ -157,5 +157,5 @@ PDK 购物清单应用程序在 `constructs/apis/myapi.ts` 中有一个构造，
 :::caution
 您可能会看到由于 lint 问题导致的构建失败。这些通常可以自动修复：
 
-<NxCommands commands={["run-many --target lint --fix"]} />
+<NxCommands commands={["run-many --target lint --configuration=fix"]} />
 :::

--- a/docs/src/content/docs/zh/snippets/pdk-migration/example/04-deploy.mdx
+++ b/docs/src/content/docs/zh/snippets/pdk-migration/example/04-deploy.mdx
@@ -63,7 +63,7 @@ import InstallCommand from '@components/install-command.astro';
 
     ```diff lang="ts"
     // packages/common/constructs/src/core/user-identity.ts
-    -this.userPool = this.createUserPool();
+    -this.userPool = this.createUserPool(mfa, mfaSecondFactor);
     +this.userPool = UserPool.fromUserPoolId(
     +  this,
     +  'UserPool',
@@ -98,7 +98,7 @@ import InstallCommand from '@components/install-command.astro';
 
     ```diff lang="ts"
     // packages/common/constructs/src/core/user-identity.ts
-    +this.userPool = this.createUserPool();
+    +this.userPool = this.createUserPool(mfa, mfaSecondFactor);
     -this.userPool = UserPool.fromUserPoolId(
     -  this,
     -  'UserPool',

--- a/docs/src/content/docs/zh/snippets/pdk-migration/example/04-deploy.mdx
+++ b/docs/src/content/docs/zh/snippets/pdk-migration/example/04-deploy.mdx
@@ -8,6 +8,7 @@ import Link from '@components/link.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Drawer from '@components/drawer.astro';
 import InstallCommand from '@components/install-command.astro';
+import PackageManagerShortCommand from '@components/package-manager-short-command.astro';
 
 
 现在我们已经完成了代码库的完整迁移，可以开始部署了。此时我们有两条路径可以选择。
@@ -22,7 +23,7 @@ import InstallCommand from '@components/install-command.astro';
 
 1. 部署新应用程序：
 
-    <NxCommands commands={["deploy infra shopping-list-infra-sandbox/*"]} />
+    <NxCommands commands={['deploy-sandbox infra']} />
 
 </Steps>
 
@@ -73,9 +74,9 @@ import InstallCommand from '@components/install-command.astro';
 
 1. 构建并部署新应用程序：
 
-    <NxCommands commands={["run-many --target build"]} />
+    <PackageManagerShortCommand commands={["build"]} />
 
-    <NxCommands commands={["deploy infra shopping-list-infra-sandbox/*"]} />
+    <NxCommands commands={['deploy-sandbox infra']} />
 
     现在我们的新应用程序已经启动并引用现有资源，尚未接收任何流量。
 
@@ -108,7 +109,7 @@ import InstallCommand from '@components/install-command.astro';
 
     然后运行构建
 
-    <NxCommands commands={["run-many --target build"]} />
+    <PackageManagerShortCommand commands={["build"]} />
 
 1. 在新应用程序的 `packages/infra` 文件夹中使用 `cdk import` 查看我们将被提示导入哪些资源。
 
@@ -199,7 +200,7 @@ import InstallCommand from '@components/install-command.astro';
 
 1. 再次部署新应用程序，以确保对这些现有资源（现在由新堆栈管理）进行任何更改：
 
-    <NxCommands commands={["deploy infra shopping-list-infra-sandbox/*"]} />
+    <NxCommands commands={['deploy-sandbox infra']} />
 
 1. 再次对新应用程序执行完整测试
 

--- a/docs/src/content/docs/zh/snippets/pdk-migration/faq/type-safe-api.mdx
+++ b/docs/src/content/docs/zh/snippets/pdk-migration/faq/type-safe-api.mdx
@@ -14,7 +14,7 @@ import InstallCommand from '@components/install-command.astro';
 
 #### 使用 OpenAPI 建模的 API
 
-Nx Plugin for AWS 支持使用 Smithy 建模的 API，但不支持直接使用 OpenAPI 建模的 API。<Link path="/guides/ts-smithy-api">`ts#smithy-api` 生成器</Link>是一个很好的起点，您可以在此基础上进行修改。您可以在 `model` 项目的 `src` 文件夹中定义 OpenAPI 规范而不是 Smithy，并修改 `build.Dockerfile` 以使用您所需的代码生成工具来生成客户端/服务器（如果它们在 NPM 上不可用）。如果您所需的工具在 NPM 上可用，您只需将它们作为开发依赖项安装到您的 Nx 工作空间，并直接将它们作为 Nx 构建目标调用。
+Nx Plugin for AWS 支持使用 Smithy 建模的 API，但不支持直接使用 OpenAPI 建模的 API。<Link path="/guides/ts-smithy-api">`ts#smithy-api` 生成器</Link>是一个很好的起点，您可以在此基础上进行修改。您可以在 `model` 项目的 `src` 文件夹中定义 OpenAPI 规范而不是 Smithy，并更新 `model` 项目的 `compile` 目标以运行您所需的代码生成工具来生成客户端/服务器。如果您所需的工具在 NPM 上可用，您可以将它们作为开发依赖项安装到您的 Nx 工作空间，并直接将它们作为 Nx 构建目标调用。
 
 ##### 后端
 
@@ -153,7 +153,7 @@ const pythonLambdaHandler = new Function(this, 'PythonImplementation', {
   ...
 });
 
-new MyApi(this, 'MyApi', {
+new Api(this, 'MyApi', {
   integrations: Api.defaultIntegrations(this)
     .withOverrides({
       echo: {

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -34,7 +34,7 @@ const MAX_PUBLISH_ATTEMPTS = 3;
  * tag promotes it to the stable version (dropping the -rc suffix) and subsequent
  * runs follow conventional-commits semver (1.0.1, 1.1.0, …).
  */
-const RELEASE_TRAIN: 'rc' | 'stable' = 'rc';
+const RELEASE_TRAIN: 'rc' | 'stable' = 'stable';
 /**
  * The bump applied when promoting the current rc series to its first stable
  * release (e.g. `major`: 1.0.0-rc.x → 1.0.0). Only used on that transition.


### PR DESCRIPTION
### Reason for this change

Promotes the 1.0 release candidate series to a stable `1.0.0` (#737).

The PDK migration guide is a point-in-time guide pinned to a specific plugin version. It was pinned to `1.0.0-rc.47`, 50 release candidates behind the current train, and had drifted from what the generators actually vend.

### Description of changes

**Release cutover**

- `scripts/release.ts`: `RELEASE_TRAIN` flipped from `'rc'` to `'stable'`. The next release off `main` sees a `v1.0.0-rc.N` tag, applies `STABLE_PROMOTION_BUMP` (`major`) and publishes `1.0.0` on the `latest` dist-tag. Every release after that follows conventional-commits semver off a stable tag with no further changes.

  Verified `STABLE_PROMOTION_BUMP` produces the intended version: `semver.inc('1.0.0-rc.97', 'major') === '1.0.0'`.

  Everything else the cutover checklist previously covered (the `next` dist-tag, `release/0.x` CI branching, the `-next` marketplace entry, `@next` install paths in docs) is already gone from the repo, so no other changes are needed.

**PDK migration guide**

- Pinned to `1.0.0` instead of `1.0.0-rc.47`, in the caution callout and the `CreateNxWorkspaceCommand`.
- `nx run-many --target lint --fix` → `nx run-many --target lint --configuration=fix` (3 occurrences). Workspaces use Biome, where auto-fix is an Nx target configuration; `--fix` is silently ignored, so a reader following the guide hit an unfixable `format` failure at each of the three "you may see a build failure due to lint issues" steps.
- `packages/api/backend/project.json` diff now includes the `"iac": "cdk"` metadata entry the generator vends.
- The `dynamo-client.ts` copy step points at the real PDK path, `handlers/typescript/src/dynamo-client.ts`.
- The `user-identity.ts` diffs in the deploy section match the current signature, `this.createUserPool(mfa, mfaSecondFactor)`.
- Type Safe API FAQ: the OpenAPI modelling path referenced a `build.Dockerfile` that no longer exists — the `model` project's `compile` target is where code generation is wired now. The mixed-language-backend snippet instantiated `MyApi` where the vended construct is `Api`.

### Description of how you validated changes

Ran the PDK migration guide end to end, for real, against `@aws/nx-plugin@1.0.0-rc.97` (one docs-only commit behind `main`, so functionally identical to the `1.0.0` this PR cuts):

- Reconstructed the [PDK shopping list application](https://aws.github.io/aws-pdk/getting_started/shopping_list_app.html) as the migration input (Smithy model, TypeScript handlers, Cloudscape pages/components, CDK constructs).
- Created the workspace with the guide's pinned command, then ran `ts#api` (`framework=smithy`), `ts#website` (`ux=cloudscape`), `ts#website#auth`, `connection` and `ts#infra` exactly as documented.
- Applied every documented migration step and verified each file path, construct name, export and generated-client path the guide names still resolves.
- `nx run-many --target build` passes for all five projects, including `infra:synth` and `infra:checkov` (the guide's Checkov suppressions for the DynamoDB table are still the right set).
- `nx dev website` starts the website on port `4200` and the local Smithy API server on `3001`, as the guide states.

Repo checks: `pnpm nx run-many --target build --all` passes, including `docs:build` (which validates internal doc links).

Not deployed to AWS — the deploy section of the guide covers CloudFormation resource import from a live PDK stack, and the changes here are the release-train constant plus documentation.

### Issue # (if applicable)

Closes #737.

> [!NOTE]
> Every v1.0 workstream in #718 is complete except the release blog post (#713), which is the one prerequisite from #737 still outstanding.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

