### PR TITLE
ci(workflows): compare a push against the last green commit

### DIFF
--- a/.github/actions/docs-only-change/action.yml
+++ b/.github/actions/docs-only-change/action.yml
@@ -18,8 +18,10 @@ runs:
       # Passed as environment variables rather than interpolated into the script.
       env:
         # A pull request checks out a merge commit, so diff the branch head to
-        # leave out commits that landed on the base since the branch forked.
-        BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+        # leave out commits that landed on the base since the branch forked. A
+        # push has the script resolve its own base - see the script.
+        BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || '' }}
         HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+        GITHUB_TOKEN: ${{ github.token }}
       # Node strips the types, so this job needs no dependencies installed.
       run: node ./scripts/docs-only-change.mts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      actions: read
     outputs:
       docs_only: ${{ steps.docs_only.outputs.docs-only }}
     steps:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -35,6 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      actions: read
     outputs:
       docs_only: ${{ steps.docs_only.outputs.docs-only }}
     steps:

--- a/scripts/docs-only-change.mts
+++ b/scripts/docs-only-change.mts
@@ -10,11 +10,23 @@ import { appendFileSync } from 'node:fs';
  * the smoke tests - they exercise generated projects, which the docs site
  * cannot affect.
  *
- * Run by the `docs-only-change` composite action, which supplies the commits to
- * diff as `BASE_SHA` and `HEAD_SHA`.
+ * Run by the `docs-only-change` composite action, which supplies the head commit
+ * as `HEAD_SHA` and, for a pull request, the base commit as `BASE_SHA`.
  */
 
 const COMMIT_SHA = /^[0-9a-f]{40}$/;
+
+const {
+  BASE_SHA,
+  HEAD_SHA,
+  GITHUB_TOKEN,
+  GITHUB_API_URL = 'https://api.github.com',
+  GITHUB_EVENT_NAME,
+  GITHUB_REPOSITORY,
+  GITHUB_REF_NAME,
+  GITHUB_RUN_ID,
+  GITHUB_OUTPUT,
+} = process.env;
 
 const git = (...args: string[]) =>
   execFileSync('git', args, { encoding: 'utf-8' });
@@ -32,6 +44,59 @@ const isHeldCommit = (sha: string | undefined): sha is string => {
   }
 };
 
+const isAncestorOf = (sha: string, descendant: string) => {
+  try {
+    git('merge-base', '--is-ancestor', sha, descendant);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+const api = async (path: string) => {
+  const response = await fetch(`${GITHUB_API_URL}${path}`, {
+    headers: {
+      accept: 'application/vnd.github+json',
+      authorization: `Bearer ${GITHUB_TOKEN}`,
+    },
+  });
+  if (!response.ok) {
+    throw new Error(`${response.status} from ${path}`);
+  }
+  return response.json();
+};
+
+/**
+ * The most recent commit on this branch whose CI run went green.
+ *
+ * A push compares against this rather than against the commit it displaced,
+ * because a run that was cancelled - which is how a batch of pushes is usually
+ * collapsed - leaves its commits untested. Comparing against the last green
+ * commit folds those commits into the diff, so a docs push landing on top of
+ * untested code still runs the smoke tests.
+ */
+const lastValidatedCommit = async (headSha: string) => {
+  // Resolving the id from this run is exact; the same endpoint keyed on the
+  // workflow's file name can answer for a stale copy of the workflow.
+  const { workflow_id } = await api(
+    `/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}`,
+  );
+  const { workflow_runs } = await api(
+    `/repos/${GITHUB_REPOSITORY}/actions/workflows/${workflow_id}/runs` +
+      `?branch=${GITHUB_REF_NAME}&status=success&per_page=50`,
+  );
+  return (workflow_runs as { head_sha: string }[])
+    .map((run) => run.head_sha)
+    .find(
+      (sha) =>
+        sha !== headSha &&
+        isHeldCommit(sha) &&
+        // A run that finished out of order, or one from before a force push,
+        // says nothing about this commit.
+        isAncestorOf(sha, headSha),
+    );
+};
+
 const isDocsOnly = (baseSha: string, headSha: string) => {
   const changed = git('diff', '--name-only', `${baseSha}...${headSha}`)
     .split('\n')
@@ -41,15 +106,34 @@ const isDocsOnly = (baseSha: string, headSha: string) => {
   );
 };
 
-const { BASE_SHA, HEAD_SHA, GITHUB_OUTPUT } = process.env;
+const resolveBaseSha = async (headSha: string) => {
+  if (BASE_SHA) {
+    return BASE_SHA;
+  }
+  if (GITHUB_EVENT_NAME !== 'push') {
+    return undefined;
+  }
+  try {
+    return await lastValidatedCommit(headSha);
+  } catch (e) {
+    console.log(`Could not resolve the last green commit: ${e}`);
+    return undefined;
+  }
+};
 
-// Anything but a pair of commits we hold - a workflow_dispatch run, a new
-// branch, a force push whose previous head is gone - runs everything.
+// Without a pair of commits to compare - a manually dispatched run, a branch
+// with no green run behind it, a force push whose previous head is gone - the
+// change is treated as touching more than the docs and everything runs.
+const baseSha = isHeldCommit(HEAD_SHA)
+  ? await resolveBaseSha(HEAD_SHA)
+  : undefined;
+
 const docsOnly =
-  isHeldCommit(BASE_SHA) && isHeldCommit(HEAD_SHA)
-    ? isDocsOnly(BASE_SHA, HEAD_SHA)
+  isHeldCommit(baseSha) && isHeldCommit(HEAD_SHA)
+    ? isDocsOnly(baseSha, HEAD_SHA)
     : false;
 
+console.log(`Comparing ${baseSha ?? '(nothing)'}...${HEAD_SHA}`);
 console.log(`docs-only=${docsOnly}`);
 
 if (GITHUB_OUTPUT) {


### PR DESCRIPTION
### Reason for this change

Follow-up to #1235, which skips the smoke tests when a change touches nothing outside `docs/`. On a **push** that comparison started from `github.event.before` — the commit the push displaced — which assumes the previous commit was validated. Cancelling a run to batch pushes is routine on this repo, and a cancelled run leaves its commits untested, so the assumption does not hold.

It has already happened on `main`:

| ci.yml run | Commit | Outcome |
| --- | --- | --- |
| [34088920234](https://github.com/awslabs/nx-plugin-for-aws/actions/runs/34088920234) | `c608c42` — #1235 itself, **not** docs only | cancelled |
| [34089531233](https://github.com/awslabs/nx-plugin-for-aws/actions/runs/34089531233) | `2ba88b7` — docs only | success, `docs-only=true`, smoke tests skipped |

`c608c42` was never smoke tested. It was only a CI change so nothing was at risk this time, but the same sequence with a generator change would land untested code on `main` — and, since #1235 also skips the release for a docs only push, would defer the release that would have exercised it.

### Description of changes

A push now compares against **the last commit on the branch whose CI run went green**, resolved through the workflow runs API, instead of `github.event.before`:

- Cancelled, failed and in-flight runs are not green, so their commits fold into the diff and a docs push landing on top of them runs the full suite.
- It is not over-conservative: consecutive docs pushes still skip the smoke tests, even when a run between them was cancelled, because the diff from the last green commit is still confined to `docs/`.
- Candidates that are not ancestors of the current commit are ignored, so a run that finished out of order, or one from before a force push, cannot be used as a base.
- Any failure resolving it — API error, no green run behind the branch — falls back to running everything.
- The workflow id comes from this run rather than from the workflow's file name: on this repo `GET /actions/workflows/ci.yml/runs` answers for a stale copy of the workflow (newest run `32791208541`), while the same endpoint keyed on id `132600525` returns the current ones.
- `workflow_dispatch` keeps its existing behaviour of running everything.
- The `changes` job now needs `actions: read` alongside `contents: read`.

**Pull requests need no equivalent change** and are untouched: a pull request diff spans the whole branch (`base.sha...head.sha`), not the increment, so a cancelled run inside a pull request cannot narrow what is compared. Verified below rather than assumed.

### Description of how you validated changes

Exercised end to end in a throwaway fork (`nx-plugin-for-aws/nxpaws-ci-skip-test`) carrying these workflows with `runs-on` and the long running step bodies stubbed, but the `changes` job and the `Smoke Tests Complete` gate verbatim.

Pushes to `main`:

| Scenario | Compared against | Result |
| --- | --- | --- |
| docs push on top of a **cancelled code push** | the last green commit, not the cancelled one | `docs-only=false`, all 57 legs ran, `Release` ran |
| docs push on top of a **cancelled docs push** | two docs commits back | `docs-only=true`, smoke jobs still skipped |
| docs push after a green run | the previous commit | `docs-only=true`, skipped, `Release` skipped, `Deploy Docs` ran |
| consecutive docs pushes | each previous commit | `docs-only=true`, skipped |
| non-docs push | the last green commit | all 57 legs ran, `Release` and `Deploy Docs` succeeded |
| `workflow_dispatch` | nothing resolved | `docs-only=false`, all 57 legs ran |

Pull requests, re-run against this script:

| Scenario | Result |
| --- | --- |
| code commit → **run cancelled** → docs commit | `docs-only=false`, all 54 legs ran — the pull request path is not incremental |
| docs only | `docs-only=true`, 6 jobs skipped, gate green, mergeable |
| docs + code | `docs-only=false`, all 54 legs ran |
| force pushed (amended docs only commit) | `docs-only=true`, skipped, mergeable |
| simulated translate push (`docs/**` plus `docs/src/i18n/schema-translations.json`) | `docs-only=true`, skipped, mergeable |
| run cancelled mid-flight | gate reports `cancelled`, pull request blocked |

### Issue # (if applicable)

Follows up #1235.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
