### PR TITLE
docs: restyle the guide option filter and default new visitors to dark

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -102,6 +102,7 @@ export default defineConfig({
         PageSidebar: './src/components/page-sidebar.astro',
         MarkdownContent: './src/components/markdown-content.astro',
         PageTitle: './src/components/page-title.astro',
+        ThemeProvider: './src/components/theme-provider.astro',
       },
       tableOfContents: {
         minHeadingLevel: 2,

--- a/docs/src/components/markdown-content.astro
+++ b/docs/src/components/markdown-content.astro
@@ -126,8 +126,8 @@ const showWorkspacePrerequisite =
 
 {resolvedMarkdown && <div data-copy-markdown={resolvedMarkdown} style="display:none" />}
 {generatorFrontmatter && <ExperimentalBanner generatorId={generatorFrontmatter} />}
-{showWorkspacePrerequisite && <Snippet name="workspace-prerequisite" />}
 {generatorFrontmatter && rawMdxForFilter && (
   <OptionFilterBar generatorId={generatorFrontmatter} rawMdx={rawMdxForFilter} />
 )}
+{showWorkspacePrerequisite && <Snippet name="workspace-prerequisite" />}
 <Default><slot /></Default>

--- a/docs/src/components/option-filter-bar.astro
+++ b/docs/src/components/option-filter-bar.astro
@@ -15,7 +15,7 @@ import {
  * Renders a filter bar above guide pages that use <OptionFilter>.
  *
  *  - Reads the page's `generator:` frontmatter to resolve the schema.
- *  - Shows one dropdown per option key that the page actually references
+ *  - Shows one chip per option key that the page actually references
  *    (not every enum on the schema).
  *  - Persists selections to localStorage keyed by generator id and syncs
  *    to the URL hash so links are shareable.
@@ -51,55 +51,127 @@ try {
 }
 
 const storageKey = `npfa:optfilter:${generatorId}`;
+
+// The label a chip and its first option show when the key is unfiltered.
+const ANY_LABEL = 'Any';
 ---
 
 {
   filterableOptions.length > 0 && (
-    <form
+    <div
       class="option-filter-bar"
       data-option-filter-bar
       data-storage-key={storageKey}
     >
-      <div class="option-filter-bar-intro">
+      <p class="option-filter-bar-intro">
+        <svg
+          class="option-filter-bar-icon"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.6"
+          stroke-linecap="round"
+        >
+          <path d="M4 7h16M4 12h16M4 17h16" />
+          <circle cx="9" cy="7" r="2.1" fill="var(--sl-color-bg)" />
+          <circle cx="15" cy="12" r="2.1" fill="var(--sl-color-bg)" />
+          <circle cx="9" cy="17" r="2.1" fill="var(--sl-color-bg)" />
+        </svg>
         <span class="option-filter-bar-title">Filter this guide</span>
         <span class="option-filter-bar-help">
-          Pick generator option values to hide sections that don't apply.
+          Pick your options to hide the sections that don't apply.
         </span>
-      </div>
+      </p>
       <div class="option-filter-bar-controls">
         {filterableOptions.map((opt) => (
-          <div class="option-filter-bar-field">
-            <label for={`optfilter-${opt.key}`}>{opt.key}</label>
-            <select
+          <div
+            class="option-filter-control"
+            data-option-filter-control
+            data-key={opt.key}
+            data-value=""
+          >
+            <button
+              type="button"
+              class="option-filter-chip"
               id={`optfilter-${opt.key}`}
-              name={opt.key}
-              data-option-filter-select
+              aria-label={`Filter by ${opt.key}`}
+              role="combobox"
+              aria-haspopup="listbox"
+              aria-expanded="false"
             >
-              <option value="">All</option>
-              {opt.enum.map((v) => (
-                <option value={v}>
-                  {v}
-                  {v === opt.default ? ' (default)' : ''}
-                </option>
+              <span class="option-filter-chip-key">{opt.key}</span>
+              <span class="option-filter-chip-value" data-option-filter-value>
+                {ANY_LABEL}
+              </span>
+              <svg
+                class="option-filter-chip-chevron"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <polyline points="6 9 12 15 18 9" />
+              </svg>
+            </button>
+            <div
+              class="option-filter-menu"
+              id={`optfilter-${opt.key}-listbox`}
+              role="listbox"
+              aria-label={opt.key}
+              hidden
+            >
+              {[undefined, ...opt.enum].map((value, index) => (
+                <div
+                  class="option-filter-menu-option"
+                  id={`optfilter-${opt.key}-option-${index}`}
+                  role="option"
+                  aria-selected={value === undefined ? 'true' : 'false'}
+                  tabindex="-1"
+                  data-value={value ?? ''}
+                >
+                  <svg
+                    class="option-filter-menu-check"
+                    viewBox="0 0 24 24"
+                    aria-hidden="true"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2.4"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  >
+                    <polyline points="4 12.5 9.5 18 20 6.5" />
+                  </svg>
+                  <span class="option-filter-menu-label">
+                    {value ?? ANY_LABEL}
+                  </span>
+                  {value !== undefined && value === opt.default && (
+                    <span class="option-filter-menu-default">default</span>
+                  )}
+                </div>
               ))}
-            </select>
+            </div>
           </div>
         ))}
         <button
           type="button"
           class="option-filter-bar-reset"
           data-option-filter-reset
+          hidden
         >
-          Reset
+          Clear
         </button>
       </div>
-    </form>
+    </div>
   )
 }
 
 <script>
   // Progressive enhancement for guide pages that use <OptionFilter>:
-  //   1. Read the user's selection from the filter bar dropdowns (defaulting
+  //   1. Read the user's selection from the filter bar chips (defaulting
   //      to values from `?f=…` in the URL and then from localStorage).
   //   2. For each <OptionFilter> block, evaluate its predicate against the
   //      selection and toggle `hidden` on the block, on the block's [id]
@@ -117,13 +189,13 @@ const storageKey = `npfa:optfilter:${generatorId}`;
 
   // Mirrors evaluatePredicate in packages/nx-plugin/src/mcp-server/option-filter.ts:
   // AND across keys, OR within a key, `not` flips the final match, and a key
-  // the user hasn't picked a value for is treated as "All — show".
+  // the user hasn't picked a value for is treated as "Any — show".
   const evaluate = (filter: Filter, selected: Record<string, string>) => {
     let matched = true;
     let anyKeyTested = false;
     for (const [k, values] of Object.entries(filter.when)) {
       const s = selected[k];
-      if (s === undefined) continue; // "All" for this key — doesn't veto.
+      if (s === undefined) continue; // "Any" for this key — doesn't veto.
       anyKeyTested = true;
       if (!values.includes(s)) {
         matched = false;
@@ -134,15 +206,185 @@ const storageKey = `npfa:optfilter:${generatorId}`;
     return filter.not ? !matched : matched;
   };
 
-  const run = () => {
-    const bar = document.querySelector<HTMLFormElement>(
-      '[data-option-filter-bar]',
+  const ANY_LABEL = 'Any';
+
+  type Control = {
+    key: string;
+    getValue: () => string;
+    setValue: (value: string) => void;
+    hasValue: (value: string) => boolean;
+    close: () => void;
+  };
+
+  /**
+   * Wires one chip up as a listbox, rather than leaving it a `<select>` whose
+   * popup the platform draws in its own colours. Keeps a select's keyboard
+   * behaviour: arrows move, Enter picks, Escape closes, Home/End jump to the
+   * ends. Focus stays on the chip, which owns the keys, so the options are
+   * tracked with aria-activedescendant instead of being tab stops.
+   */
+  const createControl = (
+    root: HTMLElement,
+    onChange: () => void,
+    onOpen: (control: Control) => void,
+  ): Control => {
+    const chip = root.querySelector<HTMLButtonElement>('[role="combobox"]')!;
+    const menu = root.querySelector<HTMLElement>('[role="listbox"]')!;
+    const valueLabel = root.querySelector<HTMLElement>(
+      '[data-option-filter-value]',
+    )!;
+    const options = Array.from(
+      menu.querySelectorAll<HTMLElement>('[role="option"]'),
     );
+
+    let activeIndex = -1;
+
+    const setActive = (index: number) => {
+      activeIndex = index;
+      for (const [i, option] of options.entries()) {
+        option.classList.toggle('is-active', i === index);
+      }
+      const active = options[index];
+      if (active) {
+        chip.setAttribute('aria-activedescendant', active.id);
+        active.scrollIntoView({ block: 'nearest' });
+      } else {
+        chip.removeAttribute('aria-activedescendant');
+      }
+    };
+
+    const isOpen = () => !menu.hidden;
+
+    const open = () => {
+      menu.hidden = false;
+      root.classList.remove('is-flipped');
+      chip.setAttribute('aria-expanded', 'true');
+      chip.setAttribute('aria-controls', menu.id);
+      root.classList.add('is-open');
+      // Opens upwards when the menu would otherwise run off the bottom of the
+      // viewport, provided there is more room above the chip than below it.
+      const menuRect = menu.getBoundingClientRect();
+      if (
+        menuRect.bottom > window.innerHeight &&
+        chip.getBoundingClientRect().top > menuRect.height
+      ) {
+        root.classList.add('is-flipped');
+      }
+      onOpen(control);
+    };
+
+    const close = ({ refocus = false } = {}) => {
+      menu.hidden = true;
+      chip.setAttribute('aria-expanded', 'false');
+      chip.removeAttribute('aria-controls');
+      root.classList.remove('is-open', 'is-flipped');
+      setActive(-1);
+      if (refocus) chip.focus();
+    };
+
+    const getValue = () => root.dataset.value ?? '';
+
+    const setValue = (value: string) => {
+      root.dataset.value = value;
+      root.classList.toggle('is-set', value !== '');
+      valueLabel.textContent = value === '' ? ANY_LABEL : value;
+      for (const option of options) {
+        option.setAttribute(
+          'aria-selected',
+          String((option.dataset.value ?? '') === value),
+        );
+      }
+    };
+
+    const choose = (index: number) => {
+      const option = options[index];
+      if (!option) return;
+      setValue(option.dataset.value ?? '');
+      close({ refocus: true });
+      onChange();
+    };
+
+    const selectedIndex = () =>
+      Math.max(
+        0,
+        options.findIndex((o) => (o.dataset.value ?? '') === getValue()),
+      );
+
+    chip.addEventListener('click', () => {
+      if (isOpen()) {
+        close();
+      } else {
+        open();
+        setActive(selectedIndex());
+      }
+    });
+
+    chip.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape') {
+        if (isOpen()) {
+          event.preventDefault();
+          close({ refocus: true });
+        }
+        return;
+      }
+
+      if (!isOpen()) {
+        if (['ArrowDown', 'ArrowUp', 'Enter', ' '].includes(event.key)) {
+          event.preventDefault();
+          open();
+          setActive(selectedIndex());
+        }
+        return;
+      }
+
+      // Tabbing on takes the menu with it, rather than leaving it open behind
+      // the control it belongs to.
+      if (event.key === 'Tab') {
+        close();
+        return;
+      }
+
+      const moves: Record<string, number> = {
+        ArrowDown: activeIndex + 1,
+        ArrowUp: activeIndex - 1,
+        Home: 0,
+        End: options.length - 1,
+      };
+      if (event.key in moves) {
+        event.preventDefault();
+        // Wraps, so holding an arrow cycles rather than sticking at an end.
+        setActive((moves[event.key] + options.length) % options.length);
+        return;
+      }
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        if (activeIndex >= 0) choose(activeIndex);
+      }
+    });
+
+    for (const [index, option] of options.entries()) {
+      option.addEventListener('pointerenter', () => setActive(index));
+      option.addEventListener('click', () => choose(index));
+    }
+
+    const control: Control = {
+      key: root.dataset.key!,
+      getValue,
+      setValue,
+      hasValue: (value) =>
+        options.some((o) => (o.dataset.value ?? '') === value),
+      close: () => close(),
+    };
+    return control;
+  };
+
+  const run = () => {
+    const bar = document.querySelector<HTMLElement>('[data-option-filter-bar]');
     if (!bar) return;
 
     const storageKey = bar.dataset.storageKey!;
-    const selects = Array.from(
-      bar.querySelectorAll<HTMLSelectElement>('[data-option-filter-select]'),
+    const reset = bar.querySelector<HTMLButtonElement>(
+      '[data-option-filter-reset]',
     );
 
     const readQueryFilters = (): Record<string, string> => {
@@ -170,18 +412,13 @@ const storageKey = `npfa:optfilter:${generatorId}`;
       }
     };
 
-    const initial = { ...readStorageFilters(), ...readQueryFilters() };
-    for (const select of selects) {
-      if (initial[select.name] !== undefined) {
-        select.value = initial[select.name];
-      }
-    }
-
+    const controls: Control[] = [];
 
     const currentFilters = (): Record<string, string> => {
       const out: Record<string, string> = {};
-      for (const select of selects) {
-        if (select.value) out[select.name] = select.value;
+      for (const control of controls) {
+        const value = control.getValue();
+        if (value) out[control.key] = value;
       }
       return out;
     };
@@ -298,6 +535,8 @@ const storageKey = `npfa:optfilter:${generatorId}`;
         if (!li) continue;
         li.hidden = hiddenIds.has(id);
       }
+      // Nothing to clear until something is filtered.
+      if (reset) reset.hidden = Object.keys(selected).length === 0;
       try {
         localStorage.setItem(storageKey, JSON.stringify(selected));
       } catch {}
@@ -320,15 +559,40 @@ const storageKey = `npfa:optfilter:${generatorId}`;
       }
     };
 
-    for (const select of selects) {
-      select.addEventListener('change', apply);
+    // Only one menu open at a time, the way a set of native popups behaves.
+    const closeOthers = (open: Control) => {
+      for (const control of controls) {
+        if (control !== open) control.close();
+      }
+    };
+
+    for (const root of bar.querySelectorAll<HTMLElement>(
+      '[data-option-filter-control]',
+    )) {
+      controls.push(createControl(root, apply, closeOthers));
     }
-    bar
-      .querySelector<HTMLButtonElement>('[data-option-filter-reset]')
-      ?.addEventListener('click', () => {
-        for (const select of selects) select.value = '';
-        apply();
-      });
+
+    // A press outside dismisses whichever menu is open.
+    window.addEventListener('pointerdown', (event) => {
+      if (bar.contains(event.target as Node)) return;
+      for (const control of controls) control.close();
+    });
+
+    // A stale link or stored value may name an option the schema no longer
+    // has, so only restore values the control can actually offer.
+    const initial = { ...readStorageFilters(), ...readQueryFilters() };
+    for (const control of controls) {
+      const value = initial[control.key];
+      if (value !== undefined && control.hasValue(value)) {
+        control.setValue(value);
+      }
+    }
+
+    reset?.addEventListener('click', () => {
+      for (const control of controls) control.setValue('');
+      apply();
+    });
+
     apply();
     // Re-run once Starlight's tab controller has registered, so the
     // `applyTabFilters` step can rely on click handlers being wired up.

--- a/docs/src/components/theme-provider.astro
+++ b/docs/src/components/theme-provider.astro
@@ -1,0 +1,26 @@
+---
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import Default from '@astrojs/starlight/components/ThemeProvider.astro';
+---
+
+{/*
+Dark is the default for a first visit rather than whatever the system prefers.
+Seeding the stored preference (rather than only setting `data-theme`) leaves
+Starlight to resolve the theme and label its picker as it normally would, and
+keeps the choice from being reverted to "Auto" on the next page.
+
+Inlined and emitted ahead of Starlight's provider so the preference is in place
+before the theme is resolved, avoiding a flash of the light theme.
+*/}
+<script is:inline>
+  if (
+    typeof localStorage !== 'undefined' &&
+    localStorage.getItem('starlight-theme') === null
+  ) {
+    localStorage.setItem('starlight-theme', 'dark');
+  }
+</script>
+<Default />

--- a/docs/src/styles/custom.css
+++ b/docs/src/styles/custom.css
@@ -644,9 +644,10 @@ p.badges > a {
 /* ============================================================
  * Option filter — conditional MDX blocks and filter bar
  * ============================================================ */
-/* Purple indent bar marks where the filtered section starts. */
+/* An indent marks how far the filtered section runs, drawn like the blockquotes
+   in the same prose so it reads as an aside rather than a callout. */
 .option-filter {
-  border-left: 3px solid var(--sl-color-accent-high, var(--sl-color-accent));
+  border-inline-start: 1px solid var(--sl-color-gray-5);
   padding: 0.25rem 0 0.25rem 1rem;
   margin: 1rem 0;
 }
@@ -655,7 +656,7 @@ p.badges > a {
   display: none;
 }
 
-/* Compact single-line pill above the block body. */
+/* The condition the block is shown for, tagged like the filter bar's chips. */
 .option-filter-label {
   display: inline-block;
   margin-bottom: 0.5rem;
@@ -663,92 +664,208 @@ p.badges > a {
   font-family: var(--__sl-font-mono), ui-monospace, monospace;
   font-size: 0.72rem;
   font-weight: 500;
-  line-height: 1.4;
-  color: var(--sl-color-text-accent);
-  background: var(--sl-color-accent-low);
-  border: 1px solid var(--sl-color-accent);
-  border-radius: 0.3rem;
+  line-height: 1.5;
+  color: var(--sl-color-gray-2);
+  background: var(--sl-color-gray-6);
+  border: 1px solid var(--sl-color-hairline);
+  border-radius: 9999px;
   white-space: nowrap;
 }
 
+/* The bar reads as page furniture above the guide — a hairline rule under a row
+   of chips — rather than a panel competing with the content below it. */
 .option-filter-bar {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
-  padding: 0.9rem 1rem;
-  margin: 0 0 1.5rem;
-  border: 1px solid var(--sl-color-gray-5);
-  border-radius: 0.5rem;
-  background: var(--sl-color-gray-6);
+  gap: 0.6rem;
+  padding: 0 0 1rem;
+  margin: 0 0 1.75rem;
+  border-bottom: 1px solid var(--sl-color-hairline);
 }
 
 .option-filter-bar-intro {
   display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.25rem 0.5rem;
+  margin: 0;
+  font-size: 0.82rem;
+  line-height: 1.5;
+}
+
+.option-filter-bar-icon {
+  width: 0.95rem;
+  height: 0.95rem;
+  flex: none;
+  color: var(--sl-color-text-accent);
 }
 
 .option-filter-bar-title {
-  font-size: 0.75rem;
   font-weight: 600;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  color: var(--sl-color-gray-2);
+  color: var(--sl-color-white);
 }
 
 .option-filter-bar-help {
-  font-size: 0.82rem;
-  color: var(--sl-color-gray-2);
-  line-height: 1.45;
-}
-
-.option-filter-bar-help em {
-  font-style: normal;
-  font-weight: 600;
-  color: var(--sl-color-text-accent);
+  color: var(--sl-color-gray-3);
 }
 
 .option-filter-bar-controls {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.75rem 1rem;
-  align-items: end;
+  align-items: center;
+  gap: 0.5rem;
 }
 
-.option-filter-bar-field {
+.option-filter-control {
+  position: relative;
   display: inline-flex;
-  flex-direction: column;
-  gap: 0.2rem;
-  font-size: 0.8rem;
 }
 
-.option-filter-bar-field label {
+/* Pill triggers, matching the graph builder's picker so both read as the same
+   control. */
+.option-filter-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.3rem 0.6rem 0.3rem 0.75rem;
+  font-family: var(--__sl-font-mono), ui-monospace, monospace;
+  font-size: 0.76rem;
+  line-height: 1.5;
+  border: 1px solid var(--sl-color-hairline);
+  border-radius: 9999px;
+  background: transparent;
   color: var(--sl-color-gray-2);
-  font-weight: 500;
+  cursor: pointer;
+  transition:
+    color 150ms ease,
+    border-color 150ms ease,
+    background-color 150ms ease;
 }
 
-.option-filter-bar-field select {
-  background: var(--sl-color-bg, var(--sl-color-gray-7));
-  color: var(--sl-color-white, inherit);
-  border: 1px solid var(--sl-color-gray-5);
+.option-filter-chip:hover,
+.option-filter-control.is-open .option-filter-chip {
+  border-color: var(--sl-color-accent);
+  color: var(--sl-color-white);
+}
+
+.option-filter-chip:focus-visible {
+  outline: none;
+  border-color: var(--sl-color-accent);
+  box-shadow: 0 0 0 3px
+    color-mix(in oklab, var(--sl-color-accent) 35%, transparent);
+}
+
+.option-filter-chip-key {
+  color: var(--sl-color-gray-3);
+}
+
+.option-filter-chip-value {
+  font-weight: 600;
+}
+
+/* A set chip carries the accent, so it's clear at a glance which keys are
+   narrowing the page. */
+.option-filter-control.is-set .option-filter-chip {
+  border-color: var(--sl-color-accent);
+  background: var(--sl-color-accent-low);
+}
+
+.option-filter-control.is-set .option-filter-chip-value {
+  color: var(--sl-color-text-accent);
+}
+
+.option-filter-chip-chevron {
+  width: 0.7rem;
+  height: 0.7rem;
+  flex: none;
+  color: var(--sl-color-gray-3);
+  transition: transform 150ms ease;
+}
+
+.option-filter-control.is-open .option-filter-chip-chevron {
+  transform: rotate(180deg);
+}
+
+.option-filter-menu {
+  position: absolute;
+  top: calc(100% + 0.35rem);
+  left: 0;
+  z-index: 10;
+  min-width: 100%;
+  width: max-content;
+  max-width: 18rem;
+  max-height: 16rem;
+  overflow-y: auto;
+  padding: 0.25rem;
+  border: 1px solid var(--sl-color-hairline);
+  border-radius: 0.5rem;
+  background: var(--sl-color-black);
+  box-shadow: 0 12px 28px -12px rgb(0 0 0 / 0.45);
+}
+
+.option-filter-menu[hidden] {
+  display: none;
+}
+
+.option-filter-control.is-flipped .option-filter-menu {
+  top: auto;
+  bottom: calc(100% + 0.35rem);
+}
+
+.option-filter-menu-option {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.3rem 0.5rem;
   border-radius: 0.35rem;
-  padding: 0.3rem 0.55rem;
-  font-size: 0.85rem;
-  min-width: 14ch;
+  font-family: var(--__sl-font-mono), ui-monospace, monospace;
+  font-size: 0.78rem;
+  color: var(--sl-color-gray-2);
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.option-filter-menu-option.is-active {
+  background: var(--sl-color-gray-6);
+  color: var(--sl-color-white);
+}
+
+.option-filter-menu-check {
+  width: 0.7rem;
+  height: 0.7rem;
+  flex: none;
+  color: var(--sl-color-text-accent);
+  opacity: 0;
+}
+
+.option-filter-menu-option[aria-selected='true'] .option-filter-menu-check {
+  opacity: 1;
+}
+
+.option-filter-menu-default {
+  margin-left: auto;
+  padding-left: 0.5rem;
+  font-family: var(--sl-font);
+  font-size: 0.7rem;
+  color: var(--sl-color-gray-3);
 }
 
 .option-filter-bar-reset {
-  margin-left: auto;
-  align-self: end;
+  padding: 0.25rem 0.35rem;
+  border: none;
   background: transparent;
-  color: var(--sl-color-text-accent);
-  border: 1px solid var(--sl-color-accent);
-  border-radius: 0.35rem;
-  padding: 0.3rem 0.7rem;
   font-size: 0.78rem;
+  color: var(--sl-color-text-accent);
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 0.25em;
   cursor: pointer;
 }
 
 .option-filter-bar-reset:hover {
-  background: var(--sl-color-accent-low);
+  text-decoration-thickness: 2px;
+}
+
+.option-filter-bar-reset[hidden] {
+  display: none;
 }

--- a/docs/src/styles/custom.css
+++ b/docs/src/styles/custom.css
@@ -678,7 +678,7 @@ p.badges > a {
   display: flex;
   flex-direction: column;
   gap: 0.6rem;
-  padding: 0 0 1rem;
+  padding: 0.5rem 0 1.1rem;
   margin: 0 0 1.75rem;
   border-bottom: 1px solid var(--sl-color-hairline);
 }


### PR DESCRIPTION
### Reason for this change

The option filter control above generator guides didn't look like the rest of the docs. It rendered as a grey bordered panel with an uppercase heading and two native `<select>`s, sitting below the blue "Start here" note — two stacked boxes before the reader reached any prose. The native dropdowns were the loudest part: their popups are drawn by the platform, white and square-cornered whatever the page's theme, so they read as browser furniture rather than part of the site.

The docs also opened in whatever theme the visitor's system preferred. The site is designed dark first, so that's what a first-time visitor should see.

### Description of changes

**The filter bar** (`docs/src/components/option-filter-bar.astro`, `docs/src/components/markdown-content.astro`, `docs/src/styles/custom.css`)

- Dropped the panel: the bar is now a row of chips under a hairline rule, so it reads as page furniture above the guide rather than a callout competing with the content.
- Moved it above the workspace prerequisite ("Start here") note, directly under the page title, so the guide's controls come before its prose.
- Merged the uppercase title and the help sentence onto one wrapping line, led by an accent sliders glyph.
- Replaced each `<select>` with a listbox built on the same pattern as the graph builder's `PresetPicker`, so the two read as one control: a pill trigger showing `key value` in the mono face, a chevron that flips on open, and a popup panel drawn in the docs' own surface colours with a check on the selected option and a muted `default` badge.
- Kept a select's keyboard behaviour: arrows move (wrapping), Enter/Space picks, Escape closes, Home/End jump to the ends, Tab takes the menu with it. Focus stays on the chip, which owns the keys, and options are tracked with `aria-activedescendant` rather than being tab stops. The menu flips above the chip when there's no room below.
- A chip with a value set carries the accent, so it's readable at a glance which keys are narrowing the page. `Reset` became a quiet `Clear` link that only appears once something is filtered.
- A value from a stale link or `localStorage` that the schema no longer offers is now ignored rather than displayed.

**Each filtered block** (`docs/src/styles/custom.css`)

The 3px purple indent and accent-filled pill are now a `1px var(--sl-color-gray-5)` indent — the same rule Starlight draws blockquotes with — and a neutral hairline pill, so a conditional section reads as an aside rather than a callout.

**Default theme** (`docs/src/components/theme-provider.astro`, `docs/astro.config.mjs`)

A `ThemeProvider` override seeds `starlight-theme` to `dark` when nothing is stored, then renders Starlight's own provider. Seeding the preference rather than only setting `data-theme` leaves Starlight to resolve the theme and label its picker as it normally would, and keeps the choice from reverting to "Auto" on the next page. It's inlined ahead of Starlight's provider so there's no flash of light theme.

### Description of how you validated changes

`nx run docs:build` passes (1540 pages, all internal links valid).

Driven in a browser against the dev server, in light and dark, at 1280px and at 390px wide:

- Opening, selecting, and clearing each chip; the `Clear` link appearing only when something is filtered and hiding itself again after.
- Escape, click-outside, and one-menu-open-at-a-time.
- Keyboard-only selection (arrows + Enter) and the flip-up placement when the bar sits low in the viewport.
- Filtering still hides the right blocks, hides matching TOC anchors, switches filtered tab groups, and round-trips through `?f=…` and `localStorage`.
- Chips wrap onto two rows on mobile with no menu overflow.

For the theme default:

- A visit with empty `localStorage` and `prefers-color-scheme: light` resolves to dark, and the picker reads "Dark".
- Choosing Light persists across reloads.
- Choosing Auto still follows the system (stored as `''`, so the seed doesn't fire) and the picker reads "Auto".

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
