### PR TITLE
docs: correct API generator in shared snippet, pnpm allowBuilds and RuntimeConfig usage

### DIFF
--- a/docs/src/content/docs/en/get_started/existing-project.mdx
+++ b/docs/src/content/docs/en/get_started/existing-project.mdx
@@ -43,7 +43,7 @@ pnpm only runs install scripts for allow-listed packages, and `nx` needs its ins
 
 ```yaml title="pnpm-workspace.yaml"
 allowBuilds:
-  - nx
+  nx: true
 ```
 </Aside>
 

--- a/docs/src/content/docs/en/snippets/api/type-safe-api-integrations.mdx
+++ b/docs/src/content/docs/en/snippets/api/type-safe-api-integrations.mdx
@@ -1,11 +1,10 @@
 ---
 title: Type-Safe API Integrations
 ---
-import { Steps, Tabs, TabItem } from '@astrojs/starlight/components';
+import { Steps } from '@astrojs/starlight/components';
 import Infrastructure from '@components/infrastructure.astro';
 import Drawer from '@components/drawer.astro';
 import OptionFilter from '@components/option-filter.astro';
-import RunGenerator from '@components/run-generator.astro';
 
 The REST/HTTP API CDK constructs are configured to provide a type-safe interface for defining integrations for each of your operations.
 
@@ -424,15 +423,7 @@ Unlike CDK, the integration pattern is baked into the generated module. To chang
 
 <Steps>
   1. Delete the previously generated API module in `packages/common/terraform/src/app/apis`
-  2. Re-run the generator that created your API with the other integration pattern:
-      <Tabs syncKey="apiLanguage">
-        <TabItem label="TypeScript">
-          <RunGenerator generator="ts#api" requiredParameters={{ integrationPattern: 'shared' }} />
-        </TabItem>
-        <TabItem label="Python">
-          <RunGenerator generator="py#api" requiredParameters={{ integrationPattern: 'shared' }} />
-        </TabItem>
-      </Tabs>
+  2. Re-run the generator that created your API with the other integration pattern (eg `--integrationPattern=shared`)
 </Steps>
 
 With the `isolated` pattern, the module reads the operations from a generated file:

--- a/docs/src/content/docs/en/snippets/api/type-safe-api-integrations.mdx
+++ b/docs/src/content/docs/en/snippets/api/type-safe-api-integrations.mdx
@@ -1,7 +1,7 @@
 ---
 title: Type-Safe API Integrations
 ---
-import { Steps } from '@astrojs/starlight/components';
+import { Steps, Tabs, TabItem } from '@astrojs/starlight/components';
 import Infrastructure from '@components/infrastructure.astro';
 import Drawer from '@components/drawer.astro';
 import OptionFilter from '@components/option-filter.astro';
@@ -424,8 +424,15 @@ Unlike CDK, the integration pattern is baked into the generated module. To chang
 
 <Steps>
   1. Delete the previously generated API module in `packages/common/terraform/src/app/apis`
-  2. Re-run the API generator with the other integration pattern:
-      <RunGenerator generator="ts#api" requiredParameters={{ integrationPattern: 'shared' }} />
+  2. Re-run the generator that created your API with the other integration pattern:
+      <Tabs syncKey="apiLanguage">
+        <TabItem label="TypeScript">
+          <RunGenerator generator="ts#api" requiredParameters={{ integrationPattern: 'shared' }} />
+        </TabItem>
+        <TabItem label="Python">
+          <RunGenerator generator="py#api" requiredParameters={{ integrationPattern: 'shared' }} />
+        </TabItem>
+      </Tabs>
 </Steps>
 
 With the `isolated` pattern, the module reads the operations from a generated file:

--- a/docs/src/content/docs/en/snippets/pdk-migration/example/02-migrate-website.mdx
+++ b/docs/src/content/docs/en/snippets/pdk-migration/example/02-migrate-website.mdx
@@ -34,13 +34,12 @@ This adds React components which manage the appropriate redirects to ensure user
 The PDK `CloudscapeReactTsWebsiteProject` relied on `@aws-northstar/ui` to provide Cognito login components in-app. If you would prefer to use this approach instead of moving to the hosted UI, you can replace the generated `packages/common/constructs/src/core/user-identity.ts` with the [implementation from PDK](https://github.com/aws/aws-pdk/blob/mainline/packages/identity/src/user-identity.ts), replacing the constructs from `@aws-cdk/aws-cognito-identitypool-alpha` with those vended by `aws-cdk-lib`, and make sure to set the relevant values in `RuntimeConfig`:
 
 ```ts
-RuntimeConfig.ensure(this).config = {
-  ...RuntimeConfig.ensure(this).config,
+RuntimeConfig.ensure(this).set('connection', 'cognitoProps', {
   region: Stack.of(this).region,
   identityPoolId: this.identityPool.identityPoolId,
   userPoolId: this.userPool.userPoolId,
   userPoolWebClientId: this.userPoolClient.userPoolClientId,
-};
+});
 ```
 
 You can then reuse the `Auth` component from your `CloudscapeReactTsWebsiteProject`.

--- a/docs/src/content/docs/es/get_started/existing-project.mdx
+++ b/docs/src/content/docs/es/get_started/existing-project.mdx
@@ -43,7 +43,7 @@ pnpm solo ejecuta scripts de instalación para paquetes en la lista de permitido
 
 ```yaml title="pnpm-workspace.yaml"
 allowBuilds:
-  - nx
+  nx: true
 ```
 </Aside>
 

--- a/docs/src/content/docs/es/snippets/api/type-safe-api-integrations.mdx
+++ b/docs/src/content/docs/es/snippets/api/type-safe-api-integrations.mdx
@@ -1,7 +1,7 @@
 ---
 title: Integraciones de API con Seguridad de Tipos
 ---
-import { Steps } from '@astrojs/starlight/components';
+import { Steps, Tabs, TabItem } from '@astrojs/starlight/components';
 import Infrastructure from '@components/infrastructure.astro';
 import Drawer from '@components/drawer.astro';
 import OptionFilter from '@components/option-filter.astro';
@@ -424,8 +424,15 @@ A diferencia de CDK, el patrón de integración está integrado en el módulo ge
 
 <Steps>
   1. Elimine el módulo de API generado previamente en `packages/common/terraform/src/app/apis`
-  2. Vuelva a ejecutar el generador de API con el otro patrón de integración:
-      <RunGenerator generator="ts#api" requiredParameters={{ integrationPattern: 'shared' }} />
+  2. Vuelva a ejecutar el generador que creó su API con el otro patrón de integración:
+      <Tabs syncKey="apiLanguage">
+        <TabItem label="TypeScript">
+          <RunGenerator generator="ts#api" requiredParameters={{ integrationPattern: 'shared' }} />
+        </TabItem>
+        <TabItem label="Python">
+          <RunGenerator generator="py#api" requiredParameters={{ integrationPattern: 'shared' }} />
+        </TabItem>
+      </Tabs>
 </Steps>
 
 Con el patrón `isolated`, el módulo lee las operaciones de un archivo generado:

--- a/docs/src/content/docs/es/snippets/api/type-safe-api-integrations.mdx
+++ b/docs/src/content/docs/es/snippets/api/type-safe-api-integrations.mdx
@@ -1,11 +1,10 @@
 ---
 title: Integraciones de API con Seguridad de Tipos
 ---
-import { Steps, Tabs, TabItem } from '@astrojs/starlight/components';
+import { Steps } from '@astrojs/starlight/components';
 import Infrastructure from '@components/infrastructure.astro';
 import Drawer from '@components/drawer.astro';
 import OptionFilter from '@components/option-filter.astro';
-import RunGenerator from '@components/run-generator.astro';
 
 Los constructos CDK de API REST/HTTP están configurados para proporcionar una interfaz con seguridad de tipos para definir integraciones para cada una de sus operaciones.
 
@@ -424,15 +423,7 @@ A diferencia de CDK, el patrón de integración está integrado en el módulo ge
 
 <Steps>
   1. Elimine el módulo de API generado previamente en `packages/common/terraform/src/app/apis`
-  2. Vuelva a ejecutar el generador que creó su API con el otro patrón de integración:
-      <Tabs syncKey="apiLanguage">
-        <TabItem label="TypeScript">
-          <RunGenerator generator="ts#api" requiredParameters={{ integrationPattern: 'shared' }} />
-        </TabItem>
-        <TabItem label="Python">
-          <RunGenerator generator="py#api" requiredParameters={{ integrationPattern: 'shared' }} />
-        </TabItem>
-      </Tabs>
+  2. Vuelva a ejecutar el generador que creó su API con el otro patrón de integración (ej. `--integrationPattern=shared`)
 </Steps>
 
 Con el patrón `isolated`, el módulo lee las operaciones de un archivo generado:

--- a/docs/src/content/docs/es/snippets/pdk-migration/example/02-migrate-website.mdx
+++ b/docs/src/content/docs/es/snippets/pdk-migration/example/02-migrate-website.mdx
@@ -34,13 +34,12 @@ Esto agrega componentes React que gestionan las redirecciones apropiadas para ga
 El `CloudscapeReactTsWebsiteProject` de PDK dependía de `@aws-northstar/ui` para proporcionar componentes de inicio de sesión de Cognito en la aplicación. Si prefieres usar este enfoque en lugar de pasar a la interfaz de usuario alojada, puedes reemplazar el `packages/common/constructs/src/core/user-identity.ts` generado con la [implementación de PDK](https://github.com/aws/aws-pdk/blob/mainline/packages/identity/src/user-identity.ts), reemplazando las construcciones de `@aws-cdk/aws-cognito-identitypool-alpha` con las proporcionadas por `aws-cdk-lib`, y asegúrate de establecer los valores relevantes en `RuntimeConfig`:
 
 ```ts
-RuntimeConfig.ensure(this).config = {
-  ...RuntimeConfig.ensure(this).config,
+RuntimeConfig.ensure(this).set('connection', 'cognitoProps', {
   region: Stack.of(this).region,
   identityPoolId: this.identityPool.identityPoolId,
   userPoolId: this.userPool.userPoolId,
   userPoolWebClientId: this.userPoolClient.userPoolClientId,
-};
+});
 ```
 
 Luego puedes reutilizar el componente `Auth` de tu `CloudscapeReactTsWebsiteProject`.

--- a/docs/src/content/docs/fr/get_started/existing-project.mdx
+++ b/docs/src/content/docs/fr/get_started/existing-project.mdx
@@ -43,7 +43,7 @@ pnpm n'exécute les scripts d'installation que pour les packages autorisés, et 
 
 ```yaml title="pnpm-workspace.yaml"
 allowBuilds:
-  - nx
+  nx: true
 ```
 </Aside>
 

--- a/docs/src/content/docs/fr/snippets/api/type-safe-api-integrations.mdx
+++ b/docs/src/content/docs/fr/snippets/api/type-safe-api-integrations.mdx
@@ -1,7 +1,7 @@
 ---
 title: Intégrations d'API Type-Safe
 ---
-import { Steps } from '@astrojs/starlight/components';
+import { Steps, Tabs, TabItem } from '@astrojs/starlight/components';
 import Infrastructure from '@components/infrastructure.astro';
 import Drawer from '@components/drawer.astro';
 import OptionFilter from '@components/option-filter.astro';
@@ -424,8 +424,15 @@ Contrairement à CDK, le modèle d'intégration est intégré dans le module gé
 
 <Steps>
   1. Supprimez le module API précédemment généré dans `packages/common/terraform/src/app/apis`
-  2. Relancez le générateur d'API avec l'autre modèle d'intégration :
-      <RunGenerator generator="ts#api" requiredParameters={{ integrationPattern: 'shared' }} />
+  2. Relancez le générateur qui a créé votre API avec l'autre modèle d'intégration :
+      <Tabs syncKey="apiLanguage">
+        <TabItem label="TypeScript">
+          <RunGenerator generator="ts#api" requiredParameters={{ integrationPattern: 'shared' }} />
+        </TabItem>
+        <TabItem label="Python">
+          <RunGenerator generator="py#api" requiredParameters={{ integrationPattern: 'shared' }} />
+        </TabItem>
+      </Tabs>
 </Steps>
 
 Avec le modèle `isolated`, le module lit les opérations depuis un fichier généré :

--- a/docs/src/content/docs/fr/snippets/api/type-safe-api-integrations.mdx
+++ b/docs/src/content/docs/fr/snippets/api/type-safe-api-integrations.mdx
@@ -1,11 +1,10 @@
 ---
 title: Intégrations d'API Type-Safe
 ---
-import { Steps, Tabs, TabItem } from '@astrojs/starlight/components';
+import { Steps } from '@astrojs/starlight/components';
 import Infrastructure from '@components/infrastructure.astro';
 import Drawer from '@components/drawer.astro';
 import OptionFilter from '@components/option-filter.astro';
-import RunGenerator from '@components/run-generator.astro';
 
 Les constructs CDK d'API REST/HTTP sont configurés pour fournir une interface type-safe pour définir des intégrations pour chacune de vos opérations.
 
@@ -424,15 +423,7 @@ Contrairement à CDK, le modèle d'intégration est intégré dans le module gé
 
 <Steps>
   1. Supprimez le module API précédemment généré dans `packages/common/terraform/src/app/apis`
-  2. Relancez le générateur qui a créé votre API avec l'autre modèle d'intégration :
-      <Tabs syncKey="apiLanguage">
-        <TabItem label="TypeScript">
-          <RunGenerator generator="ts#api" requiredParameters={{ integrationPattern: 'shared' }} />
-        </TabItem>
-        <TabItem label="Python">
-          <RunGenerator generator="py#api" requiredParameters={{ integrationPattern: 'shared' }} />
-        </TabItem>
-      </Tabs>
+  2. Relancez le générateur qui a créé votre API avec l'autre modèle d'intégration (par exemple `--integrationPattern=shared`)
 </Steps>
 
 Avec le modèle `isolated`, le module lit les opérations depuis un fichier généré :

--- a/docs/src/content/docs/fr/snippets/pdk-migration/example/02-migrate-website.mdx
+++ b/docs/src/content/docs/fr/snippets/pdk-migration/example/02-migrate-website.mdx
@@ -34,13 +34,12 @@ Cela ajoute des composants React qui gèrent les redirections appropriées pour 
 Le `CloudscapeReactTsWebsiteProject` de PDK s'appuyait sur `@aws-northstar/ui` pour fournir des composants de connexion Cognito dans l'application. Si vous préférez utiliser cette approche au lieu de passer à l'interface utilisateur hébergée, vous pouvez remplacer le fichier généré `packages/common/constructs/src/core/user-identity.ts` par l'[implémentation de PDK](https://github.com/aws/aws-pdk/blob/mainline/packages/identity/src/user-identity.ts), en remplaçant les constructions de `@aws-cdk/aws-cognito-identitypool-alpha` par celles fournies par `aws-cdk-lib`, et assurez-vous de définir les valeurs pertinentes dans `RuntimeConfig` :
 
 ```ts
-RuntimeConfig.ensure(this).config = {
-  ...RuntimeConfig.ensure(this).config,
+RuntimeConfig.ensure(this).set('connection', 'cognitoProps', {
   region: Stack.of(this).region,
   identityPoolId: this.identityPool.identityPoolId,
   userPoolId: this.userPool.userPoolId,
   userPoolWebClientId: this.userPoolClient.userPoolClientId,
-};
+});
 ```
 
 Vous pouvez ensuite réutiliser le composant `Auth` de votre `CloudscapeReactTsWebsiteProject`.

--- a/docs/src/content/docs/it/get_started/existing-project.mdx
+++ b/docs/src/content/docs/it/get_started/existing-project.mdx
@@ -43,7 +43,7 @@ pnpm esegue gli script di installazione solo per i pacchetti nella lista consent
 
 ```yaml title="pnpm-workspace.yaml"
 allowBuilds:
-  - nx
+  nx: true
 ```
 </Aside>
 

--- a/docs/src/content/docs/it/snippets/api/type-safe-api-integrations.mdx
+++ b/docs/src/content/docs/it/snippets/api/type-safe-api-integrations.mdx
@@ -1,11 +1,10 @@
 ---
 title: Integrazioni API Type-Safe
 ---
-import { Steps, Tabs, TabItem } from '@astrojs/starlight/components';
+import { Steps } from '@astrojs/starlight/components';
 import Infrastructure from '@components/infrastructure.astro';
 import Drawer from '@components/drawer.astro';
 import OptionFilter from '@components/option-filter.astro';
-import RunGenerator from '@components/run-generator.astro';
 
 I costrutti CDK REST/HTTP API sono configurati per fornire un'interfaccia type-safe per definire integrazioni per ciascuna delle tue operazioni.
 
@@ -424,15 +423,7 @@ A differenza di CDK, il pattern di integrazione è incorporato nel modulo genera
 
 <Steps>
   1. Elimina il modulo API generato precedentemente in `packages/common/terraform/src/app/apis`
-  2. Riesegui il generatore che ha creato la tua API con l'altro pattern di integrazione:
-      <Tabs syncKey="apiLanguage">
-        <TabItem label="TypeScript">
-          <RunGenerator generator="ts#api" requiredParameters={{ integrationPattern: 'shared' }} />
-        </TabItem>
-        <TabItem label="Python">
-          <RunGenerator generator="py#api" requiredParameters={{ integrationPattern: 'shared' }} />
-        </TabItem>
-      </Tabs>
+  2. Riesegui il generatore che ha creato la tua API con l'altro pattern di integrazione (es. `--integrationPattern=shared`)
 </Steps>
 
 Con il pattern `isolated`, il modulo legge le operazioni da un file generato:

--- a/docs/src/content/docs/it/snippets/api/type-safe-api-integrations.mdx
+++ b/docs/src/content/docs/it/snippets/api/type-safe-api-integrations.mdx
@@ -1,7 +1,7 @@
 ---
 title: Integrazioni API Type-Safe
 ---
-import { Steps } from '@astrojs/starlight/components';
+import { Steps, Tabs, TabItem } from '@astrojs/starlight/components';
 import Infrastructure from '@components/infrastructure.astro';
 import Drawer from '@components/drawer.astro';
 import OptionFilter from '@components/option-filter.astro';
@@ -424,8 +424,15 @@ A differenza di CDK, il pattern di integrazione è incorporato nel modulo genera
 
 <Steps>
   1. Elimina il modulo API generato precedentemente in `packages/common/terraform/src/app/apis`
-  2. Riesegui il generatore API con l'altro pattern di integrazione:
-      <RunGenerator generator="ts#api" requiredParameters={{ integrationPattern: 'shared' }} />
+  2. Riesegui il generatore che ha creato la tua API con l'altro pattern di integrazione:
+      <Tabs syncKey="apiLanguage">
+        <TabItem label="TypeScript">
+          <RunGenerator generator="ts#api" requiredParameters={{ integrationPattern: 'shared' }} />
+        </TabItem>
+        <TabItem label="Python">
+          <RunGenerator generator="py#api" requiredParameters={{ integrationPattern: 'shared' }} />
+        </TabItem>
+      </Tabs>
 </Steps>
 
 Con il pattern `isolated`, il modulo legge le operazioni da un file generato:

--- a/docs/src/content/docs/it/snippets/pdk-migration/example/02-migrate-website.mdx
+++ b/docs/src/content/docs/it/snippets/pdk-migration/example/02-migrate-website.mdx
@@ -34,13 +34,12 @@ Questo aggiunge componenti React che gestiscono i reindirizzamenti appropriati p
 Il `CloudscapeReactTsWebsiteProject` di PDK si basava su `@aws-northstar/ui` per fornire componenti di login Cognito nell'app. Se preferisci utilizzare questo approccio invece di passare all'interfaccia utente ospitata, puoi sostituire il file generato `packages/common/constructs/src/core/user-identity.ts` con l'[implementazione di PDK](https://github.com/aws/aws-pdk/blob/mainline/packages/identity/src/user-identity.ts), sostituendo i costrutti da `@aws-cdk/aws-cognito-identitypool-alpha` con quelli forniti da `aws-cdk-lib`, e assicurati di impostare i valori rilevanti in `RuntimeConfig`:
 
 ```ts
-RuntimeConfig.ensure(this).config = {
-  ...RuntimeConfig.ensure(this).config,
+RuntimeConfig.ensure(this).set('connection', 'cognitoProps', {
   region: Stack.of(this).region,
   identityPoolId: this.identityPool.identityPoolId,
   userPoolId: this.userPool.userPoolId,
   userPoolWebClientId: this.userPoolClient.userPoolClientId,
-};
+});
 ```
 
 Puoi quindi riutilizzare il componente `Auth` dal tuo `CloudscapeReactTsWebsiteProject`.

--- a/docs/src/content/docs/jp/get_started/existing-project.mdx
+++ b/docs/src/content/docs/jp/get_started/existing-project.mdx
@@ -43,7 +43,7 @@ pnpmは許可リストに登録されたパッケージのインストールス�
 
 ```yaml title="pnpm-workspace.yaml"
 allowBuilds:
-  - nx
+  nx: true
 ```
 </Aside>
 

--- a/docs/src/content/docs/jp/snippets/api/type-safe-api-integrations.mdx
+++ b/docs/src/content/docs/jp/snippets/api/type-safe-api-integrations.mdx
@@ -1,7 +1,7 @@
 ---
 title: Type-Safe API Integrations
 ---
-import { Steps } from '@astrojs/starlight/components';
+import { Steps, Tabs, TabItem } from '@astrojs/starlight/components';
 import Infrastructure from '@components/infrastructure.astro';
 import Drawer from '@components/drawer.astro';
 import OptionFilter from '@components/option-filter.astro';
@@ -424,8 +424,15 @@ CDK とは異なり、インテグレーションパターンは生成された�
 
 <Steps>
   1. `packages/common/terraform/src/app/apis` 内の以前に生成された API モジュールを削除します
-  2. 他のインテグレーションパターンで API ジェネレーターを再実行します：
-      <RunGenerator generator="ts#api" requiredParameters={{ integrationPattern: 'shared' }} />
+  2. API を作成したジェネレーターを他のインテグレーションパターンで再実行します：
+      <Tabs syncKey="apiLanguage">
+        <TabItem label="TypeScript">
+          <RunGenerator generator="ts#api" requiredParameters={{ integrationPattern: 'shared' }} />
+        </TabItem>
+        <TabItem label="Python">
+          <RunGenerator generator="py#api" requiredParameters={{ integrationPattern: 'shared' }} />
+        </TabItem>
+      </Tabs>
 </Steps>
 
 `isolated` パターンでは、モジュールは生成されたファイルからオペレーションを読み取ります：

--- a/docs/src/content/docs/jp/snippets/api/type-safe-api-integrations.mdx
+++ b/docs/src/content/docs/jp/snippets/api/type-safe-api-integrations.mdx
@@ -1,11 +1,10 @@
 ---
 title: Type-Safe API Integrations
 ---
-import { Steps, Tabs, TabItem } from '@astrojs/starlight/components';
+import { Steps } from '@astrojs/starlight/components';
 import Infrastructure from '@components/infrastructure.astro';
 import Drawer from '@components/drawer.astro';
 import OptionFilter from '@components/option-filter.astro';
-import RunGenerator from '@components/run-generator.astro';
 
 REST/HTTP API CDK コンストラクトは、各オペレーションのインテグレーションを定義するための型安全なインターフェースを提供するように構成されています。
 
@@ -424,15 +423,7 @@ CDK とは異なり、インテグレーションパターンは生成された�
 
 <Steps>
   1. `packages/common/terraform/src/app/apis` 内の以前に生成された API モジュールを削除します
-  2. API を作成したジェネレーターを他のインテグレーションパターンで再実行します：
-      <Tabs syncKey="apiLanguage">
-        <TabItem label="TypeScript">
-          <RunGenerator generator="ts#api" requiredParameters={{ integrationPattern: 'shared' }} />
-        </TabItem>
-        <TabItem label="Python">
-          <RunGenerator generator="py#api" requiredParameters={{ integrationPattern: 'shared' }} />
-        </TabItem>
-      </Tabs>
+  2. API を作成したジェネレーターを他のインテグレーションパターンで再実行します（例：`--integrationPattern=shared`）
 </Steps>
 
 `isolated` パターンでは、モジュールは生成されたファイルからオペレーションを読み取ります：

--- a/docs/src/content/docs/jp/snippets/pdk-migration/example/02-migrate-website.mdx
+++ b/docs/src/content/docs/jp/snippets/pdk-migration/example/02-migrate-website.mdx
@@ -34,13 +34,12 @@ import PackageManagerShortCommand from '@components/package-manager-short-comman
 PDK の `CloudscapeReactTsWebsiteProject` は、アプリ内で Cognito ログインコンポーネントを提供するために `@aws-northstar/ui` に依存していました。ホストUI への移行ではなく、このアプローチを使用したい場合は、生成された `packages/common/constructs/src/core/user-identity.ts` を [PDK の実装](https://github.com/aws/aws-pdk/blob/mainline/packages/identity/src/user-identity.ts) に置き換え、`@aws-cdk/aws-cognito-identitypool-alpha` のコンストラクトを `aws-cdk-lib` が提供するものに置き換え、`RuntimeConfig` に関連する値を設定してください：
 
 ```ts
-RuntimeConfig.ensure(this).config = {
-  ...RuntimeConfig.ensure(this).config,
+RuntimeConfig.ensure(this).set('connection', 'cognitoProps', {
   region: Stack.of(this).region,
   identityPoolId: this.identityPool.identityPoolId,
   userPoolId: this.userPool.userPoolId,
   userPoolWebClientId: this.userPoolClient.userPoolClientId,
-};
+});
 ```
 
 その後、`CloudscapeReactTsWebsiteProject` の `Auth` コンポーネントを再利用できます。

--- a/docs/src/content/docs/ko/get_started/existing-project.mdx
+++ b/docs/src/content/docs/ko/get_started/existing-project.mdx
@@ -43,7 +43,7 @@ pnpm은 허용 목록에 있는 패키지에 대해서만 설치 스크립트를
 
 ```yaml title="pnpm-workspace.yaml"
 allowBuilds:
-  - nx
+  nx: true
 ```
 </Aside>
 

--- a/docs/src/content/docs/ko/snippets/api/type-safe-api-integrations.mdx
+++ b/docs/src/content/docs/ko/snippets/api/type-safe-api-integrations.mdx
@@ -1,11 +1,10 @@
 ---
 title: 타입 안전 API 통합
 ---
-import { Steps, Tabs, TabItem } from '@astrojs/starlight/components';
+import { Steps } from '@astrojs/starlight/components';
 import Infrastructure from '@components/infrastructure.astro';
 import Drawer from '@components/drawer.astro';
 import OptionFilter from '@components/option-filter.astro';
-import RunGenerator from '@components/run-generator.astro';
 
 REST/HTTP API CDK 구성은 각 작업에 대한 통합을 정의하기 위한 타입 안전 인터페이스를 제공하도록 구성되어 있습니다.
 
@@ -424,15 +423,7 @@ CDK와 달리 통합 패턴은 생성된 모듈에 내장되어 있습니다. �
 
 <Steps>
   1. `packages/common/terraform/src/app/apis`에서 이전에 생성된 API 모듈을 삭제합니다
-  2. API를 생성한 생성기를 다른 통합 패턴으로 다시 실행합니다:
-      <Tabs syncKey="apiLanguage">
-        <TabItem label="TypeScript">
-          <RunGenerator generator="ts#api" requiredParameters={{ integrationPattern: 'shared' }} />
-        </TabItem>
-        <TabItem label="Python">
-          <RunGenerator generator="py#api" requiredParameters={{ integrationPattern: 'shared' }} />
-        </TabItem>
-      </Tabs>
+  2. API를 생성한 생성기를 다른 통합 패턴으로 다시 실행합니다 (예: `--integrationPattern=shared`)
 </Steps>
 
 `isolated` 패턴을 사용하면 모듈은 생성된 파일에서 작업을 읽습니다:

--- a/docs/src/content/docs/ko/snippets/api/type-safe-api-integrations.mdx
+++ b/docs/src/content/docs/ko/snippets/api/type-safe-api-integrations.mdx
@@ -1,7 +1,7 @@
 ---
 title: 타입 안전 API 통합
 ---
-import { Steps } from '@astrojs/starlight/components';
+import { Steps, Tabs, TabItem } from '@astrojs/starlight/components';
 import Infrastructure from '@components/infrastructure.astro';
 import Drawer from '@components/drawer.astro';
 import OptionFilter from '@components/option-filter.astro';
@@ -424,8 +424,15 @@ CDK와 달리 통합 패턴은 생성된 모듈에 내장되어 있습니다. �
 
 <Steps>
   1. `packages/common/terraform/src/app/apis`에서 이전에 생성된 API 모듈을 삭제합니다
-  2. 다른 통합 패턴으로 API 생성기를 다시 실행합니다:
-      <RunGenerator generator="ts#api" requiredParameters={{ integrationPattern: 'shared' }} />
+  2. API를 생성한 생성기를 다른 통합 패턴으로 다시 실행합니다:
+      <Tabs syncKey="apiLanguage">
+        <TabItem label="TypeScript">
+          <RunGenerator generator="ts#api" requiredParameters={{ integrationPattern: 'shared' }} />
+        </TabItem>
+        <TabItem label="Python">
+          <RunGenerator generator="py#api" requiredParameters={{ integrationPattern: 'shared' }} />
+        </TabItem>
+      </Tabs>
 </Steps>
 
 `isolated` 패턴을 사용하면 모듈은 생성된 파일에서 작업을 읽습니다:

--- a/docs/src/content/docs/ko/snippets/pdk-migration/example/02-migrate-website.mdx
+++ b/docs/src/content/docs/ko/snippets/pdk-migration/example/02-migrate-website.mdx
@@ -34,13 +34,12 @@ import PackageManagerShortCommand from '@components/package-manager-short-comman
 PDK `CloudscapeReactTsWebsiteProject`는 앱 내에서 Cognito 로그인 컴포넌트를 제공하기 위해 `@aws-northstar/ui`에 의존했습니다. 호스팅 UI로 이동하는 대신 이 접근 방식을 사용하려면, 생성된 `packages/common/constructs/src/core/user-identity.ts`를 [PDK의 구현](https://github.com/aws/aws-pdk/blob/mainline/packages/identity/src/user-identity.ts)으로 교체하고, `@aws-cdk/aws-cognito-identitypool-alpha`의 구성을 `aws-cdk-lib`에서 제공하는 것으로 교체한 다음, `RuntimeConfig`에서 관련 값을 설정해야 합니다:
 
 ```ts
-RuntimeConfig.ensure(this).config = {
-  ...RuntimeConfig.ensure(this).config,
+RuntimeConfig.ensure(this).set('connection', 'cognitoProps', {
   region: Stack.of(this).region,
   identityPoolId: this.identityPool.identityPoolId,
   userPoolId: this.userPool.userPoolId,
   userPoolWebClientId: this.userPoolClient.userPoolClientId,
-};
+});
 ```
 
 그런 다음 `CloudscapeReactTsWebsiteProject`의 `Auth` 컴포넌트를 재사용할 수 있습니다.

--- a/docs/src/content/docs/pt/get_started/existing-project.mdx
+++ b/docs/src/content/docs/pt/get_started/existing-project.mdx
@@ -43,7 +43,7 @@ pnpm executa scripts de instalação apenas para pacotes na lista de permissões
 
 ```yaml title="pnpm-workspace.yaml"
 allowBuilds:
-  - nx
+  nx: true
 ```
 </Aside>
 

--- a/docs/src/content/docs/pt/snippets/api/type-safe-api-integrations.mdx
+++ b/docs/src/content/docs/pt/snippets/api/type-safe-api-integrations.mdx
@@ -1,11 +1,10 @@
 ---
 title: Integrações de API Type-Safe
 ---
-import { Steps, Tabs, TabItem } from '@astrojs/starlight/components';
+import { Steps } from '@astrojs/starlight/components';
 import Infrastructure from '@components/infrastructure.astro';
 import Drawer from '@components/drawer.astro';
 import OptionFilter from '@components/option-filter.astro';
-import RunGenerator from '@components/run-generator.astro';
 
 Os construtos CDK de API REST/HTTP são configurados para fornecer uma interface type-safe para definir integrações para cada uma de suas operações.
 
@@ -424,15 +423,7 @@ Ao contrário do CDK, o padrão de integração é incorporado ao módulo gerado
 
 <Steps>
   1. Exclua o módulo de API gerado anteriormente em `packages/common/terraform/src/app/apis`
-  2. Execute novamente o gerador que criou sua API com o outro padrão de integração:
-      <Tabs syncKey="apiLanguage">
-        <TabItem label="TypeScript">
-          <RunGenerator generator="ts#api" requiredParameters={{ integrationPattern: 'shared' }} />
-        </TabItem>
-        <TabItem label="Python">
-          <RunGenerator generator="py#api" requiredParameters={{ integrationPattern: 'shared' }} />
-        </TabItem>
-      </Tabs>
+  2. Execute novamente o gerador que criou sua API com o outro padrão de integração (ex: `--integrationPattern=shared`)
 </Steps>
 
 Com o padrão `isolated`, o módulo lê as operações de um arquivo gerado:

--- a/docs/src/content/docs/pt/snippets/api/type-safe-api-integrations.mdx
+++ b/docs/src/content/docs/pt/snippets/api/type-safe-api-integrations.mdx
@@ -1,7 +1,7 @@
 ---
 title: Integrações de API Type-Safe
 ---
-import { Steps } from '@astrojs/starlight/components';
+import { Steps, Tabs, TabItem } from '@astrojs/starlight/components';
 import Infrastructure from '@components/infrastructure.astro';
 import Drawer from '@components/drawer.astro';
 import OptionFilter from '@components/option-filter.astro';
@@ -424,8 +424,15 @@ Ao contrário do CDK, o padrão de integração é incorporado ao módulo gerado
 
 <Steps>
   1. Exclua o módulo de API gerado anteriormente em `packages/common/terraform/src/app/apis`
-  2. Execute novamente o gerador de API com o outro padrão de integração:
-      <RunGenerator generator="ts#api" requiredParameters={{ integrationPattern: 'shared' }} />
+  2. Execute novamente o gerador que criou sua API com o outro padrão de integração:
+      <Tabs syncKey="apiLanguage">
+        <TabItem label="TypeScript">
+          <RunGenerator generator="ts#api" requiredParameters={{ integrationPattern: 'shared' }} />
+        </TabItem>
+        <TabItem label="Python">
+          <RunGenerator generator="py#api" requiredParameters={{ integrationPattern: 'shared' }} />
+        </TabItem>
+      </Tabs>
 </Steps>
 
 Com o padrão `isolated`, o módulo lê as operações de um arquivo gerado:

--- a/docs/src/content/docs/pt/snippets/pdk-migration/example/02-migrate-website.mdx
+++ b/docs/src/content/docs/pt/snippets/pdk-migration/example/02-migrate-website.mdx
@@ -34,13 +34,12 @@ Isso adiciona componentes React que gerenciam os redirecionamentos apropriados p
 O `CloudscapeReactTsWebsiteProject` do PDK dependia de `@aws-northstar/ui` para fornecer componentes de login do Cognito no aplicativo. Se você preferir usar essa abordagem em vez de migrar para a UI hospedada, pode substituir o `packages/common/constructs/src/core/user-identity.ts` gerado pela [implementação do PDK](https://github.com/aws/aws-pdk/blob/mainline/packages/identity/src/user-identity.ts), substituindo os construtos de `@aws-cdk/aws-cognito-identitypool-alpha` pelos fornecidos por `aws-cdk-lib`, e certifique-se de definir os valores relevantes em `RuntimeConfig`:
 
 ```ts
-RuntimeConfig.ensure(this).config = {
-  ...RuntimeConfig.ensure(this).config,
+RuntimeConfig.ensure(this).set('connection', 'cognitoProps', {
   region: Stack.of(this).region,
   identityPoolId: this.identityPool.identityPoolId,
   userPoolId: this.userPool.userPoolId,
   userPoolWebClientId: this.userPoolClient.userPoolClientId,
-};
+});
 ```
 
 Você pode então reutilizar o componente `Auth` do seu `CloudscapeReactTsWebsiteProject`.

--- a/docs/src/content/docs/vi/get_started/existing-project.mdx
+++ b/docs/src/content/docs/vi/get_started/existing-project.mdx
@@ -43,7 +43,7 @@ pnpm chỉ chạy install scripts cho các package được allow-list, và `nx`
 
 ```yaml title="pnpm-workspace.yaml"
 allowBuilds:
-  - nx
+  nx: true
 ```
 </Aside>
 

--- a/docs/src/content/docs/vi/snippets/api/type-safe-api-integrations.mdx
+++ b/docs/src/content/docs/vi/snippets/api/type-safe-api-integrations.mdx
@@ -1,7 +1,7 @@
 ---
 title: Tích hợp API An toàn Kiểu
 ---
-import { Steps } from '@astrojs/starlight/components';
+import { Steps, Tabs, TabItem } from '@astrojs/starlight/components';
 import Infrastructure from '@components/infrastructure.astro';
 import Drawer from '@components/drawer.astro';
 import OptionFilter from '@components/option-filter.astro';
@@ -424,8 +424,15 @@ Không giống như CDK, mẫu tích hợp được nhúng vào module được 
 
 <Steps>
   1. Xóa module API đã được tạo trước đó trong `packages/common/terraform/src/app/apis`
-  2. Chạy lại trình tạo API với mẫu tích hợp khác:
-      <RunGenerator generator="ts#api" requiredParameters={{ integrationPattern: 'shared' }} />
+  2. Chạy lại trình tạo đã tạo API của bạn với mẫu tích hợp khác:
+      <Tabs syncKey="apiLanguage">
+        <TabItem label="TypeScript">
+          <RunGenerator generator="ts#api" requiredParameters={{ integrationPattern: 'shared' }} />
+        </TabItem>
+        <TabItem label="Python">
+          <RunGenerator generator="py#api" requiredParameters={{ integrationPattern: 'shared' }} />
+        </TabItem>
+      </Tabs>
 </Steps>
 
 Với mẫu `isolated`, module đọc các hoạt động từ một tệp được tạo:

--- a/docs/src/content/docs/vi/snippets/api/type-safe-api-integrations.mdx
+++ b/docs/src/content/docs/vi/snippets/api/type-safe-api-integrations.mdx
@@ -1,11 +1,10 @@
 ---
 title: Tích hợp API An toàn Kiểu
 ---
-import { Steps, Tabs, TabItem } from '@astrojs/starlight/components';
+import { Steps } from '@astrojs/starlight/components';
 import Infrastructure from '@components/infrastructure.astro';
 import Drawer from '@components/drawer.astro';
 import OptionFilter from '@components/option-filter.astro';
-import RunGenerator from '@components/run-generator.astro';
 
 Các cấu trúc CDK REST/HTTP API được cấu hình để cung cấp giao diện an toàn kiểu cho việc định nghĩa tích hợp cho từng hoạt động của bạn.
 
@@ -424,15 +423,7 @@ Không giống như CDK, mẫu tích hợp được nhúng vào module được 
 
 <Steps>
   1. Xóa module API đã được tạo trước đó trong `packages/common/terraform/src/app/apis`
-  2. Chạy lại trình tạo đã tạo API của bạn với mẫu tích hợp khác:
-      <Tabs syncKey="apiLanguage">
-        <TabItem label="TypeScript">
-          <RunGenerator generator="ts#api" requiredParameters={{ integrationPattern: 'shared' }} />
-        </TabItem>
-        <TabItem label="Python">
-          <RunGenerator generator="py#api" requiredParameters={{ integrationPattern: 'shared' }} />
-        </TabItem>
-      </Tabs>
+  2. Chạy lại trình tạo đã tạo API của bạn với mẫu tích hợp khác (ví dụ `--integrationPattern=shared`)
 </Steps>
 
 Với mẫu `isolated`, module đọc các hoạt động từ một tệp được tạo:

--- a/docs/src/content/docs/vi/snippets/pdk-migration/example/02-migrate-website.mdx
+++ b/docs/src/content/docs/vi/snippets/pdk-migration/example/02-migrate-website.mdx
@@ -34,13 +34,12 @@ Generator React website ở trên không tích hợp sẵn xác thực cognito n
 `CloudscapeReactTsWebsiteProject` của PDK dựa vào `@aws-northstar/ui` để cung cấp các component đăng nhập Cognito trong ứng dụng. Nếu bạn muốn sử dụng cách tiếp cận này thay vì chuyển sang hosted UI, bạn có thể thay thế `packages/common/constructs/src/core/user-identity.ts` được tạo ra bằng [implementation từ PDK](https://github.com/aws/aws-pdk/blob/mainline/packages/identity/src/user-identity.ts), thay thế các construct từ `@aws-cdk/aws-cognito-identitypool-alpha` bằng những construct được cung cấp bởi `aws-cdk-lib`, và đảm bảo đặt các giá trị liên quan trong `RuntimeConfig`:
 
 ```ts
-RuntimeConfig.ensure(this).config = {
-  ...RuntimeConfig.ensure(this).config,
+RuntimeConfig.ensure(this).set('connection', 'cognitoProps', {
   region: Stack.of(this).region,
   identityPoolId: this.identityPool.identityPoolId,
   userPoolId: this.userPool.userPoolId,
   userPoolWebClientId: this.userPoolClient.userPoolClientId,
-};
+});
 ```
 
 Sau đó bạn có thể tái sử dụng component `Auth` từ `CloudscapeReactTsWebsiteProject` của bạn.

--- a/docs/src/content/docs/zh/get_started/existing-project.mdx
+++ b/docs/src/content/docs/zh/get_started/existing-project.mdx
@@ -43,7 +43,7 @@ pnpm 仅为允许列表中的包运行安装脚本，而 `nx` 需要其安装脚
 
 ```yaml title="pnpm-workspace.yaml"
 allowBuilds:
-  - nx
+  nx: true
 ```
 </Aside>
 

--- a/docs/src/content/docs/zh/snippets/api/type-safe-api-integrations.mdx
+++ b/docs/src/content/docs/zh/snippets/api/type-safe-api-integrations.mdx
@@ -1,11 +1,10 @@
 ---
 title: Type-Safe API 集成
 ---
-import { Steps, Tabs, TabItem } from '@astrojs/starlight/components';
+import { Steps } from '@astrojs/starlight/components';
 import Infrastructure from '@components/infrastructure.astro';
 import Drawer from '@components/drawer.astro';
 import OptionFilter from '@components/option-filter.astro';
-import RunGenerator from '@components/run-generator.astro';
 
 REST/HTTP API CDK 构造被配置为提供类型安全的接口，用于为每个操作定义集成。
 
@@ -424,15 +423,7 @@ export class MyApi<...> extends ... {
 
 <Steps>
   1. 删除 `packages/common/terraform/src/app/apis` 中先前生成的 API 模块
-  2. 使用其他集成模式重新运行创建 API 的生成器：
-      <Tabs syncKey="apiLanguage">
-        <TabItem label="TypeScript">
-          <RunGenerator generator="ts#api" requiredParameters={{ integrationPattern: 'shared' }} />
-        </TabItem>
-        <TabItem label="Python">
-          <RunGenerator generator="py#api" requiredParameters={{ integrationPattern: 'shared' }} />
-        </TabItem>
-      </Tabs>
+  2. 使用其他集成模式重新运行创建 API 的生成器（例如 `--integrationPattern=shared`）
 </Steps>
 
 使用 `isolated` 模式时，模块从生成的文件中读取操作：

--- a/docs/src/content/docs/zh/snippets/api/type-safe-api-integrations.mdx
+++ b/docs/src/content/docs/zh/snippets/api/type-safe-api-integrations.mdx
@@ -1,7 +1,7 @@
 ---
 title: Type-Safe API 集成
 ---
-import { Steps } from '@astrojs/starlight/components';
+import { Steps, Tabs, TabItem } from '@astrojs/starlight/components';
 import Infrastructure from '@components/infrastructure.astro';
 import Drawer from '@components/drawer.astro';
 import OptionFilter from '@components/option-filter.astro';
@@ -424,8 +424,15 @@ export class MyApi<...> extends ... {
 
 <Steps>
   1. 删除 `packages/common/terraform/src/app/apis` 中先前生成的 API 模块
-  2. 使用其他集成模式重新运行 API 生成器：
-      <RunGenerator generator="ts#api" requiredParameters={{ integrationPattern: 'shared' }} />
+  2. 使用其他集成模式重新运行创建 API 的生成器：
+      <Tabs syncKey="apiLanguage">
+        <TabItem label="TypeScript">
+          <RunGenerator generator="ts#api" requiredParameters={{ integrationPattern: 'shared' }} />
+        </TabItem>
+        <TabItem label="Python">
+          <RunGenerator generator="py#api" requiredParameters={{ integrationPattern: 'shared' }} />
+        </TabItem>
+      </Tabs>
 </Steps>
 
 使用 `isolated` 模式时，模块从生成的文件中读取操作：

--- a/docs/src/content/docs/zh/snippets/pdk-migration/example/02-migrate-website.mdx
+++ b/docs/src/content/docs/zh/snippets/pdk-migration/example/02-migrate-website.mdx
@@ -34,13 +34,12 @@ import PackageManagerShortCommand from '@components/package-manager-short-comman
 PDK 的 `CloudscapeReactTsWebsiteProject` 依赖于 `@aws-northstar/ui` 在应用程序内提供 Cognito 登录组件。如果您更喜欢使用这种方法而不是迁移到托管 UI，您可以将生成的 `packages/common/constructs/src/core/user-identity.ts` 替换为 [PDK 的实现](https://github.com/aws/aws-pdk/blob/mainline/packages/identity/src/user-identity.ts)，将 `@aws-cdk/aws-cognito-identitypool-alpha` 中的构造替换为 `aws-cdk-lib` 提供的构造，并确保在 `RuntimeConfig` 中设置相关值：
 
 ```ts
-RuntimeConfig.ensure(this).config = {
-  ...RuntimeConfig.ensure(this).config,
+RuntimeConfig.ensure(this).set('connection', 'cognitoProps', {
   region: Stack.of(this).region,
   identityPoolId: this.identityPool.identityPoolId,
   userPoolId: this.userPool.userPoolId,
   userPoolWebClientId: this.userPoolClient.userPoolClientId,
-};
+});
 ```
 
 然后您可以重用 `CloudscapeReactTsWebsiteProject` 中的 `Auth` 组件。


### PR DESCRIPTION
### Reason for this change

Three unrelated documentation errors found while sanity-checking the docs ahead of v1.0. Each one breaks a reader who follows the page exactly as written.

**1. The shared API integrations snippet sends FastAPI and Smithy readers to the wrong generator.**

`docs/src/content/docs/en/snippets/api/type-safe-api-integrations.mdx` is included by three guides:

- `guides/trpc.mdx:828` (frontmatter `generator: ts#api`)
- `guides/ts-smithy-api.mdx:873` (frontmatter `generator: ts#api`)
- `guides/fastapi.mdx:635` (frontmatter `generator: py#api`)

...but its Terraform "change the integration pattern" step hardcoded `generator="ts#api"`. A reader on the FastAPI page following those Steps generates a brand new **TypeScript** API instead of re-running the Python one. Both `ts#api` and `py#api` expose `integrationPattern` with the same `["isolated","shared"]` enum, so there is a correct command for each — it just was not being shown.

**2. The `pnpm-workspace.yaml` fix in `existing-project` does not work.**

The note documented `allowBuilds` as a YAML sequence:

```yaml
allowBuilds:
  - nx
```

pnpm 11 reads `allowBuilds` as a **map**. This is confirmed three ways in-repo: `packages/nx-plugin/src/utils/pnpm-workspace.ts:12` types it `Record<string, boolean>`; `packages/nx-plugin/src/utils/init.ts:133-138` writes `Object.fromEntries(deps.map(d => [d, true]))`; and this repo's own `pnpm-workspace.yaml` uses the map form (`nx: true`). With the list form `nx` is not allow-listed, so the reader still hits the `ERR_PNPM_IGNORED_BUILDS` failure that the note exists to prevent.

**3. The PDK migration walkthrough contains a snippet that cannot compile.**

`snippets/pdk-migration/example/02-migrate-website.mdx` assigned to a `config` property:

```ts
RuntimeConfig.ensure(this).config = { ...RuntimeConfig.ensure(this).config, ... };
```

`RuntimeConfig` (`packages/nx-plugin/src/utils/files/common/constructs/src/core/runtime-config.ts.template`) exposes only `ensure`, `of`, `set(namespace, key, value)` and `get(namespace)` over a `private readonly _namespaces` map. There is no `config` property, so this is a type error. The shape was also wrong: the vended `UserIdentity` construct nests exactly these four fields under one key (`utils/identity-constructs/files/cdk/core/user-identity.ts.template:122`), and consumers destructure `const { cognitoProps } = useRuntimeConfig()` (`ts/react-website/cognito-auth/files/app/components/CognitoAuth/index.tsx.template:14`).

### Description of changes

- `snippets/api/type-safe-api-integrations.mdx` — the integration-pattern step no longer names a specific generator. It now reads "Re-run the generator that created your API with the other integration pattern (eg `--integrationPattern=shared`)", which is correct on all three including guides. This also removes the last generator-specific reference from the snippet, bringing it in line with every other shared `api/` snippet (`api-choice-note`, `api-architecture`, `access-logging`, …), none of which name a generator. The now-unused `RunGenerator` import is dropped.
- `get_started/existing-project.mdx` — `- nx` → `nx: true`.
- `snippets/pdk-migration/example/02-migrate-website.mdx` — use `RuntimeConfig.ensure(this).set('connection', 'cognitoProps', { … })`.

English-only, per the contributing guide; translations are regenerated from these sources.

### Description of how you validated changes

- `pnpm nx run docs:build` — passes. 1540 pages built, and the `starlight-links-validator` reports **"All internal links are valid."**
- Confirmed `RunGenerator`, `Tabs` and `TabItem` have no remaining usage in the snippet after the change, so the removed imports leave nothing dangling.
- `pnpm nx run @aws/nx-plugin:test --skip-nx-cache` — 252 files / 4493 tests pass. Run with the cache skipped deliberately: docs are not declared inputs to that target, so it otherwise reports a cache hit and would not actually re-execute.
- Confirmed no test snapshot embeds this snippet's prose (no match for `Re-run the API generator` anywhere in the tree), so there are no snapshots to update.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
