### PR TITLE
test(ts#docs): exercise the public generator in the e2e generator matrix

### DIFF
--- a/e2e/src/smoke-tests/generator-matrix.ts
+++ b/e2e/src/smoke-tests/generator-matrix.ts
@@ -45,7 +45,7 @@ export const runGeneratorMatrix = async (
     opts,
   );
   await runCLI(
-    `generate @aws/nx-plugin:ts#astro-docs --name=docs-site --no-interactive${deferFlag}`,
+    `generate @aws/nx-plugin:ts#docs --name=docs-site --no-interactive${deferFlag}`,
     opts,
   );
   await runCLI(

--- a/packages/nx-plugin/src/internal/test-matrix/generator.ts
+++ b/packages/nx-plugin/src/internal/test-matrix/generator.ts
@@ -31,8 +31,8 @@ import {
   type TsRdbGeneratorSchema,
   tsAgentGenerator,
   tsApiGenerator,
-  tsAstroDocsGenerator,
   tsDcrProxyGenerator,
+  tsDocsGenerator,
   tsDynamoDBGenerator,
   tsInfraGenerator,
   tsLambdaFunctionGenerator,
@@ -116,7 +116,7 @@ export const internalTestMatrixGenerator = async (
     iac: 'inherit',
     ...projectDefaults,
   });
-  await tsAstroDocsGenerator(tree, { name: 'docs-site', ...defaults });
+  await tsDocsGenerator(tree, { name: 'docs-site', ...defaults });
   await tsWebsiteAuthGenerator(tree, {
     project: ts('website'),
     cognitoDomain: 'test',


### PR DESCRIPTION
### Reason for this change

Both copies of the generator matrix scaffolded the docs site via `ts#astro-docs`, which is `hidden` in `generators.json`. `ts#docs` is the documented entry point users actually run, and it was the only visible generator with no end-to-end coverage anywhere in the e2e suite — it was exercised by unit tests alone.

### Description of changes

Swapped the docs-site invocation to `ts#docs` in both places that make up the matrix, keeping them in sync:

- `e2e/src/smoke-tests/generator-matrix.ts` — the CLI matrix shared by the CDK and Terraform smoke tests
- `packages/nx-plugin/src/internal/test-matrix/generator.ts` — the in-process copy that ships with the plugin

Options are unchanged, so no behaviour changes and the generated workspace is identical. `ts#docs` is a passthrough: it strips `framework` and delegates to `tsAstroDocsGenerator`.

### Description of how you validated changes

`ts#astro-docs` is now covered indirectly rather than directly, so the equivalence was verified at each layer:

- **CLI option resolution is identical.** Compiled both schemas with ajv (`useDefaults`) against the flags the matrix passes. `ts#docs` resolves to `{name, directory: ".", framework: "astro", noTranslation: false, noBlog: false, preferInstallDependencies}`; `ts#astro-docs` to the same set minus `framework`, which `tsDocsGenerator` destructures away before delegating.
- **Output trees are byte-identical.** Ran both generators on fresh trees and deep-compared every file path and its contents (throwaway spec, not committed).
- **Metric and project metadata unchanged.** `TS_DOCS_GENERATOR_INFO` is declared but never used to record anything — `addGeneratorMetricsIfApplicable` and `metadata.generator` (`ts#astro-docs`) both still come from `TS_ASTRO_DOCS_GENERATOR_INFO`, so `g43` is not newly emitted.
- **Registration resolves** from `dist/` — `ts#docs` is non-hidden and its schema path and factory load, with a function default export.
- Unit suite green (250 files / 4454 tests), plus `lint`/`format`/`compile` on both changed projects.

The full CDK and Terraform generator matrices were run green on this branch point prior to the swap (105 and 103 generator invocations, building 40 and 37 projects respectively, plus the mocked-provider `terraform test` plan). CI re-runs both matrices through the changed line.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*