### PR TITLE
feat(connection): add from/to option aliases

### DIFF
--- a/packages/nx-plugin/src/connection/schema.json
+++ b/packages/nx-plugin/src/connection/schema.json
@@ -7,6 +7,7 @@
     "sourceProject": {
       "type": "string",
       "description": "The source project",
+      "alias": "from",
       "$default": {
         "$source": "argv",
         "index": 0
@@ -17,16 +18,19 @@
     "targetProject": {
       "type": "string",
       "description": "The target project to connect to",
+      "alias": "to",
       "x-prompt": "Select the target project to connect to",
       "x-dropdown": "projects"
     },
     "sourceComponent": {
       "type": "string",
-      "description": "The source component to connect from (component name, path relative to source project root, or generator id). Use '.' to explicitly select the project as the source."
+      "description": "The source component to connect from (component name, path relative to source project root, or generator id). Use '.' to explicitly select the project as the source.",
+      "alias": "fromComponent"
     },
     "targetComponent": {
       "type": "string",
-      "description": "The target component to connect to (component name, path relative to target project root, or generator id). Use '.' to explicitly select the project as the target."
+      "description": "The target component to connect to (component name, path relative to target project root, or generator id). Use '.' to explicitly select the project as the target.",
+      "alias": "toComponent"
     },
     "preferInstallDependencies": {
       "type": "boolean",


### PR DESCRIPTION
### Reason for this change

The `connection` generator's `sourceProject`/`targetProject` and `sourceComponent`/`targetComponent` options are verbose to type on the command line.

### Description of changes

Adds Nx option aliases to `packages/nx-plugin/src/connection/schema.json`:

| Option | Alias |
| --- | --- |
| `sourceProject` | `from` |
| `targetProject` | `to` |
| `sourceComponent` | `fromComponent` |
| `targetComponent` | `toComponent` |

Nx resolves aliases to their canonical property names before invoking the generator, so no generator code, schema types, tests or documentation needed to change. The existing option names continue to work.

### Description of how you validated changes

Existing unit tests pass unchanged (`pnpm nx run @aws/nx-plugin:test`), and the full build is green.

Validated end-to-end in a fresh workspace using the locally compiled plugin, with a `ts#project` containing both a `ts#agent` and a `ts#mcp-server` component:

```bash
# aliases
nx g @aws/nx-plugin:connection --from=ts-project --fromComponent=agent \
  --to=ts-project --toComponent=my-mcp-server --no-interactive

# kebab-case aliases, plus the positional source project
nx g @aws/nx-plugin:connection ts-project --from-component=agent \
  --to=ts-project --to-component=my-mcp-server --no-interactive

# canonical names still work
nx g @aws/nx-plugin:connection --sourceProject=ts-project --sourceComponent=agent \
  --targetProject=ts-project --targetComponent=my-mcp-server --no-interactive
```

All three produce identical changes, and `nx run-many --target build --all` passes in the generated workspace.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*