### PR TITLE
docs(dungeon-adventure): correct the tutorial against a real end-to-end run

### DIFF
--- a/docs/src/content/docs/en/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/en/get_started/tutorials/dungeon-game/1.mdx
@@ -282,7 +282,10 @@ export class GameApi<
       } as FunctionProps,
       buildDefaultIntegration: (op, props: FunctionProps) => {
         const handler = new Function(scope, `GameApi${op}Handler`, props);
-        handler.addEnvironment('RUNTIME_CONFIG_APP_ID', rc.appConfigApplicationId);
+        handler.addEnvironment(
+          'RUNTIME_CONFIG_APP_ID',
+          rc.appConfigApplicationId,
+        );
         rc.grantReadAppConfig(handler);
         return {
           handler,
@@ -1397,6 +1400,7 @@ The `connection` generator generates/updates these files:
         - copilot/
           - **index.tsx** Shadcn-themed `CopilotChat` / `CopilotSidebar` / `CopilotPopup`
           - ShadcnAssistantMessage.tsx, ShadcnUserMessage.tsx, ShadcnChatInput.tsx, ShadcnCursor.tsx, copilot.css
+        - story-agent-chat.tsx a `CopilotChat` pre-bound to the Story Agent's `agentId`
       - hooks/
         - **useAguiStoryAgent.tsx** Builds an `HttpAgent`, injects the Cognito bearer token, and pads `threadId` to AgentCore's 33-char session id
     - **main.tsx** Wraps `<App />` in `<AguiProvider>`
@@ -1476,6 +1480,8 @@ new ApplicationStage(app, 'dungeon-adventure-infra-sandbox', {
   },
 });
 
+// Define other instances of stages, such as beta and prod, below
+
 app.synth();
 ```
 
@@ -1523,7 +1529,7 @@ The `run-many` command will run a target on multiple listed subprojects (`--all`
 
 You can also trigger a build (or any other task) for a single project target by running the target on the project directly. For example, to build the `@dungeon-adventure/infra` project, run the following command:
 
-<NxCommands commands={['build infra']} />
+<NxCommands commands={['build @dungeon-adventure/infra']} />
 
 You can also omit the scope, and use the Nx shorthand syntax if you prefer:
 
@@ -1562,16 +1568,15 @@ You may be prompted with the following:
 ```bash
  NX   The workspace is out of sync
 
-[@nx/js:typescript-sync]: Some TypeScript configuration files are missing project references to the projects they depend on or contain outdated project references.
-
-This will result in an error in CI.
+[@nx/js:typescript-sync]: Some TypeScript configuration files are missing project references to the projects they depend on, contain stale project references, or have duplicate project references.
+[@aws/nx-plugin:ts#sync]: Some files are out of sync.
 
 ? Would you like to sync the identified changes to get your workspace up to date? …
 Yes, sync the changes and run the tasks
 No, run the tasks without syncing the changes
 ```
 
-This message indicates that NX has detected some files which can be updated automatically for you. In this case, it is referring to the `tsconfig.json` files which do not have Typescript references set up on references projects.
+This message indicates that NX has detected some files which can be updated automatically for you. In this case, it is referring to the `tsconfig.json` files which do not have Typescript references set up on referenced projects, and to the workspace dependencies the `@aws/nx-plugin` sync generator declares for you.
 
 Select the **Yes, sync the changes and run the tasks** option to proceed. You should notice all of you IDE related import errors get automatically resolved as the sync generator will add the missing typescript references automatically!
 

--- a/docs/src/content/docs/en/get_started/tutorials/dungeon-game/2.mdx
+++ b/docs/src/content/docs/en/get_started/tutorials/dungeon-game/2.mdx
@@ -248,6 +248,6 @@ We can try out the MCP server's tools with the [MCP Inspector](https://github.co
 
 <NxCommands commands={["mcp-server-inspect inventory"]} />
 
-This serves the MCP server locally (booting DynamoDB Local too) and launches the MCP Inspector at `http://localhost:6274` pre-configured to connect to it. Click **Connect**, switch to the **Tools** tab, click **List Tools**, and try `add-to-inventory` (e.g. `playerName: Alice`, `itemName: Rusty Sword`, `emoji: ⚔️`) followed by `list-inventory-items` to see it persisted to DynamoDB Local. Stop the server (`Ctrl+C`) when you're done.
+This serves the MCP server locally (booting DynamoDB Local too) and launches the MCP Inspector at `http://localhost:6274` pre-configured to connect to it. Toggle the switch next to the `localhost:8000` server to connect, switch to the **Tools** tab, and try `add-to-inventory` (e.g. `playerName: Alice`, `itemName: Rusty Sword`, `emoji: ⚔️`) followed by `list-inventory-items` to see it persisted to DynamoDB Local. Stop the server (`Ctrl+C`) when you're done.
 
 Congratulations, you have built and tested your first tRPC API and MCP server against a local DynamoDB table!  🎉🎉🎉

--- a/docs/src/content/docs/en/get_started/tutorials/dungeon-game/4.mdx
+++ b/docs/src/content/docs/en/get_started/tutorials/dungeon-game/4.mdx
@@ -48,6 +48,7 @@ When you ran the `connection` generator for `game-ui → story` in <Link path="g
     - copilot/
       - index.tsx Re-exports themed `CopilotChat` / `CopilotSidebar` / `CopilotPopup`.
       - ShadcnAssistantMessage.tsx, ShadcnUserMessage.tsx, ShadcnChatInput.tsx, ShadcnCursor.tsx, copilot.css
+    - story-agent-chat.tsx A `CopilotChat` pre-bound to the Story Agent's `agentId`.
   - hooks/
     - useAguiStoryAgent.tsx Instantiates an `@ag-ui/client` `HttpAgent` pointing at the deployed Story Agent and pads `threadId` to AgentCore's 33-character minimum session id.
   - main.tsx Wraps `<App />` in `<AguiProvider>`
@@ -145,6 +146,10 @@ dungeon-adventure-infra-sandbox-Application.UserIdentityUserIdentityUserPoolIdXX
 ```
 
 Navigate to your CloudFront URL (`GameUIDistributionDomainName` from the CDK outputs), sign up for a new account, and play your game running entirely on AWS!
+
+:::note[Signing up for the first time]
+Cognito emails you a code to confirm your account, then asks you to set up multi-factor authentication (an authenticator app or an SMS code) before your first sign-in — the user pool `ts#website#auth` vends requires MFA. See <Link path="guides/react-website-auth#multi-factor-authentication-mfa">Multi-factor authentication</Link> for how to relax that.
+:::
 
 ## Task 6: Mixing local and deployed components
 

--- a/docs/src/content/docs/en/get_started/tutorials/dungeon-game/wrap-up.mdx
+++ b/docs/src/content/docs/en/get_started/tutorials/dungeon-game/wrap-up.mdx
@@ -38,4 +38,13 @@ We recommend you try your hand at extending the codebase with the following capa
 
     This will prompt you for a list of stacks to delete which should comprise of the `dungeon-adventure-infra-sandbox/Application/GameUI/waf` and `dungeon-adventure-infra-sandbox/Application`.
 
-2. Enter `Y` to continue. CloudFormation will destroy your stacks.
+2. Enter `y` to continue. CloudFormation will destroy your stacks.
+
+:::caution[Two resources are kept on purpose]
+Deleting the stacks leaves two resources behind, so a teardown can't take your users or their stories with it:
+
+- The **Cognito user pool**, which `ts#website#auth` creates with deletion protection enabled.
+- The **Story Agent's session bucket**, which holds the conversation history and defaults to `RemovalPolicy.RETAIN`.
+
+Delete them by hand once you no longer need them — for the user pool, turn deletion protection off first.
+:::

--- a/docs/src/content/docs/es/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/es/get_started/tutorials/dungeon-game/1.mdx
@@ -282,7 +282,10 @@ export class GameApi<
       } as FunctionProps,
       buildDefaultIntegration: (op, props: FunctionProps) => {
         const handler = new Function(scope, `GameApi${op}Handler`, props);
-        handler.addEnvironment('RUNTIME_CONFIG_APP_ID', rc.appConfigApplicationId);
+        handler.addEnvironment(
+          'RUNTIME_CONFIG_APP_ID',
+          rc.appConfigApplicationId,
+        );
         rc.grantReadAppConfig(handler);
         return {
           handler,
@@ -1477,6 +1480,8 @@ new ApplicationStage(app, 'dungeon-adventure-infra-sandbox', {
   },
 });
 
+// Define other instances of stages, such as beta and prod, below
+
 app.synth();
 ```
 
@@ -1563,9 +1568,8 @@ Puede que se te presente lo siguiente:
 ```bash
  NX   The workspace is out of sync
 
-[@nx/js:typescript-sync]: Some TypeScript configuration files are missing project references to the projects they depend on or contain outdated project references.
-
-This will result in an error in CI.
+[@nx/js:typescript-sync]: Some TypeScript configuration files are missing project references to the projects they depend on, contain stale project references, or have duplicate project references.
+[@aws/nx-plugin:ts#sync]: Some files are out of sync.
 
 ? Would you like to sync the identified changes to get your workspace up to date? …
 Yes, sync the changes and run the tasks

--- a/docs/src/content/docs/es/get_started/tutorials/dungeon-game/2.mdx
+++ b/docs/src/content/docs/es/get_started/tutorials/dungeon-game/2.mdx
@@ -248,6 +248,6 @@ Podemos probar las herramientas del servidor MCP con el [MCP Inspector](https://
 
 <NxCommands commands={["mcp-server-inspect inventory"]} />
 
-Esto sirve el servidor MCP localmente (arrancando DynamoDB Local también) y lanza el MCP Inspector en `http://localhost:6274` preconfigurado para conectarse a él. Haz clic en **Connect**, cambia a la pestaña **Tools**, haz clic en **List Tools**, y prueba `add-to-inventory` (por ejemplo, `playerName: Alice`, `itemName: Rusty Sword`, `emoji: ⚔️`) seguido de `list-inventory-items` para verlo persistido en DynamoDB Local. Detén el servidor (`Ctrl+C`) cuando hayas terminado.
+Esto sirve el servidor MCP localmente (arrancando DynamoDB Local también) y lanza el MCP Inspector en `http://localhost:6274` preconfigurado para conectarse a él. Haz clic en el interruptor junto al servidor `localhost:8000` para conectarte, cambia a la pestaña **Tools**, y prueba `add-to-inventory` (por ejemplo, `playerName: Alice`, `itemName: Rusty Sword`, `emoji: ⚔️`) seguido de `list-inventory-items` para verlo persistido en DynamoDB Local. Detén el servidor (`Ctrl+C`) cuando hayas terminado.
 
 ¡Felicitaciones, has construido y probado tu primera API tRPC y servidor MCP contra una tabla DynamoDB local!  🎉🎉🎉

--- a/docs/src/content/docs/es/get_started/tutorials/dungeon-game/4.mdx
+++ b/docs/src/content/docs/es/get_started/tutorials/dungeon-game/4.mdx
@@ -48,6 +48,7 @@ Cuando ejecutaste el generador `connection` para `game-ui → story` en el <Link
     - copilot/
       - index.tsx Re-exports themed `CopilotChat` / `CopilotSidebar` / `CopilotPopup`.
       - ShadcnAssistantMessage.tsx, ShadcnUserMessage.tsx, ShadcnChatInput.tsx, ShadcnCursor.tsx, copilot.css
+    - story-agent-chat.tsx A `CopilotChat` pre-bound to the Story Agent's `agentId`.
   - hooks/
     - useAguiStoryAgent.tsx Instantiates an `@ag-ui/client` `HttpAgent` pointing at the deployed Story Agent and pads `threadId` to AgentCore's 33-character minimum session id.
   - main.tsx Wraps `<App />` in `<AguiProvider>`
@@ -146,6 +147,10 @@ dungeon-adventure-infra-sandbox-Application.UserIdentityUserIdentityUserPoolIdXX
 
 Navega a tu URL de CloudFront (`GameUIDistributionDomainName` de las salidas de CDK), regístrate para una nueva cuenta, ¡y juega tu juego ejecutándose completamente en AWS!
 
+:::note[Registrarse por primera vez]
+Cognito te envía un código por correo electrónico para confirmar tu cuenta, luego te pide que configures la autenticación multifactor (una aplicación de autenticación o un código SMS) antes de tu primer inicio de sesión — el user pool `ts#website#auth` que se proporciona requiere MFA. Consulta <Link path="guides/react-website-auth#multi-factor-authentication-mfa">Autenticación multifactor</Link> para saber cómo relajar eso.
+:::
+
 ## Tarea 6: Mezclar componentes locales y desplegados
 
 Has visto dos extremos del espectro: todo local (`dev`) y todo desplegado. Durante el desarrollo diario, a menudo es útil mezclar los dos — por ejemplo, iterar en el código del sitio web contra la API y el agente *reales* desplegados, o ejecutar la API localmente contra la tabla DynamoDB *real*.
@@ -165,4 +170,5 @@ Cada sitio web tiene un target `load-runtime-config` que descarga el `runtime-co
 
 Esta flexibilidad te permite probar exactamente la porción en la que estás trabajando, contra los componentes — locales o desplegados — que tengan sentido.
 
-¡Felicitaciones! Has construido, probado y desplegado tu Agentic Dungeon Adventure Game!  🎉🎉🎉���
+¡Felicitaciones! Has construido, probado y desplegado tu Agentic Dungeon Adventure Game!  🎉🎉🎉
+���

--- a/docs/src/content/docs/es/get_started/tutorials/dungeon-game/wrap-up.mdx
+++ b/docs/src/content/docs/es/get_started/tutorials/dungeon-game/wrap-up.mdx
@@ -38,4 +38,13 @@ Te recomendamos que intentes extender la base de código con las siguientes capa
 
     Esto te solicitará una lista de pilas para eliminar, que debería comprender `dungeon-adventure-infra-sandbox/Application/GameUI/waf` y `dungeon-adventure-infra-sandbox/Application`.
 
-2. Ingresa `Y` para continuar. CloudFormation destruirá tus pilas.
+2. Ingresa `y` para continuar. CloudFormation destruirá tus pilas.
+
+:::caution[Dos recursos se mantienen intencionalmente]
+Eliminar las pilas deja dos recursos atrás, para que un desmontaje no pueda llevarse a tus usuarios o sus historias:
+
+- El **grupo de usuarios de Cognito**, que `ts#website#auth` crea con protección contra eliminación habilitada.
+- El **bucket de sesión del Story Agent**, que contiene el historial de conversación y tiene por defecto `RemovalPolicy.RETAIN`.
+
+Elimínalos manualmente una vez que ya no los necesites — para el grupo de usuarios, desactiva primero la protección contra eliminación.
+:::

--- a/docs/src/content/docs/fr/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/fr/get_started/tutorials/dungeon-game/1.mdx
@@ -281,7 +281,10 @@ export class GameApi<
       } as FunctionProps,
       buildDefaultIntegration: (op, props: FunctionProps) => {
         const handler = new Function(scope, `GameApi${op}Handler`, props);
-        handler.addEnvironment('RUNTIME_CONFIG_APP_ID', rc.appConfigApplicationId);
+        handler.addEnvironment(
+          'RUNTIME_CONFIG_APP_ID',
+          rc.appConfigApplicationId,
+        );
         rc.grantReadAppConfig(handler);
         return {
           handler,
@@ -1479,6 +1482,8 @@ new ApplicationStage(app, 'dungeon-adventure-infra-sandbox', {
   },
 });
 
+// Define other instances of stages, such as beta and prod, below
+
 app.synth();
 ```
 
@@ -1565,9 +1570,8 @@ Vous serez invité avec ce qui suit :
 ```bash
  NX   The workspace is out of sync
 
-[@nx/js:typescript-sync]: Some TypeScript configuration files are missing project references to the projects they depend on or contain outdated project references.
-
-This will result in an error in CI.
+[@nx/js:typescript-sync]: Some TypeScript configuration files are missing project references to the projects they depend on, contain stale project references, or have duplicate project references.
+[@aws/nx-plugin:ts#sync]: Some files are out of sync.
 
 ? Would you like to sync the identified changes to get your workspace up to date? …
 Yes, sync the changes and run the tasks

--- a/docs/src/content/docs/fr/get_started/tutorials/dungeon-game/2.mdx
+++ b/docs/src/content/docs/fr/get_started/tutorials/dungeon-game/2.mdx
@@ -248,6 +248,6 @@ Nous pouvons essayer les outils du serveur MCP avec le [MCP Inspector](https://g
 
 <NxCommands commands={["mcp-server-inspect inventory"]} />
 
-Cela sert le serveur MCP localement (en démarrant également DynamoDB Local) et lance le MCP Inspector à `http://localhost:6274` préconfiguré pour s'y connecter. Cliquez sur **Connect**, passez à l'onglet **Tools**, cliquez sur **List Tools**, et essayez `add-to-inventory` (par exemple `playerName: Alice`, `itemName: Rusty Sword`, `emoji: ⚔️`) suivi de `list-inventory-items` pour le voir persisté dans DynamoDB Local. Arrêtez le serveur (`Ctrl+C`) lorsque vous avez terminé.
+Cela sert le serveur MCP localement (en démarrant également DynamoDB Local) et lance le MCP Inspector à `http://localhost:6274` préconfiguré pour s'y connecter. Basculez l'interrupteur à côté du serveur `localhost:8000` pour vous connecter, passez à l'onglet **Tools**, et essayez `add-to-inventory` (par exemple `playerName: Alice`, `itemName: Rusty Sword`, `emoji: ⚔️`) suivi de `list-inventory-items` pour le voir persisté dans DynamoDB Local. Arrêtez le serveur (`Ctrl+C`) lorsque vous avez terminé.
 
 Félicitations, vous avez construit et testé votre première API tRPC et serveur MCP contre une table DynamoDB locale ! 🎉🎉🎉

--- a/docs/src/content/docs/fr/get_started/tutorials/dungeon-game/4.mdx
+++ b/docs/src/content/docs/fr/get_started/tutorials/dungeon-game/4.mdx
@@ -48,6 +48,7 @@ Lorsque vous avez exécuté le générateur `connection` pour `game-ui → story
     - copilot/
       - index.tsx Re-exports themed `CopilotChat` / `CopilotSidebar` / `CopilotPopup`.
       - ShadcnAssistantMessage.tsx, ShadcnUserMessage.tsx, ShadcnChatInput.tsx, ShadcnCursor.tsx, copilot.css
+    - story-agent-chat.tsx A `CopilotChat` pre-bound to the Story Agent's `agentId`.
   - hooks/
     - useAguiStoryAgent.tsx Instantiates an `@ag-ui/client` `HttpAgent` pointing at the deployed Story Agent and pads `threadId` to AgentCore's 33-character minimum session id.
   - main.tsx Wraps `<App />` in `<AguiProvider>`
@@ -162,6 +163,10 @@ Chaque site web a une cible `load-runtime-config` qui télécharge le `runtime-c
 - **API locale → table DynamoDB réelle.** Exécutez la cible `serve` simple avec `RUNTIME_CONFIG_APP_ID` défini sur l'identifiant d'application déployé :
 
   <NxCommands env={{RUNTIME_CONFIG_APP_ID:"<RuntimeConfigApplicationId from CDK outputs>"}} commands={["serve game-api"]} />
+
+Cette flexibilité vous permet de tester exactement la partie sur laquelle vous travaillez, contre les composants — locaux ou déployés — qui ont du sens.
+
+Félicitations. Vous avez construit, testé et déployé votre jeu d'aventure de donjon agentique !  🎉🎉🎉ds env={{RUNTIME_CONFIG_APP_ID:"<RuntimeConfigApplicationId from CDK outputs>"}} commands={["serve game-api"]} />
 
 Cette flexibilité vous permet de tester exactement la partie sur laquelle vous travaillez, contre les composants — locaux ou déployés — qui ont du sens.
 

--- a/docs/src/content/docs/fr/get_started/tutorials/dungeon-game/wrap-up.mdx
+++ b/docs/src/content/docs/fr/get_started/tutorials/dungeon-game/wrap-up.mdx
@@ -38,4 +38,13 @@ Nous vous recommandons d'essayer d'étendre la base de code avec les capacités 
 
     Cela vous demandera une liste de piles à supprimer qui devrait comprendre `dungeon-adventure-infra-sandbox/Application/GameUI/waf` et `dungeon-adventure-infra-sandbox/Application`.
 
-2. Entrez `Y` pour continuer. CloudFormation détruira vos piles.
+2. Entrez `y` pour continuer. CloudFormation détruira vos piles.
+
+:::caution[Deux ressources sont conservées intentionnellement]
+La suppression des piles laisse deux ressources derrière elle, de sorte qu'un démontage ne peut pas emporter vos utilisateurs ou leurs histoires avec lui :
+
+- Le **pool d'utilisateurs Cognito**, que `ts#website#auth` crée avec la protection contre la suppression activée.
+- Le **bucket de session du Story Agent**, qui contient l'historique des conversations et utilise par défaut `RemovalPolicy.RETAIN`.
+
+Supprimez-les manuellement une fois que vous n'en avez plus besoin — pour le pool d'utilisateurs, désactivez d'abord la protection contre la suppression.
+:::

--- a/docs/src/content/docs/it/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/it/get_started/tutorials/dungeon-game/1.mdx
@@ -281,7 +281,10 @@ export class GameApi<
       } as FunctionProps,
       buildDefaultIntegration: (op, props: FunctionProps) => {
         const handler = new Function(scope, `GameApi${op}Handler`, props);
-        handler.addEnvironment('RUNTIME_CONFIG_APP_ID', rc.appConfigApplicationId);
+        handler.addEnvironment(
+          'RUNTIME_CONFIG_APP_ID',
+          rc.appConfigApplicationId,
+        );
         rc.grantReadAppConfig(handler);
         return {
           handler,
@@ -1479,6 +1482,8 @@ new ApplicationStage(app, 'dungeon-adventure-infra-sandbox', {
   },
 });
 
+// Define other instances of stages, such as beta and prod, below
+
 app.synth();
 ```
 
@@ -1565,9 +1570,8 @@ Ti verrà richiesto quanto segue:
 ```bash
  NX   The workspace is out of sync
 
-[@nx/js:typescript-sync]: Some TypeScript configuration files are missing project references to the projects they depend on or contain outdated project references.
-
-This will result in an error in CI.
+[@nx/js:typescript-sync]: Some TypeScript configuration files are missing project references to the projects they depend on, contain stale project references, or have duplicate project references.
+[@aws/nx-plugin:ts#sync]: Some files are out of sync.
 
 ? Would you like to sync the identified changes to get your workspace up to date? …
 Yes, sync the changes and run the tasks

--- a/docs/src/content/docs/it/get_started/tutorials/dungeon-game/2.mdx
+++ b/docs/src/content/docs/it/get_started/tutorials/dungeon-game/2.mdx
@@ -248,6 +248,6 @@ Possiamo provare gli strumenti del server MCP con l'[MCP Inspector](https://gith
 
 <NxCommands commands={["mcp-server-inspect inventory"]} />
 
-Questo serve il server MCP localmente (avviando anche DynamoDB Local) e lancia l'MCP Inspector su `http://localhost:6274` preconfigurato per connettersi ad esso. Clicca su **Connect**, passa alla scheda **Tools**, clicca su **List Tools** e prova `add-to-inventory` (ad es. `playerName: Alice`, `itemName: Rusty Sword`, `emoji: ⚔️`) seguito da `list-inventory-items` per vederlo persistito in DynamoDB Local. Ferma il server (`Ctrl+C`) quando hai finito.
+Questo serve il server MCP localmente (avviando anche DynamoDB Local) e lancia l'MCP Inspector su `http://localhost:6274` preconfigurato per connettersi ad esso. Attiva l'interruttore accanto al server `localhost:8000` per connetterti, passa alla scheda **Tools** e prova `add-to-inventory` (ad es. `playerName: Alice`, `itemName: Rusty Sword`, `emoji: ⚔️`) seguito da `list-inventory-items` per vederlo persistito in DynamoDB Local. Ferma il server (`Ctrl+C`) quando hai finito.
 
 Congratulazioni, hai costruito e testato la tua prima API tRPC e il server MCP contro una tabella DynamoDB locale!  🎉🎉🎉

--- a/docs/src/content/docs/it/get_started/tutorials/dungeon-game/4.mdx
+++ b/docs/src/content/docs/it/get_started/tutorials/dungeon-game/4.mdx
@@ -48,6 +48,7 @@ Quando hai eseguito il generatore `connection` per `game-ui → story` nel <Link
     - copilot/
       - index.tsx Ri-esporta `CopilotChat` / `CopilotSidebar` / `CopilotPopup` con tema.
       - ShadcnAssistantMessage.tsx, ShadcnUserMessage.tsx, ShadcnChatInput.tsx, ShadcnCursor.tsx, copilot.css
+    - story-agent-chat.tsx Un `CopilotChat` pre-associato all'`agentId` dello Story Agent.
   - hooks/
     - useAguiStoryAgent.tsx Istanzia un `HttpAgent` `@ag-ui/client` che punta allo Story Agent distribuito e riempie `threadId` al minimo di 33 caratteri per l'id di sessione di AgentCore.
   - main.tsx Avvolge `<App />` in `<AguiProvider>`
@@ -145,6 +146,10 @@ dungeon-adventure-infra-sandbox-Application.UserIdentityUserIdentityUserPoolIdXX
 ```
 
 Naviga al tuo URL CloudFront (`GameUIDistributionDomainName` dagli output CDK), registrati per un nuovo account e gioca al tuo gioco in esecuzione interamente su AWS!
+
+:::note[Registrazione per la prima volta]
+Cognito ti invia via email un codice per confermare il tuo account, quindi ti chiede di configurare l'autenticazione a più fattori (un'app di autenticazione o un codice SMS) prima del tuo primo accesso — il user pool `ts#website#auth` fornito richiede MFA. Consulta <Link path="guides/react-website-auth#multi-factor-authentication-mfa">Autenticazione a più fattori</Link> per come rilassare questo requisito.
+:::
 
 ## Task 6: Mescolare componenti locali e distribuiti
 

--- a/docs/src/content/docs/it/get_started/tutorials/dungeon-game/wrap-up.mdx
+++ b/docs/src/content/docs/it/get_started/tutorials/dungeon-game/wrap-up.mdx
@@ -38,4 +38,13 @@ Ti consigliamo di provare ad estendere il codebase con le seguenti funzionalità
 
     Questo ti chiederà una lista di stack da eliminare che dovrebbe comprendere `dungeon-adventure-infra-sandbox/Application/GameUI/waf` e `dungeon-adventure-infra-sandbox/Application`.
 
-2. Inserisci `Y` per continuare. CloudFormation distruggerà i tuoi stack.
+2. Inserisci `y` per continuare. CloudFormation distruggerà i tuoi stack.
+
+:::caution[Due risorse vengono mantenute intenzionalmente]
+L'eliminazione degli stack lascia due risorse, in modo che una rimozione non possa portare via i tuoi utenti o le loro storie:
+
+- Il **pool di utenti Cognito**, che `ts#website#auth` crea con la protezione dall'eliminazione abilitata.
+- Il **bucket di sessione dello Story Agent**, che contiene la cronologia delle conversazioni e ha come impostazione predefinita `RemovalPolicy.RETAIN`.
+
+Eliminali manualmente una volta che non ne hai più bisogno — per il pool di utenti, disattiva prima la protezione dall'eliminazione.
+:::

--- a/docs/src/content/docs/jp/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/jp/get_started/tutorials/dungeon-game/1.mdx
@@ -282,7 +282,10 @@ export class GameApi<
       } as FunctionProps,
       buildDefaultIntegration: (op, props: FunctionProps) => {
         const handler = new Function(scope, `GameApi${op}Handler`, props);
-        handler.addEnvironment('RUNTIME_CONFIG_APP_ID', rc.appConfigApplicationId);
+        handler.addEnvironment(
+          'RUNTIME_CONFIG_APP_ID',
+          rc.appConfigApplicationId,
+        );
         rc.grantReadAppConfig(handler);
         return {
           handler,
@@ -1476,6 +1479,8 @@ new ApplicationStage(app, 'dungeon-adventure-infra-sandbox', {
   },
 });
 
+// Define other instances of stages, such as beta and prod, below
+
 app.synth();
 ```
 
@@ -1562,9 +1567,8 @@ Nxは[キャッシング](https://nx.dev/concepts/how-caching-works)に依存し
 ```bash
  NX   The workspace is out of sync
 
-[@nx/js:typescript-sync]: Some TypeScript configuration files are missing project references to the projects they depend on or contain outdated project references.
-
-This will result in an error in CI.
+[@nx/js:typescript-sync]: Some TypeScript configuration files are missing project references to the projects they depend on, contain stale project references, or have duplicate project references.
+[@aws/nx-plugin:ts#sync]: Some files are out of sync.
 
 ? Would you like to sync the identified changes to get your workspace up to date? …
 Yes, sync the changes and run the tasks

--- a/docs/src/content/docs/jp/get_started/tutorials/dungeon-game/2.mdx
+++ b/docs/src/content/docs/jp/get_started/tutorials/dungeon-game/2.mdx
@@ -248,7 +248,6 @@ curl -X GET 'http://localhost:2022/games.query?input=%7B%7D'
 
 <NxCommands commands={["mcp-server-inspect inventory"]} />
 
-これにより、MCP サーバーがローカルで提供され（DynamoDB Local も起動されます）、`http://localhost:6274` で MCP Inspector が起動し、それに接続するように事前設定されます。**Connect** をクリックし、**Tools** タブに切り替え、**List Tools** をクリックして、`add-to-inventory`（例：`playerName: Alice`、`itemName: Rusty Sword`、`emoji: ⚔️`）を試し、その後 `list-inventory-items` を実行して DynamoDB Local に永続化されていることを確認します。完了したら、サーバーを停止します（`Ctrl+C`）。
+これにより、MCP サーバーがローカルで提供され（DynamoDB Local も起動されます）、`http://localhost:6274` で MCP Inspector が起動し、それに接続するように事前設定されます。`localhost:8000` サーバーの横にあるスイッチを切り替えて接続し、**Tools** タブに切り替え、`add-to-inventory`（例：`playerName: Alice`、`itemName: Rusty Sword`、`emoji: ⚔️`）を試し、その後 `list-inventory-items` を実行して DynamoDB Local に永続化されていることを確認します。完了したら、サーバーを停止します（`Ctrl+C`）。
 
 おめでとうございます。ローカル DynamoDB テーブルに対して最初の tRPC API と MCP サーバーを構築してテストしました！ 🎉🎉🎉
-

--- a/docs/src/content/docs/jp/get_started/tutorials/dungeon-game/4.mdx
+++ b/docs/src/content/docs/jp/get_started/tutorials/dungeon-game/4.mdx
@@ -48,6 +48,7 @@ import gameConversationPng from '@assets/game-conversation.png'
     - copilot/
       - index.tsx テーマ付きの`CopilotChat` / `CopilotSidebar` / `CopilotPopup`を再エクスポート。
       - ShadcnAssistantMessage.tsx, ShadcnUserMessage.tsx, ShadcnChatInput.tsx, ShadcnCursor.tsx, copilot.css
+    - story-agent-chat.tsx Story Agentの`agentId`に事前バインドされた`CopilotChat`。
   - hooks/
     - useAguiStoryAgent.tsx デプロイされたStory Agentを指す`@ag-ui/client` `HttpAgent`をインスタンス化し、`threadId`をAgentCoreの33文字の最小セッションIDにパディングします。
   - main.tsx `<App />`を`<AguiProvider>`でラップします
@@ -145,6 +146,10 @@ dungeon-adventure-infra-sandbox-Application.UserIdentityUserIdentityUserPoolIdXX
 ```
 
 CloudFront URL（CDK出力の`GameUIDistributionDomainName`）に移動し、新しいアカウントにサインアップして、完全にAWS上で実行されているゲームをプレイしてください！
+
+:::note[初回サインアップ時]
+Cognitoはアカウントを確認するためのコードをメールで送信し、初回サインイン前に多要素認証（認証アプリまたはSMSコード）の設定を求めます。`ts#website#auth`が提供するユーザープールはMFAを必要とします。これを緩和する方法については、<Link path="guides/react-website-auth#multi-factor-authentication-mfa">多要素認証</Link>を参照してください。
+:::
 
 ## タスク6: ローカルとデプロイされたコンポーネントを混在させる
 

--- a/docs/src/content/docs/jp/get_started/tutorials/dungeon-game/wrap-up.mdx
+++ b/docs/src/content/docs/jp/get_started/tutorials/dungeon-game/wrap-up.mdx
@@ -38,4 +38,14 @@ import gameConversationPng from '@assets/game-conversation.png'
 
     これにより、削除するスタックのリストが表示されます。これには `dungeon-adventure-infra-sandbox/Application/GameUI/waf` と `dungeon-adventure-infra-sandbox/Application` が含まれているはずです。
 
-2. `Y` を入力して続行します。CloudFormation がスタックを破棄します。
+2. `y` を入力して続行します。CloudFormation がスタックを破棄します。
+
+:::caution[2つのリソースは意図的に保持されます]
+スタックを削除すると2つのリソースが残るため、ティアダウンによってユーザーやストーリーが失われることはありません：
+
+- **Cognito ユーザープール**：`ts#website#auth` が削除保護を有効にして作成します。
+- **Story Agent のセッションバケット**：会話履歴を保持し、デフォルトで `RemovalPolicy.RETAIN` に設定されています。
+
+これらが不要になったら手動で削除してください。ユーザープールの場合は、まず削除保護をオフにしてください。
+:::
+

--- a/docs/src/content/docs/ko/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/ko/get_started/tutorials/dungeon-game/1.mdx
@@ -281,7 +281,10 @@ export class GameApi<
       } as FunctionProps,
       buildDefaultIntegration: (op, props: FunctionProps) => {
         const handler = new Function(scope, `GameApi${op}Handler`, props);
-        handler.addEnvironment('RUNTIME_CONFIG_APP_ID', rc.appConfigApplicationId);
+        handler.addEnvironment(
+          'RUNTIME_CONFIG_APP_ID',
+          rc.appConfigApplicationId,
+        );
         rc.grantReadAppConfig(handler);
         return {
           handler,
@@ -1479,6 +1482,8 @@ new ApplicationStage(app, 'dungeon-adventure-infra-sandbox', {
   },
 });
 
+// Define other instances of stages, such as beta and prod, below
+
 app.synth();
 ```
 
@@ -1565,9 +1570,8 @@ Nx는 [캐싱](https://nx.dev/concepts/how-caching-works)에 의존하여 이전
 ```bash
  NX   The workspace is out of sync
 
-[@nx/js:typescript-sync]: Some TypeScript configuration files are missing project references to the projects they depend on or contain outdated project references.
-
-This will result in an error in CI.
+[@nx/js:typescript-sync]: Some TypeScript configuration files are missing project references to the projects they depend on, contain stale project references, or have duplicate project references.
+[@aws/nx-plugin:ts#sync]: Some files are out of sync.
 
 ? Would you like to sync the identified changes to get your workspace up to date? …
 Yes, sync the changes and run the tasks

--- a/docs/src/content/docs/ko/get_started/tutorials/dungeon-game/2.mdx
+++ b/docs/src/content/docs/ko/get_started/tutorials/dungeon-game/2.mdx
@@ -248,6 +248,6 @@ curl -X GET 'http://localhost:2022/games.query?input=%7B%7D'
 
 <NxCommands commands={["mcp-server-inspect inventory"]} />
 
-이것은 MCP 서버를 로컬에서 제공하고 (DynamoDB Local도 부팅) `http://localhost:6274`에서 MCP Inspector를 시작하여 미리 구성된 연결을 제공합니다. **Connect**를 클릭하고, **Tools** 탭으로 전환한 다음, **List Tools**를 클릭하고, `add-to-inventory`를 시도해 보세요 (예: `playerName: Alice`, `itemName: Rusty Sword`, `emoji: ⚔️`). 그런 다음 `list-inventory-items`를 사용하여 DynamoDB Local에 지속되었는지 확인합니다. 완료되면 서버를 중지합니다 (`Ctrl+C`).
+이것은 MCP 서버를 로컬에서 제공하고 (DynamoDB Local도 부팅) `http://localhost:6274`에서 MCP Inspector를 시작하여 미리 구성된 연결을 제공합니다. `localhost:8000` 서버 옆의 스위치를 토글하여 연결하고, **Tools** 탭으로 전환한 다음, `add-to-inventory`를 시도해 보세요 (예: `playerName: Alice`, `itemName: Rusty Sword`, `emoji: ⚔️`). 그런 다음 `list-inventory-items`를 사용하여 DynamoDB Local에 지속되었는지 확인합니다. 완료되면 서버를 중지합니다 (`Ctrl+C`).
 
 축하합니다. 로컬 DynamoDB 테이블에 대해 첫 번째 tRPC API와 MCP 서버를 구축하고 테스트했습니다! 🎉🎉🎉

--- a/docs/src/content/docs/ko/get_started/tutorials/dungeon-game/4.mdx
+++ b/docs/src/content/docs/ko/get_started/tutorials/dungeon-game/4.mdx
@@ -48,6 +48,7 @@ import gameConversationPng from '@assets/game-conversation.png'
     - copilot/
       - index.tsx 테마가 적용된 `CopilotChat` / `CopilotSidebar` / `CopilotPopup`을 재내보냅니다.
       - ShadcnAssistantMessage.tsx, ShadcnUserMessage.tsx, ShadcnChatInput.tsx, ShadcnCursor.tsx, copilot.css
+    - story-agent-chat.tsx A `CopilotChat` pre-bound to the Story Agent's `agentId`.
   - hooks/
     - useAguiStoryAgent.tsx 배포된 Story Agent를 가리키는 `@ag-ui/client` `HttpAgent`를 인스턴스화하고 `threadId`를 AgentCore의 33자 최소 세션 ID로 패딩합니다.
   - main.tsx `<App />`을 `<AguiProvider>`로 래핑합니다.
@@ -145,6 +146,10 @@ dungeon-adventure-infra-sandbox-Application.UserIdentityUserIdentityUserPoolIdXX
 ```
 
 CloudFront URL(CDK 출력의 `GameUIDistributionDomainName`)로 이동하여 새 계정에 가입하고 완전히 AWS에서 실행되는 게임을 플레이하세요!
+
+:::note[처음 가입하기]
+Cognito는 계정을 확인하기 위해 코드를 이메일로 보낸 다음, 첫 로그인 전에 다단계 인증(인증 앱 또는 SMS 코드)을 설정하도록 요청합니다 — `ts#website#auth`가 제공하는 사용자 풀은 MFA를 요구합니다. 이를 완화하는 방법은 <Link path="guides/react-website-auth#multi-factor-authentication-mfa">다단계 인증</Link>을 참조하세요.
+:::
 
 ## 작업 6: 로컬 및 배포된 컴포넌트 혼합하기
 

--- a/docs/src/content/docs/ko/get_started/tutorials/dungeon-game/wrap-up.mdx
+++ b/docs/src/content/docs/ko/get_started/tutorials/dungeon-game/wrap-up.mdx
@@ -38,4 +38,13 @@ import gameConversationPng from '@assets/game-conversation.png'
 
     이 명령은 삭제할 스택 목록을 표시하며, `dungeon-adventure-infra-sandbox/Application/GameUI/waf`와 `dungeon-adventure-infra-sandbox/Application`으로 구성되어야 합니다.
 
-2. 계속하려면 `Y`를 입력하세요. CloudFormation이 스택을 삭제합니다.
+2. 계속하려면 `y`를 입력하세요. CloudFormation이 스택을 삭제합니다.
+
+:::caution[두 개의 리소스는 의도적으로 유지됩니다]
+스택을 삭제하면 두 개의 리소스가 남게 되므로, 제거 작업이 사용자나 그들의 스토리를 함께 삭제하지 않습니다:
+
+- **Cognito 사용자 풀**: `ts#website#auth`가 삭제 보호가 활성화된 상태로 생성합니다.
+- **Story Agent의 세션 버킷**: 대화 기록을 보관하며 기본적으로 `RemovalPolicy.RETAIN`으로 설정됩니다.
+
+더 이상 필요하지 않으면 수동으로 삭제하세요. 사용자 풀의 경우 먼저 삭제 보호를 해제해야 합니다.
+:::

--- a/docs/src/content/docs/pt/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/pt/get_started/tutorials/dungeon-game/1.mdx
@@ -281,7 +281,10 @@ export class GameApi<
       } as FunctionProps,
       buildDefaultIntegration: (op, props: FunctionProps) => {
         const handler = new Function(scope, `GameApi${op}Handler`, props);
-        handler.addEnvironment('RUNTIME_CONFIG_APP_ID', rc.appConfigApplicationId);
+        handler.addEnvironment(
+          'RUNTIME_CONFIG_APP_ID',
+          rc.appConfigApplicationId,
+        );
         rc.grantReadAppConfig(handler);
         return {
           handler,
@@ -1479,6 +1482,8 @@ new ApplicationStage(app, 'dungeon-adventure-infra-sandbox', {
   },
 });
 
+// Define other instances of stages, such as beta and prod, below
+
 app.synth();
 ```
 
@@ -1565,9 +1570,8 @@ Você será solicitado com o seguinte:
 ```bash
  NX   The workspace is out of sync
 
-[@nx/js:typescript-sync]: Some TypeScript configuration files are missing project references to the projects they depend on or contain outdated project references.
-
-This will result in an error in CI.
+[@nx/js:typescript-sync]: Some TypeScript configuration files are missing project references to the projects they depend on, contain stale project references, or have duplicate project references.
+[@aws/nx-plugin:ts#sync]: Some files are out of sync.
 
 ? Would you like to sync the identified changes to get your workspace up to date? …
 Yes, sync the changes and run the tasks

--- a/docs/src/content/docs/pt/get_started/tutorials/dungeon-game/2.mdx
+++ b/docs/src/content/docs/pt/get_started/tutorials/dungeon-game/2.mdx
@@ -248,6 +248,6 @@ Podemos experimentar as ferramentas do servidor MCP com o [MCP Inspector](https:
 
 <NxCommands commands={["mcp-server-inspect inventory"]} />
 
-Isso serve o servidor MCP localmente (inicializando o DynamoDB Local também) e lança o MCP Inspector em `http://localhost:6274` pré-configurado para se conectar a ele. Clique em **Connect**, mude para a aba **Tools**, clique em **List Tools**, e experimente `add-to-inventory` (por exemplo, `playerName: Alice`, `itemName: Rusty Sword`, `emoji: ⚔️`) seguido de `list-inventory-items` para vê-lo persistido no DynamoDB Local. Pare o servidor (`Ctrl+C`) quando terminar.
+Isso serve o servidor MCP localmente (inicializando o DynamoDB Local também) e lança o MCP Inspector em `http://localhost:6274` pré-configurado para se conectar a ele. Alterne o interruptor ao lado do servidor `localhost:8000` para conectar, mude para a aba **Tools**, e experimente `add-to-inventory` (por exemplo, `playerName: Alice`, `itemName: Rusty Sword`, `emoji: ⚔️`) seguido de `list-inventory-items` para vê-lo persistido no DynamoDB Local. Pare o servidor (`Ctrl+C`) quando terminar.
 
 Parabéns, você construiu e testou sua primeira API tRPC e servidor MCP contra uma tabela DynamoDB local!  🎉🎉🎉

--- a/docs/src/content/docs/pt/get_started/tutorials/dungeon-game/4.mdx
+++ b/docs/src/content/docs/pt/get_started/tutorials/dungeon-game/4.mdx
@@ -48,6 +48,7 @@ Quando você executou o gerador `connection` para `game-ui → story` no <Link p
     - copilot/
       - index.tsx Re-exporta `CopilotChat` / `CopilotSidebar` / `CopilotPopup` com tema.
       - ShadcnAssistantMessage.tsx, ShadcnUserMessage.tsx, ShadcnChatInput.tsx, ShadcnCursor.tsx, copilot.css
+    - story-agent-chat.tsx Um `CopilotChat` pré-vinculado ao `agentId` do Story Agent.
   - hooks/
     - useAguiStoryAgent.tsx Instancia um `HttpAgent` do `@ag-ui/client` apontando para o Story Agent implantado e preenche `threadId` para o mínimo de 33 caracteres de id de sessão do AgentCore.
   - main.tsx Envolve `<App />` em `<AguiProvider>`
@@ -145,6 +146,10 @@ dungeon-adventure-infra-sandbox-Application.UserIdentityUserIdentityUserPoolIdXX
 ```
 
 Navegue até sua URL do CloudFront (`GameUIDistributionDomainName` das saídas do CDK), cadastre-se para uma nova conta e jogue seu jogo rodando inteiramente na AWS!
+
+:::note[Cadastrando-se pela primeira vez]
+O Cognito envia um código por e-mail para confirmar sua conta e, em seguida, solicita que você configure a autenticação multifator (um aplicativo autenticador ou um código SMS) antes do seu primeiro login — o pool de usuários que `ts#website#auth` fornece requer MFA. Consulte <Link path="guides/react-website-auth#multi-factor-authentication-mfa">Autenticação multifator</Link> para saber como relaxar isso.
+:::
 
 ## Tarefa 6: Misturando componentes locais e implantados
 

--- a/docs/src/content/docs/pt/get_started/tutorials/dungeon-game/wrap-up.mdx
+++ b/docs/src/content/docs/pt/get_started/tutorials/dungeon-game/wrap-up.mdx
@@ -38,4 +38,13 @@ Recomendamos que você tente estender a base de código com as seguintes capacid
 
     Isso solicitará uma lista de stacks para excluir, que deve incluir `dungeon-adventure-infra-sandbox/Application/GameUI/waf` e `dungeon-adventure-infra-sandbox/Application`.
 
-2. Digite `Y` para continuar. O CloudFormation destruirá seus stacks.
+2. Digite `y` para continuar. O CloudFormation destruirá seus stacks.
+
+:::caution[Dois recursos são mantidos propositalmente]
+Excluir os stacks deixa dois recursos para trás, para que uma desmontagem não leve seus usuários ou suas histórias junto:
+
+- O **pool de usuários do Cognito**, que `ts#website#auth` cria com proteção contra exclusão habilitada.
+- O **bucket de sessão do Story Agent**, que armazena o histórico de conversas e tem como padrão `RemovalPolicy.RETAIN`.
+
+Exclua-os manualmente quando não precisar mais deles — para o pool de usuários, desative a proteção contra exclusão primeiro.
+:::

--- a/docs/src/content/docs/vi/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/vi/get_started/tutorials/dungeon-game/1.mdx
@@ -281,7 +281,10 @@ export class GameApi<
       } as FunctionProps,
       buildDefaultIntegration: (op, props: FunctionProps) => {
         const handler = new Function(scope, `GameApi${op}Handler`, props);
-        handler.addEnvironment('RUNTIME_CONFIG_APP_ID', rc.appConfigApplicationId);
+        handler.addEnvironment(
+          'RUNTIME_CONFIG_APP_ID',
+          rc.appConfigApplicationId,
+        );
         rc.grantReadAppConfig(handler);
         return {
           handler,
@@ -1479,6 +1482,8 @@ new ApplicationStage(app, 'dungeon-adventure-infra-sandbox', {
   },
 });
 
+// Define other instances of stages, such as beta and prod, below
+
 app.synth();
 ```
 
@@ -1565,9 +1570,8 @@ Bạn sẽ được nhắc với nội dung sau:
 ```bash
  NX   The workspace is out of sync
 
-[@nx/js:typescript-sync]: Some TypeScript configuration files are missing project references to the projects they depend on or contain outdated project references.
-
-This will result in an error in CI.
+[@nx/js:typescript-sync]: Some TypeScript configuration files are missing project references to the projects they depend on, contain stale project references, or have duplicate project references.
+[@aws/nx-plugin:ts#sync]: Some files are out of sync.
 
 ? Would you like to sync the identified changes to get your workspace up to date? …
 Yes, sync the changes and run the tasks

--- a/docs/src/content/docs/vi/get_started/tutorials/dungeon-game/2.mdx
+++ b/docs/src/content/docs/vi/get_started/tutorials/dungeon-game/2.mdx
@@ -248,6 +248,6 @@ Chúng ta có thể thử nghiệm các công cụ của MCP server với [MCP I
 
 <NxCommands commands={["mcp-server-inspect inventory"]} />
 
-Điều này phục vụ MCP server cục bộ (cũng khởi động DynamoDB Local) và khởi chạy MCP Inspector tại `http://localhost:6274` được cấu hình sẵn để kết nối với nó. Nhấp **Connect**, chuyển sang tab **Tools**, nhấp **List Tools**, và thử `add-to-inventory` (ví dụ: `playerName: Alice`, `itemName: Rusty Sword`, `emoji: ⚔️`) theo sau là `list-inventory-items` để xem nó được lưu vào DynamoDB Local. Dừng server (`Ctrl+C`) khi hoàn tất.
+Điều này phục vụ MCP server cục bộ (cũng khởi động DynamoDB Local) và khởi chạy MCP Inspector tại `http://localhost:6274` được cấu hình sẵn để kết nối với nó. Bật công tắc bên cạnh server `localhost:8000` để kết nối, chuyển sang tab **Tools**, và thử `add-to-inventory` (ví dụ: `playerName: Alice`, `itemName: Rusty Sword`, `emoji: ⚔️`) theo sau là `list-inventory-items` để xem nó được lưu vào DynamoDB Local. Dừng server (`Ctrl+C`) khi hoàn tất.
 
 Chúc mừng, bạn đã xây dựng và kiểm tra tRPC API và MCP server đầu tiên của mình với bảng DynamoDB cục bộ!  🎉🎉🎉

--- a/docs/src/content/docs/vi/get_started/tutorials/dungeon-game/4.mdx
+++ b/docs/src/content/docs/vi/get_started/tutorials/dungeon-game/4.mdx
@@ -48,6 +48,7 @@ Khi bạn chạy generator `connection` cho `game-ui → story` trong <Link path
     - copilot/
       - index.tsx Re-exports themed `CopilotChat` / `CopilotSidebar` / `CopilotPopup`.
       - ShadcnAssistantMessage.tsx, ShadcnUserMessage.tsx, ShadcnChatInput.tsx, ShadcnCursor.tsx, copilot.css
+    - story-agent-chat.tsx A `CopilotChat` pre-bound to the Story Agent's `agentId`.
   - hooks/
     - useAguiStoryAgent.tsx Instantiates an `@ag-ui/client` `HttpAgent` pointing at the deployed Story Agent and pads `threadId` to AgentCore's 33-character minimum session id.
   - main.tsx Wraps `<App />` in `<AguiProvider>`
@@ -145,6 +146,10 @@ dungeon-adventure-infra-sandbox-Application.UserIdentityUserIdentityUserPoolIdXX
 ```
 
 Điều hướng đến CloudFront URL của bạn (`GameUIDistributionDomainName` từ CDK outputs), đăng ký tài khoản mới và chơi trò chơi của bạn chạy hoàn toàn trên AWS!
+
+:::note[Đăng ký lần đầu tiên]
+Cognito sẽ gửi email cho bạn một mã để xác nhận tài khoản, sau đó yêu cầu bạn thiết lập xác thực đa yếu tố (một ứng dụng xác thực hoặc mã SMS) trước khi đăng nhập lần đầu — user pool `ts#website#auth` cung cấp yêu cầu MFA. Xem <Link path="guides/react-website-auth#multi-factor-authentication-mfa">Multi-factor authentication</Link> để biết cách nới lỏng điều đó.
+:::
 
 ## Nhiệm vụ 6: Kết hợp các component local và đã triển khai
 

--- a/docs/src/content/docs/vi/get_started/tutorials/dungeon-game/wrap-up.mdx
+++ b/docs/src/content/docs/vi/get_started/tutorials/dungeon-game/wrap-up.mdx
@@ -38,4 +38,13 @@ Chúng tôi khuyên bạn nên thử mở rộng codebase với các khả năng
 
     Lệnh này sẽ nhắc bạn danh sách các stack cần xóa, bao gồm `dungeon-adventure-infra-sandbox/Application/GameUI/waf` và `dungeon-adventure-infra-sandbox/Application`.
 
-2. Nhập `Y` để tiếp tục. CloudFormation sẽ hủy các stack của bạn.
+2. Nhập `y` để tiếp tục. CloudFormation sẽ hủy các stack của bạn.
+
+:::caution[Hai tài nguyên được giữ lại có chủ đích]
+Việc xóa các stack sẽ để lại hai tài nguyên, do đó quá trình dọn dẹp không thể xóa người dùng hoặc câu chuyện của họ:
+
+- **Cognito user pool**, được tạo bởi `ts#website#auth` với tính năng bảo vệ xóa được bật.
+- **Story Agent's session bucket**, chứa lịch sử hội thoại và mặc định là `RemovalPolicy.RETAIN`.
+
+Xóa chúng bằng tay khi bạn không còn cần chúng nữa — đối với user pool, hãy tắt tính năng bảo vệ xóa trước.
+:::

--- a/docs/src/content/docs/zh/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/zh/get_started/tutorials/dungeon-game/1.mdx
@@ -281,7 +281,10 @@ export class GameApi<
       } as FunctionProps,
       buildDefaultIntegration: (op, props: FunctionProps) => {
         const handler = new Function(scope, `GameApi${op}Handler`, props);
-        handler.addEnvironment('RUNTIME_CONFIG_APP_ID', rc.appConfigApplicationId);
+        handler.addEnvironment(
+          'RUNTIME_CONFIG_APP_ID',
+          rc.appConfigApplicationId,
+        );
         rc.grantReadAppConfig(handler);
         return {
           handler,
@@ -1479,6 +1482,8 @@ new ApplicationStage(app, 'dungeon-adventure-infra-sandbox', {
   },
 });
 
+// Define other instances of stages, such as beta and prod, below
+
 app.synth();
 ```
 
@@ -1565,9 +1570,8 @@ Nx 依赖[缓存](https://nx.dev/concepts/how-caching-works)，以便您可以�
 ```bash
  NX   The workspace is out of sync
 
-[@nx/js:typescript-sync]: Some TypeScript configuration files are missing project references to the projects they depend on or contain outdated project references.
-
-This will result in an error in CI.
+[@nx/js:typescript-sync]: Some TypeScript configuration files are missing project references to the projects they depend on, contain stale project references, or have duplicate project references.
+[@aws/nx-plugin:ts#sync]: Some files are out of sync.
 
 ? Would you like to sync the identified changes to get your workspace up to date? …
 Yes, sync the changes and run the tasks

--- a/docs/src/content/docs/zh/get_started/tutorials/dungeon-game/2.mdx
+++ b/docs/src/content/docs/zh/get_started/tutorials/dungeon-game/2.mdx
@@ -248,6 +248,6 @@ curl -X GET 'http://localhost:2022/games.query?input=%7B%7D'
 
 <NxCommands commands={["mcp-server-inspect inventory"]} />
 
-这会在本地提供 MCP 服务器（也会启动 DynamoDB Local）并在 `http://localhost:6274` 启动 MCP Inspector，预配置为连接到它。点击 **Connect**，切换到 **Tools** 选项卡，点击 **List Tools**，然后尝试 `add-to-inventory`（例如 `playerName: Alice`、`itemName: Rusty Sword`、`emoji: ⚔️`），然后使用 `list-inventory-items` 查看它已持久化到 DynamoDB Local。完成后停止服务器（`Ctrl+C`）。
+这会在本地提供 MCP 服务器（也会启动 DynamoDB Local）并在 `http://localhost:6274` 启动 MCP Inspector，预配置为连接到它。切换 `localhost:8000` 服务器旁边的开关以连接，切换到 **Tools** 选项卡，然后尝试 `add-to-inventory`（例如 `playerName: Alice`、`itemName: Rusty Sword`、`emoji: ⚔️`），然后使用 `list-inventory-items` 查看它已持久化到 DynamoDB Local。完成后停止服务器（`Ctrl+C`）。
 
 恭喜，您已经构建并测试了针对本地 DynamoDB 表的第一个 tRPC API 和 MCP 服务器！🎉🎉🎉

--- a/docs/src/content/docs/zh/get_started/tutorials/dungeon-game/4.mdx
+++ b/docs/src/content/docs/zh/get_started/tutorials/dungeon-game/4.mdx
@@ -48,6 +48,7 @@ import gameConversationPng from '@assets/game-conversation.png'
     - copilot/
       - index.tsx 重新导出主题化的 `CopilotChat` / `CopilotSidebar` / `CopilotPopup`。
       - ShadcnAssistantMessage.tsx, ShadcnUserMessage.tsx, ShadcnChatInput.tsx, ShadcnCursor.tsx, copilot.css
+    - story-agent-chat.tsx A `CopilotChat` pre-bound to the Story Agent's `agentId`.
   - hooks/
     - useAguiStoryAgent.tsx 实例化一个指向已部署 Story Agent 的 `@ag-ui/client` `HttpAgent`，并将 `threadId` 填充到 AgentCore 的 33 字符最小会话 id。
   - main.tsx 将 `<App />` 包装在 `<AguiProvider>` 中
@@ -145,6 +146,10 @@ dungeon-adventure-infra-sandbox-Application.UserIdentityUserIdentityUserPoolIdXX
 ```
 
 导航到您的 CloudFront URL（CDK 输出中的 `GameUIDistributionDomainName`），注册一个新账户，并玩完全在 AWS 上运行的游戏！
+
+:::note[首次注册]
+Cognito 会向您发送一封包含代码的电子邮件以确认您的账户，然后要求您在首次登录之前设置多因素身份验证（身份验证器应用程序或短信代码）——`ts#website#auth` 提供的用户池需要 MFA。有关如何放宽此要求，请参阅<Link path="guides/react-website-auth#multi-factor-authentication-mfa">多因素身份验证</Link>。
+:::
 
 ## 任务 6：混合本地和已部署的组件
 

--- a/docs/src/content/docs/zh/get_started/tutorials/dungeon-game/wrap-up.mdx
+++ b/docs/src/content/docs/zh/get_started/tutorials/dungeon-game/wrap-up.mdx
@@ -38,4 +38,13 @@ import gameConversationPng from '@assets/game-conversation.png'
 
     这将提示您选择要删除的堆栈列表，其中应包括 `dungeon-adventure-infra-sandbox/Application/GameUI/waf` 和 `dungeon-adventure-infra-sandbox/Application`。
 
-2. 输入 `Y` 继续。CloudFormation 将销毁您的堆栈。
+2. 输入 `y` 继续。CloudFormation 将销毁您的堆栈。
+
+:::caution[有两个资源被故意保留]
+删除堆栈会留下两个资源，因此拆除不会带走您的用户或他们的故事：
+
+- **Cognito 用户池**，由 `ts#website#auth` 创建并启用了删除保护。
+- **Story Agent 的会话存储桶**，它保存对话历史记录并默认为 `RemovalPolicy.RETAIN`。
+
+一旦您不再需要它们，请手动删除它们——对于用户池，请先关闭删除保护。
+:::

--- a/e2e/src/files/dungeon-adventure/3/agent.py.template
+++ b/e2e/src/files/dungeon-adventure/3/agent.py.template
@@ -4,7 +4,6 @@ from dungeon_adventure_agent_connection import InventoryMcpServerClientStrands, 
 from strands import Agent
 from strands.hooks import HookCallback, HookProvider
 
-
 AGENT_HOOKS: list[HookProvider | HookCallback] = [log_model_errors, log_tool_errors]
 
 


### PR DESCRIPTION
### Reason for this change

I followed the Dungeon Adventure tutorial end to end against `main` — every generator step by step, the local `dev` stack, a real `deploy-sandbox` to AWS, account sign-up, playing the game in a browser, the mixed local/deployed combinations, then teardown. Six things in the guide didn't match what actually happens:

1. **Module 3's `agent.py` fails the very next step.** The code block has a blank line that ruff's import rule (`I001`) rejects, so the `build` the module tells you to run next fails on `dungeon_adventure.story:lint`. The e2e test never catches it because it runs `lint` (which auto-fixes) before building.

   ```
   help: Organize imports
   Found 1 error.
   [*] 1 fixable with the `--fix` option.
   command failed with exit code  uv run ruff check dungeon_adventure_story tests 1
   ```

2. **Module 2's MCP Inspector steps describe an older Inspector.** In the version `ts#mcp-server` vends (2.4.0) there is no **Connect** button and no **List Tools** button — you connect with the toggle beside the server entry and the tool list is fetched on connect.

3. **Module 4 doesn't mention what the first sign-in involves.** The user pool `ts#website#auth` vends emails a confirmation code and requires MFA enrolment, so "sign up for a new account" is three steps, not one.

4. **The wrap-up implies teardown removes everything.** Deleting the stacks intentionally keeps the Cognito user pool (deletion protection) and the Story Agent's session bucket (`RemovalPolicy.RETAIN`), which readers should know about — the user pool can't even be deleted until protection is turned off.

5. **Module 1 shows the same command twice** for "build a single project" and "omit the scope", and quotes an out-of-sync message Nx no longer prints (it now also lists `@aws/nx-plugin:ts#sync`, and no longer says "This will result in an error in CI").

6. **Two Module 1 samples drifted** from what the generators produce: `main.ts` lost its "Define other instances of stages" comment, and `game-api.ts` shows an unwrapped `addEnvironment` call.

### Description of changes

- `e2e/src/files/dungeon-adventure/3/agent.py.template`: drop the blank line, so the code shown is what you end up with after `lint` (the template now matches the linted file byte for byte).
- `2.mdx`: describe the Inspector's connect toggle and drop the "List Tools" click.
- `4.mdx`: note the confirmation code and MFA enrolment on first sign-in, linking to the auth guide's MFA section; add the generated `story-agent-chat.tsx` to the connection file tree.
- `wrap-up.mdx`: call out the two retained resources and how to remove them; lower-case the `y` cdk actually accepts.
- `1.mdx`: scope the single-project build command, refresh the out-of-sync sample, and re-sync the `main.ts` / `game-api.ts` samples. Also lists `story-agent-chat.tsx`.

Docs only — the one non-`docs/` file is the tutorial's own code fixture.

### Description of how you validated changes

- Followed the whole tutorial on `main` in a fresh `dungeon-adventure` workspace (pnpm, `--iac=cdk`, locally built plugin via Verdaccio), step-by-step route, with the interactive `nx sync` prompt.
- Module 2: `dev game-api` against DynamoDB Local returned exactly the three documented `curl` responses; drove the MCP Inspector in a browser to confirm the corrected steps (connect toggle → **Tools** → `add-to-inventory` → `list-inventory-items` persisted `Rusty Sword ⚔️`).
- Module 3: reproduced the lint failure from the unmodified template, then confirmed the corrected template builds with no lint step in between; chatted with the agent via `agent-dev` + `agent-chat` (Bedrock, MCP inventory tools).
- Module 4: `dev game-ui` brought up all four local servers; played the game in a browser (story streamed, inventory overlay updated from the MCP tool calls, transcript rehydrated on reload).
- Deployed with `deploy-sandbox`, signed up through the hosted UI — hitting the emailed confirmation code and the MFA setup screen this PR documents — and played the deployed game end to end. Verified both Task 6 combinations (`load-runtime-config` + `serve game-ui`, and `serve game-api` with `RUNTIME_CONFIG_APP_ID`).
- Tore down with `destroy-sandbox` and confirmed the retained user pool and session bucket this PR documents were left behind (then removed them by hand).
- `nx build docs` passes (including link validation).

Note: the nested-stack half of the teardown (the `waf` stack the wrap-up already claims is in the prompt) is fixed separately in #1220.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*