### PR TITLE
docs: remove the AI assistant setup tip from the dungeon game overview

### DIFF
--- a/docs/src/content/docs/en/get_started/tutorials/dungeon-game/overview.mdx
+++ b/docs/src/content/docs/en/get_started/tutorials/dungeon-game/overview.mdx
@@ -10,7 +10,6 @@ import Drawer from '@components/drawer.astro';
 import RunGenerator from '@components/run-generator.astro';
 import NxCommands from '@components/nx-commands.astro';
 import InstallCommand from '@components/install-command.astro';
-import Link from '@components/link.astro';
 
 import baselineWebsitePng from '@assets/baseline-website.png'
 import baselineGamePng from '@assets/baseline-game.png'
@@ -139,7 +138,3 @@ Before you proceed, you will need the following global dependencies:
 <Snippet name="required-prerequisites" />
 - [AWS Credentials](https://docs.aws.amazon.com/sdkref/latest/guide/access.html) configured to your target AWS account, since this tutorial deploys the application and invokes Amazon Bedrock
 - [Docker](https://www.docker.com/) (or [Finch](https://github.com/runfinch/finch)) is required for local DynamoDB development
-
-:::tip[AI Assistant Setup]
-If you use an AI Assistant such as Kiro, Kiro CLI, Cursor, Claude Code or Cline, refer to the <Link path="/get_started/building-with-ai">install the Nx Plugin for AWS MCP server</Link> page.
-:::

--- a/docs/src/content/docs/es/get_started/tutorials/dungeon-game/overview.mdx
+++ b/docs/src/content/docs/es/get_started/tutorials/dungeon-game/overview.mdx
@@ -10,7 +10,6 @@ import Drawer from '@components/drawer.astro';
 import RunGenerator from '@components/run-generator.astro';
 import NxCommands from '@components/nx-commands.astro';
 import InstallCommand from '@components/install-command.astro';
-import Link from '@components/link.astro';
 
 import baselineWebsitePng from '@assets/baseline-website.png'
 import baselineGamePng from '@assets/baseline-game.png'
@@ -139,7 +138,3 @@ Antes de continuar, necesitarás las siguientes dependencias globales:
 <Snippet name="required-prerequisites" />
 - [AWS Credentials](https://docs.aws.amazon.com/sdkref/latest/guide/access.html) configuradas para tu cuenta AWS de destino, ya que este tutorial despliega la aplicación e invoca Amazon Bedrock
 - [Docker](https://www.docker.com/) (o [Finch](https://github.com/runfinch/finch)) es requerido para el desarrollo local de DynamoDB
-
-:::tip[Configuración de Asistente de IA]
-Si usas un Asistente de IA como Kiro, Kiro CLI, Cursor, Claude Code o Cline, consulta la página <Link path="/get_started/building-with-ai">instalar el servidor MCP de Nx Plugin for AWS</Link>.
-:::

--- a/docs/src/content/docs/fr/get_started/tutorials/dungeon-game/overview.mdx
+++ b/docs/src/content/docs/fr/get_started/tutorials/dungeon-game/overview.mdx
@@ -10,7 +10,6 @@ import Drawer from '@components/drawer.astro';
 import RunGenerator from '@components/run-generator.astro';
 import NxCommands from '@components/nx-commands.astro';
 import InstallCommand from '@components/install-command.astro';
-import Link from '@components/link.astro';
 
 import baselineWebsitePng from '@assets/baseline-website.png'
 import baselineGamePng from '@assets/baseline-game.png'
@@ -139,7 +138,3 @@ Avant de continuer, vous aurez besoin des dépendances globales suivantes :
 <Snippet name="required-prerequisites" />
 - [AWS Credentials](https://docs.aws.amazon.com/sdkref/latest/guide/access.html) configurées pour votre compte AWS cible, car ce tutoriel déploie l'application et invoque Amazon Bedrock
 - [Docker](https://www.docker.com/) (ou [Finch](https://github.com/runfinch/finch)) est requis pour le développement local de DynamoDB
-
-:::tip[Configuration de l'Assistant IA]
-Si vous utilisez un Assistant IA tel que Kiro, Kiro CLI, Cursor, Claude Code ou Cline, consultez la page <Link path="/get_started/building-with-ai">installer le serveur MCP Nx Plugin for AWS</Link>.
-:::

--- a/docs/src/content/docs/it/get_started/tutorials/dungeon-game/overview.mdx
+++ b/docs/src/content/docs/it/get_started/tutorials/dungeon-game/overview.mdx
@@ -10,7 +10,6 @@ import Drawer from '@components/drawer.astro';
 import RunGenerator from '@components/run-generator.astro';
 import NxCommands from '@components/nx-commands.astro';
 import InstallCommand from '@components/install-command.astro';
-import Link from '@components/link.astro';
 
 import baselineWebsitePng from '@assets/baseline-website.png'
 import baselineGamePng from '@assets/baseline-game.png'
@@ -139,7 +138,3 @@ Prima di procedere, avrai bisogno delle seguenti dipendenze globali:
 <Snippet name="required-prerequisites" />
 - [AWS Credentials](https://docs.aws.amazon.com/sdkref/latest/guide/access.html) configurate per il tuo account AWS di destinazione, poiché questo tutorial distribuisce l'applicazione e invoca Amazon Bedrock
 - [Docker](https://www.docker.com/) (o [Finch](https://github.com/runfinch/finch)) è richiesto per lo sviluppo locale di DynamoDB
-
-:::tip[Configurazione Assistente AI]
-Se utilizzi un Assistente AI come Kiro, Kiro CLI, Cursor, Claude Code o Cline, fai riferimento alla pagina <Link path="/get_started/building-with-ai">installa il server MCP Nx Plugin for AWS</Link>.
-:::

--- a/docs/src/content/docs/jp/get_started/tutorials/dungeon-game/overview.mdx
+++ b/docs/src/content/docs/jp/get_started/tutorials/dungeon-game/overview.mdx
@@ -10,7 +10,6 @@ import Drawer from '@components/drawer.astro';
 import RunGenerator from '@components/run-generator.astro';
 import NxCommands from '@components/nx-commands.astro';
 import InstallCommand from '@components/install-command.astro';
-import Link from '@components/link.astro';
 
 import baselineWebsitePng from '@assets/baseline-website.png'
 import baselineGamePng from '@assets/baseline-game.png'
@@ -139,7 +138,3 @@ ddb -> sessions: {
 <Snippet name="required-prerequisites" />
 - このチュートリアルではアプリケーションをデプロイし、Amazon Bedrock を呼び出すため、ターゲット AWS アカウントに設定された [AWS 認証情報](https://docs.aws.amazon.com/sdkref/latest/guide/access.html)
 - ローカル DynamoDB 開発に必要な [Docker](https://www.docker.com/)（または [Finch](https://github.com/runfinch/finch)）
-
-:::tip[AI アシスタントのセットアップ]
-Kiro、Kiro CLI、Cursor、Claude Code、Cline などの AI アシスタントを使用する場合は、<Link path="/get_started/building-with-ai">Nx Plugin for AWS MCP サーバーのインストール</Link>ページを参照してください。
-:::

--- a/docs/src/content/docs/ko/get_started/tutorials/dungeon-game/overview.mdx
+++ b/docs/src/content/docs/ko/get_started/tutorials/dungeon-game/overview.mdx
@@ -10,7 +10,6 @@ import Drawer from '@components/drawer.astro';
 import RunGenerator from '@components/run-generator.astro';
 import NxCommands from '@components/nx-commands.astro';
 import InstallCommand from '@components/install-command.astro';
-import Link from '@components/link.astro';
 
 import baselineWebsitePng from '@assets/baseline-website.png'
 import baselineGamePng from '@assets/baseline-game.png'
@@ -139,7 +138,3 @@ ddb -> sessions: {
 <Snippet name="required-prerequisites" />
 - 이 튜토리얼은 애플리케이션을 배포하고 Amazon Bedrock을 호출하므로 대상 AWS 계정에 구성된 [AWS Credentials](https://docs.aws.amazon.com/sdkref/latest/guide/access.html)
 - 로컬 DynamoDB 개발에 필요한 [Docker](https://www.docker.com/) (또는 [Finch](https://github.com/runfinch/finch))
-
-:::tip[AI 어시스턴트 설정]
-Kiro, Kiro CLI, Cursor, Claude Code 또는 Cline과 같은 AI 어시스턴트를 사용하는 경우 <Link path="/get_started/building-with-ai">Nx Plugin for AWS MCP 서버 설치</Link> 페이지를 참조하세요.
-:::

--- a/docs/src/content/docs/pt/get_started/tutorials/dungeon-game/overview.mdx
+++ b/docs/src/content/docs/pt/get_started/tutorials/dungeon-game/overview.mdx
@@ -10,7 +10,6 @@ import Drawer from '@components/drawer.astro';
 import RunGenerator from '@components/run-generator.astro';
 import NxCommands from '@components/nx-commands.astro';
 import InstallCommand from '@components/install-command.astro';
-import Link from '@components/link.astro';
 
 import baselineWebsitePng from '@assets/baseline-website.png'
 import baselineGamePng from '@assets/baseline-game.png'
@@ -139,7 +138,3 @@ Antes de prosseguir, você precisará das seguintes dependências globais:
 <Snippet name="required-prerequisites" />
 - [AWS Credentials](https://docs.aws.amazon.com/sdkref/latest/guide/access.html) configuradas para sua conta AWS de destino, já que este tutorial implanta a aplicação e invoca Amazon Bedrock
 - [Docker](https://www.docker.com/) (ou [Finch](https://github.com/runfinch/finch)) é necessário para desenvolvimento local do DynamoDB
-
-:::tip[Configuração do Assistente de IA]
-Se você usa um Assistente de IA como Kiro, Kiro CLI, Cursor, Claude Code ou Cline, consulte a página <Link path="/get_started/building-with-ai">instalar o servidor MCP do Nx Plugin for AWS</Link>.
-:::

--- a/docs/src/content/docs/vi/get_started/tutorials/dungeon-game/overview.mdx
+++ b/docs/src/content/docs/vi/get_started/tutorials/dungeon-game/overview.mdx
@@ -10,7 +10,6 @@ import Drawer from '@components/drawer.astro';
 import RunGenerator from '@components/run-generator.astro';
 import NxCommands from '@components/nx-commands.astro';
 import InstallCommand from '@components/install-command.astro';
-import Link from '@components/link.astro';
 
 import baselineWebsitePng from '@assets/baseline-website.png'
 import baselineGamePng from '@assets/baseline-game.png'
@@ -139,7 +138,3 @@ Trước khi tiếp tục, bạn sẽ cần các phụ thuộc toàn cục sau:
 <Snippet name="required-prerequisites" />
 - [AWS Credentials](https://docs.aws.amazon.com/sdkref/latest/guide/access.html) được cấu hình cho tài khoản AWS mục tiêu của bạn, vì hướng dẫn này triển khai ứng dụng và gọi Amazon Bedrock
 - [Docker](https://www.docker.com/) (hoặc [Finch](https://github.com/runfinch/finch)) là bắt buộc cho phát triển DynamoDB cục bộ
-
-:::tip[Thiết lập AI Assistant]
-Nếu bạn sử dụng AI Assistant như Kiro, Kiro CLI, Cursor, Claude Code hoặc Cline, hãy tham khảo trang <Link path="/get_started/building-with-ai">cài đặt Nx Plugin for AWS MCP server</Link>.
-:::

--- a/docs/src/content/docs/zh/get_started/tutorials/dungeon-game/overview.mdx
+++ b/docs/src/content/docs/zh/get_started/tutorials/dungeon-game/overview.mdx
@@ -10,7 +10,6 @@ import Drawer from '@components/drawer.astro';
 import RunGenerator from '@components/run-generator.astro';
 import NxCommands from '@components/nx-commands.astro';
 import InstallCommand from '@components/install-command.astro';
-import Link from '@components/link.astro';
 
 import baselineWebsitePng from '@assets/baseline-website.png'
 import baselineGamePng from '@assets/baseline-game.png'
@@ -139,7 +138,3 @@ ddb -> sessions: {
 <Snippet name="required-prerequisites" />
 - [AWS Credentials](https://docs.aws.amazon.com/sdkref/latest/guide/access.html) 配置到您的目标 AWS 账户，因为本教程会部署应用程序并调用 Amazon Bedrock
 - [Docker](https://www.docker.com/)（或 [Finch](https://github.com/runfinch/finch)）是本地 DynamoDB 开发所必需的
-
-:::tip[AI 助手设置]
-如果您使用 AI 助手，例如 Kiro、Kiro CLI、Cursor、Claude Code 或 Cline，请参阅<Link path="/get_started/building-with-ai">安装 Nx Plugin for AWS MCP 服务器</Link>页面。
-:::


### PR DESCRIPTION
### Reason for this change

The "AI Assistant Setup" tip sat at the end of the Prerequisites section of the dungeon game tutorial overview, pointing readers at the MCP server install page. The tutorial does not depend on the MCP server — it walks through running the generators directly — so the tip interrupted the prerequisites list without being actionable for the walkthrough that follows.

### Description of changes

- Removed the `:::tip[AI Assistant Setup]` aside from `get_started/tutorials/dungeon-game/overview.mdx`, so the Prerequisites section now ends on the Docker bullet.
- Dropped the `Link` import, which the tip was the only remaining user of.

### Description of how you validated changes

- Ran the docs site locally and confirmed the overview page renders with no trace of the tip, and that the Prerequisites section reads correctly without it.
- No other page linked to or depended on the removed content.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*