### PR TITLE
docs: add an AWS infrastructure view to the read-only graphs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -401,6 +401,16 @@ Everything else is inferred — whether the generator creates a project or adds 
 
 Finally, add the node's artwork and palette grouping to `PRESENTATION` in `docs/src/lib/graph-builder/catalog.ts`, alongside a logo in `docs/src/content/docs/assets/logos/`. A type without an entry still appears, just under "Other" with a generic mark.
 
+### Infrastructure Blueprints
+
+The read-only diagrams — the quick start, the tutorial, the homepage showcase and each generator guide's **Architecture** section — switch between two views of the same graph: the projects in the workspace, and the AWS infrastructure they deploy. The second comes from a **blueprint** per node type in `docs/src/lib/graph-builder/infrastructure.ts`: the resources the generator provisions, each with an icon from `docs/public/icons/aws/`, their position in the project's own little grid, and the request path through them.
+
+A resource can declare the option values it is provisioned for — `when: { infra: 'rest-lambda' }` puts a WAF in front of a REST API and leaves it out of an HTTP one — and the request path skips whatever the options leave out, so variants of the same step sit at the same grid position. That is what keeps a guide's diagram in step with the option filters the rest of the guide is written against: `<ArchitectureDiagram />` follows the reader's selection in the filter bar, and `<ArchitectureDiagram options={{ infra: 'none' }} />` pins a block that only describes one variant.
+
+A generator that adds to a project rather than taking part in a connection — a Lambda function, a website's authentication — has no node type in the palette, so its blueprint is keyed by the generator id and carries its own `label`. Everything else works the same, and its guide's `<ArchitectureDiagram />` finds it from the page's `generator:` frontmatter.
+
+Every node type in the palette needs a blueprint — `infrastructure.spec.ts` fails by name if one is missing, since a type without it would draw an empty box.
+
 ### End to End Tests
 
 The end to end tests run our generators and check that generated projects function correctly (usually by performing a build).

--- a/docs/src/components/architecture-diagram.astro
+++ b/docs/src/components/architecture-diagram.astro
@@ -1,0 +1,89 @@
+---
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { NODE_TYPES } from '../lib/graph-builder/catalog';
+import { hasBlueprint } from '../lib/graph-builder/infrastructure';
+import EmbeddedGraph from './embedded-graph.astro';
+
+/**
+ * The architecture a single generator deploys, as one project box of AWS
+ * resources — the same diagram the quick start and the tutorial show for a whole
+ * workspace, narrowed to the project this guide covers, and switchable to the
+ * project view.
+ *
+ * The project type comes from the page's own `generator` and `when` frontmatter,
+ * so a snippet shared by the TypeScript and Python versions of a guide draws the
+ * right one without being told. A generator with no node type in the graph
+ * builder's palette — one that adds to a project rather than taking part in a
+ * connection — is drawn straight from its own blueprint.
+ *
+ * Usage, from a guide or a snippet a guide includes:
+ *   <ArchitectureDiagram />
+ *   <ArchitectureDiagram options={{ infra: 'rest-lambda' }} />
+ *
+ * The diagram draws the architecture the reader's own option values deploy,
+ * following the page's filter bar. `options` pins values on top of that, for a
+ * diagram inside a block that describes one variant — a filtered <Tabs> whose
+ * prose is specific to it — so that block always draws what it is describing.
+ */
+interface Props {
+  options?: Readonly<Record<string, string | boolean>>;
+  /** The project name on the box. Defaults to one derived from the type. */
+  name?: string;
+}
+
+const { options, name } = Astro.props;
+
+const frontmatter = Astro.locals.starlightRoute?.entry?.data as
+  | { generator?: string; when?: Record<string, string | string[]> }
+  | undefined;
+const generator = frontmatter?.generator;
+const when = frontmatter?.when ?? {};
+
+// The page's generator, narrowed by the option values its frontmatter pins: the
+// `ts#api` guides share one generator, and `when: framework: [trpc]` is what says
+// which of its project types this page is about.
+const candidates = NODE_TYPES.filter(
+  (type) =>
+    type.generator === generator &&
+    hasBlueprint(type.id) &&
+    Object.entries(type.variantOptions).every(([option, value]) => {
+      const allowed = when[option];
+      if (allowed === undefined) return true;
+      return (Array.isArray(allowed) ? allowed : [allowed]).includes(value);
+    }),
+);
+
+// A generator outside the palette stands for itself.
+const subject =
+  candidates.length === 1
+    ? candidates[0].id
+    : generator !== undefined && hasBlueprint(generator)
+      ? generator
+      : undefined;
+
+// A guide naming a generator with no blueprint has nothing to draw, which is an
+// authoring mistake worth failing the build over. A snippet also renders as a page
+// of its own, with no generator behind it — there the diagram belongs to whichever
+// guide includes the snippet, so it is left out.
+if (generator !== undefined && subject === undefined) {
+  throw new Error(
+    `Architecture diagram: the page's 'generator: ${generator}' frontmatter (narrowed by 'when') matched ${candidates.length} project types with an infrastructure blueprint, and the generator has none of its own`,
+  );
+}
+---
+
+{
+  subject && (
+    <EmbeddedGraph
+      type={subject}
+      name={name}
+      options={options}
+      followPageOptions
+      view="infrastructure"
+      orientation="horizontal"
+    />
+  )
+}

--- a/docs/src/components/embedded-graph.astro
+++ b/docs/src/components/embedded-graph.astro
@@ -8,7 +8,18 @@ import { EmbeddedGraph } from './graph-builder/embedded-graph';
 import '../styles/graph-builder.css';
 
 interface Props {
-  preset: string;
+  preset?: string;
+  /** A single node type, for a guide covering one generator. */
+  type?: string;
+  name?: string;
+  /** Option values in effect, deciding what the infrastructure view shows. */
+  options?: Readonly<Record<string, string | boolean>>;
+  /** Follow the option values the page's filter bar has selected. */
+  followPageOptions?: boolean;
+  /** Which diagram to open on. Defaults to the projects view. */
+  view?: 'projects' | 'infrastructure';
+  /** Whether to offer the commands that scaffold the graph. Defaults to true. */
+  copyable?: boolean;
   workspace?: string;
   packageManager?: string;
   iac?: 'cdk' | 'terraform';
@@ -19,6 +30,12 @@ interface Props {
 
 const {
   preset,
+  type,
+  name,
+  options,
+  followPageOptions,
+  view,
+  copyable,
   workspace,
   packageManager,
   iac,
@@ -32,6 +49,12 @@ const {
   <EmbeddedGraph
     client:only="react"
     preset={preset}
+    type={type}
+    name={name}
+    options={options}
+    followPageOptions={followPageOptions}
+    view={view}
+    copyable={copyable}
     workspace={workspace}
     packageManager={packageManager}
     iac={iac}

--- a/docs/src/components/graph-builder/aws-icon.tsx
+++ b/docs/src/components/graph-builder/aws-icon.tsx
@@ -1,0 +1,27 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * An AWS service icon, served from `public/icons/aws` — the same artwork the
+ * guides' architecture diagrams use. These are public assets rather than bundled
+ * imports so a blueprint can name one as a string, without every icon in the set
+ * having to be imported whether or not a diagram uses it.
+ */
+const base = import.meta.env.BASE_URL.replace(/\/$/, '');
+
+interface Props {
+  icon: string;
+  alt: string;
+}
+
+export const AwsIcon = ({ icon, alt }: Props) => (
+  <img
+    className="gb-aws-icon"
+    src={`${base}/icons/aws/${icon}.svg`}
+    alt={alt}
+    loading="lazy"
+    draggable={false}
+  />
+);

--- a/docs/src/components/graph-builder/embedded-graph.tsx
+++ b/docs/src/components/graph-builder/embedded-graph.tsx
@@ -2,13 +2,22 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import {
+  useEffect,
+  useId,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { nodeType } from '../../lib/graph-builder/catalog';
 import type {
   EmitOptions,
   NodeOverride,
 } from '../../lib/graph-builder/commands';
 import { toScript } from '../../lib/graph-builder/commands';
+import { buildInfrastructureLayout } from '../../lib/graph-builder/infrastructure';
+import type { Graph } from '../../lib/graph-builder/model';
 import {
   edgePath,
   loopPath,
@@ -19,8 +28,11 @@ import {
   targetAnchor,
 } from './geometry';
 import { IacMark } from './iac-mark';
+import { InfraDiagram } from './infra-diagram';
 import { NodeLogo } from './node-logo';
 import { buildPresetGraph, PRESETS } from './presets';
+import { usePageOptions } from './use-page-options';
+import { type DiagramView, ViewMark, ViewToggle } from './view-toggle';
 
 /** Where the grid starts, and the spacing between its cells on each axis. */
 const ORIGIN = 24;
@@ -28,8 +40,36 @@ const X_GAP = NODE_WIDTH + 90;
 const Y_GAP = NODE_HEIGHT + 60;
 
 interface Props {
-  /** The preset to render, by id. */
-  preset: string;
+  /** The preset to render, by id. Omitted for a single-project diagram. */
+  preset?: string;
+  /**
+   * A single project to render on its own, for a guide covering one generator:
+   * either a node type from the palette or any generator with an infrastructure
+   * blueprint. The diagram is then that project's own infrastructure, with no
+   * commands to copy — the guide's own steps run the generator.
+   */
+  type?: string;
+  /** The project name shown, for a single-project diagram. */
+  name?: string;
+  /**
+   * Option values in effect for a single-project diagram, which decide what its
+   * infrastructure holds — a REST API brings a WAF, an agent with `infra: none`
+   * runs as a local process. A guide pins these to the variant it is describing.
+   */
+  options?: Readonly<Record<string, string | boolean>>;
+  /**
+   * Take the option values the reader has picked in the page's filter bar, for
+   * every option the diagram is not pinning. A guide's diagram then shows the
+   * architecture of the options the rest of the guide is filtered to.
+   */
+  followPageOptions?: boolean;
+  /** Which diagram to open on. Defaults to the projects view. */
+  view?: DiagramView;
+  /**
+   * Whether to offer the commands that scaffold the graph. A page showing what a
+   * workspace looks like, rather than having the reader build it, turns this off.
+   */
+  copyable?: boolean;
   /** The workspace name the emitted commands scaffold. */
   workspace?: string;
   packageManager?: string;
@@ -52,10 +92,13 @@ interface Props {
 
 /** Padding kept around the diagram inside its box. */
 const PADDING = 24;
+/** Room left at the top of the canvas for the view switch, clear of the diagram. */
+const TOGGLE_ROOM = 40;
 
 /**
- * A read-only view of a preset: the graph laid out top to bottom, with a button
- * to copy the whole series of scaffold commands.
+ * A read-only view of a preset, or of a single project: the graph laid out top to
+ * bottom, with a switch between the projects and the AWS infrastructure they
+ * deploy, and a button to copy the whole series of scaffold commands.
  *
  * Unlike the full builder there are no palette or inspector panels and nothing is
  * editable — it stands in a docs page to show, and hand over, exactly the
@@ -65,6 +108,12 @@ const PADDING = 24;
  */
 export const EmbeddedGraph = ({
   preset: presetId,
+  type,
+  name,
+  options: nodeOptions,
+  followPageOptions = false,
+  view: initialView = 'projects',
+  copyable = true,
   workspace = 'my-project',
   packageManager = 'pnpm',
   iac = 'cdk',
@@ -73,6 +122,14 @@ export const EmbeddedGraph = ({
   overrides,
 }: Props) => {
   const preset = PRESETS.find((entry) => entry.id === presetId);
+  /** A guide's diagram: one project, and only the architecture of it. */
+  const single = type !== undefined;
+  const [chosenView, setView] = useState<DiagramView>(initialView);
+  // Nothing to switch to for a single project, so it stays on its architecture
+  // — which is also the only view a generator without a palette node type has.
+  const view: DiagramView = single ? 'infrastructure' : chosenView;
+  const markerId = `${useId()}-arrow`;
+  const pageOptions = usePageOptions(followPageOptions);
 
   const options: EmitOptions = useMemo(
     () => ({
@@ -88,7 +145,24 @@ export const EmbeddedGraph = ({
   // horizontal graph the column is the step across and the row the slot down;
   // for a vertical one they swap. Positions come straight from the grid rather
   // than the builder's auto-packing, so a preset lands exactly as authored.
-  const graph = useMemo(() => {
+  const graph = useMemo((): Graph | undefined => {
+    if (type) {
+      return {
+        nodes: [
+          {
+            id: type,
+            type,
+            name: name ?? `my-${type.split('#').pop()}`,
+            // What the diagram pins wins over what the reader has selected: a
+            // block describing one variant draws that variant.
+            options: { ...pageOptions, ...nodeOptions },
+            x: ORIGIN,
+            y: ORIGIN,
+          },
+        ],
+        edges: [],
+      };
+    }
     if (!preset) return undefined;
     const built = buildPresetGraph(preset);
     const nodes = built.nodes.map((node, index) => {
@@ -100,12 +174,28 @@ export const EmbeddedGraph = ({
       };
     });
     return { ...built, nodes };
-  }, [preset, orientation]);
+  }, [preset, orientation, type, name, nodeOptions, pageOptions]);
+
+  // The boxes flow down the page whichever way the projects view runs: a docs
+  // column has height to spare and width to save.
+  const infrastructure = useMemo(
+    () =>
+      graph
+        ? buildInfrastructureLayout(graph, { from: orientation })
+        : undefined,
+    [graph, orientation],
+  );
 
   // The diagram's natural size, so it can be scaled to fit the content column.
   const layout = useMemo(() => {
     if (!graph || graph.nodes.length === 0) {
       return { width: PADDING * 2, height: PADDING * 2 };
+    }
+    if (view === 'infrastructure' && infrastructure) {
+      return {
+        width: infrastructure.width,
+        height: infrastructure.height,
+      };
     }
     return {
       width:
@@ -113,7 +203,7 @@ export const EmbeddedGraph = ({
       height:
         Math.max(...graph.nodes.map((node) => node.y + NODE_HEIGHT)) + PADDING,
     };
-  }, [graph]);
+  }, [graph, view, infrastructure]);
 
   const containerRef = useRef<HTMLDivElement>(null);
   const [containerWidth, setContainerWidth] = useState<number | undefined>();
@@ -133,6 +223,11 @@ export const EmbeddedGraph = ({
     containerWidth && layout.width > containerWidth
       ? containerWidth / layout.width
       : 1;
+  // Centred in the column: the infrastructure view is a stack of boxes narrower
+  // than the page, which would otherwise sit against the left edge.
+  const offset = containerWidth
+    ? Math.max(0, (containerWidth - layout.width * scale) / 2)
+    : 0;
 
   const [copied, setCopied] = useState(false);
   useEffect(() => {
@@ -142,10 +237,12 @@ export const EmbeddedGraph = ({
   }, [copied]);
 
   // Unannotated: the script is only ever copied, never shown, so it hands over
-  // commands that paste straight into a shell.
+  // commands that paste straight into a shell. Only a preset has one — a single
+  // project's diagram is drawn from a blueprint, which may be a generator the
+  // scaffold catalogue knows nothing about.
   const script = useMemo(
-    () => (graph ? toScript(graph, options, { skipWorkspace }) : ''),
-    [graph, options, skipWorkspace],
+    () => (graph && preset ? toScript(graph, options, { skipWorkspace }) : ''),
+    [graph, preset, options, skipWorkspace],
   );
 
   const copy = async () => {
@@ -163,142 +260,171 @@ export const EmbeddedGraph = ({
 
   const nodeById = new Map(graph.nodes.map((node) => [node.id, node]));
 
+  const summary =
+    view === 'infrastructure' && infrastructure
+      ? `${infrastructure.resourceCount} AWS resource${
+          infrastructure.resourceCount === 1 ? '' : 's'
+        }, ${infrastructure.connectionCount} connection${
+          infrastructure.connectionCount === 1 ? '' : 's'
+        }`
+      : graph.nodes.length === 1
+        ? '1 project'
+        : `${graph.nodes.length} projects and components, ${
+            graph.edges.length
+          } connection${graph.edges.length === 1 ? '' : 's'}`;
+
   return (
     <div className="gb-root gb-embed" data-graph-builder>
       <div className="gb-embed-bar">
-        <span className="gb-embed-hint">
-          {graph.nodes.length} project
-          {graph.nodes.length === 1 ? '' : 's'} and components,{' '}
-          {graph.edges.length} connection{graph.edges.length === 1 ? '' : 's'}
-        </span>
-        <button
-          type="button"
-          className={`gb-copy-btn${copied ? ' is-copied' : ''}`}
-          onClick={copy}
-        >
-          <svg
-            className="gb-copy-icon gb-copy-icon--copy"
-            viewBox="0 0 24 24"
-            aria-hidden="true"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
+        <span className="gb-embed-hint">{summary}</span>
+        {preset && copyable && (
+          <button
+            type="button"
+            className={`gb-copy-btn${copied ? ' is-copied' : ''}`}
+            onClick={copy}
           >
-            <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
-            <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
-          </svg>
-          <svg
-            className="gb-copy-icon gb-copy-icon--check"
-            viewBox="0 0 24 24"
-            aria-hidden="true"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2.5"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          >
-            <polyline points="20 6 9 17 4 12" />
-          </svg>
-          <span>{copied ? 'Copied' : 'Copy commands'}</span>
-        </button>
+            <svg
+              className="gb-copy-icon gb-copy-icon--copy"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+              <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+            </svg>
+            <svg
+              className="gb-copy-icon gb-copy-icon--check"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <polyline points="20 6 9 17 4 12" />
+            </svg>
+            <span>{copied ? 'Copied' : 'Copy commands'}</span>
+          </button>
+        )}
       </div>
 
       <div
         ref={containerRef}
         className="gb-embed-canvas"
-        style={{ height: layout.height * scale }}
+        style={{ height: layout.height * scale + TOGGLE_ROOM }}
       >
+        {/* One project has only its own architecture to show, so the guide
+            diagrams say which view this is rather than offering the other. */}
+        {single ? (
+          <ViewMark view={view} />
+        ) : (
+          <ViewToggle view={view} onChange={setView} />
+        )}
+
         <div
           className="gb-embed-extent"
           style={{
+            top: TOGGLE_ROOM,
+            left: offset,
             width: layout.width,
             height: layout.height,
             transform: `scale(${scale})`,
           }}
         >
-          <svg
-            className="gb-edges"
-            width={layout.width}
-            height={layout.height}
-            aria-hidden="true"
-          >
-            <defs>
-              <marker
-                id="gb-embed-arrow"
-                viewBox="0 0 10 10"
-                refX="9"
-                refY="5"
-                markerWidth="5"
-                markerHeight="5"
-                markerUnits="strokeWidth"
-                orient="auto-start-reverse"
+          {view === 'infrastructure' && infrastructure ? (
+            <InfraDiagram layout={infrastructure} markerId={markerId} />
+          ) : (
+            <>
+              <svg
+                className="gb-edges"
+                width={layout.width}
+                height={layout.height}
+                aria-hidden="true"
               >
-                <path d="M 0 1.5 L 9 5 L 0 8.5 z" fill="context-stroke" />
-              </marker>
-            </defs>
+                <defs>
+                  <marker
+                    id={markerId}
+                    viewBox="0 0 10 10"
+                    refX="9"
+                    refY="5"
+                    markerWidth="5"
+                    markerHeight="5"
+                    markerUnits="strokeWidth"
+                    orient="auto-start-reverse"
+                  >
+                    <path d="M 0 1.5 L 9 5 L 0 8.5 z" fill="context-stroke" />
+                  </marker>
+                </defs>
 
-            {graph.edges.map((edge) => {
-              const source = nodeById.get(edge.source);
-              const target = nodeById.get(edge.target);
-              if (!source || !target) return null;
-              const isLoop = source.id === target.id;
-              const path = isLoop
-                ? loopPath(source, orientation)
-                : edgePath(
-                    sourceAnchor(source, orientation),
-                    targetAnchor(target, orientation),
-                    orientation,
+                {graph.edges.map((edge) => {
+                  const source = nodeById.get(edge.source);
+                  const target = nodeById.get(edge.target);
+                  if (!source || !target) return null;
+                  const isLoop = source.id === target.id;
+                  const path = isLoop
+                    ? loopPath(source, orientation)
+                    : edgePath(
+                        sourceAnchor(source, orientation),
+                        targetAnchor(target, orientation),
+                        orientation,
+                      );
+                  return (
+                    <g key={edge.id} className="gb-edge">
+                      <path
+                        className="gb-edge-line"
+                        d={path}
+                        markerEnd={`url(#${markerId})`}
+                      />
+                    </g>
                   );
-              return (
-                <g key={edge.id} className="gb-edge">
-                  <path
-                    className="gb-edge-line"
-                    d={path}
-                    markerEnd="url(#gb-embed-arrow)"
-                  />
-                </g>
-              );
-            })}
-          </svg>
+                })}
+              </svg>
 
-          {graph.nodes.map((node) => {
-            const type = nodeType(node.type);
-            return (
-              <div
-                key={node.id}
-                className="gb-node gb-node--static"
-                style={{ left: node.x, top: node.y }}
-              >
-                <NodeLogo
-                  logo={type.logo}
-                  badge={type.badge}
-                  alt={type.label}
-                />
-                <span className="gb-node-text">
-                  <span className="gb-node-name">{node.name}</span>
-                  <span className="gb-node-type">{type.label}</span>
-                </span>
+              {graph.nodes.map((node) => {
+                const type = nodeType(node.type);
+                return (
+                  <div
+                    key={node.id}
+                    className="gb-node gb-node--static"
+                    style={{ left: node.x, top: node.y }}
+                  >
+                    <NodeLogo
+                      logo={type.logo}
+                      badge={type.badge}
+                      alt={type.label}
+                    />
+                    <span className="gb-node-text">
+                      <span className="gb-node-name">{node.name}</span>
+                      <span className="gb-node-type">{type.label}</span>
+                    </span>
 
-                {type.roles.includes('target') && (
-                  <span
-                    className={`gb-port gb-port--in gb-port--in-${orientation}`}
-                    aria-hidden="true"
-                  />
-                )}
-                {type.roles.includes('source') && (
-                  <span
-                    className={`gb-port gb-port--out gb-port--out-${orientation}`}
-                    aria-hidden="true"
-                  />
-                )}
-              </div>
-            );
-          })}
+                    {type.roles.includes('target') && (
+                      <span
+                        className={`gb-port gb-port--in gb-port--in-${orientation}`}
+                        aria-hidden="true"
+                      />
+                    )}
+                    {type.roles.includes('source') && (
+                      <span
+                        className={`gb-port gb-port--out gb-port--out-${orientation}`}
+                        aria-hidden="true"
+                      />
+                    )}
+                  </div>
+                );
+              })}
+            </>
+          )}
         </div>
 
-        <IacMark iac={iac} />
+        {/* Which provider declares the infrastructure says nothing about what it
+            is, so a single project's architecture leaves the mark off. */}
+        {!single && <IacMark iac={iac} />}
       </div>
     </div>
   );

--- a/docs/src/components/graph-builder/geometry.ts
+++ b/docs/src/components/graph-builder/geometry.ts
@@ -90,6 +90,71 @@ export const loopPath = (
   return `M ${from.x} ${from.y} C ${from.x + 90} ${from.y - 70}, ${to.x - 90} ${to.y - 70}, ${to.x} ${to.y}`;
 };
 
+export interface Rect extends Point {
+  width: number;
+  height: number;
+}
+
+const centre = (rect: Rect): Point => ({
+  x: rect.x + rect.width / 2,
+  y: rect.y + rect.height / 2,
+});
+
+/**
+ * A bezier between two boxes, leaving and entering on the sides that face each
+ * other, aimed at a rectangle inside each.
+ *
+ * The infrastructure view uses this to join a resource in one project's box to a
+ * resource in another's: the line starts on the box's border rather than at the
+ * resource, so it travels the gap between boxes instead of crossing over their
+ * contents, while still lining up with the resources it connects.
+ *
+ * Side to side that means the resource's own height, so the line runs level with
+ * what it connects. Stacked, boxes are wide and their resources sit anywhere
+ * along them, so the line drops from the middle of one box to the middle of the
+ * next rather than leaning across to a resource's column.
+ */
+export const boxPath = (
+  from: { box: Rect; resource: Rect },
+  to: { box: Rect; resource: Rect },
+): string => {
+  const delta = {
+    x: centre(to.box).x - centre(from.box).x,
+    y: centre(to.box).y - centre(from.box).y,
+  };
+  const sideways = Math.abs(delta.x) >= Math.abs(delta.y);
+  const forward = (sideways ? delta.x : delta.y) >= 0;
+
+  const start = sideways
+    ? {
+        x: forward ? from.box.x + from.box.width : from.box.x,
+        y: centre(from.resource).y,
+      }
+    : {
+        x: centre(from.box).x,
+        y: forward ? from.box.y + from.box.height : from.box.y,
+      };
+  const end = sideways
+    ? {
+        x: forward ? to.box.x : to.box.x + to.box.width,
+        y: centre(to.resource).y,
+      }
+    : {
+        x: centre(to.box).x,
+        y: forward ? to.box.y : to.box.y + to.box.height,
+      };
+
+  const span = sideways ? Math.abs(end.x - start.x) : Math.abs(end.y - start.y);
+  const curve = Math.max(24, Math.min(span * 0.5, 110)) * (forward ? 1 : -1);
+  return sideways
+    ? `M ${start.x} ${start.y} C ${start.x + curve} ${start.y}, ${end.x - curve} ${end.y}, ${end.x} ${end.y}`
+    : `M ${start.x} ${start.y} C ${start.x} ${start.y + curve}, ${end.x} ${end.y - curve}, ${end.x} ${end.y}`;
+};
+
+/** A bezier between two rectangles, meeting the sides that face each other. */
+export const rectPath = (from: Rect, to: Rect): string =>
+  boxPath({ box: from, resource: from }, { box: to, resource: to });
+
 /** Where a self-edge's delete affordance sits, clear of the node it loops around. */
 export const loopMidpoint = (
   node: Point,

--- a/docs/src/components/graph-builder/infra-diagram.tsx
+++ b/docs/src/components/graph-builder/infra-diagram.tsx
@@ -1,0 +1,181 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import type { InfraLayout } from '../../lib/graph-builder/infrastructure';
+import { AwsIcon } from './aws-icon';
+import { boxPath, rectPath } from './geometry';
+
+interface Props {
+  layout: InfraLayout;
+  /** Unique per diagram, so pages holding several keep their own arrowhead. */
+  markerId: string;
+  /** Graph node and edge ids not yet scaffolded, drawn as still to come. */
+  planned?: ReadonlySet<string>;
+  /** Ids the command that just ran scaffolded, drawn arriving. */
+  arriving?: ReadonlySet<string>;
+  /** Ids to highlight; anything else reads dimmed while some id is lit. */
+  lit?: ReadonlySet<string>;
+  onFocus?: (focus: { nodeId?: string; edgeId?: string } | undefined) => void;
+  /**
+   * The classes the host draws its own connections with, so the arrows between
+   * projects read the same as the ones in the projects view — the showcase's
+   * travel their dashes, a docs page's sit still.
+   */
+  edgeClassName?: string;
+  lineClassName?: string;
+}
+
+/**
+ * The AWS infrastructure view: one box per project, holding the resources its
+ * generator provisions and the connections between them, with the projects'
+ * connections running box to box.
+ *
+ * Rendered into whatever extent its host positions and scales — the read-only
+ * embedded graph and the homepage showcase both hand their own canvas over — so
+ * this is only the diagram itself.
+ */
+export const InfraDiagram = ({
+  layout,
+  markerId,
+  planned,
+  arriving,
+  lit,
+  onFocus,
+  edgeClassName = '',
+  lineClassName = '',
+}: Props) => {
+  const state = (id: string | undefined) =>
+    id === undefined
+      ? ''
+      : `${planned?.has(id) ? ' is-planned' : ''}${
+          arriving?.has(id) ? ' is-arriving' : ''
+        }${lit?.has(id) ? ' is-lit' : ''}${
+          lit && lit.size > 0 && !lit.has(id) ? ' is-dimmed' : ''
+        }`;
+
+  return (
+    <>
+      <svg
+        className="gb-edges"
+        width={layout.width}
+        height={layout.height}
+        aria-hidden="true"
+      >
+        <defs>
+          <marker
+            id={markerId}
+            viewBox="0 0 10 10"
+            refX="9"
+            refY="5"
+            markerWidth="5"
+            markerHeight="5"
+            markerUnits="strokeWidth"
+            orient="auto-start-reverse"
+          >
+            <path d="M 0 1.5 L 9 5 L 0 8.5 z" fill="context-stroke" />
+          </marker>
+        </defs>
+
+        {layout.connections.map((connection) => {
+          const path = boxPath(connection.from, connection.to);
+          return (
+            <g
+              key={connection.id}
+              className={`gb-edge ${edgeClassName}${state(connection.edgeId)}`}
+              onPointerEnter={
+                connection.edgeId
+                  ? () => onFocus?.({ edgeId: connection.edgeId })
+                  : undefined
+              }
+              onPointerLeave={
+                connection.edgeId ? () => onFocus?.(undefined) : undefined
+              }
+            >
+              {/* A connection is a thin line to hit, so pointing at it is picked
+                  up by a wider invisible path over the top. */}
+              {onFocus && <path className="gb-edge-hit" d={path} />}
+              <path
+                className={`gb-edge-line ${lineClassName}`}
+                d={path}
+                markerEnd={`url(#${markerId})`}
+              />
+            </g>
+          );
+        })}
+      </svg>
+
+      {layout.boxes.map((box) => (
+        <div
+          key={box.id}
+          className={`gb-infra-box${box.bare ? ' gb-infra-box--bare' : ''}${state(
+            box.nodeId,
+          )}`}
+          style={{
+            left: box.x,
+            top: box.y,
+            width: box.width,
+            height: box.height,
+          }}
+          onPointerEnter={
+            box.nodeId ? () => onFocus?.({ nodeId: box.nodeId }) : undefined
+          }
+          onPointerLeave={box.nodeId ? () => onFocus?.(undefined) : undefined}
+        >
+          {!box.bare && (
+            <span className="gb-infra-box-head">
+              <span className="gb-infra-box-name">{box.name}</span>
+              <span className="gb-infra-box-type">{box.typeLabel}</span>
+            </span>
+          )}
+
+          {box.links.length > 0 && (
+            <svg
+              className="gb-edges"
+              width={box.width}
+              height={box.height}
+              aria-hidden="true"
+            >
+              {/* A project's own plumbing: the same arrow, drawn a little
+                  smaller, and solid whatever the host's connections do. */}
+              {box.links.map((link) => (
+                <g key={link.id} className="gb-edge gb-edge--internal">
+                  <path
+                    className="gb-edge-line"
+                    d={rectPath(link.from, link.to)}
+                    markerEnd={`url(#${markerId})`}
+                  />
+                </g>
+              ))}
+            </svg>
+          )}
+
+          {box.resources.map((resource) => (
+            <div
+              key={resource.id}
+              className={`gb-infra-res${
+                resource.icon ? '' : ' gb-infra-res--plain'
+              }`}
+              style={{
+                left: resource.x,
+                top: resource.y,
+                width: resource.width,
+                height: resource.height,
+              }}
+            >
+              {resource.icon && (
+                <AwsIcon icon={resource.icon} alt={resource.label} />
+              )}
+              <span className="gb-infra-res-label">{resource.label}</span>
+              {resource.detail && (
+                <span className="gb-infra-res-detail">{resource.detail}</span>
+              )}
+            </div>
+          ))}
+        </div>
+      ))}
+    </>
+  );
+};
+
+export default InfraDiagram;

--- a/docs/src/components/graph-builder/preset-showcase.tsx
+++ b/docs/src/components/graph-builder/preset-showcase.tsx
@@ -13,6 +13,10 @@ import {
 import { nodeType } from '../../lib/graph-builder/catalog';
 import type { EmitOptions, ScriptLine } from '../../lib/graph-builder/commands';
 import { toScript, toScriptLines } from '../../lib/graph-builder/commands';
+import {
+  buildInfrastructureLayout,
+  type InfraLayout,
+} from '../../lib/graph-builder/infrastructure';
 import type { Graph } from '../../lib/graph-builder/model';
 import type { CommandFocus } from './command-list';
 import { FLOW_PHASES, FlowSteps } from './flow-steps';
@@ -25,6 +29,7 @@ import {
   targetAnchor,
 } from './geometry';
 import { type Iac, IacMark } from './iac-mark';
+import { InfraDiagram } from './infra-diagram';
 import { NodeLogo } from './node-logo';
 import {
   buildPresetGraph,
@@ -32,6 +37,7 @@ import {
   type Preset,
   SHOWCASE_PRESET_IDS,
 } from './presets';
+import { type DiagramView, ViewToggle } from './view-toggle';
 
 /** Where the grid starts, and the spacing between its cells on each axis. */
 const ORIGIN = 24;
@@ -39,6 +45,8 @@ const X_GAP = NODE_WIDTH + 90;
 const Y_GAP = NODE_HEIGHT + 60;
 /** Padding kept around the diagram inside its panel. */
 const PADDING = 24;
+/** Room left at the top of the canvas for the view switch, clear of the diagram. */
+const TOGGLE_ROOM = 40;
 
 /** How fast the assistant is shown typing, and running what it writes. */
 const TYPE_MS = 26;
@@ -57,6 +65,8 @@ interface Stage {
   /** The diagram's natural size, before it is scaled to the panel. */
   readonly width: number;
   readonly height: number;
+  /** The same workspace as the AWS infrastructure it deploys. */
+  readonly infrastructure: InfraLayout;
 }
 
 /**
@@ -76,8 +86,20 @@ const toStage = (preset: Preset): Stage => {
     graph,
     width: Math.max(...nodes.map((node) => node.x + NODE_WIDTH)) + PADDING,
     height: Math.max(...nodes.map((node) => node.y + NODE_HEIGHT)) + PADDING,
+    // The showcase panel is as wide as the landing page, so its boxes flow the
+    // same way across as the projects they were built from.
+    infrastructure: buildInfrastructureLayout(graph, {
+      from: 'horizontal',
+      flow: 'horizontal',
+    }),
   };
 };
+
+/** The size of a stage's diagram in the view being shown. */
+const sizeOf = (stage: Stage, view: DiagramView) =>
+  view === 'infrastructure'
+    ? { width: stage.infrastructure.width, height: stage.infrastructure.height }
+    : { width: stage.width, height: stage.height };
 
 interface Props {
   /** The graph builder page, which each example can be opened in to edit. */
@@ -118,7 +140,9 @@ export const PresetShowcase = ({ builderHref }: Props) => {
   const [focus, setFocus] = useState<CommandFocus | undefined>();
   /** Set by the mark on the diagram, overriding the example's own provider. */
   const [iacOverride, setIacOverride] = useState<Iac | undefined>();
+  const [view, setView] = useState<DiagramView>('projects');
   const tabsId = useId();
+  const markerId = `${useId()}-arrow`;
   const rootRef = useRef<HTMLDivElement>(null);
   const tabsRef = useRef<HTMLDivElement>(null);
 
@@ -284,20 +308,32 @@ export const PresetShowcase = ({ builderHref }: Props) => {
   }, []);
 
   // One scale for every example, set by the widest: it fills a big panel and holds
-  // its size as the showcase cycles. Below the floor a phone scrolls the diagram
-  // sideways rather than shrinking labels past reading, and the panel stands as
-  // tall as the tallest example so its height is steady too.
+  // its size as the showcase cycles, so labels never change size between
+  // examples. Below the floor a phone scrolls the diagram sideways rather than
+  // shrinking labels past reading.
+  const size = sizeOf(stage, view);
   const scale = canvasWidth
     ? Math.min(
         MAX_SCALE,
         Math.max(
           MIN_SCALE,
-          Math.min(...stages.map((entry) => canvasWidth / entry.width)),
+          Math.min(
+            ...stages.map((entry) => canvasWidth / sizeOf(entry, view).width),
+          ),
         ),
       )
     : 1;
-  const canvasHeight = Math.max(...stages.map((entry) => entry.height * scale));
-  const fitsCanvas = !canvasWidth || stage.width * scale <= canvasWidth;
+  // Project diagrams are all much of a height, so the panel stands as tall as the
+  // tallest and holds still as the showcase cycles. Boxes of AWS resources are
+  // not: the deepest example is three times the shallowest, which would leave the
+  // small ones in a band of empty canvas, so there the panel is as tall as the
+  // example on show. The stylesheet eases the change, so it settles rather than
+  // jumps.
+  const canvasHeight =
+    view === 'infrastructure'
+      ? sizeOf(stage, view).height * scale
+      : Math.max(...stages.map((entry) => sizeOf(entry, view).height * scale));
+  const fitsCanvas = !canvasWidth || size.width * scale <= canvasWidth;
 
   /** Arrows move between the examples, Home and End jump to the ends. */
   const onTabsKeyDown = (event: React.KeyboardEvent) => {
@@ -368,6 +404,22 @@ export const PresetShowcase = ({ builderHref }: Props) => {
 
   /** How long an example holds altogether, for the fill on its tab. */
   const cycleMs = durations.reduce((total, ms) => total + ms, 0);
+
+  // The infrastructure view tells the same story from ids rather than a callback
+  // per node, so what has been scaffolded is gathered up for it.
+  const plannedIds = new Set(
+    [...graph.nodes, ...graph.edges]
+      .map((entry) => entry.id)
+      .filter((id) => isPlanned(id)),
+  );
+  const litIds = new Set([
+    ...litNodeIds,
+    ...(focus?.edgeId ? [focus.edgeId] : []),
+  ]);
+  const connections =
+    view === 'infrastructure'
+      ? stage.infrastructure.connectionCount
+      : graph.edges.length;
 
   const summary = `${graph.nodes.length} project${
     graph.nodes.length === 1 ? '' : 's'
@@ -470,12 +522,14 @@ export const PresetShowcase = ({ builderHref }: Props) => {
             </p>
             <div className="ps-panel-actions">
               <span className="ps-stat">
-                {graph.nodes.length} project
-                {graph.nodes.length === 1 ? '' : 's'}
+                {view === 'infrastructure'
+                  ? `${stage.infrastructure.resourceCount} AWS resources`
+                  : `${graph.nodes.length} project${
+                      graph.nodes.length === 1 ? '' : 's'
+                    }`}
               </span>
               <span className="ps-stat">
-                {graph.edges.length} connection
-                {graph.edges.length === 1 ? '' : 's'}
+                {connections} connection{connections === 1 ? '' : 's'}
               </span>
               <a
                 className="gb-action gb-action--primary gb-action--small"
@@ -498,22 +552,25 @@ export const PresetShowcase = ({ builderHref }: Props) => {
             </div>
           </div>
 
-          {/* The mark sits outside the scrolling canvas, so it stays pinned to
-              the corner when a wide diagram is scrolled sideways. */}
+          {/* The switch and the mark sit outside the scrolling canvas, so they
+              stay pinned to their corners when a wide diagram is scrolled
+              sideways. */}
           <div className="ps-canvas-frame">
+            <ViewToggle view={view} onChange={setView} />
             <div
               ref={canvasRef}
               className="ps-canvas"
-              style={{ height: canvasHeight }}
+              style={{ height: canvasHeight + TOGGLE_ROOM }}
             >
-              {/* Keyed on the example, so switching remounts the diagram and its
-                plan arrives again. */}
+              {/* Keyed on the example and the view, so switching remounts the
+                diagram and its plan arrives again. */}
               <div
-                key={preset.id}
+                key={`${preset.id}-${view}`}
                 className="ps-extent"
                 style={{
-                  width: stage.width,
-                  height: stage.height,
+                  top: TOGGLE_ROOM,
+                  width: size.width,
+                  height: size.height,
                   // Centred across the panel while it fits; pinned to the left once
                   // it doesn't, so the overflow is somewhere the canvas can scroll.
                   ...(fitsCanvas
@@ -527,109 +584,127 @@ export const PresetShowcase = ({ builderHref }: Props) => {
                         transform: `scale(${scale})`,
                       }),
                   // Centred in the panel, which is as tall as the tallest example.
-                  marginTop: (canvasHeight - stage.height * scale) / 2,
+                  marginTop: (canvasHeight - size.height * scale) / 2,
                 }}
               >
-                <svg
-                  className="gb-edges"
-                  width={stage.width}
-                  height={stage.height}
-                  aria-hidden="true"
-                >
-                  <defs>
-                    <marker
-                      id="ps-arrow"
-                      viewBox="0 0 10 10"
-                      refX="9"
-                      refY="5"
-                      markerWidth="5"
-                      markerHeight="5"
-                      markerUnits="strokeWidth"
-                      orient="auto-start-reverse"
+                {view === 'infrastructure' ? (
+                  <InfraDiagram
+                    layout={stage.infrastructure}
+                    markerId={markerId}
+                    planned={plannedIds}
+                    arriving={arriving}
+                    lit={litIds}
+                    onFocus={setFocus}
+                    edgeClassName="ps-edge"
+                    lineClassName="ps-edge-line"
+                  />
+                ) : (
+                  <>
+                    <svg
+                      className="gb-edges"
+                      width={size.width}
+                      height={size.height}
+                      aria-hidden="true"
                     >
-                      <path d="M 0 1.5 L 9 5 L 0 8.5 z" fill="context-stroke" />
-                    </marker>
-                  </defs>
+                      <defs>
+                        <marker
+                          id="ps-arrow"
+                          viewBox="0 0 10 10"
+                          refX="9"
+                          refY="5"
+                          markerWidth="5"
+                          markerHeight="5"
+                          markerUnits="strokeWidth"
+                          orient="auto-start-reverse"
+                        >
+                          <path
+                            d="M 0 1.5 L 9 5 L 0 8.5 z"
+                            fill="context-stroke"
+                          />
+                        </marker>
+                      </defs>
 
-                  {graph.edges.map((edge) => {
-                    const source = nodeById.get(edge.source);
-                    const target = nodeById.get(edge.target);
-                    if (!source || !target) return null;
-                    const path =
-                      source.id === target.id
-                        ? loopPath(source, 'horizontal')
-                        : edgePath(
-                            sourceAnchor(source, 'horizontal'),
-                            targetAnchor(target, 'horizontal'),
-                            'horizontal',
-                          );
-                    const isLit = focus?.edgeId === edge.id;
-                    return (
-                      <g
-                        key={edge.id}
-                        className={`gb-edge ps-edge${isLit ? ' is-active' : ''}${
-                          focus && !isLit ? ' is-dimmed' : ''
-                        }${isPlanned(edge.id) ? ' is-planned' : ''}${
-                          arriving?.has(edge.id) ? ' is-arriving' : ''
-                        }`}
-                        onPointerEnter={() => setFocus({ edgeId: edge.id })}
-                        onPointerLeave={() => setFocus(undefined)}
-                      >
-                        {/* A connection is a thin line to hit, so pointing at it is
+                      {graph.edges.map((edge) => {
+                        const source = nodeById.get(edge.source);
+                        const target = nodeById.get(edge.target);
+                        if (!source || !target) return null;
+                        const path =
+                          source.id === target.id
+                            ? loopPath(source, 'horizontal')
+                            : edgePath(
+                                sourceAnchor(source, 'horizontal'),
+                                targetAnchor(target, 'horizontal'),
+                                'horizontal',
+                              );
+                        const isLit = focus?.edgeId === edge.id;
+                        return (
+                          <g
+                            key={edge.id}
+                            className={`gb-edge ps-edge${isLit ? ' is-active' : ''}${
+                              focus && !isLit ? ' is-dimmed' : ''
+                            }${isPlanned(edge.id) ? ' is-planned' : ''}${
+                              arriving?.has(edge.id) ? ' is-arriving' : ''
+                            }`}
+                            onPointerEnter={() => setFocus({ edgeId: edge.id })}
+                            onPointerLeave={() => setFocus(undefined)}
+                          >
+                            {/* A connection is a thin line to hit, so pointing at it is
                           picked up by a wider invisible path over the top. */}
-                        <path className="gb-edge-hit" d={path} />
-                        {/* Dashes travelling the path, so a connection reads as a
+                            <path className="gb-edge-hit" d={path} />
+                            {/* Dashes travelling the path, so a connection reads as a
                           direction of flow. */}
-                        <path
-                          className="gb-edge-line ps-edge-line"
-                          d={path}
-                          markerEnd="url(#ps-arrow)"
-                        />
-                      </g>
-                    );
-                  })}
-                </svg>
+                            <path
+                              className="gb-edge-line ps-edge-line"
+                              d={path}
+                              markerEnd="url(#ps-arrow)"
+                            />
+                          </g>
+                        );
+                      })}
+                    </svg>
 
-                {graph.nodes.map((node) => {
-                  const type = nodeType(node.type);
-                  const isLit = litNodeIds.has(node.id);
-                  return (
-                    <div
-                      key={node.id}
-                      className={`gb-node gb-node--static ps-node${
-                        isLit ? ' is-lit' : ''
-                      }${focus && !isLit ? ' is-dimmed' : ''}${
-                        isPlanned(node.id) ? ' is-planned' : ''
-                      }${arriving?.has(node.id) ? ' is-arriving' : ''}`}
-                      style={{ left: node.x, top: node.y }}
-                      onPointerEnter={() => setFocus({ nodeId: node.id })}
-                      onPointerLeave={() => setFocus(undefined)}
-                    >
-                      <NodeLogo
-                        logo={type.logo}
-                        badge={type.badge}
-                        alt={type.label}
-                      />
-                      <span className="gb-node-text">
-                        <span className="gb-node-name">{node.name}</span>
-                        <span className="gb-node-type">{type.label}</span>
-                      </span>
+                    {graph.nodes.map((node) => {
+                      const type = nodeType(node.type);
+                      const isLit = litNodeIds.has(node.id);
+                      return (
+                        <div
+                          key={node.id}
+                          className={`gb-node gb-node--static ps-node${
+                            isLit ? ' is-lit' : ''
+                          }${focus && !isLit ? ' is-dimmed' : ''}${
+                            isPlanned(node.id) ? ' is-planned' : ''
+                          }${arriving?.has(node.id) ? ' is-arriving' : ''}`}
+                          style={{ left: node.x, top: node.y }}
+                          onPointerEnter={() => setFocus({ nodeId: node.id })}
+                          onPointerLeave={() => setFocus(undefined)}
+                        >
+                          <NodeLogo
+                            logo={type.logo}
+                            badge={type.badge}
+                            alt={type.label}
+                          />
+                          <span className="gb-node-text">
+                            <span className="gb-node-name">{node.name}</span>
+                            <span className="gb-node-type">{type.label}</span>
+                          </span>
 
-                      {type.roles.includes('target') && (
-                        <span
-                          className="gb-port gb-port--in gb-port--in-horizontal"
-                          aria-hidden="true"
-                        />
-                      )}
-                      {type.roles.includes('source') && (
-                        <span
-                          className="gb-port gb-port--out gb-port--out-horizontal"
-                          aria-hidden="true"
-                        />
-                      )}
-                    </div>
-                  );
-                })}
+                          {type.roles.includes('target') && (
+                            <span
+                              className="gb-port gb-port--in gb-port--in-horizontal"
+                              aria-hidden="true"
+                            />
+                          )}
+                          {type.roles.includes('source') && (
+                            <span
+                              className="gb-port gb-port--out gb-port--out-horizontal"
+                              aria-hidden="true"
+                            />
+                          )}
+                        </div>
+                      );
+                    })}
+                  </>
+                )}
               </div>
             </div>
             <IacMark iac={iac} onSwitch={setIacOverride} />

--- a/docs/src/components/graph-builder/use-page-options.ts
+++ b/docs/src/components/graph-builder/use-page-options.ts
@@ -1,0 +1,42 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { useEffect, useState } from 'react';
+
+/**
+ * The generator option values the page's filter bar has selected.
+ *
+ * A guide's diagram is not itself configurable — the reader picks option values
+ * once, in the filter bar at the top of the page, and every part of the guide
+ * follows. The bar publishes its selection on the element itself and announces
+ * each change, so a diagram redraws with the architecture those options deploy.
+ *
+ * Pages without a filter bar simply never see a selection.
+ */
+export const usePageOptions = (
+  enabled: boolean,
+): Readonly<Record<string, string>> => {
+  const [selected, setSelected] = useState<Readonly<Record<string, string>>>(
+    {},
+  );
+
+  useEffect(() => {
+    if (!enabled) return;
+    const bar = document.querySelector<HTMLElement>('[data-option-filter-bar]');
+    if (bar?.dataset.selection) {
+      try {
+        setSelected(JSON.parse(bar.dataset.selection));
+      } catch {
+        // A malformed selection is nothing to act on; the next change re-reads it.
+      }
+    }
+    const onChange = (event: Event) =>
+      setSelected((event as CustomEvent<Record<string, string>>).detail ?? {});
+    document.addEventListener('npfa:option-filter-change', onChange);
+    return () =>
+      document.removeEventListener('npfa:option-filter-change', onChange);
+  }, [enabled]);
+
+  return selected;
+};

--- a/docs/src/components/graph-builder/view-toggle.tsx
+++ b/docs/src/components/graph-builder/view-toggle.tsx
@@ -1,0 +1,96 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/** Which diagram a read-only graph is showing. */
+export type DiagramView = 'projects' | 'infrastructure';
+
+const PROJECTS_ICON = (
+  <svg
+    viewBox="0 0 24 24"
+    aria-hidden="true"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.8"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <rect x="2.5" y="9" width="6" height="6" rx="1.5" />
+    <rect x="15.5" y="3.5" width="6" height="6" rx="1.5" />
+    <rect x="15.5" y="14.5" width="6" height="6" rx="1.5" />
+    <path d="M8.5 12h3.5M12 12V6.5h3.5M12 12v5.5h3.5" />
+  </svg>
+);
+
+const AWS_ICON = (
+  <svg
+    viewBox="0 0 24 24"
+    aria-hidden="true"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.8"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M6.5 18.5h11a3.75 3.75 0 0 0 .4-7.48 5.5 5.5 0 0 0-10.6-1.4A3.8 3.8 0 0 0 6.5 18.5Z" />
+    <path d="M9.5 21.5c2.5 1.3 6.5 1.3 9 0" />
+  </svg>
+);
+
+interface Props {
+  view: DiagramView;
+  onChange: (view: DiagramView) => void;
+}
+
+/**
+ * The switch between the two ways of reading the same graph: the projects a
+ * workspace holds, and the AWS infrastructure they deploy.
+ *
+ * Sits in the top left of the diagram it belongs to, showing both options at once
+ * so the other view is visible rather than something to be discovered.
+ */
+export const ViewToggle = ({ view, onChange }: Props) => (
+  <div className="gb-view-toggle">
+    <button
+      type="button"
+      className={`gb-view-toggle-btn${view === 'projects' ? ' is-active' : ''}`}
+      aria-pressed={view === 'projects'}
+      aria-label="Show the projects in the workspace"
+      title="Show the projects in the workspace"
+      onClick={() => onChange('projects')}
+    >
+      {PROJECTS_ICON}
+      <span>Projects</span>
+    </button>
+    <button
+      type="button"
+      className={`gb-view-toggle-btn${
+        view === 'infrastructure' ? ' is-active' : ''
+      }`}
+      aria-pressed={view === 'infrastructure'}
+      aria-label="Show the AWS infrastructure the projects deploy"
+      title="Show the AWS infrastructure the projects deploy"
+      onClick={() => onChange('infrastructure')}
+    >
+      {AWS_ICON}
+      <span>AWS</span>
+    </button>
+  </div>
+);
+
+/**
+ * The same pill, saying which diagram this is, where there is nothing to switch
+ * to — a guide's architecture diagram is one project's AWS infrastructure and
+ * nothing else.
+ */
+export const ViewMark = ({ view }: { view: DiagramView }) => (
+  <div className="gb-view-toggle gb-view-toggle--static">
+    <span className="gb-view-toggle-btn is-active">
+      {view === 'projects' ? PROJECTS_ICON : AWS_ICON}
+      <span>{view === 'projects' ? 'Projects' : 'AWS'}</span>
+    </span>
+  </div>
+);
+
+export default ViewToggle;

--- a/docs/src/components/option-filter-bar.astro
+++ b/docs/src/components/option-filter-bar.astro
@@ -504,6 +504,13 @@ const ANY_LABEL = 'Any';
 
     const apply = () => {
       const selected = currentFilters();
+      // Published for anything on the page that renders from the selection
+      // rather than being shown or hidden by it — the architecture diagram draws
+      // the infrastructure the selected options deploy.
+      bar.dataset.selection = JSON.stringify(selected);
+      document.dispatchEvent(
+        new CustomEvent('npfa:option-filter-change', { detail: selected }),
+      );
       const blocks = document.querySelectorAll<HTMLElement>('.option-filter');
       const hiddenIds = new Set<string>();
       for (const block of blocks) {

--- a/docs/src/content/docs/en/get_started/tutorials/dungeon-game/overview.mdx
+++ b/docs/src/content/docs/en/get_started/tutorials/dungeon-game/overview.mdx
@@ -16,6 +16,7 @@ import baselineGamePng from '@assets/baseline-game.png'
 import nxGraphPng from '@assets/nx-graph.png'
 import gameSelectPng from '@assets/game-select.png'
 import gameConversationPng from '@assets/game-conversation.png'
+import EmbeddedGraph from '@components/embedded-graph.astro';
 
 
 Using this tutorial, you will build an Agentic AI-powered dungeon adventure game with `@aws/nx-plugin`. This tutorial does not assume any existing knowledge of the `@aws/nx-plugin` or related technologies. 
@@ -51,76 +52,9 @@ The game interface will resemble something like this diagram:
 
 ### Application architecture
 
-The Agentic AI-powered dungeon adventure game is built using the following architecture:
+The Agentic AI-powered dungeon adventure game is built using the following architecture — switch to **Projects** to see the workspace it is built from, which you scaffold in Module 1:
 
-```d2 inline=true
-direction: down
-
-browser: Web Browser {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
-
-cognito: Cognito / IAM {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cognito.svg
-}
-
-cloudfront: CloudFront {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cloudfront.svg
-}
-
-s3: Static Assets\n(S3) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/s3.svg
-}
-
-apigw: API Gateway\n(Game API) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/api-gateway.svg
-}
-
-lambda: tRPC API\n(Lambda) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/lambda.svg
-}
-
-story: Story Agent\n(AgentCore) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/bedrock-agentcore-runtime.svg
-}
-
-mcp: Inventory MCP\n(AgentCore) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/bedrock-agentcore-runtime.svg
-}
-
-ddb: Game State\n(DynamoDB) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/dynamodb.svg
-}
-
-sessions: Story Sessions\n(S3) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/s3.svg
-}
-
-browser -> cognito: Sign in
-browser -> cloudfront
-cloudfront -> s3
-browser -> apigw
-apigw -> lambda
-lambda -> ddb
-lambda -> sessions: Read transcripts
-browser -> story: AG-UI stream
-story -> sessions: Persist turns
-story -> mcp: Tool calls
-mcp -> ddb
-ddb -> sessions: {
-  style.opacity: 0
-}
-```
+<EmbeddedGraph preset="dungeon-adventure" workspace="dungeon-adventure" iac="cdk" view="infrastructure" copyable={false} />
 
 - React/Vite frontend website utilising:
   - Amazon Cognito/Identity Pools for secure API calls.

--- a/docs/src/content/docs/en/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/en/guides/agentcore-gateway.mdx
@@ -14,6 +14,7 @@ import Snippet from '@components/snippet.astro';
 import Link from '@components/link.astro';
 import NxCommands from '@components/nx-commands.astro';
 import OptionFilter from '@components/option-filter.astro';
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
 Generate an [Amazon Bedrock AgentCore Gateway](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/gateway.html) project. An AgentCore Gateway is a managed entry point in front of your MCP servers or agents, authenticating inbound requests (IAM or Cognito) and signing outbound traffic to its targets with IAM SigV4.
 
@@ -89,32 +90,7 @@ The Gateway URL is automatically registered in the `agentcore.gateways.<ClassNam
 
 The deployed Gateway has the following architecture, with an [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACL in front of the Gateway, which routes on to its downstream MCP server targets:
 
-```d2 inline=true
-direction: right
-
-client: Client {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
-
-waf: WAF {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/waf.svg
-}
-
-gateway: AgentCore Gateway\n(MCP, IAM or Cognito auth) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/bedrock-agentcore-gateway.svg
-}
-
-targets: Downstream MCP Servers\n(Gateway targets) {
-  shape: rectangle
-}
-
-client -> waf
-waf -> gateway
-gateway -> targets
-```
+<ArchitectureDiagram />
 
 ## Authentication
 

--- a/docs/src/content/docs/en/guides/py-dynamodb.mdx
+++ b/docs/src/content/docs/en/guides/py-dynamodb.mdx
@@ -11,6 +11,7 @@ import Link from '@components/link.astro';
 import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import Snippet from '@components/snippet.astro';
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
 This generator creates a new Python project backed by [Amazon DynamoDB](https://aws.amazon.com/dynamodb/), using [PynamoDB](https://pynamodb.readthedocs.io/) for entity modelling. It generates the application code and infrastructure needed to provision and manage a DynamoDB table using AWS CDK or Terraform, with single-table design support and built-in local development via DynamoDB Local.
 
@@ -52,6 +53,12 @@ The local development scripts are shared across all DynamoDB projects (both Type
 ### Infrastructure
 
 <Snippet name="dynamodb/infrastructure" />
+
+#### Architecture
+
+The deployed project provisions the table itself, which any project it is connected to reads and writes:
+
+<ArchitectureDiagram />
 
 ## Local Development
 

--- a/docs/src/content/docs/en/guides/react-website-auth.mdx
+++ b/docs/src/content/docs/en/guides/react-website-auth.mdx
@@ -10,6 +10,7 @@ import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Infrastructure from '@components/infrastructure.astro';
 import Snippet from '@components/snippet.astro';
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
 The React Website Authentication generator adds authentication to your React website using [Amazon Cognito](https://aws.amazon.com/cognito/).
 
@@ -71,38 +72,7 @@ You will also find the following infrastructure code generated based on your sel
 
 This generator adds an Amazon Cognito user pool (for sign-in) and an identity pool (for federating signed-in users to scoped IAM credentials) to the existing static-website architecture:
 
-```d2 inline=true
-direction: right
-
-browser: Web Browser {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
-
-waf: WAF {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/waf.svg
-}
-
-cognito: Cognito\n(User + Identity Pool) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cognito.svg
-}
-
-iam: Scoped IAM\nCredentials {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/iam.svg
-}
-
-backend: Authenticated\nAWS Resources {
-  shape: rectangle
-}
-
-browser -> waf: Sign in
-waf -> cognito
-cognito -> iam
-browser -> backend: IAM/Cognito
-```
+<ArchitectureDiagram name="my-website" />
 
 #### Threat protection
 

--- a/docs/src/content/docs/en/guides/react-website.mdx
+++ b/docs/src/content/docs/en/guides/react-website.mdx
@@ -17,6 +17,7 @@ import PackageManagerShortCommand from '@components/package-manager-short-comman
 import Infrastructure from '@components/infrastructure.astro';
 import Snippet from '@components/snippet.astro';
 import OptionFilter from '@components/option-filter.astro';
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
 This generator creates a new [React](https://react.dev/) website with [shadcn/ui](https://ui.shadcn.com/) configured by default, along with the AWS CDK or Terraform infrastructure to deploy your website to the cloud as a static website hosted in [S3](https://aws.amazon.com/s3/), served by [CloudFront](https://aws.amazon.com/cloudfront/) and protected by [WAF](https://aws.amazon.com/waf/).
 
@@ -106,35 +107,9 @@ The generator creates infrastructure as code for deploying your website based on
 
 #### Architecture
 
-The deployed website has the following architecture:
+The deployed website has the following architecture: your built assets in an S3 bucket, served by a CloudFront distribution with an AWS WAFv2 Web ACL in front of it.
 
-```d2 inline=true
-direction: right
-
-browser: Web Browser {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
-
-waf: WAF {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/waf.svg
-}
-
-cloudfront: CloudFront {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cloudfront.svg
-}
-
-s3: Static Assets\n(S3) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/s3.svg
-}
-
-browser -> waf
-waf -> cloudfront
-cloudfront -> s3
-```
+<ArchitectureDiagram />
 
 ## Implementing your Website
 

--- a/docs/src/content/docs/en/guides/ts-dynamodb.mdx
+++ b/docs/src/content/docs/en/guides/ts-dynamodb.mdx
@@ -11,6 +11,7 @@ import Link from '@components/link.astro';
 import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import Snippet from '@components/snippet.astro';
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
 This generator creates a new TypeScript DynamoDB project backed by [Amazon DynamoDB](https://aws.amazon.com/dynamodb/), using [ElectroDB](https://electrodb.dev/) for type-safe entity modelling. It generates the application code and infrastructure needed to provision and manage a DynamoDB table using AWS CDK or Terraform, with single-table design support and built-in local development via DynamoDB Local.
 
@@ -52,6 +53,12 @@ The local development scripts are shared across all DynamoDB projects (both Type
 ### Infrastructure
 
 <Snippet name="dynamodb/infrastructure" />
+
+#### Architecture
+
+The deployed project provisions the table itself, which any project it is connected to reads and writes:
+
+<ArchitectureDiagram />
 
 ## Local Development
 

--- a/docs/src/content/docs/en/guides/ts-smithy-api.mdx
+++ b/docs/src/content/docs/en/guides/ts-smithy-api.mdx
@@ -20,6 +20,7 @@ import Snippet from '@components/snippet.astro';
 import OptionFilter from '@components/option-filter.astro';
 import InstallCommand from '@components/install-command.astro';
 import { TS_VERSIONS } from '../../../../../../packages/nx-plugin/src/utils/versions';
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
 [Smithy](https://smithy.io/) is a protocol-agnostic interface definition language for authoring APIs in a model driven fashion.
 
@@ -126,47 +127,7 @@ This project is generated using the <Link path="/guides/terraform-project">`terr
 
 The deployed Smithy API has the following architecture, with an [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACL in front of the API Gateway stage:
 
-```d2 inline=true
-direction: right
-
-client: Client {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
-
-waf: WAF {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/waf.svg
-}
-
-apigw: API Gateway\n(REST API) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/api-gateway.svg
-}
-
-lambda: Lambda\n(Smithy Server SDK) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/lambda.svg
-}
-
-cw: CloudWatch\n(Logs, Metrics) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cloudwatch.svg
-  near: top-right
-}
-
-xray: X-Ray\n(Traces) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/xray.svg
-  near: bottom-right
-}
-
-client -> waf
-waf -> apigw
-apigw -> lambda
-lambda -> cw
-lambda -> xray
-```
+<ArchitectureDiagram options={{ infra: 'rest-lambda' }} />
 
 ## Implementing your Smithy API
 

--- a/docs/src/content/docs/en/snippets/agent/architecture.mdx
+++ b/docs/src/content/docs/en/snippets/agent/architecture.mdx
@@ -2,71 +2,28 @@
 title: Agent Architecture
 ---
 import { Tabs, TabItem } from '@astrojs/starlight/components';
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
 <Tabs syncKey="infra">
-<TabItem label="Bedrock AgentCore Runtime" _filter={{ infra: 'agentcore' }}>
+<TabItem label="AgentCore Runtime" _filter={{ infra: 'agentcore' }}>
 
-When deployed to [Bedrock AgentCore Runtime](https://aws.amazon.com/bedrock/agentcore/), the agent is built into a container image, pushed to Amazon ECR and run in AgentCore Runtime. Clients invoke the AgentCore Runtime data plane endpoint, which forwards requests to your agent. The agent calls Amazon Bedrock for model inference and may invoke tools, MCP servers, or downstream APIs.
+When deployed to [Bedrock AgentCore Runtime](https://aws.amazon.com/bedrock/agentcore/), your agent's code is packaged as a zip and run in the AgentCore managed runtime. Clients invoke the AgentCore Runtime data plane endpoint, which forwards requests to your agent. The agent calls Amazon Bedrock for model inference and may invoke tools, MCP servers, or downstream APIs.
 
-```d2 inline=true
-direction: right
+<ArchitectureDiagram options={{ infra: 'agentcore' }} />
 
-client: Client {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
+</TabItem>
+<TabItem label="AgentCore Runtime (container)" _filter={{ infra: 'agentcore-ecr' }}>
 
-ecr: ECR {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/ecr.svg
-}
+With `infra: agentcore-ecr`, the agent is built into a container image, pushed to Amazon ECR and run in AgentCore Runtime. This gives you OS-level control over the runtime environment, at the cost of a longer build and deploy cycle than the zip packaging above.
 
-agentcore: Strands Agent\n(AgentCore Runtime) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/bedrock-agentcore-runtime.svg
-}
+<ArchitectureDiagram options={{ infra: 'agentcore-ecr' }} />
 
-bedrock: Bedrock\n(Model Inference) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/bedrock.svg
-  near: top-right
-}
-
-cw: CloudWatch\n(Logs, Metrics) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cloudwatch.svg
-  near: bottom-right
-}
-
-client -> agentcore
-ecr -> agentcore: Container\nimage
-agentcore -> bedrock: InvokeModel
-agentcore -> cw
-```
 </TabItem>
 <TabItem label="None (local only)" _filter={{ infra: 'none' }}>
 
 With `infra: none`, no AWS infrastructure is generated. The agent runs as a local process and calls Amazon Bedrock for model inference.
 
-```d2 inline=true
-direction: right
+<ArchitectureDiagram options={{ infra: 'none' }} />
 
-client: Client {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
-
-agent: Strands Agent\n(local process) {
-  shape: rectangle
-}
-
-bedrock: Bedrock\n(Model Inference) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/bedrock.svg
-}
-
-client -> agent
-agent -> bedrock: InvokeModel
-```
 </TabItem>
 </Tabs>

--- a/docs/src/content/docs/en/snippets/api/api-architecture.mdx
+++ b/docs/src/content/docs/en/snippets/api/api-architecture.mdx
@@ -2,91 +2,20 @@
 title: API Architecture
 ---
 import { Tabs, TabItem } from '@astrojs/starlight/components';
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
-The deployed application has the following architecture:
+The deployed application has the following architecture: an API Gateway API in front of a Lambda function running your handler.
 
 <Tabs syncKey="http-rest">
 <TabItem label="REST API" _filter={{ infra: 'rest-lambda' }}>
-```d2 inline=true
-direction: right
 
-client: Client {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
-
-waf: WAF {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/waf.svg
-}
-
-apigw: API Gateway\n(REST API) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/api-gateway.svg
-}
-
-lambda: Lambda {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/lambda.svg
-}
-
-cw: CloudWatch\n(Logs, Metrics) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cloudwatch.svg
-  near: top-right
-}
-
-xray: X-Ray\n(Traces) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/xray.svg
-  near: bottom-right
-}
-
-client -> waf
-waf -> apigw
-apigw -> lambda
-lambda -> cw
-lambda -> xray
-```
+<ArchitectureDiagram options={{ infra: 'rest-lambda' }} />
 
 REST APIs include an [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACL in front of the API Gateway stage with the AWS managed default ruleset enabled.
 </TabItem>
 <TabItem label="HTTP API" _filter={{ infra: 'http-lambda' }}>
-```d2 inline=true
-direction: right
 
-client: Client {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
-
-apigw: API Gateway\n(HTTP API) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/api-gateway.svg
-}
-
-lambda: Lambda {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/lambda.svg
-}
-
-cw: CloudWatch\n(Logs, Metrics) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cloudwatch.svg
-  near: top-right
-}
-
-xray: X-Ray\n(Traces) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/xray.svg
-  near: bottom-right
-}
-
-client -> apigw
-apigw -> lambda
-lambda -> cw
-lambda -> xray
-```
+<ArchitectureDiagram options={{ infra: 'http-lambda' }} />
 
 HTTP APIs do not support WAF directly — if you need WAF protection, choose REST API instead or front the HTTP API with a CloudFront distribution.
 </TabItem>

--- a/docs/src/content/docs/en/snippets/lambda-function/architecture.mdx
+++ b/docs/src/content/docs/en/snippets/lambda-function/architecture.mdx
@@ -1,36 +1,10 @@
 ---
 title: Lambda Function Architecture
 ---
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
-The deployed function has the following architecture:
+The deployed function has the following architecture, with its logs, metrics and traces going to CloudWatch and X-Ray:
 
-```d2 inline=true
-direction: right
-
-source: Event Source\n(SNS, SQS, ...) {
-  shape: rectangle
-}
-
-lambda: Lambda {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/lambda.svg
-}
-
-cw: CloudWatch\n(Logs, Metrics) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cloudwatch.svg
-  near: top-right
-}
-
-xray: X-Ray\n(Traces) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/xray.svg
-  near: bottom-right
-}
-
-source -> lambda
-lambda -> cw
-lambda -> xray
-```
+<ArchitectureDiagram name="my-function" />
 
 The generator vends the function itself; you wire the event source up in your stack to invoke it (for example, an API Gateway integration, an EventBridge rule, an S3 notification or an SQS event source mapping).

--- a/docs/src/content/docs/en/snippets/mcp/architecture.mdx
+++ b/docs/src/content/docs/en/snippets/mcp/architecture.mdx
@@ -2,57 +2,28 @@
 title: MCP Server Architecture
 ---
 import { Tabs, TabItem } from '@astrojs/starlight/components';
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
 <Tabs syncKey="infra">
-<TabItem label="Bedrock AgentCore Runtime" _filter={{ infra: 'agentcore' }}>
+<TabItem label="AgentCore Runtime" _filter={{ infra: 'agentcore' }}>
 
-When deployed to [Bedrock AgentCore Runtime](https://aws.amazon.com/bedrock/agentcore/), the MCP server is built into a container image, pushed to Amazon ECR, and run in AgentCore Runtime. AI assistants invoke the AgentCore Runtime data plane endpoint, which forwards `tools/*` and `resources/*` calls to your server over the [streamable HTTP transport](https://modelcontextprotocol.io/specification/draft/basic/transports#streamable-http).
+When deployed to [Bedrock AgentCore Runtime](https://aws.amazon.com/bedrock/agentcore/), your server's code is packaged as a zip and run in the AgentCore managed runtime. AI assistants invoke the AgentCore Runtime data plane endpoint, which forwards `tools/*` and `resources/*` calls to your server over the [streamable HTTP transport](https://modelcontextprotocol.io/specification/draft/basic/transports#streamable-http).
 
-```d2 inline=true
-direction: right
+<ArchitectureDiagram options={{ infra: 'agentcore' }} />
 
-assistant: AI Assistant {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
+</TabItem>
+<TabItem label="AgentCore Runtime (container)" _filter={{ infra: 'agentcore-ecr' }}>
 
-ecr: ECR {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/ecr.svg
-}
+With `infra: agentcore-ecr`, the MCP server is built into a container image, pushed to Amazon ECR and run in AgentCore Runtime. This gives you OS-level control over the runtime environment, at the cost of a longer build and deploy cycle than the zip packaging above.
 
-agentcore: MCP Server\n(AgentCore Runtime) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/bedrock-agentcore-runtime.svg
-}
+<ArchitectureDiagram options={{ infra: 'agentcore-ecr' }} />
 
-cw: CloudWatch\n(Logs, Metrics) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cloudwatch.svg
-}
-
-assistant -> agentcore: Streamable\nHTTP
-ecr -> agentcore: Container\nimage
-agentcore -> cw
-```
 </TabItem>
 <TabItem label="None (local only)" _filter={{ infra: 'none' }}>
 
 With `infra: none`, no AWS infrastructure is generated. The MCP server is configured for local STDIO and HTTP transports only, and is consumed by AI assistants running on the same machine.
 
-```d2 inline=true
-direction: right
+<ArchitectureDiagram options={{ infra: 'none' }} />
 
-assistant: AI Assistant {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
-
-server: MCP Server\n(local process) {
-  shape: rectangle
-}
-
-assistant -> server: STDIO\nor\nStreamable HTTP
-```
 </TabItem>
 </Tabs>

--- a/docs/src/content/docs/en/snippets/rdb/architecture.mdx
+++ b/docs/src/content/docs/en/snippets/rdb/architecture.mdx
@@ -1,39 +1,8 @@
 ---
 title: RDB Architecture
 ---
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
 The deployed database has the following architecture. By default, an [Amazon RDS Proxy](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-proxy.html) sits in front of the Aurora cluster to pool connections and to enable [IAM authentication](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.html) — see [Disable RDS Proxy](#disable-rds-proxy) for the alternative. The architecture is the same whether you select the PostgreSQL or MySQL engine; only the Aurora engine flavor differs.
 
-```d2 inline=true
-direction: right
-
-app: Application\n(Lambda, Agent, ...) {
-  shape: hexagon
-}
-
-proxy: RDS Proxy {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/rds.svg
-}
-
-migrations: Migrations Lambda {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/lambda.svg
-}
-
-aurora: Aurora\n(PostgreSQL or MySQL) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/aurora.svg
-}
-
-secrets: Secrets Manager\n(DB credentials) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/secrets-manager.svg
-}
-
-app -> proxy: SQL (IAM auth)
-proxy -> aurora
-migrations -> aurora: Schema migrations
-migrations -> secrets: Admin credentials
-aurora -> secrets: Generates and rotates\nadmin credentials
-```
+<ArchitectureDiagram />

--- a/docs/src/content/docs/es/get_started/tutorials/dungeon-game/overview.mdx
+++ b/docs/src/content/docs/es/get_started/tutorials/dungeon-game/overview.mdx
@@ -16,6 +16,7 @@ import baselineGamePng from '@assets/baseline-game.png'
 import nxGraphPng from '@assets/nx-graph.png'
 import gameSelectPng from '@assets/game-select.png'
 import gameConversationPng from '@assets/game-conversation.png'
+import EmbeddedGraph from '@components/embedded-graph.astro';
 
 
 Usando este tutorial, construirás un juego de aventuras de mazmorra impulsado por IA Agéntica con `@aws/nx-plugin`. Este tutorial no asume ningún conocimiento previo de `@aws/nx-plugin` o tecnologías relacionadas. 
@@ -51,76 +52,9 @@ La interfaz del juego se parecerá a algo como este diagrama:
 
 ### Arquitectura de la aplicación
 
-El juego de aventuras de mazmorra impulsado por IA Agéntica se construye usando la siguiente arquitectura:
+El juego de aventuras de mazmorra impulsado por IA Agéntica se construye usando la siguiente arquitectura — cambia a **Projects** para ver el espacio de trabajo desde el cual se construye, que crearás en el Módulo 1:
 
-```d2 inline=true
-direction: down
-
-browser: Web Browser {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
-
-cognito: Cognito / IAM {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cognito.svg
-}
-
-cloudfront: CloudFront {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cloudfront.svg
-}
-
-s3: Static Assets\n(S3) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/s3.svg
-}
-
-apigw: API Gateway\n(Game API) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/api-gateway.svg
-}
-
-lambda: tRPC API\n(Lambda) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/lambda.svg
-}
-
-story: Story Agent\n(AgentCore) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/bedrock-agentcore-runtime.svg
-}
-
-mcp: Inventory MCP\n(AgentCore) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/bedrock-agentcore-runtime.svg
-}
-
-ddb: Game State\n(DynamoDB) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/dynamodb.svg
-}
-
-sessions: Story Sessions\n(S3) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/s3.svg
-}
-
-browser -> cognito: Sign in
-browser -> cloudfront
-cloudfront -> s3
-browser -> apigw
-apigw -> lambda
-lambda -> ddb
-lambda -> sessions: Read transcripts
-browser -> story: AG-UI stream
-story -> sessions: Persist turns
-story -> mcp: Tool calls
-mcp -> ddb
-ddb -> sessions: {
-  style.opacity: 0
-}
-```
+<EmbeddedGraph preset="dungeon-adventure" workspace="dungeon-adventure" iac="cdk" view="infrastructure" copyable={false} />
 
 - Sitio web frontend React/Vite que utiliza:
   - Amazon Cognito/Identity Pools para llamadas API seguras.

--- a/docs/src/content/docs/es/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/es/guides/agentcore-gateway.mdx
@@ -14,6 +14,7 @@ import Snippet from '@components/snippet.astro';
 import Link from '@components/link.astro';
 import NxCommands from '@components/nx-commands.astro';
 import OptionFilter from '@components/option-filter.astro';
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
 Genera un proyecto de [Amazon Bedrock AgentCore Gateway](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/gateway.html). Un AgentCore Gateway es un punto de entrada administrado frente a tus servidores MCP o agentes, autenticando solicitudes entrantes (IAM o Cognito) y firmando el tráfico saliente hacia sus destinos con IAM SigV4.
 
@@ -89,32 +90,7 @@ La URL del Gateway se registra automáticamente en el namespace `agentcore.gatew
 
 El Gateway desplegado tiene la siguiente arquitectura, con un Web ACL de [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) frente al Gateway, que enruta hacia sus destinos de servidor MCP descendentes:
 
-```d2 inline=true
-direction: right
-
-client: Client {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
-
-waf: WAF {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/waf.svg
-}
-
-gateway: AgentCore Gateway\n(MCP, IAM or Cognito auth) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/bedrock-agentcore-gateway.svg
-}
-
-targets: Downstream MCP Servers\n(Gateway targets) {
-  shape: rectangle
-}
-
-client -> waf
-waf -> gateway
-gateway -> targets
-```
+<ArchitectureDiagram />
 
 ## Autenticación
 

--- a/docs/src/content/docs/es/guides/py-dynamodb.mdx
+++ b/docs/src/content/docs/es/guides/py-dynamodb.mdx
@@ -11,6 +11,7 @@ import Link from '@components/link.astro';
 import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import Snippet from '@components/snippet.astro';
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
 Este generador crea un nuevo proyecto de Python respaldado por [Amazon DynamoDB](https://aws.amazon.com/dynamodb/), utilizando [PynamoDB](https://pynamodb.readthedocs.io/) para el modelado de entidades. Genera el código de aplicación y la infraestructura necesaria para aprovisionar y administrar una tabla de DynamoDB usando AWS CDK o Terraform, con soporte para diseño de tabla única y desarrollo local integrado a través de DynamoDB Local.
 
@@ -52,6 +53,12 @@ Los scripts de desarrollo local se comparten entre todos los proyectos de Dynamo
 ### Infraestructura
 
 <Snippet name="dynamodb/infrastructure" />
+
+#### Arquitectura
+
+El proyecto desplegado aprovisiona la tabla en sí, la cual cualquier proyecto al que esté conectado lee y escribe:
+
+<ArchitectureDiagram />
 
 ## Desarrollo Local
 

--- a/docs/src/content/docs/es/guides/react-website-auth.mdx
+++ b/docs/src/content/docs/es/guides/react-website-auth.mdx
@@ -10,6 +10,7 @@ import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Infrastructure from '@components/infrastructure.astro';
 import Snippet from '@components/snippet.astro';
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
 El generador de Autenticación de Sitio Web React agrega autenticación a tu sitio web React usando [Amazon Cognito](https://aws.amazon.com/cognito/).
 
@@ -71,44 +72,13 @@ También encontrarás el siguiente código de infraestructura generado según tu
 
 Este generador agrega un user pool de Amazon Cognito (para inicio de sesión) y un identity pool (para federar usuarios autenticados a credenciales IAM con alcance) a la arquitectura de sitio web estático existente:
 
-```d2 inline=true
-direction: right
-
-browser: Web Browser {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
-
-waf: WAF {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/waf.svg
-}
-
-cognito: Cognito\n(User + Identity Pool) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cognito.svg
-}
-
-iam: Scoped IAM\nCredentials {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/iam.svg
-}
-
-backend: Authenticated\nAWS Resources {
-  shape: rectangle
-}
-
-browser -> waf: Sign in
-waf -> cognito
-cognito -> iam
-browser -> backend: IAM/Cognito
-```
+<ArchitectureDiagram name="my-website" />
 
 #### Protección contra amenazas
 
-El User Pool se crea en el [plan de características Plus](https://docs.aws.amazon.com/cognito/latest/developerguide/feature-plans-features-plus.html) de Cognito con [protección contra amenazas](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pool-settings-threat-protection.html) configurada en modo `AUDIT` para autenticación estándar. En modo auditoría, Cognito asigna un nivel de riesgo a cada inicio de sesión y registra la evaluación en CloudWatch sin bloquear a los usuarios.
+El User Pool se crea en el [plan de características Plus](https://docs.aws.amazon.com/cognito/latest/developerguide/feature-plans-features-plus.html) de Cognito con [protección contra amenazas](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pool-settings-threat-protection.html) en **modo de solo auditoría** para autenticación estándar. En modo de solo auditoría, Cognito asigna un nivel de riesgo a cada inicio de sesión y registra la evaluación sin bloquear a los usuarios.
 
-Una vez que hayas observado las evaluaciones de riesgo para tus usuarios, puedes cambiar a la aplicación de función completa para responder automáticamente a actividades riesgosas (por ejemplo, requerir MFA o bloquear el inicio de sesión):
+Una vez que hayas observado las evaluaciones de riesgo para tus usuarios, puedes cambiar a la aplicación de función completa para responder automáticamente a actividades riesgosas (por ejemplo, requerir MFA o bloquear el inicio de sesión), luego configurar la respuesta por nivel de riesgo a través de [autenticación adaptativa](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pool-settings-adaptive-authentication.html):
 
 <Infrastructure>
 <Fragment slot="cdk">
@@ -187,13 +157,13 @@ Esta regla marca las direcciones de loopback en argumentos de consulta como inte
 Necesitarás agregar la infraestructura de identidad de usuario a tu stack, declarándola _antes_ del sitio web:
 
 ```ts title="packages/infra/src/stacks/application-stack.ts" {3,9}
-import { Stack } from 'aws-cdk-lib';
+import { Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { MyWebsite, UserIdentity } from '@my-scope/common-constructs';
 
 export class ApplicationStack extends Stack {
-  constructor(scope: Construct, id: string) {
-    super(scope, id);
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
 
     new UserIdentity(this, 'Identity');
 
@@ -256,13 +226,13 @@ Para otorgar a los usuarios autenticados acceso para realizar ciertas acciones, 
 <Infrastructure>
 <Fragment slot="cdk">
 ```ts title="packages/infra/src/stacks/application-stack.ts" {12}
-import { Stack } from 'aws-cdk-lib';
+import { Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { MyWebsite, UserIdentity, MyApi } from '@my-scope/common-constructs';
 
 export class ApplicationStack extends Stack {
-  constructor(scope: Construct, id: string) {
-    super(scope, id);
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
 
     const identity = new UserIdentity(this, 'Identity');
     const api = new MyApi(this, 'MyApi', {

--- a/docs/src/content/docs/es/guides/react-website.mdx
+++ b/docs/src/content/docs/es/guides/react-website.mdx
@@ -17,6 +17,7 @@ import PackageManagerShortCommand from '@components/package-manager-short-comman
 import Infrastructure from '@components/infrastructure.astro';
 import Snippet from '@components/snippet.astro';
 import OptionFilter from '@components/option-filter.astro';
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
 Este generador crea un nuevo sitio web [React](https://react.dev/) con [shadcn/ui](https://ui.shadcn.com/) configurado por defecto, junto con la infraestructura AWS CDK o Terraform para desplegar tu sitio web en la nube como un sitio web estático alojado en [S3](https://aws.amazon.com/s3/), servido por [CloudFront](https://aws.amazon.com/cloudfront/) y protegido por [WAF](https://aws.amazon.com/waf/).
 
@@ -50,16 +51,23 @@ El generador creará la siguiente estructura de proyecto en el directorio `<dire
     - config.ts Application configuration (eg. logo)
     - components
       - AppLayout Components for the overall layout and navigation bar
+      - app-sidebar.tsx Sidebar navigation (shadcn only)
+      - alert.tsx Alert component wrapping your UX provider's own
+      - spinner.tsx Spinner component wrapping your UX provider's own
     - hooks
       - useAppLayout.tsx Hook for adjusting the AppLayout from nested components (Cloudscape only)
     - routes
+      - \_\_root.tsx Root route, wrapping every page in the AppLayout
       - index.tsx Example route (or page) for TanStack Router
+    - routeTree.gen.ts Route tree, generated and maintained by TanStack Router
     - styles.css Global styles
   - vite.config.mts Vite and Vitest configuration
+  - project.json Nx project defining the project's targets
   - tsconfig.json Base TypeScript configuration for source and tests
   - tsconfig.app.json TypeScript configuration for source code
   - tsconfig.spec.json TypeScript configuration for tests
   - package.json Project manifest defining the project's package name and dependencies
+  - README.md Project README
 </FileTree>
 
 :::note[Sin TanStack Router]
@@ -99,35 +107,9 @@ El generador crea infraestructura como código para desplegar tu sitio web basá
 
 #### Arquitectura
 
-El sitio web desplegado tiene la siguiente arquitectura:
+El sitio web desplegado tiene la siguiente arquitectura: tus activos construidos en un bucket S3, servidos por una distribución CloudFront con un Web ACL de AWS WAFv2 frente a ella.
 
-```d2 inline=true
-direction: right
-
-browser: Web Browser {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
-
-waf: WAF {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/waf.svg
-}
-
-cloudfront: CloudFront {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cloudfront.svg
-}
-
-s3: Static Assets\n(S3) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/s3.svg
-}
-
-browser -> waf
-waf -> cloudfront
-cloudfront -> s3
-```
+<ArchitectureDiagram />
 
 ## Implementar tu Sitio Web
 
@@ -157,26 +139,32 @@ Tu sitio web viene con [TanStack Router](https://tanstack.com/router/v1) configu
 
 Puedes usar el componente `Link` o el hook `useNavigate` para navegar entre páginas:
 
-```tsx {1, 4, 8-9, 14}
+```tsx {1, 8, 12-13, 18}
 import { Link, useNavigate } from '@tanstack/react-router';
 
-export const MyComponent = () => {
+export const MyComponent = ({
+  createProduct,
+}: {
+  createProduct: () => Promise<string>;
+}) => {
   const navigate = useNavigate();
 
   const submit = async () => {
-    const id = await ...
+    const id = await createProduct();
     // Use `navigate` for redirecting after some asynchronous action
-    navigate({ to: '/products/$id', { params: { id }} });
+    navigate({ to: '/products/$id', params: { id } });
   };
 
   return (
     <>
       <Link to="/products">Cancel</Link>
-      <Button onClick={submit}>Submit</Button>
+      <button onClick={submit}>Submit</button>
     </>
-  )
+  );
 };
 ```
+
+`$id` in the `to` path is a [path parameter](https://tanstack.com/router/latest/docs/framework/react/guide/path-params), supplied through `params`. Swap the plain `<button>` for your UX kit's own button component as needed.
 
 Para más detalles, consulta la documentación de [TanStack Router](https://tanstack.com/router/latest/docs/framework/react/overview).
 
@@ -191,13 +179,13 @@ Para desplegar tu sitio web, recomendamos usar el <Link path="guides/typescript-
 Puedes usar el constructo CDK generado para ti en `packages/common/constructs` para desplegar tu sitio web.
 
 ```ts title="packages/infra/src/stacks/application-stack.ts" {3, 9}
-import { Stack } from 'aws-cdk-lib';
+import { Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { MyWebsite } from '@my-scope/common-constructs';
 
 export class ApplicationStack extends Stack {
-  constructor(scope: Construct, id: string) {
-    super(scope, id);
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
 
     new MyWebsite(this, 'MyWebsite');
   }
@@ -266,13 +254,13 @@ La distribución CloudFront está protegida por un Web ACL de [AWS WAFv2](https:
 Para optar por no usarlo, establece `enableWaf` en `false` cuando crees tu sitio web:
 
 ```ts title="packages/infra/src/stacks/application-stack.ts" {10,15-18}
-import { Stack } from 'aws-cdk-lib';
+import { Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { MyWebsite, suppressRules } from '@my-scope/common-constructs';
 
 export class ApplicationStack extends Stack {
-  constructor(scope: Construct, id: string) {
-    super(scope, id);
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
 
     const website = new MyWebsite(this, 'MyWebsite', {
       enableWaf: false,
@@ -318,14 +306,14 @@ El bucket del sitio web, el bucket de logs de la distribución CloudFront y el g
 Si deseas usar una configuración de cifrado diferente, pasa las propiedades `encryption`, `encryptionKey` y `enableKeyRotation` cuando crees tu sitio web:
 
 ```ts title="packages/infra/src/stacks/application-stack.ts" {11}
-import { Stack } from 'aws-cdk-lib';
+import { Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { BucketEncryption } from 'aws-cdk-lib/aws-s3';
 import { MyWebsite } from '@my-scope/common-constructs';
 
 export class ApplicationStack extends Stack {
-  constructor(scope: Construct, id: string) {
-    super(scope, id);
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
 
     new MyWebsite(this, 'MyWebsite', {
       encryption: BucketEncryption.S3_MANAGED,
@@ -401,11 +389,12 @@ module "my_website" {
 ```
 
 :::caution[Checkov: S3_MANAGED]
-Elegir `S3_MANAGED` falla el escaneo de seguridad `checkov` con `CKV_AWS_145` en los buckets del sitio web y de logs de distribución. El objetivo `test` proporcionado no acepta un `--config-file`, pero `checkov` descubre automáticamente un `.checkov.yaml` en su directorio de trabajo, así que coloca uno en `packages/infra/src`:
+Elegir `S3_MANAGED` falla tu objetivo `checkov` del proyecto con `CKV_AWS_145` en los buckets del sitio web y de logs de distribución. El objetivo ejecuta `checkov` contra el `checkov.yml` de tu propio proyecto, así que agrega la verificación a su lista `skip-check`:
 
-```yaml title="packages/infra/src/.checkov.yaml"
+```yaml title="packages/infra/checkov.yml" {3}
 skip-check:
-  - CKV_AWS_145
+  # ...
+  - CKV_AWS_145 # S3 buckets are not KMS encrypted when encryption is S3_MANAGED
 ```
 :::
 
@@ -439,11 +428,12 @@ module "my_website" {
 ```
 
 :::caution[Checkov: rotación de clave deshabilitada]
-Deshabilitar la rotación de clave en la clave creada automáticamente falla el escaneo de seguridad `checkov` con `CKV_AWS_7`. Agrégalo al mismo `.checkov.yaml`:
+Deshabilitar la rotación de clave en la clave creada automáticamente falla tu objetivo `checkov` del proyecto con `CKV_AWS_7`. Agrégalo a la misma lista `skip-check` en `packages/infra/checkov.yml`:
 
-```yaml title="packages/infra/src/.checkov.yaml"
+```yaml title="packages/infra/checkov.yml" {3}
 skip-check:
-  - CKV_AWS_7
+  # ...
+  - CKV_AWS_7 # Key rotation is disabled on the website's KMS key
 ```
 :::
 </Fragment>
@@ -458,14 +448,14 @@ Por defecto, la distribución usa el nombre de dominio CloudFront predeterminado
 Pasa las propiedades `certificate` y `domainNames` cuando crees tu sitio web:
 
 ```ts title="packages/infra/src/stacks/application-stack.ts" {11-13}
-import { Stack } from 'aws-cdk-lib';
+import { Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { Certificate } from 'aws-cdk-lib/aws-certificatemanager';
 import { MyWebsite } from '@my-scope/common-constructs';
 
 export class ApplicationStack extends Stack {
-  constructor(scope: Construct, id: string) {
-    super(scope, id);
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
 
     new MyWebsite(this, 'MyWebsite', {
       domainNames: ['www.example.com'],
@@ -508,13 +498,13 @@ El constructo CDK `RuntimeConfig` se puede usar para agregar y recuperar configu
 Tu constructo CDK de sitio web desplegará el namespace `connection` de la configuración en tiempo de ejecución como un archivo `runtime-config.json` en la raíz de tu bucket S3.
 
 ```ts title="packages/infra/src/stacks/application-stack.ts"
-import { Stack } from 'aws-cdk-lib';
+import { Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { MyWebsite, MyApi } from '@my-scope/common-constructs';
 
 export class ApplicationStack extends Stack {
-  constructor(scope: Construct, id: string) {
-    super(scope, id);
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
 
     // Website can be declared at any point, since runtime config is resolved lazily
     new MyWebsite(this, 'MyWebsite');
@@ -581,6 +571,10 @@ const MyComponent = () => {
   const apiUrl = runtimeConfig.apis.MyApi;
 };
 ```
+
+:::note[Agregado cuando lo necesitas]
+`src/hooks/useRuntimeConfig.tsx` y `src/components/RuntimeConfig` se agregan a tu sitio web por el generador <Link path="/guides/react-website-auth">`ts#website#auth`</Link> y los generadores de <Link path="guides/connection">`connection`</Link>, ya que son los que ponen valores en la configuración en tiempo de ejecución. Un sitio web sin ninguno de los dos no tiene configuración en tiempo de ejecución para leer, por lo que el hook no se proporciona hasta que uno se haya ejecutado.
+:::
 
 :::note[Configuración en Tiempo de Ejecución]
 Para obtener detalles sobre cómo se almacena la configuración en tiempo de ejecución en AWS AppConfig y cómo los consumidores del lado del servidor (funciones Lambda, agentes) pueden recuperarla, consulta la guía de <Link path="guides/runtime-config">Configuración en Tiempo de Ejecución</Link>.

--- a/docs/src/content/docs/es/guides/ts-dynamodb.mdx
+++ b/docs/src/content/docs/es/guides/ts-dynamodb.mdx
@@ -11,6 +11,7 @@ import Link from '@components/link.astro';
 import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import Snippet from '@components/snippet.astro';
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
 Este generador crea un nuevo proyecto TypeScript DynamoDB respaldado por [Amazon DynamoDB](https://aws.amazon.com/dynamodb/), utilizando [ElectroDB](https://electrodb.dev/) para el modelado de entidades con seguridad de tipos. Genera el código de aplicación y la infraestructura necesaria para aprovisionar y administrar una tabla DynamoDB utilizando AWS CDK o Terraform, con soporte para diseño de tabla única y desarrollo local integrado a través de DynamoDB Local.
 
@@ -52,6 +53,12 @@ Los scripts de desarrollo local se comparten entre todos los proyectos DynamoDB 
 ### Infraestructura
 
 <Snippet name="dynamodb/infrastructure" />
+
+#### Arquitectura
+
+El proyecto desplegado aprovisiona la tabla en sí, la cual cualquier proyecto al que esté conectado lee y escribe:
+
+<ArchitectureDiagram />
 
 ## Desarrollo Local
 

--- a/docs/src/content/docs/es/guides/ts-smithy-api.mdx
+++ b/docs/src/content/docs/es/guides/ts-smithy-api.mdx
@@ -20,6 +20,7 @@ import Snippet from '@components/snippet.astro';
 import OptionFilter from '@components/option-filter.astro';
 import InstallCommand from '@components/install-command.astro';
 import { TS_VERSIONS } from '../../../../../../packages/nx-plugin/src/utils/versions';
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
 [Smithy](https://smithy.io/) es un lenguaje de definición de interfaz independiente del protocolo para crear APIs de manera orientada a modelos.
 
@@ -126,47 +127,7 @@ Este proyecto se genera usando el generador <Link path="/guides/terraform-projec
 
 La API de Smithy desplegada tiene la siguiente arquitectura, con un Web ACL de [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) frente al stage de API Gateway:
 
-```d2 inline=true
-direction: right
-
-client: Client {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
-
-waf: WAF {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/waf.svg
-}
-
-apigw: API Gateway\n(REST API) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/api-gateway.svg
-}
-
-lambda: Lambda\n(Smithy Server SDK) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/lambda.svg
-}
-
-cw: CloudWatch\n(Logs, Metrics) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cloudwatch.svg
-  near: top-right
-}
-
-xray: X-Ray\n(Traces) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/xray.svg
-  near: bottom-right
-}
-
-client -> waf
-waf -> apigw
-apigw -> lambda
-lambda -> cw
-lambda -> xray
-```
+<ArchitectureDiagram options={{ infra: 'rest-lambda' }} />
 
 ## Implementar tu API de Smithy
 

--- a/docs/src/content/docs/es/snippets/agent/architecture.mdx
+++ b/docs/src/content/docs/es/snippets/agent/architecture.mdx
@@ -2,71 +2,28 @@
 title: Arquitectura del Agente
 ---
 import { Tabs, TabItem } from '@astrojs/starlight/components';
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
 <Tabs syncKey="infra">
-<TabItem label="Bedrock AgentCore Runtime" _filter={{ infra: 'agentcore' }}>
+<TabItem label="AgentCore Runtime" _filter={{ infra: 'agentcore' }}>
 
-Cuando se despliega en [Bedrock AgentCore Runtime](https://aws.amazon.com/bedrock/agentcore/), el agente se construye en una imagen de contenedor, se envía a Amazon ECR y se ejecuta en AgentCore Runtime. Los clientes invocan el endpoint del plano de datos de AgentCore Runtime, que reenvía las solicitudes a tu agente. El agente llama a Amazon Bedrock para la inferencia del modelo y puede invocar herramientas, servidores MCP o APIs descendentes.
+Cuando se despliega en [Bedrock AgentCore Runtime](https://aws.amazon.com/bedrock/agentcore/), el código de tu agente se empaqueta como un zip y se ejecuta en el runtime administrado de AgentCore. Los clientes invocan el endpoint del plano de datos de AgentCore Runtime, que reenvía las solicitudes a tu agente. El agente llama a Amazon Bedrock para la inferencia del modelo y puede invocar herramientas, servidores MCP o APIs descendentes.
 
-```d2 inline=true
-direction: right
+<ArchitectureDiagram options={{ infra: 'agentcore' }} />
 
-client: Client {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
+</TabItem>
+<TabItem label="AgentCore Runtime (container)" _filter={{ infra: 'agentcore-ecr' }}>
 
-ecr: ECR {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/ecr.svg
-}
+Con `infra: agentcore-ecr`, el agente se construye en una imagen de contenedor, se envía a Amazon ECR y se ejecuta en AgentCore Runtime. Esto te da control a nivel de sistema operativo sobre el entorno de ejecución, a costa de un ciclo de construcción y despliegue más largo que el empaquetado zip anterior.
 
-agentcore: Strands Agent\n(AgentCore Runtime) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/bedrock-agentcore-runtime.svg
-}
+<ArchitectureDiagram options={{ infra: 'agentcore-ecr' }} />
 
-bedrock: Bedrock\n(Model Inference) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/bedrock.svg
-  near: top-right
-}
-
-cw: CloudWatch\n(Logs, Metrics) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cloudwatch.svg
-  near: bottom-right
-}
-
-client -> agentcore
-ecr -> agentcore: Container\nimage
-agentcore -> bedrock: InvokeModel
-agentcore -> cw
-```
 </TabItem>
 <TabItem label="None (local only)" _filter={{ infra: 'none' }}>
 
 Con `infra: none`, no se genera infraestructura de AWS. El agente se ejecuta como un proceso local y llama a Amazon Bedrock para la inferencia del modelo.
 
-```d2 inline=true
-direction: right
+<ArchitectureDiagram options={{ infra: 'none' }} />
 
-client: Client {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
-
-agent: Strands Agent\n(local process) {
-  shape: rectangle
-}
-
-bedrock: Bedrock\n(Model Inference) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/bedrock.svg
-}
-
-client -> agent
-agent -> bedrock: InvokeModel
-```
 </TabItem>
 </Tabs>

--- a/docs/src/content/docs/es/snippets/api/api-architecture.mdx
+++ b/docs/src/content/docs/es/snippets/api/api-architecture.mdx
@@ -2,91 +2,20 @@
 title: Arquitectura de API
 ---
 import { Tabs, TabItem } from '@astrojs/starlight/components';
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
-La aplicación desplegada tiene la siguiente arquitectura:
+La aplicación desplegada tiene la siguiente arquitectura: una API de API Gateway frente a una función Lambda que ejecuta tu manejador.
 
 <Tabs syncKey="http-rest">
 <TabItem label="REST API" _filter={{ infra: 'rest-lambda' }}>
-```d2 inline=true
-direction: right
 
-client: Client {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
-
-waf: WAF {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/waf.svg
-}
-
-apigw: API Gateway\n(REST API) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/api-gateway.svg
-}
-
-lambda: Lambda {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/lambda.svg
-}
-
-cw: CloudWatch\n(Logs, Metrics) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cloudwatch.svg
-  near: top-right
-}
-
-xray: X-Ray\n(Traces) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/xray.svg
-  near: bottom-right
-}
-
-client -> waf
-waf -> apigw
-apigw -> lambda
-lambda -> cw
-lambda -> xray
-```
+<ArchitectureDiagram options={{ infra: 'rest-lambda' }} />
 
 Las REST APIs incluyen una Web ACL de [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) frente a la etapa de API Gateway con el conjunto de reglas predeterminado administrado por AWS habilitado.
 </TabItem>
 <TabItem label="HTTP API" _filter={{ infra: 'http-lambda' }}>
-```d2 inline=true
-direction: right
 
-client: Client {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
-
-apigw: API Gateway\n(HTTP API) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/api-gateway.svg
-}
-
-lambda: Lambda {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/lambda.svg
-}
-
-cw: CloudWatch\n(Logs, Metrics) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cloudwatch.svg
-  near: top-right
-}
-
-xray: X-Ray\n(Traces) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/xray.svg
-  near: bottom-right
-}
-
-client -> apigw
-apigw -> lambda
-lambda -> cw
-lambda -> xray
-```
+<ArchitectureDiagram options={{ infra: 'http-lambda' }} />
 
 Las HTTP APIs no admiten WAF directamente — si necesitas protección WAF, elige REST API en su lugar o coloca la HTTP API detrás de una distribución de CloudFront.
 </TabItem>

--- a/docs/src/content/docs/es/snippets/lambda-function/architecture.mdx
+++ b/docs/src/content/docs/es/snippets/lambda-function/architecture.mdx
@@ -1,36 +1,10 @@
 ---
 title: Arquitectura de Lambda Function
 ---
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
-La función desplegada tiene la siguiente arquitectura:
+La función desplegada tiene la siguiente arquitectura, con sus logs, métricas y trazas yendo a CloudWatch y X-Ray:
 
-```d2 inline=true
-direction: right
-
-source: Event Source\n(SNS, SQS, ...) {
-  shape: rectangle
-}
-
-lambda: Lambda {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/lambda.svg
-}
-
-cw: CloudWatch\n(Logs, Metrics) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cloudwatch.svg
-  near: top-right
-}
-
-xray: X-Ray\n(Traces) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/xray.svg
-  near: bottom-right
-}
-
-source -> lambda
-lambda -> cw
-lambda -> xray
-```
+<ArchitectureDiagram name="my-function" />
 
 El generador proporciona la función en sí; usted conecta la fuente de eventos en su stack para invocarla (por ejemplo, una integración de API Gateway, una regla de EventBridge, una notificación de S3 o un mapeo de fuente de eventos de SQS).

--- a/docs/src/content/docs/es/snippets/mcp/architecture.mdx
+++ b/docs/src/content/docs/es/snippets/mcp/architecture.mdx
@@ -2,57 +2,28 @@
 title: Arquitectura del Servidor MCP
 ---
 import { Tabs, TabItem } from '@astrojs/starlight/components';
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
 <Tabs syncKey="infra">
-<TabItem label="Bedrock AgentCore Runtime" _filter={{ infra: 'agentcore' }}>
+<TabItem label="AgentCore Runtime" _filter={{ infra: 'agentcore' }}>
 
-Cuando se despliega en [Bedrock AgentCore Runtime](https://aws.amazon.com/bedrock/agentcore/), el servidor MCP se construye en una imagen de contenedor, se envía a Amazon ECR y se ejecuta en AgentCore Runtime. Los asistentes de IA invocan el endpoint del plano de datos de AgentCore Runtime, que reenvía las llamadas `tools/*` y `resources/*` a tu servidor a través del [transporte HTTP transmisible](https://modelcontextprotocol.io/specification/draft/basic/transports#streamable-http).
+Cuando se despliega en [Bedrock AgentCore Runtime](https://aws.amazon.com/bedrock/agentcore/), el código de tu servidor se empaqueta como un zip y se ejecuta en el runtime administrado de AgentCore. Los asistentes de IA invocan el endpoint del plano de datos de AgentCore Runtime, que reenvía las llamadas `tools/*` y `resources/*` a tu servidor a través del [transporte HTTP transmisible](https://modelcontextprotocol.io/specification/draft/basic/transports#streamable-http).
 
-```d2 inline=true
-direction: right
+<ArchitectureDiagram options={{ infra: 'agentcore' }} />
 
-assistant: AI Assistant {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
+</TabItem>
+<TabItem label="AgentCore Runtime (container)" _filter={{ infra: 'agentcore-ecr' }}>
 
-ecr: ECR {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/ecr.svg
-}
+Con `infra: agentcore-ecr`, el servidor MCP se construye en una imagen de contenedor, se envía a Amazon ECR y se ejecuta en AgentCore Runtime. Esto te da control a nivel de sistema operativo sobre el entorno de ejecución, a costa de un ciclo de construcción y despliegue más largo que el empaquetado zip anterior.
 
-agentcore: MCP Server\n(AgentCore Runtime) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/bedrock-agentcore-runtime.svg
-}
+<ArchitectureDiagram options={{ infra: 'agentcore-ecr' }} />
 
-cw: CloudWatch\n(Logs, Metrics) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cloudwatch.svg
-}
-
-assistant -> agentcore: Streamable\nHTTP
-ecr -> agentcore: Container\nimage
-agentcore -> cw
-```
 </TabItem>
 <TabItem label="None (local only)" _filter={{ infra: 'none' }}>
 
 Con `infra: none`, no se genera infraestructura de AWS. El servidor MCP está configurado solo para transportes STDIO y HTTP locales, y es consumido por asistentes de IA que se ejecutan en la misma máquina.
 
-```d2 inline=true
-direction: right
+<ArchitectureDiagram options={{ infra: 'none' }} />
 
-assistant: AI Assistant {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
-
-server: MCP Server\n(local process) {
-  shape: rectangle
-}
-
-assistant -> server: STDIO\nor\nStreamable HTTP
-```
 </TabItem>
 </Tabs>

--- a/docs/src/content/docs/es/snippets/rdb/architecture.mdx
+++ b/docs/src/content/docs/es/snippets/rdb/architecture.mdx
@@ -1,39 +1,8 @@
 ---
 title: Arquitectura RDB
 ---
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
 La base de datos desplegada tiene la siguiente arquitectura. Por defecto, un [Amazon RDS Proxy](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-proxy.html) se sitúa frente al clúster Aurora para agrupar conexiones y habilitar la [autenticación IAM](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.html) — consulta [Deshabilitar RDS Proxy](#disable-rds-proxy) para la alternativa. La arquitectura es la misma ya sea que selecciones el motor PostgreSQL o MySQL; solo difiere el tipo de motor Aurora.
 
-```d2 inline=true
-direction: right
-
-app: Application\n(Lambda, Agent, ...) {
-  shape: hexagon
-}
-
-proxy: RDS Proxy {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/rds.svg
-}
-
-migrations: Migrations Lambda {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/lambda.svg
-}
-
-aurora: Aurora\n(PostgreSQL or MySQL) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/aurora.svg
-}
-
-secrets: Secrets Manager\n(DB credentials) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/secrets-manager.svg
-}
-
-app -> proxy: SQL (IAM auth)
-proxy -> aurora
-migrations -> aurora: Schema migrations
-migrations -> secrets: Admin credentials
-aurora -> secrets: Generates and rotates\nadmin credentials
-```
+<ArchitectureDiagram />

--- a/docs/src/content/docs/fr/get_started/tutorials/dungeon-game/overview.mdx
+++ b/docs/src/content/docs/fr/get_started/tutorials/dungeon-game/overview.mdx
@@ -16,6 +16,7 @@ import baselineGamePng from '@assets/baseline-game.png'
 import nxGraphPng from '@assets/nx-graph.png'
 import gameSelectPng from '@assets/game-select.png'
 import gameConversationPng from '@assets/game-conversation.png'
+import EmbeddedGraph from '@components/embedded-graph.astro';
 
 
 En utilisant ce tutoriel, vous allez construire un jeu d'aventure de donjon alimenté par une IA agentique avec `@aws/nx-plugin`. Ce tutoriel ne suppose aucune connaissance préalable du `@aws/nx-plugin` ou des technologies associées. 
@@ -51,76 +52,9 @@ L'interface du jeu ressemblera à quelque chose comme ce diagramme :
 
 ### Architecture de l'application
 
-Le jeu d'aventure de donjon alimenté par une IA agentique est construit en utilisant l'architecture suivante :
+Le jeu d'aventure de donjon alimenté par une IA agentique est construit en utilisant l'architecture suivante — basculez vers **Projects** pour voir l'espace de travail à partir duquel il est construit, que vous échafaudez dans le Module 1 :
 
-```d2 inline=true
-direction: down
-
-browser: Web Browser {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
-
-cognito: Cognito / IAM {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cognito.svg
-}
-
-cloudfront: CloudFront {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cloudfront.svg
-}
-
-s3: Static Assets\n(S3) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/s3.svg
-}
-
-apigw: API Gateway\n(Game API) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/api-gateway.svg
-}
-
-lambda: tRPC API\n(Lambda) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/lambda.svg
-}
-
-story: Story Agent\n(AgentCore) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/bedrock-agentcore-runtime.svg
-}
-
-mcp: Inventory MCP\n(AgentCore) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/bedrock-agentcore-runtime.svg
-}
-
-ddb: Game State\n(DynamoDB) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/dynamodb.svg
-}
-
-sessions: Story Sessions\n(S3) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/s3.svg
-}
-
-browser -> cognito: Sign in
-browser -> cloudfront
-cloudfront -> s3
-browser -> apigw
-apigw -> lambda
-lambda -> ddb
-lambda -> sessions: Read transcripts
-browser -> story: AG-UI stream
-story -> sessions: Persist turns
-story -> mcp: Tool calls
-mcp -> ddb
-ddb -> sessions: {
-  style.opacity: 0
-}
-```
+<EmbeddedGraph preset="dungeon-adventure" workspace="dungeon-adventure" iac="cdk" view="infrastructure" copyable={false} />
 
 - Site web frontend React/Vite utilisant :
   - Amazon Cognito/Identity Pools pour des appels API sécurisés.

--- a/docs/src/content/docs/fr/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/fr/guides/agentcore-gateway.mdx
@@ -14,6 +14,7 @@ import Snippet from '@components/snippet.astro';
 import Link from '@components/link.astro';
 import NxCommands from '@components/nx-commands.astro';
 import OptionFilter from '@components/option-filter.astro';
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
 Génère un projet [Amazon Bedrock AgentCore Gateway](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/gateway.html). Un AgentCore Gateway est un point d'entrée géré devant vos serveurs MCP ou agents, authentifiant les requêtes entrantes (IAM ou Cognito) et signant le trafic sortant vers ses cibles avec IAM SigV4.
 
@@ -89,32 +90,7 @@ L'URL du Gateway est automatiquement enregistrée dans l'espace de noms `agentco
 
 Le Gateway déployé a l'architecture suivante, avec une Web ACL [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) devant le Gateway, qui route vers ses cibles de serveur MCP en aval :
 
-```d2 inline=true
-direction: right
-
-client: Client {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
-
-waf: WAF {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/waf.svg
-}
-
-gateway: AgentCore Gateway\n(MCP, IAM or Cognito auth) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/bedrock-agentcore-gateway.svg
-}
-
-targets: Downstream MCP Servers\n(Gateway targets) {
-  shape: rectangle
-}
-
-client -> waf
-waf -> gateway
-gateway -> targets
-```
+<ArchitectureDiagram />
 
 ## Authentification
 

--- a/docs/src/content/docs/fr/guides/py-dynamodb.mdx
+++ b/docs/src/content/docs/fr/guides/py-dynamodb.mdx
@@ -11,6 +11,7 @@ import Link from '@components/link.astro';
 import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import Snippet from '@components/snippet.astro';
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
 Ce générateur crée un nouveau projet Python soutenu par [Amazon DynamoDB](https://aws.amazon.com/dynamodb/), utilisant [PynamoDB](https://pynamodb.readthedocs.io/) pour la modélisation des entités. Il génère le code d'application et l'infrastructure nécessaires pour provisionner et gérer une table DynamoDB en utilisant AWS CDK ou Terraform, avec prise en charge de la conception à table unique et développement local intégré via DynamoDB Local.
 
@@ -52,6 +53,12 @@ Les scripts de développement local sont partagés entre tous les projets Dynamo
 ### Infrastructure
 
 <Snippet name="dynamodb/infrastructure" />
+
+#### Architecture
+
+Le projet déployé provisionne la table elle-même, que tout projet auquel il est connecté lit et écrit :
+
+<ArchitectureDiagram />
 
 ## Développement local
 

--- a/docs/src/content/docs/fr/guides/react-website-auth.mdx
+++ b/docs/src/content/docs/fr/guides/react-website-auth.mdx
@@ -10,6 +10,7 @@ import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Infrastructure from '@components/infrastructure.astro';
 import Snippet from '@components/snippet.astro';
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
 Le générateur d'authentification de site Web React ajoute l'authentification à votre site Web React en utilisant [Amazon Cognito](https://aws.amazon.com/cognito/).
 
@@ -71,38 +72,7 @@ Vous trouverez également le code d'infrastructure suivant généré en fonction
 
 Ce générateur ajoute un user pool Amazon Cognito (pour la connexion) et un identity pool (pour fédérer les utilisateurs connectés vers des informations d'identification IAM délimitées) à l'architecture de site Web statique existante :
 
-```d2 inline=true
-direction: right
-
-browser: Web Browser {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
-
-waf: WAF {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/waf.svg
-}
-
-cognito: Cognito\n(User + Identity Pool) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cognito.svg
-}
-
-iam: Scoped IAM\nCredentials {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/iam.svg
-}
-
-backend: Authenticated\nAWS Resources {
-  shape: rectangle
-}
-
-browser -> waf: Sign in
-waf -> cognito
-cognito -> iam
-browser -> backend: IAM/Cognito
-```
+<ArchitectureDiagram name="my-website" />
 
 #### Protection contre les menaces
 
@@ -187,13 +157,13 @@ Cette règle signale les adresses de bouclage dans les arguments de requête com
 Vous devrez ajouter l'infrastructure d'identité utilisateur à votre stack, en la déclarant _avant_ le site Web :
 
 ```ts title="packages/infra/src/stacks/application-stack.ts" {3,9}
-import { Stack } from 'aws-cdk-lib';
+import { Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { MyWebsite, UserIdentity } from '@my-scope/common-constructs';
 
 export class ApplicationStack extends Stack {
-  constructor(scope: Construct, id: string) {
-    super(scope, id);
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
 
     new UserIdentity(this, 'Identity');
 
@@ -256,13 +226,13 @@ Afin d'accorder aux utilisateurs authentifiés l'accès pour effectuer certaines
 <Infrastructure>
 <Fragment slot="cdk">
 ```ts title="packages/infra/src/stacks/application-stack.ts" {12}
-import { Stack } from 'aws-cdk-lib';
+import { Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { MyWebsite, UserIdentity, MyApi } from '@my-scope/common-constructs';
 
 export class ApplicationStack extends Stack {
-  constructor(scope: Construct, id: string) {
-    super(scope, id);
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
 
     const identity = new UserIdentity(this, 'Identity');
     const api = new MyApi(this, 'MyApi', {

--- a/docs/src/content/docs/fr/guides/react-website.mdx
+++ b/docs/src/content/docs/fr/guides/react-website.mdx
@@ -17,6 +17,7 @@ import PackageManagerShortCommand from '@components/package-manager-short-comman
 import Infrastructure from '@components/infrastructure.astro';
 import Snippet from '@components/snippet.astro';
 import OptionFilter from '@components/option-filter.astro';
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
 Ce générateur crée un nouveau site Web [React](https://react.dev/) avec [shadcn/ui](https://ui.shadcn.com/) configuré par défaut, ainsi que l'infrastructure AWS CDK ou Terraform pour déployer votre site Web dans le cloud en tant que site Web statique hébergé dans [S3](https://aws.amazon.com/s3/), servi par [CloudFront](https://aws.amazon.com/cloudfront/) et protégé par [WAF](https://aws.amazon.com/waf/).
 
@@ -50,16 +51,23 @@ Le générateur créera la structure de projet suivante dans le répertoire `<di
     - config.ts Application configuration (eg. logo)
     - components
       - AppLayout Components for the overall layout and navigation bar
+      - app-sidebar.tsx Sidebar navigation (shadcn only)
+      - alert.tsx Alert component wrapping your UX provider's own
+      - spinner.tsx Spinner component wrapping your UX provider's own
     - hooks
       - useAppLayout.tsx Hook for adjusting the AppLayout from nested components (Cloudscape only)
     - routes
+      - \_\_root.tsx Root route, wrapping every page in the AppLayout
       - index.tsx Example route (or page) for TanStack Router
+    - routeTree.gen.ts Route tree, generated and maintained by TanStack Router
     - styles.css Global styles
   - vite.config.mts Vite and Vitest configuration
+  - project.json Nx project defining the project's targets
   - tsconfig.json Base TypeScript configuration for source and tests
   - tsconfig.app.json TypeScript configuration for source code
   - tsconfig.spec.json TypeScript configuration for tests
   - package.json Project manifest defining the project's package name and dependencies
+  - README.md Project README
 </FileTree>
 
 :::note[Sans TanStack Router]
@@ -99,35 +107,9 @@ Le générateur crée l'infrastructure as code pour déployer votre site Web en 
 
 #### Architecture
 
-Le site Web déployé a l'architecture suivante :
+Le site Web déployé a l'architecture suivante : vos ressources construites dans un bucket S3, servies par une distribution CloudFront avec une Web ACL AWS WAFv2 devant elle.
 
-```d2 inline=true
-direction: right
-
-browser: Web Browser {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
-
-waf: WAF {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/waf.svg
-}
-
-cloudfront: CloudFront {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cloudfront.svg
-}
-
-s3: Static Assets\n(S3) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/s3.svg
-}
-
-browser -> waf
-waf -> cloudfront
-cloudfront -> s3
-```
+<ArchitectureDiagram />
 
 ## Implémenter votre site Web
 
@@ -157,28 +139,32 @@ Votre site Web est livré avec [TanStack Router](https://tanstack.com/router/v1)
 
 Vous pouvez utiliser le composant `Link` ou le hook `useNavigate` pour naviguer entre les pages :
 
-```tsx {1, 4, 8-9, 14}
+```tsx {1, 8, 12-13, 18}
 import { Link, useNavigate } from '@tanstack/react-router';
 
-export const MyComponent = () => {
+export const MyComponent = ({
+  createProduct,
+}: {
+  createProduct: () => Promise<string>;
+}) => {
   const navigate = useNavigate();
 
   const submit = async () => {
-    const id = await ...
+    const id = await createProduct();
     // Use `navigate` for redirecting after some asynchronous action
-    navigate({ to: '/products/$id', { params: { id }} });
+    navigate({ to: '/products/$id', params: { id } });
   };
 
   return (
     <>
       <Link to="/products">Cancel</Link>
-      <Button onClick={submit}>Submit</Button>
+      <button onClick={submit}>Submit</button>
     </>
-  )
+  );
 };
 ```
 
-Pour plus de détails, consultez la documentation [TanStack Router](https://tanstack.com/router/latest/docs/framework/react/overview).
+`$id` dans le chemin `to` est un [paramètre de chemin](https://tanstack.com/router/latest/docs/framework/react/guide/path-params), fourni via `params`. Remplacez le simple `<button>` par le composant bouton de votre kit UX selon vos besoins.
 
 ## Déployer votre site Web
 
@@ -191,13 +177,13 @@ Pour déployer votre site Web, nous recommandons d'utiliser le <Link path="guide
 Vous pouvez utiliser le construct CDK généré pour vous dans `packages/common/constructs` pour déployer votre site Web.
 
 ```ts title="packages/infra/src/stacks/application-stack.ts" {3, 9}
-import { Stack } from 'aws-cdk-lib';
+import { Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { MyWebsite } from '@my-scope/common-constructs';
 
 export class ApplicationStack extends Stack {
-  constructor(scope: Construct, id: string) {
-    super(scope, id);
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
 
     new MyWebsite(this, 'MyWebsite');
   }
@@ -266,13 +252,13 @@ La distribution CloudFront est protégée par une Web ACL [AWS WAFv2](https://do
 Pour désactiver, définissez `enableWaf` sur `false` lorsque vous créez votre site Web :
 
 ```ts title="packages/infra/src/stacks/application-stack.ts" {10,15-18}
-import { Stack } from 'aws-cdk-lib';
+import { Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { MyWebsite, suppressRules } from '@my-scope/common-constructs';
 
 export class ApplicationStack extends Stack {
-  constructor(scope: Construct, id: string) {
-    super(scope, id);
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
 
     const website = new MyWebsite(this, 'MyWebsite', {
       enableWaf: false,
@@ -318,14 +304,14 @@ Le bucket du site Web, le bucket de logs de la distribution CloudFront et le gro
 Si vous souhaitez utiliser une configuration de chiffrement différente, passez les props `encryption`, `encryptionKey` et `enableKeyRotation` lorsque vous créez votre site Web :
 
 ```ts title="packages/infra/src/stacks/application-stack.ts" {11}
-import { Stack } from 'aws-cdk-lib';
+import { Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { BucketEncryption } from 'aws-cdk-lib/aws-s3';
 import { MyWebsite } from '@my-scope/common-constructs';
 
 export class ApplicationStack extends Stack {
-  constructor(scope: Construct, id: string) {
-    super(scope, id);
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
 
     new MyWebsite(this, 'MyWebsite', {
       encryption: BucketEncryption.S3_MANAGED,
@@ -401,11 +387,12 @@ module "my_website" {
 ```
 
 :::caution[Checkov: S3_MANAGED]
-Choisir `S3_MANAGED` échoue l'analyse de sécurité `checkov` avec `CKV_AWS_145` sur les buckets du site Web et des logs de distribution. La cible `test` fournie n'accepte pas de `--config-file`, mais `checkov` découvre automatiquement un `.checkov.yaml` dans son répertoire de travail, donc déposez-en un dans `packages/infra/src` :
+Choisir `S3_MANAGED` échoue la cible `checkov` de votre projet avec `CKV_AWS_145` sur les buckets du site Web et des logs de distribution. La cible exécute `checkov` contre le `checkov.yml` de votre propre projet, donc ajoutez la vérification à sa liste `skip-check` :
 
-```yaml title="packages/infra/src/.checkov.yaml"
+```yaml title="packages/infra/checkov.yml" {3}
 skip-check:
-  - CKV_AWS_145
+  # ...
+  - CKV_AWS_145 # S3 buckets are not KMS encrypted when encryption is S3_MANAGED
 ```
 :::
 
@@ -439,11 +426,12 @@ module "my_website" {
 ```
 
 :::caution[Checkov: rotation de clé désactivée]
-La désactivation de la rotation de clé sur la clé créée automatiquement échoue l'analyse de sécurité `checkov` avec `CKV_AWS_7`. Ajoutez-le au même `.checkov.yaml` :
+La désactivation de la rotation de clé sur la clé créée automatiquement échoue la cible `checkov` de votre projet avec `CKV_AWS_7`. Ajoutez-le à la même liste `skip-check` dans `packages/infra/checkov.yml` :
 
-```yaml title="packages/infra/src/.checkov.yaml"
+```yaml title="packages/infra/checkov.yml" {3}
 skip-check:
-  - CKV_AWS_7
+  # ...
+  - CKV_AWS_7 # Key rotation is disabled on the website's KMS key
 ```
 :::
 </Fragment>
@@ -458,14 +446,14 @@ Par défaut, la distribution utilise le nom de domaine CloudFront par défaut (`
 Passez les props `certificate` et `domainNames` lorsque vous créez votre site Web :
 
 ```ts title="packages/infra/src/stacks/application-stack.ts" {11-13}
-import { Stack } from 'aws-cdk-lib';
+import { Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { Certificate } from 'aws-cdk-lib/aws-certificatemanager';
 import { MyWebsite } from '@my-scope/common-constructs';
 
 export class ApplicationStack extends Stack {
-  constructor(scope: Construct, id: string) {
-    super(scope, id);
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
 
     new MyWebsite(this, 'MyWebsite', {
       domainNames: ['www.example.com'],
@@ -508,13 +496,13 @@ Le construct CDK `RuntimeConfig` peut être utilisé pour ajouter et récupérer
 Votre construct CDK de site Web déploiera l'espace de noms `connection` de la configuration d'exécution en tant que fichier `runtime-config.json` à la racine de votre bucket S3.
 
 ```ts title="packages/infra/src/stacks/application-stack.ts"
-import { Stack } from 'aws-cdk-lib';
+import { Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { MyWebsite, MyApi } from '@my-scope/common-constructs';
 
 export class ApplicationStack extends Stack {
-  constructor(scope: Construct, id: string) {
-    super(scope, id);
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
 
     // Website can be declared at any point, since runtime config is resolved lazily
     new MyWebsite(this, 'MyWebsite');
@@ -581,6 +569,10 @@ const MyComponent = () => {
   const apiUrl = runtimeConfig.apis.MyApi;
 };
 ```
+
+:::note[Ajouté quand vous en avez besoin]
+`src/hooks/useRuntimeConfig.tsx` et `src/components/RuntimeConfig` sont ajoutés à votre site Web par le générateur <Link path="/guides/react-website-auth">`ts#website#auth`</Link> et les générateurs <Link path="guides/connection">`connection`</Link>, car ce sont eux qui mettent des valeurs dans la configuration d'exécution. Un site Web sans aucun des deux n'a pas de configuration d'exécution à lire, donc le hook n'est pas fourni tant que l'un d'eux n'a pas été exécuté.
+:::
 
 :::note[Configuration d'exécution]
 Pour plus de détails sur la façon dont la configuration d'exécution est stockée dans AWS AppConfig et comment les consommateurs côté serveur (fonctions Lambda, agents) peuvent la récupérer, consultez le guide <Link path="guides/runtime-config">Configuration d'exécution</Link>.

--- a/docs/src/content/docs/fr/guides/ts-dynamodb.mdx
+++ b/docs/src/content/docs/fr/guides/ts-dynamodb.mdx
@@ -11,6 +11,7 @@ import Link from '@components/link.astro';
 import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import Snippet from '@components/snippet.astro';
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
 Ce générateur crée un nouveau projet TypeScript DynamoDB soutenu par [Amazon DynamoDB](https://aws.amazon.com/dynamodb/), utilisant [ElectroDB](https://electrodb.dev/) pour la modélisation d'entités type-safe. Il génère le code d'application et l'infrastructure nécessaires pour provisionner et gérer une table DynamoDB en utilisant AWS CDK ou Terraform, avec prise en charge de la conception à table unique et développement local intégré via DynamoDB Local.
 
@@ -52,6 +53,12 @@ Les scripts de développement local sont partagés entre tous les projets Dynamo
 ### Infrastructure
 
 <Snippet name="dynamodb/infrastructure" />
+
+#### Architecture
+
+Le projet déployé provisionne la table elle-même, que tout projet auquel il est connecté lit et écrit :
+
+<ArchitectureDiagram />
 
 ## Développement local
 

--- a/docs/src/content/docs/fr/guides/ts-smithy-api.mdx
+++ b/docs/src/content/docs/fr/guides/ts-smithy-api.mdx
@@ -20,6 +20,7 @@ import Snippet from '@components/snippet.astro';
 import OptionFilter from '@components/option-filter.astro';
 import InstallCommand from '@components/install-command.astro';
 import { TS_VERSIONS } from '../../../../../../packages/nx-plugin/src/utils/versions';
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
 [Smithy](https://smithy.io/) est un langage de définition d'interface indépendant du protocole pour créer des API de manière pilotée par modèle.
 
@@ -126,47 +127,7 @@ Ce projet est généré en utilisant le générateur <Link path="/guides/terrafo
 
 L'API Smithy déployée a l'architecture suivante, avec une Web ACL [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) devant l'étape API Gateway :
 
-```d2 inline=true
-direction: right
-
-client: Client {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
-
-waf: WAF {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/waf.svg
-}
-
-apigw: API Gateway\n(REST API) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/api-gateway.svg
-}
-
-lambda: Lambda\n(Smithy Server SDK) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/lambda.svg
-}
-
-cw: CloudWatch\n(Logs, Metrics) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cloudwatch.svg
-  near: top-right
-}
-
-xray: X-Ray\n(Traces) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/xray.svg
-  near: bottom-right
-}
-
-client -> waf
-waf -> apigw
-apigw -> lambda
-lambda -> cw
-lambda -> xray
-```
+<ArchitectureDiagram options={{ infra: 'rest-lambda' }} />
 
 ## Implémenter votre API Smithy
 

--- a/docs/src/content/docs/fr/snippets/agent/architecture.mdx
+++ b/docs/src/content/docs/fr/snippets/agent/architecture.mdx
@@ -2,71 +2,28 @@
 title: Architecture de l'Agent
 ---
 import { Tabs, TabItem } from '@astrojs/starlight/components';
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
 <Tabs syncKey="infra">
-<TabItem label="Bedrock AgentCore Runtime" _filter={{ infra: 'agentcore' }}>
+<TabItem label="AgentCore Runtime" _filter={{ infra: 'agentcore' }}>
 
-Lorsqu'il est déployé sur [Bedrock AgentCore Runtime](https://aws.amazon.com/bedrock/agentcore/), l'agent est construit dans une image de conteneur, poussé vers Amazon ECR et exécuté dans AgentCore Runtime. Les clients invoquent le point de terminaison du plan de données AgentCore Runtime, qui transmet les requêtes à votre agent. L'agent appelle Amazon Bedrock pour l'inférence du modèle et peut invoquer des outils, des serveurs MCP ou des API en aval.
+Lorsqu'il est déployé sur [Bedrock AgentCore Runtime](https://aws.amazon.com/bedrock/agentcore/), le code de votre agent est empaqueté sous forme de zip et exécuté dans le runtime géré AgentCore. Les clients invoquent le point de terminaison du plan de données AgentCore Runtime, qui transmet les requêtes à votre agent. L'agent appelle Amazon Bedrock pour l'inférence du modèle et peut invoquer des outils, des serveurs MCP ou des API en aval.
 
-```d2 inline=true
-direction: right
+<ArchitectureDiagram options={{ infra: 'agentcore' }} />
 
-client: Client {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
+</TabItem>
+<TabItem label="AgentCore Runtime (container)" _filter={{ infra: 'agentcore-ecr' }}>
 
-ecr: ECR {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/ecr.svg
-}
+Avec `infra: agentcore-ecr`, l'agent est construit dans une image de conteneur, poussé vers Amazon ECR et exécuté dans AgentCore Runtime. Cela vous donne un contrôle au niveau du système d'exploitation sur l'environnement d'exécution, au prix d'un cycle de construction et de déploiement plus long que l'empaquetage zip ci-dessus.
 
-agentcore: Strands Agent\n(AgentCore Runtime) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/bedrock-agentcore-runtime.svg
-}
+<ArchitectureDiagram options={{ infra: 'agentcore-ecr' }} />
 
-bedrock: Bedrock\n(Model Inference) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/bedrock.svg
-  near: top-right
-}
-
-cw: CloudWatch\n(Logs, Metrics) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cloudwatch.svg
-  near: bottom-right
-}
-
-client -> agentcore
-ecr -> agentcore: Container\nimage
-agentcore -> bedrock: InvokeModel
-agentcore -> cw
-```
 </TabItem>
 <TabItem label="None (local only)" _filter={{ infra: 'none' }}>
 
 Avec `infra: none`, aucune infrastructure AWS n'est générée. L'agent s'exécute en tant que processus local et appelle Amazon Bedrock pour l'inférence du modèle.
 
-```d2 inline=true
-direction: right
+<ArchitectureDiagram options={{ infra: 'none' }} />
 
-client: Client {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
-
-agent: Strands Agent\n(local process) {
-  shape: rectangle
-}
-
-bedrock: Bedrock\n(Model Inference) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/bedrock.svg
-}
-
-client -> agent
-agent -> bedrock: InvokeModel
-```
 </TabItem>
 </Tabs>

--- a/docs/src/content/docs/fr/snippets/api/api-architecture.mdx
+++ b/docs/src/content/docs/fr/snippets/api/api-architecture.mdx
@@ -2,91 +2,20 @@
 title: Architecture de l'API
 ---
 import { Tabs, TabItem } from '@astrojs/starlight/components';
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
-L'application déployée a l'architecture suivante :
+L'application déployée a l'architecture suivante : une API API Gateway devant une fonction Lambda exécutant votre gestionnaire.
 
 <Tabs syncKey="http-rest">
 <TabItem label="REST API" _filter={{ infra: 'rest-lambda' }}>
-```d2 inline=true
-direction: right
 
-client: Client {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
-
-waf: WAF {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/waf.svg
-}
-
-apigw: API Gateway\n(REST API) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/api-gateway.svg
-}
-
-lambda: Lambda {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/lambda.svg
-}
-
-cw: CloudWatch\n(Logs, Metrics) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cloudwatch.svg
-  near: top-right
-}
-
-xray: X-Ray\n(Traces) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/xray.svg
-  near: bottom-right
-}
-
-client -> waf
-waf -> apigw
-apigw -> lambda
-lambda -> cw
-lambda -> xray
-```
+<ArchitectureDiagram options={{ infra: 'rest-lambda' }} />
 
 Les REST APIs incluent une Web ACL [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) devant l'étape API Gateway avec l'ensemble de règles par défaut géré par AWS activé.
 </TabItem>
 <TabItem label="HTTP API" _filter={{ infra: 'http-lambda' }}>
-```d2 inline=true
-direction: right
 
-client: Client {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
-
-apigw: API Gateway\n(HTTP API) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/api-gateway.svg
-}
-
-lambda: Lambda {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/lambda.svg
-}
-
-cw: CloudWatch\n(Logs, Metrics) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cloudwatch.svg
-  near: top-right
-}
-
-xray: X-Ray\n(Traces) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/xray.svg
-  near: bottom-right
-}
-
-client -> apigw
-apigw -> lambda
-lambda -> cw
-lambda -> xray
-```
+<ArchitectureDiagram options={{ infra: 'http-lambda' }} />
 
 Les HTTP APIs ne prennent pas en charge WAF directement — si vous avez besoin de la protection WAF, choisissez REST API à la place ou placez l'HTTP API derrière une distribution CloudFront.
 </TabItem>

--- a/docs/src/content/docs/fr/snippets/lambda-function/architecture.mdx
+++ b/docs/src/content/docs/fr/snippets/lambda-function/architecture.mdx
@@ -1,36 +1,10 @@
 ---
 title: Architecture de la fonction Lambda
 ---
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
-La fonction déployée a l'architecture suivante :
+La fonction déployée a l'architecture suivante, avec ses logs, métriques et traces envoyés vers CloudWatch et X-Ray :
 
-```d2 inline=true
-direction: right
-
-source: Event Source\n(SNS, SQS, ...) {
-  shape: rectangle
-}
-
-lambda: Lambda {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/lambda.svg
-}
-
-cw: CloudWatch\n(Logs, Metrics) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cloudwatch.svg
-  near: top-right
-}
-
-xray: X-Ray\n(Traces) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/xray.svg
-  near: bottom-right
-}
-
-source -> lambda
-lambda -> cw
-lambda -> xray
-```
+<ArchitectureDiagram name="my-function" />
 
 Le générateur fournit la fonction elle-même ; vous connectez la source d'événements dans votre stack pour l'invoquer (par exemple, une intégration API Gateway, une règle EventBridge, une notification S3 ou un mappage de source d'événements SQS).

--- a/docs/src/content/docs/fr/snippets/mcp/architecture.mdx
+++ b/docs/src/content/docs/fr/snippets/mcp/architecture.mdx
@@ -2,57 +2,28 @@
 title: Architecture du serveur MCP
 ---
 import { Tabs, TabItem } from '@astrojs/starlight/components';
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
 <Tabs syncKey="infra">
-<TabItem label="Bedrock AgentCore Runtime" _filter={{ infra: 'agentcore' }}>
+<TabItem label="AgentCore Runtime" _filter={{ infra: 'agentcore' }}>
 
-Lorsqu'il est déployé sur [Bedrock AgentCore Runtime](https://aws.amazon.com/bedrock/agentcore/), le serveur MCP est construit dans une image de conteneur, poussé vers Amazon ECR et exécuté dans AgentCore Runtime. Les assistants IA invoquent le point de terminaison du plan de données AgentCore Runtime, qui transmet les appels `tools/*` et `resources/*` à votre serveur via le [transport HTTP diffusable](https://modelcontextprotocol.io/specification/draft/basic/transports#streamable-http).
+Lorsqu'il est déployé sur [Bedrock AgentCore Runtime](https://aws.amazon.com/bedrock/agentcore/), le code de votre serveur est empaqueté sous forme de zip et exécuté dans le runtime géré AgentCore. Les assistants IA invoquent le point de terminaison du plan de données AgentCore Runtime, qui transmet les appels `tools/*` et `resources/*` à votre serveur via le [transport HTTP diffusable](https://modelcontextprotocol.io/specification/draft/basic/transports#streamable-http).
 
-```d2 inline=true
-direction: right
+<ArchitectureDiagram options={{ infra: 'agentcore' }} />
 
-assistant: AI Assistant {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
+</TabItem>
+<TabItem label="AgentCore Runtime (container)" _filter={{ infra: 'agentcore-ecr' }}>
 
-ecr: ECR {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/ecr.svg
-}
+Avec `infra: agentcore-ecr`, le serveur MCP est construit dans une image de conteneur, poussé vers Amazon ECR et exécuté dans AgentCore Runtime. Cela vous donne un contrôle au niveau du système d'exploitation sur l'environnement d'exécution, au prix d'un cycle de construction et de déploiement plus long que l'empaquetage zip ci-dessus.
 
-agentcore: MCP Server\n(AgentCore Runtime) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/bedrock-agentcore-runtime.svg
-}
+<ArchitectureDiagram options={{ infra: 'agentcore-ecr' }} />
 
-cw: CloudWatch\n(Logs, Metrics) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cloudwatch.svg
-}
-
-assistant -> agentcore: Streamable\nHTTP
-ecr -> agentcore: Container\nimage
-agentcore -> cw
-```
 </TabItem>
 <TabItem label="None (local only)" _filter={{ infra: 'none' }}>
 
 Avec `infra: none`, aucune infrastructure AWS n'est générée. Le serveur MCP est configuré uniquement pour les transports STDIO et HTTP locaux, et est consommé par des assistants IA s'exécutant sur la même machine.
 
-```d2 inline=true
-direction: right
+<ArchitectureDiagram options={{ infra: 'none' }} />
 
-assistant: AI Assistant {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
-
-server: MCP Server\n(local process) {
-  shape: rectangle
-}
-
-assistant -> server: STDIO\nor\nStreamable HTTP
-```
 </TabItem>
 </Tabs>

--- a/docs/src/content/docs/fr/snippets/rdb/architecture.mdx
+++ b/docs/src/content/docs/fr/snippets/rdb/architecture.mdx
@@ -1,39 +1,8 @@
 ---
 title: Architecture RDB
 ---
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
 La base de données déployée a l'architecture suivante. Par défaut, un [Amazon RDS Proxy](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-proxy.html) se trouve devant le cluster Aurora pour mettre en commun les connexions et pour activer [l'authentification IAM](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.html) — voir [Désactiver RDS Proxy](#disable-rds-proxy) pour l'alternative. L'architecture est la même que vous sélectionniez le moteur PostgreSQL ou MySQL ; seule la variante du moteur Aurora diffère.
 
-```d2 inline=true
-direction: right
-
-app: Application\n(Lambda, Agent, ...) {
-  shape: hexagon
-}
-
-proxy: RDS Proxy {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/rds.svg
-}
-
-migrations: Migrations Lambda {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/lambda.svg
-}
-
-aurora: Aurora\n(PostgreSQL or MySQL) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/aurora.svg
-}
-
-secrets: Secrets Manager\n(DB credentials) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/secrets-manager.svg
-}
-
-app -> proxy: SQL (IAM auth)
-proxy -> aurora
-migrations -> aurora: Schema migrations
-migrations -> secrets: Admin credentials
-aurora -> secrets: Generates and rotates\nadmin credentials
-```
+<ArchitectureDiagram />

--- a/docs/src/content/docs/it/get_started/tutorials/dungeon-game/overview.mdx
+++ b/docs/src/content/docs/it/get_started/tutorials/dungeon-game/overview.mdx
@@ -16,6 +16,7 @@ import baselineGamePng from '@assets/baseline-game.png'
 import nxGraphPng from '@assets/nx-graph.png'
 import gameSelectPng from '@assets/game-select.png'
 import gameConversationPng from '@assets/game-conversation.png'
+import EmbeddedGraph from '@components/embedded-graph.astro';
 
 
 Utilizzando questo tutorial, costruirai un gioco d'avventura dungeon alimentato da AI Agentica con `@aws/nx-plugin`. Questo tutorial non presuppone alcuna conoscenza pregressa di `@aws/nx-plugin` o delle tecnologie correlate. 
@@ -51,76 +52,9 @@ L'interfaccia del gioco assomiglierà a qualcosa come questo diagramma:
 
 ### Architettura dell'applicazione
 
-Il gioco d'avventura dungeon alimentato da AI Agentica è costruito utilizzando la seguente architettura:
+Il gioco d'avventura dungeon alimentato da AI Agentica è costruito utilizzando la seguente architettura — passa a **Projects** per vedere il workspace da cui è costruito, che creerai nel Modulo 1:
 
-```d2 inline=true
-direction: down
-
-browser: Web Browser {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
-
-cognito: Cognito / IAM {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cognito.svg
-}
-
-cloudfront: CloudFront {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cloudfront.svg
-}
-
-s3: Static Assets\n(S3) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/s3.svg
-}
-
-apigw: API Gateway\n(Game API) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/api-gateway.svg
-}
-
-lambda: tRPC API\n(Lambda) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/lambda.svg
-}
-
-story: Story Agent\n(AgentCore) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/bedrock-agentcore-runtime.svg
-}
-
-mcp: Inventory MCP\n(AgentCore) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/bedrock-agentcore-runtime.svg
-}
-
-ddb: Game State\n(DynamoDB) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/dynamodb.svg
-}
-
-sessions: Story Sessions\n(S3) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/s3.svg
-}
-
-browser -> cognito: Sign in
-browser -> cloudfront
-cloudfront -> s3
-browser -> apigw
-apigw -> lambda
-lambda -> ddb
-lambda -> sessions: Read transcripts
-browser -> story: AG-UI stream
-story -> sessions: Persist turns
-story -> mcp: Tool calls
-mcp -> ddb
-ddb -> sessions: {
-  style.opacity: 0
-}
-```
+<EmbeddedGraph preset="dungeon-adventure" workspace="dungeon-adventure" iac="cdk" view="infrastructure" copyable={false} />
 
 - Sito web frontend React/Vite che utilizza:
   - Amazon Cognito/Identity Pools per chiamate API sicure.

--- a/docs/src/content/docs/it/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/it/guides/agentcore-gateway.mdx
@@ -14,6 +14,7 @@ import Snippet from '@components/snippet.astro';
 import Link from '@components/link.astro';
 import NxCommands from '@components/nx-commands.astro';
 import OptionFilter from '@components/option-filter.astro';
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
 Genera un progetto [Amazon Bedrock AgentCore Gateway](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/gateway.html). Un AgentCore Gateway è un punto di ingresso gestito davanti ai tuoi server MCP o agenti, che autentica le richieste in entrata (IAM o Cognito) e firma il traffico in uscita verso i suoi target con IAM SigV4.
 
@@ -89,32 +90,7 @@ L'URL del Gateway viene automaticamente registrato nello spazio dei nomi `agentc
 
 Il Gateway distribuito ha la seguente architettura, con un Web ACL [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) davanti al Gateway, che instrada verso i suoi target di server MCP downstream:
 
-```d2 inline=true
-direction: right
-
-client: Client {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
-
-waf: WAF {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/waf.svg
-}
-
-gateway: AgentCore Gateway\n(MCP, IAM or Cognito auth) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/bedrock-agentcore-gateway.svg
-}
-
-targets: Downstream MCP Servers\n(Gateway targets) {
-  shape: rectangle
-}
-
-client -> waf
-waf -> gateway
-gateway -> targets
-```
+<ArchitectureDiagram />
 
 ## Autenticazione
 

--- a/docs/src/content/docs/it/guides/py-dynamodb.mdx
+++ b/docs/src/content/docs/it/guides/py-dynamodb.mdx
@@ -11,6 +11,7 @@ import Link from '@components/link.astro';
 import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import Snippet from '@components/snippet.astro';
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
 Questo generatore crea un nuovo progetto Python supportato da [Amazon DynamoDB](https://aws.amazon.com/dynamodb/), utilizzando [PynamoDB](https://pynamodb.readthedocs.io/) per la modellazione delle entità. Genera il codice dell'applicazione e l'infrastruttura necessaria per il provisioning e la gestione di una tabella DynamoDB utilizzando AWS CDK o Terraform, con supporto per il design a tabella singola e sviluppo locale integrato tramite DynamoDB Local.
 
@@ -52,6 +53,12 @@ Gli script di sviluppo locale sono condivisi tra tutti i progetti DynamoDB (sia 
 ### Infrastruttura
 
 <Snippet name="dynamodb/infrastructure" />
+
+#### Architettura
+
+Il progetto distribuito effettua il provisioning della tabella stessa, che qualsiasi progetto a cui è connesso legge e scrive:
+
+<ArchitectureDiagram />
 
 ## Sviluppo Locale
 

--- a/docs/src/content/docs/it/guides/react-website-auth.mdx
+++ b/docs/src/content/docs/it/guides/react-website-auth.mdx
@@ -10,6 +10,7 @@ import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Infrastructure from '@components/infrastructure.astro';
 import Snippet from '@components/snippet.astro';
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
 Il generatore React Website Authentication aggiunge l'autenticazione al tuo sito web React utilizzando [Amazon Cognito](https://aws.amazon.com/cognito/).
 
@@ -71,44 +72,13 @@ Troverai anche il seguente codice di infrastruttura generato in base al tuo `iac
 
 Questo generatore aggiunge un user pool Amazon Cognito (per l'accesso) e un identity pool (per federare gli utenti autenticati a credenziali IAM con ambito) all'architettura esistente del sito web statico:
 
-```d2 inline=true
-direction: right
-
-browser: Web Browser {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
-
-waf: WAF {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/waf.svg
-}
-
-cognito: Cognito\n(User + Identity Pool) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cognito.svg
-}
-
-iam: Scoped IAM\nCredentials {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/iam.svg
-}
-
-backend: Authenticated\nAWS Resources {
-  shape: rectangle
-}
-
-browser -> waf: Sign in
-waf -> cognito
-cognito -> iam
-browser -> backend: IAM/Cognito
-```
+<ArchitectureDiagram name="my-website" />
 
 #### Protezione dalle minacce
 
-Il User Pool viene creato sul [piano funzionalità Plus](https://docs.aws.amazon.com/cognito/latest/developerguide/feature-plans-features-plus.html) di Cognito con la [protezione dalle minacce](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pool-settings-threat-protection.html) impostata sulla modalità `AUDIT` per l'autenticazione standard. In modalità audit, Cognito assegna un livello di rischio a ogni accesso e registra la valutazione su CloudWatch senza bloccare gli utenti.
+Il User Pool viene creato sul [piano funzionalità Plus](https://docs.aws.amazon.com/cognito/latest/developerguide/feature-plans-features-plus.html) di Cognito con la [protezione dalle minacce](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pool-settings-threat-protection.html) in modalità di applicazione **solo audit** per l'autenticazione standard. In modalità solo audit, Cognito assegna un livello di rischio a ogni accesso e registra la valutazione senza bloccare gli utenti.
 
-Una volta osservate le valutazioni del rischio per i tuoi utenti, puoi passare all'applicazione completa delle funzionalità per rispondere automaticamente alle attività rischiose (ad esempio richiedendo MFA o bloccando l'accesso):
+Una volta osservate le valutazioni del rischio per i tuoi utenti, puoi passare all'applicazione completa delle funzionalità per rispondere automaticamente alle attività rischiose (ad esempio richiedendo MFA o bloccando l'accesso), quindi configurare la risposta per livello di rischio tramite l'[autenticazione adattiva](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pool-settings-adaptive-authentication.html):
 
 <Infrastructure>
 <Fragment slot="cdk">
@@ -187,13 +157,13 @@ Questa regola contrassegna gli indirizzi di loopback negli argomenti di query co
 Dovrai aggiungere l'infrastruttura di identità utente al tuo stack, dichiarandola _prima_ del sito web:
 
 ```ts title="packages/infra/src/stacks/application-stack.ts" {3,9}
-import { Stack } from 'aws-cdk-lib';
+import { Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { MyWebsite, UserIdentity } from '@my-scope/common-constructs';
 
 export class ApplicationStack extends Stack {
-  constructor(scope: Construct, id: string) {
-    super(scope, id);
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
 
     new UserIdentity(this, 'Identity');
 
@@ -256,13 +226,13 @@ Per concedere agli utenti autenticati l'accesso per eseguire determinate azioni,
 <Infrastructure>
 <Fragment slot="cdk">
 ```ts title="packages/infra/src/stacks/application-stack.ts" {12}
-import { Stack } from 'aws-cdk-lib';
+import { Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { MyWebsite, UserIdentity, MyApi } from '@my-scope/common-constructs';
 
 export class ApplicationStack extends Stack {
-  constructor(scope: Construct, id: string) {
-    super(scope, id);
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
 
     const identity = new UserIdentity(this, 'Identity');
     const api = new MyApi(this, 'MyApi', {

--- a/docs/src/content/docs/it/guides/react-website.mdx
+++ b/docs/src/content/docs/it/guides/react-website.mdx
@@ -17,6 +17,7 @@ import PackageManagerShortCommand from '@components/package-manager-short-comman
 import Infrastructure from '@components/infrastructure.astro';
 import Snippet from '@components/snippet.astro';
 import OptionFilter from '@components/option-filter.astro';
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
 Questo generatore crea un nuovo sito web [React](https://react.dev/) con [shadcn/ui](https://ui.shadcn.com/) configurato di default, insieme all'infrastruttura AWS CDK o Terraform per distribuire il tuo sito web nel cloud come sito web statico ospitato in [S3](https://aws.amazon.com/s3/), servito da [CloudFront](https://aws.amazon.com/cloudfront/) e protetto da [WAF](https://aws.amazon.com/waf/).
 
@@ -99,35 +100,9 @@ Il generatore crea infrastruttura come codice per distribuire il tuo sito web in
 
 #### Architettura
 
-Il sito web distribuito ha la seguente architettura:
+Il sito web distribuito ha la seguente architettura: le tue risorse compilate in un bucket S3, servite da una distribuzione CloudFront con un AWS WAFv2 Web ACL davanti ad essa.
 
-```d2 inline=true
-direction: right
-
-browser: Web Browser {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
-
-waf: WAF {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/waf.svg
-}
-
-cloudfront: CloudFront {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cloudfront.svg
-}
-
-s3: Static Assets\n(S3) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/s3.svg
-}
-
-browser -> waf
-waf -> cloudfront
-cloudfront -> s3
-```
+<ArchitectureDiagram />
 
 ## Implementare il tuo sito web
 
@@ -160,21 +135,25 @@ Puoi utilizzare il componente `Link` o l'hook `useNavigate` per navigare tra le 
 ```tsx {1, 4, 8-9, 14}
 import { Link, useNavigate } from '@tanstack/react-router';
 
-export const MyComponent = () => {
+export const MyComponent = ({
+  createProduct,
+}: {
+  createProduct: () => Promise<string>;
+}) => {
   const navigate = useNavigate();
 
   const submit = async () => {
-    const id = await ...
+    const id = await createProduct();
     // Use `navigate` for redirecting after some asynchronous action
-    navigate({ to: '/products/$id', { params: { id }} });
+    navigate({ to: '/products/$id', params: { id } });
   };
 
   return (
     <>
       <Link to="/products">Cancel</Link>
-      <Button onClick={submit}>Submit</Button>
+      <button onClick={submit}>Submit</button>
     </>
-  )
+  );
 };
 ```
 
@@ -191,13 +170,13 @@ Per distribuire il tuo sito web, consigliamo di utilizzare il <Link path="guides
 Puoi utilizzare il costrutto CDK generato per te in `packages/common/constructs` per distribuire il tuo sito web.
 
 ```ts title="packages/infra/src/stacks/application-stack.ts" {3, 9}
-import { Stack } from 'aws-cdk-lib';
+import { Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { MyWebsite } from '@my-scope/common-constructs';
 
 export class ApplicationStack extends Stack {
-  constructor(scope: Construct, id: string) {
-    super(scope, id);
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
 
     new MyWebsite(this, 'MyWebsite');
   }
@@ -266,13 +245,13 @@ La distribuzione CloudFront è protetta da un [AWS WAFv2](https://docs.aws.amazo
 Per disattivare, imposta `enableWaf` su `false` quando crei il tuo sito web:
 
 ```ts title="packages/infra/src/stacks/application-stack.ts" {10,15-18}
-import { Stack } from 'aws-cdk-lib';
+import { Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { MyWebsite, suppressRules } from '@my-scope/common-constructs';
 
 export class ApplicationStack extends Stack {
-  constructor(scope: Construct, id: string) {
-    super(scope, id);
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
 
     const website = new MyWebsite(this, 'MyWebsite', {
       enableWaf: false,
@@ -318,14 +297,14 @@ Il bucket del sito web, il bucket dei log della distribuzione CloudFront e il gr
 Se desideri utilizzare una configurazione di crittografia diversa, passa le proprietà `encryption`, `encryptionKey` e `enableKeyRotation` quando crei il tuo sito web:
 
 ```ts title="packages/infra/src/stacks/application-stack.ts" {11}
-import { Stack } from 'aws-cdk-lib';
+import { Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { BucketEncryption } from 'aws-cdk-lib/aws-s3';
 import { MyWebsite } from '@my-scope/common-constructs';
 
 export class ApplicationStack extends Stack {
-  constructor(scope: Construct, id: string) {
-    super(scope, id);
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
 
     new MyWebsite(this, 'MyWebsite', {
       encryption: BucketEncryption.S3_MANAGED,
@@ -405,7 +384,8 @@ Scegliere `S3_MANAGED` fa fallire la scansione di sicurezza `checkov` con `CKV_A
 
 ```yaml title="packages/infra/src/.checkov.yaml"
 skip-check:
-  - CKV_AWS_145
+  # ...
+  - CKV_AWS_145 # S3 buckets are not KMS encrypted when encryption is S3_MANAGED
 ```
 :::
 
@@ -443,7 +423,8 @@ Disabilitare la rotazione delle chiavi sulla chiave creata automaticamente fa fa
 
 ```yaml title="packages/infra/src/.checkov.yaml"
 skip-check:
-  - CKV_AWS_7
+  # ...
+  - CKV_AWS_7 # Key rotation is disabled on the website's KMS key
 ```
 :::
 </Fragment>
@@ -458,14 +439,14 @@ Di default, la distribuzione utilizza il nome di dominio CloudFront predefinito 
 Passa le proprietà `certificate` e `domainNames` quando crei il tuo sito web:
 
 ```ts title="packages/infra/src/stacks/application-stack.ts" {11-13}
-import { Stack } from 'aws-cdk-lib';
+import { Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { Certificate } from 'aws-cdk-lib/aws-certificatemanager';
 import { MyWebsite } from '@my-scope/common-constructs';
 
 export class ApplicationStack extends Stack {
-  constructor(scope: Construct, id: string) {
-    super(scope, id);
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
 
     new MyWebsite(this, 'MyWebsite', {
       domainNames: ['www.example.com'],
@@ -508,13 +489,13 @@ Il costrutto CDK `RuntimeConfig` può essere utilizzato per aggiungere e recuper
 Il tuo costrutto CDK del sito web distribuirà il namespace `connection` della configurazione runtime come file `runtime-config.json` nella radice del tuo bucket S3.
 
 ```ts title="packages/infra/src/stacks/application-stack.ts"
-import { Stack } from 'aws-cdk-lib';
+import { Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { MyWebsite, MyApi } from '@my-scope/common-constructs';
 
 export class ApplicationStack extends Stack {
-  constructor(scope: Construct, id: string) {
-    super(scope, id);
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
 
     // Website can be declared at any point, since runtime config is resolved lazily
     new MyWebsite(this, 'MyWebsite');

--- a/docs/src/content/docs/it/guides/ts-dynamodb.mdx
+++ b/docs/src/content/docs/it/guides/ts-dynamodb.mdx
@@ -11,6 +11,7 @@ import Link from '@components/link.astro';
 import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import Snippet from '@components/snippet.astro';
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
 Questo generatore crea un nuovo progetto TypeScript DynamoDB supportato da [Amazon DynamoDB](https://aws.amazon.com/dynamodb/), utilizzando [ElectroDB](https://electrodb.dev/) per la modellazione di entità type-safe. Genera il codice dell'applicazione e l'infrastruttura necessaria per il provisioning e la gestione di una tabella DynamoDB utilizzando AWS CDK o Terraform, con supporto per il design single-table e sviluppo locale integrato tramite DynamoDB Local.
 
@@ -52,6 +53,12 @@ Gli script di sviluppo locale sono condivisi tra tutti i progetti DynamoDB (sia 
 ### Infrastruttura
 
 <Snippet name="dynamodb/infrastructure" />
+
+#### Architettura
+
+Il progetto distribuito effettua il provisioning della tabella stessa, che qualsiasi progetto ad essa connesso legge e scrive:
+
+<ArchitectureDiagram />
 
 ## Sviluppo locale
 

--- a/docs/src/content/docs/it/guides/ts-smithy-api.mdx
+++ b/docs/src/content/docs/it/guides/ts-smithy-api.mdx
@@ -20,6 +20,7 @@ import Snippet from '@components/snippet.astro';
 import OptionFilter from '@components/option-filter.astro';
 import InstallCommand from '@components/install-command.astro';
 import { TS_VERSIONS } from '../../../../../../packages/nx-plugin/src/utils/versions';
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
 [Smithy](https://smithy.io/) è un linguaggio di definizione di interfacce indipendente dal protocollo per la creazione di API in modo model-driven.
 
@@ -126,47 +127,7 @@ Questo progetto è generato utilizzando il generatore <Link path="/guides/terraf
 
 L'API Smithy distribuita ha la seguente architettura, con un Web ACL [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) davanti allo stage API Gateway:
 
-```d2 inline=true
-direction: right
-
-client: Client {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
-
-waf: WAF {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/waf.svg
-}
-
-apigw: API Gateway\n(REST API) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/api-gateway.svg
-}
-
-lambda: Lambda\n(Smithy Server SDK) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/lambda.svg
-}
-
-cw: CloudWatch\n(Logs, Metrics) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cloudwatch.svg
-  near: top-right
-}
-
-xray: X-Ray\n(Traces) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/xray.svg
-  near: bottom-right
-}
-
-client -> waf
-waf -> apigw
-apigw -> lambda
-lambda -> cw
-lambda -> xray
-```
+<ArchitectureDiagram options={{ infra: 'rest-lambda' }} />
 
 ## Implementare la tua Smithy API
 

--- a/docs/src/content/docs/it/snippets/agent/architecture.mdx
+++ b/docs/src/content/docs/it/snippets/agent/architecture.mdx
@@ -2,71 +2,28 @@
 title: Architettura dell'Agent
 ---
 import { Tabs, TabItem } from '@astrojs/starlight/components';
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
 <Tabs syncKey="infra">
-<TabItem label="Bedrock AgentCore Runtime" _filter={{ infra: 'agentcore' }}>
+<TabItem label="AgentCore Runtime" _filter={{ infra: 'agentcore' }}>
 
-Quando viene distribuito su [Bedrock AgentCore Runtime](https://aws.amazon.com/bedrock/agentcore/), l'agent viene compilato in un'immagine container, caricato su Amazon ECR ed eseguito in AgentCore Runtime. I client invocano l'endpoint del data plane di AgentCore Runtime, che inoltra le richieste al tuo agent. L'agent chiama Amazon Bedrock per l'inferenza del modello e può invocare strumenti, server MCP o API downstream.
+Quando viene distribuito su [Bedrock AgentCore Runtime](https://aws.amazon.com/bedrock/agentcore/), il codice del tuo agent viene impacchettato come zip ed eseguito nel runtime gestito di AgentCore. I client invocano l'endpoint del data plane di AgentCore Runtime, che inoltra le richieste al tuo agent. L'agent chiama Amazon Bedrock per l'inferenza del modello e può invocare strumenti, server MCP o API downstream.
 
-```d2 inline=true
-direction: right
+<ArchitectureDiagram options={{ infra: 'agentcore' }} />
 
-client: Client {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
+</TabItem>
+<TabItem label="AgentCore Runtime (container)" _filter={{ infra: 'agentcore-ecr' }}>
 
-ecr: ECR {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/ecr.svg
-}
+Con `infra: agentcore-ecr`, l'agent viene compilato in un'immagine container, caricato su Amazon ECR ed eseguito in AgentCore Runtime. Questo ti dà il controllo a livello di sistema operativo sull'ambiente di runtime, al costo di un ciclo di build e deploy più lungo rispetto al packaging zip sopra descritto.
 
-agentcore: Strands Agent\n(AgentCore Runtime) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/bedrock-agentcore-runtime.svg
-}
+<ArchitectureDiagram options={{ infra: 'agentcore-ecr' }} />
 
-bedrock: Bedrock\n(Model Inference) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/bedrock.svg
-  near: top-right
-}
-
-cw: CloudWatch\n(Logs, Metrics) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cloudwatch.svg
-  near: bottom-right
-}
-
-client -> agentcore
-ecr -> agentcore: Container\nimage
-agentcore -> bedrock: InvokeModel
-agentcore -> cw
-```
 </TabItem>
 <TabItem label="None (local only)" _filter={{ infra: 'none' }}>
 
 Con `infra: none`, non viene generata alcuna infrastruttura AWS. L'agent viene eseguito come processo locale e chiama Amazon Bedrock per l'inferenza del modello.
 
-```d2 inline=true
-direction: right
+<ArchitectureDiagram options={{ infra: 'none' }} />
 
-client: Client {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
-
-agent: Strands Agent\n(local process) {
-  shape: rectangle
-}
-
-bedrock: Bedrock\n(Model Inference) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/bedrock.svg
-}
-
-client -> agent
-agent -> bedrock: InvokeModel
-```
 </TabItem>
 </Tabs>

--- a/docs/src/content/docs/it/snippets/api/api-architecture.mdx
+++ b/docs/src/content/docs/it/snippets/api/api-architecture.mdx
@@ -2,91 +2,20 @@
 title: Architettura API
 ---
 import { Tabs, TabItem } from '@astrojs/starlight/components';
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
-L'applicazione distribuita ha la seguente architettura:
+L'applicazione distribuita ha la seguente architettura: un'API di API Gateway davanti a una funzione Lambda che esegue il tuo handler.
 
 <Tabs syncKey="http-rest">
 <TabItem label="REST API" _filter={{ infra: 'rest-lambda' }}>
-```d2 inline=true
-direction: right
 
-client: Client {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
-
-waf: WAF {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/waf.svg
-}
-
-apigw: API Gateway\n(REST API) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/api-gateway.svg
-}
-
-lambda: Lambda {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/lambda.svg
-}
-
-cw: CloudWatch\n(Logs, Metrics) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cloudwatch.svg
-  near: top-right
-}
-
-xray: X-Ray\n(Traces) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/xray.svg
-  near: bottom-right
-}
-
-client -> waf
-waf -> apigw
-apigw -> lambda
-lambda -> cw
-lambda -> xray
-```
+<ArchitectureDiagram options={{ infra: 'rest-lambda' }} />
 
 Le REST API includono una Web ACL [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) davanti allo stage di API Gateway con il set di regole predefinito gestito da AWS abilitato.
 </TabItem>
 <TabItem label="HTTP API" _filter={{ infra: 'http-lambda' }}>
-```d2 inline=true
-direction: right
 
-client: Client {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
-
-apigw: API Gateway\n(HTTP API) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/api-gateway.svg
-}
-
-lambda: Lambda {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/lambda.svg
-}
-
-cw: CloudWatch\n(Logs, Metrics) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cloudwatch.svg
-  near: top-right
-}
-
-xray: X-Ray\n(Traces) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/xray.svg
-  near: bottom-right
-}
-
-client -> apigw
-apigw -> lambda
-lambda -> cw
-lambda -> xray
-```
+<ArchitectureDiagram options={{ infra: 'http-lambda' }} />
 
 Le HTTP API non supportano direttamente WAF — se hai bisogno della protezione WAF, scegli REST API oppure posiziona l'HTTP API dietro una distribuzione CloudFront.
 </TabItem>

--- a/docs/src/content/docs/it/snippets/lambda-function/architecture.mdx
+++ b/docs/src/content/docs/it/snippets/lambda-function/architecture.mdx
@@ -1,36 +1,10 @@
 ---
 title: Architettura della Lambda Function
 ---
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
-La funzione distribuita ha la seguente architettura:
+La funzione distribuita ha la seguente architettura, con i suoi log, metriche e tracce che vanno a CloudWatch e X-Ray:
 
-```d2 inline=true
-direction: right
-
-source: Event Source\n(SNS, SQS, ...) {
-  shape: rectangle
-}
-
-lambda: Lambda {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/lambda.svg
-}
-
-cw: CloudWatch\n(Logs, Metrics) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cloudwatch.svg
-  near: top-right
-}
-
-xray: X-Ray\n(Traces) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/xray.svg
-  near: bottom-right
-}
-
-source -> lambda
-lambda -> cw
-lambda -> xray
-```
+<ArchitectureDiagram name="my-function" />
 
 Il generatore fornisce la funzione stessa; è necessario collegare la sorgente degli eventi nello stack per invocarla (ad esempio, un'integrazione API Gateway, una regola EventBridge, una notifica S3 o un mapping di sorgente eventi SQS).

--- a/docs/src/content/docs/it/snippets/mcp/architecture.mdx
+++ b/docs/src/content/docs/it/snippets/mcp/architecture.mdx
@@ -2,57 +2,28 @@
 title: Architettura del Server MCP
 ---
 import { Tabs, TabItem } from '@astrojs/starlight/components';
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
 <Tabs syncKey="infra">
-<TabItem label="Bedrock AgentCore Runtime" _filter={{ infra: 'agentcore' }}>
+<TabItem label="AgentCore Runtime" _filter={{ infra: 'agentcore' }}>
 
-Quando viene distribuito su [Bedrock AgentCore Runtime](https://aws.amazon.com/bedrock/agentcore/), il server MCP viene costruito in un'immagine container, caricato su Amazon ECR ed eseguito in AgentCore Runtime. Gli assistenti AI invocano l'endpoint del data plane di AgentCore Runtime, che inoltra le chiamate `tools/*` e `resources/*` al tuo server tramite il [trasporto HTTP streamable](https://modelcontextprotocol.io/specification/draft/basic/transports#streamable-http).
+Quando viene distribuito su [Bedrock AgentCore Runtime](https://aws.amazon.com/bedrock/agentcore/), il codice del tuo server viene impacchettato come zip ed eseguito nel runtime gestito di AgentCore. Gli assistenti AI invocano l'endpoint del data plane di AgentCore Runtime, che inoltra le chiamate `tools/*` e `resources/*` al tuo server tramite il [trasporto HTTP streamable](https://modelcontextprotocol.io/specification/draft/basic/transports#streamable-http).
 
-```d2 inline=true
-direction: right
+<ArchitectureDiagram options={{ infra: 'agentcore' }} />
 
-assistant: AI Assistant {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
+</TabItem>
+<TabItem label="AgentCore Runtime (container)" _filter={{ infra: 'agentcore-ecr' }}>
 
-ecr: ECR {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/ecr.svg
-}
+Con `infra: agentcore-ecr`, il server MCP viene costruito in un'immagine container, caricato su Amazon ECR ed eseguito in AgentCore Runtime. Questo ti offre il controllo a livello di sistema operativo sull'ambiente di runtime, al costo di un ciclo di build e deploy più lungo rispetto al packaging zip sopra descritto.
 
-agentcore: MCP Server\n(AgentCore Runtime) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/bedrock-agentcore-runtime.svg
-}
+<ArchitectureDiagram options={{ infra: 'agentcore-ecr' }} />
 
-cw: CloudWatch\n(Logs, Metrics) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cloudwatch.svg
-}
-
-assistant -> agentcore: Streamable\nHTTP
-ecr -> agentcore: Container\nimage
-agentcore -> cw
-```
 </TabItem>
 <TabItem label="None (local only)" _filter={{ infra: 'none' }}>
 
 Con `infra: none`, non viene generata alcuna infrastruttura AWS. Il server MCP è configurato solo per i trasporti STDIO e HTTP locali, ed è utilizzato da assistenti AI in esecuzione sulla stessa macchina.
 
-```d2 inline=true
-direction: right
+<ArchitectureDiagram options={{ infra: 'none' }} />
 
-assistant: AI Assistant {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
-
-server: MCP Server\n(local process) {
-  shape: rectangle
-}
-
-assistant -> server: STDIO\nor\nStreamable HTTP
-```
 </TabItem>
 </Tabs>

--- a/docs/src/content/docs/it/snippets/rdb/architecture.mdx
+++ b/docs/src/content/docs/it/snippets/rdb/architecture.mdx
@@ -1,39 +1,8 @@
 ---
 title: Architettura RDB
 ---
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
 Il database distribuito ha la seguente architettura. Per impostazione predefinita, un [Amazon RDS Proxy](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-proxy.html) si trova davanti al cluster Aurora per raggruppare le connessioni e per abilitare l'[autenticazione IAM](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.html) — vedi [Disable RDS Proxy](#disable-rds-proxy) per l'alternativa. L'architettura è la stessa sia che si selezioni il motore PostgreSQL o MySQL; solo il tipo di motore Aurora differisce.
 
-```d2 inline=true
-direction: right
-
-app: Application\n(Lambda, Agent, ...) {
-  shape: hexagon
-}
-
-proxy: RDS Proxy {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/rds.svg
-}
-
-migrations: Migrations Lambda {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/lambda.svg
-}
-
-aurora: Aurora\n(PostgreSQL or MySQL) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/aurora.svg
-}
-
-secrets: Secrets Manager\n(DB credentials) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/secrets-manager.svg
-}
-
-app -> proxy: SQL (IAM auth)
-proxy -> aurora
-migrations -> aurora: Schema migrations
-migrations -> secrets: Admin credentials
-aurora -> secrets: Generates and rotates\nadmin credentials
-```
+<ArchitectureDiagram />

--- a/docs/src/content/docs/jp/get_started/tutorials/dungeon-game/overview.mdx
+++ b/docs/src/content/docs/jp/get_started/tutorials/dungeon-game/overview.mdx
@@ -16,6 +16,7 @@ import baselineGamePng from '@assets/baseline-game.png'
 import nxGraphPng from '@assets/nx-graph.png'
 import gameSelectPng from '@assets/game-select.png'
 import gameConversationPng from '@assets/game-conversation.png'
+import EmbeddedGraph from '@components/embedded-graph.astro';
 
 
 このチュートリアルでは、`@aws/nx-plugin` を使用してエージェント型 AI を活用したダンジョンアドベンチャーゲームを構築します。このチュートリアルは、`@aws/nx-plugin` や関連技術に関する既存の知識を前提としていません。
@@ -51,76 +52,9 @@ import gameConversationPng from '@assets/game-conversation.png'
 
 ### アプリケーションアーキテクチャ
 
-エージェント型 AI を活用したダンジョンアドベンチャーゲームは、以下のアーキテクチャを使用して構築されています：
+エージェント型 AI を活用したダンジョンアドベンチャーゲームは、以下のアーキテクチャを使用して構築されています — **Projects** に切り替えると、モジュール 1 でスキャフォールドする、構築元のワークスペースを確認できます：
 
-```d2 inline=true
-direction: down
-
-browser: Web Browser {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
-
-cognito: Cognito / IAM {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cognito.svg
-}
-
-cloudfront: CloudFront {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cloudfront.svg
-}
-
-s3: Static Assets\n(S3) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/s3.svg
-}
-
-apigw: API Gateway\n(Game API) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/api-gateway.svg
-}
-
-lambda: tRPC API\n(Lambda) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/lambda.svg
-}
-
-story: Story Agent\n(AgentCore) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/bedrock-agentcore-runtime.svg
-}
-
-mcp: Inventory MCP\n(AgentCore) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/bedrock-agentcore-runtime.svg
-}
-
-ddb: Game State\n(DynamoDB) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/dynamodb.svg
-}
-
-sessions: Story Sessions\n(S3) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/s3.svg
-}
-
-browser -> cognito: Sign in
-browser -> cloudfront
-cloudfront -> s3
-browser -> apigw
-apigw -> lambda
-lambda -> ddb
-lambda -> sessions: Read transcripts
-browser -> story: AG-UI stream
-story -> sessions: Persist turns
-story -> mcp: Tool calls
-mcp -> ddb
-ddb -> sessions: {
-  style.opacity: 0
-}
-```
+<EmbeddedGraph preset="dungeon-adventure" workspace="dungeon-adventure" iac="cdk" view="infrastructure" copyable={false} />
 
 - React/Vite フロントエンドウェブサイトは以下を利用します：
   - 安全な API 呼び出しのための Amazon Cognito/Identity Pools

--- a/docs/src/content/docs/jp/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/jp/guides/agentcore-gateway.mdx
@@ -14,6 +14,7 @@ import Snippet from '@components/snippet.astro';
 import Link from '@components/link.astro';
 import NxCommands from '@components/nx-commands.astro';
 import OptionFilter from '@components/option-filter.astro';
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
 [Amazon Bedrock AgentCore Gateway](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/gateway.html)プロジェクトを生成します。AgentCore Gatewayは、MCPサーバーまたはエージェントの前に配置されるマネージドエントリーポイントで、インバウンドリクエストを認証し（IAMまたはCognito）、ターゲットへのアウトバウンドトラフィックにIAM SigV4で署名します。
 
@@ -89,32 +90,7 @@ Gateway URLは、<Link path="guides/runtime-config">Runtime Configuration</Link>
 
 デプロイされたGatewayは以下のアーキテクチャを持ち、Gatewayの前に[AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACLがあり、下流のMCPサーバーターゲットにルーティングします：
 
-```d2 inline=true
-direction: right
-
-client: Client {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
-
-waf: WAF {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/waf.svg
-}
-
-gateway: AgentCore Gateway\n(MCP, IAM or Cognito auth) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/bedrock-agentcore-gateway.svg
-}
-
-targets: Downstream MCP Servers\n(Gateway targets) {
-  shape: rectangle
-}
-
-client -> waf
-waf -> gateway
-gateway -> targets
-```
+<ArchitectureDiagram />
 
 ## 認証
 

--- a/docs/src/content/docs/jp/guides/py-dynamodb.mdx
+++ b/docs/src/content/docs/jp/guides/py-dynamodb.mdx
@@ -11,6 +11,7 @@ import Link from '@components/link.astro';
 import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import Snippet from '@components/snippet.astro';
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
 このジェネレーターは、[Amazon DynamoDB](https://aws.amazon.com/dynamodb/) をバックエンドとする新しい Python プロジェクトを作成します。エンティティモデリングには [PynamoDB](https://pynamodb.readthedocs.io/) を使用します。AWS CDK または Terraform を使用して DynamoDB テーブルをプロビジョニングおよび管理するために必要なアプリケーションコードとインフラストラクチャを生成し、シングルテーブル設計のサポートと DynamoDB Local による組み込みのローカル開発環境を提供します。
 
@@ -52,6 +53,12 @@ import Snippet from '@components/snippet.astro';
 ### インフラストラクチャ
 
 <Snippet name="dynamodb/infrastructure" />
+
+#### アーキテクチャ
+
+デプロイされたプロジェクトはテーブル自体をプロビジョニングし、接続されたすべてのプロジェクトがそれを読み書きします：
+
+<ArchitectureDiagram />
 
 ## ローカル開発
 

--- a/docs/src/content/docs/jp/guides/react-website-auth.mdx
+++ b/docs/src/content/docs/jp/guides/react-website-auth.mdx
@@ -10,6 +10,7 @@ import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Infrastructure from '@components/infrastructure.astro';
 import Snippet from '@components/snippet.astro';
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
 React Webサイト認証ジェネレーターは、[Amazon Cognito](https://aws.amazon.com/cognito/)を使用してReact Webサイトに認証を追加します。
 
@@ -71,44 +72,13 @@ React Webサイトに次の変更が加えられます：
 
 このジェネレーターは、既存のstatic-websiteアーキテクチャにAmazon Cognito User Pool（サインイン用）とIdentity Pool（サインインしたユーザーをスコープ付きIAM認証情報にフェデレートするため）を追加します：
 
-```d2 inline=true
-direction: right
-
-browser: Web Browser {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
-
-waf: WAF {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/waf.svg
-}
-
-cognito: Cognito\n(User + Identity Pool) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cognito.svg
-}
-
-iam: Scoped IAM\nCredentials {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/iam.svg
-}
-
-backend: Authenticated\nAWS Resources {
-  shape: rectangle
-}
-
-browser -> waf: Sign in
-waf -> cognito
-cognito -> iam
-browser -> backend: IAM/Cognito
-```
+<ArchitectureDiagram name="my-website" />
 
 #### 脅威保護
 
-User Poolは、標準認証に対して[脅威保護](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pool-settings-threat-protection.html)を`AUDIT`モードに設定したCognito [Plus機能プラン](https://docs.aws.amazon.com/cognito/latest/developerguide/feature-plans-features-plus.html)で作成されます。監査モードでは、Cognitoは各サインインにリスクレベルを割り当て、ユーザーをブロックすることなく評価をCloudWatchに記録します。
+User Poolは、標準認証に対して[脅威保護](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pool-settings-threat-protection.html)を**監査のみ**の強制に設定したCognito [Plus機能プラン](https://docs.aws.amazon.com/cognito/latest/developerguide/feature-plans-features-plus.html)で作成されます。監査のみモードでは、Cognitoは各サインインにリスクレベルを割り当て、ユーザーをブロックすることなく評価を記録します。
 
-ユーザーのリスク評価を観察した後、完全機能の強制に切り替えて、リスクの高いアクティビティに自動的に対応できます（例：MFAの要求やサインインのブロック）：
+ユーザーのリスク評価を観察した後、完全機能の強制に切り替えて、リスクの高いアクティビティに自動的に対応し（例：MFAの要求やサインインのブロック）、[適応認証](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pool-settings-adaptive-authentication.html)を介してリスクレベルごとに応答を設定できます：
 
 <Infrastructure>
 <Fragment slot="cdk">
@@ -187,13 +157,13 @@ module "user_identity" {
 スタックにユーザーIDインフラストラクチャを追加する必要があります。Webサイトの_前に_宣言してください：
 
 ```ts title="packages/infra/src/stacks/application-stack.ts" {3,9}
-import { Stack } from 'aws-cdk-lib';
+import { Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { MyWebsite, UserIdentity } from '@my-scope/common-constructs';
 
 export class ApplicationStack extends Stack {
-  constructor(scope: Construct, id: string) {
-    super(scope, id);
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
 
     new UserIdentity(this, 'Identity');
 
@@ -256,13 +226,13 @@ APIの呼び出し権限の付与など、認証されたユーザーが特定�
 <Infrastructure>
 <Fragment slot="cdk">
 ```ts title="packages/infra/src/stacks/application-stack.ts" {12}
-import { Stack } from 'aws-cdk-lib';
+import { Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { MyWebsite, UserIdentity, MyApi } from '@my-scope/common-constructs';
 
 export class ApplicationStack extends Stack {
-  constructor(scope: Construct, id: string) {
-    super(scope, id);
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
 
     const identity = new UserIdentity(this, 'Identity');
     const api = new MyApi(this, 'MyApi', {

--- a/docs/src/content/docs/jp/guides/react-website.mdx
+++ b/docs/src/content/docs/jp/guides/react-website.mdx
@@ -17,6 +17,7 @@ import PackageManagerShortCommand from '@components/package-manager-short-comman
 import Infrastructure from '@components/infrastructure.astro';
 import Snippet from '@components/snippet.astro';
 import OptionFilter from '@components/option-filter.astro';
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
 このジェネレーターは、デフォルトで[shadcn/ui](https://ui.shadcn.com/)が設定された新しい[React](https://react.dev/)ウェブサイトと、[S3](https://aws.amazon.com/s3/)でホストされ、[CloudFront](https://aws.amazon.com/cloudfront/)で配信され、[WAF](https://aws.amazon.com/waf/)で保護される静的ウェブサイトとしてクラウドにデプロイするためのAWS CDKまたはTerraformインフラストラクチャを作成します。
 
@@ -50,16 +51,23 @@ import OptionFilter from '@components/option-filter.astro';
     - config.ts アプリケーション設定（例：ロゴ）
     - components
       - AppLayout 全体のレイアウトとナビゲーションバーのコンポーネント
+      - app-sidebar.tsx サイドバーナビゲーション（shadcnのみ）
+      - alert.tsx UXプロバイダー独自のものをラップするAlertコンポーネント
+      - spinner.tsx UXプロバイダー独自のものをラップするSpinnerコンポーネント
     - hooks
       - useAppLayout.tsx ネストされたコンポーネントからAppLayoutを調整するためのフック（Cloudscapeのみ）
     - routes
+      - \_\_root.tsx ルートルート、すべてのページをAppLayoutでラップ
       - index.tsx TanStack Routerのルート（またはページ）の例
+    - routeTree.gen.ts TanStack Routerによって生成および管理されるルートツリー
     - styles.css グローバルスタイル
   - vite.config.mts ViteとVitestの設定
+  - project.json プロジェクトのターゲットを定義するNxプロジェクト
   - tsconfig.json ソースとテストのベースTypeScript設定
   - tsconfig.app.json ソースコード用のTypeScript設定
   - tsconfig.spec.json テスト用のTypeScript設定
   - package.json プロジェクトのパッケージ名と依存関係を定義するプロジェクトマニフェスト
+  - README.md プロジェクトREADME
 </FileTree>
 
 :::note[TanStack Routerを使用しない場合]
@@ -99,35 +107,9 @@ import OptionFilter from '@components/option-filter.astro';
 
 #### アーキテクチャ
 
-デプロイされたウェブサイトは以下のアーキテクチャを持ちます：
+デプロイされたウェブサイトは以下のアーキテクチャを持ちます：S3バケット内のビルドされたアセットが、AWS WAFv2 Web ACLを前面に配置したCloudFrontディストリビューションによって配信されます。
 
-```d2 inline=true
-direction: right
-
-browser: Web Browser {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
-
-waf: WAF {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/waf.svg
-}
-
-cloudfront: CloudFront {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cloudfront.svg
-}
-
-s3: Static Assets\n(S3) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/s3.svg
-}
-
-browser -> waf
-waf -> cloudfront
-cloudfront -> s3
-```
+<ArchitectureDiagram />
 
 ## ウェブサイトの実装
 
@@ -157,26 +139,32 @@ cloudfront -> s3
 
 ページ間を移動するには、`Link`コンポーネントまたは`useNavigate`フックを使用できます：
 
-```tsx {1, 4, 8-9, 14}
+```tsx {1, 8, 12-13, 18}
 import { Link, useNavigate } from '@tanstack/react-router';
 
-export const MyComponent = () => {
+export const MyComponent = ({
+  createProduct,
+}: {
+  createProduct: () => Promise<string>;
+}) => {
   const navigate = useNavigate();
 
   const submit = async () => {
-    const id = await ...
+    const id = await createProduct();
     // Use `navigate` for redirecting after some asynchronous action
-    navigate({ to: '/products/$id', { params: { id }} });
+    navigate({ to: '/products/$id', params: { id } });
   };
 
   return (
     <>
       <Link to="/products">Cancel</Link>
-      <Button onClick={submit}>Submit</Button>
+      <button onClick={submit}>Submit</button>
     </>
-  )
+  );
 };
 ```
+
+`to`パスの`$id`は[パスパラメーター](https://tanstack.com/router/latest/docs/framework/react/guide/path-params)で、`params`を通じて提供されます。必要に応じて、プレーンな`<button>`をUXキット独自のボタンコンポーネントに置き換えてください。
 
 詳細については、[TanStack Router](https://tanstack.com/router/latest/docs/framework/react/overview)ドキュメントを確認してください。
 
@@ -191,13 +179,13 @@ React websiteジェネレーターは、選択した`iac`に基づいてCDKま�
 `packages/common/constructs`に生成されたCDKコンストラクトを使用してウェブサイトをデプロイできます。
 
 ```ts title="packages/infra/src/stacks/application-stack.ts" {3, 9}
-import { Stack } from 'aws-cdk-lib';
+import { Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { MyWebsite } from '@my-scope/common-constructs';
 
 export class ApplicationStack extends Stack {
-  constructor(scope: Construct, id: string) {
-    super(scope, id);
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
 
     new MyWebsite(this, 'MyWebsite');
   }
@@ -266,13 +254,13 @@ CloudFrontディストリビューションは、デフォルトで[AWS WAFv2](h
 オプトアウトするには、ウェブサイトを作成する際に`enableWaf`を`false`に設定します：
 
 ```ts title="packages/infra/src/stacks/application-stack.ts" {10,15-18}
-import { Stack } from 'aws-cdk-lib';
+import { Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { MyWebsite, suppressRules } from '@my-scope/common-constructs';
 
 export class ApplicationStack extends Stack {
-  constructor(scope: Construct, id: string) {
-    super(scope, id);
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
 
     const website = new MyWebsite(this, 'MyWebsite', {
       enableWaf: false,
@@ -318,14 +306,14 @@ module "my_website" {
 異なる暗号化設定を使用する場合は、ウェブサイトを作成する際に`encryption`、`encryptionKey`、および`enableKeyRotation`プロパティを渡します：
 
 ```ts title="packages/infra/src/stacks/application-stack.ts" {11}
-import { Stack } from 'aws-cdk-lib';
+import { Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { BucketEncryption } from 'aws-cdk-lib/aws-s3';
 import { MyWebsite } from '@my-scope/common-constructs';
 
 export class ApplicationStack extends Stack {
-  constructor(scope: Construct, id: string) {
-    super(scope, id);
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
 
     new MyWebsite(this, 'MyWebsite', {
       encryption: BucketEncryption.S3_MANAGED,
@@ -401,11 +389,12 @@ module "my_website" {
 ```
 
 :::caution[Checkov: S3_MANAGED]
-`S3_MANAGED`を選択すると、ウェブサイトおよびディストリビューションログバケットで`checkov`セキュリティスキャンが`CKV_AWS_145`で失敗します。提供された`test`ターゲットは`--config-file`を受け入れませんが、`checkov`は作業ディレクトリ内の`.checkov.yaml`を自動検出するため、`packages/infra/src`に配置してください：
+`S3_MANAGED`を選択すると、ウェブサイトおよびディストリビューションログバケットで`checkov`ターゲットが`CKV_AWS_145`で失敗します。ターゲットはプロジェクト独自の`checkov.yml`に対して`checkov`を実行するため、その`skip-check`リストにチェックを追加してください：
 
-```yaml title="packages/infra/src/.checkov.yaml"
+```yaml title="packages/infra/checkov.yml" {3}
 skip-check:
-  - CKV_AWS_145
+  # ...
+  - CKV_AWS_145 # S3 buckets are not KMS encrypted when encryption is S3_MANAGED
 ```
 :::
 
@@ -439,11 +428,12 @@ module "my_website" {
 ```
 
 :::caution[Checkov: キーローテーション無効]
-自動的に作成されたキーでキーローテーションを無効にすると、`checkov`セキュリティスキャンが`CKV_AWS_7`で失敗します。同じ`.checkov.yaml`に追加してください：
+自動的に作成されたキーでキーローテーションを無効にすると、プロジェクトの`checkov`ターゲットが`CKV_AWS_7`で失敗します。`packages/infra/checkov.yml`の同じ`skip-check`リストに追加してください：
 
-```yaml title="packages/infra/src/.checkov.yaml"
+```yaml title="packages/infra/checkov.yml" {3}
 skip-check:
-  - CKV_AWS_7
+  # ...
+  - CKV_AWS_7 # Key rotation is disabled on the website's KMS key
 ```
 :::
 </Fragment>
@@ -458,14 +448,14 @@ skip-check:
 ウェブサイトを作成する際に`certificate`と`domainNames`プロパティを渡します：
 
 ```ts title="packages/infra/src/stacks/application-stack.ts" {11-13}
-import { Stack } from 'aws-cdk-lib';
+import { Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { Certificate } from 'aws-cdk-lib/aws-certificatemanager';
 import { MyWebsite } from '@my-scope/common-constructs';
 
 export class ApplicationStack extends Stack {
-  constructor(scope: Construct, id: string) {
-    super(scope, id);
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
 
     new MyWebsite(this, 'MyWebsite', {
       domainNames: ['www.example.com'],
@@ -508,13 +498,13 @@ module "my_website" {
 ウェブサイトCDKコンストラクトは、ランタイム設定の`connection`名前空間を`runtime-config.json`ファイルとしてS3バケットのルートにデプロイします。
 
 ```ts title="packages/infra/src/stacks/application-stack.ts"
-import { Stack } from 'aws-cdk-lib';
+import { Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { MyWebsite, MyApi } from '@my-scope/common-constructs';
 
 export class ApplicationStack extends Stack {
-  constructor(scope: Construct, id: string) {
-    super(scope, id);
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
 
     // Website can be declared at any point, since runtime config is resolved lazily
     new MyWebsite(this, 'MyWebsite');
@@ -581,6 +571,10 @@ const MyComponent = () => {
   const apiUrl = runtimeConfig.apis.MyApi;
 };
 ```
+
+:::note[必要なときに追加]
+`src/hooks/useRuntimeConfig.tsx`と`src/components/RuntimeConfig`は、<Link path="/guides/react-website-auth">`ts#website#auth`</Link>ジェネレーターと<Link path="guides/connection">`connection`</Link>ジェネレーターによってウェブサイトに追加されます。これらがランタイム設定に値を入れるためです。どちらも持たないウェブサイトには読み取るランタイム設定がないため、いずれかが実行されるまでフックは提供されません。
+:::
 
 :::note[ランタイム設定]
 ランタイム設定がAWS AppConfigにどのように保存されるか、およびサーバーサイドコンシューマー（Lambda関数、エージェント）がそれを取得する方法の詳細については、<Link path="guides/runtime-config">ランタイム設定</Link>ガイドを参照してください。

--- a/docs/src/content/docs/jp/guides/ts-dynamodb.mdx
+++ b/docs/src/content/docs/jp/guides/ts-dynamodb.mdx
@@ -11,6 +11,7 @@ import Link from '@components/link.astro';
 import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import Snippet from '@components/snippet.astro';
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
 このジェネレーターは、[Amazon DynamoDB](https://aws.amazon.com/dynamodb/) をバックエンドとする新しい TypeScript DynamoDB プロジェクトを作成します。型安全なエンティティモデリングには [ElectroDB](https://electrodb.dev/) を使用します。AWS CDK または Terraform を使用して DynamoDB テーブルをプロビジョニングおよび管理するために必要なアプリケーションコードとインフラストラクチャを生成し、シングルテーブル設計のサポートと DynamoDB Local によるローカル開発機能を備えています。
 
@@ -52,6 +53,12 @@ import Snippet from '@components/snippet.astro';
 ### インフラストラクチャ
 
 <Snippet name="dynamodb/infrastructure" />
+
+#### アーキテクチャ
+
+デプロイされたプロジェクトはテーブル自体をプロビジョニングし、接続されたすべてのプロジェクトがそれを読み書きします：
+
+<ArchitectureDiagram />
 
 ## ローカル開発
 

--- a/docs/src/content/docs/jp/guides/ts-smithy-api.mdx
+++ b/docs/src/content/docs/jp/guides/ts-smithy-api.mdx
@@ -20,6 +20,7 @@ import Snippet from '@components/snippet.astro';
 import OptionFilter from '@components/option-filter.astro';
 import InstallCommand from '@components/install-command.astro';
 import { TS_VERSIONS } from '../../../../../../packages/nx-plugin/src/utils/versions';
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
 [Smithy](https://smithy.io/) は、モデル駆動型の方法で API を作成するためのプロトコルに依存しないインターフェース定義言語です。
 
@@ -126,47 +127,7 @@ Smithy TypeScript API ジェネレーターは、サービス定義に Smithy �
 
 デプロイされた Smithy API は次のアーキテクチャを持ち、API Gateway ステージの前に [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACL が配置されます：
 
-```d2 inline=true
-direction: right
-
-client: Client {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
-
-waf: WAF {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/waf.svg
-}
-
-apigw: API Gateway\n(REST API) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/api-gateway.svg
-}
-
-lambda: Lambda\n(Smithy Server SDK) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/lambda.svg
-}
-
-cw: CloudWatch\n(Logs, Metrics) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cloudwatch.svg
-  near: top-right
-}
-
-xray: X-Ray\n(Traces) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/xray.svg
-  near: bottom-right
-}
-
-client -> waf
-waf -> apigw
-apigw -> lambda
-lambda -> cw
-lambda -> xray
-```
+<ArchitectureDiagram options={{ infra: 'rest-lambda' }} />
 
 ## Smithy API の実装
 

--- a/docs/src/content/docs/jp/snippets/agent/architecture.mdx
+++ b/docs/src/content/docs/jp/snippets/agent/architecture.mdx
@@ -2,72 +2,28 @@
 title: エージェントアーキテクチャ
 ---
 import { Tabs, TabItem } from '@astrojs/starlight/components';
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
 <Tabs syncKey="infra">
-<TabItem label="Bedrock AgentCore Runtime" _filter={{ infra: 'agentcore' }}>
+<TabItem label="AgentCore Runtime" _filter={{ infra: 'agentcore' }}>
 
-[Bedrock AgentCore Runtime](https://aws.amazon.com/bedrock/agentcore/)にデプロイされると、エージェントはコンテナイメージにビルドされ、Amazon ECRにプッシュされ、AgentCore Runtimeで実行されます。クライアントはAgentCore Runtimeデータプレーンエンドポイントを呼び出し、リクエストをエージェントに転送します。エージェントはモデル推論のためにAmazon Bedrockを呼び出し、ツール、MCPサーバー、またはダウンストリームAPIを呼び出すことができます。
+[Bedrock AgentCore Runtime](https://aws.amazon.com/bedrock/agentcore/)にデプロイされると、エージェントのコードはzipとしてパッケージ化され、AgentCore管理ランタイムで実行されます。クライアントはAgentCore Runtimeデータプレーンエンドポイントを呼び出し、リクエストをエージェントに転送します。エージェントはモデル推論のためにAmazon Bedrockを呼び出し、ツール、MCPサーバー、またはダウンストリームAPIを呼び出すことができます。
 
-```d2 inline=true
-direction: right
+<ArchitectureDiagram options={{ infra: 'agentcore' }} />
 
-client: Client {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
+</TabItem>
+<TabItem label="AgentCore Runtime (container)" _filter={{ infra: 'agentcore-ecr' }}>
 
-ecr: ECR {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/ecr.svg
-}
+`infra: agentcore-ecr`の場合、エージェントはコンテナイメージにビルドされ、Amazon ECRにプッシュされ、AgentCore Runtimeで実行されます。これにより、上記のzipパッケージングよりもビルドとデプロイサイクルが長くなる代わりに、ランタイム環境をOSレベルで制御できます。
 
-agentcore: Strands Agent\n(AgentCore Runtime) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/bedrock-agentcore-runtime.svg
-}
+<ArchitectureDiagram options={{ infra: 'agentcore-ecr' }} />
 
-bedrock: Bedrock\n(Model Inference) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/bedrock.svg
-  near: top-right
-}
-
-cw: CloudWatch\n(Logs, Metrics) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cloudwatch.svg
-  near: bottom-right
-}
-
-client -> agentcore
-ecr -> agentcore: Container\nimage
-agentcore -> bedrock: InvokeModel
-agentcore -> cw
-```
 </TabItem>
 <TabItem label="None (local only)" _filter={{ infra: 'none' }}>
 
 `infra: none`の場合、AWSインフラストラクチャは生成されません。エージェントはローカルプロセスとして実行され、モデル推論のためにAmazon Bedrockを呼び出します。
 
-```d2 inline=true
-direction: right
+<ArchitectureDiagram options={{ infra: 'none' }} />
 
-client: Client {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
-
-agent: Strands Agent\n(local process) {
-  shape: rectangle
-}
-
-bedrock: Bedrock\n(Model Inference) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/bedrock.svg
-}
-
-client -> agent
-agent -> bedrock: InvokeModel
-```
 </TabItem>
 </Tabs>
-

--- a/docs/src/content/docs/jp/snippets/api/api-architecture.mdx
+++ b/docs/src/content/docs/jp/snippets/api/api-architecture.mdx
@@ -2,91 +2,20 @@
 title: APIアーキテクチャ
 ---
 import { Tabs, TabItem } from '@astrojs/starlight/components';
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
-デプロイされたアプリケーションは以下のアーキテクチャを持ちます：
+デプロイされたアプリケーションは以下のアーキテクチャを持ちます：ハンドラーを実行するLambda関数の前にAPI Gateway APIが配置されます。
 
 <Tabs syncKey="http-rest">
 <TabItem label="REST API" _filter={{ infra: 'rest-lambda' }}>
-```d2 inline=true
-direction: right
 
-client: Client {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
-
-waf: WAF {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/waf.svg
-}
-
-apigw: API Gateway\n(REST API) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/api-gateway.svg
-}
-
-lambda: Lambda {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/lambda.svg
-}
-
-cw: CloudWatch\n(Logs, Metrics) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cloudwatch.svg
-  near: top-right
-}
-
-xray: X-Ray\n(Traces) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/xray.svg
-  near: bottom-right
-}
-
-client -> waf
-waf -> apigw
-apigw -> lambda
-lambda -> cw
-lambda -> xray
-```
+<ArchitectureDiagram options={{ infra: 'rest-lambda' }} />
 
 REST APIには、API Gatewayステージの前に[AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACLが含まれており、AWSマネージドのデフォルトルールセットが有効になっています。
 </TabItem>
 <TabItem label="HTTP API" _filter={{ infra: 'http-lambda' }}>
-```d2 inline=true
-direction: right
 
-client: Client {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
-
-apigw: API Gateway\n(HTTP API) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/api-gateway.svg
-}
-
-lambda: Lambda {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/lambda.svg
-}
-
-cw: CloudWatch\n(Logs, Metrics) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cloudwatch.svg
-  near: top-right
-}
-
-xray: X-Ray\n(Traces) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/xray.svg
-  near: bottom-right
-}
-
-client -> apigw
-apigw -> lambda
-lambda -> cw
-lambda -> xray
-```
+<ArchitectureDiagram options={{ infra: 'http-lambda' }} />
 
 HTTP APIは直接WAFをサポートしていません。WAF保護が必要な場合は、代わりにREST APIを選択するか、HTTP APIの前にCloudFrontディストリビューションを配置してください。
 </TabItem>

--- a/docs/src/content/docs/jp/snippets/lambda-function/architecture.mdx
+++ b/docs/src/content/docs/jp/snippets/lambda-function/architecture.mdx
@@ -1,36 +1,10 @@
 ---
 title: Lambda Function アーキテクチャ
 ---
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
-デプロイされた関数は以下のアーキテクチャを持ちます：
+デプロイされた関数は以下のアーキテクチャを持ち、ログ、メトリクス、トレースは CloudWatch と X-Ray に送信されます：
 
-```d2 inline=true
-direction: right
-
-source: Event Source\n(SNS, SQS, ...) {
-  shape: rectangle
-}
-
-lambda: Lambda {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/lambda.svg
-}
-
-cw: CloudWatch\n(Logs, Metrics) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cloudwatch.svg
-  near: top-right
-}
-
-xray: X-Ray\n(Traces) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/xray.svg
-  near: bottom-right
-}
-
-source -> lambda
-lambda -> cw
-lambda -> xray
-```
+<ArchitectureDiagram name="my-function" />
 
 ジェネレーターは関数自体を提供します。イベントソースを呼び出すためにスタック内で接続します（例：API Gateway 統合、EventBridge ルール、S3 通知、または SQS イベントソースマッピング）。

--- a/docs/src/content/docs/jp/snippets/mcp/architecture.mdx
+++ b/docs/src/content/docs/jp/snippets/mcp/architecture.mdx
@@ -2,57 +2,28 @@
 title: MCP Server アーキテクチャ
 ---
 import { Tabs, TabItem } from '@astrojs/starlight/components';
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
 <Tabs syncKey="infra">
-<TabItem label="Bedrock AgentCore Runtime" _filter={{ infra: 'agentcore' }}>
+<TabItem label="AgentCore Runtime" _filter={{ infra: 'agentcore' }}>
 
-[Bedrock AgentCore Runtime](https://aws.amazon.com/bedrock/agentcore/) にデプロイされると、MCP サーバーはコンテナイメージにビルドされ、Amazon ECR にプッシュされ、AgentCore Runtime で実行されます。AI アシスタントは AgentCore Runtime データプレーンエンドポイントを呼び出し、[streamable HTTP transport](https://modelcontextprotocol.io/specification/draft/basic/transports#streamable-http) を介して `tools/*` および `resources/*` の呼び出しをサーバーに転送します。
+[Bedrock AgentCore Runtime](https://aws.amazon.com/bedrock/agentcore/) にデプロイされると、サーバーのコードは zip としてパッケージ化され、AgentCore マネージドランタイムで実行されます。AI アシスタントは AgentCore Runtime データプレーンエンドポイントを呼び出し、[streamable HTTP transport](https://modelcontextprotocol.io/specification/draft/basic/transports#streamable-http) を介して `tools/*` および `resources/*` の呼び出しをサーバーに転送します。
 
-```d2 inline=true
-direction: right
+<ArchitectureDiagram options={{ infra: 'agentcore' }} />
 
-assistant: AI Assistant {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
+</TabItem>
+<TabItem label="AgentCore Runtime (container)" _filter={{ infra: 'agentcore-ecr' }}>
 
-ecr: ECR {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/ecr.svg
-}
+`infra: agentcore-ecr` の場合、MCP サーバーはコンテナイメージにビルドされ、Amazon ECR にプッシュされ、AgentCore Runtime で実行されます。これにより、ランタイム環境に対する OS レベルの制御が可能になりますが、上記の zip パッケージングよりもビルドとデプロイのサイクルが長くなります。
 
-agentcore: MCP Server\n(AgentCore Runtime) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/bedrock-agentcore-runtime.svg
-}
+<ArchitectureDiagram options={{ infra: 'agentcore-ecr' }} />
 
-cw: CloudWatch\n(Logs, Metrics) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cloudwatch.svg
-}
-
-assistant -> agentcore: Streamable\nHTTP
-ecr -> agentcore: Container\nimage
-agentcore -> cw
-```
 </TabItem>
 <TabItem label="None (local only)" _filter={{ infra: 'none' }}>
 
 `infra: none` の場合、AWS インフラストラクチャは生成されません。MCP サーバーはローカルの STDIO および HTTP トランスポート専用に構成され、同じマシン上で実行されている AI アシスタントによって使用されます。
 
-```d2 inline=true
-direction: right
+<ArchitectureDiagram options={{ infra: 'none' }} />
 
-assistant: AI Assistant {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
-
-server: MCP Server\n(local process) {
-  shape: rectangle
-}
-
-assistant -> server: STDIO\nor\nStreamable HTTP
-```
 </TabItem>
 </Tabs>

--- a/docs/src/content/docs/jp/snippets/rdb/architecture.mdx
+++ b/docs/src/content/docs/jp/snippets/rdb/architecture.mdx
@@ -1,39 +1,8 @@
 ---
 title: RDB アーキテクチャ
 ---
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
 デプロイされたデータベースは以下のアーキテクチャを持ちます。デフォルトでは、[Amazon RDS Proxy](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-proxy.html) が Aurora クラスターの前に配置され、接続をプールし、[IAM 認証](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.html)を有効にします — 代替案については [RDS Proxy を無効にする](#disable-rds-proxy) を参照してください。PostgreSQL または MySQL エンジンのどちらを選択しても、アーキテクチャは同じです。異なるのは Aurora エンジンのフレーバーのみです。
 
-```d2 inline=true
-direction: right
-
-app: Application\n(Lambda, Agent, ...) {
-  shape: hexagon
-}
-
-proxy: RDS Proxy {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/rds.svg
-}
-
-migrations: Migrations Lambda {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/lambda.svg
-}
-
-aurora: Aurora\n(PostgreSQL or MySQL) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/aurora.svg
-}
-
-secrets: Secrets Manager\n(DB credentials) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/secrets-manager.svg
-}
-
-app -> proxy: SQL (IAM auth)
-proxy -> aurora
-migrations -> aurora: Schema migrations
-migrations -> secrets: Admin credentials
-aurora -> secrets: Generates and rotates\nadmin credentials
-```
+<ArchitectureDiagram />

--- a/docs/src/content/docs/ko/get_started/tutorials/dungeon-game/overview.mdx
+++ b/docs/src/content/docs/ko/get_started/tutorials/dungeon-game/overview.mdx
@@ -16,6 +16,7 @@ import baselineGamePng from '@assets/baseline-game.png'
 import nxGraphPng from '@assets/nx-graph.png'
 import gameSelectPng from '@assets/game-select.png'
 import gameConversationPng from '@assets/game-conversation.png'
+import EmbeddedGraph from '@components/embedded-graph.astro';
 
 
 이 튜토리얼을 통해 `@aws/nx-plugin`으로 에이전틱 AI 기반 던전 어드벤처 게임을 구축하게 됩니다. 이 튜토리얼은 `@aws/nx-plugin` 또는 관련 기술에 대한 기존 지식을 가정하지 않습니다.
@@ -51,76 +52,9 @@ import gameConversationPng from '@assets/game-conversation.png'
 
 ### 애플리케이션 아키텍처
 
-에이전틱 AI 기반 던전 어드벤처 게임은 다음 아키텍처를 사용하여 구축됩니다:
+에이전틱 AI 기반 던전 어드벤처 게임은 다음 아키텍처를 사용하여 구축됩니다 — **Projects**로 전환하여 Module 1에서 스캐폴드하는 워크스페이스를 확인하세요:
 
-```d2 inline=true
-direction: down
-
-browser: Web Browser {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
-
-cognito: Cognito / IAM {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cognito.svg
-}
-
-cloudfront: CloudFront {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cloudfront.svg
-}
-
-s3: Static Assets\n(S3) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/s3.svg
-}
-
-apigw: API Gateway\n(Game API) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/api-gateway.svg
-}
-
-lambda: tRPC API\n(Lambda) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/lambda.svg
-}
-
-story: Story Agent\n(AgentCore) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/bedrock-agentcore-runtime.svg
-}
-
-mcp: Inventory MCP\n(AgentCore) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/bedrock-agentcore-runtime.svg
-}
-
-ddb: Game State\n(DynamoDB) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/dynamodb.svg
-}
-
-sessions: Story Sessions\n(S3) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/s3.svg
-}
-
-browser -> cognito: Sign in
-browser -> cloudfront
-cloudfront -> s3
-browser -> apigw
-apigw -> lambda
-lambda -> ddb
-lambda -> sessions: Read transcripts
-browser -> story: AG-UI stream
-story -> sessions: Persist turns
-story -> mcp: Tool calls
-mcp -> ddb
-ddb -> sessions: {
-  style.opacity: 0
-}
-```
+<EmbeddedGraph preset="dungeon-adventure" workspace="dungeon-adventure" iac="cdk" view="infrastructure" copyable={false} />
 
 - React/Vite 프론트엔드 웹사이트는 다음을 활용합니다:
   - 안전한 API 호출을 위한 Amazon Cognito/Identity Pools.

--- a/docs/src/content/docs/ko/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/ko/guides/agentcore-gateway.mdx
@@ -14,6 +14,7 @@ import Snippet from '@components/snippet.astro';
 import Link from '@components/link.astro';
 import NxCommands from '@components/nx-commands.astro';
 import OptionFilter from '@components/option-filter.astro';
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
 [Amazon Bedrock AgentCore Gateway](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/gateway.html) 프로젝트를 생성합니다. AgentCore Gateway는 MCP 서버 또는 에이전트 앞에 있는 관리형 진입점으로, 인바운드 요청을 인증하고(IAM 또는 Cognito) 대상으로 가는 아웃바운드 트래픽에 IAM SigV4로 서명합니다.
 
@@ -89,32 +90,7 @@ Gateway URL은 <Link path="guides/runtime-config">런타임 구성</Link>의 `ag
 
 배포된 Gateway는 다음 아키텍처를 가지며, Gateway 앞에 [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACL이 있고, 다운스트림 MCP 서버 대상으로 라우팅합니다:
 
-```d2 inline=true
-direction: right
-
-client: Client {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
-
-waf: WAF {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/waf.svg
-}
-
-gateway: AgentCore Gateway\n(MCP, IAM or Cognito auth) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/bedrock-agentcore-gateway.svg
-}
-
-targets: Downstream MCP Servers\n(Gateway targets) {
-  shape: rectangle
-}
-
-client -> waf
-waf -> gateway
-gateway -> targets
-```
+<ArchitectureDiagram />
 
 ## 인증
 

--- a/docs/src/content/docs/ko/guides/py-dynamodb.mdx
+++ b/docs/src/content/docs/ko/guides/py-dynamodb.mdx
@@ -11,6 +11,7 @@ import Link from '@components/link.astro';
 import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import Snippet from '@components/snippet.astro';
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
 이 생성기는 [Amazon DynamoDB](https://aws.amazon.com/dynamodb/)를 기반으로 하는 새로운 Python 프로젝트를 생성하며, 엔티티 모델링을 위해 [PynamoDB](https://pynamodb.readthedocs.io/)를 사용합니다. AWS CDK 또는 Terraform을 사용하여 DynamoDB 테이블을 프로비저닝하고 관리하는 데 필요한 애플리케이션 코드와 인프라를 생성하며, 단일 테이블 설계 지원과 DynamoDB Local을 통한 로컬 개발 기능이 내장되어 있습니다.
 
@@ -52,6 +53,12 @@ import Snippet from '@components/snippet.astro';
 ### 인프라
 
 <Snippet name="dynamodb/infrastructure" />
+
+#### 아키텍처
+
+배포된 프로젝트는 테이블 자체를 프로비저닝하며, 연결된 모든 프로젝트가 이를 읽고 씁니다:
+
+<ArchitectureDiagram />
 
 ## 로컬 개발
 

--- a/docs/src/content/docs/ko/guides/react-website-auth.mdx
+++ b/docs/src/content/docs/ko/guides/react-website-auth.mdx
@@ -10,6 +10,7 @@ import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Infrastructure from '@components/infrastructure.astro';
 import Snippet from '@components/snippet.astro';
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
 React 웹사이트 인증 생성기는 [Amazon Cognito](https://aws.amazon.com/cognito/)를 사용하여 React 웹사이트에 인증을 추가합니다.
 
@@ -71,44 +72,13 @@ React 웹사이트에서 다음과 같은 변경 사항을 확인할 수 있습�
 
 이 생성기는 기존 정적 웹사이트 아키텍처에 Amazon Cognito 사용자 풀(로그인용)과 자격 증명 풀(로그인한 사용자를 범위가 지정된 IAM 자격 증명으로 페더레이션하기 위한)을 추가합니다:
 
-```d2 inline=true
-direction: right
-
-browser: Web Browser {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
-
-waf: WAF {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/waf.svg
-}
-
-cognito: Cognito\n(User + Identity Pool) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cognito.svg
-}
-
-iam: Scoped IAM\nCredentials {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/iam.svg
-}
-
-backend: Authenticated\nAWS Resources {
-  shape: rectangle
-}
-
-browser -> waf: Sign in
-waf -> cognito
-cognito -> iam
-browser -> backend: IAM/Cognito
-```
+<ArchitectureDiagram name="my-website" />
 
 #### 위협 보호
 
-User Pool은 표준 인증을 위해 [위협 보호](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pool-settings-threat-protection.html)가 `AUDIT` 모드로 설정된 Cognito [Plus 기능 플랜](https://docs.aws.amazon.com/cognito/latest/developerguide/feature-plans-features-plus.html)에서 생성됩니다. 감사 모드에서 Cognito는 각 로그인에 위험 수준을 할당하고 사용자를 차단하지 않고 평가를 CloudWatch에 기록합니다.
+User Pool은 표준 인증을 위해 [위협 보호](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pool-settings-threat-protection.html)가 **audit-only** 적용으로 설정된 Cognito [Plus 기능 플랜](https://docs.aws.amazon.com/cognito/latest/developerguide/feature-plans-features-plus.html)에서 생성됩니다. audit-only에서 Cognito는 각 로그인에 위험 수준을 할당하고 사용자를 차단하지 않고 평가를 기록합니다.
 
-사용자에 대한 위험 평가를 관찰한 후, 위험한 활동에 자동으로 대응하도록 전체 기능 적용으로 전환할 수 있습니다(예: MFA 요구 또는 로그인 차단):
+사용자에 대한 위험 평가를 관찰한 후, 위험한 활동에 자동으로 대응하도록(예: MFA 요구 또는 로그인 차단) 전체 기능 적용으로 전환한 다음 [적응형 인증](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pool-settings-adaptive-authentication.html)을 통해 위험 수준별로 응답을 구성할 수 있습니다:
 
 <Infrastructure>
 <Fragment slot="cdk">
@@ -187,13 +157,13 @@ module "user_identity" {
 스택에 사용자 자격 증명 인프라를 추가해야 하며, 웹사이트 _이전에_ 선언해야 합니다:
 
 ```ts title="packages/infra/src/stacks/application-stack.ts" {3,9}
-import { Stack } from 'aws-cdk-lib';
+import { Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { MyWebsite, UserIdentity } from '@my-scope/common-constructs';
 
 export class ApplicationStack extends Stack {
-  constructor(scope: Construct, id: string) {
-    super(scope, id);
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
 
     new UserIdentity(this, 'Identity');
 
@@ -256,13 +226,13 @@ API 호출 권한 부여와 같이 인증된 사용자에게 특정 작업을 �
 <Infrastructure>
 <Fragment slot="cdk">
 ```ts title="packages/infra/src/stacks/application-stack.ts" {12}
-import { Stack } from 'aws-cdk-lib';
+import { Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { MyWebsite, UserIdentity, MyApi } from '@my-scope/common-constructs';
 
 export class ApplicationStack extends Stack {
-  constructor(scope: Construct, id: string) {
-    super(scope, id);
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
 
     const identity = new UserIdentity(this, 'Identity');
     const api = new MyApi(this, 'MyApi', {

--- a/docs/src/content/docs/ko/guides/react-website.mdx
+++ b/docs/src/content/docs/ko/guides/react-website.mdx
@@ -17,6 +17,7 @@ import PackageManagerShortCommand from '@components/package-manager-short-comman
 import Infrastructure from '@components/infrastructure.astro';
 import Snippet from '@components/snippet.astro';
 import OptionFilter from '@components/option-filter.astro';
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
 이 생성기는 기본적으로 [shadcn/ui](https://ui.shadcn.com/)가 구성된 새로운 [React](https://react.dev/) 웹사이트를 생성하며, [S3](https://aws.amazon.com/s3/)에 호스팅되고 [CloudFront](https://aws.amazon.com/cloudfront/)로 제공되며 [WAF](https://aws.amazon.com/waf/)로 보호되는 정적 웹사이트로 클라우드에 배포하기 위한 AWS CDK 또는 Terraform 인프라를 함께 생성합니다.
 
@@ -50,16 +51,23 @@ import OptionFilter from '@components/option-filter.astro';
     - config.ts 애플리케이션 구성 (예: 로고)
     - components
       - AppLayout 전체 레이아웃 및 네비게이션 바를 위한 컴포넌트
+      - app-sidebar.tsx 사이드바 네비게이션 (shadcn 전용)
+      - alert.tsx UX 프로바이더의 자체 Alert 컴포넌트를 래핑하는 Alert 컴포넌트
+      - spinner.tsx UX 프로바이더의 자체 Spinner 컴포넌트를 래핑하는 Spinner 컴포넌트
     - hooks
       - useAppLayout.tsx 중첩된 컴포넌트에서 AppLayout을 조정하기 위한 훅 (Cloudscape 전용)
     - routes
+      - \_\_root.tsx 모든 페이지를 AppLayout으로 래핑하는 루트 라우트
       - index.tsx TanStack Router를 위한 예제 라우트 (또는 페이지)
+    - routeTree.gen.ts TanStack Router에 의해 생성 및 유지 관리되는 라우트 트리
     - styles.css 전역 스타일
   - vite.config.mts Vite 및 Vitest 구성
+  - project.json 프로젝트의 타겟을 정의하는 Nx 프로젝트
   - tsconfig.json 소스 및 테스트를 위한 기본 TypeScript 구성
   - tsconfig.app.json 소스 코드를 위한 TypeScript 구성
   - tsconfig.spec.json 테스트를 위한 TypeScript 구성
   - package.json 프로젝트의 패키지 이름과 의존성을 정의하는 프로젝트 매니페스트
+  - README.md 프로젝트 README
 </FileTree>
 
 :::note[TanStack Router 없이]
@@ -99,35 +107,9 @@ import OptionFilter from '@components/option-filter.astro';
 
 #### 아키텍처
 
-배포된 웹사이트는 다음과 같은 아키텍처를 가집니다:
+배포된 웹사이트는 다음과 같은 아키텍처를 가집니다: S3 버킷에 있는 빌드된 자산이 AWS WAFv2 Web ACL이 앞에 있는 CloudFront 배포를 통해 제공됩니다.
 
-```d2 inline=true
-direction: right
-
-browser: Web Browser {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
-
-waf: WAF {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/waf.svg
-}
-
-cloudfront: CloudFront {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cloudfront.svg
-}
-
-s3: Static Assets\n(S3) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/s3.svg
-}
-
-browser -> waf
-waf -> cloudfront
-cloudfront -> s3
-```
+<ArchitectureDiagram />
 
 ## 웹사이트 구현
 
@@ -157,26 +139,32 @@ cloudfront -> s3
 
 페이지 간 탐색을 위해 `Link` 컴포넌트 또는 `useNavigate` 훅을 사용할 수 있습니다:
 
-```tsx {1, 4, 8-9, 14}
+```tsx {1, 8, 12-13, 18}
 import { Link, useNavigate } from '@tanstack/react-router';
 
-export const MyComponent = () => {
+export const MyComponent = ({
+  createProduct,
+}: {
+  createProduct: () => Promise<string>;
+}) => {
   const navigate = useNavigate();
 
   const submit = async () => {
-    const id = await ...
+    const id = await createProduct();
     // Use `navigate` for redirecting after some asynchronous action
-    navigate({ to: '/products/$id', { params: { id }} });
+    navigate({ to: '/products/$id', params: { id } });
   };
 
   return (
     <>
       <Link to="/products">Cancel</Link>
-      <Button onClick={submit}>Submit</Button>
+      <button onClick={submit}>Submit</button>
     </>
-  )
+  );
 };
 ```
+
+`to` 경로의 `$id`는 `params`를 통해 제공되는 [경로 매개변수](https://tanstack.com/router/latest/docs/framework/react/guide/path-params)입니다. 필요에 따라 일반 `<button>`을 UX 키트의 자체 버튼 컴포넌트로 교체하세요.
 
 자세한 내용은 [TanStack Router](https://tanstack.com/router/latest/docs/framework/react/overview) 문서를 확인하세요.
 
@@ -191,13 +179,13 @@ React 웹사이트 생성기는 선택한 `iac`에 따라 CDK 또는 Terraform �
 `packages/common/constructs`에 생성된 CDK 구성을 사용하여 웹사이트를 배포할 수 있습니다.
 
 ```ts title="packages/infra/src/stacks/application-stack.ts" {3, 9}
-import { Stack } from 'aws-cdk-lib';
+import { Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { MyWebsite } from '@my-scope/common-constructs';
 
 export class ApplicationStack extends Stack {
-  constructor(scope: Construct, id: string) {
-    super(scope, id);
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
 
     new MyWebsite(this, 'MyWebsite');
   }
@@ -266,13 +254,13 @@ CloudFront 배포는 기본적으로 [AWS WAFv2](https://docs.aws.amazon.com/waf
 비활성화하려면 웹사이트를 생성할 때 `enableWaf`를 `false`로 설정하세요:
 
 ```ts title="packages/infra/src/stacks/application-stack.ts" {10,15-18}
-import { Stack } from 'aws-cdk-lib';
+import { Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { MyWebsite, suppressRules } from '@my-scope/common-constructs';
 
 export class ApplicationStack extends Stack {
-  constructor(scope: Construct, id: string) {
-    super(scope, id);
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
 
     const website = new MyWebsite(this, 'MyWebsite', {
       enableWaf: false,
@@ -318,14 +306,14 @@ module "my_website" {
 다른 암호화 구성을 사용하려면 웹사이트를 생성할 때 `encryption`, `encryptionKey` 및 `enableKeyRotation` 속성을 전달하세요:
 
 ```ts title="packages/infra/src/stacks/application-stack.ts" {11}
-import { Stack } from 'aws-cdk-lib';
+import { Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { BucketEncryption } from 'aws-cdk-lib/aws-s3';
 import { MyWebsite } from '@my-scope/common-constructs';
 
 export class ApplicationStack extends Stack {
-  constructor(scope: Construct, id: string) {
-    super(scope, id);
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
 
     new MyWebsite(this, 'MyWebsite', {
       encryption: BucketEncryption.S3_MANAGED,
@@ -401,11 +389,12 @@ module "my_website" {
 ```
 
 :::caution[Checkov: S3_MANAGED]
-`S3_MANAGED`를 선택하면 웹사이트 및 배포 로그 버킷에서 `checkov` 보안 스캔이 `CKV_AWS_145`로 실패합니다. 제공된 `test` 타겟은 `--config-file`을 허용하지 않지만, `checkov`는 작업 디렉토리에서 `.checkov.yaml`을 자동으로 발견하므로 `packages/infra/src`에 하나를 추가하세요:
+`S3_MANAGED`를 선택하면 프로젝트의 `checkov` 타겟이 웹사이트 및 배포 로그 버킷에서 `CKV_AWS_145`로 실패합니다. 타겟은 프로젝트 자체의 `checkov.yml`에 대해 `checkov`를 실행하므로 `skip-check` 목록에 검사를 추가하세요:
 
-```yaml title="packages/infra/src/.checkov.yaml"
+```yaml title="packages/infra/checkov.yml" {3}
 skip-check:
-  - CKV_AWS_145
+  # ...
+  - CKV_AWS_145 # S3 buckets are not KMS encrypted when encryption is S3_MANAGED
 ```
 :::
 
@@ -439,11 +428,12 @@ module "my_website" {
 ```
 
 :::caution[Checkov: 키 로테이션 비활성화]
-자동으로 생성된 키에서 키 로테이션을 비활성화하면 `checkov` 보안 스캔이 `CKV_AWS_7`로 실패합니다. 동일한 `.checkov.yaml`에 추가하세요:
+자동으로 생성된 키에서 키 로테이션을 비활성화하면 프로젝트의 `checkov` 타겟이 `CKV_AWS_7`로 실패합니다. 동일한 `skip-check` 목록을 `packages/infra/checkov.yml`에 추가하세요:
 
-```yaml title="packages/infra/src/.checkov.yaml"
+```yaml title="packages/infra/checkov.yml" {3}
 skip-check:
-  - CKV_AWS_7
+  # ...
+  - CKV_AWS_7 # Key rotation is disabled on the website's KMS key
 ```
 :::
 </Fragment>
@@ -458,14 +448,14 @@ skip-check:
 웹사이트를 생성할 때 `certificate` 및 `domainNames` 속성을 전달하세요:
 
 ```ts title="packages/infra/src/stacks/application-stack.ts" {11-13}
-import { Stack } from 'aws-cdk-lib';
+import { Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { Certificate } from 'aws-cdk-lib/aws-certificatemanager';
 import { MyWebsite } from '@my-scope/common-constructs';
 
 export class ApplicationStack extends Stack {
-  constructor(scope: Construct, id: string) {
-    super(scope, id);
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
 
     new MyWebsite(this, 'MyWebsite', {
       domainNames: ['www.example.com'],
@@ -508,13 +498,13 @@ module "my_website" {
 웹사이트 CDK 구성은 런타임 구성의 `connection` 네임스페이스를 S3 버킷의 루트에 `runtime-config.json` 파일로 배포합니다.
 
 ```ts title="packages/infra/src/stacks/application-stack.ts"
-import { Stack } from 'aws-cdk-lib';
+import { Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { MyWebsite, MyApi } from '@my-scope/common-constructs';
 
 export class ApplicationStack extends Stack {
-  constructor(scope: Construct, id: string) {
-    super(scope, id);
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
 
     // Website can be declared at any point, since runtime config is resolved lazily
     new MyWebsite(this, 'MyWebsite');
@@ -581,6 +571,10 @@ const MyComponent = () => {
   const apiUrl = runtimeConfig.apis.MyApi;
 };
 ```
+
+:::note[필요할 때 추가됨]
+`src/hooks/useRuntimeConfig.tsx` 및 `src/components/RuntimeConfig`는 <Link path="/guides/react-website-auth">`ts#website#auth`</Link> 생성기와 <Link path="guides/connection">`connection`</Link> 생성기에 의해 웹사이트에 추가됩니다. 이들이 런타임 구성에 값을 넣기 때문입니다. 둘 다 없는 웹사이트는 읽을 런타임 구성이 없으므로 둘 중 하나가 실행될 때까지 훅이 제공되지 않습니다.
+:::
 
 :::note[런타임 구성]
 런타임 구성이 AWS AppConfig에 저장되는 방법과 서버 측 소비자(Lambda 함수, 에이전트)가 이를 검색하는 방법에 대한 자세한 내용은 <Link path="guides/runtime-config">런타임 구성</Link> 가이드를 참조하세요.

--- a/docs/src/content/docs/ko/guides/ts-dynamodb.mdx
+++ b/docs/src/content/docs/ko/guides/ts-dynamodb.mdx
@@ -11,6 +11,7 @@ import Link from '@components/link.astro';
 import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import Snippet from '@components/snippet.astro';
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
 이 생성기는 [Amazon DynamoDB](https://aws.amazon.com/dynamodb/)를 기반으로 하는 새로운 TypeScript DynamoDB 프로젝트를 생성하며, 타입 안전 엔티티 모델링을 위해 [ElectroDB](https://electrodb.dev/)를 사용합니다. AWS CDK 또는 Terraform을 사용하여 DynamoDB 테이블을 프로비저닝하고 관리하는 데 필요한 애플리케이션 코드와 인프라를 생성하며, 단일 테이블 설계 지원과 DynamoDB Local을 통한 로컬 개발 환경을 내장하고 있습니다.
 
@@ -52,6 +53,12 @@ import Snippet from '@components/snippet.astro';
 ### 인프라
 
 <Snippet name="dynamodb/infrastructure" />
+
+#### 아키텍처
+
+배포된 프로젝트는 테이블 자체를 프로비저닝하며, 연결된 모든 프로젝트가 이를 읽고 씁니다:
+
+<ArchitectureDiagram />
 
 ## 로컬 개발
 

--- a/docs/src/content/docs/ko/guides/ts-smithy-api.mdx
+++ b/docs/src/content/docs/ko/guides/ts-smithy-api.mdx
@@ -20,6 +20,7 @@ import Snippet from '@components/snippet.astro';
 import OptionFilter from '@components/option-filter.astro';
 import InstallCommand from '@components/install-command.astro';
 import { TS_VERSIONS } from '../../../../../../packages/nx-plugin/src/utils/versions';
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
 [Smithy](https://smithy.io/)는 모델 기반 방식으로 API를 작성하기 위한 프로토콜 독립적 인터페이스 정의 언어입니다.
 
@@ -126,47 +127,7 @@ Smithy TypeScript API 생성기는 서비스 정의를 위해 Smithy를 사용�
 
 배포된 Smithy API는 API Gateway 스테이지 앞에 [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACL이 있는 다음과 같은 아키텍처를 가집니다:
 
-```d2 inline=true
-direction: right
-
-client: Client {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
-
-waf: WAF {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/waf.svg
-}
-
-apigw: API Gateway\n(REST API) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/api-gateway.svg
-}
-
-lambda: Lambda\n(Smithy Server SDK) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/lambda.svg
-}
-
-cw: CloudWatch\n(Logs, Metrics) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cloudwatch.svg
-  near: top-right
-}
-
-xray: X-Ray\n(Traces) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/xray.svg
-  near: bottom-right
-}
-
-client -> waf
-waf -> apigw
-apigw -> lambda
-lambda -> cw
-lambda -> xray
-```
+<ArchitectureDiagram options={{ infra: 'rest-lambda' }} />
 
 ## Smithy API 구현
 

--- a/docs/src/content/docs/ko/snippets/agent/architecture.mdx
+++ b/docs/src/content/docs/ko/snippets/agent/architecture.mdx
@@ -2,71 +2,28 @@
 title: 에이전트 아키텍처
 ---
 import { Tabs, TabItem } from '@astrojs/starlight/components';
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
 <Tabs syncKey="infra">
-<TabItem label="Bedrock AgentCore Runtime" _filter={{ infra: 'agentcore' }}>
+<TabItem label="AgentCore Runtime" _filter={{ infra: 'agentcore' }}>
 
-[Bedrock AgentCore Runtime](https://aws.amazon.com/bedrock/agentcore/)에 배포되면, 에이전트는 컨테이너 이미지로 빌드되어 Amazon ECR에 푸시되고 AgentCore Runtime에서 실행됩니다. 클라이언트는 AgentCore Runtime 데이터 플레인 엔드포인트를 호출하며, 이는 요청을 에이전트로 전달합니다. 에이전트는 모델 추론을 위해 Amazon Bedrock을 호출하고 도구, MCP 서버 또는 다운스트림 API를 호출할 수 있습니다.
+[Bedrock AgentCore Runtime](https://aws.amazon.com/bedrock/agentcore/)에 배포되면, 에이전트의 코드는 zip으로 패키징되어 AgentCore 관리형 런타임에서 실행됩니다. 클라이언트는 AgentCore Runtime 데이터 플레인 엔드포인트를 호출하며, 이는 요청을 에이전트로 전달합니다. 에이전트는 모델 추론을 위해 Amazon Bedrock을 호출하고 도구, MCP 서버 또는 다운스트림 API를 호출할 수 있습니다.
 
-```d2 inline=true
-direction: right
+<ArchitectureDiagram options={{ infra: 'agentcore' }} />
 
-client: Client {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
+</TabItem>
+<TabItem label="AgentCore Runtime (container)" _filter={{ infra: 'agentcore-ecr' }}>
 
-ecr: ECR {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/ecr.svg
-}
+`infra: agentcore-ecr`을 사용하면 에이전트는 컨테이너 이미지로 빌드되어 Amazon ECR에 푸시되고 AgentCore Runtime에서 실행됩니다. 이를 통해 런타임 환경에 대한 OS 수준의 제어가 가능하지만, 위의 zip 패키징보다 빌드 및 배포 주기가 더 길어집니다.
 
-agentcore: Strands Agent\n(AgentCore Runtime) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/bedrock-agentcore-runtime.svg
-}
+<ArchitectureDiagram options={{ infra: 'agentcore-ecr' }} />
 
-bedrock: Bedrock\n(Model Inference) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/bedrock.svg
-  near: top-right
-}
-
-cw: CloudWatch\n(Logs, Metrics) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cloudwatch.svg
-  near: bottom-right
-}
-
-client -> agentcore
-ecr -> agentcore: Container\nimage
-agentcore -> bedrock: InvokeModel
-agentcore -> cw
-```
 </TabItem>
 <TabItem label="None (local only)" _filter={{ infra: 'none' }}>
 
 `infra: none`을 사용하면 AWS 인프라가 생성되지 않습니다. 에이전트는 로컬 프로세스로 실행되며 모델 추론을 위해 Amazon Bedrock을 호출합니다.
 
-```d2 inline=true
-direction: right
+<ArchitectureDiagram options={{ infra: 'none' }} />
 
-client: Client {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
-
-agent: Strands Agent\n(local process) {
-  shape: rectangle
-}
-
-bedrock: Bedrock\n(Model Inference) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/bedrock.svg
-}
-
-client -> agent
-agent -> bedrock: InvokeModel
-```
 </TabItem>
 </Tabs>

--- a/docs/src/content/docs/ko/snippets/api/api-architecture.mdx
+++ b/docs/src/content/docs/ko/snippets/api/api-architecture.mdx
@@ -2,91 +2,20 @@
 title: API 아키텍처
 ---
 import { Tabs, TabItem } from '@astrojs/starlight/components';
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
-배포된 애플리케이션은 다음과 같은 아키텍처를 가집니다:
+배포된 애플리케이션은 다음과 같은 아키텍처를 가집니다: 핸들러를 실행하는 Lambda 함수 앞에 API Gateway API가 있습니다.
 
 <Tabs syncKey="http-rest">
 <TabItem label="REST API" _filter={{ infra: 'rest-lambda' }}>
-```d2 inline=true
-direction: right
 
-client: Client {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
-
-waf: WAF {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/waf.svg
-}
-
-apigw: API Gateway\n(REST API) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/api-gateway.svg
-}
-
-lambda: Lambda {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/lambda.svg
-}
-
-cw: CloudWatch\n(Logs, Metrics) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cloudwatch.svg
-  near: top-right
-}
-
-xray: X-Ray\n(Traces) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/xray.svg
-  near: bottom-right
-}
-
-client -> waf
-waf -> apigw
-apigw -> lambda
-lambda -> cw
-lambda -> xray
-```
+<ArchitectureDiagram options={{ infra: 'rest-lambda' }} />
 
 REST API는 API Gateway 스테이지 앞에 AWS 관리형 기본 규칙 세트가 활성화된 [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACL을 포함합니다.
 </TabItem>
 <TabItem label="HTTP API" _filter={{ infra: 'http-lambda' }}>
-```d2 inline=true
-direction: right
 
-client: Client {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
-
-apigw: API Gateway\n(HTTP API) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/api-gateway.svg
-}
-
-lambda: Lambda {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/lambda.svg
-}
-
-cw: CloudWatch\n(Logs, Metrics) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cloudwatch.svg
-  near: top-right
-}
-
-xray: X-Ray\n(Traces) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/xray.svg
-  near: bottom-right
-}
-
-client -> apigw
-apigw -> lambda
-lambda -> cw
-lambda -> xray
-```
+<ArchitectureDiagram options={{ infra: 'http-lambda' }} />
 
 HTTP API는 WAF를 직접 지원하지 않습니다 — WAF 보호가 필요한 경우 REST API를 선택하거나 HTTP API 앞에 CloudFront 배포를 배치하세요.
 </TabItem>

--- a/docs/src/content/docs/ko/snippets/lambda-function/architecture.mdx
+++ b/docs/src/content/docs/ko/snippets/lambda-function/architecture.mdx
@@ -1,36 +1,10 @@
 ---
 title: Lambda Function 아키텍처
 ---
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
-배포된 함수는 다음과 같은 아키텍처를 가집니다:
+배포된 함수는 로그, 메트릭 및 트레이스가 CloudWatch와 X-Ray로 전송되는 다음과 같은 아키텍처를 가집니다:
 
-```d2 inline=true
-direction: right
-
-source: Event Source\n(SNS, SQS, ...) {
-  shape: rectangle
-}
-
-lambda: Lambda {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/lambda.svg
-}
-
-cw: CloudWatch\n(Logs, Metrics) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cloudwatch.svg
-  near: top-right
-}
-
-xray: X-Ray\n(Traces) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/xray.svg
-  near: bottom-right
-}
-
-source -> lambda
-lambda -> cw
-lambda -> xray
-```
+<ArchitectureDiagram name="my-function" />
 
 생성기는 함수 자체를 제공하며, 스택에서 이벤트 소스를 연결하여 함수를 호출합니다(예: API Gateway 통합, EventBridge 규칙, S3 알림 또는 SQS 이벤트 소스 매핑).

--- a/docs/src/content/docs/ko/snippets/mcp/architecture.mdx
+++ b/docs/src/content/docs/ko/snippets/mcp/architecture.mdx
@@ -2,57 +2,28 @@
 title: MCP 서버 아키텍처
 ---
 import { Tabs, TabItem } from '@astrojs/starlight/components';
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
 <Tabs syncKey="infra">
-<TabItem label="Bedrock AgentCore Runtime" _filter={{ infra: 'agentcore' }}>
+<TabItem label="AgentCore Runtime" _filter={{ infra: 'agentcore' }}>
 
-[Bedrock AgentCore Runtime](https://aws.amazon.com/bedrock/agentcore/)에 배포되면 MCP 서버는 컨테이너 이미지로 빌드되어 Amazon ECR에 푸시되고 AgentCore Runtime에서 실행됩니다. AI 어시스턴트는 AgentCore Runtime 데이터 플레인 엔드포인트를 호출하며, 이는 [streamable HTTP transport](https://modelcontextprotocol.io/specification/draft/basic/transports#streamable-http)를 통해 `tools/*` 및 `resources/*` 호출을 서버로 전달합니다.
+[Bedrock AgentCore Runtime](https://aws.amazon.com/bedrock/agentcore/)에 배포되면 서버의 코드는 zip으로 패키징되어 AgentCore 관리형 런타임에서 실행됩니다. AI 어시스턴트는 AgentCore Runtime 데이터 플레인 엔드포인트를 호출하며, 이는 [streamable HTTP transport](https://modelcontextprotocol.io/specification/draft/basic/transports#streamable-http)를 통해 `tools/*` 및 `resources/*` 호출을 서버로 전달합니다.
 
-```d2 inline=true
-direction: right
+<ArchitectureDiagram options={{ infra: 'agentcore' }} />
 
-assistant: AI Assistant {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
+</TabItem>
+<TabItem label="AgentCore Runtime (container)" _filter={{ infra: 'agentcore-ecr' }}>
 
-ecr: ECR {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/ecr.svg
-}
+`infra: agentcore-ecr`을 사용하면 MCP 서버는 컨테이너 이미지로 빌드되어 Amazon ECR에 푸시되고 AgentCore Runtime에서 실행됩니다. 이를 통해 런타임 환경에 대한 OS 수준의 제어가 가능하지만, 위의 zip 패키징보다 빌드 및 배포 주기가 더 길어집니다.
 
-agentcore: MCP Server\n(AgentCore Runtime) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/bedrock-agentcore-runtime.svg
-}
+<ArchitectureDiagram options={{ infra: 'agentcore-ecr' }} />
 
-cw: CloudWatch\n(Logs, Metrics) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cloudwatch.svg
-}
-
-assistant -> agentcore: Streamable\nHTTP
-ecr -> agentcore: Container\nimage
-agentcore -> cw
-```
 </TabItem>
 <TabItem label="None (local only)" _filter={{ infra: 'none' }}>
 
 `infra: none`을 사용하면 AWS 인프라가 생성되지 않습니다. MCP 서버는 로컬 STDIO 및 HTTP 전송만을 위해 구성되며, 동일한 머신에서 실행되는 AI 어시스턴트에서 사용됩니다.
 
-```d2 inline=true
-direction: right
+<ArchitectureDiagram options={{ infra: 'none' }} />
 
-assistant: AI Assistant {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
-
-server: MCP Server\n(local process) {
-  shape: rectangle
-}
-
-assistant -> server: STDIO\nor\nStreamable HTTP
-```
 </TabItem>
 </Tabs>

--- a/docs/src/content/docs/ko/snippets/rdb/architecture.mdx
+++ b/docs/src/content/docs/ko/snippets/rdb/architecture.mdx
@@ -1,39 +1,8 @@
 ---
 title: RDB 아키텍처
 ---
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
 배포된 데이터베이스는 다음과 같은 아키텍처를 가집니다. 기본적으로 [Amazon RDS Proxy](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-proxy.html)가 Aurora 클러스터 앞에 위치하여 연결을 풀링하고 [IAM 인증](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.html)을 활성화합니다 — 대안은 [RDS Proxy 비활성화](#disable-rds-proxy)를 참조하세요. PostgreSQL 또는 MySQL 엔진을 선택하든 아키텍처는 동일하며, Aurora 엔진 유형만 다릅니다.
 
-```d2 inline=true
-direction: right
-
-app: Application\n(Lambda, Agent, ...) {
-  shape: hexagon
-}
-
-proxy: RDS Proxy {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/rds.svg
-}
-
-migrations: Migrations Lambda {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/lambda.svg
-}
-
-aurora: Aurora\n(PostgreSQL or MySQL) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/aurora.svg
-}
-
-secrets: Secrets Manager\n(DB credentials) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/secrets-manager.svg
-}
-
-app -> proxy: SQL (IAM auth)
-proxy -> aurora
-migrations -> aurora: Schema migrations
-migrations -> secrets: Admin credentials
-aurora -> secrets: Generates and rotates\nadmin credentials
-```
+<ArchitectureDiagram />

--- a/docs/src/content/docs/pt/get_started/tutorials/dungeon-game/overview.mdx
+++ b/docs/src/content/docs/pt/get_started/tutorials/dungeon-game/overview.mdx
@@ -16,6 +16,7 @@ import baselineGamePng from '@assets/baseline-game.png'
 import nxGraphPng from '@assets/nx-graph.png'
 import gameSelectPng from '@assets/game-select.png'
 import gameConversationPng from '@assets/game-conversation.png'
+import EmbeddedGraph from '@components/embedded-graph.astro';
 
 
 Usando este tutorial, você construirá um jogo de aventura em masmorra com IA Agêntica usando `@aws/nx-plugin`. Este tutorial não assume nenhum conhecimento prévio do `@aws/nx-plugin` ou tecnologias relacionadas. 
@@ -51,76 +52,9 @@ A interface do jogo se parecerá com algo assim:
 
 ### Arquitetura da aplicação
 
-O jogo de aventura em masmorra com IA Agêntica é construído usando a seguinte arquitetura:
+O jogo de aventura em masmorra com IA Agêntica é construído usando a seguinte arquitetura — mude para **Projects** para ver o workspace a partir do qual ele é construído, que você cria no Módulo 1:
 
-```d2 inline=true
-direction: down
-
-browser: Web Browser {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
-
-cognito: Cognito / IAM {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cognito.svg
-}
-
-cloudfront: CloudFront {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cloudfront.svg
-}
-
-s3: Static Assets\n(S3) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/s3.svg
-}
-
-apigw: API Gateway\n(Game API) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/api-gateway.svg
-}
-
-lambda: tRPC API\n(Lambda) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/lambda.svg
-}
-
-story: Story Agent\n(AgentCore) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/bedrock-agentcore-runtime.svg
-}
-
-mcp: Inventory MCP\n(AgentCore) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/bedrock-agentcore-runtime.svg
-}
-
-ddb: Game State\n(DynamoDB) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/dynamodb.svg
-}
-
-sessions: Story Sessions\n(S3) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/s3.svg
-}
-
-browser -> cognito: Sign in
-browser -> cloudfront
-cloudfront -> s3
-browser -> apigw
-apigw -> lambda
-lambda -> ddb
-lambda -> sessions: Read transcripts
-browser -> story: AG-UI stream
-story -> sessions: Persist turns
-story -> mcp: Tool calls
-mcp -> ddb
-ddb -> sessions: {
-  style.opacity: 0
-}
-```
+<EmbeddedGraph preset="dungeon-adventure" workspace="dungeon-adventure" iac="cdk" view="infrastructure" copyable={false} />
 
 - Site frontend React/Vite utilizando:
   - Amazon Cognito/Identity Pools para chamadas de API seguras.

--- a/docs/src/content/docs/pt/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/pt/guides/agentcore-gateway.mdx
@@ -14,6 +14,7 @@ import Snippet from '@components/snippet.astro';
 import Link from '@components/link.astro';
 import NxCommands from '@components/nx-commands.astro';
 import OptionFilter from '@components/option-filter.astro';
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
 Gera um projeto [Amazon Bedrock AgentCore Gateway](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/gateway.html). Um AgentCore Gateway é um ponto de entrada gerenciado na frente dos seus servidores MCP ou agentes, autenticando solicitações de entrada (IAM ou Cognito) e assinando o tráfego de saída para seus destinos com IAM SigV4.
 
@@ -89,32 +90,7 @@ A URL do Gateway é automaticamente registrada no namespace `agentcore.gateways.
 
 O Gateway implantado tem a seguinte arquitetura, com um [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACL na frente do Gateway, que roteia para seus destinos de servidor MCP downstream:
 
-```d2 inline=true
-direction: right
-
-client: Client {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
-
-waf: WAF {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/waf.svg
-}
-
-gateway: AgentCore Gateway\n(MCP, IAM or Cognito auth) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/bedrock-agentcore-gateway.svg
-}
-
-targets: Downstream MCP Servers\n(Gateway targets) {
-  shape: rectangle
-}
-
-client -> waf
-waf -> gateway
-gateway -> targets
-```
+<ArchitectureDiagram />
 
 ## Autenticação
 

--- a/docs/src/content/docs/pt/guides/py-dynamodb.mdx
+++ b/docs/src/content/docs/pt/guides/py-dynamodb.mdx
@@ -11,6 +11,7 @@ import Link from '@components/link.astro';
 import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import Snippet from '@components/snippet.astro';
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
 Este gerador cria um novo projeto Python apoiado pelo [Amazon DynamoDB](https://aws.amazon.com/dynamodb/), usando [PynamoDB](https://pynamodb.readthedocs.io/) para modelagem de entidades. Ele gera o código da aplicação e a infraestrutura necessária para provisionar e gerenciar uma tabela DynamoDB usando AWS CDK ou Terraform, com suporte a design de tabela única e desenvolvimento local integrado via DynamoDB Local.
 
@@ -52,6 +53,12 @@ Os scripts de desenvolvimento local são compartilhados entre todos os projetos 
 ### Infraestrutura
 
 <Snippet name="dynamodb/infrastructure" />
+
+#### Arquitetura
+
+O projeto implantado provisiona a própria tabela, que qualquer projeto conectado a ela lê e escreve:
+
+<ArchitectureDiagram />
 
 ## Desenvolvimento Local
 

--- a/docs/src/content/docs/pt/guides/react-website-auth.mdx
+++ b/docs/src/content/docs/pt/guides/react-website-auth.mdx
@@ -10,6 +10,7 @@ import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Infrastructure from '@components/infrastructure.astro';
 import Snippet from '@components/snippet.astro';
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
 O gerador de Autenticação de Website React adiciona autenticação ao seu website React usando [Amazon Cognito](https://aws.amazon.com/cognito/).
 
@@ -71,44 +72,13 @@ Você também encontrará o seguinte código de infraestrutura gerado com base n
 
 Este gerador adiciona um user pool do Amazon Cognito (para login) e um identity pool (para federar usuários autenticados a credenciais IAM com escopo) à arquitetura de website estático existente:
 
-```d2 inline=true
-direction: right
-
-browser: Web Browser {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
-
-waf: WAF {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/waf.svg
-}
-
-cognito: Cognito\n(User + Identity Pool) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cognito.svg
-}
-
-iam: Scoped IAM\nCredentials {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/iam.svg
-}
-
-backend: Authenticated\nAWS Resources {
-  shape: rectangle
-}
-
-browser -> waf: Sign in
-waf -> cognito
-cognito -> iam
-browser -> backend: IAM/Cognito
-```
+<ArchitectureDiagram name="my-website" />
 
 #### Proteção contra ameaças
 
-O User Pool é criado no [plano de recursos Plus](https://docs.aws.amazon.com/cognito/latest/developerguide/feature-plans-features-plus.html) do Cognito com [proteção contra ameaças](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pool-settings-threat-protection.html) definida para o modo `AUDIT` para autenticação padrão. No modo de auditoria, o Cognito atribui um nível de risco a cada login e registra a avaliação no CloudWatch sem bloquear usuários.
+O User Pool é criado no [plano de recursos Plus](https://docs.aws.amazon.com/cognito/latest/developerguide/feature-plans-features-plus.html) do Cognito com [proteção contra ameaças](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pool-settings-threat-protection.html) em aplicação **somente auditoria** para autenticação padrão. Em somente auditoria, o Cognito atribui um nível de risco a cada login e registra a avaliação sem bloquear usuários.
 
-Depois de observar as avaliações de risco para seus usuários, você pode mudar para a aplicação de função completa para responder automaticamente a atividades arriscadas (por exemplo, exigir MFA ou bloquear login):
+Depois de observar as avaliações de risco para seus usuários, você pode mudar para aplicação de função completa para responder automaticamente a atividades arriscadas (por exemplo, exigir MFA ou bloquear login) e, em seguida, configurar a resposta por nível de risco via [autenticação adaptativa](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pool-settings-adaptive-authentication.html):
 
 <Infrastructure>
 <Fragment slot="cdk">
@@ -187,13 +157,13 @@ Esta regra sinaliza endereços de loopback em argumentos de consulta como tentat
 Você precisará adicionar a infraestrutura de identidade de usuário ao seu stack, declarando-a _antes_ do website:
 
 ```ts title="packages/infra/src/stacks/application-stack.ts" {3,9}
-import { Stack } from 'aws-cdk-lib';
+import { Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { MyWebsite, UserIdentity } from '@my-scope/common-constructs';
 
 export class ApplicationStack extends Stack {
-  constructor(scope: Construct, id: string) {
-    super(scope, id);
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
 
     new UserIdentity(this, 'Identity');
 
@@ -256,13 +226,13 @@ Para conceder aos usuários autenticados acesso para executar certas ações, co
 <Infrastructure>
 <Fragment slot="cdk">
 ```ts title="packages/infra/src/stacks/application-stack.ts" {12}
-import { Stack } from 'aws-cdk-lib';
+import { Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { MyWebsite, UserIdentity, MyApi } from '@my-scope/common-constructs';
 
 export class ApplicationStack extends Stack {
-  constructor(scope: Construct, id: string) {
-    super(scope, id);
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
 
     const identity = new UserIdentity(this, 'Identity');
     const api = new MyApi(this, 'MyApi', {

--- a/docs/src/content/docs/pt/guides/react-website.mdx
+++ b/docs/src/content/docs/pt/guides/react-website.mdx
@@ -17,6 +17,7 @@ import PackageManagerShortCommand from '@components/package-manager-short-comman
 import Infrastructure from '@components/infrastructure.astro';
 import Snippet from '@components/snippet.astro';
 import OptionFilter from '@components/option-filter.astro';
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
 Este gerador cria um novo site [React](https://react.dev/) com [shadcn/ui](https://ui.shadcn.com/) configurado por padrão, juntamente com a infraestrutura AWS CDK ou Terraform para implantar seu site na nuvem como um site estático hospedado no [S3](https://aws.amazon.com/s3/), servido pelo [CloudFront](https://aws.amazon.com/cloudfront/) e protegido pelo [WAF](https://aws.amazon.com/waf/).
 
@@ -50,16 +51,23 @@ O gerador criará a seguinte estrutura de projeto no diretório `<directory>/<na
     - config.ts Application configuration (eg. logo)
     - components
       - AppLayout Components for the overall layout and navigation bar
+      - app-sidebar.tsx Sidebar navigation (shadcn only)
+      - alert.tsx Alert component wrapping your UX provider's own
+      - spinner.tsx Spinner component wrapping your UX provider's own
     - hooks
       - useAppLayout.tsx Hook for adjusting the AppLayout from nested components (Cloudscape only)
     - routes
+      - \_\_root.tsx Root route, wrapping every page in the AppLayout
       - index.tsx Example route (or page) for TanStack Router
+    - routeTree.gen.ts Route tree, generated and maintained by TanStack Router
     - styles.css Global styles
   - vite.config.mts Vite and Vitest configuration
+  - project.json Nx project defining the project's targets
   - tsconfig.json Base TypeScript configuration for source and tests
   - tsconfig.app.json TypeScript configuration for source code
   - tsconfig.spec.json TypeScript configuration for tests
   - package.json Project manifest defining the project's package name and dependencies
+  - README.md Project README
 </FileTree>
 
 :::note[Sem TanStack Router]
@@ -99,35 +107,9 @@ O gerador cria infraestrutura como código para implantar seu site com base no `
 
 #### Arquitetura
 
-O site implantado tem a seguinte arquitetura:
+O site implantado tem a seguinte arquitetura: seus assets construídos em um bucket S3, servidos por uma distribuição CloudFront com um AWS WAFv2 Web ACL na frente dele.
 
-```d2 inline=true
-direction: right
-
-browser: Web Browser {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
-
-waf: WAF {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/waf.svg
-}
-
-cloudfront: CloudFront {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cloudfront.svg
-}
-
-s3: Static Assets\n(S3) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/s3.svg
-}
-
-browser -> waf
-waf -> cloudfront
-cloudfront -> s3
-```
+<ArchitectureDiagram />
 
 ## Implementando seu Site
 
@@ -157,26 +139,32 @@ Seu site vem com [TanStack Router](https://tanstack.com/router/v1) configurado p
 
 Você pode usar o componente `Link` ou o hook `useNavigate` para navegar entre páginas:
 
-```tsx {1, 4, 8-9, 14}
+```tsx {1, 8, 12-13, 18}
 import { Link, useNavigate } from '@tanstack/react-router';
 
-export const MyComponent = () => {
+export const MyComponent = ({
+  createProduct,
+}: {
+  createProduct: () => Promise<string>;
+}) => {
   const navigate = useNavigate();
 
   const submit = async () => {
-    const id = await ...
+    const id = await createProduct();
     // Use `navigate` for redirecting after some asynchronous action
-    navigate({ to: '/products/$id', { params: { id }} });
+    navigate({ to: '/products/$id', params: { id } });
   };
 
   return (
     <>
       <Link to="/products">Cancel</Link>
-      <Button onClick={submit}>Submit</Button>
+      <button onClick={submit}>Submit</button>
     </>
-  )
+  );
 };
 ```
+
+`$id` in the `to` path is a [path parameter](https://tanstack.com/router/latest/docs/framework/react/guide/path-params), supplied through `params`. Swap the plain `<button>` for your UX kit's own button component as needed.
 
 Para mais detalhes, confira a documentação do [TanStack Router](https://tanstack.com/router/latest/docs/framework/react/overview).
 
@@ -191,13 +179,13 @@ Para implantar seu site, recomendamos usar o <Link path="guides/typescript-infra
 Você pode usar o construct CDK gerado para você em `packages/common/constructs` para implantar seu site.
 
 ```ts title="packages/infra/src/stacks/application-stack.ts" {3, 9}
-import { Stack } from 'aws-cdk-lib';
+import { Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { MyWebsite } from '@my-scope/common-constructs';
 
 export class ApplicationStack extends Stack {
-  constructor(scope: Construct, id: string) {
-    super(scope, id);
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
 
     new MyWebsite(this, 'MyWebsite');
   }
@@ -266,13 +254,13 @@ A distribuição CloudFront é protegida por um [AWS WAFv2](https://docs.aws.ama
 Para desativar, defina `enableWaf` como `false` ao criar seu site:
 
 ```ts title="packages/infra/src/stacks/application-stack.ts" {10,15-18}
-import { Stack } from 'aws-cdk-lib';
+import { Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { MyWebsite, suppressRules } from '@my-scope/common-constructs';
 
 export class ApplicationStack extends Stack {
-  constructor(scope: Construct, id: string) {
-    super(scope, id);
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
 
     const website = new MyWebsite(this, 'MyWebsite', {
       enableWaf: false,
@@ -318,14 +306,14 @@ O bucket do site, o bucket de log da distribuição CloudFront e o grupo CloudWa
 Se você quiser usar uma configuração de criptografia diferente, passe as props `encryption`, `encryptionKey` e `enableKeyRotation` ao criar seu site:
 
 ```ts title="packages/infra/src/stacks/application-stack.ts" {11}
-import { Stack } from 'aws-cdk-lib';
+import { Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { BucketEncryption } from 'aws-cdk-lib/aws-s3';
 import { MyWebsite } from '@my-scope/common-constructs';
 
 export class ApplicationStack extends Stack {
-  constructor(scope: Construct, id: string) {
-    super(scope, id);
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
 
     new MyWebsite(this, 'MyWebsite', {
       encryption: BucketEncryption.S3_MANAGED,
@@ -401,11 +389,12 @@ module "my_website" {
 ```
 
 :::caution[Checkov: S3_MANAGED]
-Escolher `S3_MANAGED` falha na verificação de segurança `checkov` com `CKV_AWS_145` nos buckets de site e log de distribuição. O target `test` fornecido não aceita um `--config-file`, mas `checkov` descobre automaticamente um `.checkov.yaml` em seu diretório de trabalho, então coloque um em `packages/infra/src`:
+Escolher `S3_MANAGED` falha no target `checkov` do seu projeto com `CKV_AWS_145` nos buckets de site e log de distribuição. O target executa `checkov` contra o `checkov.yml` do seu próprio projeto, então adicione a verificação à sua lista `skip-check`:
 
-```yaml title="packages/infra/src/.checkov.yaml"
+```yaml title="packages/infra/checkov.yml" {3}
 skip-check:
-  - CKV_AWS_145
+  # ...
+  - CKV_AWS_145 # S3 buckets are not KMS encrypted when encryption is S3_MANAGED
 ```
 :::
 
@@ -439,11 +428,12 @@ module "my_website" {
 ```
 
 :::caution[Checkov: rotação de chave desativada]
-Desativar a rotação de chave na chave criada automaticamente falha na verificação de segurança `checkov` com `CKV_AWS_7`. Adicione-o ao mesmo `.checkov.yaml`:
+Desativar a rotação de chave na chave criada automaticamente falha no target `checkov` do seu projeto com `CKV_AWS_7`. Adicione-o à mesma lista `skip-check` em `packages/infra/checkov.yml`:
 
-```yaml title="packages/infra/src/.checkov.yaml"
+```yaml title="packages/infra/checkov.yml" {3}
 skip-check:
-  - CKV_AWS_7
+  # ...
+  - CKV_AWS_7 # Key rotation is disabled on the website's KMS key
 ```
 :::
 </Fragment>
@@ -458,14 +448,14 @@ Por padrão, a distribuição usa o nome de domínio padrão do CloudFront (`*.c
 Passe as props `certificate` e `domainNames` ao criar seu site:
 
 ```ts title="packages/infra/src/stacks/application-stack.ts" {11-13}
-import { Stack } from 'aws-cdk-lib';
+import { Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { Certificate } from 'aws-cdk-lib/aws-certificatemanager';
 import { MyWebsite } from '@my-scope/common-constructs';
 
 export class ApplicationStack extends Stack {
-  constructor(scope: Construct, id: string) {
-    super(scope, id);
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
 
     new MyWebsite(this, 'MyWebsite', {
       domainNames: ['www.example.com'],
@@ -508,13 +498,13 @@ O construct CDK `RuntimeConfig` pode ser usado para adicionar e recuperar config
 Seu construct CDK de site implantará o namespace `connection` da configuração de runtime como um arquivo `runtime-config.json` na raiz do seu bucket S3.
 
 ```ts title="packages/infra/src/stacks/application-stack.ts"
-import { Stack } from 'aws-cdk-lib';
+import { Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { MyWebsite, MyApi } from '@my-scope/common-constructs';
 
 export class ApplicationStack extends Stack {
-  constructor(scope: Construct, id: string) {
-    super(scope, id);
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
 
     // Website can be declared at any point, since runtime config is resolved lazily
     new MyWebsite(this, 'MyWebsite');
@@ -581,6 +571,10 @@ const MyComponent = () => {
   const apiUrl = runtimeConfig.apis.MyApi;
 };
 ```
+
+:::note[Adicionado quando você precisa]
+`src/hooks/useRuntimeConfig.tsx` e `src/components/RuntimeConfig` são adicionados ao seu site pelo gerador <Link path="/guides/react-website-auth">`ts#website#auth`</Link> e pelos geradores <Link path="guides/connection">`connection`</Link>, já que são eles que colocam valores na configuração de runtime. Um site sem nenhum dos dois não tem configuração de runtime para ler, então o hook não é fornecido até que um tenha sido executado.
+:::
 
 :::note[Configuração de Runtime]
 Para detalhes sobre como a configuração de runtime é armazenada no AWS AppConfig e como consumidores do lado do servidor (funções Lambda, agentes) podem recuperá-la, consulte o guia <Link path="guides/runtime-config">Configuração de Runtime</Link>.
@@ -687,28 +681,28 @@ Use o gerador <Link path="guides/connection">`connection`</Link> para integrar e
   <ConnectionCard
     title="React to tRPC"
     description="Call a tRPC API from a React website"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'pt'}/guides/connection/react-trpc`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/react-trpc`}
     source="react"
     target="trpc"
   />
   <ConnectionCard
     title="React to FastAPI"
     description="Call a Python FastAPI from a React website"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'pt'}/guides/connection/react-fastapi`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/react-fastapi`}
     source="react"
     target="fastapi"
   />
   <ConnectionCard
     title="React to Smithy API"
     description="Call a Smithy API from a React website"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'pt'}/guides/connection/react-smithy`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/react-smithy`}
     source="react"
     target="smithy"
   />
   <ConnectionCard
     title="React to Python Agent"
     description="Call a Python Agent from a React website"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'pt'}/guides/connection/react-py-agent`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/react-py-agent`}
     source="react"
     target="strands"
     targetBadge="python"
@@ -716,7 +710,7 @@ Use o gerador <Link path="guides/connection">`connection`</Link> para integrar e
   <ConnectionCard
     title="React to TypeScript Agent"
     description="Call a TypeScript Agent from a React website"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'pt'}/guides/connection/react-ts-agent`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/react-ts-agent`}
     source="react"
     target="strands"
     targetBadge="typescript"
@@ -724,14 +718,14 @@ Use o gerador <Link path="guides/connection">`connection`</Link> para integrar e
   <ConnectionCard
     title="React to AG-UI Agent"
     description="Call an Agent exposing the AG-UI protocol from a React website via CopilotKit"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'pt'}/guides/connection/react-agui`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/react-agui`}
     source="react"
     target="copilotkit"
   />
   <ConnectionCard
     title="React Website to AgentCore Gateway"
     description="Connect a React website to agents through an AgentCore Gateway"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'pt'}/guides/connection/react-agentcore-gateway`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/react-agentcore-gateway`}
     source="react"
     target="agentcore"
   />

--- a/docs/src/content/docs/pt/guides/ts-dynamodb.mdx
+++ b/docs/src/content/docs/pt/guides/ts-dynamodb.mdx
@@ -11,6 +11,7 @@ import Link from '@components/link.astro';
 import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import Snippet from '@components/snippet.astro';
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
 Este gerador cria um novo projeto TypeScript DynamoDB apoiado pelo [Amazon DynamoDB](https://aws.amazon.com/dynamodb/), usando [ElectroDB](https://electrodb.dev/) para modelagem de entidades com segurança de tipo. Ele gera o código da aplicação e a infraestrutura necessária para provisionar e gerenciar uma tabela DynamoDB usando AWS CDK ou Terraform, com suporte para design de tabela única e desenvolvimento local integrado via DynamoDB Local.
 
@@ -52,6 +53,12 @@ Os scripts de desenvolvimento local são compartilhados entre todos os projetos 
 ### Infraestrutura
 
 <Snippet name="dynamodb/infrastructure" />
+
+#### Arquitetura
+
+O projeto implantado provisiona a própria tabela, que qualquer projeto conectado a ela lê e escreve:
+
+<ArchitectureDiagram />
 
 ## Desenvolvimento Local
 

--- a/docs/src/content/docs/pt/guides/ts-smithy-api.mdx
+++ b/docs/src/content/docs/pt/guides/ts-smithy-api.mdx
@@ -20,6 +20,7 @@ import Snippet from '@components/snippet.astro';
 import OptionFilter from '@components/option-filter.astro';
 import InstallCommand from '@components/install-command.astro';
 import { TS_VERSIONS } from '../../../../../../packages/nx-plugin/src/utils/versions';
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
 [Smithy](https://smithy.io/) é uma linguagem de definição de interface independente de protocolo para criar APIs de forma orientada a modelos.
 
@@ -126,47 +127,7 @@ Este projeto é gerado usando o gerador <Link path="/guides/terraform-project">`
 
 A API Smithy implantada tem a seguinte arquitetura, com um Web ACL [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) na frente do estágio do API Gateway:
 
-```d2 inline=true
-direction: right
-
-client: Client {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
-
-waf: WAF {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/waf.svg
-}
-
-apigw: API Gateway\n(REST API) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/api-gateway.svg
-}
-
-lambda: Lambda\n(Smithy Server SDK) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/lambda.svg
-}
-
-cw: CloudWatch\n(Logs, Metrics) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cloudwatch.svg
-  near: top-right
-}
-
-xray: X-Ray\n(Traces) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/xray.svg
-  near: bottom-right
-}
-
-client -> waf
-waf -> apigw
-apigw -> lambda
-lambda -> cw
-lambda -> xray
-```
+<ArchitectureDiagram options={{ infra: 'rest-lambda' }} />
 
 ## Implementando sua API Smithy
 

--- a/docs/src/content/docs/pt/snippets/agent/architecture.mdx
+++ b/docs/src/content/docs/pt/snippets/agent/architecture.mdx
@@ -2,71 +2,28 @@
 title: Arquitetura do Agente
 ---
 import { Tabs, TabItem } from '@astrojs/starlight/components';
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
 <Tabs syncKey="infra">
-<TabItem label="Bedrock AgentCore Runtime" _filter={{ infra: 'agentcore' }}>
+<TabItem label="AgentCore Runtime" _filter={{ infra: 'agentcore' }}>
 
-Quando implantado no [Bedrock AgentCore Runtime](https://aws.amazon.com/bedrock/agentcore/), o agente é construído em uma imagem de contêiner, enviado para o Amazon ECR e executado no AgentCore Runtime. Os clientes invocam o endpoint do plano de dados do AgentCore Runtime, que encaminha as solicitações para o seu agente. O agente chama o Amazon Bedrock para inferência de modelo e pode invocar ferramentas, servidores MCP ou APIs downstream.
+Quando implantado no [Bedrock AgentCore Runtime](https://aws.amazon.com/bedrock/agentcore/), o código do seu agente é empacotado como um zip e executado no runtime gerenciado do AgentCore. Os clientes invocam o endpoint do plano de dados do AgentCore Runtime, que encaminha as solicitações para o seu agente. O agente chama o Amazon Bedrock para inferência de modelo e pode invocar ferramentas, servidores MCP ou APIs downstream.
 
-```d2 inline=true
-direction: right
+<ArchitectureDiagram options={{ infra: 'agentcore' }} />
 
-client: Client {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
+</TabItem>
+<TabItem label="AgentCore Runtime (container)" _filter={{ infra: 'agentcore-ecr' }}>
 
-ecr: ECR {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/ecr.svg
-}
+Com `infra: agentcore-ecr`, o agente é construído em uma imagem de contêiner, enviado para o Amazon ECR e executado no AgentCore Runtime. Isso oferece controle no nível do sistema operacional sobre o ambiente de runtime, ao custo de um ciclo de build e deploy mais longo do que o empacotamento zip acima.
 
-agentcore: Strands Agent\n(AgentCore Runtime) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/bedrock-agentcore-runtime.svg
-}
+<ArchitectureDiagram options={{ infra: 'agentcore-ecr' }} />
 
-bedrock: Bedrock\n(Model Inference) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/bedrock.svg
-  near: top-right
-}
-
-cw: CloudWatch\n(Logs, Metrics) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cloudwatch.svg
-  near: bottom-right
-}
-
-client -> agentcore
-ecr -> agentcore: Container\nimage
-agentcore -> bedrock: InvokeModel
-agentcore -> cw
-```
 </TabItem>
 <TabItem label="None (local only)" _filter={{ infra: 'none' }}>
 
 Com `infra: none`, nenhuma infraestrutura AWS é gerada. O agente é executado como um processo local e chama o Amazon Bedrock para inferência de modelo.
 
-```d2 inline=true
-direction: right
+<ArchitectureDiagram options={{ infra: 'none' }} />
 
-client: Client {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
-
-agent: Strands Agent\n(local process) {
-  shape: rectangle
-}
-
-bedrock: Bedrock\n(Model Inference) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/bedrock.svg
-}
-
-client -> agent
-agent -> bedrock: InvokeModel
-```
 </TabItem>
 </Tabs>

--- a/docs/src/content/docs/pt/snippets/api/api-architecture.mdx
+++ b/docs/src/content/docs/pt/snippets/api/api-architecture.mdx
@@ -2,91 +2,20 @@
 title: Arquitetura da API
 ---
 import { Tabs, TabItem } from '@astrojs/starlight/components';
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
-A aplicação implantada possui a seguinte arquitetura:
+A aplicação implantada possui a seguinte arquitetura: uma API do API Gateway na frente de uma função Lambda executando seu manipulador.
 
 <Tabs syncKey="http-rest">
 <TabItem label="REST API" _filter={{ infra: 'rest-lambda' }}>
-```d2 inline=true
-direction: right
 
-client: Client {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
-
-waf: WAF {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/waf.svg
-}
-
-apigw: API Gateway\n(REST API) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/api-gateway.svg
-}
-
-lambda: Lambda {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/lambda.svg
-}
-
-cw: CloudWatch\n(Logs, Metrics) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cloudwatch.svg
-  near: top-right
-}
-
-xray: X-Ray\n(Traces) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/xray.svg
-  near: bottom-right
-}
-
-client -> waf
-waf -> apigw
-apigw -> lambda
-lambda -> cw
-lambda -> xray
-```
+<ArchitectureDiagram options={{ infra: 'rest-lambda' }} />
 
 As REST APIs incluem um Web ACL do [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) na frente do estágio do API Gateway com o conjunto de regras padrão gerenciado pela AWS habilitado.
 </TabItem>
 <TabItem label="HTTP API" _filter={{ infra: 'http-lambda' }}>
-```d2 inline=true
-direction: right
 
-client: Client {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
-
-apigw: API Gateway\n(HTTP API) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/api-gateway.svg
-}
-
-lambda: Lambda {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/lambda.svg
-}
-
-cw: CloudWatch\n(Logs, Metrics) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cloudwatch.svg
-  near: top-right
-}
-
-xray: X-Ray\n(Traces) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/xray.svg
-  near: bottom-right
-}
-
-client -> apigw
-apigw -> lambda
-lambda -> cw
-lambda -> xray
-```
+<ArchitectureDiagram options={{ infra: 'http-lambda' }} />
 
 As HTTP APIs não suportam WAF diretamente — se você precisar de proteção WAF, escolha REST API em vez disso ou coloque a HTTP API atrás de uma distribuição CloudFront.
 </TabItem>

--- a/docs/src/content/docs/pt/snippets/lambda-function/architecture.mdx
+++ b/docs/src/content/docs/pt/snippets/lambda-function/architecture.mdx
@@ -1,36 +1,10 @@
 ---
 title: Arquitetura da Função Lambda
 ---
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
-A função implantada possui a seguinte arquitetura:
+A função implantada possui a seguinte arquitetura, com seus logs, métricas e traces indo para o CloudWatch e X-Ray:
 
-```d2 inline=true
-direction: right
-
-source: Event Source\n(SNS, SQS, ...) {
-  shape: rectangle
-}
-
-lambda: Lambda {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/lambda.svg
-}
-
-cw: CloudWatch\n(Logs, Metrics) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cloudwatch.svg
-  near: top-right
-}
-
-xray: X-Ray\n(Traces) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/xray.svg
-  near: bottom-right
-}
-
-source -> lambda
-lambda -> cw
-lambda -> xray
-```
+<ArchitectureDiagram name="my-function" />
 
 O gerador fornece a função em si; você conecta a origem do evento em sua stack para invocá-la (por exemplo, uma integração com API Gateway, uma regra do EventBridge, uma notificação do S3 ou um mapeamento de origem de eventos do SQS).

--- a/docs/src/content/docs/pt/snippets/mcp/architecture.mdx
+++ b/docs/src/content/docs/pt/snippets/mcp/architecture.mdx
@@ -2,57 +2,28 @@
 title: Arquitetura do Servidor MCP
 ---
 import { Tabs, TabItem } from '@astrojs/starlight/components';
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
 <Tabs syncKey="infra">
-<TabItem label="Bedrock AgentCore Runtime" _filter={{ infra: 'agentcore' }}>
+<TabItem label="AgentCore Runtime" _filter={{ infra: 'agentcore' }}>
 
-Quando implantado no [Bedrock AgentCore Runtime](https://aws.amazon.com/bedrock/agentcore/), o servidor MCP é construído em uma imagem de contêiner, enviado para o Amazon ECR e executado no AgentCore Runtime. Assistentes de IA invocam o endpoint do plano de dados do AgentCore Runtime, que encaminha chamadas `tools/*` e `resources/*` para o seu servidor através do [transporte HTTP streamable](https://modelcontextprotocol.io/specification/draft/basic/transports#streamable-http).
+Quando implantado no [Bedrock AgentCore Runtime](https://aws.amazon.com/bedrock/agentcore/), o código do seu servidor é empacotado como um zip e executado no runtime gerenciado do AgentCore. Assistentes de IA invocam o endpoint do plano de dados do AgentCore Runtime, que encaminha chamadas `tools/*` e `resources/*` para o seu servidor através do [transporte HTTP streamable](https://modelcontextprotocol.io/specification/draft/basic/transports#streamable-http).
 
-```d2 inline=true
-direction: right
+<ArchitectureDiagram options={{ infra: 'agentcore' }} />
 
-assistant: AI Assistant {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
+</TabItem>
+<TabItem label="AgentCore Runtime (container)" _filter={{ infra: 'agentcore-ecr' }}>
 
-ecr: ECR {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/ecr.svg
-}
+Com `infra: agentcore-ecr`, o servidor MCP é construído em uma imagem de contêiner, enviado para o Amazon ECR e executado no AgentCore Runtime. Isso oferece controle em nível de sistema operacional sobre o ambiente de runtime, ao custo de um ciclo de build e deploy mais longo do que o empacotamento zip acima.
 
-agentcore: MCP Server\n(AgentCore Runtime) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/bedrock-agentcore-runtime.svg
-}
+<ArchitectureDiagram options={{ infra: 'agentcore-ecr' }} />
 
-cw: CloudWatch\n(Logs, Metrics) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cloudwatch.svg
-}
-
-assistant -> agentcore: Streamable\nHTTP
-ecr -> agentcore: Container\nimage
-agentcore -> cw
-```
 </TabItem>
 <TabItem label="None (local only)" _filter={{ infra: 'none' }}>
 
 Com `infra: none`, nenhuma infraestrutura AWS é gerada. O servidor MCP é configurado apenas para transportes STDIO e HTTP locais, e é consumido por assistentes de IA executando na mesma máquina.
 
-```d2 inline=true
-direction: right
+<ArchitectureDiagram options={{ infra: 'none' }} />
 
-assistant: AI Assistant {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
-
-server: MCP Server\n(local process) {
-  shape: rectangle
-}
-
-assistant -> server: STDIO\nor\nStreamable HTTP
-```
 </TabItem>
 </Tabs>

--- a/docs/src/content/docs/pt/snippets/rdb/architecture.mdx
+++ b/docs/src/content/docs/pt/snippets/rdb/architecture.mdx
@@ -1,39 +1,8 @@
 ---
 title: Arquitetura RDB
 ---
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
 O banco de dados implantado possui a seguinte arquitetura. Por padrão, um [Amazon RDS Proxy](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-proxy.html) fica na frente do cluster Aurora para agrupar conexões e habilitar [autenticação IAM](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.html) — veja [Desabilitar RDS Proxy](#disable-rds-proxy) para a alternativa. A arquitetura é a mesma independentemente de você selecionar o mecanismo PostgreSQL ou MySQL; apenas o tipo de mecanismo Aurora difere.
 
-```d2 inline=true
-direction: right
-
-app: Application\n(Lambda, Agent, ...) {
-  shape: hexagon
-}
-
-proxy: RDS Proxy {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/rds.svg
-}
-
-migrations: Migrations Lambda {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/lambda.svg
-}
-
-aurora: Aurora\n(PostgreSQL or MySQL) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/aurora.svg
-}
-
-secrets: Secrets Manager\n(DB credentials) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/secrets-manager.svg
-}
-
-app -> proxy: SQL (IAM auth)
-proxy -> aurora
-migrations -> aurora: Schema migrations
-migrations -> secrets: Admin credentials
-aurora -> secrets: Generates and rotates\nadmin credentials
-```
+<ArchitectureDiagram />

--- a/docs/src/content/docs/vi/get_started/tutorials/dungeon-game/overview.mdx
+++ b/docs/src/content/docs/vi/get_started/tutorials/dungeon-game/overview.mdx
@@ -16,6 +16,7 @@ import baselineGamePng from '@assets/baseline-game.png'
 import nxGraphPng from '@assets/nx-graph.png'
 import gameSelectPng from '@assets/game-select.png'
 import gameConversationPng from '@assets/game-conversation.png'
+import EmbeddedGraph from '@components/embedded-graph.astro';
 
 
 Sử dụng hướng dẫn này, bạn sẽ xây dựng một trò chơi phiêu lưu dungeon được hỗ trợ bởi AI Agentic với `@aws/nx-plugin`. Hướng dẫn này không yêu cầu bất kỳ kiến thức nào về `@aws/nx-plugin` hoặc các công nghệ liên quan.
@@ -51,76 +52,9 @@ Giao diện trò chơi sẽ giống như sơ đồ này:
 
 ### Kiến trúc ứng dụng
 
-Trò chơi phiêu lưu dungeon được hỗ trợ bởi AI Agentic được xây dựng sử dụng kiến trúc sau:
+Trò chơi phiêu lưu dungeon được hỗ trợ bởi AI Agentic được xây dựng sử dụng kiến trúc sau — chuyển sang **Projects** để xem workspace mà nó được xây dựng từ đó, mà bạn sẽ tạo khung trong Module 1:
 
-```d2 inline=true
-direction: down
-
-browser: Web Browser {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
-
-cognito: Cognito / IAM {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cognito.svg
-}
-
-cloudfront: CloudFront {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cloudfront.svg
-}
-
-s3: Static Assets\n(S3) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/s3.svg
-}
-
-apigw: API Gateway\n(Game API) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/api-gateway.svg
-}
-
-lambda: tRPC API\n(Lambda) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/lambda.svg
-}
-
-story: Story Agent\n(AgentCore) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/bedrock-agentcore-runtime.svg
-}
-
-mcp: Inventory MCP\n(AgentCore) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/bedrock-agentcore-runtime.svg
-}
-
-ddb: Game State\n(DynamoDB) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/dynamodb.svg
-}
-
-sessions: Story Sessions\n(S3) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/s3.svg
-}
-
-browser -> cognito: Sign in
-browser -> cloudfront
-cloudfront -> s3
-browser -> apigw
-apigw -> lambda
-lambda -> ddb
-lambda -> sessions: Read transcripts
-browser -> story: AG-UI stream
-story -> sessions: Persist turns
-story -> mcp: Tool calls
-mcp -> ddb
-ddb -> sessions: {
-  style.opacity: 0
-}
-```
+<EmbeddedGraph preset="dungeon-adventure" workspace="dungeon-adventure" iac="cdk" view="infrastructure" copyable={false} />
 
 - Website frontend React/Vite sử dụng:
   - Amazon Cognito/Identity Pools cho các lời gọi API an toàn.

--- a/docs/src/content/docs/vi/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/vi/guides/agentcore-gateway.mdx
@@ -14,6 +14,7 @@ import Snippet from '@components/snippet.astro';
 import Link from '@components/link.astro';
 import NxCommands from '@components/nx-commands.astro';
 import OptionFilter from '@components/option-filter.astro';
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
 Tạo một dự án [Amazon Bedrock AgentCore Gateway](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/gateway.html). AgentCore Gateway là một điểm vào được quản lý đặt trước các MCP server hoặc agent của bạn, xác thực các yêu cầu đến (IAM hoặc Cognito) và ký lưu lượng đi đến các target của nó bằng IAM SigV4.
 
@@ -89,32 +90,7 @@ URL của Gateway được tự động đăng ký trong namespace `agentcore.ga
 
 Gateway được triển khai có kiến trúc sau, với một [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACL đặt trước Gateway, định tuyến đến các MCP server target phía sau:
 
-```d2 inline=true
-direction: right
-
-client: Client {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
-
-waf: WAF {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/waf.svg
-}
-
-gateway: AgentCore Gateway\n(MCP, IAM or Cognito auth) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/bedrock-agentcore-gateway.svg
-}
-
-targets: Downstream MCP Servers\n(Gateway targets) {
-  shape: rectangle
-}
-
-client -> waf
-waf -> gateway
-gateway -> targets
-```
+<ArchitectureDiagram />
 
 ## Xác thực
 

--- a/docs/src/content/docs/vi/guides/py-dynamodb.mdx
+++ b/docs/src/content/docs/vi/guides/py-dynamodb.mdx
@@ -11,6 +11,7 @@ import Link from '@components/link.astro';
 import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import Snippet from '@components/snippet.astro';
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
 Generator này tạo một dự án Python mới được hỗ trợ bởi [Amazon DynamoDB](https://aws.amazon.com/dynamodb/), sử dụng [PynamoDB](https://pynamodb.readthedocs.io/) để mô hình hóa thực thể. Nó tạo ra mã ứng dụng và cơ sở hạ tầng cần thiết để cung cấp và quản lý bảng DynamoDB bằng AWS CDK hoặc Terraform, với hỗ trợ thiết kế bảng đơn và phát triển cục bộ tích hợp sẵn thông qua DynamoDB Local.
 
@@ -52,6 +53,12 @@ Các script phát triển cục bộ được chia sẻ giữa tất cả các d
 ### Cơ sở hạ tầng
 
 <Snippet name="dynamodb/infrastructure" />
+
+#### Kiến trúc
+
+Dự án được triển khai cung cấp chính bảng đó, mà bất kỳ dự án nào được kết nối với nó đều đọc và ghi:
+
+<ArchitectureDiagram />
 
 ## Phát triển cục bộ
 

--- a/docs/src/content/docs/vi/guides/react-website-auth.mdx
+++ b/docs/src/content/docs/vi/guides/react-website-auth.mdx
@@ -10,6 +10,7 @@ import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Infrastructure from '@components/infrastructure.astro';
 import Snippet from '@components/snippet.astro';
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
 Generator Xác thực Website React thêm xác thực vào website React của bạn bằng cách sử dụng [Amazon Cognito](https://aws.amazon.com/cognito/).
 
@@ -71,44 +72,13 @@ Bạn cũng sẽ tìm thấy mã cơ sở hạ tầng sau được tạo dựa t
 
 Generator này thêm một Amazon Cognito user pool (để đăng nhập) và một identity pool (để liên kết người dùng đã đăng nhập với thông tin xác thực IAM có phạm vi) vào kiến trúc static-website hiện có:
 
-```d2 inline=true
-direction: right
-
-browser: Web Browser {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
-
-waf: WAF {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/waf.svg
-}
-
-cognito: Cognito\n(User + Identity Pool) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cognito.svg
-}
-
-iam: Scoped IAM\nCredentials {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/iam.svg
-}
-
-backend: Authenticated\nAWS Resources {
-  shape: rectangle
-}
-
-browser -> waf: Sign in
-waf -> cognito
-cognito -> iam
-browser -> backend: IAM/Cognito
-```
+<ArchitectureDiagram name="my-website" />
 
 #### Bảo vệ khỏi mối đe dọa
 
-User Pool được tạo trên [gói tính năng Plus](https://docs.aws.amazon.com/cognito/latest/developerguide/feature-plans-features-plus.html) của Cognito với [bảo vệ khỏi mối đe dọa](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pool-settings-threat-protection.html) được đặt ở chế độ `AUDIT` cho xác thực tiêu chuẩn. Ở chế độ kiểm toán, Cognito gán một mức độ rủi ro cho mỗi lần đăng nhập và ghi lại đánh giá vào CloudWatch mà không chặn người dùng.
+User Pool được tạo trên [gói tính năng Plus](https://docs.aws.amazon.com/cognito/latest/developerguide/feature-plans-features-plus.html) của Cognito với [bảo vệ khỏi mối đe dọa](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pool-settings-threat-protection.html) ở chế độ thực thi **chỉ kiểm toán** cho xác thực tiêu chuẩn. Ở chế độ chỉ kiểm toán, Cognito gán một mức độ rủi ro cho mỗi lần đăng nhập và ghi lại đánh giá mà không chặn người dùng.
 
-Sau khi bạn đã quan sát các đánh giá rủi ro cho người dùng của mình, bạn có thể chuyển sang chế độ thực thi đầy đủ chức năng để tự động phản hồi hoạt động rủi ro (ví dụ: yêu cầu MFA hoặc chặn đăng nhập):
+Sau khi bạn đã quan sát các đánh giá rủi ro cho người dùng của mình, bạn có thể chuyển sang chế độ thực thi đầy đủ chức năng để tự động phản hồi hoạt động rủi ro (ví dụ: yêu cầu MFA hoặc chặn đăng nhập), sau đó cấu hình phản hồi cho từng mức độ rủi ro thông qua [xác thực thích ứng](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pool-settings-adaptive-authentication.html):
 
 <Infrastructure>
 <Fragment slot="cdk">
@@ -187,13 +157,13 @@ Quy tắc này đánh dấu các địa chỉ loopback trong tham số truy vấ
 Bạn sẽ cần thêm cơ sở hạ tầng user identity vào stack của mình, khai báo nó _trước_ website:
 
 ```ts title="packages/infra/src/stacks/application-stack.ts" {3,9}
-import { Stack } from 'aws-cdk-lib';
+import { Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { MyWebsite, UserIdentity } from '@my-scope/common-constructs';
 
 export class ApplicationStack extends Stack {
-  constructor(scope: Construct, id: string) {
-    super(scope, id);
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
 
     new UserIdentity(this, 'Identity');
 
@@ -256,13 +226,13 @@ Chỉnh sửa `callback_urls`/`logout_urls` trong `packages/common/terraform/src
 <Infrastructure>
 <Fragment slot="cdk">
 ```ts title="packages/infra/src/stacks/application-stack.ts" {12}
-import { Stack } from 'aws-cdk-lib';
+import { Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { MyWebsite, UserIdentity, MyApi } from '@my-scope/common-constructs';
 
 export class ApplicationStack extends Stack {
-  constructor(scope: Construct, id: string) {
-    super(scope, id);
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
 
     const identity = new UserIdentity(this, 'Identity');
     const api = new MyApi(this, 'MyApi', {

--- a/docs/src/content/docs/vi/guides/react-website.mdx
+++ b/docs/src/content/docs/vi/guides/react-website.mdx
@@ -17,6 +17,7 @@ import PackageManagerShortCommand from '@components/package-manager-short-comman
 import Infrastructure from '@components/infrastructure.astro';
 import Snippet from '@components/snippet.astro';
 import OptionFilter from '@components/option-filter.astro';
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
 Generator này tạo một website [React](https://react.dev/) mới với [shadcn/ui](https://ui.shadcn.com/) được cấu hình mặc định, cùng với cơ sở hạ tầng AWS CDK hoặc Terraform để triển khai website của bạn lên cloud dưới dạng website tĩnh được lưu trữ trong [S3](https://aws.amazon.com/s3/), phục vụ bởi [CloudFront](https://aws.amazon.com/cloudfront/) và được bảo vệ bởi [WAF](https://aws.amazon.com/waf/).
 
@@ -50,16 +51,23 @@ Generator sẽ tạo cấu trúc dự án sau trong thư mục `<directory>/<nam
     - config.ts Application configuration (eg. logo)
     - components
       - AppLayout Components for the overall layout and navigation bar
+      - app-sidebar.tsx Sidebar navigation (shadcn only)
+      - alert.tsx Alert component wrapping your UX provider's own
+      - spinner.tsx Spinner component wrapping your UX provider's own
     - hooks
       - useAppLayout.tsx Hook for adjusting the AppLayout from nested components (Cloudscape only)
     - routes
+      - \_\_root.tsx Root route, wrapping every page in the AppLayout
       - index.tsx Example route (or page) for TanStack Router
+    - routeTree.gen.ts Route tree, generated and maintained by TanStack Router
     - styles.css Global styles
   - vite.config.mts Vite and Vitest configuration
+  - project.json Nx project defining the project's targets
   - tsconfig.json Base TypeScript configuration for source and tests
   - tsconfig.app.json TypeScript configuration for source code
   - tsconfig.spec.json TypeScript configuration for tests
   - package.json Project manifest defining the project's package name and dependencies
+  - README.md Project README
 </FileTree>
 
 :::note[Không có TanStack Router]
@@ -99,35 +107,9 @@ Generator tạo infrastructure as code để triển khai website của bạn d�
 
 #### Kiến trúc
 
-Website được triển khai có kiến trúc như sau:
+Website được triển khai có kiến trúc như sau: các built assets của bạn trong một S3 bucket, được phục vụ bởi một CloudFront distribution với AWS WAFv2 Web ACL ở phía trước nó.
 
-```d2 inline=true
-direction: right
-
-browser: Web Browser {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
-
-waf: WAF {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/waf.svg
-}
-
-cloudfront: CloudFront {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cloudfront.svg
-}
-
-s3: Static Assets\n(S3) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/s3.svg
-}
-
-browser -> waf
-waf -> cloudfront
-cloudfront -> s3
-```
+<ArchitectureDiagram />
 
 ## Triển khai Website của bạn
 
@@ -157,26 +139,32 @@ Website của bạn đi kèm với [TanStack Router](https://tanstack.com/router
 
 Bạn có thể sử dụng component `Link` hoặc hook `useNavigate` để điều hướng giữa các trang:
 
-```tsx {1, 4, 8-9, 14}
+```tsx {1, 8, 12-13, 18}
 import { Link, useNavigate } from '@tanstack/react-router';
 
-export const MyComponent = () => {
+export const MyComponent = ({
+  createProduct,
+}: {
+  createProduct: () => Promise<string>;
+}) => {
   const navigate = useNavigate();
 
   const submit = async () => {
-    const id = await ...
+    const id = await createProduct();
     // Use `navigate` for redirecting after some asynchronous action
-    navigate({ to: '/products/$id', { params: { id }} });
+    navigate({ to: '/products/$id', params: { id } });
   };
 
   return (
     <>
       <Link to="/products">Cancel</Link>
-      <Button onClick={submit}>Submit</Button>
+      <button onClick={submit}>Submit</button>
     </>
-  )
+  );
 };
 ```
+
+`$id` trong đường dẫn `to` là một [path parameter](https://tanstack.com/router/latest/docs/framework/react/guide/path-params), được cung cấp thông qua `params`. Thay thế `<button>` thông thường bằng button component của bộ UX kit của bạn khi cần thiết.
 
 Để biết thêm chi tiết, hãy xem tài liệu [TanStack Router](https://tanstack.com/router/latest/docs/framework/react/overview).
 
@@ -191,13 +179,13 @@ Generator React website tạo infrastructure as code CDK hoặc Terraform dựa 
 Bạn có thể sử dụng CDK construct được tạo cho bạn trong `packages/common/constructs` để triển khai website của mình.
 
 ```ts title="packages/infra/src/stacks/application-stack.ts" {3, 9}
-import { Stack } from 'aws-cdk-lib';
+import { Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { MyWebsite } from '@my-scope/common-constructs';
 
 export class ApplicationStack extends Stack {
-  constructor(scope: Construct, id: string) {
-    super(scope, id);
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
 
     new MyWebsite(this, 'MyWebsite');
   }
@@ -266,13 +254,13 @@ CloudFront distribution được bảo vệ bởi một [AWS WAFv2](https://docs
 Để từ chối, đặt `enableWaf` thành `false` khi bạn tạo website của mình:
 
 ```ts title="packages/infra/src/stacks/application-stack.ts" {10,15-18}
-import { Stack } from 'aws-cdk-lib';
+import { Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { MyWebsite, suppressRules } from '@my-scope/common-constructs';
 
 export class ApplicationStack extends Stack {
-  constructor(scope: Construct, id: string) {
-    super(scope, id);
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
 
     const website = new MyWebsite(this, 'MyWebsite', {
       enableWaf: false,
@@ -318,14 +306,14 @@ Website bucket, CloudFront distribution log bucket, và CloudWatch Logs group nh
 Nếu bạn muốn sử dụng cấu hình mã hóa khác, hãy truyền các props `encryption`, `encryptionKey` và `enableKeyRotation` khi bạn tạo website của mình:
 
 ```ts title="packages/infra/src/stacks/application-stack.ts" {11}
-import { Stack } from 'aws-cdk-lib';
+import { Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { BucketEncryption } from 'aws-cdk-lib/aws-s3';
 import { MyWebsite } from '@my-scope/common-constructs';
 
 export class ApplicationStack extends Stack {
-  constructor(scope: Construct, id: string) {
-    super(scope, id);
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
 
     new MyWebsite(this, 'MyWebsite', {
       encryption: BucketEncryption.S3_MANAGED,
@@ -401,11 +389,12 @@ module "my_website" {
 ```
 
 :::caution[Checkov: S3_MANAGED]
-Chọn `S3_MANAGED` làm thất bại quét bảo mật `checkov` với `CKV_AWS_145` trên website và distribution log buckets. Target `test` được cung cấp không chấp nhận `--config-file`, nhưng `checkov` tự động phát hiện một `.checkov.yaml` trong thư mục làm việc của nó, vì vậy hãy đặt một cái trong `packages/infra/src`:
+Chọn `S3_MANAGED` làm thất bại target `checkov` của dự án của bạn với `CKV_AWS_145` trên website và distribution log buckets. Target chạy `checkov` đối với `checkov.yml` của chính dự án của bạn, vì vậy hãy thêm check vào danh sách `skip-check` của nó:
 
-```yaml title="packages/infra/src/.checkov.yaml"
+```yaml title="packages/infra/checkov.yml" {3}
 skip-check:
-  - CKV_AWS_145
+  # ...
+  - CKV_AWS_145 # S3 buckets are not KMS encrypted when encryption is S3_MANAGED
 ```
 :::
 
@@ -439,11 +428,12 @@ module "my_website" {
 ```
 
 :::caution[Checkov: xoay khóa bị vô hiệu hóa]
-Vô hiệu hóa xoay khóa trên khóa được tạo tự động làm thất bại quét bảo mật `checkov` với `CKV_AWS_7`. Thêm nó vào cùng một `.checkov.yaml`:
+Vô hiệu hóa xoay khóa trên khóa được tạo tự động làm thất bại target `checkov` của dự án của bạn với `CKV_AWS_7`. Thêm nó vào cùng danh sách `skip-check` trong `packages/infra/checkov.yml`:
 
-```yaml title="packages/infra/src/.checkov.yaml"
+```yaml title="packages/infra/checkov.yml" {3}
 skip-check:
-  - CKV_AWS_7
+  # ...
+  - CKV_AWS_7 # Key rotation is disabled on the website's KMS key
 ```
 :::
 </Fragment>
@@ -458,14 +448,14 @@ Theo mặc định, distribution sử dụng tên miền CloudFront mặc địn
 Truyền các props `certificate` và `domainNames` khi bạn tạo website của mình:
 
 ```ts title="packages/infra/src/stacks/application-stack.ts" {11-13}
-import { Stack } from 'aws-cdk-lib';
+import { Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { Certificate } from 'aws-cdk-lib/aws-certificatemanager';
 import { MyWebsite } from '@my-scope/common-constructs';
 
 export class ApplicationStack extends Stack {
-  constructor(scope: Construct, id: string) {
-    super(scope, id);
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
 
     new MyWebsite(this, 'MyWebsite', {
       domainNames: ['www.example.com'],
@@ -508,13 +498,13 @@ CDK construct `RuntimeConfig` có thể được sử dụng để thêm và tru
 CDK construct website của bạn sẽ triển khai namespace `connection` của runtime configuration dưới dạng file `runtime-config.json` vào thư mục gốc của S3 bucket của bạn.
 
 ```ts title="packages/infra/src/stacks/application-stack.ts"
-import { Stack } from 'aws-cdk-lib';
+import { Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { MyWebsite, MyApi } from '@my-scope/common-constructs';
 
 export class ApplicationStack extends Stack {
-  constructor(scope: Construct, id: string) {
-    super(scope, id);
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
 
     // Website can be declared at any point, since runtime config is resolved lazily
     new MyWebsite(this, 'MyWebsite');
@@ -581,6 +571,10 @@ const MyComponent = () => {
   const apiUrl = runtimeConfig.apis.MyApi;
 };
 ```
+
+:::note[Added when you need it]
+`src/hooks/useRuntimeConfig.tsx` và `src/components/RuntimeConfig` được thêm vào website của bạn bởi generator <Link path="/guides/react-website-auth">`ts#website#auth`</Link> và các generators <Link path="guides/connection">`connection`</Link>, vì đó là những gì đưa các giá trị vào runtime configuration. Một website không có cả hai sẽ không có runtime configuration để đọc, vì vậy hook không được cung cấp cho đến khi một trong số chúng đã chạy.
+:::
 
 :::note[Runtime Configuration]
 Để biết chi tiết về cách runtime configuration được lưu trữ trong AWS AppConfig và cách các consumers phía server (Lambda functions, agents) có thể truy xuất nó, hãy xem hướng dẫn <Link path="guides/runtime-config">Runtime Configuration</Link>.

--- a/docs/src/content/docs/vi/guides/ts-dynamodb.mdx
+++ b/docs/src/content/docs/vi/guides/ts-dynamodb.mdx
@@ -11,6 +11,7 @@ import Link from '@components/link.astro';
 import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import Snippet from '@components/snippet.astro';
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
 Generator này tạo một dự án TypeScript DynamoDB mới được hỗ trợ bởi [Amazon DynamoDB](https://aws.amazon.com/dynamodb/), sử dụng [ElectroDB](https://electrodb.dev/) để mô hình hóa thực thể an toàn kiểu. Nó tạo ra mã ứng dụng và cơ sở hạ tầng cần thiết để cung cấp và quản lý bảng DynamoDB bằng AWS CDK hoặc Terraform, với hỗ trợ thiết kế bảng đơn và phát triển cục bộ tích hợp sẵn thông qua DynamoDB Local.
 
@@ -52,6 +53,12 @@ Các script phát triển cục bộ được chia sẻ trên tất cả các d�
 ### Cơ sở hạ tầng
 
 <Snippet name="dynamodb/infrastructure" />
+
+#### Kiến trúc
+
+Dự án được triển khai cung cấp chính bảng đó, mà bất kỳ dự án nào được kết nối với nó đều đọc và ghi:
+
+<ArchitectureDiagram />
 
 ## Phát triển Cục bộ
 

--- a/docs/src/content/docs/vi/guides/ts-smithy-api.mdx
+++ b/docs/src/content/docs/vi/guides/ts-smithy-api.mdx
@@ -20,6 +20,7 @@ import Snippet from '@components/snippet.astro';
 import OptionFilter from '@components/option-filter.astro';
 import InstallCommand from '@components/install-command.astro';
 import { TS_VERSIONS } from '../../../../../../packages/nx-plugin/src/utils/versions';
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
 [Smithy](https://smithy.io/) là một ngôn ngữ định nghĩa giao diện độc lập với giao thức để tạo API theo cách hướng mô hình.
 
@@ -126,47 +127,7 @@ Dự án này được tạo bằng trình tạo <Link path="/guides/terraform-p
 
 Smithy API được triển khai có kiến trúc sau, với [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACL ở phía trước API Gateway stage:
 
-```d2 inline=true
-direction: right
-
-client: Client {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
-
-waf: WAF {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/waf.svg
-}
-
-apigw: API Gateway\n(REST API) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/api-gateway.svg
-}
-
-lambda: Lambda\n(Smithy Server SDK) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/lambda.svg
-}
-
-cw: CloudWatch\n(Logs, Metrics) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cloudwatch.svg
-  near: top-right
-}
-
-xray: X-Ray\n(Traces) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/xray.svg
-  near: bottom-right
-}
-
-client -> waf
-waf -> apigw
-apigw -> lambda
-lambda -> cw
-lambda -> xray
-```
+<ArchitectureDiagram options={{ infra: 'rest-lambda' }} />
 
 ## Triển khai Smithy API của bạn
 

--- a/docs/src/content/docs/vi/snippets/agent/architecture.mdx
+++ b/docs/src/content/docs/vi/snippets/agent/architecture.mdx
@@ -2,71 +2,28 @@
 title: Kiến trúc Agent
 ---
 import { Tabs, TabItem } from '@astrojs/starlight/components';
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
 <Tabs syncKey="infra">
-<TabItem label="Bedrock AgentCore Runtime" _filter={{ infra: 'agentcore' }}>
+<TabItem label="AgentCore Runtime" _filter={{ infra: 'agentcore' }}>
 
-Khi được triển khai lên [Bedrock AgentCore Runtime](https://aws.amazon.com/bedrock/agentcore/), agent được xây dựng thành một container image, đẩy lên Amazon ECR và chạy trong AgentCore Runtime. Các client gọi đến data plane endpoint của AgentCore Runtime, endpoint này chuyển tiếp các yêu cầu đến agent của bạn. Agent gọi Amazon Bedrock để suy luận mô hình và có thể gọi các công cụ, MCP server, hoặc các API downstream.
+Khi được triển khai lên [Bedrock AgentCore Runtime](https://aws.amazon.com/bedrock/agentcore/), mã nguồn của agent được đóng gói dưới dạng zip và chạy trong AgentCore managed runtime. Các client gọi đến data plane endpoint của AgentCore Runtime, endpoint này chuyển tiếp các yêu cầu đến agent của bạn. Agent gọi Amazon Bedrock để suy luận mô hình và có thể gọi các công cụ, MCP server, hoặc các API downstream.
 
-```d2 inline=true
-direction: right
+<ArchitectureDiagram options={{ infra: 'agentcore' }} />
 
-client: Client {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
+</TabItem>
+<TabItem label="AgentCore Runtime (container)" _filter={{ infra: 'agentcore-ecr' }}>
 
-ecr: ECR {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/ecr.svg
-}
+Với `infra: agentcore-ecr`, agent được xây dựng thành một container image, đẩy lên Amazon ECR và chạy trong AgentCore Runtime. Điều này cho phép bạn kiểm soát môi trường runtime ở cấp độ hệ điều hành, với chi phí là chu kỳ build và deploy dài hơn so với cách đóng gói zip ở trên.
 
-agentcore: Strands Agent\n(AgentCore Runtime) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/bedrock-agentcore-runtime.svg
-}
+<ArchitectureDiagram options={{ infra: 'agentcore-ecr' }} />
 
-bedrock: Bedrock\n(Model Inference) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/bedrock.svg
-  near: top-right
-}
-
-cw: CloudWatch\n(Logs, Metrics) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cloudwatch.svg
-  near: bottom-right
-}
-
-client -> agentcore
-ecr -> agentcore: Container\nimage
-agentcore -> bedrock: InvokeModel
-agentcore -> cw
-```
 </TabItem>
 <TabItem label="None (local only)" _filter={{ infra: 'none' }}>
 
 Với `infra: none`, không có cơ sở hạ tầng AWS nào được tạo ra. Agent chạy như một tiến trình cục bộ và gọi Amazon Bedrock để suy luận mô hình.
 
-```d2 inline=true
-direction: right
+<ArchitectureDiagram options={{ infra: 'none' }} />
 
-client: Client {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
-
-agent: Strands Agent\n(local process) {
-  shape: rectangle
-}
-
-bedrock: Bedrock\n(Model Inference) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/bedrock.svg
-}
-
-client -> agent
-agent -> bedrock: InvokeModel
-```
 </TabItem>
 </Tabs>

--- a/docs/src/content/docs/vi/snippets/api/api-architecture.mdx
+++ b/docs/src/content/docs/vi/snippets/api/api-architecture.mdx
@@ -2,91 +2,20 @@
 title: Kiến trúc API
 ---
 import { Tabs, TabItem } from '@astrojs/starlight/components';
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
-Ứng dụng được triển khai có kiến trúc như sau:
+Ứng dụng được triển khai có kiến trúc như sau: một API Gateway API đặt trước một hàm Lambda chạy handler của bạn.
 
 <Tabs syncKey="http-rest">
 <TabItem label="REST API" _filter={{ infra: 'rest-lambda' }}>
-```d2 inline=true
-direction: right
 
-client: Client {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
-
-waf: WAF {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/waf.svg
-}
-
-apigw: API Gateway\n(REST API) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/api-gateway.svg
-}
-
-lambda: Lambda {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/lambda.svg
-}
-
-cw: CloudWatch\n(Logs, Metrics) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cloudwatch.svg
-  near: top-right
-}
-
-xray: X-Ray\n(Traces) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/xray.svg
-  near: bottom-right
-}
-
-client -> waf
-waf -> apigw
-apigw -> lambda
-lambda -> cw
-lambda -> xray
-```
+<ArchitectureDiagram options={{ infra: 'rest-lambda' }} />
 
 REST APIs bao gồm một [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACL đặt trước API Gateway stage với bộ quy tắc mặc định được quản lý bởi AWS được kích hoạt.
 </TabItem>
 <TabItem label="HTTP API" _filter={{ infra: 'http-lambda' }}>
-```d2 inline=true
-direction: right
 
-client: Client {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
-
-apigw: API Gateway\n(HTTP API) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/api-gateway.svg
-}
-
-lambda: Lambda {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/lambda.svg
-}
-
-cw: CloudWatch\n(Logs, Metrics) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cloudwatch.svg
-  near: top-right
-}
-
-xray: X-Ray\n(Traces) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/xray.svg
-  near: bottom-right
-}
-
-client -> apigw
-apigw -> lambda
-lambda -> cw
-lambda -> xray
-```
+<ArchitectureDiagram options={{ infra: 'http-lambda' }} />
 
 HTTP APIs không hỗ trợ WAF trực tiếp — nếu bạn cần bảo vệ WAF, hãy chọn REST API thay thế hoặc đặt HTTP API phía sau một CloudFront distribution.
 </TabItem>

--- a/docs/src/content/docs/vi/snippets/lambda-function/architecture.mdx
+++ b/docs/src/content/docs/vi/snippets/lambda-function/architecture.mdx
@@ -1,36 +1,10 @@
 ---
 title: Kiến trúc Lambda Function
 ---
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
-Hàm được triển khai có kiến trúc như sau:
+Hàm được triển khai có kiến trúc như sau, với các log, số liệu và trace của nó được gửi đến CloudWatch và X-Ray:
 
-```d2 inline=true
-direction: right
-
-source: Event Source\n(SNS, SQS, ...) {
-  shape: rectangle
-}
-
-lambda: Lambda {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/lambda.svg
-}
-
-cw: CloudWatch\n(Logs, Metrics) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cloudwatch.svg
-  near: top-right
-}
-
-xray: X-Ray\n(Traces) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/xray.svg
-  near: bottom-right
-}
-
-source -> lambda
-lambda -> cw
-lambda -> xray
-```
+<ArchitectureDiagram name="my-function" />
 
 Generator tạo ra chính hàm đó; bạn kết nối nguồn sự kiện trong stack của mình để gọi nó (ví dụ: tích hợp API Gateway, quy tắc EventBridge, thông báo S3 hoặc ánh xạ nguồn sự kiện SQS).

--- a/docs/src/content/docs/vi/snippets/mcp/architecture.mdx
+++ b/docs/src/content/docs/vi/snippets/mcp/architecture.mdx
@@ -2,57 +2,28 @@
 title: Kiến trúc MCP Server
 ---
 import { Tabs, TabItem } from '@astrojs/starlight/components';
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
 <Tabs syncKey="infra">
-<TabItem label="Bedrock AgentCore Runtime" _filter={{ infra: 'agentcore' }}>
+<TabItem label="AgentCore Runtime" _filter={{ infra: 'agentcore' }}>
 
-Khi triển khai lên [Bedrock AgentCore Runtime](https://aws.amazon.com/bedrock/agentcore/), MCP server được xây dựng thành container image, đẩy lên Amazon ECR, và chạy trong AgentCore Runtime. Các trợ lý AI gọi đến data plane endpoint của AgentCore Runtime, endpoint này chuyển tiếp các lời gọi `tools/*` và `resources/*` đến server của bạn qua [streamable HTTP transport](https://modelcontextprotocol.io/specification/draft/basic/transports#streamable-http).
+Khi triển khai lên [Bedrock AgentCore Runtime](https://aws.amazon.com/bedrock/agentcore/), mã nguồn của server được đóng gói dưới dạng zip và chạy trong AgentCore managed runtime. Các trợ lý AI gọi đến data plane endpoint của AgentCore Runtime, endpoint này chuyển tiếp các lời gọi `tools/*` và `resources/*` đến server của bạn qua [streamable HTTP transport](https://modelcontextprotocol.io/specification/draft/basic/transports#streamable-http).
 
-```d2 inline=true
-direction: right
+<ArchitectureDiagram options={{ infra: 'agentcore' }} />
 
-assistant: AI Assistant {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
+</TabItem>
+<TabItem label="AgentCore Runtime (container)" _filter={{ infra: 'agentcore-ecr' }}>
 
-ecr: ECR {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/ecr.svg
-}
+Với `infra: agentcore-ecr`, MCP server được xây dựng thành container image, đẩy lên Amazon ECR và chạy trong AgentCore Runtime. Điều này cho phép bạn kiểm soát môi trường runtime ở cấp độ hệ điều hành, với chi phí là chu kỳ build và deploy dài hơn so với đóng gói zip ở trên.
 
-agentcore: MCP Server\n(AgentCore Runtime) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/bedrock-agentcore-runtime.svg
-}
+<ArchitectureDiagram options={{ infra: 'agentcore-ecr' }} />
 
-cw: CloudWatch\n(Logs, Metrics) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cloudwatch.svg
-}
-
-assistant -> agentcore: Streamable\nHTTP
-ecr -> agentcore: Container\nimage
-agentcore -> cw
-```
 </TabItem>
 <TabItem label="None (local only)" _filter={{ infra: 'none' }}>
 
 Với `infra: none`, không có cơ sở hạ tầng AWS nào được tạo ra. MCP server được cấu hình chỉ cho STDIO và HTTP transports cục bộ, và được sử dụng bởi các trợ lý AI chạy trên cùng một máy.
 
-```d2 inline=true
-direction: right
+<ArchitectureDiagram options={{ infra: 'none' }} />
 
-assistant: AI Assistant {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
-
-server: MCP Server\n(local process) {
-  shape: rectangle
-}
-
-assistant -> server: STDIO\nor\nStreamable HTTP
-```
 </TabItem>
 </Tabs>

--- a/docs/src/content/docs/vi/snippets/rdb/architecture.mdx
+++ b/docs/src/content/docs/vi/snippets/rdb/architecture.mdx
@@ -1,39 +1,8 @@
 ---
 title: Kiến trúc RDB
 ---
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
 Cơ sở dữ liệu được triển khai có kiến trúc như sau. Theo mặc định, một [Amazon RDS Proxy](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-proxy.html) đứng trước cụm Aurora để gộp các kết nối và kích hoạt [xác thực IAM](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.html) — xem [Vô hiệu hóa RDS Proxy](#disable-rds-proxy) để biết phương án thay thế. Kiến trúc giống nhau cho dù bạn chọn engine PostgreSQL hay MySQL; chỉ có phiên bản Aurora engine là khác nhau.
 
-```d2 inline=true
-direction: right
-
-app: Application\n(Lambda, Agent, ...) {
-  shape: hexagon
-}
-
-proxy: RDS Proxy {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/rds.svg
-}
-
-migrations: Migrations Lambda {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/lambda.svg
-}
-
-aurora: Aurora\n(PostgreSQL or MySQL) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/aurora.svg
-}
-
-secrets: Secrets Manager\n(DB credentials) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/secrets-manager.svg
-}
-
-app -> proxy: SQL (IAM auth)
-proxy -> aurora
-migrations -> aurora: Schema migrations
-migrations -> secrets: Admin credentials
-aurora -> secrets: Generates and rotates\nadmin credentials
-```
+<ArchitectureDiagram />

--- a/docs/src/content/docs/zh/get_started/tutorials/dungeon-game/overview.mdx
+++ b/docs/src/content/docs/zh/get_started/tutorials/dungeon-game/overview.mdx
@@ -16,6 +16,7 @@ import baselineGamePng from '@assets/baseline-game.png'
 import nxGraphPng from '@assets/nx-graph.png'
 import gameSelectPng from '@assets/game-select.png'
 import gameConversationPng from '@assets/game-conversation.png'
+import EmbeddedGraph from '@components/embedded-graph.astro';
 
 
 通过本教程，您将使用 `@aws/nx-plugin` 构建一个智能体 AI 驱动的地牢冒险游戏。本教程不假设您对 `@aws/nx-plugin` 或相关技术有任何现有知识。
@@ -51,76 +52,9 @@ import gameConversationPng from '@assets/game-conversation.png'
 
 ### 应用程序架构
 
-智能体 AI 驱动的地牢冒险游戏使用以下架构构建：
+智能体 AI 驱动的地牢冒险游戏使用以下架构构建 — 切换到 **Projects** 查看构建它的工作空间，您将在模块 1 中搭建该工作空间：
 
-```d2 inline=true
-direction: down
-
-browser: Web Browser {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
-
-cognito: Cognito / IAM {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cognito.svg
-}
-
-cloudfront: CloudFront {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cloudfront.svg
-}
-
-s3: Static Assets\n(S3) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/s3.svg
-}
-
-apigw: API Gateway\n(Game API) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/api-gateway.svg
-}
-
-lambda: tRPC API\n(Lambda) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/lambda.svg
-}
-
-story: Story Agent\n(AgentCore) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/bedrock-agentcore-runtime.svg
-}
-
-mcp: Inventory MCP\n(AgentCore) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/bedrock-agentcore-runtime.svg
-}
-
-ddb: Game State\n(DynamoDB) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/dynamodb.svg
-}
-
-sessions: Story Sessions\n(S3) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/s3.svg
-}
-
-browser -> cognito: Sign in
-browser -> cloudfront
-cloudfront -> s3
-browser -> apigw
-apigw -> lambda
-lambda -> ddb
-lambda -> sessions: Read transcripts
-browser -> story: AG-UI stream
-story -> sessions: Persist turns
-story -> mcp: Tool calls
-mcp -> ddb
-ddb -> sessions: {
-  style.opacity: 0
-}
-```
+<EmbeddedGraph preset="dungeon-adventure" workspace="dungeon-adventure" iac="cdk" view="infrastructure" copyable={false} />
 
 - React/Vite 前端网站，使用：
   - Amazon Cognito/Identity Pools 进行安全的 API 调用。

--- a/docs/src/content/docs/zh/guides/agentcore-gateway.mdx
+++ b/docs/src/content/docs/zh/guides/agentcore-gateway.mdx
@@ -14,6 +14,7 @@ import Snippet from '@components/snippet.astro';
 import Link from '@components/link.astro';
 import NxCommands from '@components/nx-commands.astro';
 import OptionFilter from '@components/option-filter.astro';
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
 生成一个 [Amazon Bedrock AgentCore Gateway](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/gateway.html) 项目。AgentCore Gateway 是位于您的 MCP 服务器或代理前面的托管入口点，对入站请求进行身份验证（IAM 或 Cognito），并使用 IAM SigV4 对其目标的出站流量进行签名。
 
@@ -89,32 +90,7 @@ Gateway URL 会自动注册到 <Link path="guides/runtime-config">运行时配�
 
 部署的 Gateway 具有以下架构，在 Gateway 前面有一个 [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACL，它路由到其下游 MCP 服务器目标：
 
-```d2 inline=true
-direction: right
-
-client: Client {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
-
-waf: WAF {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/waf.svg
-}
-
-gateway: AgentCore Gateway\n(MCP, IAM or Cognito auth) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/bedrock-agentcore-gateway.svg
-}
-
-targets: Downstream MCP Servers\n(Gateway targets) {
-  shape: rectangle
-}
-
-client -> waf
-waf -> gateway
-gateway -> targets
-```
+<ArchitectureDiagram />
 
 ## 身份验证
 

--- a/docs/src/content/docs/zh/guides/py-dynamodb.mdx
+++ b/docs/src/content/docs/zh/guides/py-dynamodb.mdx
@@ -11,6 +11,7 @@ import Link from '@components/link.astro';
 import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import Snippet from '@components/snippet.astro';
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
 此生成器创建一个由 [Amazon DynamoDB](https://aws.amazon.com/dynamodb/) 支持的新 Python 项目，使用 [PynamoDB](https://pynamodb.readthedocs.io/) 进行实体建模。它生成应用程序代码和基础设施，用于使用 AWS CDK 或 Terraform 配置和管理 DynamoDB 表，支持单表设计并通过 DynamoDB Local 内置本地开发。
 
@@ -52,6 +53,12 @@ import Snippet from '@components/snippet.astro';
 ### 基础设施
 
 <Snippet name="dynamodb/infrastructure" />
+
+#### 架构
+
+已部署的项目配置表本身，任何连接到它的项目都可以读取和写入：
+
+<ArchitectureDiagram />
 
 ## 本地开发
 

--- a/docs/src/content/docs/zh/guides/react-website-auth.mdx
+++ b/docs/src/content/docs/zh/guides/react-website-auth.mdx
@@ -10,6 +10,7 @@ import GeneratorParameters from '@components/generator-parameters.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Infrastructure from '@components/infrastructure.astro';
 import Snippet from '@components/snippet.astro';
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
 React 网站身份验证生成器使用 [Amazon Cognito](https://aws.amazon.com/cognito/) 为您的 React 网站添加身份验证功能。
 
@@ -71,38 +72,7 @@ React 网站身份验证生成器使用 [Amazon Cognito](https://aws.amazon.com/
 
 此生成器在现有静态网站架构中添加了 Amazon Cognito 用户池（用于登录）和身份池（用于将已登录用户联合到作用域 IAM 凭证）：
 
-```d2 inline=true
-direction: right
-
-browser: Web Browser {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
-
-waf: WAF {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/waf.svg
-}
-
-cognito: Cognito\n(User + Identity Pool) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cognito.svg
-}
-
-iam: Scoped IAM\nCredentials {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/iam.svg
-}
-
-backend: Authenticated\nAWS Resources {
-  shape: rectangle
-}
-
-browser -> waf: Sign in
-waf -> cognito
-cognito -> iam
-browser -> backend: IAM/Cognito
-```
+<ArchitectureDiagram name="my-website" />
 
 #### 威胁防护
 
@@ -187,13 +157,13 @@ module "user_identity" {
 您需要将用户身份基础设施添加到您的堆栈中，在网站_之前_声明它：
 
 ```ts title="packages/infra/src/stacks/application-stack.ts" {3,9}
-import { Stack } from 'aws-cdk-lib';
+import { Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { MyWebsite, UserIdentity } from '@my-scope/common-constructs';
 
 export class ApplicationStack extends Stack {
-  constructor(scope: Construct, id: string) {
-    super(scope, id);
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
 
     new UserIdentity(this, 'Identity');
 
@@ -256,13 +226,13 @@ module "my_website" {
 <Infrastructure>
 <Fragment slot="cdk">
 ```ts title="packages/infra/src/stacks/application-stack.ts" {12}
-import { Stack } from 'aws-cdk-lib';
+import { Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { MyWebsite, UserIdentity, MyApi } from '@my-scope/common-constructs';
 
 export class ApplicationStack extends Stack {
-  constructor(scope: Construct, id: string) {
-    super(scope, id);
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
 
     const identity = new UserIdentity(this, 'Identity');
     const api = new MyApi(this, 'MyApi', {

--- a/docs/src/content/docs/zh/guides/react-website.mdx
+++ b/docs/src/content/docs/zh/guides/react-website.mdx
@@ -17,6 +17,7 @@ import PackageManagerShortCommand from '@components/package-manager-short-comman
 import Infrastructure from '@components/infrastructure.astro';
 import Snippet from '@components/snippet.astro';
 import OptionFilter from '@components/option-filter.astro';
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
 此生成器创建一个新的 [React](https://react.dev/) 网站，默认配置了 [shadcn/ui](https://ui.shadcn.com/)，以及用于将网站部署到云端的 AWS CDK 或 Terraform 基础设施，作为托管在 [S3](https://aws.amazon.com/s3/) 中的静态网站，由 [CloudFront](https://aws.amazon.com/cloudfront/) 提供服务，并受 [WAF](https://aws.amazon.com/waf/) 保护。
 
@@ -50,16 +51,23 @@ import OptionFilter from '@components/option-filter.astro';
     - config.ts 应用程序配置（例如 logo）
     - components
       - AppLayout 整体布局和导航栏的组件
+      - app-sidebar.tsx 侧边栏导航（仅限 shadcn）
+      - alert.tsx 包装您的 UX 提供者自己的 Alert 组件
+      - spinner.tsx 包装您的 UX 提供者自己的 Spinner 组件
     - hooks
       - useAppLayout.tsx 用于从嵌套组件调整 AppLayout 的钩子（仅限 Cloudscape）
     - routes
+      - \_\_root.tsx 根路由，将每个页面包装在 AppLayout 中
       - index.tsx TanStack Router 的示例路由（或页面）
+    - routeTree.gen.ts 路由树，由 TanStack Router 生成和维护
     - styles.css 全局样式
   - vite.config.mts Vite 和 Vitest 配置
+  - project.json 定义项目目标的 Nx 项目
   - tsconfig.json 源代码和测试的基础 TypeScript 配置
   - tsconfig.app.json 源代码的 TypeScript 配置
   - tsconfig.spec.json 测试的 TypeScript 配置
   - package.json 定义项目包名称和依赖项的项目清单
+  - README.md 项目 README
 </FileTree>
 
 :::note[不使用 TanStack Router]
@@ -99,35 +107,9 @@ import OptionFilter from '@components/option-filter.astro';
 
 #### 架构
 
-部署的网站具有以下架构：
+部署的网站具有以下架构：您在 S3 存储桶中构建的资源，由 CloudFront 分配提供服务，前面有一个 AWS WAFv2 Web ACL。
 
-```d2 inline=true
-direction: right
-
-browser: Web Browser {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
-
-waf: WAF {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/waf.svg
-}
-
-cloudfront: CloudFront {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cloudfront.svg
-}
-
-s3: Static Assets\n(S3) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/s3.svg
-}
-
-browser -> waf
-waf -> cloudfront
-cloudfront -> s3
-```
+<ArchitectureDiagram />
 
 ## 实现您的网站
 
@@ -157,26 +139,32 @@ cloudfront -> s3
 
 您可以使用 `Link` 组件或 `useNavigate` 钩子在页面之间导航：
 
-```tsx {1, 4, 8-9, 14}
+```tsx {1, 8, 12-13, 18}
 import { Link, useNavigate } from '@tanstack/react-router';
 
-export const MyComponent = () => {
+export const MyComponent = ({
+  createProduct,
+}: {
+  createProduct: () => Promise<string>;
+}) => {
   const navigate = useNavigate();
 
   const submit = async () => {
-    const id = await ...
+    const id = await createProduct();
     // Use `navigate` for redirecting after some asynchronous action
-    navigate({ to: '/products/$id', { params: { id }} });
+    navigate({ to: '/products/$id', params: { id } });
   };
 
   return (
     <>
       <Link to="/products">Cancel</Link>
-      <Button onClick={submit}>Submit</Button>
+      <button onClick={submit}>Submit</button>
     </>
-  )
+  );
 };
 ```
+
+`to` 路径中的 `$id` 是一个[路径参数](https://tanstack.com/router/latest/docs/framework/react/guide/path-params)，通过 `params` 提供。根据需要将普通的 `<button>` 替换为您的 UX 套件自己的按钮组件。
 
 有关更多详细信息，请查看 [TanStack Router](https://tanstack.com/router/latest/docs/framework/react/overview) 文档。
 
@@ -191,13 +179,13 @@ React 网站生成器根据您选择的 `iac` 创建 CDK 或 Terraform 基础设
 您可以使用在 `packages/common/constructs` 中为您生成的 CDK 构造来部署您的网站。
 
 ```ts title="packages/infra/src/stacks/application-stack.ts" {3, 9}
-import { Stack } from 'aws-cdk-lib';
+import { Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { MyWebsite } from '@my-scope/common-constructs';
 
 export class ApplicationStack extends Stack {
-  constructor(scope: Construct, id: string) {
-    super(scope, id);
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
 
     new MyWebsite(this, 'MyWebsite');
   }
@@ -266,13 +254,13 @@ CloudFront 分配应用响应标头策略，在所有响应上设置 `Strict-Tra
 要选择退出，在创建网站时将 `enableWaf` 设置为 `false`：
 
 ```ts title="packages/infra/src/stacks/application-stack.ts" {10,15-18}
-import { Stack } from 'aws-cdk-lib';
+import { Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { MyWebsite, suppressRules } from '@my-scope/common-constructs';
 
 export class ApplicationStack extends Stack {
-  constructor(scope: Construct, id: string) {
-    super(scope, id);
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
 
     const website = new MyWebsite(this, 'MyWebsite', {
       enableWaf: false,
@@ -318,14 +306,14 @@ module "my_website" {
 如果您想使用不同的加密配置，请在创建网站时传递 `encryption`、`encryptionKey` 和 `enableKeyRotation` 属性：
 
 ```ts title="packages/infra/src/stacks/application-stack.ts" {11}
-import { Stack } from 'aws-cdk-lib';
+import { Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { BucketEncryption } from 'aws-cdk-lib/aws-s3';
 import { MyWebsite } from '@my-scope/common-constructs';
 
 export class ApplicationStack extends Stack {
-  constructor(scope: Construct, id: string) {
-    super(scope, id);
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
 
     new MyWebsite(this, 'MyWebsite', {
       encryption: BucketEncryption.S3_MANAGED,
@@ -401,11 +389,12 @@ module "my_website" {
 ```
 
 :::caution[Checkov: S3_MANAGED]
-选择 `S3_MANAGED` 会导致 `checkov` 安全扫描在网站和分配日志存储桶上失败，错误为 `CKV_AWS_145`。提供的 `test` 目标不接受 `--config-file`，但 `checkov` 会自动发现其工作目录中的 `.checkov.yaml`，因此在 `packages/infra/src` 中放置一个：
+选择 `S3_MANAGED` 会导致项目的 `checkov` 目标在网站和分配日志存储桶上失败，错误为 `CKV_AWS_145`。该目标针对项目自己的 `checkov.yml` 运行 `checkov`，因此将检查添加到其 `skip-check` 列表中：
 
-```yaml title="packages/infra/src/.checkov.yaml"
+```yaml title="packages/infra/checkov.yml" {3}
 skip-check:
-  - CKV_AWS_145
+  # ...
+  - CKV_AWS_145 # S3 buckets are not KMS encrypted when encryption is S3_MANAGED
 ```
 :::
 
@@ -439,11 +428,12 @@ module "my_website" {
 ```
 
 :::caution[Checkov: 禁用密钥轮换]
-在自动创建的密钥上禁用密钥轮换会导致 `checkov` 安全扫描失败，错误为 `CKV_AWS_7`。将其添加到同一个 `.checkov.yaml`：
+在自动创建的密钥上禁用密钥轮换会导致项目的 `checkov` 目标失败，错误为 `CKV_AWS_7`。将其添加到同一个 `skip-check` 列表中的 `packages/infra/checkov.yml`：
 
-```yaml title="packages/infra/src/.checkov.yaml"
+```yaml title="packages/infra/checkov.yml" {3}
 skip-check:
-  - CKV_AWS_7
+  # ...
+  - CKV_AWS_7 # Key rotation is disabled on the website's KMS key
 ```
 :::
 </Fragment>
@@ -458,14 +448,14 @@ skip-check:
 在创建网站时传递 `certificate` 和 `domainNames` 属性：
 
 ```ts title="packages/infra/src/stacks/application-stack.ts" {11-13}
-import { Stack } from 'aws-cdk-lib';
+import { Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { Certificate } from 'aws-cdk-lib/aws-certificatemanager';
 import { MyWebsite } from '@my-scope/common-constructs';
 
 export class ApplicationStack extends Stack {
-  constructor(scope: Construct, id: string) {
-    super(scope, id);
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
 
     new MyWebsite(this, 'MyWebsite', {
       domainNames: ['www.example.com'],
@@ -508,13 +498,13 @@ module "my_website" {
 您的网站 CDK 构造将把运行时配置的 `connection` 命名空间作为 `runtime-config.json` 文件部署到 S3 存储桶的根目录。
 
 ```ts title="packages/infra/src/stacks/application-stack.ts"
-import { Stack } from 'aws-cdk-lib';
+import { Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { MyWebsite, MyApi } from '@my-scope/common-constructs';
 
 export class ApplicationStack extends Stack {
-  constructor(scope: Construct, id: string) {
-    super(scope, id);
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
 
     // Website can be declared at any point, since runtime config is resolved lazily
     new MyWebsite(this, 'MyWebsite');
@@ -581,6 +571,10 @@ const MyComponent = () => {
   const apiUrl = runtimeConfig.apis.MyApi;
 };
 ```
+
+:::note[需要时添加]
+`src/hooks/useRuntimeConfig.tsx` 和 `src/components/RuntimeConfig` 由 <Link path="/guides/react-website-auth">`ts#website#auth`</Link> 生成器和 <Link path="guides/connection">`connection`</Link> 生成器添加到您的网站，因为这些是将值放入运行时配置的内容。没有这两者的网站没有要读取的运行时配置，因此在其中一个运行之前不会提供钩子。
+:::
 
 :::note[运行时配置]
 有关运行时配置如何存储在 AWS AppConfig 中以及服务器端消费者（Lambda 函数、代理）如何检索它的详细信息，请参阅<Link path="guides/runtime-config">运行时配置</Link>指南。
@@ -687,28 +681,28 @@ const MyComponent = () => {
   <ConnectionCard
     title="React 到 tRPC"
     description="从 React 网站调用 tRPC API"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'zh'}/guides/connection/react-trpc`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/react-trpc`}
     source="react"
     target="trpc"
   />
   <ConnectionCard
     title="React 到 FastAPI"
     description="从 React 网站调用 Python FastAPI"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'zh'}/guides/connection/react-fastapi`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/react-fastapi`}
     source="react"
     target="fastapi"
   />
   <ConnectionCard
     title="React 到 Smithy API"
     description="从 React 网站调用 Smithy API"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'zh'}/guides/connection/react-smithy`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/react-smithy`}
     source="react"
     target="smithy"
   />
   <ConnectionCard
     title="React 到 Python Agent"
     description="从 React 网站调用 Python Agent"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'zh'}/guides/connection/react-py-agent`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/react-py-agent`}
     source="react"
     target="strands"
     targetBadge="python"
@@ -716,7 +710,7 @@ const MyComponent = () => {
   <ConnectionCard
     title="React 到 TypeScript Agent"
     description="从 React 网站调用 TypeScript Agent"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'zh'}/guides/connection/react-ts-agent`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/react-ts-agent`}
     source="react"
     target="strands"
     targetBadge="typescript"
@@ -724,14 +718,14 @@ const MyComponent = () => {
   <ConnectionCard
     title="React 到 AG-UI Agent"
     description="通过 CopilotKit 从 React 网站调用公开 AG-UI 协议的 Agent"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'zh'}/guides/connection/react-agui`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/react-agui`}
     source="react"
     target="copilotkit"
   />
   <ConnectionCard
     title="React 网站到 AgentCore Gateway"
     description="通过 AgentCore Gateway 将 React 网站连接到代理"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'zh'}/guides/connection/react-agentcore-gateway`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/react-agentcore-gateway`}
     source="react"
     target="agentcore"
   />

--- a/docs/src/content/docs/zh/guides/ts-dynamodb.mdx
+++ b/docs/src/content/docs/zh/guides/ts-dynamodb.mdx
@@ -11,6 +11,7 @@ import Link from '@components/link.astro';
 import RunGenerator from '@components/run-generator.astro';
 import GeneratorParameters from '@components/generator-parameters.astro';
 import Snippet from '@components/snippet.astro';
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
 此生成器创建一个新的 TypeScript DynamoDB 项目，由 [Amazon DynamoDB](https://aws.amazon.com/dynamodb/) 支持，使用 [ElectroDB](https://electrodb.dev/) 进行类型安全的实体建模。它生成应用程序代码和基础设施，用于使用 AWS CDK 或 Terraform 配置和管理 DynamoDB 表，支持单表设计，并通过 DynamoDB Local 内置本地开发功能。
 
@@ -52,6 +53,12 @@ import Snippet from '@components/snippet.astro';
 ### 基础设施
 
 <Snippet name="dynamodb/infrastructure" />
+
+#### 架构
+
+部署的项目配置表本身，任何连接到它的项目都可以读取和写入：
+
+<ArchitectureDiagram />
 
 ## 本地开发
 
@@ -159,21 +166,21 @@ const result = await entity.query.primary({ id: '123' }).go();
   <ConnectionCard
     title="tRPC API to TypeScript DynamoDB"
     description="将 tRPC API 连接到 DynamoDB 表"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'zh'}/guides/connection/trpc-dynamodb`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/trpc-dynamodb`}
     source="trpc"
     target="dynamodb"
   />
   <ConnectionCard
     title="Smithy API to TypeScript DynamoDB"
     description="将 Smithy API 连接到 DynamoDB 表"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'zh'}/guides/connection/smithy-dynamodb`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/smithy-dynamodb`}
     source="smithy"
     target="dynamodb"
   />
   <ConnectionCard
     title="TypeScript Agent to TypeScript DynamoDB"
     description="将 TypeScript Agent 连接到 DynamoDB 表"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'zh'}/guides/connection/ts-agent-dynamodb`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/ts-agent-dynamodb`}
     source="strands"
     sourceBadge="typescript"
     target="dynamodb"
@@ -181,7 +188,7 @@ const result = await entity.query.primary({ id: '123' }).go();
   <ConnectionCard
     title="MCP Server to TypeScript DynamoDB"
     description="将 TypeScript MCP Server 连接到 DynamoDB 表"
-    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'zh'}/guides/connection/ts-mcp-server-dynamodb`}
+    href={`/nx-plugin-for-aws/${Astro.currentLocale || 'en'}/guides/connection/ts-mcp-server-dynamodb`}
     source="mcp"
     target="dynamodb"
   />

--- a/docs/src/content/docs/zh/guides/ts-smithy-api.mdx
+++ b/docs/src/content/docs/zh/guides/ts-smithy-api.mdx
@@ -20,6 +20,7 @@ import Snippet from '@components/snippet.astro';
 import OptionFilter from '@components/option-filter.astro';
 import InstallCommand from '@components/install-command.astro';
 import { TS_VERSIONS } from '../../../../../../packages/nx-plugin/src/utils/versions';
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
 [Smithy](https://smithy.io/) 是一种与协议无关的接口定义语言，用于以模型驱动的方式编写 API。
 
@@ -126,47 +127,7 @@ Smithy TypeScript API 生成器使用 Smithy 进行服务定义，并使用 [Smi
 
 部署的 Smithy API 具有以下架构，在 API Gateway 阶段前面有一个 [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACL：
 
-```d2 inline=true
-direction: right
-
-client: Client {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
-
-waf: WAF {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/waf.svg
-}
-
-apigw: API Gateway\n(REST API) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/api-gateway.svg
-}
-
-lambda: Lambda\n(Smithy Server SDK) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/lambda.svg
-}
-
-cw: CloudWatch\n(Logs, Metrics) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cloudwatch.svg
-  near: top-right
-}
-
-xray: X-Ray\n(Traces) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/xray.svg
-  near: bottom-right
-}
-
-client -> waf
-waf -> apigw
-apigw -> lambda
-lambda -> cw
-lambda -> xray
-```
+<ArchitectureDiagram options={{ infra: 'rest-lambda' }} />
 
 ## 实现您的 Smithy API
 

--- a/docs/src/content/docs/zh/snippets/agent/architecture.mdx
+++ b/docs/src/content/docs/zh/snippets/agent/architecture.mdx
@@ -2,71 +2,28 @@
 title: Agent 架构
 ---
 import { Tabs, TabItem } from '@astrojs/starlight/components';
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
 <Tabs syncKey="infra">
-<TabItem label="Bedrock AgentCore Runtime" _filter={{ infra: 'agentcore' }}>
+<TabItem label="AgentCore Runtime" _filter={{ infra: 'agentcore' }}>
 
-当部署到 [Bedrock AgentCore Runtime](https://aws.amazon.com/bedrock/agentcore/) 时，agent 会被构建为容器镜像，推送到 Amazon ECR 并在 AgentCore Runtime 中运行。客户端调用 AgentCore Runtime 数据平面端点，该端点将请求转发到您的 agent。agent 调用 Amazon Bedrock 进行模型推理，并可能调用工具、MCP 服务器或下游 API。
+当部署到 [Bedrock AgentCore Runtime](https://aws.amazon.com/bedrock/agentcore/) 时,您的 agent 代码会被打包为 zip 文件并在 AgentCore 托管运行时中运行。客户端调用 AgentCore Runtime 数据平面端点,该端点将请求转发到您的 agent。agent 调用 Amazon Bedrock 进行模型推理,并可能调用工具、MCP 服务器或下游 API。
 
-```d2 inline=true
-direction: right
+<ArchitectureDiagram options={{ infra: 'agentcore' }} />
 
-client: Client {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
+</TabItem>
+<TabItem label="AgentCore Runtime (container)" _filter={{ infra: 'agentcore-ecr' }}>
 
-ecr: ECR {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/ecr.svg
-}
+使用 `infra: agentcore-ecr` 时,agent 会被构建为容器镜像,推送到 Amazon ECR 并在 AgentCore Runtime 中运行。这使您可以在操作系统级别控制运行时环境,但代价是比上述 zip 打包方式更长的构建和部署周期。
 
-agentcore: Strands Agent\n(AgentCore Runtime) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/bedrock-agentcore-runtime.svg
-}
+<ArchitectureDiagram options={{ infra: 'agentcore-ecr' }} />
 
-bedrock: Bedrock\n(Model Inference) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/bedrock.svg
-  near: top-right
-}
-
-cw: CloudWatch\n(Logs, Metrics) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cloudwatch.svg
-  near: bottom-right
-}
-
-client -> agentcore
-ecr -> agentcore: Container\nimage
-agentcore -> bedrock: InvokeModel
-agentcore -> cw
-```
 </TabItem>
 <TabItem label="None (local only)" _filter={{ infra: 'none' }}>
 
-使用 `infra: none` 时，不会生成 AWS 基础设施。agent 作为本地进程运行，并调用 Amazon Bedrock 进行模型推理。
+使用 `infra: none` 时,不会生成 AWS 基础设施。agent 作为本地进程运行,并调用 Amazon Bedrock 进行模型推理。
 
-```d2 inline=true
-direction: right
+<ArchitectureDiagram options={{ infra: 'none' }} />
 
-client: Client {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
-
-agent: Strands Agent\n(local process) {
-  shape: rectangle
-}
-
-bedrock: Bedrock\n(Model Inference) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/bedrock.svg
-}
-
-client -> agent
-agent -> bedrock: InvokeModel
-```
 </TabItem>
 </Tabs>

--- a/docs/src/content/docs/zh/snippets/api/api-architecture.mdx
+++ b/docs/src/content/docs/zh/snippets/api/api-architecture.mdx
@@ -2,91 +2,20 @@
 title: API 架构
 ---
 import { Tabs, TabItem } from '@astrojs/starlight/components';
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
-已部署的应用程序具有以下架构：
+已部署的应用程序具有以下架构：在运行您的处理程序的 Lambda 函数前面有一个 API Gateway API。
 
 <Tabs syncKey="http-rest">
 <TabItem label="REST API" _filter={{ infra: 'rest-lambda' }}>
-```d2 inline=true
-direction: right
 
-client: Client {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
-
-waf: WAF {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/waf.svg
-}
-
-apigw: API Gateway\n(REST API) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/api-gateway.svg
-}
-
-lambda: Lambda {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/lambda.svg
-}
-
-cw: CloudWatch\n(Logs, Metrics) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cloudwatch.svg
-  near: top-right
-}
-
-xray: X-Ray\n(Traces) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/xray.svg
-  near: bottom-right
-}
-
-client -> waf
-waf -> apigw
-apigw -> lambda
-lambda -> cw
-lambda -> xray
-```
+<ArchitectureDiagram options={{ infra: 'rest-lambda' }} />
 
 REST API 在 API Gateway 阶段前包含一个 [AWS WAFv2](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html) Web ACL，并启用了 AWS 托管的默认规则集。
 </TabItem>
 <TabItem label="HTTP API" _filter={{ infra: 'http-lambda' }}>
-```d2 inline=true
-direction: right
 
-client: Client {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
-
-apigw: API Gateway\n(HTTP API) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/api-gateway.svg
-}
-
-lambda: Lambda {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/lambda.svg
-}
-
-cw: CloudWatch\n(Logs, Metrics) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cloudwatch.svg
-  near: top-right
-}
-
-xray: X-Ray\n(Traces) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/xray.svg
-  near: bottom-right
-}
-
-client -> apigw
-apigw -> lambda
-lambda -> cw
-lambda -> xray
-```
+<ArchitectureDiagram options={{ infra: 'http-lambda' }} />
 
 HTTP API 不直接支持 WAF——如果您需要 WAF 保护，请选择 REST API，或者在 HTTP API 前面使用 CloudFront 分配。
 </TabItem>

--- a/docs/src/content/docs/zh/snippets/lambda-function/architecture.mdx
+++ b/docs/src/content/docs/zh/snippets/lambda-function/architecture.mdx
@@ -1,36 +1,10 @@
 ---
 title: Lambda Function 架构
 ---
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
-已部署的函数具有以下架构：
+已部署的函数具有以下架构，其日志、指标和跟踪信息将发送到 CloudWatch 和 X-Ray：
 
-```d2 inline=true
-direction: right
-
-source: Event Source\n(SNS, SQS, ...) {
-  shape: rectangle
-}
-
-lambda: Lambda {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/lambda.svg
-}
-
-cw: CloudWatch\n(Logs, Metrics) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cloudwatch.svg
-  near: top-right
-}
-
-xray: X-Ray\n(Traces) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/xray.svg
-  near: bottom-right
-}
-
-source -> lambda
-lambda -> cw
-lambda -> xray
-```
+<ArchitectureDiagram name="my-function" />
 
 生成器提供函数本身；您需要在堆栈中连接事件源以调用它（例如，API Gateway 集成、EventBridge 规则、S3 通知或 SQS 事件源映射）。

--- a/docs/src/content/docs/zh/snippets/mcp/architecture.mdx
+++ b/docs/src/content/docs/zh/snippets/mcp/architecture.mdx
@@ -2,57 +2,28 @@
 title: MCP Server 架构
 ---
 import { Tabs, TabItem } from '@astrojs/starlight/components';
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
 <Tabs syncKey="infra">
-<TabItem label="Bedrock AgentCore Runtime" _filter={{ infra: 'agentcore' }}>
+<TabItem label="AgentCore Runtime" _filter={{ infra: 'agentcore' }}>
 
-当部署到 [Bedrock AgentCore Runtime](https://aws.amazon.com/bedrock/agentcore/) 时，MCP server 会被构建为容器镜像，推送到 Amazon ECR，并在 AgentCore Runtime 中运行。AI 助手调用 AgentCore Runtime 数据平面端点，该端点通过 [streamable HTTP transport](https://modelcontextprotocol.io/specification/draft/basic/transports#streamable-http) 将 `tools/*` 和 `resources/*` 调用转发到您的服务器。
+当部署到 [Bedrock AgentCore Runtime](https://aws.amazon.com/bedrock/agentcore/) 时，您的服务器代码会被打包为 zip 文件并在 AgentCore 托管运行时中运行。AI 助手调用 AgentCore Runtime 数据平面端点，该端点通过 [streamable HTTP transport](https://modelcontextprotocol.io/specification/draft/basic/transports#streamable-http) 将 `tools/*` 和 `resources/*` 调用转发到您的服务器。
 
-```d2 inline=true
-direction: right
+<ArchitectureDiagram options={{ infra: 'agentcore' }} />
 
-assistant: AI Assistant {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
+</TabItem>
+<TabItem label="AgentCore Runtime (container)" _filter={{ infra: 'agentcore-ecr' }}>
 
-ecr: ECR {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/ecr.svg
-}
+使用 `infra: agentcore-ecr` 时，MCP server 会被构建为容器镜像，推送到 Amazon ECR 并在 AgentCore Runtime 中运行。这使您可以在操作系统级别控制运行时环境，但代价是比上面的 zip 打包方式具有更长的构建和部署周期。
 
-agentcore: MCP Server\n(AgentCore Runtime) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/bedrock-agentcore-runtime.svg
-}
+<ArchitectureDiagram options={{ infra: 'agentcore-ecr' }} />
 
-cw: CloudWatch\n(Logs, Metrics) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/cloudwatch.svg
-}
-
-assistant -> agentcore: Streamable\nHTTP
-ecr -> agentcore: Container\nimage
-agentcore -> cw
-```
 </TabItem>
 <TabItem label="None (local only)" _filter={{ infra: 'none' }}>
 
 使用 `infra: none` 时，不会生成 AWS 基础设施。MCP server 仅配置为本地 STDIO 和 HTTP 传输，并由运行在同一台机器上的 AI 助手使用。
 
-```d2 inline=true
-direction: right
+<ArchitectureDiagram options={{ infra: 'none' }} />
 
-assistant: AI Assistant {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/client.svg
-}
-
-server: MCP Server\n(local process) {
-  shape: rectangle
-}
-
-assistant -> server: STDIO\nor\nStreamable HTTP
-```
 </TabItem>
 </Tabs>

--- a/docs/src/content/docs/zh/snippets/rdb/architecture.mdx
+++ b/docs/src/content/docs/zh/snippets/rdb/architecture.mdx
@@ -1,39 +1,8 @@
 ---
 title: RDB 架构
 ---
+import ArchitectureDiagram from '@components/architecture-diagram.astro';
 
 已部署的数据库具有以下架构。默认情况下，[Amazon RDS Proxy](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-proxy.html) 位于 Aurora 集群前面以池化连接并启用 [IAM 身份验证](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.html) — 有关替代方案，请参阅[禁用 RDS Proxy](#disable-rds-proxy)。无论您选择 PostgreSQL 还是 MySQL 引擎，架构都是相同的；只有 Aurora 引擎类型不同。
 
-```d2 inline=true
-direction: right
-
-app: Application\n(Lambda, Agent, ...) {
-  shape: hexagon
-}
-
-proxy: RDS Proxy {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/rds.svg
-}
-
-migrations: Migrations Lambda {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/lambda.svg
-}
-
-aurora: Aurora\n(PostgreSQL or MySQL) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/aurora.svg
-}
-
-secrets: Secrets Manager\n(DB credentials) {
-  shape: image
-  icon: /nx-plugin-for-aws/icons/aws/secrets-manager.svg
-}
-
-app -> proxy: SQL (IAM auth)
-proxy -> aurora
-migrations -> aurora: Schema migrations
-migrations -> secrets: Admin credentials
-aurora -> secrets: Generates and rotates\nadmin credentials
-```
+<ArchitectureDiagram />

--- a/docs/src/lib/graph-builder/catalog.ts
+++ b/docs/src/lib/graph-builder/catalog.ts
@@ -309,6 +309,15 @@ export const CATEGORY_ORDER = [
   'Other',
 ] as const;
 
+/**
+ * The options a generator with no node type of its own exposes — a Lambda
+ * function, a website's authentication — so the infrastructure view can resolve
+ * its option values the same way it does for a node in the palette.
+ */
+export const generatorProperties = (
+  generatorId: string,
+): readonly NodeProperty[] => toProperties(schemaOf(generatorId), {});
+
 export const nodeType = (id: string): NodeType => {
   const found = NODE_TYPES.find((t) => t.id === id);
   if (!found) throw new Error(`Graph builder: unknown node type '${id}'`);

--- a/docs/src/lib/graph-builder/infrastructure.spec.ts
+++ b/docs/src/lib/graph-builder/infrastructure.spec.ts
@@ -1,0 +1,254 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  buildPresetGraph,
+  PRESETS,
+} from '../../components/graph-builder/presets';
+import { NODE_TYPES } from './catalog';
+import { buildInfrastructureLayout, hasBlueprint } from './infrastructure';
+import type { Graph } from './model';
+
+/** A one-project graph, as a generator guide's diagram draws. */
+const single = (
+  type: string,
+  options: Record<string, string | boolean> = {},
+): Graph => ({
+  nodes: [{ id: 'n', type, name: 'my-project', options, x: 24, y: 24 }],
+  edges: [],
+});
+
+const labelsOf = (graph: Graph): string[] =>
+  buildInfrastructureLayout(graph)
+    .boxes.flatMap((box) => box.resources)
+    .map((resource) =>
+      resource.detail
+        ? `${resource.label} (${resource.detail})`
+        : resource.label,
+    );
+
+describe('infrastructure view', () => {
+  // Every type the palette offers is a project a diagram can be asked to draw, so
+  // a new one without a blueprint would render an empty box.
+  it.each(NODE_TYPES.map((type) => type.id))(
+    'should have a blueprint for %s',
+    (id) => {
+      expect(hasBlueprint(id)).toBe(true);
+    },
+  );
+
+  it.each(PRESETS.map((preset) => [preset.id, preset] as const))(
+    'should lay out the %s preset',
+    (_id, preset) => {
+      const graph = buildPresetGraph(preset);
+      const layout = buildInfrastructureLayout(graph);
+
+      // One box per project, plus the caller tile standing in for whoever calls
+      // the projects nothing else in the diagram does.
+      expect(layout.boxes.filter((box) => !box.bare)).toHaveLength(
+        preset.nodes.length,
+      );
+      expect(layout.boxes.filter((box) => box.bare)).toHaveLength(1);
+
+      // Every project's connections are drawn, and every box holds something.
+      expect(
+        layout.connections.filter((connection) => connection.edgeId),
+      ).toHaveLength(graph.edges.length);
+      for (const box of layout.boxes) {
+        expect(box.resources.length).toBeGreaterThan(0);
+        expect(box.width).toBeGreaterThan(0);
+        expect(box.height).toBeGreaterThan(0);
+      }
+
+      // Boxes are laid out on a grid sized to their contents, so none can overlap.
+      for (const box of layout.boxes) {
+        for (const other of layout.boxes) {
+          if (box === other) continue;
+          const overlaps =
+            box.x < other.x + other.width &&
+            other.x < box.x + box.width &&
+            box.y < other.y + other.height &&
+            other.y < box.y + box.height;
+          expect(overlaps).toBe(false);
+        }
+      }
+
+      // Everything fits inside the extent the diagram reports.
+      for (const box of layout.boxes) {
+        expect(box.x + box.width).toBeLessThanOrEqual(layout.width);
+        expect(box.y + box.height).toBeLessThanOrEqual(layout.height);
+      }
+    },
+  );
+
+  // The variants a guide's option filters switch between, which the diagram has to
+  // agree with — the WAF a REST stage brings is the clearest case.
+  it('should draw a REST API behind a WAF', () => {
+    expect(labelsOf(single('ts#trpc-api', { infra: 'rest-lambda' }))).toEqual([
+      'Client',
+      'WAF',
+      'API Gateway (REST API)',
+      'Lambda (Router)',
+    ]);
+  });
+
+  it('should draw an HTTP API without a WAF', () => {
+    expect(labelsOf(single('ts#trpc-api', { infra: 'http-lambda' }))).toEqual([
+      'Client',
+      'API Gateway (HTTP API)',
+      'Lambda (Router)',
+    ]);
+  });
+
+  it('should draw an agent as a local process when it deploys no infrastructure', () => {
+    const layout = buildInfrastructureLayout(
+      single('ts#agent', { infra: 'none' }),
+    );
+    const resources = layout.boxes.flatMap((box) => box.resources);
+    expect(resources.map((resource) => resource.label)).toEqual([
+      'Client',
+      'Agent',
+      'Bedrock',
+    ]);
+    // A local process is not an AWS resource, so it draws without an icon.
+    expect(resources.find((resource) => resource.label === 'Agent')?.icon).toBe(
+      undefined,
+    );
+  });
+
+  it('should draw the container image registry only when the agent is built as one', () => {
+    expect(labelsOf(single('ts#agent', { infra: 'agentcore' }))).not.toContain(
+      'ECR (Container image)',
+    );
+    expect(labelsOf(single('ts#agent', { infra: 'agentcore-ecr' }))).toContain(
+      'ECR (Container image)',
+    );
+  });
+
+  it('should draw the database engine the project uses', () => {
+    expect(labelsOf(single('ts#rdb', { engine: 'mysql' }))).toContain(
+      'Aurora (MySQL)',
+    );
+    expect(labelsOf(single('ts#rdb', { engine: 'postgres' }))).toContain(
+      'Aurora (PostgreSQL)',
+    );
+  });
+
+  // A project can be generated without infrastructure, which reads better as a
+  // stated absence than as an empty box.
+  it('should say so when a project deploys nothing', () => {
+    expect(labelsOf(single('ts#dynamodb', { infra: 'none' }))).toContain(
+      'DynamoDB Local (local container)',
+    );
+    expect(labelsOf(single('ts#rdb', { infra: 'none' }))).toContain(
+      'No infrastructure',
+    );
+  });
+
+  // The website is the one project whose outbound connections leave from the
+  // middle of its path: it is the page CloudFront served that calls an API.
+  it('should connect a website to an API from its distribution', () => {
+    const graph: Graph = {
+      nodes: [
+        {
+          id: 'site',
+          type: 'ts#react-website',
+          name: 'website',
+          options: {},
+          x: 24,
+          y: 24,
+        },
+        {
+          id: 'api',
+          type: 'ts#trpc-api',
+          name: 'my-api',
+          options: {},
+          x: 322,
+          y: 24,
+        },
+      ],
+      edges: [{ id: 'e', source: 'site', target: 'api' }],
+    };
+    const layout = buildInfrastructureLayout(graph);
+    const connection = layout.connections.find((entry) => entry.edgeId === 'e');
+    const site = layout.boxes.find((box) => box.nodeId === 'site')!;
+    const api = layout.boxes.find((box) => box.nodeId === 'api')!;
+    const cloudfront = site.resources.find(
+      (resource) => resource.id === 'cloudfront',
+    )!;
+    const waf = api.resources.find((resource) => resource.id === 'waf')!;
+
+    expect(connection?.from.resource.x).toBe(site.x + cloudfront.x);
+    expect(connection?.to.resource.x).toBe(api.x + waf.x);
+  });
+
+  // A gateway fronts something even when the diagram holds nothing for it to
+  // front, so on its own guide it hands off to a tile standing in for its targets.
+  it('should draw what a gateway hands off to when nothing else does', () => {
+    expect(labelsOf(single('agentcore-gateway'))).toEqual([
+      'Client',
+      'WAF',
+      'AgentCore Gateway (MCP)',
+      'IAM (SigV4 auth)',
+      'Gateway targets (MCP servers or agents)',
+    ]);
+  });
+
+  it('should leave the hand-off out once the gateway has a target of its own', () => {
+    const graph: Graph = {
+      nodes: [
+        {
+          id: 'gateway',
+          type: 'agentcore-gateway',
+          name: 'gateway',
+          options: {},
+          x: 24,
+          y: 24,
+        },
+        {
+          id: 'tools',
+          type: 'ts#mcp-server',
+          name: 'tools',
+          options: {},
+          x: 322,
+          y: 24,
+        },
+      ],
+      edges: [{ id: 'e', source: 'gateway', target: 'tools' }],
+    };
+    expect(labelsOf(graph)).not.toContain(
+      'Gateway targets (MCP servers or agents)',
+    );
+  });
+
+  // Generators that add to a project rather than taking part in a connection have
+  // no node type in the palette, so their guides draw straight from a blueprint.
+  it('should draw a generator that has no node type of its own', () => {
+    expect(labelsOf(single('ts#lambda-function'))).toEqual([
+      'Event source (SQS, EventBridge, …)',
+      'Lambda',
+    ]);
+    expect(labelsOf(single('ts#website#auth'))).toEqual([
+      'Web Browser',
+      'Cognito (User pool)',
+      'Cognito (Identity pool)',
+      'IAM (Scoped credentials)',
+      'Authenticated resources (APIs, agents, …)',
+    ]);
+  });
+
+  it('should take the box label from the blueprint where there is no node type', () => {
+    const [box] = buildInfrastructureLayout(
+      single('py#lambda-function'),
+    ).boxes.filter((entry) => !entry.bare);
+    expect(box.typeLabel).toBe('Lambda Function');
+  });
+
+  it('should have nothing to draw for an empty graph', () => {
+    const layout = buildInfrastructureLayout({ nodes: [], edges: [] });
+    expect(layout.boxes).toEqual([]);
+    expect(layout.connections).toEqual([]);
+  });
+});

--- a/docs/src/lib/graph-builder/infrastructure.ts
+++ b/docs/src/lib/graph-builder/infrastructure.ts
@@ -1,0 +1,1054 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import type { Orientation } from '../../components/graph-builder/geometry';
+import { generatorProperties, NODE_TYPES, type NodeProperty } from './catalog';
+import type { Graph, GraphNode } from './model';
+
+/**
+ * The AWS infrastructure view of a graph: what each project deploys, and how the
+ * deployed resources connect.
+ *
+ * Each node type declares a *blueprint* — the resources its generator provisions,
+ * laid out on a small grid, and the request path through them. A blueprint is
+ * resolved against the option values in effect for a node, so a REST API shows
+ * its WAF and an HTTP API doesn't, and an agent with `infra: none` shows a local
+ * process rather than an AgentCore Runtime.
+ *
+ * Resolved blueprints become *boxes*: one per project, holding its own resources
+ * and their interconnections. Connections between projects run box to box,
+ * leaving the source box beside the resource that reaches out and arriving at the
+ * one that receives traffic, so a website box can connect to an API box without
+ * either box's internals being redrawn.
+ */
+
+type OptionValue = string | boolean;
+
+/**
+ * Option values something in a blueprint is present for: AND across keys, OR
+ * within a key. Values are compared against the node's options, falling back to
+ * each option's schema default.
+ */
+export type OptionPredicate = Readonly<
+  Record<string, OptionValue | readonly OptionValue[]>
+>;
+
+/** One AWS resource inside a project's box. */
+export interface BlueprintResource {
+  readonly id: string;
+  readonly label: string;
+  /** A second line, e.g. the API flavour or what a bucket holds. */
+  readonly detail?: string;
+  /**
+   * The artwork, named after a file in `public/icons/aws`. Omitted for something
+   * that isn't an AWS resource, like a local process, which draws as a plain
+   * tile.
+   */
+  readonly icon?: string;
+  /** Position in the box's own grid. */
+  readonly column: number;
+  readonly row: number;
+  /** The option values this resource is provisioned for. Always, if absent. */
+  readonly when?: OptionPredicate;
+}
+
+/** A connection between two resources in the same box. */
+export interface BlueprintLink {
+  readonly from: string;
+  readonly to: string;
+}
+
+export interface Blueprint {
+  /**
+   * What the box is called, for a generator with no node type of its own — a
+   * Lambda function, a website's authentication. Node types take theirs from the
+   * palette instead.
+   */
+  readonly label?: string;
+  readonly resources: readonly BlueprintResource[];
+  /**
+   * The request path through the box, from what receives traffic to what serves
+   * it. Resources the options leave out are skipped rather than breaking the
+   * chain, so variants of the same step can sit at the same grid position and
+   * only the provisioned one is joined up.
+   */
+  readonly path: readonly string[];
+  /** Connections off the request path, such as a runtime reaching a model. */
+  readonly links?: readonly BlueprintLink[];
+  /**
+   * Where a connection from another project arrives, and where one leaving for
+   * another project departs. Default to the ends of the request path, which is
+   * what all but a website wants — a browser calls an API from the page
+   * CloudFront served, not from the bucket behind it.
+   */
+  readonly entry?: string;
+  readonly exit?: string;
+  /** What calls this project, drawn when nothing else in the diagram does. */
+  readonly caller?: ExternalTile;
+  /**
+   * What this project hands off to, drawn when it connects to nothing else in the
+   * diagram — a gateway with no targets of its own still fronts something.
+   */
+  readonly downstream?: ExternalTile;
+}
+
+/** Something outside the workspace, drawn as a tile at one end of the diagram. */
+export interface ExternalTile {
+  readonly label: string;
+  readonly detail?: string;
+  /**
+   * The mark to draw. Defaults to the generic client one; `null` for something no
+   * single service stands for, which draws as a plain tile.
+   */
+  readonly icon?: string | null;
+}
+
+/**
+ * What each node type deploys.
+ *
+ * These mirror the architecture the generator guides describe, down to the
+ * variants their option filters switch between — the diagram is the same content
+ * as the prose, so the two must agree.
+ */
+const BLUEPRINTS: Readonly<Record<string, Blueprint>> = {
+  'ts#react-website': {
+    resources: [
+      {
+        id: 'waf',
+        label: 'WAF',
+        icon: 'waf',
+        column: 0,
+        row: 0,
+        when: { infra: 'cloudfront-s3' },
+      },
+      {
+        id: 'cloudfront',
+        label: 'CloudFront',
+        icon: 'cloudfront',
+        column: 1,
+        row: 0,
+        when: { infra: 'cloudfront-s3' },
+      },
+      {
+        id: 's3',
+        label: 'S3',
+        detail: 'Static assets',
+        icon: 's3',
+        column: 2,
+        row: 0,
+        when: { infra: 'cloudfront-s3' },
+      },
+    ],
+    path: ['waf', 'cloudfront', 's3'],
+    // The page the browser loaded from CloudFront is what calls an API, so
+    // connections leave from there rather than from the bucket.
+    exit: 'cloudfront',
+    caller: { label: 'Web Browser' },
+  },
+
+  ...apiBlueprints('ts#trpc-api', 'py#fast-api'),
+  // Smithy APIs are REST only, so the HTTP variant is dropped rather than being
+  // left as a state the guide's filters can never select.
+  ...apiBlueprints('ts#smithy-api'),
+
+  ...agentBlueprints('ts#agent', 'py#agent'),
+  ...mcpServerBlueprints('ts#mcp-server', 'py#mcp-server'),
+
+  'agentcore-gateway': {
+    resources: [
+      {
+        id: 'waf',
+        label: 'WAF',
+        icon: 'waf',
+        column: 0,
+        row: 0,
+        when: { infra: 'agentcore' },
+      },
+      {
+        id: 'gateway-mcp',
+        label: 'AgentCore Gateway',
+        detail: 'MCP',
+        icon: 'bedrock-agentcore-gateway',
+        column: 1,
+        row: 0,
+        when: { infra: 'agentcore', protocol: 'mcp' },
+      },
+      {
+        id: 'gateway-http',
+        label: 'AgentCore Gateway',
+        detail: 'HTTP',
+        icon: 'bedrock-agentcore-gateway',
+        column: 1,
+        row: 0,
+        when: { infra: 'agentcore', protocol: 'http' },
+      },
+      {
+        id: 'cognito',
+        label: 'Cognito',
+        detail: 'Token auth',
+        icon: 'cognito',
+        column: 1,
+        row: 1,
+        when: { infra: 'agentcore', auth: 'cognito' },
+      },
+      {
+        id: 'iam',
+        label: 'IAM',
+        detail: 'SigV4 auth',
+        icon: 'iam',
+        column: 1,
+        row: 1,
+        when: { infra: 'agentcore', auth: 'iam' },
+      },
+    ],
+    path: ['waf', 'gateway-mcp', 'gateway-http'],
+    caller: { label: 'Client' },
+    downstream: {
+      label: 'Gateway targets',
+      detail: 'MCP servers or agents',
+      icon: 'bedrock-agentcore-runtime',
+    },
+    links: [
+      { from: 'cognito', to: 'gateway-mcp' },
+      { from: 'cognito', to: 'gateway-http' },
+      { from: 'iam', to: 'gateway-mcp' },
+      { from: 'iam', to: 'gateway-http' },
+    ],
+  },
+
+  ...dynamodbBlueprints('ts#dynamodb', 'py#dynamodb'),
+  ...rdbBlueprints('ts#rdb', 'py#rdb'),
+
+  // Generators with no node type of their own: they add to a project rather than
+  // taking part in a connection, so they are named here.
+  ...lambdaFunctionBlueprints('ts#lambda-function', 'py#lambda-function'),
+
+  'ts#website#auth': {
+    label: 'Authentication',
+    resources: [
+      {
+        id: 'user-pool',
+        label: 'Cognito',
+        detail: 'User pool',
+        icon: 'cognito',
+        column: 0,
+        row: 0,
+      },
+      {
+        id: 'identity-pool',
+        label: 'Cognito',
+        detail: 'Identity pool',
+        icon: 'cognito',
+        column: 1,
+        row: 0,
+      },
+      {
+        id: 'iam',
+        label: 'IAM',
+        detail: 'Scoped credentials',
+        icon: 'iam',
+        column: 2,
+        row: 0,
+      },
+    ],
+    path: ['user-pool', 'identity-pool', 'iam'],
+    caller: { label: 'Web Browser' },
+    // Whatever the signed-in user's credentials reach: no one service stands for
+    // it, so the tile carries no mark.
+    downstream: {
+      label: 'Authenticated resources',
+      detail: 'APIs, agents, …',
+      icon: null,
+    },
+  },
+};
+
+/** The Lambda function blueprint: the function an event source invokes. */
+function lambdaFunctionBlueprints(
+  ...types: string[]
+): Record<string, Blueprint> {
+  const blueprint: Blueprint = {
+    label: 'Lambda Function',
+    resources: [
+      {
+        id: 'lambda',
+        label: 'Lambda',
+        icon: 'lambda',
+        column: 0,
+        row: 0,
+        when: { infra: 'lambda' },
+      },
+      {
+        id: 'local',
+        label: 'Handler',
+        detail: 'local only',
+        column: 0,
+        row: 0,
+        when: { infra: 'none' },
+      },
+    ],
+    path: ['lambda', 'local'],
+    // The generator vends the function; the event source is wired up in your own
+    // stack, so it stands outside the project.
+    caller: { label: 'Event source', detail: 'SQS, EventBridge, …' },
+  };
+  return Object.fromEntries(types.map((type) => [type, blueprint]));
+}
+
+/** The API blueprint: a Lambda behind API Gateway, with a WAF on REST stages. */
+function apiBlueprints(...types: string[]): Record<string, Blueprint> {
+  const blueprint: Blueprint = {
+    resources: [
+      {
+        id: 'waf',
+        label: 'WAF',
+        icon: 'waf',
+        column: 0,
+        row: 0,
+        when: { infra: 'rest-lambda' },
+      },
+      {
+        id: 'apigw-rest',
+        label: 'API Gateway',
+        detail: 'REST API',
+        icon: 'api-gateway',
+        column: 1,
+        row: 0,
+        when: { infra: 'rest-lambda' },
+      },
+      {
+        id: 'apigw-http',
+        label: 'API Gateway',
+        detail: 'HTTP API',
+        icon: 'api-gateway',
+        column: 1,
+        row: 0,
+        when: { infra: 'http-lambda' },
+      },
+      {
+        id: 'lambda',
+        label: 'Lambda',
+        detail: 'Router',
+        icon: 'lambda',
+        column: 2,
+        row: 0,
+        when: { infra: ['rest-lambda', 'http-lambda'] },
+      },
+      {
+        id: 'local',
+        label: 'API',
+        detail: 'local process',
+        column: 0,
+        row: 0,
+        when: { infra: 'none' },
+      },
+    ],
+    path: ['waf', 'apigw-rest', 'apigw-http', 'lambda', 'local'],
+    caller: { label: 'Client' },
+  };
+  return Object.fromEntries(types.map((type) => [type, blueprint]));
+}
+
+/** The agent blueprint: an AgentCore Runtime calling Bedrock for inference. */
+function agentBlueprints(...types: string[]): Record<string, Blueprint> {
+  const blueprint: Blueprint = {
+    resources: [
+      {
+        id: 'ecr',
+        label: 'ECR',
+        detail: 'Container image',
+        icon: 'ecr',
+        column: 0,
+        row: 1,
+        when: { infra: 'agentcore-ecr' },
+      },
+      {
+        id: 'runtime',
+        label: 'AgentCore Runtime',
+        detail: 'Strands agent',
+        icon: 'bedrock-agentcore-runtime',
+        column: 1,
+        row: 0,
+        when: { infra: ['agentcore', 'agentcore-ecr'] },
+      },
+      {
+        id: 'local',
+        label: 'Agent',
+        detail: 'local process',
+        column: 1,
+        row: 0,
+        when: { infra: 'none' },
+      },
+      {
+        id: 'sessions',
+        label: 'S3',
+        detail: 'Session state',
+        icon: 's3',
+        column: 1,
+        row: 1,
+        when: { infra: ['agentcore', 'agentcore-ecr'], session: 's3' },
+      },
+      {
+        id: 'bedrock',
+        label: 'Bedrock',
+        detail: 'Model inference',
+        icon: 'bedrock',
+        column: 2,
+        row: 0,
+      },
+    ],
+    path: ['runtime', 'local'],
+    links: [
+      { from: 'ecr', to: 'runtime' },
+      { from: 'runtime', to: 'sessions' },
+      { from: 'runtime', to: 'bedrock' },
+      { from: 'local', to: 'bedrock' },
+    ],
+    caller: { label: 'Client' },
+  };
+  return Object.fromEntries(types.map((type) => [type, blueprint]));
+}
+
+/** The MCP server blueprint: tools served from an AgentCore Runtime. */
+function mcpServerBlueprints(...types: string[]): Record<string, Blueprint> {
+  const blueprint: Blueprint = {
+    resources: [
+      {
+        id: 'ecr',
+        label: 'ECR',
+        detail: 'Container image',
+        icon: 'ecr',
+        column: 0,
+        row: 1,
+        when: { infra: 'agentcore-ecr' },
+      },
+      {
+        id: 'runtime',
+        label: 'AgentCore Runtime',
+        detail: 'MCP server',
+        icon: 'bedrock-agentcore-runtime',
+        column: 1,
+        row: 0,
+        when: { infra: ['agentcore', 'agentcore-ecr'] },
+      },
+      {
+        id: 'local',
+        label: 'MCP Server',
+        detail: 'local process',
+        column: 1,
+        row: 0,
+        when: { infra: 'none' },
+      },
+    ],
+    path: ['runtime', 'local'],
+    links: [{ from: 'ecr', to: 'runtime' }],
+    caller: { label: 'AI Assistant' },
+  };
+  return Object.fromEntries(types.map((type) => [type, blueprint]));
+}
+
+/** The DynamoDB blueprint: the table itself. */
+function dynamodbBlueprints(...types: string[]): Record<string, Blueprint> {
+  const blueprint: Blueprint = {
+    resources: [
+      {
+        id: 'table',
+        label: 'DynamoDB',
+        detail: 'Table',
+        icon: 'dynamodb',
+        column: 0,
+        row: 0,
+        when: { infra: 'dynamodb' },
+      },
+      {
+        id: 'local',
+        label: 'DynamoDB Local',
+        detail: 'local container',
+        column: 0,
+        row: 0,
+        when: { infra: 'none' },
+      },
+    ],
+    path: ['table', 'local'],
+    caller: { label: 'Application' },
+  };
+  return Object.fromEntries(types.map((type) => [type, blueprint]));
+}
+
+/** The relational database blueprint: Aurora behind an RDS Proxy. */
+function rdbBlueprints(...types: string[]): Record<string, Blueprint> {
+  const blueprint: Blueprint = {
+    resources: [
+      {
+        id: 'proxy',
+        label: 'RDS Proxy',
+        detail: 'IAM auth',
+        icon: 'rds',
+        column: 0,
+        row: 0,
+        when: { infra: 'aurora' },
+      },
+      {
+        id: 'aurora-postgres',
+        label: 'Aurora',
+        detail: 'PostgreSQL',
+        icon: 'aurora',
+        column: 1,
+        row: 0,
+        when: { infra: 'aurora', engine: 'postgres' },
+      },
+      {
+        id: 'aurora-mysql',
+        label: 'Aurora',
+        detail: 'MySQL',
+        icon: 'aurora',
+        column: 1,
+        row: 0,
+        when: { infra: 'aurora', engine: 'mysql' },
+      },
+      {
+        id: 'secrets',
+        label: 'Secrets Manager',
+        detail: 'DB credentials',
+        icon: 'secrets-manager',
+        column: 2,
+        row: 0,
+        when: { infra: 'aurora' },
+      },
+      {
+        id: 'migrations',
+        label: 'Lambda',
+        detail: 'Migrations',
+        icon: 'lambda',
+        column: 1,
+        row: 1,
+        when: { infra: 'aurora' },
+      },
+    ],
+    path: ['proxy', 'aurora-postgres', 'aurora-mysql'],
+    links: [
+      { from: 'aurora-postgres', to: 'secrets' },
+      { from: 'aurora-mysql', to: 'secrets' },
+      { from: 'migrations', to: 'aurora-postgres' },
+      { from: 'migrations', to: 'aurora-mysql' },
+    ],
+    caller: { label: 'Application', detail: 'Lambda, agent, …' },
+  };
+  return Object.fromEntries(types.map((type) => [type, blueprint]));
+}
+
+/** Whether a node type has an infrastructure blueprint. */
+export const hasBlueprint = (type: string): boolean => type in BLUEPRINTS;
+
+/* ---------- Sizing ---------- */
+
+/** A resource tile, and the spacing between tiles inside a box. */
+const RESOURCE_WIDTH = 104;
+const RESOURCE_HEIGHT = 92;
+const RESOURCE_GAP_X = 20;
+const RESOURCE_GAP_Y = 16;
+/** Room inside a box, with more at the top for its label. */
+const BOX_PADDING = 12;
+const BOX_HEADER = 32;
+/** Space between boxes, and around the diagram. */
+const BOX_GAP = 44;
+const ORIGIN = 20;
+
+export interface Rect {
+  readonly x: number;
+  readonly y: number;
+  readonly width: number;
+  readonly height: number;
+}
+
+/** A resource placed in its box, positioned relative to the box's top left. */
+export interface PlacedResource extends Rect {
+  readonly id: string;
+  readonly label: string;
+  readonly detail?: string;
+  readonly icon?: string;
+}
+
+/** A connection between two resources in the same box, in box coordinates. */
+export interface PlacedLink {
+  readonly id: string;
+  readonly from: Rect;
+  readonly to: Rect;
+}
+
+/** One project's infrastructure, drawn as a labelled box of resources. */
+export interface InfraBox extends Rect {
+  readonly id: string;
+  /** The graph node this box was built from, absent for the caller tile. */
+  readonly nodeId?: string;
+  readonly name: string;
+  readonly typeLabel: string;
+  /** The caller tile stands on its own, outside any project. */
+  readonly bare?: boolean;
+  readonly resources: readonly PlacedResource[];
+  readonly links: readonly PlacedLink[];
+}
+
+/** Where a cross-project connection attaches: a resource, and the box holding it. */
+export interface InfraAnchor {
+  readonly boxId: string;
+  readonly box: Rect;
+  readonly resource: Rect;
+}
+
+/** A connection between two projects' infrastructure. */
+export interface InfraConnection {
+  readonly id: string;
+  /** The graph edge this came from, absent for the caller's own connection. */
+  readonly edgeId?: string;
+  readonly from: InfraAnchor;
+  readonly to: InfraAnchor;
+}
+
+export interface InfraLayout {
+  readonly boxes: readonly InfraBox[];
+  readonly connections: readonly InfraConnection[];
+  readonly width: number;
+  readonly height: number;
+  /** AWS resources drawn, for the diagram's summary line. */
+  readonly resourceCount: number;
+  readonly connectionCount: number;
+}
+
+/**
+ * What a box is drawn from: its name in the diagram, and the options whose
+ * defaults decide what it holds.
+ *
+ * A node type in the palette carries both. A generator with no node type — a
+ * Lambda function, a website's authentication — takes its label from its
+ * blueprint and its options straight from its schema.
+ */
+const subjects = new Map<
+  string,
+  { label: string; properties: readonly NodeProperty[] }
+>();
+const subjectOf = (type: string) => {
+  const cached = subjects.get(type);
+  if (cached) return cached;
+  const known = NODE_TYPES.find((entry) => entry.id === type);
+  const subject = known
+    ? { label: known.label, properties: known.properties }
+    : {
+        label: BLUEPRINTS[type]?.label ?? type,
+        properties: generatorProperties(type),
+      };
+  subjects.set(type, subject);
+  return subject;
+};
+
+/** Whether a node's options satisfy a predicate. */
+const matches = (node: GraphNode, predicate?: OptionPredicate): boolean => {
+  if (!predicate) return true;
+  const { properties } = subjectOf(node.type);
+  return Object.entries(predicate).every(([option, wanted]) => {
+    const value =
+      option in node.options
+        ? node.options[option]
+        : properties.find((property) => property.name === option)?.default;
+    const allowed = Array.isArray(wanted) ? wanted : [wanted];
+    return allowed.includes(value as OptionValue);
+  });
+};
+
+/**
+ * Group values into steps along an axis, returning each value's step index.
+ * Positions come from a grid, so anything within a few pixels is one step.
+ */
+const rankAxis = (values: readonly number[]): Map<number, number> => {
+  const sorted = [...new Set(values)].sort((a, b) => a - b);
+  const ranks = new Map<number, number>();
+  let rank = -1;
+  let previous: number | undefined;
+  for (const value of sorted) {
+    if (previous === undefined || value - previous > 8) rank += 1;
+    ranks.set(value, rank);
+    previous = value;
+  }
+  return ranks;
+};
+
+/** Map the grid positions in use onto consecutive ones, in order. */
+const compact = (positions: readonly number[]): Map<number, number> =>
+  new Map(
+    [...new Set(positions)]
+      .sort((a, b) => a - b)
+      .map((position, index) => [position, index]),
+  );
+
+/**
+ * The room a box's label needs, so a project called `inventory-server` isn't
+ * clipped by a box holding one narrow resource. Estimated from the label's length
+ * rather than measured — the stylesheet ellipsises anything left over, so being a
+ * few pixels out costs a little slack rather than a broken layout.
+ */
+const headerWidth = (name: string, typeLabel: string): number =>
+  BOX_PADDING * 2 + name.length * 8.8 + typeLabel.length * 7.6 + 14;
+
+/** A box's resources and internal links, resolved against a node's options. */
+const resolveBox = (node: GraphNode) => {
+  const blueprint = BLUEPRINTS[node.type];
+  const present = (blueprint?.resources ?? []).filter((resource) =>
+    matches(node, resource.when),
+  );
+
+  // Closed up, so a resource the options left out doesn't leave a gutter where
+  // its column or row was.
+  const columns = compact(present.map((resource) => resource.column));
+  const rows = compact(present.map((resource) => resource.row));
+
+  const resources: PlacedResource[] = present.map((resource) => ({
+    id: resource.id,
+    label: resource.label,
+    ...(resource.detail ? { detail: resource.detail } : {}),
+    ...(resource.icon ? { icon: resource.icon } : {}),
+    x:
+      BOX_PADDING +
+      (columns.get(resource.column) ?? 0) * (RESOURCE_WIDTH + RESOURCE_GAP_X),
+    y:
+      BOX_HEADER +
+      (rows.get(resource.row) ?? 0) * (RESOURCE_HEIGHT + RESOURCE_GAP_Y),
+    width: RESOURCE_WIDTH,
+    height: RESOURCE_HEIGHT,
+  }));
+
+  // A project with `infra: none` provisions nothing, which reads better as a
+  // stated absence than as an empty box.
+  if (resources.length === 0) {
+    resources.push({
+      id: 'none',
+      label: 'No infrastructure',
+      x: BOX_PADDING,
+      y: BOX_HEADER,
+      width: RESOURCE_WIDTH,
+      height: RESOURCE_HEIGHT,
+    });
+  }
+
+  const byId = new Map(resources.map((resource) => [resource.id, resource]));
+  const links: PlacedLink[] = [];
+  const link = (from: string, to: string) => {
+    const source = byId.get(from);
+    const target = byId.get(to);
+    if (!source || !target) return;
+    links.push({ id: `${from}-${to}`, from: source, to: target });
+  };
+
+  // The request path, closing over the steps this node's options left out.
+  const onPath = (blueprint?.path ?? []).filter((id) => byId.has(id));
+  for (let i = 1; i < onPath.length; i += 1) link(onPath[i - 1], onPath[i]);
+  for (const extra of blueprint?.links ?? []) link(extra.from, extra.to);
+
+  const width = Math.max(
+    Math.max(...resources.map((resource) => resource.x + resource.width)) +
+      BOX_PADDING,
+    headerWidth(node.name, subjectOf(node.type).label),
+  );
+  const height =
+    Math.max(...resources.map((resource) => resource.y + resource.height)) +
+    BOX_PADDING;
+
+  // Where connections from other projects attach. The path's ends are the
+  // default; a blueprint naming a step the options left out falls back to them.
+  const entry = byId.has(blueprint?.entry ?? '')
+    ? blueprint!.entry!
+    : onPath.at(0);
+  const exit = byId.has(blueprint?.exit ?? '')
+    ? blueprint!.exit!
+    : onPath.at(-1);
+
+  return {
+    resources,
+    links,
+    width,
+    height,
+    entry: byId.get(entry ?? '') ?? resources[0],
+    exit: byId.get(exit ?? '') ?? resources[0],
+    caller: blueprint?.caller,
+    downstream: blueprint?.downstream,
+  };
+};
+
+export interface LayoutOptions {
+  /**
+   * The flow axis of the positions the graph's nodes carry, which is what says
+   * which step along the flow — and which slot across it — each box takes.
+   */
+  readonly from?: Orientation;
+  /**
+   * Which way the boxes themselves flow. Defaults to down the diagram, since a
+   * box of resources laid out left to right is far wider than a project node:
+   * stacked, a workspace's infrastructure stays legible in a docs column, where
+   * the same boxes side by side would have to be scaled past reading. A host with
+   * room to spare — the homepage's showcase — asks for `horizontal` instead.
+   */
+  readonly flow?: Orientation;
+}
+
+/**
+ * Build the AWS infrastructure layout for a graph.
+ *
+ * Boxes keep the graph's own arrangement, with columns and rows sized to the boxes
+ * in them, so a project deploying five resources doesn't crowd one deploying a
+ * single table.
+ */
+export const buildInfrastructureLayout = (
+  graph: Graph,
+  { from = 'horizontal', flow = 'vertical' }: LayoutOptions = {},
+): InfraLayout => {
+  if (graph.nodes.length === 0) {
+    return {
+      boxes: [],
+      connections: [],
+      width: ORIGIN * 2,
+      height: ORIGIN * 2,
+      resourceCount: 0,
+      connectionCount: 0,
+    };
+  }
+
+  // Each node's step along the graph's own flow, and its slot across it, become
+  // the row and column of its box — transposed when the boxes flow the other way.
+  const alongX = rankAxis(graph.nodes.map((node) => node.x));
+  const alongY = rankAxis(graph.nodes.map((node) => node.y));
+  const sideways = from === 'horizontal';
+  const stepOf = (node: GraphNode) =>
+    (sideways ? alongX.get(node.x) : alongY.get(node.y)) ?? 0;
+  const slotOf = (node: GraphNode) =>
+    (sideways ? alongY.get(node.y) : alongX.get(node.x)) ?? 0;
+  const stacked = flow === 'vertical';
+
+  const resolved = graph.nodes.map((node) => ({
+    node,
+    column: stacked ? slotOf(node) : stepOf(node),
+    row: stacked ? stepOf(node) : slotOf(node),
+    ...resolveBox(node),
+  }));
+
+  const columns = Math.max(...resolved.map((entry) => entry.column)) + 1;
+  const rows = Math.max(...resolved.map((entry) => entry.row)) + 1;
+  const columnWidths = Array.from({ length: columns }, (_, column) =>
+    Math.max(
+      ...resolved
+        .filter((entry) => entry.column === column)
+        .map((entry) => entry.width),
+    ),
+  );
+  const rowHeights = Array.from({ length: rows }, (_, row) =>
+    Math.max(
+      ...resolved
+        .filter((entry) => entry.row === row)
+        .map((entry) => entry.height),
+    ),
+  );
+
+  const offsets = (sizes: readonly number[]) =>
+    sizes.map((_, index) =>
+      sizes
+        .slice(0, index)
+        .reduce((total, size) => total + size + BOX_GAP, ORIGIN),
+    );
+  const columnX = offsets(columnWidths);
+  const rowY = offsets(rowHeights);
+
+  // Boxes with nothing pointing at them are what a caller reaches, and boxes
+  // pointing at nothing are where the diagram hands off, so those tiles sit at
+  // either end of the graph's own flow axis.
+  const targeted = new Set(graph.edges.map((edge) => edge.target));
+  const sourced = new Set(graph.edges.map((edge) => edge.source));
+  const entryBoxes = resolved.filter((entry) => !targeted.has(entry.node.id));
+  const exitBoxes = resolved.filter((entry) => !sourced.has(entry.node.id));
+  const caller = bareTile(
+    'caller',
+    entryBoxes.map((entry) => entry.caller),
+    'Client',
+  );
+  const downstream = bareTile(
+    'downstream',
+    exitBoxes.map((entry) => entry.downstream),
+  );
+  // Ahead of a stack of boxes the caller sits above them; beside a single row it
+  // reads better in line with them, the way a guide's own diagram runs.
+  const along: Orientation = stacked && rows > 1 ? 'vertical' : 'horizontal';
+  const shift = caller
+    ? along === 'vertical'
+      ? { x: 0, y: caller.height + BOX_GAP }
+      : { x: caller.width + BOX_GAP, y: 0 }
+    : { x: 0, y: 0 };
+
+  const boxes: InfraBox[] = resolved.map((entry) => ({
+    id: entry.node.id,
+    nodeId: entry.node.id,
+    name: entry.node.name,
+    typeLabel: subjectOf(entry.node.type).label,
+    // Centred in its column and row, so boxes of different sizes line up on
+    // their middles rather than their edges.
+    x:
+      shift.x +
+      columnX[entry.column] +
+      (columnWidths[entry.column] - entry.width) / 2,
+    y: shift.y + rowY[entry.row] + (rowHeights[entry.row] - entry.height) / 2,
+    width: entry.width,
+    height: entry.height,
+    resources: entry.resources,
+    links: entry.links,
+  }));
+
+  const boxById = new Map(boxes.map((box) => [box.id, box]));
+  const anchorOf = (boxId: string, resource: PlacedResource): InfraAnchor => {
+    const box = boxById.get(boxId)!;
+    return {
+      boxId,
+      box,
+      resource: {
+        x: box.x + resource.x,
+        y: box.y + resource.y,
+        width: resource.width,
+        height: resource.height,
+      },
+    };
+  };
+
+  const resolvedById = new Map(
+    resolved.map((entry) => [entry.node.id, entry] as const),
+  );
+  const connections: InfraConnection[] = [];
+  for (const edge of graph.edges) {
+    const source = resolvedById.get(edge.source);
+    const target = resolvedById.get(edge.target);
+    if (!source || !target || source === target) continue;
+    connections.push({
+      id: edge.id,
+      edgeId: edge.id,
+      from: anchorOf(source.node.id, source.exit),
+      to: anchorOf(target.node.id, target.entry),
+    });
+  }
+
+  /**
+   * Put a bare tile at one end of the flow, centred on the boxes it connects to,
+   * and join it to each of them.
+   */
+  const placeTile = (
+    tile: InfraBox,
+    attached: typeof resolved,
+    end: 'start' | 'finish',
+  ) => {
+    const against = attached.map((entry) => boxById.get(entry.node.id)!);
+    const middle =
+      (Math.min(
+        ...against.map((box) => (along === 'vertical' ? box.x : box.y)),
+      ) +
+        Math.max(
+          ...against.map((box) =>
+            along === 'vertical' ? box.x + box.width : box.y + box.height,
+          ),
+        )) /
+      2;
+    const after =
+      Math.max(
+        ...boxes.map((box) =>
+          along === 'vertical' ? box.y + box.height : box.x + box.width,
+        ),
+      ) + BOX_GAP;
+    const placed: InfraBox = {
+      ...tile,
+      x:
+        along === 'vertical'
+          ? middle - tile.width / 2
+          : end === 'start'
+            ? ORIGIN
+            : after,
+      y:
+        along === 'vertical'
+          ? end === 'start'
+            ? ORIGIN
+            : after
+          : middle - tile.height / 2,
+    };
+    // In reading order: the caller ahead of the projects, the hand-off after them.
+    if (end === 'start') boxes.unshift(placed);
+    else boxes.push(placed);
+    boxById.set(placed.id, placed);
+    for (const entry of attached) {
+      const box = anchorOf(
+        entry.node.id,
+        end === 'start' ? entry.entry : entry.exit,
+      );
+      const own = anchorOf(placed.id, placed.resources[0]);
+      connections.push({
+        id: `${tile.id}-${entry.node.id}`,
+        from: end === 'start' ? own : box,
+        to: end === 'start' ? box : own,
+      });
+    }
+  };
+
+  if (caller) placeTile(caller, entryBoxes, 'start');
+  if (downstream) placeTile(downstream, exitBoxes, 'finish');
+
+  return {
+    boxes,
+    connections,
+    width: Math.max(...boxes.map((box) => box.x + box.width)) + ORIGIN,
+    height: Math.max(...boxes.map((box) => box.y + box.height)) + ORIGIN,
+    resourceCount: resolved.reduce(
+      (total, entry) => total + entry.resources.length,
+      0,
+    ),
+    connectionCount:
+      connections.length +
+      resolved.reduce((total, entry) => total + entry.links.length, 0),
+  };
+};
+
+/**
+ * A tile standing in for something outside the workspace at one end of the
+ * diagram: whoever calls its entry points — a browser for a website, an AI
+ * assistant for an MCP server — or whatever its last projects hand off to.
+ *
+ * One tile serves every box at that end, so it is only drawn where they all
+ * declare one; where they declare different ones it falls back to the generic
+ * label, and without a fallback it isn't drawn at all.
+ */
+const bareTile = (
+  id: string,
+  declared: readonly (ExternalTile | undefined)[],
+  fallbackLabel?: string,
+): InfraBox | undefined => {
+  if (declared.length === 0) return undefined;
+  if (declared.some((entry) => entry === undefined)) return undefined;
+  const first = declared[0]!;
+  const agreed = declared.every((entry) => entry!.label === first.label);
+  if (!agreed && !fallbackLabel) return undefined;
+  const tile = agreed ? first : { label: fallbackLabel! };
+
+  return {
+    id,
+    name: tile.label,
+    typeLabel: tile.label,
+    bare: true,
+    x: 0,
+    y: 0,
+    width: RESOURCE_WIDTH,
+    height: RESOURCE_HEIGHT,
+    resources: [
+      {
+        id,
+        label: tile.label,
+        ...(tile.detail ? { detail: tile.detail } : {}),
+        ...(tile.icon === null ? {} : { icon: tile.icon ?? 'client' }),
+        x: 0,
+        y: 0,
+        width: RESOURCE_WIDTH,
+        height: RESOURCE_HEIGHT,
+      },
+    ],
+    links: [],
+  };
+};

--- a/docs/src/styles/graph-builder.css
+++ b/docs/src/styles/graph-builder.css
@@ -593,6 +593,14 @@
   cursor: pointer;
 }
 
+/* A connection inside a project's box is its own plumbing rather than traffic
+ * between projects: the same arrow, a little smaller, and always solid. */
+.gb-edge--internal .gb-edge-line {
+  stroke-width: 1.6;
+  stroke-dasharray: none;
+  animation: none;
+}
+
 .gb-edge--error .gb-edge-line {
   stroke: var(--gb-danger);
   stroke-dasharray: 6 4;
@@ -1005,6 +1013,180 @@
 
 .gb-loading--embed {
   height: 18rem;
+}
+
+/* ---------- View switch ---------- */
+
+/* Sits in the top left of a diagram, with both views on show so the other one is
+ * visible rather than hidden behind an icon whose meaning has to be guessed. */
+.gb-view-toggle {
+  position: absolute;
+  top: 0.5rem;
+  left: 0.5rem;
+  z-index: 4;
+  display: inline-flex;
+  padding: 2px;
+  gap: 2px;
+  border: 1px solid var(--gb-border);
+  border-radius: 9999px;
+  background: color-mix(in oklab, var(--gb-panel) 88%, transparent);
+  backdrop-filter: blur(4px);
+}
+
+.gb-view-toggle-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.2rem 0.6rem;
+  border: 0;
+  border-radius: 9999px;
+  background: transparent;
+  color: var(--gb-muted);
+  font: inherit;
+  font-size: 0.72rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition:
+    background 150ms ease,
+    color 150ms ease;
+}
+
+.gb-view-toggle-btn svg {
+  width: 0.95rem;
+  height: 0.95rem;
+}
+
+.gb-view-toggle-btn:hover {
+  color: var(--gb-text);
+}
+
+.gb-view-toggle-btn.is-active {
+  background: var(--gb-accent-soft);
+  color: var(--sl-color-text-accent);
+}
+
+.gb-view-toggle-btn:focus-visible {
+  outline: 2px solid var(--gb-accent);
+  outline-offset: 1px;
+}
+
+/* Saying which diagram this is, where there is nothing to switch to. */
+.gb-view-toggle--static .gb-view-toggle-btn {
+  cursor: default;
+}
+
+/* ---------- AWS infrastructure view ---------- */
+
+/* One box per project, holding the resources its generator deploys. The box is
+ * what another project's box connects to, so its border is the boundary the
+ * connections start and end on. */
+.gb-infra-box {
+  position: absolute;
+  box-sizing: border-box;
+  border: 1px solid var(--gb-border);
+  border-radius: var(--gb-radius);
+  background: color-mix(in oklab, var(--gb-panel) 55%, transparent);
+}
+
+/* The caller — a browser, an AI assistant — stands outside any project, so it
+ * carries no boundary of its own. */
+.gb-infra-box--bare {
+  border: 0;
+  background: transparent;
+}
+
+.gb-infra-box-head {
+  position: absolute;
+  top: 0.6rem;
+  left: 0.75rem;
+  right: 0.75rem;
+  display: flex;
+  align-items: baseline;
+  gap: 0.4rem;
+  min-width: 0;
+}
+
+.gb-infra-box-name {
+  font-size: 0.8rem;
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.gb-infra-box-type {
+  font-size: 0.65rem;
+  color: var(--gb-muted);
+  white-space: nowrap;
+}
+
+.gb-infra-res {
+  position: absolute;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.2rem;
+  padding: 0.4rem;
+  text-align: center;
+  border: 1px solid var(--gb-border-soft);
+  border-radius: var(--gb-radius-sm);
+  background: var(--gb-panel);
+  box-shadow: 0 1px 2px rgb(0 0 0 / 0.14);
+}
+
+/* Something that isn't an AWS resource — a local process, or a project deploying
+ * nothing at all — reads as a placeholder rather than as deployed. */
+.gb-infra-res--plain {
+  border-style: dashed;
+  background: transparent;
+  box-shadow: none;
+}
+
+.gb-aws-icon {
+  width: 2.1rem;
+  height: 2.1rem;
+  object-fit: contain;
+  pointer-events: none;
+}
+
+.gb-infra-res-label {
+  font-size: 0.7rem;
+  font-weight: 600;
+  line-height: 1.2;
+}
+
+.gb-infra-res-detail {
+  font-size: 0.63rem;
+  line-height: 1.2;
+  color: var(--gb-muted);
+}
+
+/* The same plan-and-arrive treatment the projects view uses, so switching views
+ * mid-sequence keeps telling the same story. */
+.gb-infra-box {
+  transition:
+    border-color 300ms ease,
+    box-shadow 300ms ease,
+    opacity 300ms ease,
+    filter 300ms ease;
+}
+
+.gb-infra-box.is-planned {
+  opacity: 0.4;
+  border-style: dashed;
+  filter: grayscale(1);
+}
+
+.gb-infra-box.is-arriving,
+.gb-infra-box.is-lit {
+  border-color: var(--gb-accent);
+  box-shadow: 0 0 0 3px var(--gb-accent-soft);
+}
+
+.gb-infra-box.is-dimmed {
+  opacity: 0.3;
 }
 
 /* ---------- Inspector ---------- */
@@ -1850,13 +2032,16 @@
   color: var(--gb-muted);
 }
 
-/* Holds the IaC mark still while the canvas inside it scrolls sideways. */
+/* Holds the view switch and the IaC mark still while the canvas inside it
+ * scrolls sideways. */
 .ps-canvas-frame {
   position: relative;
 }
 
 .ps-canvas {
   position: relative;
+  /* Sized to the example on show, eased so cycling settles rather than jumps. */
+  transition: height 350ms ease;
   /* A diagram too wide for a phone is scrolled rather than shrunk past reading. */
   overflow-x: auto;
   overflow-y: hidden;
@@ -1990,6 +2175,10 @@
 @media (prefers-reduced-motion: reduce) {
   .ps-root * {
     animation-delay: 0ms !important;
+  }
+
+  .ps-canvas {
+    transition: none;
   }
 
   .ps-edge-line {

--- a/packages/nx-plugin/src/mcp-server/generator-info.spec.ts
+++ b/packages/nx-plugin/src/mcp-server/generator-info.spec.ts
@@ -138,6 +138,23 @@ Here's how to run a generator:
     expect(result).not.toContain('<RunGenerator');
   });
 
+  // The architecture diagram is artwork the docs site draws; the prose beside it
+  // carries the same description, so an agent reading a guide gets that instead
+  // of a tag it can make nothing of.
+  it('should drop ArchitectureDiagram components', async () => {
+    const input = `
+# Test Guide
+The deployed API has the following architecture:
+<ArchitectureDiagram options={{ infra: 'rest-lambda' }} />
+`;
+
+    const result = await postProcessGuide(input, generators);
+    expect(result).toContain(
+      'The deployed API has the following architecture:',
+    );
+    expect(result).not.toContain('ArchitectureDiagram');
+  });
+
   it('should transform RunGenerator components with package manager prefix', async () => {
     const input = `
 # Test Guide

--- a/packages/nx-plugin/src/mcp-server/guide-pipeline.ts
+++ b/packages/nx-plugin/src/mcp-server/guide-pipeline.ts
@@ -14,7 +14,8 @@ import fs from 'fs';
  *   3. Component transforms — `<NxCommands>` / `<RunGenerator>` /
  *      `<GeneratorParameters>` / `<CreateNxWorkspaceCommand>` /
  *      `<InstallCommand>` / `<PackageManagerShortCommand>` /
- *      `<PackageManagerExecCommand>` render down to markdown.
+ *      `<PackageManagerExecCommand>` render down to markdown, and
+ *      `<ArchitectureDiagram>` drops out as it has no text form.
  */
 import type { Root, RootContent } from 'mdast';
 import type { MdxJsxFlowElement } from 'mdast-util-mdx-jsx';
@@ -488,6 +489,12 @@ const renderComponent = (
         ),
       ];
     }
+    // A diagram of the AWS resources a project deploys, drawn from the docs
+    // site's own artwork. There is nothing to render as text — the prose beside
+    // it describes the same architecture — so it is dropped rather than left as
+    // a stray tag.
+    case 'ArchitectureDiagram':
+      return [];
     default:
       return undefined;
   }


### PR DESCRIPTION
### Reason for this change

The read-only diagrams — the quick start, the tutorial and the homepage showcase — drew one thing: the projects a workspace holds. What those projects *deploy* was only ever shown as hand-written [d2](https://d2lang.com/) diagrams, one per generator guide, maintained separately from the graph and from the generators' own options.

### Description of changes

**A switch between the two views.** A control in the top left of each read-only diagram turns the same graph into the AWS infrastructure it deploys: one box per project, holding the resources its generator provisions, with the projects' connections running box to box (border to border, aimed at the resource that reaches out and the one that receives traffic, so a box's internals are never redrawn to make a connection). Arrows match the projects view; a project's own internal plumbing draws a little smaller and always solid.

**Declared, not drawn.** Each node type declares a *blueprint* in `docs/src/lib/graph-builder/infrastructure.ts`: the resources (icons from the existing `public/icons/aws/` set), their place in the project's own small grid, and the request path through them. Resources declare the option values they are provisioned for — `when: { infra: 'rest-lambda' }` puts a WAF in front of a REST API and leaves it out of an HTTP one — and the path closes over whatever the options leave out, so variants of a step share a grid position. Generators that add to a project rather than taking part in a connection (Lambda functions, website authentication) have no node type in the palette, so their blueprints are keyed by generator id and carry their own label.

**Guides.** Every generator guide's `#### Architecture` d2 diagram is replaced by `<ArchitectureDiagram />`, which resolves the project from the page's own `generator:`/`when:` frontmatter — so the snippets shared by the TypeScript and Python guides draw the right one — and defaults to the AWS view of that single project box, with a static `AWS` pill rather than a switch (there is nothing to switch to for one project) and no IaC mark (which provider declares the infrastructure says nothing about what it is). Variants stay in step with the prose: the diagram follows the reader's selection in the page's option filter bar, and a filtered `<Tabs>` block describing one variant pins it with `options={{ infra: 'http-lambda' }}`. The DynamoDB guides gain an Architecture section, and the agent and MCP server snippets gain the missing `agentcore-ecr` variant (their `agentcore` prose described the container flow, which is now `agentcore-ecr`).

**Showcase and tutorial overview.** The homepage showcase gets the same switch, keeping its plan-and-arrive story, and its panel is sized to the example on show in the AWS view (project diagrams are all much of a height, so that view keeps its steady panel). The Dungeon Adventure overview's hand-drawn architecture is now the tutorial's own preset in the AWS view.

`<ArchitectureDiagram>` has no text form, so the MCP `generator-guide` pipeline drops it rather than leaving an agent a stray tag; the prose beside each diagram now states the architecture in words.

The graph builder itself is unchanged.

### Description of how you validated changes

- `docs/src/lib/graph-builder/infrastructure.spec.ts`: fails by name if a palette node type has no blueprint; checks every preset lays out without overlapping or overflowing its extent; pins the REST/HTTP, `agentcore-ecr`, engine, `infra: none`, website-exit, gateway hand-off and blueprint-only-generator cases.
- `pnpm nx test @aws/nx-plugin -- src/mcp-server` (159 tests), with a new one for dropping the component from a rendered guide.
- `astro build`: 1540 pages, all internal links valid. `nx lint @aws/nx-plugin` clean.
- Walked the affected pages in a browser, light and dark: homepage, quick start, tutorial overview and Module 1, the graph builder, and the react-website, react-website-auth, trpc, ts-agent (all three variants), ts-rdb, ts-dynamodb, agentcore-gateway, fastapi, py-mcp-server, ts-smithy-api and both Lambda function guides — no console errors, and changing a filter chip (gateway `protocol` mcp → http) redraws the diagram.

Translations still carry the old d2 diagrams; they regenerate from English.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*