### PR TITLE
docs: point generator guides at workspace creation as the starting point

### DIFF
--- a/docs/src/components/markdown-content.astro
+++ b/docs/src/components/markdown-content.astro
@@ -15,6 +15,7 @@ import {
 } from '../../../packages/nx-plugin/src/utils/generators';
 import ExperimentalBanner from './experimental-banner.astro';
 import OptionFilterBar from './option-filter-bar.astro';
+import Snippet from './snippet.astro';
 import * as path from 'path';
 import * as fs from 'fs';
 
@@ -114,10 +115,18 @@ if (!isSnippet && starlightRoute?.entry?.id) {
     // If anything fails, we just won't have the copy button
   }
 }
+
+// Generator guides assume a workspace with the plugin installed, so point
+// readers at the starting point if they don't have one yet.
+const showWorkspacePrerequisite =
+  starlightRoute?.id?.includes('/guides/') === true &&
+  (generatorFrontmatter !== undefined ||
+    rawMdxForFilter.includes('<RunGenerator'));
 ---
 
 {resolvedMarkdown && <div data-copy-markdown={resolvedMarkdown} style="display:none" />}
 {generatorFrontmatter && <ExperimentalBanner generatorId={generatorFrontmatter} />}
+{showWorkspacePrerequisite && <Snippet name="workspace-prerequisite" />}
 {generatorFrontmatter && rawMdxForFilter && (
   <OptionFilterBar generatorId={generatorFrontmatter} rawMdx={rawMdxForFilter} />
 )}

--- a/docs/src/content/docs/en/snippets/workspace-prerequisite.mdx
+++ b/docs/src/content/docs/en/snippets/workspace-prerequisite.mdx
@@ -1,0 +1,8 @@
+---
+title: Workspace Prerequisite
+---
+import Link from '@components/link.astro';
+
+:::note[Start here]
+Generators run inside an Nx workspace with `@aws/nx-plugin` installed. If you don't have one yet, start by <Link path="guides/workspace">creating a workspace</Link>, or <Link path="get_started/existing-project">adding the plugin to an existing project</Link>.
+:::

--- a/docs/src/content/docs/es/snippets/workspace-prerequisite.mdx
+++ b/docs/src/content/docs/es/snippets/workspace-prerequisite.mdx
@@ -1,0 +1,8 @@
+---
+title: Requisito previo del espacio de trabajo
+---
+import Link from '@components/link.astro';
+
+:::note[Comienza aquí]
+Los generadores se ejecutan dentro de un espacio de trabajo Nx con `@aws/nx-plugin` instalado. Si aún no tienes uno, comienza por <Link path="guides/workspace">crear un espacio de trabajo</Link>, o <Link path="get_started/existing-project">agregar el plugin a un proyecto existente</Link>.
+:::

--- a/docs/src/content/docs/fr/snippets/workspace-prerequisite.mdx
+++ b/docs/src/content/docs/fr/snippets/workspace-prerequisite.mdx
@@ -1,0 +1,8 @@
+---
+title: Prérequis de l'espace de travail
+---
+import Link from '@components/link.astro';
+
+:::note[Commencez ici]
+Les générateurs s'exécutent à l'intérieur d'un espace de travail Nx avec `@aws/nx-plugin` installé. Si vous n'en avez pas encore, commencez par <Link path="guides/workspace">créer un espace de travail</Link>, ou <Link path="get_started/existing-project">ajouter le plugin à un projet existant</Link>.
+:::

--- a/docs/src/content/docs/it/snippets/workspace-prerequisite.mdx
+++ b/docs/src/content/docs/it/snippets/workspace-prerequisite.mdx
@@ -1,0 +1,8 @@
+---
+title: Prerequisito Workspace
+---
+import Link from '@components/link.astro';
+
+:::note[Inizia da qui]
+I generatori vengono eseguiti all'interno di un workspace Nx con `@aws/nx-plugin` installato. Se non ne hai ancora uno, inizia <Link path="guides/workspace">creando un workspace</Link>, oppure <Link path="get_started/existing-project">aggiungendo il plugin a un progetto esistente</Link>.
+:::

--- a/docs/src/content/docs/jp/snippets/workspace-prerequisite.mdx
+++ b/docs/src/content/docs/jp/snippets/workspace-prerequisite.mdx
@@ -1,0 +1,8 @@
+---
+title: ワークスペースの前提条件
+---
+import Link from '@components/link.astro';
+
+:::note[ここから始める]
+ジェネレーターは `@aws/nx-plugin` がインストールされた Nx ワークスペース内で実行されます。まだワークスペースがない場合は、<Link path="guides/workspace">ワークスペースの作成</Link>から始めるか、<Link path="get_started/existing-project">既存のプロジェクトにプラグインを追加</Link>してください。
+:::

--- a/docs/src/content/docs/ko/snippets/workspace-prerequisite.mdx
+++ b/docs/src/content/docs/ko/snippets/workspace-prerequisite.mdx
@@ -1,0 +1,8 @@
+---
+title: 워크스페이스 전제 조건
+---
+import Link from '@components/link.astro';
+
+:::note[여기서 시작하세요]
+제너레이터는 `@aws/nx-plugin`이 설치된 Nx 워크스페이스 내에서 실행됩니다. 아직 워크스페이스가 없다면 <Link path="guides/workspace">워크스페이스 생성</Link>부터 시작하거나, <Link path="get_started/existing-project">기존 프로젝트에 플러그인 추가</Link>를 진행하세요.
+:::

--- a/docs/src/content/docs/pt/snippets/workspace-prerequisite.mdx
+++ b/docs/src/content/docs/pt/snippets/workspace-prerequisite.mdx
@@ -1,0 +1,8 @@
+---
+title: Pré-requisito de Workspace
+---
+import Link from '@components/link.astro';
+
+:::note[Comece aqui]
+Geradores são executados dentro de um workspace Nx com `@aws/nx-plugin` instalado. Se você ainda não tem um, comece <Link path="guides/workspace">criando um workspace</Link>, ou <Link path="get_started/existing-project">adicionando o plugin a um projeto existente</Link>.
+:::

--- a/docs/src/content/docs/vi/snippets/workspace-prerequisite.mdx
+++ b/docs/src/content/docs/vi/snippets/workspace-prerequisite.mdx
@@ -1,0 +1,8 @@
+---
+title: Điều kiện tiên quyết về Workspace
+---
+import Link from '@components/link.astro';
+
+:::note[Bắt đầu tại đây]
+Các Generator chạy bên trong một Nx workspace đã cài đặt `@aws/nx-plugin`. Nếu bạn chưa có, hãy bắt đầu bằng cách <Link path="guides/workspace">tạo một workspace</Link>, hoặc <Link path="get_started/existing-project">thêm plugin vào một dự án hiện có</Link>.
+:::

--- a/docs/src/content/docs/zh/snippets/workspace-prerequisite.mdx
+++ b/docs/src/content/docs/zh/snippets/workspace-prerequisite.mdx
@@ -1,0 +1,8 @@
+---
+title: 工作区前提条件
+---
+import Link from '@components/link.astro';
+
+:::note[从这里开始]
+生成器在安装了 `@aws/nx-plugin` 的 Nx 工作区内运行。如果您还没有工作区，请先<Link path="guides/workspace">创建一个工作区</Link>，或<Link path="get_started/existing-project">将插件添加到现有项目</Link>。
+:::


### PR DESCRIPTION
### Reason for this change

Generator guides jump straight into running a generator without saying where the workspace comes from. A reader who lands on one from the sidebar (which is how most people navigate the docs) gets no signal that they need to create a workspace, or add `@aws/nx-plugin` to an existing project, before any of the instructions on the page will work.

### Description of changes

Renders a "Start here" note at the top of generator guide pages, linking to the Workspaces guide and the "Add to an existing project" guide.

- New `workspace-prerequisite` snippet holds the wording, so it is picked up by the usual docs translation workflow.
- It is rendered from the shared `MarkdownContent` override, alongside the existing experimental banner, so no per-guide edits are needed and new guides get it automatically.
- Shown on any page under `guides/` that either has `generator:` frontmatter or uses `<RunGenerator>`. That covers all 33 generator guides, including the framework-chooser hubs the sidebar links directly (`ts#api`, `py#api`, `ts#website`, `ts#docs`).
- Deliberately not shown on the Workspaces guide itself, on the conceptual guides (security, runtime config, local development, docker bundling), or on the quick start and tutorials, where creating a workspace is already step 1.

### Description of how you validated changes

- Ran the docs site locally and confirmed the note renders on all 29 guides using `<RunGenerator>` plus the 4 framework-chooser hub pages, and is absent from the 5 pages listed above and from the quick start.
- Confirmed both links resolve to the right locale-relative URLs.
- `pnpm nx run docs:build` passes: 1540 pages built, internal link validation clean.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*