### PR TITLE
fix(ts#infra): destroy the whole sandbox stage, including nested stacks

### DIFF
--- a/docs/src/content/docs/en/guides/typescript-infrastructure.mdx
+++ b/docs/src/content/docs/en/guides/typescript-infrastructure.mdx
@@ -467,7 +467,9 @@ Destroying is irreversible, so CDK asks you to confirm the stacks it is about to
 
 The `destroy` target tears down whichever stage or stacks you name:
 
-<NxCommands commands={['destroy <my-infra> <my-infra>-sandbox/*']} />
+<NxCommands commands={['destroy <my-infra> <my-infra>-sandbox/**']} />
+
+Use `/**` rather than `/*` for a whole stage: destroying only deletes the stacks the pattern selects, and `/*` misses stacks nested below the stage's stacks, such as the `us-east-1` WebACL stack a website creates for its CloudFront distribution.
 
 To tear down an individual stack, give the full stack name:
 

--- a/docs/src/content/docs/es/guides/typescript-infrastructure.mdx
+++ b/docs/src/content/docs/es/guides/typescript-infrastructure.mdx
@@ -467,7 +467,9 @@ Desmantelar es irreversible, por lo que CDK te pide que confirmes los stacks que
 
 El target `destroy` desmantela el stage o stacks que nombres:
 
-<NxCommands commands={['destroy <my-infra> <my-infra>-sandbox/*']} />
+<NxCommands commands={['destroy <my-infra> <my-infra>-sandbox/**']} />
+
+Usa `/**` en lugar de `/*` para un stage completo: desmantelar solo elimina los stacks que el patrón selecciona, y `/*` omite los stacks anidados debajo de los stacks del stage, como el stack WebACL de `us-east-1` que un sitio web crea para su distribución de CloudFront.
 
 Para desmantelar un stack individual, proporciona el nombre completo del stack:
 

--- a/docs/src/content/docs/fr/guides/typescript-infrastructure.mdx
+++ b/docs/src/content/docs/fr/guides/typescript-infrastructure.mdx
@@ -467,7 +467,9 @@ La destruction est irréversible, donc CDK vous demande de confirmer les stacks 
 
 La cible `destroy` détruit le stage ou les stacks que vous nommez :
 
-<NxCommands commands={['destroy <my-infra> <my-infra>-sandbox/*']} />
+<NxCommands commands={['destroy <my-infra> <my-infra>-sandbox/**']} />
+
+Utilisez `/**` plutôt que `/*` pour un stage entier : la destruction ne supprime que les stacks sélectionnées par le motif, et `/*` manque les stacks imbriquées sous les stacks du stage, telles que la stack WebACL `us-east-1` qu'un site web crée pour sa distribution CloudFront.
 
 Pour détruire une stack individuelle, donnez le nom complet de la stack :
 

--- a/docs/src/content/docs/it/guides/typescript-infrastructure.mdx
+++ b/docs/src/content/docs/it/guides/typescript-infrastructure.mdx
@@ -467,7 +467,9 @@ La distruzione è irreversibile, quindi CDK ti chiede di confermare gli stack ch
 
 Il target `destroy` smantella qualsiasi stage o stack tu nomini:
 
-<NxCommands commands={['destroy <my-infra> <my-infra>-sandbox/*']} />
+<NxCommands commands={['destroy <my-infra> <my-infra>-sandbox/**']} />
+
+Usa `/**` invece di `/*` per uno stage completo: la distruzione elimina solo gli stack selezionati dal pattern, e `/*` perde gli stack annidati sotto gli stack dello stage, come lo stack WebACL `us-east-1` che un sito web crea per la sua distribuzione CloudFront.
 
 Per smantellare un singolo stack, fornisci il nome completo dello stack:
 

--- a/docs/src/content/docs/jp/guides/typescript-infrastructure.mdx
+++ b/docs/src/content/docs/jp/guides/typescript-infrastructure.mdx
@@ -467,7 +467,9 @@ CI/CDパイプラインの一部としてAWSにデプロイする場合は、`de
 
 `destroy`ターゲットは、指定したステージまたはスタックを削除します：
 
-<NxCommands commands={['destroy <my-infra> <my-infra>-sandbox/*']} />
+<NxCommands commands={['destroy <my-infra> <my-infra>-sandbox/**']} />
+
+ステージ全体を削除する場合は、`/*`ではなく`/**`を使用してください：削除はパターンが選択したスタックのみを削除し、`/*`ではステージのスタックの下にネストされたスタック（例えば、WebサイトがCloudFrontディストリビューション用に作成する`us-east-1` WebACLスタック）を見逃します。
 
 個別のスタックを削除するには、完全なスタック名を指定します：
 

--- a/docs/src/content/docs/ko/guides/typescript-infrastructure.mdx
+++ b/docs/src/content/docs/ko/guides/typescript-infrastructure.mdx
@@ -467,7 +467,9 @@ CI/CD 파이프라인의 일부로 AWS에 배포하는 경우 `deploy-ci` 타겟
 
 `destroy` 타겟은 지정한 스테이지 또는 스택을 해체합니다:
 
-<NxCommands commands={['destroy <my-infra> <my-infra>-sandbox/*']} />
+<NxCommands commands={['destroy <my-infra> <my-infra>-sandbox/**']} />
+
+전체 스테이지에는 `/*`가 아닌 `/**`를 사용하세요: 해체는 패턴이 선택한 스택만 삭제하며, `/*`는 웹사이트가 CloudFront 배포를 위해 생성하는 `us-east-1` WebACL 스택과 같이 스테이지의 스택 아래에 중첩된 스택을 놓칩니다.
 
 개별 스택을 해체하려면 전체 스택 이름을 제공하세요:
 

--- a/docs/src/content/docs/pt/guides/typescript-infrastructure.mdx
+++ b/docs/src/content/docs/pt/guides/typescript-infrastructure.mdx
@@ -467,7 +467,9 @@ Desmontar é irreversível, então o CDK pede que você confirme os stacks que e
 
 O target `destroy` desmonta qualquer stage ou stacks que você nomear:
 
-<NxCommands commands={['destroy <my-infra> <my-infra>-sandbox/*']} />
+<NxCommands commands={['destroy <my-infra> <my-infra>-sandbox/**']} />
+
+Use `/**` em vez de `/*` para um stage completo: desmontar apenas exclui os stacks que o padrão seleciona, e `/*` perde stacks aninhados abaixo dos stacks do stage, como o stack WebACL `us-east-1` que um website cria para sua distribuição CloudFront.
 
 Para desmontar um stack individual, forneça o nome completo do stack:
 

--- a/docs/src/content/docs/vi/guides/typescript-infrastructure.mdx
+++ b/docs/src/content/docs/vi/guides/typescript-infrastructure.mdx
@@ -467,7 +467,9 @@ Việc phá bỏ là không thể đảo ngược, vì vậy CDK yêu cầu bạ
 
 Target `destroy` phá bỏ bất kỳ stage hoặc stack nào bạn đặt tên:
 
-<NxCommands commands={['destroy <my-infra> <my-infra>-sandbox/*']} />
+<NxCommands commands={['destroy <my-infra> <my-infra>-sandbox/**']} />
+
+Sử dụng `/**` thay vì `/*` cho toàn bộ stage: việc phá bỏ chỉ xóa các stack mà pattern chọn, và `/*` bỏ sót các stack lồng bên dưới các stack của stage, chẳng hạn như stack WebACL `us-east-1` mà một website tạo ra cho CloudFront distribution của nó.
 
 Để phá bỏ một stack riêng lẻ, cung cấp tên stack đầy đủ:
 

--- a/docs/src/content/docs/zh/guides/typescript-infrastructure.mdx
+++ b/docs/src/content/docs/zh/guides/typescript-infrastructure.mdx
@@ -467,7 +467,9 @@ npx cdk bootstrap aws://<account-id>/<region>
 
 `destroy` 目标拆除您命名的任何阶段或堆栈：
 
-<NxCommands commands={['destroy <my-infra> <my-infra>-sandbox/*']} />
+<NxCommands commands={['destroy <my-infra> <my-infra>-sandbox/**']} />
+
+对于整个阶段，使用 `/**` 而不是 `/*`：销毁仅删除模式选择的堆栈，而 `/*` 会遗漏嵌套在阶段堆栈下方的堆栈，例如网站为其 CloudFront 分配创建的 `us-east-1` WebACL 堆栈。
 
 要拆除单个堆栈，请提供完整的堆栈名称：
 

--- a/packages/nx-plugin/src/infra/app/__snapshots__/generator.spec.ts.snap
+++ b/packages/nx-plugin/src/infra/app/__snapshots__/generator.spec.ts.snap
@@ -191,7 +191,7 @@ exports[`infra generator > should configure project.json with correct targets > 
       ],
       "executor": "nx:run-commands",
       "options": {
-        "command": "cdk deploy --require-approval=never "proj-test-sandbox/*" --express",
+        "command": "cdk deploy --require-approval=never "proj-test-sandbox/**" --express",
         "cwd": "{projectRoot}",
       },
     },
@@ -220,7 +220,7 @@ exports[`infra generator > should configure project.json with correct targets > 
       ],
       "executor": "nx:run-commands",
       "options": {
-        "command": "cdk destroy "proj-test-sandbox/*"",
+        "command": "cdk destroy "proj-test-sandbox/**"",
         "cwd": "{projectRoot}",
       },
     },
@@ -803,7 +803,7 @@ exports[`infra generator > should handle custom project names correctly > custom
       ],
       "executor": "nx:run-commands",
       "options": {
-        "command": "cdk deploy --require-approval=never "proj-custom-infra-sandbox/*" --express",
+        "command": "cdk deploy --require-approval=never "proj-custom-infra-sandbox/**" --express",
         "cwd": "{projectRoot}",
       },
     },
@@ -832,7 +832,7 @@ exports[`infra generator > should handle custom project names correctly > custom
       ],
       "executor": "nx:run-commands",
       "options": {
-        "command": "cdk destroy "proj-custom-infra-sandbox/*"",
+        "command": "cdk destroy "proj-custom-infra-sandbox/**"",
         "cwd": "{projectRoot}",
       },
     },

--- a/packages/nx-plugin/src/infra/app/generator.spec.ts
+++ b/packages/nx-plugin/src/infra/app/generator.spec.ts
@@ -94,7 +94,7 @@ describe('infra generator', () => {
       options: {
         cwd: '{projectRoot}',
         command:
-          'cdk deploy --require-approval=never "proj-test-sandbox/*" --express',
+          'cdk deploy --require-approval=never "proj-test-sandbox/**" --express',
       },
       dependsOn: ['^assemble', 'compile'],
     });
@@ -119,7 +119,7 @@ describe('infra generator', () => {
       executor: 'nx:run-commands',
       options: {
         cwd: '{projectRoot}',
-        command: 'cdk destroy "proj-test-sandbox/*"',
+        command: 'cdk destroy "proj-test-sandbox/**"',
       },
       dependsOn: ['^assemble', 'compile'],
     });
@@ -399,7 +399,7 @@ describe('infra generator', () => {
 
         expect(mainTs).toContain(`new ApplicationStage(app, '${stage}'`);
         expect(config.targets[target].options.command).toBe(
-          `${cdkCommand} "${stage}/*"${suffix}`,
+          `${cdkCommand} "${stage}/**"${suffix}`,
         );
       },
     );
@@ -408,7 +408,7 @@ describe('infra generator', () => {
       await tsInfraGenerator(tree, options);
       const config = readProjectConfiguration(tree, '@proj/test');
       expect(config.targets[target].options.command).toContain(
-        '"proj-test-sandbox/*"',
+        '"proj-test-sandbox/**"',
       );
     });
 
@@ -458,7 +458,7 @@ describe('infra generator', () => {
         // where the script looks it up in stages.config.ts - so any flags must
         // trail it.
         expect(config.targets[`${action}-sandbox`].options.command).toBe(
-          `tsx packages/common/scripts/src/infra/infra-${action}.ts packages/test "proj-test-sandbox/*"${action === 'deploy' ? ' --express' : ''}`,
+          `tsx packages/common/scripts/src/infra/infra-${action}.ts packages/test "proj-test-sandbox/**"${action === 'deploy' ? ' --express' : ''}`,
         );
         expect(config.targets[`${action}-sandbox`].dependsOn).toEqual([
           '^assemble',

--- a/packages/nx-plugin/src/infra/app/generator.ts
+++ b/packages/nx-plugin/src/infra/app/generator.ts
@@ -140,8 +140,11 @@ export async function tsInfraGenerator(
   const scopeAlias = npmScopePrefix;
   const fullyQualifiedName = `${npmScopePrefix}${schema.name}`;
   const namespace = kebabCase(fullyQualifiedName);
-  // The stage instantiated in main.ts. Quoted so the shell does not glob `*`.
-  const sandboxStagePattern = `"${namespace}-sandbox/*"`;
+  // The stage instantiated in main.ts. `**` so the pattern also selects stacks
+  // nested below the stage's own stacks, such as the `us-east-1` WebACL stack a
+  // website creates - `cdk destroy` only deletes the stacks its pattern selects,
+  // so a single `*` leaves those behind. Quoted so the shell does not glob.
+  const sandboxStagePattern = `"${namespace}-sandbox/**"`;
 
   // `tsProjectGenerator` scaffolds a library `src`, which the CDK app layout
   // replaces. Only on creation — on a re-run this is the user's infrastructure.

--- a/packages/nx-plugin/src/migrations/latest/sandbox-pattern-nested-stacks/metadata.json
+++ b/packages/nx-plugin/src/migrations/latest/sandbox-pattern-nested-stacks/metadata.json
@@ -1,0 +1,3 @@
+{
+  "description": "Update the deploy-sandbox and destroy-sandbox stage patterns to match stacks nested below the stage's stacks, so cdk destroy removes the website WebACL stack"
+}

--- a/packages/nx-plugin/src/migrations/latest/sandbox-pattern-nested-stacks/migration.spec.ts
+++ b/packages/nx-plugin/src/migrations/latest/sandbox-pattern-nested-stacks/migration.spec.ts
@@ -1,0 +1,212 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import {
+  addProjectConfiguration,
+  type ProjectConfiguration,
+  readProjectConfiguration,
+  type Tree,
+  updateProjectConfiguration,
+} from '@nx/devkit';
+import {
+  INFRA_APP_GENERATOR_INFO,
+  tsInfraGenerator,
+} from '../../../infra/app/generator.js';
+import { readProjectConfigurationUnqualified } from '../../../utils/nx.js';
+import { createTreeUsingTsSolutionSetup } from '../../../utils/test.js';
+import migration from './migration.js';
+
+const infraProject = (
+  overrides: Record<string, string> = {},
+): ProjectConfiguration => ({
+  name: 'infra',
+  root: 'packages/infra',
+  metadata: { generator: INFRA_APP_GENERATOR_INFO.id } as any,
+  targets: {
+    'deploy-sandbox': {
+      executor: 'nx:run-commands',
+      options: {
+        cwd: '{projectRoot}',
+        command:
+          overrides['deploy-sandbox'] ??
+          'cdk deploy --require-approval=never "proj-infra-sandbox/*" --express',
+      },
+    },
+    'destroy-sandbox': {
+      executor: 'nx:run-commands',
+      options: {
+        cwd: '{projectRoot}',
+        command:
+          overrides['destroy-sandbox'] ?? 'cdk destroy "proj-infra-sandbox/*"',
+      },
+    },
+    deploy: {
+      executor: 'nx:run-commands',
+      options: {
+        cwd: '{projectRoot}',
+        command: 'cdk deploy --require-approval=never',
+      },
+    },
+    'destroy-ci': {
+      executor: 'nx:run-commands',
+      options: {
+        cwd: '{projectRoot}',
+        command: 'cdk destroy --app ../../dist/{projectRoot}/cdk.out',
+      },
+    },
+  },
+});
+
+describe('sandbox-pattern-nested-stacks migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeUsingTsSolutionSetup();
+  });
+
+  it('should widen the stage pattern of both sandbox targets', async () => {
+    addProjectConfiguration(tree, 'infra', infraProject());
+
+    const { nextSteps } = await migration(tree);
+
+    const { targets } = readProjectConfiguration(tree, 'infra');
+    expect(targets['deploy-sandbox'].options.command).toBe(
+      'cdk deploy --require-approval=never "proj-infra-sandbox/**" --express',
+    );
+    expect(targets['destroy-sandbox'].options.command).toBe(
+      'cdk destroy "proj-infra-sandbox/**"',
+    );
+    expect(nextSteps).toHaveLength(0);
+  });
+
+  it('should widen a renamed sandbox stage', async () => {
+    addProjectConfiguration(
+      tree,
+      'infra',
+      infraProject({ 'destroy-sandbox': 'cdk destroy "my-own-sandbox/*"' }),
+    );
+
+    await migration(tree);
+
+    expect(
+      readProjectConfiguration(tree, 'infra').targets['destroy-sandbox'].options
+        .command,
+    ).toBe('cdk destroy "my-own-sandbox/**"');
+  });
+
+  it('should widen the pattern for stage-config projects', async () => {
+    const script = 'tsx packages/common/scripts/src/infra/infra-destroy.ts';
+    addProjectConfiguration(
+      tree,
+      'infra',
+      infraProject({
+        'destroy-sandbox': `${script} packages/infra "proj-infra-sandbox/*"`,
+      }),
+    );
+
+    const { nextSteps } = await migration(tree);
+
+    // The stage pattern stays the positional argument the script reads it from.
+    expect(
+      readProjectConfiguration(tree, 'infra').targets['destroy-sandbox'].options
+        .command,
+    ).toBe(`${script} packages/infra "proj-infra-sandbox/**"`);
+    expect(nextSteps).toHaveLength(0);
+  });
+
+  it('should leave targets which name no stage alone', async () => {
+    addProjectConfiguration(tree, 'infra', infraProject());
+
+    await migration(tree);
+
+    const { targets } = readProjectConfiguration(tree, 'infra');
+    expect(targets.deploy.options.command).toBe(
+      'cdk deploy --require-approval=never',
+    );
+    expect(targets['destroy-ci'].options.command).toBe(
+      'cdk destroy --app ../../dist/{projectRoot}/cdk.out',
+    );
+  });
+
+  it('should not touch projects from other generators', async () => {
+    addProjectConfiguration(tree, 'infra', {
+      ...infraProject(),
+      metadata: { generator: 'ts#project' } as any,
+    });
+
+    const { nextSteps } = await migration(tree);
+
+    expect(
+      readProjectConfiguration(tree, 'infra').targets['destroy-sandbox'].options
+        .command,
+    ).toBe('cdk destroy "proj-infra-sandbox/*"');
+    expect(nextSteps).toHaveLength(0);
+  });
+
+  it('should report a customised command rather than rewriting it', async () => {
+    addProjectConfiguration(
+      tree,
+      'infra',
+      infraProject({
+        'destroy-sandbox': './scripts/my-teardown.sh "proj-infra-sandbox/*"',
+      }),
+    );
+
+    const { nextSteps } = await migration(tree);
+
+    expect(
+      readProjectConfiguration(tree, 'infra').targets['destroy-sandbox'].options
+        .command,
+    ).toBe('./scripts/my-teardown.sh "proj-infra-sandbox/*"');
+    expect(nextSteps).toHaveLength(1);
+    expect(nextSteps[0]).toContain('destroy-sandbox');
+  });
+
+  it.each([false, true])(
+    'should converge a generated project (stageConfig=%s) which still has the narrow pattern',
+    async (stageConfig) => {
+      await tsInfraGenerator(tree, {
+        name: 'infra',
+        directory: 'packages',
+        stageConfig,
+      } as any);
+
+      const generated = readProjectConfigurationUnqualified(tree, 'infra');
+      const vended = structuredClone(generated.targets);
+      expect(vended['deploy-sandbox'].options.command).toContain('-sandbox/**');
+      expect(vended['destroy-sandbox'].options.command).toContain(
+        '-sandbox/**',
+      );
+
+      // Narrow both patterns, as a workspace generated by an earlier version has.
+      for (const targetName of ['deploy-sandbox', 'destroy-sandbox']) {
+        generated.targets[targetName].options.command = generated.targets[
+          targetName
+        ].options.command.replace('-sandbox/**', '-sandbox/*');
+      }
+      updateProjectConfiguration(tree, generated.name, generated);
+
+      const { nextSteps } = await migration(tree);
+
+      expect(nextSteps).toHaveLength(0);
+      expect(
+        readProjectConfigurationUnqualified(tree, 'infra').targets,
+      ).toEqual(vended);
+    },
+  );
+
+  it('should be idempotent', async () => {
+    addProjectConfiguration(tree, 'infra', infraProject());
+
+    await migration(tree);
+    const afterFirst = tree.read('packages/infra/project.json', 'utf-8');
+
+    const { nextSteps } = await migration(tree);
+
+    expect(nextSteps).toHaveLength(0);
+    expect(tree.read('packages/infra/project.json', 'utf-8')).toEqual(
+      afterFirst,
+    );
+  });
+});

--- a/packages/nx-plugin/src/migrations/latest/sandbox-pattern-nested-stacks/migration.ts
+++ b/packages/nx-plugin/src/migrations/latest/sandbox-pattern-nested-stacks/migration.ts
@@ -1,0 +1,99 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import {
+  getProjects,
+  type MigrationReturnObject,
+  type TargetConfiguration,
+  type Tree,
+  updateProjectConfiguration,
+} from '@nx/devkit';
+import { INFRA_APP_GENERATOR_INFO } from '../../../infra/app/generator.js';
+import { formatFilesInSubtree } from '../../../utils/format.js';
+
+/**
+ * Widen the stage pattern of the sandbox targets of ts#infra projects from
+ * `<stage>/*` to `<stage>/**`.
+ *
+ * A single `*` matches the stage's own stacks but nothing below them, so it
+ * misses stacks a construct creates inside a stack - such as the `us-east-1`
+ * WebACL stack a website creates for its CloudFront distribution.
+ * `cdk destroy` only deletes the stacks its pattern selects, so
+ * `destroy-sandbox` left that stack, and the WebACL it bills for, deployed.
+ */
+
+const SANDBOX_TARGETS = ['deploy-sandbox', 'destroy-sandbox'];
+
+/** A quoted or bare stage pattern ending in a single `*`, ie `"my-sandbox/*"`. */
+const SINGLE_STAR_PATTERN = /^("?)\S+\/\*\1$/;
+
+const widen = (token: string): string => token.replace(/\/\*("?)$/, '/**$1');
+
+/**
+ * Whether the command is one of the deploy/destroy commands this generator
+ * vends - either a direct `cdk deploy`/`cdk destroy`, or the stage-config
+ * script that wraps it. Anything else has been hand-written and is reported
+ * rather than rewritten.
+ */
+const isGeneratedCommand = (command: string): boolean =>
+  /(^|\s)cdk\s+(deploy|destroy)(\s|$)/.test(command) ||
+  command.includes('infra-deploy.ts') ||
+  command.includes('infra-destroy.ts');
+
+export default async function migration(
+  tree: Tree,
+): Promise<MigrationReturnObject> {
+  const nextSteps: string[] = [];
+  let migrated = false;
+
+  for (const [name, project] of getProjects(tree)) {
+    if (
+      (project.metadata as { generator?: string } | undefined)?.generator !==
+      INFRA_APP_GENERATOR_INFO.id
+    ) {
+      continue;
+    }
+
+    let projectChanged = false;
+
+    for (const targetName of SANDBOX_TARGETS) {
+      const target: TargetConfiguration | undefined =
+        project.targets?.[targetName];
+      const command = target?.options?.command;
+      if (!target || typeof command !== 'string') {
+        continue;
+      }
+
+      const args = command.split(/\s+/);
+      // Nothing to widen: already `/**`, or the pattern has been removed. Keeps
+      // re-runs - and a project generated after this change - a no-op.
+      if (!args.some((arg) => SINGLE_STAR_PATTERN.test(arg))) {
+        continue;
+      }
+
+      if (!isGeneratedCommand(command)) {
+        nextSteps.push(
+          `${name}: its ${targetName} target has been customised, so it was left as it is. Widen its stage pattern from "<stage>/*" to "<stage>/**" so it also matches stacks nested below the stage's stacks, such as a website's WebACL stack.`,
+        );
+        continue;
+      }
+
+      target.options.command = args
+        .map((arg) => (SINGLE_STAR_PATTERN.test(arg) ? widen(arg) : arg))
+        .join(' ');
+      projectChanged = true;
+    }
+
+    if (projectChanged) {
+      updateProjectConfiguration(tree, name, project);
+      migrated = true;
+    }
+  }
+
+  if (migrated) {
+    await formatFilesInSubtree(tree);
+  }
+
+  return { nextSteps };
+}


### PR DESCRIPTION
### Reason for this change

Tearing down a sandbox leaves a website's Web ACL stack deployed, and billing.

`destroy-sandbox` runs `cdk destroy "<stage>/*"`. A single `*` matches the stage's own stacks but nothing below them, and a static website creates its CloudFront Web ACL in a separate `us-east-1` stack *inside* the application stack (`<stage>/Application/website/waf`). `cdk destroy` only deletes the stacks its pattern selects — it does not extend the selection to dependencies the way `cdk deploy` does — so the Web ACL stack was silently skipped:

```
> cdk destroy "my-project-infra-sandbox/*"
Are you sure you want to delete: my-project-infra-sandbox/Application (y/n) y
my-project-infra-sandbox/Application: destroying... [1/1]
```

The `waf` stack was still `CREATE_COMPLETE` afterwards, and re-running `destroy-sandbox` never picked it up. The account I validated this in has eight orphaned CloudFront-scope Web ACLs with no associated distributions — one per sandbox torn down this way.

`deploy-sandbox` uses the same pattern but was unaffected, because deploying a stack also deploys the stacks it depends on.

This also makes the [Dungeon Adventure tutorial's teardown step](https://awslabs.github.io/nx-plugin-for-aws/get_started/tutorials/dungeon-game/wrap-up/) correct again — it already tells the reader to expect both the `waf` and `Application` stacks in the confirmation prompt.

### Description of changes

- `ts#infra` now vends `"<stage>/**"` as the sandbox stage pattern for `deploy-sandbox` and `destroy-sandbox` (both share one constant), so the pattern also matches stacks nested below the stage's stacks.
- New deterministic migration `sandbox-pattern-nested-stacks` widens the pattern in the sandbox targets of existing `ts#infra` projects. It covers both the plain `cdk deploy`/`cdk destroy` commands and the `infra-deploy.ts`/`infra-destroy.ts` stage-config scripts (leaving the pattern as the positional argument those scripts read), skips targets whose command has been customised and reports them via `nextSteps`, and is a no-op on a workspace already generated with `/**`.
- The `ts#infra` guide's "Tearing Down a Specific Stage" example now uses `/**`, with a line explaining why a whole stage needs it.

### Description of how you validated changes

- Unit tests: 9 new tests for the migration (both target names, a renamed sandbox stage, stage-config projects, other generators' projects, a customised command reported rather than rewritten, convergence of a project generated by `tsInfraGenerator` with the pattern narrowed back, idempotency), plus updated `ts#infra` generator assertions and snapshots. Full `@aws/nx-plugin` suite passes (4463 tests).
- Reproduced the bug against a real deployment: deployed a quick-start style workspace (tRPC API + React website + Cognito + `ts#infra`) with the published pattern, ran `nx destroy-sandbox infra`, and confirmed `my-project-infra-sandbox-ApplicationwebsitewafD8559179` survived with its Web ACL intact. Confirmed `cdk destroy "<stage>/**"` selects and deletes both stacks.
- Validated the fix end to end on AWS: ran the new migration in that existing workspace with `nx migrate --run-migrations` (it rewrote both sandbox targets), redeployed with `nx deploy-sandbox infra` (both stacks created), then ran `nx destroy-sandbox infra` — the prompt now lists `my-project-infra-sandbox/Application/website/waf, my-project-infra-sandbox/Application` and both are destroyed. Afterwards no `my-project` CloudFormation stacks, buckets, or Web ACLs from the run remained.
- `nx run @aws/nx-plugin:build` (compile, format, lint, test, generate-migrations) passes.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
