### PR TITLE
docs: build the generator and workspace commands from their options

### DIFF
--- a/docs/src/components/command-card-field.astro
+++ b/docs/src/components/command-card-field.astro
@@ -1,0 +1,100 @@
+---
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * One option's control inside a command card: pills for a fixed set of values, a
+ * checkbox for a flag, a text or number box otherwise.
+ *
+ * `value` is what the control starts on — the value the page pins, or a boolean's
+ * own default, so the command reads as the guide intends until the reader changes
+ * something. A locked option belongs to a walkthrough whose prose is written
+ * around it, so it shows its value without offering to change it.
+ */
+import type { GeneratorOption } from '../lib/generator-options';
+
+interface Props {
+  option: GeneratorOption;
+  /** Unique per card, so labels point at their own controls. */
+  idPrefix: string;
+  value: string;
+  locked: boolean;
+  /** Enum values past this point are collapsed behind the toggle. */
+  collapseAfter: number;
+  strings: { required: string; showAll: string; showFewer: string };
+}
+
+const { option, idPrefix, value, locked, collapseAfter, strings } =
+  Astro.props as Props;
+const id = `${idPrefix}-${option.key}`;
+// A locked enum states the one value that applies rather than listing the rest.
+const values = locked ? option.values.filter((v) => v === value) : option.values;
+---
+
+<div class:list={['command-card-field', { 'is-locked': locked }]}>
+  <p class="command-card-field-head">
+    <label class="command-card-field-name" for={id}>{option.key}</label>
+    {
+      option.required && (
+        <span class="command-card-field-required">{strings.required}</span>
+      )
+    }
+  </p>
+  {
+    option.control === 'enum' ? (
+      <div class="command-card-pills" role="group" aria-label={option.key} id={id}>
+        {values.map((enumValue, index) => (
+          <button
+            type="button"
+            class:list={[
+              'command-card-pill',
+              { 'is-overflow': index >= collapseAfter },
+            ]}
+            data-option-pill={option.key}
+            data-value={enumValue}
+            aria-pressed={String(value === enumValue)}
+            disabled={locked}
+          >
+            {enumValue}
+          </button>
+        ))}
+        {values.length > collapseAfter && (
+          <button
+            type="button"
+            class="command-card-more-values"
+            data-command-card-more
+            data-label-more={`${strings.showAll} ${values.length}`}
+            data-label-fewer={strings.showFewer}
+          >
+            {strings.showAll} {values.length}
+          </button>
+        )}
+      </div>
+    ) : option.control === 'boolean' ? (
+      <label class="command-card-check">
+        <input
+          type="checkbox"
+          id={id}
+          data-option-check={option.key}
+          checked={value === 'true'}
+          disabled={locked}
+        />
+        <span data-option-check-label>{value === 'true' ? 'true' : 'false'}</span>
+      </label>
+    ) : (
+      <input
+        class="command-card-input"
+        type={option.control === 'number' ? 'number' : 'text'}
+        id={id}
+        data-option-input={option.key}
+        value={value}
+        placeholder={option.default ?? `<${option.key}>`}
+        autocomplete="off"
+        spellcheck="false"
+        readonly={locked}
+      />
+    )
+  }
+</div>

--- a/docs/src/components/command-card-terminals.astro
+++ b/docs/src/components/command-card-terminals.astro
@@ -1,0 +1,91 @@
+---
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * The command itself, once per package manager, as a prompt line the card's
+ * script rewrites whenever an option changes.
+ */
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+import {
+  buildCommandTokens,
+  PACKAGE_MANAGERS,
+  type CardConfig,
+} from '../lib/command-card';
+
+interface Props {
+  config: CardConfig;
+  values: Record<string, string>;
+  copyLabel: string;
+}
+
+const { config, values, copyLabel } = Astro.props as Props;
+---
+
+<Tabs syncKey="cli-command">
+  {
+    PACKAGE_MANAGERS.map((pm) => (
+      <TabItem label={pm.label} icon={pm.icon}>
+        <div class="command-card-terminal">
+          <code class="command-card-command" data-command-card-command={pm.label}>
+            <span class="command-card-prompt" aria-hidden="true">$</span>
+            {buildCommandTokens(config, { packageManager: pm.label, values }).map(
+              (token) => (
+                <Fragment>
+                  {' '}
+                  <span
+                    class={`command-card-token is-${token.kind}`}
+                    data-token-key={token.key}
+                  >
+                    {token.kind === 'option' ? (
+                      <Fragment>
+                        <span class="command-card-token-label">{token.label}</span>
+                        <span class="command-card-token-value">{token.value}</span>
+                      </Fragment>
+                    ) : (
+                      token.text
+                    )}
+                  </span>
+                </Fragment>
+              ),
+            )}
+          </code>
+          <button
+            type="button"
+            class="command-card-copy"
+            data-command-card-copy
+            aria-label={copyLabel}
+          >
+            <svg
+              class="command-card-copy-icon command-card-copy-icon--copy"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+              <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+            </svg>
+            <svg
+              class="command-card-copy-icon command-card-copy-icon--check"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2.5"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <polyline points="20 6 9 17 4 12" />
+            </svg>
+          </button>
+        </div>
+      </TabItem>
+    ))
+  }
+</Tabs>

--- a/docs/src/components/command-card.astro
+++ b/docs/src/components/command-card.astro
@@ -1,0 +1,454 @@
+---
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * The card a guide's command lives in: a titled frame, the command itself (passed
+ * in, since the run-generator card offers an Nx Console route alongside it), and
+ * the controls that write it.
+ *
+ * A control per option — pills for a fixed set of values, a checkbox for a flag, a
+ * text box otherwise — rewrites the command as the reader types, so they leave
+ * with their own invocation rather than one to edit afterwards. A walkthrough
+ * whose prose is written around the values it passes locks them instead.
+ */
+import CommandCardField from './command-card-field.astro';
+import type { CardConfig } from '../lib/command-card';
+import type { CommandCardStrings } from '../lib/command-card-strings';
+import type { GeneratorOption } from '../lib/generator-options';
+
+interface Props {
+  config: CardConfig;
+  options: GeneratorOption[];
+  /** The value each option starts on, keyed by option name. */
+  initial: Record<string, string>;
+  title: string;
+  /** What the command runs, shown beside the title. */
+  target: string;
+  /** Options whose controls state their value without offering to change it. */
+  locked: Set<string>;
+  strings: CommandCardStrings;
+  /** Offered where the command supports it, which the create wrapper doesn't. */
+  showDryRun?: boolean;
+}
+
+const {
+  config,
+  options,
+  initial,
+  title,
+  target,
+  locked,
+  strings,
+  showDryRun = false,
+} = Astro.props as Props;
+
+// A page can run the same generator more than once (the tutorials wire several
+// connections in a row), so each card counts itself and keys its labels on that.
+const cardCountSymbol = Symbol.for('npfa:command-card-count');
+const locals = Astro.locals as Record<symbol, number>;
+locals[cardCountSymbol] = (locals[cardCountSymbol] ?? 0) + 1;
+const idPrefix = `cc${locals[cardCountSymbol]}`;
+
+// Enum values past this point are collapsed behind a toggle, matching the options
+// reference panel, so a long list stays one row tall.
+const COLLAPSE_AFTER = 6;
+
+// A locked option is only worth a row where the page pins it: the others would
+// restate a default the reader can neither see in the command nor change.
+const pinnedKeys = new Set(config.prescribed);
+const shown = options.filter(
+  (option) => !locked.has(option.key) || pinnedKeys.has(option.key),
+);
+// Everything is locked on a walkthrough card, so its options read as a summary of
+// the step rather than an invitation to change it.
+const isPinned = shown.every((option) => locked.has(option.key));
+---
+
+<div class="command-card not-content" data-command-card data-config={JSON.stringify(config)}>
+  <p class="command-card-head">
+    <span class="command-card-mark" aria-hidden="true">
+      <svg
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="1.7"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      >
+        <path d="M4 5.5h16a1 1 0 0 1 1 1v11a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1v-11a1 1 0 0 1 1-1Z" />
+        <path d="M7 10.2 9.4 12.5 7 14.8" />
+        <path d="M12.4 15h4.2" />
+      </svg>
+    </span>
+    <span class="command-card-title">{title}</span>
+    <code class="command-card-target">{target}</code>
+  </p>
+
+  <slot />
+
+  {
+    shown.length > 0 && (
+      <details class="command-card-builder" open={!isPinned}>
+        <summary class="command-card-builder-summary">
+          <svg
+            class="command-card-chevron"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2.2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <polyline points="9 6 15 12 9 18" />
+          </svg>
+          <span class="command-card-builder-title">
+            {isPinned ? strings.pinned : strings.build}
+          </span>
+          <span class="command-card-builder-count">{shown.length}</span>
+          {!isPinned && (
+            <button
+              type="button"
+              class="command-card-reset"
+              data-command-card-reset
+              hidden
+            >
+              {strings.reset}
+            </button>
+          )}
+        </summary>
+
+        <div class="command-card-fields">
+          {shown.map((option) => (
+            <CommandCardField
+              option={option}
+              idPrefix={idPrefix}
+              value={initial[option.key] ?? ''}
+              locked={locked.has(option.key)}
+              collapseAfter={COLLAPSE_AFTER}
+              strings={strings}
+            />
+          ))}
+        </div>
+
+        {showDryRun && (
+          <p class="command-card-footer">
+            <label class="command-card-dry-run">
+              <input type="checkbox" data-command-card-dry-run />
+              <code>--dry-run</code>
+            </label>
+            <span class="command-card-dry-run-help">
+              {strings.dryRunSummary}
+            </span>
+          </p>
+        )}
+      </details>
+    )
+  }
+</div>
+
+<script>
+  import {
+    buildCommandTokens,
+    emittedValues,
+    type CardConfig,
+    type CommandToken,
+  } from '../lib/command-card';
+
+  /**
+   * Rebuilds a card's command from its controls, on every keystroke and click.
+   *
+   * Enum options the page's filter bar also exposes are kept in step with it, so
+   * picking a value here narrows the guide and picking one there lands in the
+   * command.
+   */
+  const wire = (card: HTMLElement) => {
+    let config: CardConfig;
+    try {
+      config = JSON.parse(card.dataset.config!);
+    } catch {
+      return;
+    }
+
+    const blocks = Array.from(
+      card.querySelectorAll<HTMLElement>('[data-command-card-command]'),
+    );
+    const inputs = Array.from(
+      card.querySelectorAll<HTMLInputElement>('[data-option-input]'),
+    );
+    const checks = Array.from(
+      card.querySelectorAll<HTMLInputElement>('[data-option-check]'),
+    );
+    const pills = Array.from(
+      card.querySelectorAll<HTMLButtonElement>('[data-option-pill]'),
+    );
+    const dryRun = card.querySelector<HTMLInputElement>(
+      '[data-command-card-dry-run]',
+    );
+    const reset = card.querySelector<HTMLButtonElement>(
+      '[data-command-card-reset]',
+    );
+    const vscodeValues = card.querySelector<HTMLElement>(
+      '[data-command-card-values]',
+    );
+
+    // Where the card started, to reset back to and to spot a reader's changes.
+    const initial = {
+      inputs: inputs.map((input) => input.value),
+      checks: checks.map((check) => check.checked),
+      pills: pills.map((pill) => pill.getAttribute('aria-pressed') === 'true'),
+    };
+
+    const filterBar = document.querySelector<HTMLElement>(
+      '[data-option-filter-bar]',
+    );
+    const filterKeys = new Set(
+      Array.from(
+        filterBar?.querySelectorAll<HTMLElement>(
+          '[data-option-filter-control]',
+        ) ?? [],
+      ).map((control) => control.dataset.key),
+    );
+
+    const entered = (): Record<string, string> => {
+      const values: Record<string, string> = {};
+      for (const input of inputs) {
+        values[input.dataset.optionInput!] = input.value.trim();
+      }
+      for (const check of checks) {
+        values[check.dataset.optionCheck!] = String(check.checked);
+      }
+      for (const pill of pills) {
+        if (pill.getAttribute('aria-pressed') === 'true') {
+          values[pill.dataset.optionPill!] = pill.dataset.value!;
+        }
+      }
+      return values;
+    };
+
+    // Keys carried by the command last render, so only an option that has just
+    // appeared animates in rather than every token on every keystroke.
+    let previousKeys = new Set(
+      Array.from(
+        blocks[0]?.querySelectorAll<HTMLElement>('[data-token-key]') ?? [],
+      )
+        .map((token) => token.dataset.tokenKey!)
+        .filter(Boolean),
+    );
+
+    const paint = (block: HTMLElement, tokens: CommandToken[]) => {
+      const prompt = block.querySelector('.command-card-prompt');
+      block.textContent = '';
+      if (prompt) block.append(prompt);
+      for (const token of tokens) {
+        const span = document.createElement('span');
+        span.className = `command-card-token is-${token.kind}`;
+        if (token.key) {
+          span.dataset.tokenKey = token.key;
+          if (!previousKeys.has(token.key)) span.classList.add('is-new');
+        }
+        if (token.kind === 'option') {
+          const label = document.createElement('span');
+          label.className = 'command-card-token-label';
+          label.textContent = token.label!;
+          const value = document.createElement('span');
+          value.className = 'command-card-token-value';
+          value.textContent = token.value!;
+          span.append(label, value);
+        } else {
+          span.textContent = token.text;
+        }
+        // A real space between tokens, so selecting the line copies a command
+        // rather than one run-together word.
+        block.append(' ', span);
+      }
+    };
+
+    const render = () => {
+      const values = emittedValues(entered(), config.options);
+      for (const block of blocks) {
+        paint(
+          block,
+          buildCommandTokens(config, {
+            packageManager: block.dataset.commandCardCommand!,
+            values,
+            dryRun: dryRun?.checked,
+          }),
+        );
+      }
+      previousKeys = new Set(Object.keys(values));
+
+      if (vscodeValues) {
+        vscodeValues.textContent = '';
+        for (const [key, value] of Object.entries(values)) {
+          const item = document.createElement('li');
+          const name = document.createElement('b');
+          name.textContent = `${key}:`;
+          item.append(name, ` ${value}`);
+          vscodeValues.append(item);
+        }
+      }
+
+      if (reset) {
+        const changed =
+          inputs.some((input, i) => input.value !== initial.inputs[i]) ||
+          checks.some((check, i) => check.checked !== initial.checks[i]) ||
+          pills.some(
+            (pill, i) =>
+              (pill.getAttribute('aria-pressed') === 'true') !==
+              initial.pills[i],
+          ) ||
+          dryRun?.checked === true;
+        reset.hidden = !changed;
+      }
+    };
+
+    const setPill = (key: string, value: string) => {
+      for (const pill of pills) {
+        if (pill.dataset.optionPill !== key) continue;
+        pill.setAttribute('aria-pressed', String(pill.dataset.value === value));
+      }
+    };
+
+    // Each box shows the value it passes, so `false` reads as deliberate.
+    const syncCheckLabel = (check: HTMLInputElement) => {
+      const label = check.parentElement?.querySelector<HTMLElement>(
+        '[data-option-check-label]',
+      );
+      if (label) label.textContent = String(check.checked);
+    };
+
+    for (const input of inputs) {
+      input.addEventListener('input', render);
+    }
+    for (const check of checks) {
+      check.addEventListener('change', () => {
+        syncCheckLabel(check);
+        render();
+      });
+    }
+    dryRun?.addEventListener('change', render);
+
+    for (const pill of pills) {
+      pill.addEventListener('click', () => {
+        const key = pill.dataset.optionPill!;
+        // Picking the value already picked clears it, so the option goes back to
+        // whatever the generator would prompt for.
+        const value =
+          pill.getAttribute('aria-pressed') === 'true'
+            ? ''
+            : pill.dataset.value!;
+        setPill(key, value);
+        render();
+        if (filterKeys.has(key)) {
+          document.dispatchEvent(
+            new CustomEvent('npfa:option-filter-set', {
+              detail: { key, value },
+            }),
+          );
+        }
+      });
+    }
+
+    for (const more of card.querySelectorAll<HTMLElement>(
+      '[data-command-card-more]',
+    )) {
+      more.addEventListener('click', () => {
+        const expanded = more
+          .closest('.command-card-pills')!
+          .classList.toggle('is-expanded');
+        more.textContent = expanded
+          ? more.dataset.labelFewer!
+          : more.dataset.labelMore!;
+      });
+    }
+
+    reset?.addEventListener('click', (event) => {
+      // The button sits in the summary, whose default action would collapse the
+      // section the reader is resetting.
+      event.preventDefault();
+      inputs.forEach((input, i) => {
+        input.value = initial.inputs[i];
+      });
+      checks.forEach((check, i) => {
+        check.checked = initial.checks[i];
+        syncCheckLabel(check);
+      });
+      pills.forEach((pill, i) => {
+        pill.setAttribute('aria-pressed', String(initial.pills[i]));
+      });
+      if (dryRun) dryRun.checked = false;
+      render();
+    });
+
+    for (const button of card.querySelectorAll<HTMLButtonElement>(
+      '[data-command-card-copy]',
+    )) {
+      button.addEventListener('click', async () => {
+        const block = button
+          .closest('.command-card-terminal')
+          ?.querySelector<HTMLElement>('[data-command-card-command]');
+        const tokens = Array.from(
+          block?.querySelectorAll<HTMLElement>('.command-card-token') ?? [],
+        );
+        const text = tokens.map((token) => token.textContent).join(' ');
+        if (!text) return;
+        try {
+          await navigator.clipboard.writeText(text);
+          button.classList.add('is-copied');
+          setTimeout(() => button.classList.remove('is-copied'), 1600);
+        } catch {
+          // Clipboard access can be denied; the command stays selectable.
+        }
+      });
+    }
+
+    // A value picked in the filter bar (or in the options panel that drives it)
+    // belongs in the command too — except where this guide pins the option, whose
+    // value the guide's prose is written around.
+    const pinned = new Set(config.prescribed);
+    const applyFilterSelection = (selected: Record<string, string>) => {
+      let changed = false;
+      for (const [key, value] of Object.entries(selected)) {
+        if (!filterKeys.has(key) || pinned.has(key)) continue;
+        const owned = pills.filter((pill) => pill.dataset.optionPill === key);
+        if (!owned.some((pill) => pill.dataset.value === value)) continue;
+        setPill(key, value);
+        changed = true;
+      }
+      if (changed) render();
+    };
+
+    document.addEventListener('npfa:option-filter-change', (event) => {
+      applyFilterSelection(
+        ((event as CustomEvent).detail ?? {}) as Record<string, string>,
+      );
+    });
+    if (filterBar?.dataset.selection) {
+      try {
+        applyFilterSelection(JSON.parse(filterBar.dataset.selection));
+      } catch {
+        // A malformed selection is nothing to act on.
+      }
+    }
+
+    render();
+  };
+
+  const run = () => {
+    for (const card of document.querySelectorAll<HTMLElement>(
+      '[data-command-card]',
+    )) {
+      wire(card);
+    }
+  };
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', run);
+  } else {
+    run();
+  }
+</script>

--- a/docs/src/components/command-card.astro
+++ b/docs/src/components/command-card.astro
@@ -91,7 +91,7 @@ const isPinned = shown.every((option) => locked.has(option.key));
 
   {
     shown.length > 0 && (
-      <details class="command-card-builder" open={!isPinned}>
+      <details class="command-card-builder">
         <summary class="command-card-builder-summary">
           <svg
             class="command-card-chevron"

--- a/docs/src/components/create-nx-workspace-command.astro
+++ b/docs/src/components/create-nx-workspace-command.astro
@@ -1,8 +1,114 @@
 ---
-import PackageManagerCommand from './package-manager-command.astro';
-import { buildCreateNxWorkspaceCommand } from '../../../packages/nx-plugin/src/utils/commands';
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
-const { workspace, iac, tag, module, extraArgs } = Astro.props;
-const buildCommand = (pm) => buildCreateNxWorkspaceCommand(pm, workspace, iac, tag, module, extraArgs);
+/**
+ * The command that creates a workspace, in the same card the generators use: the
+ * reader picks their IaC provider, container engine and the rest of the preset's
+ * options and the command rewrites as they go.
+ *
+ * `readonly` marks a walkthrough step whose prose is written around the values it
+ * passes, leaving `editable` the options the reader still chooses for themselves.
+ */
+import {
+  createSchemaLookup,
+  resolveGeneratorsJson,
+} from '../../../packages/nx-plugin/src/mcp-server/schema-registry';
+import { emittedValues, type WorkspaceCardConfig } from '../lib/command-card';
+import { commandCardStrings } from '../lib/command-card-strings';
+import {
+  readGeneratorOptions,
+  type GeneratorOption,
+} from '../lib/generator-options';
+import CommandCard from './command-card.astro';
+import CommandCardTerminals from './command-card-terminals.astro';
+
+const {
+  workspace,
+  iac,
+  module,
+  tag,
+  extraArgs,
+  values: pinnedValues = {},
+  readonly = false,
+  editable = [],
+} = Astro.props;
+const locale = Astro.currentLocale || 'en';
+const strings = commandCardStrings(locale);
+
+// The workspace name is the preset's own argument rather than one of its options,
+// so it leads the list the card shows.
+const NAME_OPTION: GeneratorOption = {
+  key: 'workspace',
+  control: 'text',
+  type: 'string',
+  values: [],
+  required: true,
+};
+
+let options: GeneratorOption[] = [NAME_OPTION];
+try {
+  const generatorsJson = resolveGeneratorsJson(process.cwd());
+  if (generatorsJson) {
+    options = [
+      NAME_OPTION,
+      ...readGeneratorOptions(createSchemaLookup(generatorsJson)('preset')),
+    ];
+  }
+} catch {
+  options = [NAME_OPTION];
+}
+
+const prescribed: Record<string, string> = Object.fromEntries(
+  Object.entries({ workspace, iac, module, ...pinnedValues })
+    .filter(([, value]) => value !== undefined)
+    .map(([key, value]) => [key, String(value)]),
+);
+const initial: Record<string, string> = Object.fromEntries(
+  options.map((option) => [
+    option.key,
+    prescribed[option.key] ??
+      (option.control === 'boolean' ? option.default ?? 'false' : ''),
+  ]),
+);
+const locked = new Set(
+  readonly
+    ? options
+        .map((option) => option.key)
+        .filter((key) => !editable.includes(key))
+    : [],
+);
+
+const config: WorkspaceCardConfig = {
+  kind: 'workspace',
+  tag,
+  extraArgs,
+  positional: ['workspace'],
+  order: options.map((option) => option.key),
+  prescribed: Object.keys(prescribed),
+  options: options.map(({ key, control, default: fallback }) => ({
+    key,
+    control,
+    default: fallback,
+  })),
+};
+const values = emittedValues(initial, options);
 ---
-<PackageManagerCommand buildCommand={buildCommand} />
+
+<CommandCard
+  config={config}
+  options={options}
+  initial={initial}
+  title={strings.workspaceTitle}
+  target={tag ? `@aws/nx-workspace@${tag}` : '@aws/nx-workspace'}
+  locked={locked}
+  strings={strings}
+>
+  <CommandCardTerminals
+    config={config}
+    values={values}
+    copyLabel={strings.copyCommand}
+  />
+</CommandCard>

--- a/docs/src/components/generator-parameters.astro
+++ b/docs/src/components/generator-parameters.astro
@@ -13,6 +13,7 @@
  */
 import GeneratorsJson from '../../../packages/nx-plugin/generators.json';
 import schemaTranslations from '../i18n/schema-translations.json';
+import { readGeneratorOptions } from '../lib/generator-options';
 
 const { generator } = Astro.props;
 const schemas = Object.entries(import.meta.glob('../../../packages/nx-plugin/**/schema.json', { eager: true, query: '?raw' }));
@@ -109,27 +110,10 @@ const getDescription = (parameter, fallback) => {
 // (e.g. every Powertools event schema) stays one row tall.
 const COLLAPSE_AFTER = 6;
 
-// The order the reader meets the options in: what they must supply, then what
-// the generator considers important, then the rest, with anything marked
-// internal last. Schema order breaks ties.
-const RANKS = { required: 0, important: 1, normal: 2, internal: 3 };
-const rankOf = (parameterSchema, isRequired) => {
-  if (isRequired) return RANKS.required;
-  return RANKS[parameterSchema['x-priority']] ?? RANKS.normal;
-};
-
-const required = schema.required ?? [];
-const parameters = Object.entries(schema.properties)
-  .map(([key, parameterSchema]) => ({
-    key,
-    required: required.includes(key),
-    rank: rankOf(parameterSchema, required.includes(key)),
-    type: parameterSchema.enum ? 'enum' : parameterSchema.type ?? 'string',
-    values: (parameterSchema.enum ?? []).map(String),
-    default: parameterSchema.default === undefined ? undefined : String(parameterSchema.default),
-    description: getDescription(key, parameterSchema.description),
-  }))
-  .sort((a, b) => a.rank - b.rank);
+const parameters = readGeneratorOptions(schema).map((option) => ({
+  ...option,
+  description: getDescription(option.key, option.description),
+}));
 ---
 
 <div class="gen-params not-content" data-gen-params>

--- a/docs/src/components/run-generator.astro
+++ b/docs/src/components/run-generator.astro
@@ -1,19 +1,98 @@
 ---
-import { Tabs, TabItem, Steps } from '@astrojs/starlight/components';
-import NxCommands from './nx-commands.astro';
-// `positional` names the parameters the generator takes as arguments rather than
-// flags, shortening the CLI command without changing what the Nx Console lists.
-const { namespace = '@aws/nx-plugin', generator, requiredParameters = {}, positional = [], noInteractive = false } = Astro.props;
-const locale = Astro.currentLocale || 'en';
-const args = [
-  ...positional.map((name) => requiredParameters[name]),
-  ...Object.entries(requiredParameters)
-    .filter(([name]) => !positional.includes(name))
-    .map(([name, value]) => `--${name}=${value}`),
-];
-const cliCommand = `g ${namespace}:${generator}${args.length !== 0 ? ` ${args.join(' ')}` : ''}${noInteractive ? ' --no-interactive' : ''}`;
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
-const strings = {
+/**
+ * The command that runs a generator — the thing a guide's reader came for.
+ *
+ * `positional` names the options the generator takes as arguments rather than
+ * flags, shortening the command without changing what the Nx Console lists.
+ * `readonly` marks a walkthrough step whose prose is written around the values it
+ * passes, leaving `editable` the options the reader still chooses for themselves.
+ */
+import { Steps, TabItem, Tabs } from '@astrojs/starlight/components';
+import {
+  createSchemaLookup,
+  resolveGeneratorsJson,
+} from '../../../packages/nx-plugin/src/mcp-server/schema-registry';
+import { emittedValues, type GeneratorCardConfig } from '../lib/command-card';
+import { commandCardStrings } from '../lib/command-card-strings';
+import {
+  readGeneratorOptions,
+  type GeneratorOption,
+} from '../lib/generator-options';
+import CommandCard from './command-card.astro';
+import CommandCardTerminals from './command-card-terminals.astro';
+
+const {
+  namespace = '@aws/nx-plugin',
+  generator,
+  requiredParameters = {},
+  positional = [],
+  noInteractive = false,
+  readonly = false,
+  editable = [],
+} = Astro.props;
+const locale = Astro.currentLocale || 'en';
+const strings = commandCardStrings(locale);
+
+// A tutorial may run a generator it has just written, which no schema describes.
+// Those cards show the command alone.
+let options: GeneratorOption[] = [];
+try {
+  const generatorsJson = resolveGeneratorsJson(process.cwd());
+  if (generatorsJson && namespace === '@aws/nx-plugin') {
+    options = readGeneratorOptions(
+      createSchemaLookup(generatorsJson)(generator),
+    );
+  }
+} catch {
+  options = [];
+}
+
+// The values the page prescribes are the card's starting point, so the command
+// reads exactly as the guide intends until the reader changes something.
+const prescribed: Record<string, string> = Object.fromEntries(
+  Object.entries(requiredParameters).map(([key, value]) => [
+    key,
+    String(value),
+  ]),
+);
+const initial: Record<string, string> = Object.fromEntries(
+  options.map((option) => [
+    option.key,
+    prescribed[option.key] ??
+      (option.control === 'boolean' ? option.default ?? 'false' : ''),
+  ]),
+);
+const locked = new Set(
+  readonly
+    ? options
+        .map((option) => option.key)
+        .filter((key) => !editable.includes(key))
+    : [],
+);
+
+const config: GeneratorCardConfig = {
+  kind: 'generator',
+  namespace,
+  generator,
+  positional,
+  noInteractive,
+  order: options.map((option) => option.key),
+  // The options this guide pins, which a filter-bar selection must not overwrite.
+  prescribed: Object.keys(prescribed),
+  options: options.map(({ key, control, default: fallback }) => ({
+    key,
+    control,
+    default: fallback,
+  })),
+};
+const values = emittedValues(initial, options);
+
+const vscodeStrings = {
   installPlugin: {
     en: 'Install the',
     jp: 'インストール',
@@ -90,41 +169,48 @@ const strings = {
     pt: 'Preencha os parâmetros obrigatórios',
     zh: '填写必需参数',
     vi: 'Điền các tham số bắt buộc'
-  },
-  dryRunSummary: {
-    en: 'You can also perform a dry-run to see what files would be changed',
-    jp: '変更されるファイルを確認するためにドライランを実行することもできます',
-    ko: '어떤 파일이 변경될지 확인하기 위해 드라이 런을 수행할 수도 있습니다',
-    fr: 'Vous pouvez également effectuer une simulation pour voir quels fichiers seraient modifiés',
-    it: 'Puoi anche eseguire una prova per vedere quali file verrebbero modificati',
-    es: 'También puede realizar una ejecución en seco para ver qué archivos se cambiarían',
-    pt: 'Você também pode realizar uma execução simulada para ver quais arquivos seriam alterados',
-    zh: '您还可以执行试运行以查看哪些文件会被更改',
-    vi: 'Bạn cũng có thể thực hiện chạy thử để xem những tệp nào sẽ bị thay đổi'
   }
 };
-
-const localeString = (name) => strings[name][locale] || strings[name]['en'];
+const vscodeString = (name) =>
+  vscodeStrings[name][locale] || vscodeStrings[name]['en'];
 ---
 
-<Tabs syncKey="generator-usage">
-  <TabItem label="CLI">
-    <NxCommands commands={[cliCommand]} />
-    <details>
-      <summary>{localeString('dryRunSummary')}</summary>
-      <NxCommands commands={[`${cliCommand} --dry-run`]} />
-    </details>
-  </TabItem>
-  <TabItem label="VSCode">
-    <Steps>
-      <ol>
-        <li>{localeString('installPlugin')} <a href="https://marketplace.visualstudio.com/items?itemName=nrwl.angular-console">Nx Console VSCode Plugin</a> {localeString('ifNotAlready')}</li>
-        <li>{localeString('openNxConsole')}</li>
-        <li>{localeString('clickGenerate')} <code>Generate (UI)</code> {localeString('inCommonNxCommands')}</li>
-        <li>{localeString('searchFor')} <code>{namespace} - {generator}</code></li>
-        <li>{localeString('fillRequiredParams')}<ul>{Object.keys(requiredParameters).length !== 0 && Object.entries(requiredParameters).map(([k,v]) => <li><b>{k}:</b> {v}</li>)}</ul></li>
-        <li>{localeString('clickGenerate')} <code>Generate</code></li>
-      </ol>
-    </Steps>
-  </TabItem>
-</Tabs>
+<CommandCard
+  config={config}
+  options={options}
+  initial={initial}
+  title={strings.runTitle}
+  target={`${namespace}:${generator}`}
+  locked={locked}
+  strings={strings}
+  showDryRun
+>
+  <Tabs syncKey="generator-usage">
+    <TabItem label="CLI">
+      <CommandCardTerminals
+        config={config}
+        values={values}
+        copyLabel={strings.copyCommand}
+      />
+    </TabItem>
+    <TabItem label="VSCode">
+      <Steps>
+        <ol>
+          <li>{vscodeString('installPlugin')} <a href="https://marketplace.visualstudio.com/items?itemName=nrwl.angular-console">Nx Console VSCode Plugin</a> {vscodeString('ifNotAlready')}</li>
+          <li>{vscodeString('openNxConsole')}</li>
+          <li>{vscodeString('clickGenerate')} <code>Generate (UI)</code> {vscodeString('inCommonNxCommands')}</li>
+          <li>{vscodeString('searchFor')} <code>{namespace} - {generator}</code></li>
+          <li>
+            {vscodeString('fillRequiredParams')}
+            <ul data-command-card-values>
+              {Object.entries(values).map(([key, value]) => (
+                <li><b>{key}:</b> {value}</li>
+              ))}
+            </ul>
+          </li>
+          <li>{vscodeString('clickGenerate')} <code>Generate</code></li>
+        </ol>
+      </Steps>
+    </TabItem>
+  </Tabs>
+</CommandCard>

--- a/docs/src/content/docs/en/get_started/quick-start.mdx
+++ b/docs/src/content/docs/en/get_started/quick-start.mdx
@@ -28,7 +28,7 @@ The following global dependencies are needed before proceeding:
 
 Create an <Link path="guides/workspace">Nx workspace</Link> with the package manager of your choice, and open the directory it creates:
 
-<CreateNxWorkspaceCommand workspace="my-project" />
+<CreateNxWorkspaceCommand workspace="my-project" readonly editable={['iac', 'containers']} />
 
 ```sh
 cd my-project
@@ -73,25 +73,25 @@ Depending on the type of project you're building, you can choose any combination
 
 #### Add a tRPC API
 
-<RunGenerator generator="ts#api" requiredParameters={{ name: 'demo-api', framework: 'trpc' }} positional={['name']} noInteractive />
+<RunGenerator generator="ts#api" requiredParameters={{ name: 'demo-api', framework: 'trpc' }} positional={['name']} noInteractive readonly />
 
 This will create the API inside the `packages/demo-api` folder.
 
 #### Add a React Website
 
-<RunGenerator generator="ts#website" requiredParameters={{ name: 'demo-website' }} positional={['name']} noInteractive />
+<RunGenerator generator="ts#website" requiredParameters={{ name: 'demo-website' }} positional={['name']} noInteractive readonly />
 
 This scaffolds a new React website in `packages/demo-website`.
 
 #### Add Cognito Authentication
 
-<RunGenerator generator="ts#website#auth" requiredParameters={{ project: 'demo-website' }} noInteractive />
+<RunGenerator generator="ts#website#auth" requiredParameters={{ project: 'demo-website' }} noInteractive readonly />
 
 This sets up the necessary infrastructure and React code to add Cognito Authentication to your website.
 
 #### Connect Frontend to Backend
 
-<RunGenerator generator="connection" requiredParameters={{ sourceProject: 'demo-website', targetProject: 'demo-api' }} noInteractive />
+<RunGenerator generator="connection" requiredParameters={{ sourceProject: 'demo-website', targetProject: 'demo-api' }} noInteractive readonly />
 
 This configures the necessary providers to ensure your website can call your tRPC API.
 
@@ -101,12 +101,12 @@ Add the infrastructure project based on your chosen IAC provider.
 
 <Infrastructure>
 <Fragment slot="cdk">
-<RunGenerator generator="ts#infra" requiredParameters={{ name: 'infra' }} positional={['name']} noInteractive />
+<RunGenerator generator="ts#infra" requiredParameters={{ name: 'infra' }} positional={['name']} noInteractive readonly />
 
 This configures a CDK App which you can use to deploy your infrastructure on AWS.
 </Fragment>
 <Fragment slot="terraform">
-<RunGenerator generator="terraform#project" requiredParameters={{ name: 'infra' }} positional={['name']} noInteractive />
+<RunGenerator generator="terraform#project" requiredParameters={{ name: 'infra' }} positional={['name']} noInteractive readonly />
 
 This configures a Terraform project which you can use to deploy your infrastructure on AWS.
 </Fragment>

--- a/docs/src/content/docs/en/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/en/get_started/tutorials/dungeon-game/1.mdx
@@ -26,7 +26,7 @@ import gameConversationPng from '@assets/game-conversation.png'
 
 To create a new monorepo, from within your desired directory, run the following command:
 
-<CreateNxWorkspaceCommand workspace="dungeon-adventure" iac="cdk" />
+<CreateNxWorkspaceCommand workspace="dungeon-adventure" iac="cdk" readonly />
 
 :::note[CDK as IaC Provider]
 We use `--iac=cdk` as we will use CDK for infrastructure as code in this tutorial. The Nx Plugin for AWS also supports `terraform`.
@@ -72,7 +72,7 @@ Rather than copying the commands all at once, you can run each generator individ
 
 First, let's create our Game API. To do this, create a tRPC API called `GameApi` using these steps:
 
-<RunGenerator generator="ts#api" requiredParameters={{ name: "GameApi", framework: "trpc" }} noInteractive />
+<RunGenerator generator="ts#api" requiredParameters={{ name: "GameApi", framework: "trpc" }} noInteractive readonly />
 
 <br />
 
@@ -403,7 +403,7 @@ Now let's create our Story Agent.
 
 To create a Python project:
 
-<RunGenerator generator="py#project" requiredParameters={{name:"story"}} noInteractive />
+<RunGenerator generator="py#project" requiredParameters={{name:"story"}} noInteractive readonly />
 
 You will see some new files appear in your file tree.
 <details>
@@ -433,7 +433,7 @@ This has configured a Python project and [UV Workspace](https://docs.astral.sh/u
 
 To add a Strands agent to the project with the `py#agent` generator:
 
-<RunGenerator generator="py#agent" requiredParameters={{project:"story", auth:"cognito", protocol:"ag-ui"}} noInteractive />
+<RunGenerator generator="py#agent" requiredParameters={{project:"story", auth:"cognito", protocol:"ag-ui"}} noInteractive readonly />
 
 :::note[AG-UI protocol]
 We choose `--protocol=ag-ui` so the agent speaks the [Agent-User Interaction protocol](https://docs.copilotkit.ai/aws-strands/protocol) — this lets our React website talk to it directly via [CopilotKit](https://docs.copilotkit.ai/), with streaming, tool calls, and conversation history handled by the protocol instead of a hand-rolled HTTP client.
@@ -916,7 +916,7 @@ Let us create an MCP server to provide tools for our Story Agent to manage a pla
 
 First, we create a TypeScript project:
 
-<RunGenerator generator="ts#project" requiredParameters={{name:"inventory"}} noInteractive />
+<RunGenerator generator="ts#project" requiredParameters={{name:"inventory"}} noInteractive readonly />
 
 This will create an empty TypeScript project.
 
@@ -944,7 +944,7 @@ The `ts#project` generator generates these files.
 
 Next, we'll add an MCP server to our TypeScript project:
 
-<RunGenerator generator="ts#mcp-server" requiredParameters={{project:"inventory"}} noInteractive />
+<RunGenerator generator="ts#mcp-server" requiredParameters={{project:"inventory"}} noInteractive readonly />
 
 This will add an MCP server.
 <details>
@@ -977,7 +977,7 @@ The `ts#mcp-server` generator generates these files.
 
 Our game state — saved games and each player's inventory — lives in [Amazon DynamoDB](https://aws.amazon.com/dynamodb/). Create a DynamoDB project called `DungeonDb` with the `ts#dynamodb` generator:
 
-<RunGenerator generator="ts#dynamodb" requiredParameters={{name:"DungeonDb"}} noInteractive />
+<RunGenerator generator="ts#dynamodb" requiredParameters={{name:"DungeonDb"}} noInteractive readonly />
 
 :::tip[Local-first development]
 The `ts#dynamodb` generator vends a `dev` target that runs [DynamoDB Local](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html) in a container. Combined with the `connection` generator (which we run below), this means **the entire game runs on your machine without a deployment** until the end of the tutorial.
@@ -1029,7 +1029,7 @@ Next, we will create the UI which will allow you to interact with the game.
 
 To create the UI, create a website called `GameUI` using these steps:
 
-<RunGenerator generator="ts#website" requiredParameters={{name:"GameUI", ux:"shadcn"}} noInteractive />
+<RunGenerator generator="ts#website" requiredParameters={{name:"GameUI", ux:"shadcn"}} noInteractive readonly />
 
 :::note[Shadcn UI]
 We select `--ux=shadcn` so the generated website uses [shadcn/ui](https://ui.shadcn.com/) components styled with Tailwind — all our route code uses shadcn primitives like `Card`, `Button`, and `Input`, and the `connection` generator later wires a matching shadcn-themed [CopilotKit](https://docs.copilotkit.ai/) chat surface.
@@ -1166,7 +1166,7 @@ A component will be rendered when navigating to the `/` route. `@tanstack/react-
 
 Let us configure our Game UI to require authenticated access via Amazon Cognito using these steps:
 
-<RunGenerator generator="ts#website#auth" requiredParameters={{cognitoDomain:"game-ui", project:"@dungeon-adventure/game-ui", allowSignup:true}} noInteractive />
+<RunGenerator generator="ts#website#auth" requiredParameters={{cognitoDomain:"game-ui", project:"@dungeon-adventure/game-ui", allowSignup:true}} noInteractive readonly />
 
 You will see some new files appear/change in your file tree.
 
@@ -1250,7 +1250,7 @@ The `RuntimeConfigProvider` and `CognitoAuth` components have been added to the 
 
 Let us configure our Game UI to connect to our previously created Game API.
 
-<RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-ui", targetProject:"@dungeon-adventure/game-api"}} noInteractive />
+<RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-ui", targetProject:"@dungeon-adventure/game-api"}} noInteractive readonly />
 
 You will see some new files have appear/change in your file tree.
 
@@ -1344,7 +1344,7 @@ The `main.tsx` file has been updated via an AST transform to inject the tRPC pro
 
 Let us connect our Story Agent to the Inventory MCP server so the agent can discover and invoke the MCP server's tools.
 
-<RunGenerator generator="connection" requiredParameters={{sourceProject:"story", targetProject:"inventory"}} noInteractive />
+<RunGenerator generator="connection" requiredParameters={{sourceProject:"story", targetProject:"inventory"}} noInteractive readonly />
 
 <details>
 <summary>Examine the Story Agent → Inventory MCP connection files</summary>
@@ -1384,7 +1384,7 @@ For more details, refer to the <Link path="guides/connection/py-agent-mcp">Pytho
 
 Let us connect our Game UI to the Story Agent. Since the agent speaks AG-UI, the `connection` generator wires up [CopilotKit](https://docs.copilotkit.ai/): a themed chat component and an `@ag-ui/client` `HttpAgent` ready to render.
 
-<RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-ui", targetProject:"story"}} noInteractive />
+<RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-ui", targetProject:"story"}} noInteractive readonly />
 
 <details>
 <summary>Examine the UI → Story Agent connection files</summary>
@@ -1419,9 +1419,9 @@ For more details, refer to the <Link path="guides/connection/react-agui">React t
 
 Both the Game API and the Inventory MCP server read and write our DynamoDB table, so let us connect them to the `DungeonDb` project. The `connection` generator detects that the target is a `ts#dynamodb` project and wires each source project's `dev` target to start DynamoDB Local automatically.
 
-<RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-api", targetProject:"@dungeon-adventure/dungeon-db"}} noInteractive />
+<RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-api", targetProject:"@dungeon-adventure/dungeon-db"}} noInteractive readonly />
 
-<RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/inventory", targetProject:"@dungeon-adventure/dungeon-db"}} noInteractive />
+<RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/inventory", targetProject:"@dungeon-adventure/dungeon-db"}} noInteractive readonly />
 
 <Aside type="tip" title="One command boots the whole stack locally">
 Because the Story Agent's `agent-dev` already depends on the Inventory MCP server's `mcp-server-dev` (via the `story → inventory` connection above), and both the Game API and MCP server now depend on `dungeon-db:dev`, running any one project's `dev` target starts every dependency it needs in the right order.
@@ -1431,7 +1431,7 @@ Because the Story Agent's `agent-dev` already depends on the Inventory MCP serve
 
 Let us create the final sub-project for the CDK infrastructure.
 
-<RunGenerator generator="ts#infra" requiredParameters={{name:"infra"}} noInteractive />
+<RunGenerator generator="ts#infra" requiredParameters={{name:"infra"}} noInteractive readonly />
 
 You will see some new files have appear/change in your file tree.
 

--- a/docs/src/content/docs/en/guides/typescript-project.mdx
+++ b/docs/src/content/docs/en/guides/typescript-project.mdx
@@ -228,9 +228,9 @@ npm has no catalog feature, so versions are declared directly in each `package.j
 
 ##### Opting out of catalogs
 
-Catalogs are enabled by default. To turn them off, create your workspace with `--catalog false`:
+Catalogs are enabled by default. To turn them off, create your workspace with `--catalog=false`:
 
-<CreateNxWorkspaceCommand workspace="my-project" extraArgs="--catalog false" />
+<CreateNxWorkspaceCommand workspace="my-project" values={{ catalog: false }} />
 
 Or set it in `aws-nx-plugin.config.mts` at any time:
 

--- a/docs/src/content/docs/es/get_started/quick-start.mdx
+++ b/docs/src/content/docs/es/get_started/quick-start.mdx
@@ -28,7 +28,7 @@ Las siguientes dependencias globales son necesarias antes de continuar:
 
 Crea un <Link path="guides/workspace">espacio de trabajo Nx</Link> con el gestor de paquetes de tu elección, y abre el directorio que crea:
 
-<CreateNxWorkspaceCommand workspace="my-project" />
+<CreateNxWorkspaceCommand workspace="my-project" readonly editable={['iac', 'containers']} />
 
 ```sh
 cd my-project
@@ -73,25 +73,25 @@ Dependiendo del tipo de proyecto que estés construyendo, puedes elegir cualquie
 
 #### Agregar una API tRPC
 
-<RunGenerator generator="ts#api" requiredParameters={{ name: 'demo-api', framework: 'trpc' }} positional={['name']} noInteractive />
+<RunGenerator generator="ts#api" requiredParameters={{ name: 'demo-api', framework: 'trpc' }} positional={['name']} noInteractive readonly />
 
 Esto creará la API dentro de la carpeta `packages/demo-api`.
 
 #### Agregar un Sitio Web React
 
-<RunGenerator generator="ts#website" requiredParameters={{ name: 'demo-website' }} positional={['name']} noInteractive />
+<RunGenerator generator="ts#website" requiredParameters={{ name: 'demo-website' }} positional={['name']} noInteractive readonly />
 
 Esto estructura un nuevo sitio web React en `packages/demo-website`.
 
 #### Agregar Autenticación Cognito
 
-<RunGenerator generator="ts#website#auth" requiredParameters={{ project: 'demo-website' }} noInteractive />
+<RunGenerator generator="ts#website#auth" requiredParameters={{ project: 'demo-website' }} noInteractive readonly />
 
 Esto configura la infraestructura necesaria y el código React para agregar Autenticación Cognito a tu sitio web.
 
 #### Conectar Frontend con Backend
 
-<RunGenerator generator="connection" requiredParameters={{ sourceProject: 'demo-website', targetProject: 'demo-api' }} noInteractive />
+<RunGenerator generator="connection" requiredParameters={{ sourceProject: 'demo-website', targetProject: 'demo-api' }} noInteractive readonly />
 
 Esto configura los proveedores necesarios para asegurar que tu sitio web pueda llamar a tu API tRPC.
 
@@ -101,12 +101,12 @@ Agrega el proyecto de infraestructura basado en tu proveedor IAC elegido.
 
 <Infrastructure>
 <Fragment slot="cdk">
-<RunGenerator generator="ts#infra" requiredParameters={{ name: 'infra' }} positional={['name']} noInteractive />
+<RunGenerator generator="ts#infra" requiredParameters={{ name: 'infra' }} positional={['name']} noInteractive readonly />
 
 Esto configura una Aplicación CDK que puedes usar para desplegar tu infraestructura en AWS.
 </Fragment>
 <Fragment slot="terraform">
-<RunGenerator generator="terraform#project" requiredParameters={{ name: 'infra' }} positional={['name']} noInteractive />
+<RunGenerator generator="terraform#project" requiredParameters={{ name: 'infra' }} positional={['name']} noInteractive readonly />
 
 Esto configura un proyecto Terraform que puedes usar para desplegar tu infraestructura en AWS.
 </Fragment>

--- a/docs/src/content/docs/es/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/es/get_started/tutorials/dungeon-game/1.mdx
@@ -26,7 +26,7 @@ import gameConversationPng from '@assets/game-conversation.png'
 
 Para crear un nuevo monorepo, desde el directorio deseado, ejecuta el siguiente comando:
 
-<CreateNxWorkspaceCommand workspace="dungeon-adventure" iac="cdk" />
+<CreateNxWorkspaceCommand workspace="dungeon-adventure" iac="cdk" readonly />
 
 :::note[CDK como proveedor de IaC]
 Usamos `--iac=cdk` ya que utilizaremos CDK para infraestructura como código en este tutorial. El Nx Plugin for AWS también soporta `terraform`.
@@ -72,7 +72,7 @@ En lugar de copiar todos los comandos a la vez, puedes ejecutar cada generador i
 
 Primero, creemos nuestra Game API. Para hacerlo, crea una API tRPC llamada `GameApi` siguiendo estos pasos:
 
-<RunGenerator generator="ts#api" requiredParameters={{ name: "GameApi", framework: "trpc" }} noInteractive />
+<RunGenerator generator="ts#api" requiredParameters={{ name: "GameApi", framework: "trpc" }} noInteractive readonly />
 
 <br />
 
@@ -403,7 +403,7 @@ Ahora creemos nuestro Story Agent.
 
 Para crear un proyecto Python:
 
-<RunGenerator generator="py#project" requiredParameters={{name:"story"}} noInteractive />
+<RunGenerator generator="py#project" requiredParameters={{name:"story"}} noInteractive readonly />
 
 Verás algunos archivos nuevos aparecer en tu árbol de archivos.
 <details>
@@ -433,7 +433,7 @@ Esto ha configurado un proyecto Python y un [UV Workspace](https://docs.astral.s
 
 Para agregar un agente Strands al proyecto con el generador `py#agent`:
 
-<RunGenerator generator="py#agent" requiredParameters={{project:"story", auth:"cognito", protocol:"ag-ui"}} noInteractive />
+<RunGenerator generator="py#agent" requiredParameters={{project:"story", auth:"cognito", protocol:"ag-ui"}} noInteractive readonly />
 
 :::note[Protocolo AG-UI]
 Elegimos `--protocol=ag-ui` para que el agente hable el [protocolo Agent-User Interaction](https://docs.copilotkit.ai/aws-strands/protocol) — esto permite que nuestro sitio web React se comunique directamente con él a través de [CopilotKit](https://docs.copilotkit.ai/), con streaming, llamadas a herramientas e historial de conversación gestionados por el protocolo en lugar de un cliente HTTP personalizado.
@@ -917,7 +917,7 @@ Creemos un servidor MCP para proporcionar herramientas a nuestro Story Agent par
 
 Primero, creamos un proyecto TypeScript:
 
-<RunGenerator generator="ts#project" requiredParameters={{name:"inventory"}} noInteractive />
+<RunGenerator generator="ts#project" requiredParameters={{name:"inventory"}} noInteractive readonly />
 
 Esto creará un proyecto TypeScript vacío.
 
@@ -945,7 +945,7 @@ El generador `ts#project` genera estos archivos.
 
 A continuación, agregaremos un servidor MCP a nuestro proyecto TypeScript:
 
-<RunGenerator generator="ts#mcp-server" requiredParameters={{project:"inventory"}} noInteractive />
+<RunGenerator generator="ts#mcp-server" requiredParameters={{project:"inventory"}} noInteractive readonly />
 
 Esto agregará un servidor MCP.
 <details>
@@ -978,7 +978,7 @@ El generador `ts#mcp-server` genera estos archivos.
 
 Nuestro estado de juego — partidas guardadas e inventario de cada jugador — vive en [Amazon DynamoDB](https://aws.amazon.com/dynamodb/). Crea un proyecto DynamoDB llamado `DungeonDb` con el generador `ts#dynamodb`:
 
-<RunGenerator generator="ts#dynamodb" requiredParameters={{name:"DungeonDb"}} noInteractive />
+<RunGenerator generator="ts#dynamodb" requiredParameters={{name:"DungeonDb"}} noInteractive readonly />
 
 :::tip[Desarrollo local primero]
 El generador `ts#dynamodb` vende un objetivo `dev` que ejecuta [DynamoDB Local](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html) en un contenedor. Combinado con el generador `connection` (que ejecutamos a continuación), esto significa que **el juego completo se ejecuta en tu máquina sin un despliegue** hasta el final del tutorial.
@@ -1030,7 +1030,7 @@ A continuación, crearemos la UI que te permitirá interactuar con el juego.
 
 Para crear la UI, crea un sitio web llamado `GameUI` siguiendo estos pasos:
 
-<RunGenerator generator="ts#website" requiredParameters={{name:"GameUI", ux:"shadcn"}} noInteractive />
+<RunGenerator generator="ts#website" requiredParameters={{name:"GameUI", ux:"shadcn"}} noInteractive readonly />
 
 :::note[Shadcn UI]
 Seleccionamos `--ux=shadcn` para que el sitio web generado use componentes de [shadcn/ui](https://ui.shadcn.com/) estilizados con Tailwind — todo nuestro código de rutas usa primitivas de shadcn como `Card`, `Button` e `Input`, y el generador `connection` más adelante conecta una superficie de chat de [CopilotKit](https://docs.copilotkit.ai/) con tema shadcn coincidente.
@@ -1167,7 +1167,7 @@ Un componente se renderizará al navegar a la ruta `/`. `@tanstack/react-router`
 
 Configuremos nuestra Game UI para requerir acceso autenticado a través de Amazon Cognito siguiendo estos pasos:
 
-<RunGenerator generator="ts#website#auth" requiredParameters={{cognitoDomain:"game-ui", project:"@dungeon-adventure/game-ui", allowSignup:true}} noInteractive />
+<RunGenerator generator="ts#website#auth" requiredParameters={{cognitoDomain:"game-ui", project:"@dungeon-adventure/game-ui", allowSignup:true}} noInteractive readonly />
 
 Verás algunos archivos nuevos aparecer/cambiar en tu árbol de archivos.
 
@@ -1251,7 +1251,7 @@ Los componentes `RuntimeConfigProvider` y `CognitoAuth` se han agregado al archi
 
 Configuremos nuestra Game UI para conectarse a nuestra Game API creada anteriormente.
 
-<RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-ui", targetProject:"@dungeon-adventure/game-api"}} noInteractive />
+<RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-ui", targetProject:"@dungeon-adventure/game-api"}} noInteractive readonly />
 
 Verás algunos archivos nuevos aparecer/cambiar en tu árbol de archivos.
 
@@ -1345,7 +1345,7 @@ El archivo `main.tsx` ha sido actualizado mediante una transformación AST para 
 
 Conectemos nuestro Story Agent al servidor MCP de inventario para que el agente pueda descubrir e invocar las herramientas del servidor MCP.
 
-<RunGenerator generator="connection" requiredParameters={{sourceProject:"story", targetProject:"inventory"}} noInteractive />
+<RunGenerator generator="connection" requiredParameters={{sourceProject:"story", targetProject:"inventory"}} noInteractive readonly />
 
 <details>
 <summary>Examinar los archivos de conexión Story Agent → Inventory MCP</summary>
@@ -1385,7 +1385,7 @@ Para más detalles, consulta la <Link path="guides/connection/py-agent-mcp">guí
 
 Conectemos nuestra Game UI al Story Agent. Dado que el agente habla AG-UI, el generador `connection` conecta [CopilotKit](https://docs.copilotkit.ai/): un componente de chat con tema y un `HttpAgent` de `@ag-ui/client` listo para renderizar.
 
-<RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-ui", targetProject:"story"}} noInteractive />
+<RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-ui", targetProject:"story"}} noInteractive readonly />
 
 <details>
 <summary>Examinar los archivos de conexión UI → Story Agent</summary>
@@ -1419,9 +1419,9 @@ Para más detalles, consulta la <Link path="guides/connection/react-agui">guía 
 
 Tanto la Game API como el servidor MCP de inventario leen y escriben en nuestra tabla DynamoDB, así que conectémoslos al proyecto `DungeonDb`. El generador `connection` detecta que el objetivo es un proyecto `ts#dynamodb` y conecta el objetivo `dev` de cada proyecto fuente para iniciar DynamoDB Local automáticamente.
 
-<RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-api", targetProject:"@dungeon-adventure/dungeon-db"}} noInteractive />
+<RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-api", targetProject:"@dungeon-adventure/dungeon-db"}} noInteractive readonly />
 
-<RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/inventory", targetProject:"@dungeon-adventure/dungeon-db"}} noInteractive />
+<RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/inventory", targetProject:"@dungeon-adventure/dungeon-db"}} noInteractive readonly />
 
 <Aside type="tip" title="Un comando inicia toda la pila localmente">
 Dado que el `agent-dev` del Story Agent ya depende del `mcp-server-dev` del servidor MCP de inventario (a través de la conexión `story → inventory` anterior), y tanto la Game API como el servidor MCP ahora dependen de `dungeon-db:dev`, ejecutar el objetivo `dev` de cualquier proyecto inicia todas las dependencias que necesita en el orden correcto.
@@ -1431,7 +1431,7 @@ Dado que el `agent-dev` del Story Agent ya depende del `mcp-server-dev` del serv
 
 Creemos el sub-proyecto final para la infraestructura CDK.
 
-<RunGenerator generator="ts#infra" requiredParameters={{name:"infra"}} noInteractive />
+<RunGenerator generator="ts#infra" requiredParameters={{name:"infra"}} noInteractive readonly />
 
 Verás algunos archivos nuevos aparecer/cambiar en tu árbol de archivos.
 

--- a/docs/src/content/docs/es/guides/typescript-project.mdx
+++ b/docs/src/content/docs/es/guides/typescript-project.mdx
@@ -228,9 +228,9 @@ npm no tiene una función de catálogo, por lo que las versiones se declaran dir
 
 ##### Optar por no usar catálogos
 
-Los catálogos están habilitados por defecto. Para desactivarlos, crea tu workspace con `--catalog false`:
+Los catálogos están habilitados por defecto. Para desactivarlos, crea tu workspace con `--catalog=false`:
 
-<CreateNxWorkspaceCommand workspace="my-project" extraArgs="--catalog false" />
+<CreateNxWorkspaceCommand workspace="my-project" values={{ catalog: false }} />
 
 O configúralo en `aws-nx-plugin.config.mts` en cualquier momento:
 

--- a/docs/src/content/docs/fr/get_started/quick-start.mdx
+++ b/docs/src/content/docs/fr/get_started/quick-start.mdx
@@ -28,7 +28,7 @@ Les dépendances globales suivantes sont nécessaires avant de continuer :
 
 Créez un <Link path="guides/workspace">espace de travail Nx</Link> avec le gestionnaire de paquets de votre choix, et ouvrez le répertoire qu'il crée :
 
-<CreateNxWorkspaceCommand workspace="my-project" />
+<CreateNxWorkspaceCommand workspace="my-project" readonly editable={['iac', 'containers']} />
 
 ```sh
 cd my-project
@@ -73,25 +73,25 @@ Selon le type de projet que vous construisez, vous pouvez choisir n'importe quel
 
 #### Ajouter une API tRPC
 
-<RunGenerator generator="ts#api" requiredParameters={{ name: 'demo-api', framework: 'trpc' }} positional={['name']} noInteractive />
+<RunGenerator generator="ts#api" requiredParameters={{ name: 'demo-api', framework: 'trpc' }} positional={['name']} noInteractive readonly />
 
 Cela créera l'API dans le dossier `packages/demo-api`.
 
 #### Ajouter un site web React
 
-<RunGenerator generator="ts#website" requiredParameters={{ name: 'demo-website' }} positional={['name']} noInteractive />
+<RunGenerator generator="ts#website" requiredParameters={{ name: 'demo-website' }} positional={['name']} noInteractive readonly />
 
 Cela génère un nouveau site web React dans `packages/demo-website`.
 
 #### Ajouter l'authentification Cognito
 
-<RunGenerator generator="ts#website#auth" requiredParameters={{ project: 'demo-website' }} noInteractive />
+<RunGenerator generator="ts#website#auth" requiredParameters={{ project: 'demo-website' }} noInteractive readonly />
 
 Cela configure l'infrastructure nécessaire et le code React pour ajouter l'authentification Cognito à votre site web.
 
 #### Connecter le frontend au backend
 
-<RunGenerator generator="connection" requiredParameters={{ sourceProject: 'demo-website', targetProject: 'demo-api' }} noInteractive />
+<RunGenerator generator="connection" requiredParameters={{ sourceProject: 'demo-website', targetProject: 'demo-api' }} noInteractive readonly />
 
 Cela configure les fournisseurs nécessaires pour garantir que votre site web peut appeler votre API tRPC.
 
@@ -101,12 +101,12 @@ Ajoutez le projet d'infrastructure en fonction de votre fournisseur IAC choisi.
 
 <Infrastructure>
 <Fragment slot="cdk">
-<RunGenerator generator="ts#infra" requiredParameters={{ name: 'infra' }} positional={['name']} noInteractive />
+<RunGenerator generator="ts#infra" requiredParameters={{ name: 'infra' }} positional={['name']} noInteractive readonly />
 
 Cela configure une application CDK que vous pouvez utiliser pour déployer votre infrastructure sur AWS.
 </Fragment>
 <Fragment slot="terraform">
-<RunGenerator generator="terraform#project" requiredParameters={{ name: 'infra' }} positional={['name']} noInteractive />
+<RunGenerator generator="terraform#project" requiredParameters={{ name: 'infra' }} positional={['name']} noInteractive readonly />
 
 Cela configure un projet Terraform que vous pouvez utiliser pour déployer votre infrastructure sur AWS.
 </Fragment>

--- a/docs/src/content/docs/fr/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/fr/get_started/tutorials/dungeon-game/1.mdx
@@ -26,7 +26,7 @@ import gameConversationPng from '@assets/game-conversation.png'
 
 Pour créer un nouveau monorepo, depuis le répertoire de votre choix, exécutez la commande suivante :
 
-<CreateNxWorkspaceCommand workspace="dungeon-adventure" iac="cdk" />
+<CreateNxWorkspaceCommand workspace="dungeon-adventure" iac="cdk" readonly />
 
 :::note[CDK comme fournisseur IaC]
 Nous utilisons `--iac=cdk` car nous utiliserons CDK pour l'infrastructure en tant que code dans ce tutoriel. Le Nx Plugin for AWS prend également en charge `terraform`.
@@ -72,7 +72,7 @@ Plutôt que de copier toutes les commandes en une seule fois, vous pouvez exécu
 
 Commençons par créer notre API de jeu. Pour ce faire, créez une API tRPC appelée `GameApi` en suivant ces étapes :
 
-<RunGenerator generator="ts#api" requiredParameters={{ name: "GameApi", framework: "trpc" }} noInteractive />
+<RunGenerator generator="ts#api" requiredParameters={{ name: "GameApi", framework: "trpc" }} noInteractive readonly />
 
 <br />
 
@@ -402,7 +402,7 @@ Créons maintenant notre agent Story.
 
 Pour créer un projet Python :
 
-<RunGenerator generator="py#project" requiredParameters={{name:"story"}} noInteractive />
+<RunGenerator generator="py#project" requiredParameters={{name:"story"}} noInteractive readonly />
 
 Vous verrez de nouveaux fichiers apparaître dans votre arborescence de fichiers.
 <details>
@@ -432,7 +432,7 @@ Cela a configuré un projet Python et un [UV Workspace](https://docs.astral.sh/u
 
 Pour ajouter un agent Strands au projet avec le générateur `py#agent` :
 
-<RunGenerator generator="py#agent" requiredParameters={{project:"story", auth:"cognito", protocol:"ag-ui"}} noInteractive />
+<RunGenerator generator="py#agent" requiredParameters={{project:"story", auth:"cognito", protocol:"ag-ui"}} noInteractive readonly />
 
 :::note[Protocole AG-UI]
 Nous choisissons `--protocol=ag-ui` pour que l'agent parle le [protocole Agent-User Interaction](https://docs.copilotkit.ai/aws-strands/protocol) — cela permet à notre site web React de lui parler directement via [CopilotKit](https://docs.copilotkit.ai/), avec le streaming, les appels d'outils et l'historique des conversations gérés par le protocole plutôt qu'un client HTTP personnalisé.
@@ -918,7 +918,7 @@ Créons un serveur MCP pour fournir des outils à notre agent Story afin de gér
 
 Tout d'abord, nous créons un projet TypeScript :
 
-<RunGenerator generator="ts#project" requiredParameters={{name:"inventory"}} noInteractive />
+<RunGenerator generator="ts#project" requiredParameters={{name:"inventory"}} noInteractive readonly />
 
 Cela créera un projet TypeScript vide.
 
@@ -946,7 +946,7 @@ Le générateur `ts#project` génère ces fichiers.
 
 Ensuite, nous allons ajouter un serveur MCP à notre projet TypeScript :
 
-<RunGenerator generator="ts#mcp-server" requiredParameters={{project:"inventory"}} noInteractive />
+<RunGenerator generator="ts#mcp-server" requiredParameters={{project:"inventory"}} noInteractive readonly />
 
 Cela ajoutera un serveur MCP.
 <details>
@@ -980,7 +980,7 @@ Le générateur `ts#mcp-server` génère ces fichiers.
 
 L'état de notre jeu — les parties sauvegardées et l'inventaire de chaque joueur — réside dans [Amazon DynamoDB](https://aws.amazon.com/dynamodb/). Créez un projet DynamoDB appelé `DungeonDb` avec le générateur `ts#dynamodb` :
 
-<RunGenerator generator="ts#dynamodb" requiredParameters={{name:"DungeonDb"}} noInteractive />
+<RunGenerator generator="ts#dynamodb" requiredParameters={{name:"DungeonDb"}} noInteractive readonly />
 
 :::tip[Développement local en premier]
 Le générateur `ts#dynamodb` fournit une cible `dev` qui exécute [DynamoDB Local](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html) dans un conteneur. Combiné avec le générateur `connection` (que nous exécutons ci-dessous), cela signifie que **le jeu entier fonctionne sur votre machine sans déploiement** jusqu'à la fin du tutoriel.
@@ -1032,7 +1032,7 @@ Ensuite, nous allons créer l'interface utilisateur qui vous permettra d'interag
 
 Pour créer l'interface utilisateur, créez un site web appelé `GameUI` en suivant ces étapes :
 
-<RunGenerator generator="ts#website" requiredParameters={{name:"GameUI", ux:"shadcn"}} noInteractive />
+<RunGenerator generator="ts#website" requiredParameters={{name:"GameUI", ux:"shadcn"}} noInteractive readonly />
 
 :::note[Shadcn UI]
 Nous sélectionnons `--ux=shadcn` pour que le site web généré utilise les composants [shadcn/ui](https://ui.shadcn.com/) stylisés avec Tailwind — tout notre code de route utilise des primitives shadcn comme `Card`, `Button` et `Input`, et le générateur `connection` connecte plus tard une surface de chat [CopilotKit](https://docs.copilotkit.ai/) avec un thème shadcn correspondant.
@@ -1169,7 +1169,7 @@ Un composant sera rendu lors de la navigation vers la route `/`. `@tanstack/reac
 
 Configurons notre interface de jeu pour exiger un accès authentifié via Amazon Cognito en suivant ces étapes :
 
-<RunGenerator generator="ts#website#auth" requiredParameters={{cognitoDomain:"game-ui", project:"@dungeon-adventure/game-ui", allowSignup:true}} noInteractive />
+<RunGenerator generator="ts#website#auth" requiredParameters={{cognitoDomain:"game-ui", project:"@dungeon-adventure/game-ui", allowSignup:true}} noInteractive readonly />
 
 Vous verrez de nouveaux fichiers apparaître/changer dans votre arborescence de fichiers.
 
@@ -1253,7 +1253,7 @@ Les composants `RuntimeConfigProvider` et `CognitoAuth` ont été ajoutés au fi
 
 Configurons notre interface de jeu pour se connecter à notre API de jeu précédemment créée.
 
-<RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-ui", targetProject:"@dungeon-adventure/game-api"}} noInteractive />
+<RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-ui", targetProject:"@dungeon-adventure/game-api"}} noInteractive readonly />
 
 Vous verrez de nouveaux fichiers apparaître/changer dans votre arborescence de fichiers.
 
@@ -1347,7 +1347,7 @@ Le fichier `main.tsx` a été mis à jour via une transformation AST pour inject
 
 Connectons notre agent Story au serveur MCP d'inventaire afin que l'agent puisse découvrir et invoquer les outils du serveur MCP.
 
-<RunGenerator generator="connection" requiredParameters={{sourceProject:"story", targetProject:"inventory"}} noInteractive />
+<RunGenerator generator="connection" requiredParameters={{sourceProject:"story", targetProject:"inventory"}} noInteractive readonly />
 
 <details>
 <summary>Examiner les fichiers de connexion Agent Story → MCP d'inventaire</summary>
@@ -1387,7 +1387,7 @@ Pour plus de détails, consultez le <Link path="guides/connection/py-agent-mcp">
 
 Connectons notre interface de jeu à l'agent Story. Puisque l'agent parle AG-UI, le générateur `connection` connecte [CopilotKit](https://docs.copilotkit.ai/) : un composant de chat avec thème et un `HttpAgent` `@ag-ui/client` prêt à être rendu.
 
-<RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-ui", targetProject:"story"}} noInteractive />
+<RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-ui", targetProject:"story"}} noInteractive readonly />
 
 <details>
 <summary>Examiner les fichiers de connexion UI → Agent Story</summary>
@@ -1421,9 +1421,9 @@ Pour plus de détails, consultez le <Link path="guides/connection/react-agui">gu
 
 L'API de jeu et le serveur MCP d'inventaire lisent et écrivent dans notre table DynamoDB, alors connectons-les au projet `DungeonDb`. Le générateur `connection` détecte que la cible est un projet `ts#dynamodb` et connecte la cible `dev` de chaque projet source pour démarrer DynamoDB Local automatiquement.
 
-<RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-api", targetProject:"@dungeon-adventure/dungeon-db"}} noInteractive />
+<RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-api", targetProject:"@dungeon-adventure/dungeon-db"}} noInteractive readonly />
 
-<RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/inventory", targetProject:"@dungeon-adventure/dungeon-db"}} noInteractive />
+<RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/inventory", targetProject:"@dungeon-adventure/dungeon-db"}} noInteractive readonly />
 
 <Aside type="tip" title="Une commande démarre toute la pile localement">
 Parce que le `agent-dev` de l'agent Story dépend déjà du `mcp-server-dev` du serveur MCP d'inventaire (via la connexion `story → inventory` ci-dessus), et que l'API de jeu et le serveur MCP dépendent maintenant de `dungeon-db:dev`, l'exécution de la cible `dev` d'un projet démarre toutes ses dépendances dans le bon ordre.
@@ -1433,7 +1433,7 @@ Parce que le `agent-dev` de l'agent Story dépend déjà du `mcp-server-dev` du 
 
 Créons le dernier sous-projet pour l'infrastructure CDK.
 
-<RunGenerator generator="ts#infra" requiredParameters={{name:"infra"}} noInteractive />
+<RunGenerator generator="ts#infra" requiredParameters={{name:"infra"}} noInteractive readonly />
 
 Vous verrez de nouveaux fichiers apparaître/changer dans votre arborescence de fichiers.
 

--- a/docs/src/content/docs/fr/guides/typescript-project.mdx
+++ b/docs/src/content/docs/fr/guides/typescript-project.mdx
@@ -228,9 +228,9 @@ npm n'a pas de fonctionnalité de catalogue, donc les versions sont déclarées 
 
 ##### Désactiver les catalogues
 
-Les catalogues sont activés par défaut. Pour les désactiver, créez votre espace de travail avec `--catalog false` :
+Les catalogues sont activés par défaut. Pour les désactiver, créez votre espace de travail avec `--catalog=false` :
 
-<CreateNxWorkspaceCommand workspace="my-project" extraArgs="--catalog false" />
+<CreateNxWorkspaceCommand workspace="my-project" values={{ catalog: false }} />
 
 Ou définissez-le dans `aws-nx-plugin.config.mts` à tout moment :
 

--- a/docs/src/content/docs/it/get_started/quick-start.mdx
+++ b/docs/src/content/docs/it/get_started/quick-start.mdx
@@ -28,7 +28,7 @@ Le seguenti dipendenze globali sono necessarie prima di procedere:
 
 Crea un <Link path="guides/workspace">workspace Nx</Link> con il package manager di tua scelta e apri la directory che crea:
 
-<CreateNxWorkspaceCommand workspace="my-project" />
+<CreateNxWorkspaceCommand workspace="my-project" readonly editable={['iac', 'containers']} />
 
 ```sh
 cd my-project
@@ -73,25 +73,25 @@ A seconda del tipo di progetto che stai costruendo, puoi scegliere qualsiasi com
 
 #### Aggiungere un'API tRPC
 
-<RunGenerator generator="ts#api" requiredParameters={{ name: 'demo-api', framework: 'trpc' }} positional={['name']} noInteractive />
+<RunGenerator generator="ts#api" requiredParameters={{ name: 'demo-api', framework: 'trpc' }} positional={['name']} noInteractive readonly />
 
 Questo creerà l'API all'interno della cartella `packages/demo-api`.
 
 #### Aggiungere un Sito Web React
 
-<RunGenerator generator="ts#website" requiredParameters={{ name: 'demo-website' }} positional={['name']} noInteractive />
+<RunGenerator generator="ts#website" requiredParameters={{ name: 'demo-website' }} positional={['name']} noInteractive readonly />
 
 Questo crea un nuovo sito web React in `packages/demo-website`.
 
 #### Aggiungere l'Autenticazione Cognito
 
-<RunGenerator generator="ts#website#auth" requiredParameters={{ project: 'demo-website' }} noInteractive />
+<RunGenerator generator="ts#website#auth" requiredParameters={{ project: 'demo-website' }} noInteractive readonly />
 
 Questo configura l'infrastruttura necessaria e il codice React per aggiungere l'autenticazione Cognito al tuo sito web.
 
 #### Connettere Frontend e Backend
 
-<RunGenerator generator="connection" requiredParameters={{ sourceProject: 'demo-website', targetProject: 'demo-api' }} noInteractive />
+<RunGenerator generator="connection" requiredParameters={{ sourceProject: 'demo-website', targetProject: 'demo-api' }} noInteractive readonly />
 
 Questo configura i provider necessari per garantire che il tuo sito web possa chiamare la tua API tRPC.
 
@@ -101,12 +101,12 @@ Aggiungi il progetto di infrastruttura in base al tuo provider IAC scelto.
 
 <Infrastructure>
 <Fragment slot="cdk">
-<RunGenerator generator="ts#infra" requiredParameters={{ name: 'infra' }} positional={['name']} noInteractive />
+<RunGenerator generator="ts#infra" requiredParameters={{ name: 'infra' }} positional={['name']} noInteractive readonly />
 
 Questo configura un'app CDK che puoi utilizzare per distribuire la tua infrastruttura su AWS.
 </Fragment>
 <Fragment slot="terraform">
-<RunGenerator generator="terraform#project" requiredParameters={{ name: 'infra' }} positional={['name']} noInteractive />
+<RunGenerator generator="terraform#project" requiredParameters={{ name: 'infra' }} positional={['name']} noInteractive readonly />
 
 Questo configura un progetto Terraform che puoi utilizzare per distribuire la tua infrastruttura su AWS.
 </Fragment>

--- a/docs/src/content/docs/it/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/it/get_started/tutorials/dungeon-game/1.mdx
@@ -26,7 +26,7 @@ import gameConversationPng from '@assets/game-conversation.png'
 
 Per creare un nuovo monorepo, dalla directory desiderata, esegui il seguente comando:
 
-<CreateNxWorkspaceCommand workspace="dungeon-adventure" iac="cdk" />
+<CreateNxWorkspaceCommand workspace="dungeon-adventure" iac="cdk" readonly />
 
 :::note[CDK come provider IaC]
 Utilizziamo `--iac=cdk` poiché useremo CDK per l'infrastruttura come codice in questo tutorial. Nx Plugin for AWS supporta anche `terraform`.
@@ -72,7 +72,7 @@ Invece di copiare tutti i comandi in una volta, puoi eseguire ogni generatore in
 
 Prima, creiamo la nostra Game API. Per farlo, crea un'API tRPC chiamata `GameApi` usando questi passaggi:
 
-<RunGenerator generator="ts#api" requiredParameters={{ name: "GameApi", framework: "trpc" }} noInteractive />
+<RunGenerator generator="ts#api" requiredParameters={{ name: "GameApi", framework: "trpc" }} noInteractive readonly />
 
 <br />
 
@@ -402,7 +402,7 @@ Ora creiamo il nostro Story Agent.
 
 Per creare un progetto Python:
 
-<RunGenerator generator="py#project" requiredParameters={{name:"story"}} noInteractive />
+<RunGenerator generator="py#project" requiredParameters={{name:"story"}} noInteractive readonly />
 
 Vedrai alcuni nuovi file apparire nel tuo albero dei file.
 <details>
@@ -432,7 +432,7 @@ Questo ha configurato un progetto Python e [UV Workspace](https://docs.astral.sh
 
 Per aggiungere un agente Strands al progetto con il generatore `py#agent`:
 
-<RunGenerator generator="py#agent" requiredParameters={{project:"story", auth:"cognito", protocol:"ag-ui"}} noInteractive />
+<RunGenerator generator="py#agent" requiredParameters={{project:"story", auth:"cognito", protocol:"ag-ui"}} noInteractive readonly />
 
 :::note[Protocollo AG-UI]
 Scegliamo `--protocol=ag-ui` in modo che l'agente parli il [protocollo Agent-User Interaction](https://docs.copilotkit.ai/aws-strands/protocol) — questo permette al nostro sito web React di comunicare direttamente con esso tramite [CopilotKit](https://docs.copilotkit.ai/), con streaming, chiamate di strumenti e cronologia delle conversazioni gestiti dal protocollo invece di un client HTTP fatto a mano.
@@ -918,7 +918,7 @@ Creiamo un server MCP per fornire strumenti al nostro Story Agent per gestire l'
 
 Prima, creiamo un progetto TypeScript:
 
-<RunGenerator generator="ts#project" requiredParameters={{name:"inventory"}} noInteractive />
+<RunGenerator generator="ts#project" requiredParameters={{name:"inventory"}} noInteractive readonly />
 
 Questo creerà un progetto TypeScript vuoto.
 
@@ -946,7 +946,7 @@ Il generatore `ts#project` genera questi file.
 
 Successivamente, aggiungeremo un server MCP al nostro progetto TypeScript:
 
-<RunGenerator generator="ts#mcp-server" requiredParameters={{project:"inventory"}} noInteractive />
+<RunGenerator generator="ts#mcp-server" requiredParameters={{project:"inventory"}} noInteractive readonly />
 
 Questo aggiungerà un server MCP.
 <details>
@@ -980,7 +980,7 @@ Il generatore `ts#mcp-server` genera questi file.
 
 Lo stato del nostro gioco — partite salvate e inventario di ogni giocatore — risiede in [Amazon DynamoDB](https://aws.amazon.com/dynamodb/). Crea un progetto DynamoDB chiamato `DungeonDb` con il generatore `ts#dynamodb`:
 
-<RunGenerator generator="ts#dynamodb" requiredParameters={{name:"DungeonDb"}} noInteractive />
+<RunGenerator generator="ts#dynamodb" requiredParameters={{name:"DungeonDb"}} noInteractive readonly />
 
 :::tip[Sviluppo local-first]
 Il generatore `ts#dynamodb` fornisce un target `dev` che esegue [DynamoDB Local](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html) in un container. Combinato con il generatore `connection` (che eseguiamo qui sotto), questo significa che **l'intero gioco viene eseguito sulla tua macchina senza un deployment** fino alla fine del tutorial.
@@ -1032,7 +1032,7 @@ Successivamente, creeremo l'UI che ti permetterà di interagire con il gioco.
 
 Per creare l'UI, crea un sito web chiamato `GameUI` usando questi passaggi:
 
-<RunGenerator generator="ts#website" requiredParameters={{name:"GameUI", ux:"shadcn"}} noInteractive />
+<RunGenerator generator="ts#website" requiredParameters={{name:"GameUI", ux:"shadcn"}} noInteractive readonly />
 
 :::note[Shadcn UI]
 Selezioniamo `--ux=shadcn` in modo che il sito web generato utilizzi componenti [shadcn/ui](https://ui.shadcn.com/) stilizzati con Tailwind — tutto il nostro codice delle route utilizza primitive shadcn come `Card`, `Button` e `Input`, e il generatore `connection` successivamente collega una superficie di chat [CopilotKit](https://docs.copilotkit.ai/) con tema shadcn corrispondente.
@@ -1169,7 +1169,7 @@ Un componente verrà renderizzato quando si naviga verso la route `/`. `@tanstac
 
 Configuriamo la nostra Game UI per richiedere l'accesso autenticato tramite Amazon Cognito usando questi passaggi:
 
-<RunGenerator generator="ts#website#auth" requiredParameters={{cognitoDomain:"game-ui", project:"@dungeon-adventure/game-ui", allowSignup:true}} noInteractive />
+<RunGenerator generator="ts#website#auth" requiredParameters={{cognitoDomain:"game-ui", project:"@dungeon-adventure/game-ui", allowSignup:true}} noInteractive readonly />
 
 Vedrai alcuni nuovi file apparire/cambiare nel tuo albero dei file.
 
@@ -1253,7 +1253,7 @@ I componenti `RuntimeConfigProvider` e `CognitoAuth` sono stati aggiunti al file
 
 Configuriamo la nostra Game UI per connettersi alla nostra Game API creata in precedenza.
 
-<RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-ui", targetProject:"@dungeon-adventure/game-api"}} noInteractive />
+<RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-ui", targetProject:"@dungeon-adventure/game-api"}} noInteractive readonly />
 
 Vedrai alcuni nuovi file apparire/cambiare nel tuo albero dei file.
 
@@ -1347,7 +1347,7 @@ Il file `main.tsx` è stato aggiornato tramite una trasformazione AST per iniett
 
 Connettiamo il nostro Story Agent al server MCP Inventory in modo che l'agente possa scoprire e invocare gli strumenti del server MCP.
 
-<RunGenerator generator="connection" requiredParameters={{sourceProject:"story", targetProject:"inventory"}} noInteractive />
+<RunGenerator generator="connection" requiredParameters={{sourceProject:"story", targetProject:"inventory"}} noInteractive readonly />
 
 <details>
 <summary>Esamina i file di connessione Story Agent → Inventory MCP</summary>
@@ -1387,7 +1387,7 @@ Per maggiori dettagli, consulta la <Link path="guides/connection/py-agent-mcp">g
 
 Connettiamo la nostra Game UI allo Story Agent. Poiché l'agente parla AG-UI, il generatore `connection` collega [CopilotKit](https://docs.copilotkit.ai/): un componente chat con tema e un `HttpAgent` `@ag-ui/client` pronto per il rendering.
 
-<RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-ui", targetProject:"story"}} noInteractive />
+<RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-ui", targetProject:"story"}} noInteractive readonly />
 
 <details>
 <summary>Esamina i file di connessione UI → Story Agent</summary>
@@ -1421,9 +1421,9 @@ Per maggiori dettagli, consulta la <Link path="guides/connection/react-agui">gui
 
 Sia la Game API che il server MCP Inventory leggono e scrivono la nostra tabella DynamoDB, quindi connettiamoli al progetto `DungeonDb`. Il generatore `connection` rileva che il target è un progetto `ts#dynamodb` e collega il target `dev` di ogni progetto sorgente per avviare automaticamente DynamoDB Local.
 
-<RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-api", targetProject:"@dungeon-adventure/dungeon-db"}} noInteractive />
+<RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-api", targetProject:"@dungeon-adventure/dungeon-db"}} noInteractive readonly />
 
-<RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/inventory", targetProject:"@dungeon-adventure/dungeon-db"}} noInteractive />
+<RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/inventory", targetProject:"@dungeon-adventure/dungeon-db"}} noInteractive readonly />
 
 <Aside type="tip" title="Un comando avvia l'intero stack localmente">
 Poiché l'`agent-dev` dello Story Agent dipende già dal `mcp-server-dev` del server MCP Inventory (tramite la connessione `story → inventory` sopra), e sia la Game API che il server MCP ora dipendono da `dungeon-db:dev`, eseguire il target `dev` di qualsiasi progetto avvia ogni dipendenza di cui ha bisogno nell'ordine giusto.
@@ -1433,7 +1433,7 @@ Poiché l'`agent-dev` dello Story Agent dipende già dal `mcp-server-dev` del se
 
 Creiamo il sotto-progetto finale per l'infrastruttura CDK.
 
-<RunGenerator generator="ts#infra" requiredParameters={{name:"infra"}} noInteractive />
+<RunGenerator generator="ts#infra" requiredParameters={{name:"infra"}} noInteractive readonly />
 
 Vedrai alcuni nuovi file apparire/cambiare nel tuo albero dei file.
 

--- a/docs/src/content/docs/it/guides/typescript-project.mdx
+++ b/docs/src/content/docs/it/guides/typescript-project.mdx
@@ -228,9 +228,9 @@ npm non ha una funzionalità di catalogo, quindi le versioni sono dichiarate dir
 
 ##### Disattivare i cataloghi
 
-I cataloghi sono abilitati per impostazione predefinita. Per disattivarli, crea il tuo workspace con `--catalog false`:
+I cataloghi sono abilitati per impostazione predefinita. Per disattivarli, crea il tuo workspace con `--catalog=false`:
 
-<CreateNxWorkspaceCommand workspace="my-project" extraArgs="--catalog false" />
+<CreateNxWorkspaceCommand workspace="my-project" values={{ catalog: false }} />
 
 Oppure impostalo in `aws-nx-plugin.config.mts` in qualsiasi momento:
 

--- a/docs/src/content/docs/jp/get_started/quick-start.mdx
+++ b/docs/src/content/docs/jp/get_started/quick-start.mdx
@@ -28,7 +28,7 @@ import Prompt from '@components/prompt.astro';
 
 お好みのパッケージマネージャーで <Link path="guides/workspace">Nx ワークスペース</Link>を作成し、作成されたディレクトリを開きます：
 
-<CreateNxWorkspaceCommand workspace="my-project" />
+<CreateNxWorkspaceCommand workspace="my-project" readonly editable={['iac', 'containers']} />
 
 ```sh
 cd my-project
@@ -73,25 +73,25 @@ Infrastructure as Code プロバイダーとして [CDK](https://docs.aws.amazon
 
 #### tRPC API を追加する
 
-<RunGenerator generator="ts#api" requiredParameters={{ name: 'demo-api', framework: 'trpc' }} positional={['name']} noInteractive />
+<RunGenerator generator="ts#api" requiredParameters={{ name: 'demo-api', framework: 'trpc' }} positional={['name']} noInteractive readonly />
 
 これにより、`packages/demo-api` フォルダー内に API が作成されます。
 
 #### React ウェブサイトを追加する
 
-<RunGenerator generator="ts#website" requiredParameters={{ name: 'demo-website' }} positional={['name']} noInteractive />
+<RunGenerator generator="ts#website" requiredParameters={{ name: 'demo-website' }} positional={['name']} noInteractive readonly />
 
 これにより、`packages/demo-website` に新しい React ウェブサイトがスキャフォールドされます。
 
 #### Cognito 認証を追加する
 
-<RunGenerator generator="ts#website#auth" requiredParameters={{ project: 'demo-website' }} noInteractive />
+<RunGenerator generator="ts#website#auth" requiredParameters={{ project: 'demo-website' }} noInteractive readonly />
 
 これにより、ウェブサイトに Cognito 認証を追加するために必要なインフラストラクチャと React コードが設定されます。
 
 #### フロントエンドとバックエンドを接続する
 
-<RunGenerator generator="connection" requiredParameters={{ sourceProject: 'demo-website', targetProject: 'demo-api' }} noInteractive />
+<RunGenerator generator="connection" requiredParameters={{ sourceProject: 'demo-website', targetProject: 'demo-api' }} noInteractive readonly />
 
 これにより、ウェブサイトが tRPC API を呼び出せるようにするために必要なプロバイダーが設定されます。
 
@@ -101,12 +101,12 @@ Infrastructure as Code プロバイダーとして [CDK](https://docs.aws.amazon
 
 <Infrastructure>
 <Fragment slot="cdk">
-<RunGenerator generator="ts#infra" requiredParameters={{ name: 'infra' }} positional={['name']} noInteractive />
+<RunGenerator generator="ts#infra" requiredParameters={{ name: 'infra' }} positional={['name']} noInteractive readonly />
 
 これにより、AWS にインフラストラクチャをデプロイするために使用できる CDK アプリが設定されます。
 </Fragment>
 <Fragment slot="terraform">
-<RunGenerator generator="terraform#project" requiredParameters={{ name: 'infra' }} positional={['name']} noInteractive />
+<RunGenerator generator="terraform#project" requiredParameters={{ name: 'infra' }} positional={['name']} noInteractive readonly />
 
 これにより、AWS にインフラストラクチャをデプロイするために使用できる Terraform プロジェクトが設定されます。
 </Fragment>

--- a/docs/src/content/docs/jp/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/jp/get_started/tutorials/dungeon-game/1.mdx
@@ -26,7 +26,7 @@ import gameConversationPng from '@assets/game-conversation.png'
 
 新しいモノレポを作成するには、目的のディレクトリ内で次のコマンドを実行します:
 
-<CreateNxWorkspaceCommand workspace="dungeon-adventure" iac="cdk" />
+<CreateNxWorkspaceCommand workspace="dungeon-adventure" iac="cdk" readonly />
 
 :::note[IaCプロバイダーとしてのCDK]
 このチュートリアルではインフラストラクチャをコードとして管理するためにCDKを使用するため、`--iac=cdk`を使用します。Nx Plugin for AWSは`terraform`もサポートしています。
@@ -72,7 +72,7 @@ import gameConversationPng from '@assets/game-conversation.png'
 
 まず、Game APIを作成しましょう。これを行うには、次の手順で`GameApi`というtRPC APIを作成します:
 
-<RunGenerator generator="ts#api" requiredParameters={{ name: "GameApi", framework: "trpc" }} noInteractive />
+<RunGenerator generator="ts#api" requiredParameters={{ name: "GameApi", framework: "trpc" }} noInteractive readonly />
 
 <br />
 
@@ -403,7 +403,7 @@ export class GameApi<
 
 Pythonプロジェクトを作成するには:
 
-<RunGenerator generator="py#project" requiredParameters={{name:"story"}} noInteractive />
+<RunGenerator generator="py#project" requiredParameters={{name:"story"}} noInteractive readonly />
 
 ファイルツリーに新しいファイルが表示されます。
 <details>
@@ -433,7 +433,7 @@ Pythonプロジェクトを作成するには:
 
 `py#agent`ジェネレーターを使用してプロジェクトにStrandsエージェントを追加するには:
 
-<RunGenerator generator="py#agent" requiredParameters={{project:"story", auth:"cognito", protocol:"ag-ui"}} noInteractive />
+<RunGenerator generator="py#agent" requiredParameters={{project:"story", auth:"cognito", protocol:"ag-ui"}} noInteractive readonly />
 
 :::note[AG-UIプロトコル]
 `--protocol=ag-ui`を選択することで、エージェントが[Agent-User Interactionプロトコル](https://docs.copilotkit.ai/aws-strands/protocol)を話すようになります。これにより、Reactウェブサイトが[CopilotKit](https://docs.copilotkit.ai/)を介して直接通信でき、ストリーミング、ツール呼び出し、会話履歴がプロトコルによって処理され、手作りのHTTPクライアントは不要になります。
@@ -916,7 +916,7 @@ Story Agentがプレイヤーのインベントリを管理するためのツー
 
 まず、TypeScriptプロジェクトを作成します:
 
-<RunGenerator generator="ts#project" requiredParameters={{name:"inventory"}} noInteractive />
+<RunGenerator generator="ts#project" requiredParameters={{name:"inventory"}} noInteractive readonly />
 
 これにより、空のTypeScriptプロジェクトが作成されます。
 
@@ -944,7 +944,7 @@ Story Agentがプレイヤーのインベントリを管理するためのツー
 
 次に、TypeScriptプロジェクトにMCPサーバーを追加します:
 
-<RunGenerator generator="ts#mcp-server" requiredParameters={{project:"inventory"}} noInteractive />
+<RunGenerator generator="ts#mcp-server" requiredParameters={{project:"inventory"}} noInteractive readonly />
 
 これによりMCPサーバーが追加されます。
 <details>
@@ -977,7 +977,7 @@ Story Agentがプレイヤーのインベントリを管理するためのツー
 
 ゲームの状態（保存されたゲームと各プレイヤーのインベントリ）は[Amazon DynamoDB](https://aws.amazon.com/dynamodb/)に保存されます。`ts#dynamodb`ジェネレーターを使用して`DungeonDb`というDynamoDBプロジェクトを作成します:
 
-<RunGenerator generator="ts#dynamodb" requiredParameters={{name:"DungeonDb"}} noInteractive />
+<RunGenerator generator="ts#dynamodb" requiredParameters={{name:"DungeonDb"}} noInteractive readonly />
 
 :::tip[ローカルファースト開発]
 `ts#dynamodb`ジェネレーターは、コンテナ内で[DynamoDB Local](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html)を実行する`dev`ターゲットを提供します。`connection`ジェネレーター（以下で実行します）と組み合わせることで、**チュートリアルの最後までデプロイなしでゲーム全体がマシン上で実行されます**。
@@ -1029,7 +1029,7 @@ Story Agentがプレイヤーのインベントリを管理するためのツー
 
 UIを作成するには、次の手順で`GameUI`というウェブサイトを作成します:
 
-<RunGenerator generator="ts#website" requiredParameters={{name:"GameUI", ux:"shadcn"}} noInteractive />
+<RunGenerator generator="ts#website" requiredParameters={{name:"GameUI", ux:"shadcn"}} noInteractive readonly />
 
 :::note[Shadcn UI]
 生成されたウェブサイトがTailwindでスタイル設定された[shadcn/ui](https://ui.shadcn.com/)コンポーネントを使用するように、`--ux=shadcn`を選択します。すべてのルートコードは`Card`、`Button`、`Input`などのshadcnプリミティブを使用し、後の`connection`ジェネレーターは、一致するshadcnテーマの[CopilotKit](https://docs.copilotkit.ai/)チャットサーフェスを接続します。
@@ -1166,7 +1166,7 @@ function RouteComponent() {
 
 Amazon Cognitoを介した認証アクセスを必要とするようにGame UIを設定しましょう:
 
-<RunGenerator generator="ts#website#auth" requiredParameters={{cognitoDomain:"game-ui", project:"@dungeon-adventure/game-ui", allowSignup:true}} noInteractive />
+<RunGenerator generator="ts#website#auth" requiredParameters={{cognitoDomain:"game-ui", project:"@dungeon-adventure/game-ui", allowSignup:true}} noInteractive readonly />
 
 ファイルツリーに新しいファイルが表示/変更されます。
 
@@ -1250,7 +1250,7 @@ root &&
 
 以前に作成したGame APIに接続するようにGame UIを設定しましょう。
 
-<RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-ui", targetProject:"@dungeon-adventure/game-api"}} noInteractive />
+<RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-ui", targetProject:"@dungeon-adventure/game-api"}} noInteractive readonly />
 
 ファイルツリーに新しいファイルが表示/変更されます。
 
@@ -1344,7 +1344,7 @@ root &&
 
 Story AgentをInventory MCPサーバーに接続して、エージェントがMCPサーバーのツールを検出して呼び出せるようにしましょう。
 
-<RunGenerator generator="connection" requiredParameters={{sourceProject:"story", targetProject:"inventory"}} noInteractive />
+<RunGenerator generator="connection" requiredParameters={{sourceProject:"story", targetProject:"inventory"}} noInteractive readonly />
 
 <details>
 <summary>Story Agent → Inventory MCP接続ファイルを確認する</summary>
@@ -1384,7 +1384,7 @@ Story AgentをInventory MCPサーバーに接続して、エージェントがMC
 
 Game UIをStory Agentに接続しましょう。エージェントがAG-UIを話すため、`connection`ジェネレーターは[CopilotKit](https://docs.copilotkit.ai/)を接続します: テーマ付きチャットコンポーネントと、レンダリング準備ができた`@ag-ui/client` `HttpAgent`です。
 
-<RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-ui", targetProject:"story"}} noInteractive />
+<RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-ui", targetProject:"story"}} noInteractive readonly />
 
 <details>
 <summary>UI → Story Agent接続ファイルを確認する</summary>
@@ -1418,9 +1418,9 @@ Game UIをStory Agentに接続しましょう。エージェントがAG-UIを話
 
 Game APIとInventory MCPサーバーの両方がDynamoDBテーブルを読み書きするため、`DungeonDb`プロジェクトに接続しましょう。`connection`ジェネレーターは、ターゲットが`ts#dynamodb`プロジェクトであることを検出し、各ソースプロジェクトの`dev`ターゲットを接続してDynamoDB Localを自動的に起動します。
 
-<RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-api", targetProject:"@dungeon-adventure/dungeon-db"}} noInteractive />
+<RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-api", targetProject:"@dungeon-adventure/dungeon-db"}} noInteractive readonly />
 
-<RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/inventory", targetProject:"@dungeon-adventure/dungeon-db"}} noInteractive />
+<RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/inventory", targetProject:"@dungeon-adventure/dungeon-db"}} noInteractive readonly />
 
 <Aside type="tip" title="1つのコマンドでスタック全体をローカルで起動">
 Story Agentの`agent-dev`は既にInventory MCPサーバーの`mcp-server-dev`に依存しており（上記の`story → inventory`接続経由）、Game APIとMCPサーバーの両方が`dungeon-db:dev`に依存しているため、任意の1つのプロジェクトの`dev`ターゲットを実行すると、必要なすべての依存関係が正しい順序で起動します。
@@ -1430,7 +1430,7 @@ Story Agentの`agent-dev`は既にInventory MCPサーバーの`mcp-server-dev`�
 
 CDKインフラストラクチャ用の最終サブプロジェクトを作成しましょう。
 
-<RunGenerator generator="ts#infra" requiredParameters={{name:"infra"}} noInteractive />
+<RunGenerator generator="ts#infra" requiredParameters={{name:"infra"}} noInteractive readonly />
 
 ファイルツリーに新しいファイルが表示/変更されます。
 

--- a/docs/src/content/docs/jp/guides/typescript-project.mdx
+++ b/docs/src/content/docs/jp/guides/typescript-project.mdx
@@ -228,9 +228,9 @@ npm にはカタログ機能がないため、バージョンは各 `package.jso
 
 ##### カタログのオプトアウト
 
-カタログはデフォルトで有効になっています。オフにするには、`--catalog false` でワークスペースを作成します：
+カタログはデフォルトで有効になっています。オフにするには、`--catalog=false` でワークスペースを作成します：
 
-<CreateNxWorkspaceCommand workspace="my-project" extraArgs="--catalog false" />
+<CreateNxWorkspaceCommand workspace="my-project" values={{ catalog: false }} />
 
 または、いつでも `aws-nx-plugin.config.mts` で設定します：
 

--- a/docs/src/content/docs/ko/get_started/quick-start.mdx
+++ b/docs/src/content/docs/ko/get_started/quick-start.mdx
@@ -28,7 +28,7 @@ import Prompt from '@components/prompt.astro';
 
 원하는 패키지 매니저로 <Link path="guides/workspace">Nx 워크스페이스</Link>를 생성하고, 생성된 디렉터리를 엽니다:
 
-<CreateNxWorkspaceCommand workspace="my-project" />
+<CreateNxWorkspaceCommand workspace="my-project" readonly editable={['iac', 'containers']} />
 
 ```sh
 cd my-project
@@ -73,25 +73,25 @@ cd my-project
 
 #### tRPC API 추가
 
-<RunGenerator generator="ts#api" requiredParameters={{ name: 'demo-api', framework: 'trpc' }} positional={['name']} noInteractive />
+<RunGenerator generator="ts#api" requiredParameters={{ name: 'demo-api', framework: 'trpc' }} positional={['name']} noInteractive readonly />
 
 이렇게 하면 `packages/demo-api` 폴더 내에 API가 생성됩니다.
 
 #### React 웹사이트 추가
 
-<RunGenerator generator="ts#website" requiredParameters={{ name: 'demo-website' }} positional={['name']} noInteractive />
+<RunGenerator generator="ts#website" requiredParameters={{ name: 'demo-website' }} positional={['name']} noInteractive readonly />
 
 이렇게 하면 `packages/demo-website`에 새 React 웹사이트가 스캐폴딩됩니다.
 
 #### Cognito 인증 추가
 
-<RunGenerator generator="ts#website#auth" requiredParameters={{ project: 'demo-website' }} noInteractive />
+<RunGenerator generator="ts#website#auth" requiredParameters={{ project: 'demo-website' }} noInteractive readonly />
 
 이렇게 하면 웹사이트에 Cognito 인증을 추가하는 데 필요한 인프라와 React 코드가 설정됩니다.
 
 #### 프론트엔드와 백엔드 연결
 
-<RunGenerator generator="connection" requiredParameters={{ sourceProject: 'demo-website', targetProject: 'demo-api' }} noInteractive />
+<RunGenerator generator="connection" requiredParameters={{ sourceProject: 'demo-website', targetProject: 'demo-api' }} noInteractive readonly />
 
 이렇게 하면 웹사이트가 tRPC API를 호출할 수 있도록 필요한 프로바이더가 구성됩니다.
 
@@ -101,12 +101,12 @@ cd my-project
 
 <Infrastructure>
 <Fragment slot="cdk">
-<RunGenerator generator="ts#infra" requiredParameters={{ name: 'infra' }} positional={['name']} noInteractive />
+<RunGenerator generator="ts#infra" requiredParameters={{ name: 'infra' }} positional={['name']} noInteractive readonly />
 
 이렇게 하면 AWS에 인프라를 배포하는 데 사용할 수 있는 CDK 앱이 구성됩니다.
 </Fragment>
 <Fragment slot="terraform">
-<RunGenerator generator="terraform#project" requiredParameters={{ name: 'infra' }} positional={['name']} noInteractive />
+<RunGenerator generator="terraform#project" requiredParameters={{ name: 'infra' }} positional={['name']} noInteractive readonly />
 
 이렇게 하면 AWS에 인프라를 배포하는 데 사용할 수 있는 Terraform 프로젝트가 구성됩니다.
 </Fragment>

--- a/docs/src/content/docs/ko/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/ko/get_started/tutorials/dungeon-game/1.mdx
@@ -26,7 +26,7 @@ import gameConversationPng from '@assets/game-conversation.png'
 
 새 모노레포를 생성하려면 원하는 디렉토리 내에서 다음 명령을 실행하세요:
 
-<CreateNxWorkspaceCommand workspace="dungeon-adventure" iac="cdk" />
+<CreateNxWorkspaceCommand workspace="dungeon-adventure" iac="cdk" readonly />
 
 :::note[IaC 제공자로서의 CDK]
 이 튜토리얼에서는 인프라를 코드로 관리하기 위해 CDK를 사용하므로 `--iac=cdk`를 사용합니다. Nx Plugin for AWS는 `terraform`도 지원합니다.
@@ -72,7 +72,7 @@ import gameConversationPng from '@assets/game-conversation.png'
 
 먼저 Game API를 생성하겠습니다. 이를 위해 다음 단계를 사용하여 `GameApi`라는 tRPC API를 생성합니다:
 
-<RunGenerator generator="ts#api" requiredParameters={{ name: "GameApi", framework: "trpc" }} noInteractive />
+<RunGenerator generator="ts#api" requiredParameters={{ name: "GameApi", framework: "trpc" }} noInteractive readonly />
 
 <br />
 
@@ -402,7 +402,7 @@ export class GameApi<
 
 Python 프로젝트를 생성하려면:
 
-<RunGenerator generator="py#project" requiredParameters={{name:"story"}} noInteractive />
+<RunGenerator generator="py#project" requiredParameters={{name:"story"}} noInteractive readonly />
 
 파일 트리에 새 파일들이 나타나는 것을 볼 수 있습니다.
 <details>
@@ -432,7 +432,7 @@ Python 프로젝트를 생성하려면:
 
 `py#agent` 제너레이터를 사용하여 프로젝트에 Strands 에이전트를 추가하려면:
 
-<RunGenerator generator="py#agent" requiredParameters={{project:"story", auth:"cognito", protocol:"ag-ui"}} noInteractive />
+<RunGenerator generator="py#agent" requiredParameters={{project:"story", auth:"cognito", protocol:"ag-ui"}} noInteractive readonly />
 
 :::note[AG-UI 프로토콜]
 `--protocol=ag-ui`를 선택하여 에이전트가 [Agent-User Interaction 프로토콜](https://docs.copilotkit.ai/aws-strands/protocol)을 사용하도록 합니다. 이를 통해 React 웹사이트가 [CopilotKit](https://docs.copilotkit.ai/)를 통해 직접 통신할 수 있으며, 스트리밍, 도구 호출, 대화 기록이 수동으로 작성한 HTTP 클라이언트 대신 프로토콜에 의해 처리됩니다.
@@ -918,7 +918,7 @@ Story Agent가 플레이어의 인벤토리를 관리할 수 있도록 도구를
 
 먼저 TypeScript 프로젝트를 생성합니다:
 
-<RunGenerator generator="ts#project" requiredParameters={{name:"inventory"}} noInteractive />
+<RunGenerator generator="ts#project" requiredParameters={{name:"inventory"}} noInteractive readonly />
 
 이렇게 하면 빈 TypeScript 프로젝트가 생성됩니다.
 
@@ -946,7 +946,7 @@ Story Agent가 플레이어의 인벤토리를 관리할 수 있도록 도구를
 
 다음으로 TypeScript 프로젝트에 MCP 서버를 추가하겠습니다:
 
-<RunGenerator generator="ts#mcp-server" requiredParameters={{project:"inventory"}} noInteractive />
+<RunGenerator generator="ts#mcp-server" requiredParameters={{project:"inventory"}} noInteractive readonly />
 
 이렇게 하면 MCP 서버가 추가됩니다.
 <details>
@@ -980,7 +980,7 @@ Story Agent가 플레이어의 인벤토리를 관리할 수 있도록 도구를
 
 게임 상태(저장된 게임 및 각 플레이어의 인벤토리)는 [Amazon DynamoDB](https://aws.amazon.com/dynamodb/)에 저장됩니다. `ts#dynamodb` 제너레이터를 사용하여 `DungeonDb`라는 DynamoDB 프로젝트를 생성합니다:
 
-<RunGenerator generator="ts#dynamodb" requiredParameters={{name:"DungeonDb"}} noInteractive />
+<RunGenerator generator="ts#dynamodb" requiredParameters={{name:"DungeonDb"}} noInteractive readonly />
 
 :::tip[로컬 우선 개발]
 `ts#dynamodb` 제너레이터는 컨테이너에서 [DynamoDB Local](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html)을 실행하는 `dev` 타겟을 제공합니다. 아래에서 실행할 `connection` 제너레이터와 결합하면 **튜토리얼 끝까지 배포 없이 전체 게임이 로컬 머신에서 실행됩니다**.
@@ -1032,7 +1032,7 @@ Story Agent가 플레이어의 인벤토리를 관리할 수 있도록 도구를
 
 UI를 생성하려면 다음 단계를 사용하여 `GameUI`라는 웹사이트를 생성합니다:
 
-<RunGenerator generator="ts#website" requiredParameters={{name:"GameUI", ux:"shadcn"}} noInteractive />
+<RunGenerator generator="ts#website" requiredParameters={{name:"GameUI", ux:"shadcn"}} noInteractive readonly />
 
 :::note[Shadcn UI]
 `--ux=shadcn`을 선택하여 생성된 웹사이트가 Tailwind로 스타일이 지정된 [shadcn/ui](https://ui.shadcn.com/) 컴포넌트를 사용하도록 합니다. 모든 라우트 코드는 `Card`, `Button`, `Input`과 같은 shadcn 프리미티브를 사용하며, 나중에 `connection` 제너레이터가 일치하는 shadcn 테마의 [CopilotKit](https://docs.copilotkit.ai/) 채팅 표면을 연결합니다.
@@ -1169,7 +1169,7 @@ function RouteComponent() {
 
 Amazon Cognito를 통한 인증된 액세스를 요구하도록 Game UI를 구성하겠습니다:
 
-<RunGenerator generator="ts#website#auth" requiredParameters={{cognitoDomain:"game-ui", project:"@dungeon-adventure/game-ui", allowSignup:true}} noInteractive />
+<RunGenerator generator="ts#website#auth" requiredParameters={{cognitoDomain:"game-ui", project:"@dungeon-adventure/game-ui", allowSignup:true}} noInteractive readonly />
 
 파일 트리에 새 파일들이 나타나거나 변경되는 것을 볼 수 있습니다.
 
@@ -1253,7 +1253,7 @@ root &&
 
 이전에 생성한 Game API에 연결하도록 Game UI를 구성하겠습니다.
 
-<RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-ui", targetProject:"@dungeon-adventure/game-api"}} noInteractive />
+<RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-ui", targetProject:"@dungeon-adventure/game-api"}} noInteractive readonly />
 
 파일 트리에 새 파일들이 나타나거나 변경되는 것을 볼 수 있습니다.
 
@@ -1347,7 +1347,7 @@ root &&
 
 에이전트가 MCP 서버의 도구를 발견하고 호출할 수 있도록 Story Agent를 Inventory MCP 서버에 연결하겠습니다.
 
-<RunGenerator generator="connection" requiredParameters={{sourceProject:"story", targetProject:"inventory"}} noInteractive />
+<RunGenerator generator="connection" requiredParameters={{sourceProject:"story", targetProject:"inventory"}} noInteractive readonly />
 
 <details>
 <summary>Story Agent → Inventory MCP 연결 파일 살펴보기</summary>
@@ -1387,7 +1387,7 @@ root &&
 
 Game UI를 Story Agent에 연결하겠습니다. 에이전트가 AG-UI를 사용하므로 `connection` 제너레이터는 [CopilotKit](https://docs.copilotkit.ai/)를 연결합니다: 테마가 적용된 채팅 컴포넌트와 렌더링할 준비가 된 `@ag-ui/client` `HttpAgent`.
 
-<RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-ui", targetProject:"story"}} noInteractive />
+<RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-ui", targetProject:"story"}} noInteractive readonly />
 
 <details>
 <summary>UI → Story Agent 연결 파일 살펴보기</summary>
@@ -1421,9 +1421,9 @@ Game UI를 Story Agent에 연결하겠습니다. 에이전트가 AG-UI를 사용
 
 Game API와 Inventory MCP 서버 모두 DynamoDB 테이블을 읽고 쓰므로 `DungeonDb` 프로젝트에 연결하겠습니다. `connection` 제너레이터는 대상이 `ts#dynamodb` 프로젝트임을 감지하고 각 소스 프로젝트의 `dev` 타겟을 DynamoDB Local을 자동으로 시작하도록 연결합니다.
 
-<RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-api", targetProject:"@dungeon-adventure/dungeon-db"}} noInteractive />
+<RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-api", targetProject:"@dungeon-adventure/dungeon-db"}} noInteractive readonly />
 
-<RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/inventory", targetProject:"@dungeon-adventure/dungeon-db"}} noInteractive />
+<RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/inventory", targetProject:"@dungeon-adventure/dungeon-db"}} noInteractive readonly />
 
 <Aside type="tip" title="하나의 명령으로 전체 스택을 로컬에서 부팅">
 Story Agent의 `agent-dev`는 이미 Inventory MCP 서버의 `mcp-server-dev`에 의존하고(위의 `story → inventory` 연결을 통해), Game API와 MCP 서버 모두 이제 `dungeon-db:dev`에 의존하므로 어떤 프로젝트의 `dev` 타겟을 실행하든 필요한 모든 의존성을 올바른 순서로 시작합니다.
@@ -1433,7 +1433,7 @@ Story Agent의 `agent-dev`는 이미 Inventory MCP 서버의 `mcp-server-dev`에
 
 CDK 인프라를 위한 최종 하위 프로젝트를 생성하겠습니다.
 
-<RunGenerator generator="ts#infra" requiredParameters={{name:"infra"}} noInteractive />
+<RunGenerator generator="ts#infra" requiredParameters={{name:"infra"}} noInteractive readonly />
 
 파일 트리에 새 파일들이 나타나거나 변경되는 것을 볼 수 있습니다.
 

--- a/docs/src/content/docs/ko/guides/typescript-project.mdx
+++ b/docs/src/content/docs/ko/guides/typescript-project.mdx
@@ -228,9 +228,9 @@ npm에는 카탈로그 기능이 없으므로 버전이 각 `package.json`에 �
 
 ##### 카탈로그 옵트아웃
 
-카탈로그는 기본적으로 활성화되어 있습니다. 비활성화하려면 `--catalog false`로 워크스페이스를 생성하세요:
+카탈로그는 기본적으로 활성화되어 있습니다. 비활성화하려면 `--catalog=false`로 워크스페이스를 생성하세요:
 
-<CreateNxWorkspaceCommand workspace="my-project" extraArgs="--catalog false" />
+<CreateNxWorkspaceCommand workspace="my-project" values={{ catalog: false }} />
 
 또는 언제든지 `aws-nx-plugin.config.mts`에서 설정하세요:
 

--- a/docs/src/content/docs/pt/get_started/quick-start.mdx
+++ b/docs/src/content/docs/pt/get_started/quick-start.mdx
@@ -28,7 +28,7 @@ As seguintes dependências globais são necessárias antes de prosseguir:
 
 Crie um <Link path="guides/workspace">workspace Nx</Link> com o gerenciador de pacotes de sua escolha e abra o diretório que ele cria:
 
-<CreateNxWorkspaceCommand workspace="my-project" />
+<CreateNxWorkspaceCommand workspace="my-project" readonly editable={['iac', 'containers']} />
 
 ```sh
 cd my-project
@@ -73,25 +73,25 @@ Dependendo do tipo de projeto que você está construindo, você pode escolher q
 
 #### Adicionar uma API tRPC
 
-<RunGenerator generator="ts#api" requiredParameters={{ name: 'demo-api', framework: 'trpc' }} positional={['name']} noInteractive />
+<RunGenerator generator="ts#api" requiredParameters={{ name: 'demo-api', framework: 'trpc' }} positional={['name']} noInteractive readonly />
 
 Isso criará a API dentro da pasta `packages/demo-api`.
 
 #### Adicionar um Website React
 
-<RunGenerator generator="ts#website" requiredParameters={{ name: 'demo-website' }} positional={['name']} noInteractive />
+<RunGenerator generator="ts#website" requiredParameters={{ name: 'demo-website' }} positional={['name']} noInteractive readonly />
 
 Isso estrutura um novo website React em `packages/demo-website`.
 
 #### Adicionar Autenticação Cognito
 
-<RunGenerator generator="ts#website#auth" requiredParameters={{ project: 'demo-website' }} noInteractive />
+<RunGenerator generator="ts#website#auth" requiredParameters={{ project: 'demo-website' }} noInteractive readonly />
 
 Isso configura a infraestrutura necessária e o código React para adicionar Autenticação Cognito ao seu website.
 
 #### Conectar Frontend ao Backend
 
-<RunGenerator generator="connection" requiredParameters={{ sourceProject: 'demo-website', targetProject: 'demo-api' }} noInteractive />
+<RunGenerator generator="connection" requiredParameters={{ sourceProject: 'demo-website', targetProject: 'demo-api' }} noInteractive readonly />
 
 Isso configura os provedores necessários para garantir que seu website possa chamar sua API tRPC.
 
@@ -101,12 +101,12 @@ Adicione o projeto de infraestrutura com base no seu provedor IAC escolhido.
 
 <Infrastructure>
 <Fragment slot="cdk">
-<RunGenerator generator="ts#infra" requiredParameters={{ name: 'infra' }} positional={['name']} noInteractive />
+<RunGenerator generator="ts#infra" requiredParameters={{ name: 'infra' }} positional={['name']} noInteractive readonly />
 
 Isso configura uma CDK App que você pode usar para implantar sua infraestrutura na AWS.
 </Fragment>
 <Fragment slot="terraform">
-<RunGenerator generator="terraform#project" requiredParameters={{ name: 'infra' }} positional={['name']} noInteractive />
+<RunGenerator generator="terraform#project" requiredParameters={{ name: 'infra' }} positional={['name']} noInteractive readonly />
 
 Isso configura um projeto Terraform que você pode usar para implantar sua infraestrutura na AWS.
 </Fragment>

--- a/docs/src/content/docs/pt/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/pt/get_started/tutorials/dungeon-game/1.mdx
@@ -26,7 +26,7 @@ import gameConversationPng from '@assets/game-conversation.png'
 
 Para criar um novo monorepo, dentro do diretório desejado, execute o seguinte comando:
 
-<CreateNxWorkspaceCommand workspace="dungeon-adventure" iac="cdk" />
+<CreateNxWorkspaceCommand workspace="dungeon-adventure" iac="cdk" readonly />
 
 :::note[CDK como Provedor de IaC]
 Usamos `--iac=cdk` pois utilizaremos CDK para infraestrutura como código neste tutorial. O Nx Plugin for AWS também suporta `terraform`.
@@ -72,7 +72,7 @@ Em vez de copiar os comandos de uma vez, você pode executar cada gerador indivi
 
 Primeiro, vamos criar nossa API do Jogo. Para fazer isso, crie uma API tRPC chamada `GameApi` usando estas etapas:
 
-<RunGenerator generator="ts#api" requiredParameters={{ name: "GameApi", framework: "trpc" }} noInteractive />
+<RunGenerator generator="ts#api" requiredParameters={{ name: "GameApi", framework: "trpc" }} noInteractive readonly />
 
 <br />
 
@@ -402,7 +402,7 @@ Agora vamos criar nosso Agente de História.
 
 Para criar um projeto Python:
 
-<RunGenerator generator="py#project" requiredParameters={{name:"story"}} noInteractive />
+<RunGenerator generator="py#project" requiredParameters={{name:"story"}} noInteractive readonly />
 
 Você verá alguns novos arquivos aparecerem na sua árvore de arquivos.
 <details>
@@ -432,7 +432,7 @@ Isso configurou um projeto Python e [UV Workspace](https://docs.astral.sh/uv/con
 
 Para adicionar um agente Strands ao projeto com o gerador `py#agent`:
 
-<RunGenerator generator="py#agent" requiredParameters={{project:"story", auth:"cognito", protocol:"ag-ui"}} noInteractive />
+<RunGenerator generator="py#agent" requiredParameters={{project:"story", auth:"cognito", protocol:"ag-ui"}} noInteractive readonly />
 
 :::note[Protocolo AG-UI]
 Escolhemos `--protocol=ag-ui` para que o agente fale o [protocolo Agent-User Interaction](https://docs.copilotkit.ai/aws-strands/protocol) — isso permite que nosso website React converse com ele diretamente via [CopilotKit](https://docs.copilotkit.ai/), com streaming, chamadas de ferramentas e histórico de conversação tratados pelo protocolo em vez de um cliente HTTP feito à mão.
@@ -918,7 +918,7 @@ Vamos criar um servidor MCP para fornecer ferramentas para nosso Story Agent ger
 
 Primeiro, criamos um projeto TypeScript:
 
-<RunGenerator generator="ts#project" requiredParameters={{name:"inventory"}} noInteractive />
+<RunGenerator generator="ts#project" requiredParameters={{name:"inventory"}} noInteractive readonly />
 
 Isso criará um projeto TypeScript vazio.
 
@@ -946,7 +946,7 @@ O gerador `ts#project` gera estes arquivos.
 
 Em seguida, adicionaremos um servidor MCP ao nosso projeto TypeScript:
 
-<RunGenerator generator="ts#mcp-server" requiredParameters={{project:"inventory"}} noInteractive />
+<RunGenerator generator="ts#mcp-server" requiredParameters={{project:"inventory"}} noInteractive readonly />
 
 Isso adicionará um servidor MCP.
 <details>
@@ -980,7 +980,7 @@ O gerador `ts#mcp-server` gera estes arquivos.
 
 O estado do nosso jogo — jogos salvos e o inventário de cada jogador — vive no [Amazon DynamoDB](https://aws.amazon.com/dynamodb/). Crie um projeto DynamoDB chamado `DungeonDb` com o gerador `ts#dynamodb`:
 
-<RunGenerator generator="ts#dynamodb" requiredParameters={{name:"DungeonDb"}} noInteractive />
+<RunGenerator generator="ts#dynamodb" requiredParameters={{name:"DungeonDb"}} noInteractive readonly />
 
 :::tip[Desenvolvimento local-first]
 O gerador `ts#dynamodb` fornece um target `dev` que executa [DynamoDB Local](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html) em um contêiner. Combinado com o gerador `connection` (que executamos abaixo), isso significa que **o jogo inteiro roda na sua máquina sem uma implantação** até o final do tutorial.
@@ -1032,7 +1032,7 @@ Em seguida, criaremos a UI que permitirá interagir com o jogo.
 
 Para criar a UI, crie um website chamado `GameUI` usando estas etapas:
 
-<RunGenerator generator="ts#website" requiredParameters={{name:"GameUI", ux:"shadcn"}} noInteractive />
+<RunGenerator generator="ts#website" requiredParameters={{name:"GameUI", ux:"shadcn"}} noInteractive readonly />
 
 :::note[Shadcn UI]
 Selecionamos `--ux=shadcn` para que o website gerado use componentes [shadcn/ui](https://ui.shadcn.com/) estilizados com Tailwind — todo o nosso código de rota usa primitivos shadcn como `Card`, `Button` e `Input`, e o gerador `connection` posteriormente conecta uma superfície de chat [CopilotKit](https://docs.copilotkit.ai/) com tema shadcn correspondente.
@@ -1169,7 +1169,7 @@ Um componente será renderizado ao navegar para a rota `/`. `@tanstack/react-rou
 
 Vamos configurar nossa Game UI para exigir acesso autenticado via Amazon Cognito usando estas etapas:
 
-<RunGenerator generator="ts#website#auth" requiredParameters={{cognitoDomain:"game-ui", project:"@dungeon-adventure/game-ui", allowSignup:true}} noInteractive />
+<RunGenerator generator="ts#website#auth" requiredParameters={{cognitoDomain:"game-ui", project:"@dungeon-adventure/game-ui", allowSignup:true}} noInteractive readonly />
 
 Você verá alguns novos arquivos aparecerem/mudarem na sua árvore de arquivos.
 
@@ -1253,7 +1253,7 @@ Os componentes `RuntimeConfigProvider` e `CognitoAuth` foram adicionados ao arqu
 
 Vamos configurar nossa Game UI para se conectar à nossa Game API criada anteriormente.
 
-<RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-ui", targetProject:"@dungeon-adventure/game-api"}} noInteractive />
+<RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-ui", targetProject:"@dungeon-adventure/game-api"}} noInteractive readonly />
 
 Você verá alguns novos arquivos aparecerem/mudarem na sua árvore de arquivos.
 
@@ -1347,7 +1347,7 @@ O arquivo `main.tsx` foi atualizado via uma transformação AST para injetar os 
 
 Vamos conectar nosso Story Agent ao servidor MCP de Inventário para que o agente possa descobrir e invocar as ferramentas do servidor MCP.
 
-<RunGenerator generator="connection" requiredParameters={{sourceProject:"story", targetProject:"inventory"}} noInteractive />
+<RunGenerator generator="connection" requiredParameters={{sourceProject:"story", targetProject:"inventory"}} noInteractive readonly />
 
 <details>
 <summary>Examine os arquivos de conexão Agente de História → MCP de Inventário</summary>
@@ -1387,7 +1387,7 @@ Para mais detalhes, consulte o <Link path="guides/connection/py-agent-mcp">guia 
 
 Vamos conectar nossa Game UI ao Story Agent. Como o agente fala AG-UI, o gerador `connection` conecta o [CopilotKit](https://docs.copilotkit.ai/): um componente de chat com tema e um `HttpAgent` do `@ag-ui/client` pronto para renderizar.
 
-<RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-ui", targetProject:"story"}} noInteractive />
+<RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-ui", targetProject:"story"}} noInteractive readonly />
 
 <details>
 <summary>Examine os arquivos de conexão UI → Agente de História</summary>
@@ -1421,9 +1421,9 @@ Para mais detalhes, consulte o <Link path="guides/connection/react-agui">guia de
 
 Tanto a Game API quanto o servidor MCP de Inventário leem e escrevem em nossa tabela DynamoDB, então vamos conectá-los ao projeto `DungeonDb`. O gerador `connection` detecta que o alvo é um projeto `ts#dynamodb` e conecta o target `dev` de cada projeto de origem para iniciar o DynamoDB Local automaticamente.
 
-<RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-api", targetProject:"@dungeon-adventure/dungeon-db"}} noInteractive />
+<RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-api", targetProject:"@dungeon-adventure/dungeon-db"}} noInteractive readonly />
 
-<RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/inventory", targetProject:"@dungeon-adventure/dungeon-db"}} noInteractive />
+<RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/inventory", targetProject:"@dungeon-adventure/dungeon-db"}} noInteractive readonly />
 
 <Aside type="tip" title="Um comando inicializa toda a pilha localmente">
 Como o `agent-dev` do Story Agent já depende do `mcp-server-dev` do servidor MCP de Inventário (via a conexão `story → inventory` acima), e tanto a Game API quanto o servidor MCP agora dependem de `dungeon-db:dev`, executar o target `dev` de qualquer projeto inicia todas as dependências necessárias na ordem correta.
@@ -1433,7 +1433,7 @@ Como o `agent-dev` do Story Agent já depende do `mcp-server-dev` do servidor MC
 
 Vamos criar o sub-projeto final para a infraestrutura CDK.
 
-<RunGenerator generator="ts#infra" requiredParameters={{name:"infra"}} noInteractive />
+<RunGenerator generator="ts#infra" requiredParameters={{name:"infra"}} noInteractive readonly />
 
 Você verá alguns novos arquivos aparecerem/mudarem na sua árvore de arquivos.
 

--- a/docs/src/content/docs/pt/guides/typescript-project.mdx
+++ b/docs/src/content/docs/pt/guides/typescript-project.mdx
@@ -228,9 +228,9 @@ O npm não tem recurso de catálogo, então as versões são declaradas diretame
 
 ##### Desativando catálogos
 
-Os catálogos são habilitados por padrão. Para desativá-los, crie seu workspace com `--catalog false`:
+Os catálogos são habilitados por padrão. Para desativá-los, crie seu workspace com `--catalog=false`:
 
-<CreateNxWorkspaceCommand workspace="my-project" extraArgs="--catalog false" />
+<CreateNxWorkspaceCommand workspace="my-project" values={{ catalog: false }} />
 
 Ou defina-o em `aws-nx-plugin.config.mts` a qualquer momento:
 

--- a/docs/src/content/docs/vi/get_started/quick-start.mdx
+++ b/docs/src/content/docs/vi/get_started/quick-start.mdx
@@ -28,7 +28,7 @@ Các phụ thuộc toàn cục sau đây cần được cài đặt trước khi
 
 Tạo một <Link path="guides/workspace">Nx workspace</Link> với trình quản lý gói mà bạn chọn, và mở thư mục nó tạo ra:
 
-<CreateNxWorkspaceCommand workspace="my-project" />
+<CreateNxWorkspaceCommand workspace="my-project" readonly editable={['iac', 'containers']} />
 
 ```sh
 cd my-project
@@ -73,25 +73,25 @@ Tùy thuộc vào loại dự án bạn đang xây dựng, bạn có thể chọ
 
 #### Thêm tRPC API
 
-<RunGenerator generator="ts#api" requiredParameters={{ name: 'demo-api', framework: 'trpc' }} positional={['name']} noInteractive />
+<RunGenerator generator="ts#api" requiredParameters={{ name: 'demo-api', framework: 'trpc' }} positional={['name']} noInteractive readonly />
 
 Lệnh này sẽ tạo API bên trong thư mục `packages/demo-api`.
 
 #### Thêm React Website
 
-<RunGenerator generator="ts#website" requiredParameters={{ name: 'demo-website' }} positional={['name']} noInteractive />
+<RunGenerator generator="ts#website" requiredParameters={{ name: 'demo-website' }} positional={['name']} noInteractive readonly />
 
 Lệnh này tạo khung một React website mới trong `packages/demo-website`.
 
 #### Thêm Cognito Authentication
 
-<RunGenerator generator="ts#website#auth" requiredParameters={{ project: 'demo-website' }} noInteractive />
+<RunGenerator generator="ts#website#auth" requiredParameters={{ project: 'demo-website' }} noInteractive readonly />
 
 Lệnh này thiết lập cơ sở hạ tầng và mã React cần thiết để thêm Cognito Authentication vào website của bạn.
 
 #### Kết Nối Frontend với Backend
 
-<RunGenerator generator="connection" requiredParameters={{ sourceProject: 'demo-website', targetProject: 'demo-api' }} noInteractive />
+<RunGenerator generator="connection" requiredParameters={{ sourceProject: 'demo-website', targetProject: 'demo-api' }} noInteractive readonly />
 
 Lệnh này cấu hình các providers cần thiết để đảm bảo website của bạn có thể gọi tRPC API.
 
@@ -101,12 +101,12 @@ Thêm dự án infrastructure dựa trên nhà cung cấp IAC bạn đã chọn.
 
 <Infrastructure>
 <Fragment slot="cdk">
-<RunGenerator generator="ts#infra" requiredParameters={{ name: 'infra' }} positional={['name']} noInteractive />
+<RunGenerator generator="ts#infra" requiredParameters={{ name: 'infra' }} positional={['name']} noInteractive readonly />
 
 Lệnh này cấu hình một CDK App mà bạn có thể sử dụng để triển khai cơ sở hạ tầng của mình trên AWS.
 </Fragment>
 <Fragment slot="terraform">
-<RunGenerator generator="terraform#project" requiredParameters={{ name: 'infra' }} positional={['name']} noInteractive />
+<RunGenerator generator="terraform#project" requiredParameters={{ name: 'infra' }} positional={['name']} noInteractive readonly />
 
 Lệnh này cấu hình một dự án Terraform mà bạn có thể sử dụng để triển khai cơ sở hạ tầng của mình trên AWS.
 </Fragment>

--- a/docs/src/content/docs/vi/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/vi/get_started/tutorials/dungeon-game/1.mdx
@@ -26,7 +26,7 @@ import gameConversationPng from '@assets/game-conversation.png'
 
 Để tạo monorepo mới, từ thư mục mong muốn của bạn, chạy lệnh sau:
 
-<CreateNxWorkspaceCommand workspace="dungeon-adventure" iac="cdk" />
+<CreateNxWorkspaceCommand workspace="dungeon-adventure" iac="cdk" readonly />
 
 :::note[CDK làm IaC Provider]
 Chúng ta sử dụng `--iac=cdk` vì chúng ta sẽ sử dụng CDK cho infrastructure as code trong hướng dẫn này. Nx Plugin for AWS cũng hỗ trợ `terraform`.
@@ -72,7 +72,7 @@ Thay vì sao chép tất cả các lệnh cùng một lúc, bạn có thể ch�
 
 Đầu tiên, hãy tạo Game API của chúng ta. Để làm điều này, tạo một tRPC API có tên `GameApi` bằng các bước sau:
 
-<RunGenerator generator="ts#api" requiredParameters={{ name: "GameApi", framework: "trpc" }} noInteractive />
+<RunGenerator generator="ts#api" requiredParameters={{ name: "GameApi", framework: "trpc" }} noInteractive readonly />
 
 <br />
 
@@ -402,7 +402,7 @@ Bây giờ hãy tạo Story Agent của chúng ta.
 
 Để tạo một dự án Python:
 
-<RunGenerator generator="py#project" requiredParameters={{name:"story"}} noInteractive />
+<RunGenerator generator="py#project" requiredParameters={{name:"story"}} noInteractive readonly />
 
 Bạn sẽ thấy một số tệp mới xuất hiện trong cây tệp của mình.
 <details>
@@ -432,7 +432,7 @@ Bạn sẽ thấy một số tệp mới xuất hiện trong cây tệp của m�
 
 Để thêm một Strands agent vào dự án với generator `py#agent`:
 
-<RunGenerator generator="py#agent" requiredParameters={{project:"story", auth:"cognito", protocol:"ag-ui"}} noInteractive />
+<RunGenerator generator="py#agent" requiredParameters={{project:"story", auth:"cognito", protocol:"ag-ui"}} noInteractive readonly />
 
 :::note[Giao thức AG-UI]
 Chúng ta chọn `--protocol=ag-ui` để agent sử dụng [giao thức Agent-User Interaction](https://docs.copilotkit.ai/aws-strands/protocol) — điều này cho phép website React của chúng ta nói chuyện trực tiếp với nó thông qua [CopilotKit](https://docs.copilotkit.ai/), với streaming, tool calls và lịch sử hội thoại được xử lý bởi giao thức thay vì một HTTP client tự viết.
@@ -918,7 +918,7 @@ Hãy tạo một MCP server để cung cấp các công cụ cho Story Agent c�
 
 Đầu tiên, chúng ta tạo một dự án TypeScript:
 
-<RunGenerator generator="ts#project" requiredParameters={{name:"inventory"}} noInteractive />
+<RunGenerator generator="ts#project" requiredParameters={{name:"inventory"}} noInteractive readonly />
 
 Điều này sẽ tạo ra một dự án TypeScript trống.
 
@@ -946,7 +946,7 @@ Generator `ts#project` tạo ra các tệp sau.
 
 Tiếp theo, chúng ta sẽ thêm một MCP server vào dự án TypeScript của mình:
 
-<RunGenerator generator="ts#mcp-server" requiredParameters={{project:"inventory"}} noInteractive />
+<RunGenerator generator="ts#mcp-server" requiredParameters={{project:"inventory"}} noInteractive readonly />
 
 Điều này sẽ thêm một MCP server.
 <details>
@@ -980,7 +980,7 @@ Generator `ts#mcp-server` tạo ra các tệp sau.
 
 Trạng thái trò chơi của chúng ta — các trò chơi đã lưu và kho đồ của mỗi người chơi — nằm trong [Amazon DynamoDB](https://aws.amazon.com/dynamodb/). Tạo một dự án DynamoDB có tên `DungeonDb` với generator `ts#dynamodb`:
 
-<RunGenerator generator="ts#dynamodb" requiredParameters={{name:"DungeonDb"}} noInteractive />
+<RunGenerator generator="ts#dynamodb" requiredParameters={{name:"DungeonDb"}} noInteractive readonly />
 
 :::tip[Phát triển ưu tiên cục bộ]
 Generator `ts#dynamodb` cung cấp một mục tiêu `dev` chạy [DynamoDB Local](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html) trong một container. Kết hợp với generator `connection` (mà chúng ta chạy bên dưới), điều này có nghĩa là **toàn bộ trò chơi chạy trên máy của bạn mà không cần triển khai** cho đến cuối hướng dẫn.
@@ -1032,7 +1032,7 @@ Tiếp theo, chúng ta sẽ tạo UI cho phép bạn tương tác với trò ch�
 
 Để tạo UI, tạo một website có tên `GameUI` bằng các bước sau:
 
-<RunGenerator generator="ts#website" requiredParameters={{name:"GameUI", ux:"shadcn"}} noInteractive />
+<RunGenerator generator="ts#website" requiredParameters={{name:"GameUI", ux:"shadcn"}} noInteractive readonly />
 
 :::note[Shadcn UI]
 Chúng ta chọn `--ux=shadcn` để website được tạo ra sử dụng các thành phần [shadcn/ui](https://ui.shadcn.com/) được tạo kiểu với Tailwind — tất cả mã route của chúng ta sử dụng các nguyên thủy shadcn như `Card`, `Button` và `Input`, và generator `connection` sau này kết nối một bề mặt chat [CopilotKit](https://docs.copilotkit.ai/) có chủ đề shadcn phù hợp.
@@ -1169,7 +1169,7 @@ Một thành phần sẽ được hiển thị khi điều hướng đến route
 
 Hãy cấu hình Game UI của chúng ta để yêu cầu truy cập được xác thực thông qua Amazon Cognito bằng các bước sau:
 
-<RunGenerator generator="ts#website#auth" requiredParameters={{cognitoDomain:"game-ui", project:"@dungeon-adventure/game-ui", allowSignup:true}} noInteractive />
+<RunGenerator generator="ts#website#auth" requiredParameters={{cognitoDomain:"game-ui", project:"@dungeon-adventure/game-ui", allowSignup:true}} noInteractive readonly />
 
 Bạn sẽ thấy một số tệp mới xuất hiện/thay đổi trong cây tệp của mình.
 
@@ -1253,7 +1253,7 @@ Các thành phần `RuntimeConfigProvider` và `CognitoAuth` đã được thêm
 
 Hãy cấu hình Game UI của chúng ta để kết nối với Game API đã tạo trước đó.
 
-<RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-ui", targetProject:"@dungeon-adventure/game-api"}} noInteractive />
+<RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-ui", targetProject:"@dungeon-adventure/game-api"}} noInteractive readonly />
 
 Bạn sẽ thấy một số tệp mới xuất hiện/thay đổi trong cây tệp của mình.
 
@@ -1347,7 +1347,7 @@ Tệp `main.tsx` đã được cập nhật thông qua một biến đổi AST �
 
 Hãy kết nối Story Agent của chúng ta với Inventory MCP server để agent có thể khám phá và gọi các công cụ của MCP server.
 
-<RunGenerator generator="connection" requiredParameters={{sourceProject:"story", targetProject:"inventory"}} noInteractive />
+<RunGenerator generator="connection" requiredParameters={{sourceProject:"story", targetProject:"inventory"}} noInteractive readonly />
 
 <details>
 <summary>Kiểm tra các tệp kết nối Story Agent → Inventory MCP</summary>
@@ -1387,7 +1387,7 @@ Generator:
 
 Hãy kết nối Game UI của chúng ta với Story Agent. Vì agent sử dụng AG-UI, generator `connection` kết nối [CopilotKit](https://docs.copilotkit.ai/): một thành phần chat có chủ đề và một `HttpAgent` `@ag-ui/client` sẵn sàng để hiển thị.
 
-<RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-ui", targetProject:"story"}} noInteractive />
+<RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-ui", targetProject:"story"}} noInteractive readonly />
 
 <details>
 <summary>Kiểm tra các tệp kết nối UI → Story Agent</summary>
@@ -1421,9 +1421,9 @@ Generator:
 
 Cả Game API và Inventory MCP server đều đọc và ghi bảng DynamoDB của chúng ta, vì vậy hãy kết nối chúng với dự án `DungeonDb`. Generator `connection` phát hiện rằng mục tiêu là một dự án `ts#dynamodb` và kết nối mục tiêu `dev` của mỗi dự án nguồn để tự động khởi động DynamoDB Local.
 
-<RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-api", targetProject:"@dungeon-adventure/dungeon-db"}} noInteractive />
+<RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-api", targetProject:"@dungeon-adventure/dungeon-db"}} noInteractive readonly />
 
-<RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/inventory", targetProject:"@dungeon-adventure/dungeon-db"}} noInteractive />
+<RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/inventory", targetProject:"@dungeon-adventure/dungeon-db"}} noInteractive readonly />
 
 <Aside type="tip" title="Một lệnh khởi động toàn bộ stack cục bộ">
 Vì `agent-dev` của Story Agent đã phụ thuộc vào `mcp-server-dev` của Inventory MCP server (thông qua kết nối `story → inventory` ở trên), và cả Game API và MCP server hiện phụ thuộc vào `dungeon-db:dev`, việc chạy mục tiêu `dev` của bất kỳ dự án nào sẽ khởi động mọi phụ thuộc mà nó cần theo đúng thứ tự.
@@ -1433,7 +1433,7 @@ Vì `agent-dev` của Story Agent đã phụ thuộc vào `mcp-server-dev` của
 
 Hãy tạo dự án con cuối cùng cho cơ sở hạ tầng CDK.
 
-<RunGenerator generator="ts#infra" requiredParameters={{name:"infra"}} noInteractive />
+<RunGenerator generator="ts#infra" requiredParameters={{name:"infra"}} noInteractive readonly />
 
 Bạn sẽ thấy một số tệp mới xuất hiện/thay đổi trong cây tệp của mình.
 

--- a/docs/src/content/docs/vi/guides/typescript-project.mdx
+++ b/docs/src/content/docs/vi/guides/typescript-project.mdx
@@ -228,9 +228,9 @@ npm không có tính năng catalog, vì vậy các phiên bản được khai b�
 
 ##### Từ chối catalogs
 
-Catalogs được bật theo mặc định. Để tắt chúng, hãy tạo workspace của bạn với `--catalog false`:
+Catalogs được bật theo mặc định. Để tắt chúng, hãy tạo workspace của bạn với `--catalog=false`:
 
-<CreateNxWorkspaceCommand workspace="my-project" extraArgs="--catalog false" />
+<CreateNxWorkspaceCommand workspace="my-project" values={{ catalog: false }} />
 
 Hoặc đặt nó trong `aws-nx-plugin.config.mts` bất kỳ lúc nào:
 

--- a/docs/src/content/docs/zh/get_started/quick-start.mdx
+++ b/docs/src/content/docs/zh/get_started/quick-start.mdx
@@ -28,7 +28,7 @@ import Prompt from '@components/prompt.astro';
 
 使用您选择的包管理器创建一个 <Link path="guides/workspace">Nx 工作空间</Link>,并打开它创建的目录:
 
-<CreateNxWorkspaceCommand workspace="my-project" />
+<CreateNxWorkspaceCommand workspace="my-project" readonly editable={['iac', 'containers']} />
 
 ```sh
 cd my-project
@@ -73,25 +73,25 @@ cd my-project
 
 #### 添加 tRPC API
 
-<RunGenerator generator="ts#api" requiredParameters={{ name: 'demo-api', framework: 'trpc' }} positional={['name']} noInteractive />
+<RunGenerator generator="ts#api" requiredParameters={{ name: 'demo-api', framework: 'trpc' }} positional={['name']} noInteractive readonly />
 
 这将在 `packages/demo-api` 文件夹中创建 API。
 
 #### 添加 React 网站
 
-<RunGenerator generator="ts#website" requiredParameters={{ name: 'demo-website' }} positional={['name']} noInteractive />
+<RunGenerator generator="ts#website" requiredParameters={{ name: 'demo-website' }} positional={['name']} noInteractive readonly />
 
 这将在 `packages/demo-website` 中搭建一个新的 React 网站。
 
 #### 添加 Cognito 身份验证
 
-<RunGenerator generator="ts#website#auth" requiredParameters={{ project: 'demo-website' }} noInteractive />
+<RunGenerator generator="ts#website#auth" requiredParameters={{ project: 'demo-website' }} noInteractive readonly />
 
 这将设置必要的基础设施和 React 代码,以便为您的网站添加 Cognito 身份验证。
 
 #### 连接前端到后端
 
-<RunGenerator generator="connection" requiredParameters={{ sourceProject: 'demo-website', targetProject: 'demo-api' }} noInteractive />
+<RunGenerator generator="connection" requiredParameters={{ sourceProject: 'demo-website', targetProject: 'demo-api' }} noInteractive readonly />
 
 这将配置必要的提供程序,以确保您的网站可以调用您的 tRPC API。
 
@@ -101,12 +101,12 @@ cd my-project
 
 <Infrastructure>
 <Fragment slot="cdk">
-<RunGenerator generator="ts#infra" requiredParameters={{ name: 'infra' }} positional={['name']} noInteractive />
+<RunGenerator generator="ts#infra" requiredParameters={{ name: 'infra' }} positional={['name']} noInteractive readonly />
 
 这将配置一个 CDK 应用程序,您可以使用它在 AWS 上部署基础设施。
 </Fragment>
 <Fragment slot="terraform">
-<RunGenerator generator="terraform#project" requiredParameters={{ name: 'infra' }} positional={['name']} noInteractive />
+<RunGenerator generator="terraform#project" requiredParameters={{ name: 'infra' }} positional={['name']} noInteractive readonly />
 
 这将配置一个 Terraform 项目,您可以使用它在 AWS 上部署基础设施。
 </Fragment>

--- a/docs/src/content/docs/zh/get_started/tutorials/dungeon-game/1.mdx
+++ b/docs/src/content/docs/zh/get_started/tutorials/dungeon-game/1.mdx
@@ -26,7 +26,7 @@ import gameConversationPng from '@assets/game-conversation.png'
 
 要创建一个新的 monorepo，请在您希望的目录中运行以下命令：
 
-<CreateNxWorkspaceCommand workspace="dungeon-adventure" iac="cdk" />
+<CreateNxWorkspaceCommand workspace="dungeon-adventure" iac="cdk" readonly />
 
 :::note[CDK 作为 IaC 提供商]
 我们使用 `--iac=cdk`，因为在本教程中我们将使用 CDK 作为基础设施即代码工具。Nx Plugin for AWS 同样支持 `terraform`。
@@ -72,7 +72,7 @@ import gameConversationPng from '@assets/game-conversation.png'
 
 首先，让我们创建 Game API。为此，请按照以下步骤创建一个名为 `GameApi` 的 tRPC API：
 
-<RunGenerator generator="ts#api" requiredParameters={{ name: "GameApi", framework: "trpc" }} noInteractive />
+<RunGenerator generator="ts#api" requiredParameters={{ name: "GameApi", framework: "trpc" }} noInteractive readonly />
 
 <br />
 
@@ -402,7 +402,7 @@ export class GameApi<
 
 创建一个 Python 项目：
 
-<RunGenerator generator="py#project" requiredParameters={{name:"story"}} noInteractive />
+<RunGenerator generator="py#project" requiredParameters={{name:"story"}} noInteractive readonly />
 
 您将看到文件树中出现一些新文件。
 <details>
@@ -432,7 +432,7 @@ export class GameApi<
 
 使用 `py#agent` 生成器向项目添加 Strands agent：
 
-<RunGenerator generator="py#agent" requiredParameters={{project:"story", auth:"cognito", protocol:"ag-ui"}} noInteractive />
+<RunGenerator generator="py#agent" requiredParameters={{project:"story", auth:"cognito", protocol:"ag-ui"}} noInteractive readonly />
 
 :::note[AG-UI 协议]
 我们选择 `--protocol=ag-ui`，使 agent 使用 [Agent-User Interaction 协议](https://docs.copilotkit.ai/aws-strands/protocol)——这让我们的 React 网站可以通过 [CopilotKit](https://docs.copilotkit.ai/) 直接与其通信，流式传输、工具调用和对话历史均由协议处理，无需手写 HTTP 客户端。
@@ -918,7 +918,7 @@ export class StoryAgent extends Construct implements IGrantable, IConnectable {
 
 首先，我们创建一个 TypeScript 项目：
 
-<RunGenerator generator="ts#project" requiredParameters={{name:"inventory"}} noInteractive />
+<RunGenerator generator="ts#project" requiredParameters={{name:"inventory"}} noInteractive readonly />
 
 这将创建一个空的 TypeScript 项目。
 
@@ -946,7 +946,7 @@ export class StoryAgent extends Construct implements IGrantable, IConnectable {
 
 接下来，我们将向 TypeScript 项目添加一个 MCP 服务器：
 
-<RunGenerator generator="ts#mcp-server" requiredParameters={{project:"inventory"}} noInteractive />
+<RunGenerator generator="ts#mcp-server" requiredParameters={{project:"inventory"}} noInteractive readonly />
 
 这将添加一个 MCP 服务器。
 <details>
@@ -980,7 +980,7 @@ export class StoryAgent extends Construct implements IGrantable, IConnectable {
 
 我们的游戏状态——已保存的游戏和每个玩家的库存——存储在 [Amazon DynamoDB](https://aws.amazon.com/dynamodb/) 中。使用 `ts#dynamodb` 生成器创建一个名为 `DungeonDb` 的 DynamoDB 项目：
 
-<RunGenerator generator="ts#dynamodb" requiredParameters={{name:"DungeonDb"}} noInteractive />
+<RunGenerator generator="ts#dynamodb" requiredParameters={{name:"DungeonDb"}} noInteractive readonly />
 
 :::tip[本地优先开发]
 `ts#dynamodb` 生成器提供了一个 `dev` 目标，在容器中运行 [DynamoDB Local](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html)。结合 `connection` 生成器（我们在下面运行），这意味着**整个游戏可以在您的机器上运行，无需部署**，直到教程结束。
@@ -1032,7 +1032,7 @@ export class StoryAgent extends Construct implements IGrantable, IConnectable {
 
 要创建 UI，请按照以下步骤创建一个名为 `GameUI` 的网站：
 
-<RunGenerator generator="ts#website" requiredParameters={{name:"GameUI", ux:"shadcn"}} noInteractive />
+<RunGenerator generator="ts#website" requiredParameters={{name:"GameUI", ux:"shadcn"}} noInteractive readonly />
 
 :::note[Shadcn UI]
 我们选择 `--ux=shadcn`，使生成的网站使用以 Tailwind 样式化的 [shadcn/ui](https://ui.shadcn.com/) 组件——我们所有的路由代码都使用 `Card`、`Button` 和 `Input` 等 shadcn 原语，`connection` 生成器稍后会连接一个匹配 shadcn 主题的 [CopilotKit](https://docs.copilotkit.ai/) 聊天界面。
@@ -1169,7 +1169,7 @@ function RouteComponent() {
 
 让我们使用以下步骤配置 Game UI，通过 Amazon Cognito 要求经过身份验证的访问：
 
-<RunGenerator generator="ts#website#auth" requiredParameters={{cognitoDomain:"game-ui", project:"@dungeon-adventure/game-ui", allowSignup:true}} noInteractive />
+<RunGenerator generator="ts#website#auth" requiredParameters={{cognitoDomain:"game-ui", project:"@dungeon-adventure/game-ui", allowSignup:true}} noInteractive readonly />
 
 您将看到文件树中出现/更改一些新文件。
 
@@ -1253,7 +1253,7 @@ root &&
 
 让我们配置 Game UI 以连接到我们之前创建的 Game API。
 
-<RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-ui", targetProject:"@dungeon-adventure/game-api"}} noInteractive />
+<RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-ui", targetProject:"@dungeon-adventure/game-api"}} noInteractive readonly />
 
 您将看到文件树中出现/更改一些新文件。
 
@@ -1347,7 +1347,7 @@ root &&
 
 让我们将 Story Agent 连接到 Inventory MCP 服务器，使 agent 能够发现并调用 MCP 服务器的工具。
 
-<RunGenerator generator="connection" requiredParameters={{sourceProject:"story", targetProject:"inventory"}} noInteractive />
+<RunGenerator generator="connection" requiredParameters={{sourceProject:"story", targetProject:"inventory"}} noInteractive readonly />
 
 <details>
 <summary>查看 Story Agent → Inventory MCP 连接文件</summary>
@@ -1387,7 +1387,7 @@ root &&
 
 让我们将 Game UI 连接到 Story Agent。由于 agent 使用 AG-UI 协议，`connection` 生成器会连接 [CopilotKit](https://docs.copilotkit.ai/)：一个主题化的聊天组件和一个准备好渲染的 `@ag-ui/client` `HttpAgent`。
 
-<RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-ui", targetProject:"story"}} noInteractive />
+<RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-ui", targetProject:"story"}} noInteractive readonly />
 
 <details>
 <summary>查看 UI → Story Agent 连接文件</summary>
@@ -1421,9 +1421,9 @@ root &&
 
 Game API 和 Inventory MCP 服务器都读写我们的 DynamoDB 表，因此让我们将它们连接到 `DungeonDb` 项目。`connection` 生成器检测到目标是 `ts#dynamodb` 项目，并将每个源项目的 `dev` 目标配置为自动启动 DynamoDB Local。
 
-<RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-api", targetProject:"@dungeon-adventure/dungeon-db"}} noInteractive />
+<RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/game-api", targetProject:"@dungeon-adventure/dungeon-db"}} noInteractive readonly />
 
-<RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/inventory", targetProject:"@dungeon-adventure/dungeon-db"}} noInteractive />
+<RunGenerator generator="connection" requiredParameters={{sourceProject:"@dungeon-adventure/inventory", targetProject:"@dungeon-adventure/dungeon-db"}} noInteractive readonly />
 
 <Aside type="tip" title="一条命令启动整个本地堆栈">
 因为 Story Agent 的 `agent-dev` 已经依赖于 Inventory MCP 服务器的 `mcp-server-dev`（通过上面的 `story → inventory` 连接），而 Game API 和 MCP 服务器现在都依赖于 `dungeon-db:dev`，运行任何一个项目的 `dev` 目标都会按正确顺序启动它所需的每个依赖项。
@@ -1433,7 +1433,7 @@ Game API 和 Inventory MCP 服务器都读写我们的 DynamoDB 表，因此让�
 
 让我们为 CDK 基础设施创建最终的子项目。
 
-<RunGenerator generator="ts#infra" requiredParameters={{name:"infra"}} noInteractive />
+<RunGenerator generator="ts#infra" requiredParameters={{name:"infra"}} noInteractive readonly />
 
 您将看到文件树中出现/更改一些新文件。
 

--- a/docs/src/content/docs/zh/guides/typescript-project.mdx
+++ b/docs/src/content/docs/zh/guides/typescript-project.mdx
@@ -228,9 +228,9 @@ npm 没有目录功能，因此版本直接在每个 `package.json` 中声明。
 
 ##### 选择退出目录
 
-目录默认启用。要关闭它们，请使用 `--catalog false` 创建工作区：
+目录默认启用。要关闭它们，请使用 `--catalog=false` 创建工作区：
 
-<CreateNxWorkspaceCommand workspace="my-project" extraArgs="--catalog false" />
+<CreateNxWorkspaceCommand workspace="my-project" values={{ catalog: false }} />
 
 或随时在 `aws-nx-plugin.config.mts` 中设置：
 

--- a/docs/src/lib/command-card-strings.ts
+++ b/docs/src/lib/command-card-strings.ts
@@ -1,0 +1,133 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * The chrome shared by the command cards, in each language the docs ship in.
+ *
+ * Kept here rather than in either card so the run-generator and create-workspace
+ * cards label the same controls the same way.
+ */
+const STRINGS = {
+  runTitle: {
+    en: 'Run this generator',
+    jp: 'このジェネレーターを実行',
+    ko: '이 제너레이터 실행',
+    fr: 'Exécuter ce générateur',
+    it: 'Esegui questo generatore',
+    es: 'Ejecute este generador',
+    pt: 'Execute este gerador',
+    zh: '运行此生成器',
+    vi: 'Chạy generator này',
+  },
+  workspaceTitle: {
+    en: 'Create your workspace',
+    jp: 'ワークスペースを作成',
+    ko: '워크스페이스 생성',
+    fr: 'Créez votre espace de travail',
+    it: 'Crea il tuo workspace',
+    es: 'Cree su espacio de trabajo',
+    pt: 'Crie seu workspace',
+    zh: '创建工作区',
+    vi: 'Tạo workspace của bạn',
+  },
+  build: {
+    en: 'Build your command',
+    jp: 'コマンドを組み立てる',
+    ko: '명령 구성하기',
+    fr: 'Composez votre commande',
+    it: 'Componi il tuo comando',
+    es: 'Construya su comando',
+    pt: 'Monte seu comando',
+    zh: '构建你的命令',
+    vi: 'Xây dựng lệnh của bạn',
+  },
+  pinned: {
+    en: 'Options for this step',
+    jp: 'このステップのオプション',
+    ko: '이 단계의 옵션',
+    fr: 'Options de cette étape',
+    it: 'Opzioni di questo passaggio',
+    es: 'Opciones de este paso',
+    pt: 'Opções desta etapa',
+    zh: '此步骤的选项',
+    vi: 'Tùy chọn cho bước này',
+  },
+  copyCommand: {
+    en: 'Copy the command',
+    jp: 'コマンドをコピー',
+    ko: '명령 복사',
+    fr: 'Copier la commande',
+    it: 'Copia il comando',
+    es: 'Copiar el comando',
+    pt: 'Copiar o comando',
+    zh: '复制命令',
+    vi: 'Sao chép lệnh',
+  },
+  reset: {
+    en: 'Reset',
+    jp: 'リセット',
+    ko: '초기화',
+    fr: 'Réinitialiser',
+    it: 'Reimposta',
+    es: 'Restablecer',
+    pt: 'Redefinir',
+    zh: '重置',
+    vi: 'Đặt lại',
+  },
+  required: {
+    en: 'Required',
+    jp: '必須',
+    ko: '필수',
+    fr: 'Requis',
+    it: 'Obbligatorio',
+    es: 'Requerido',
+    pt: 'Obrigatório',
+    zh: '必需',
+    vi: 'Bắt buộc',
+  },
+  showAll: {
+    en: 'Show all',
+    jp: 'すべて表示',
+    ko: '전체 보기',
+    fr: 'Tout afficher',
+    it: 'Mostra tutti',
+    es: 'Mostrar todo',
+    pt: 'Mostrar tudo',
+    zh: '显示全部',
+    vi: 'Hiện tất cả',
+  },
+  showFewer: {
+    en: 'Show fewer',
+    jp: '折りたたむ',
+    ko: '접기',
+    fr: 'Réduire',
+    it: 'Mostra meno',
+    es: 'Mostrar menos',
+    pt: 'Mostrar menos',
+    zh: '收起',
+    vi: 'Thu gọn',
+  },
+  dryRunSummary: {
+    en: 'You can also perform a dry-run to see what files would be changed',
+    jp: '変更されるファイルを確認するためにドライランを実行することもできます',
+    ko: '어떤 파일이 변경될지 확인하기 위해 드라이 런을 수행할 수도 있습니다',
+    fr: 'Vous pouvez également effectuer une simulation pour voir quels fichiers seraient modifiés',
+    it: 'Puoi anche eseguire una prova per vedere quali file verrebbero modificati',
+    es: 'También puede realizar una ejecución en seco para ver qué archivos se cambiarían',
+    pt: 'Você também pode realizar uma execução simulada para ver quais arquivos seriam alterados',
+    zh: '您还可以执行试运行以查看哪些文件会被更改',
+    vi: 'Bạn cũng có thể thực hiện chạy thử để xem những tệp nào sẽ bị thay đổi',
+  },
+} as const;
+
+export type CommandCardStrings = Record<keyof typeof STRINGS, string>;
+
+export const commandCardStrings = (locale: string): CommandCardStrings =>
+  Object.fromEntries(
+    Object.entries(STRINGS).map(([key, translations]) => [
+      key,
+      (translations as Record<string, string>)[locale] ?? translations.en,
+    ]),
+  ) as CommandCardStrings;

--- a/docs/src/lib/command-card.spec.ts
+++ b/docs/src/lib/command-card.spec.ts
@@ -1,0 +1,256 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { describe, expect, it } from 'vitest';
+import { buildCreateNxWorkspaceCommand } from '../../../packages/nx-plugin/src/utils/commands';
+import {
+  buildCommandTokens,
+  type CardConfig,
+  type CommandRequest,
+  emittedValues,
+  type GeneratorCardConfig,
+  quoteValue,
+  renderCommand,
+  type WorkspaceCardConfig,
+} from './command-card';
+import { readGeneratorOptions } from './generator-options';
+
+const command = (config: CardConfig, request: CommandRequest) =>
+  renderCommand(buildCommandTokens(config, request));
+
+const generatorCard = (
+  overrides: Partial<GeneratorCardConfig> = {},
+): GeneratorCardConfig => ({
+  kind: 'generator',
+  namespace: '@aws/nx-plugin',
+  generator: 'ts#lambda-function',
+  positional: [],
+  order: [],
+  prescribed: [],
+  options: [],
+  noInteractive: false,
+  ...overrides,
+});
+
+const workspaceCard = (
+  overrides: Partial<WorkspaceCardConfig> = {},
+): WorkspaceCardConfig => ({
+  kind: 'workspace',
+  positional: ['workspace'],
+  order: ['workspace', 'iac', 'module'],
+  prescribed: [],
+  options: [],
+  ...overrides,
+});
+
+describe('generator options', () => {
+  const schema = {
+    properties: {
+      later: { type: 'string' },
+      infra: {
+        type: 'string',
+        enum: ['lambda', 'none'],
+        default: 'lambda',
+        'x-priority': 'important',
+      },
+      hidden: { type: 'string', 'x-priority': 'internal' },
+      name: { type: 'string' },
+      install: { type: 'boolean', default: true },
+      count: { type: 'number' },
+    },
+    required: ['name'],
+  };
+
+  it('should order required options, then important, then the rest', () => {
+    expect(readGeneratorOptions(schema).map((o) => o.key)).toEqual([
+      'name',
+      'infra',
+      'later',
+      'install',
+      'count',
+      'hidden',
+    ]);
+  });
+
+  it('should read the control each option is entered with', () => {
+    const controls = Object.fromEntries(
+      readGeneratorOptions(schema).map((o) => [o.key, o.control]),
+    );
+
+    expect(controls).toEqual({
+      name: 'text',
+      infra: 'enum',
+      later: 'text',
+      install: 'boolean',
+      count: 'number',
+      hidden: 'text',
+    });
+  });
+
+  it('should have no options without a schema', () => {
+    expect(readGeneratorOptions(undefined)).toEqual([]);
+  });
+});
+
+describe('generator command', () => {
+  it('should build the bare command when no option has a value', () => {
+    expect(
+      command(generatorCard(), { packageManager: 'pnpm', values: {} }),
+    ).toBe('pnpm nx g @aws/nx-plugin:ts#lambda-function');
+  });
+
+  it('should use each package manager’s exec prefix', () => {
+    expect(
+      command(generatorCard(), { packageManager: 'npm', values: {} }),
+    ).toBe('npx nx g @aws/nx-plugin:ts#lambda-function');
+    expect(
+      command(generatorCard(), { packageManager: 'bun', values: {} }),
+    ).toBe('bunx nx g @aws/nx-plugin:ts#lambda-function');
+  });
+
+  it('should pass positional options as bare arguments, in order', () => {
+    expect(
+      command(
+        generatorCard({
+          generator: 'ts#api',
+          positional: ['name'],
+          order: ['name', 'framework'],
+          noInteractive: true,
+        }),
+        {
+          packageManager: 'pnpm',
+          values: { name: 'demo-api', framework: 'trpc' },
+        },
+      ),
+    ).toBe(
+      'pnpm nx g @aws/nx-plugin:ts#api demo-api --framework=trpc --no-interactive',
+    );
+  });
+
+  it('should emit the remaining options in schema order', () => {
+    expect(
+      command(generatorCard({ order: ['project', 'name'] }), {
+        packageManager: 'pnpm',
+        values: { name: 'MyFunction', project: 'my-lib' },
+      }),
+    ).toBe(
+      'pnpm nx g @aws/nx-plugin:ts#lambda-function --project=my-lib --name=MyFunction',
+    );
+  });
+
+  it('should leave options the reader has not filled in off the command', () => {
+    expect(
+      command(generatorCard(), {
+        packageManager: 'pnpm',
+        values: { name: '', project: 'my-lib' },
+      }),
+    ).toBe('pnpm nx g @aws/nx-plugin:ts#lambda-function --project=my-lib');
+  });
+
+  it('should still pass an option the schema does not declare', () => {
+    expect(
+      command(generatorCard({ order: ['name'] }), {
+        packageManager: 'pnpm',
+        values: { extra: 'yes' },
+      }),
+    ).toBe('pnpm nx g @aws/nx-plugin:ts#lambda-function --extra=yes');
+  });
+
+  it('should append the dry run flag last', () => {
+    expect(
+      command(generatorCard({ noInteractive: true }), {
+        packageManager: 'pnpm',
+        values: { name: 'MyFunction' },
+        dryRun: true,
+      }),
+    ).toBe(
+      'pnpm nx g @aws/nx-plugin:ts#lambda-function --name=MyFunction --no-interactive --dry-run',
+    );
+  });
+
+  it('should quote a value the shell would otherwise split', () => {
+    expect(quoteValue('MyFunction')).toBe('MyFunction');
+    expect(quoteValue('@scope/pkg')).toBe('@scope/pkg');
+    expect(quoteValue('Adds a procedure')).toBe("'Adds a procedure'");
+    expect(quoteValue("it's")).toBe(`'it'\\''s'`);
+  });
+});
+
+describe('create workspace command', () => {
+  it.each(['pnpm', 'yarn', 'npm', 'bun'])(
+    'should render what the MCP server renders for %s',
+    (packageManager) => {
+      expect(
+        command(workspaceCard(), {
+          packageManager,
+          values: { workspace: 'my-project' },
+        }),
+      ).toBe(buildCreateNxWorkspaceCommand(packageManager, 'my-project'));
+    },
+  );
+
+  it('should match the MCP server with an iac provider, tag and module', () => {
+    expect(
+      command(workspaceCard({ tag: '1.0.0' }), {
+        packageManager: 'npm',
+        values: { workspace: 'my-project', iac: 'cdk', module: 'cjs' },
+      }),
+    ).toBe(
+      buildCreateNxWorkspaceCommand('npm', 'my-project', 'cdk', '1.0.0', 'cjs'),
+    );
+  });
+
+  it('should append extra arguments verbatim', () => {
+    expect(
+      command(workspaceCard({ extraArgs: '--catalog false' }), {
+        packageManager: 'pnpm',
+        values: { workspace: 'my-project' },
+      }),
+    ).toBe('pnpm create @aws/nx-workspace my-project --catalog false');
+  });
+
+  it('should pass the preset options the reader picks', () => {
+    expect(
+      command(workspaceCard({ order: ['workspace', 'iac', 'containers'] }), {
+        packageManager: 'pnpm',
+        values: {
+          workspace: 'my-project',
+          containers: 'finch',
+          iac: 'terraform',
+        },
+      }),
+    ).toBe(
+      'pnpm create @aws/nx-workspace my-project --iac=terraform --containers=finch',
+    );
+  });
+});
+
+describe('emitted values', () => {
+  const options = [
+    { key: 'install', control: 'boolean' as const, default: 'true' },
+    { key: 'allowSignup', control: 'boolean' as const, default: 'false' },
+    { key: 'name', control: 'text' as const },
+  ];
+
+  it('should pass a boolean only where it differs from the generator default', () => {
+    expect(
+      emittedValues(
+        { install: 'true', allowSignup: 'true', name: 'demo' },
+        options,
+      ),
+    ).toEqual({ allowSignup: 'true', name: 'demo' });
+  });
+
+  it('should pass a cleared boolean as false rather than dropping it', () => {
+    expect(emittedValues({ install: 'false' }, options)).toEqual({
+      install: 'false',
+    });
+  });
+
+  it('should drop empty values', () => {
+    expect(emittedValues({ name: '', allowSignup: 'false' }, options)).toEqual(
+      {},
+    );
+  });
+});

--- a/docs/src/lib/command-card.ts
+++ b/docs/src/lib/command-card.ts
@@ -1,0 +1,214 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import {
+  buildPackageManagerExecCommand,
+  PACKAGE_MANAGER_COMMANDS,
+} from '../../../packages/nx-plugin/src/utils/commands';
+import type { GeneratorOption, OptionControl } from './generator-options';
+
+/**
+ * The command a card shows, assembled from the option values the reader entered.
+ *
+ * Shared by the cards' server render and the script that rebuilds the command as
+ * the reader types, so the first paint and every keystroke agree. Two commands
+ * are built this way: `nx g <generator>` and the `create @aws/nx-workspace` that
+ * starts a workspace off.
+ */
+
+/** The package managers the command is offered for, in the order the tabs show them. */
+export const PACKAGE_MANAGERS = [
+  { label: 'pnpm', icon: 'pnpm' },
+  { label: 'yarn', icon: 'seti:yarn' },
+  { label: 'npm', icon: 'seti:npm' },
+  { label: 'bun', icon: 'bun' },
+] as const;
+
+/** A piece of the command, tagged so the terminal block can colour it. */
+export interface CommandToken {
+  kind: 'exec' | 'subcommand' | 'target' | 'argument' | 'option' | 'flag';
+  /** The whole token, as it appears on the command line. */
+  text: string;
+  /** The option an argument or option token carries a value for. */
+  key?: string;
+  /** An option token's `--key=` and value, coloured apart from each other. */
+  label?: string;
+  value?: string;
+}
+
+/** What a card needs to rebuild its command, serialised onto the card element. */
+export type CardConfig = GeneratorCardConfig | WorkspaceCardConfig;
+
+interface BaseCardConfig {
+  /** Options passed as bare arguments, in the order they appear. */
+  positional: string[];
+  /** The order the remaining options are emitted in. */
+  order: string[];
+  /** The options the page pins, whose controls a reader can't drive. */
+  prescribed: string[];
+  options: Pick<GeneratorOption, 'key' | 'control' | 'default'>[];
+}
+
+export interface GeneratorCardConfig extends BaseCardConfig {
+  kind: 'generator';
+  namespace: string;
+  generator: string;
+  noInteractive: boolean;
+}
+
+export interface WorkspaceCardConfig extends BaseCardConfig {
+  kind: 'workspace';
+  /** A version tag to install the create package at, e.g. `1.0.0`. */
+  tag?: string;
+  /** Anything the schema doesn't cover, appended to the command verbatim. */
+  extraArgs?: string;
+}
+
+export interface CommandRequest {
+  packageManager: string;
+  /** Values by option name. An empty value is left off the command. */
+  values: Record<string, string>;
+  dryRun?: boolean;
+}
+
+/**
+ * Quote a value the shell would otherwise split or interpret, so a description or
+ * a path with spaces stays one argument.
+ */
+export const quoteValue = (value: string) =>
+  /^[\w.@:/+#,=-]+$/.test(value) ? value : `'${value.replace(/'/g, `'\\''`)}'`;
+
+/**
+ * The value an option contributes to the command, or undefined when it
+ * contributes nothing.
+ *
+ * A boolean is only passed when it differs from the generator's own default —
+ * ticking a box that is on by default should leave the command alone, and
+ * clearing one should pass `=false` rather than nothing.
+ */
+export const emittedValue = (
+  value: string | undefined,
+  option?: { control: OptionControl; default?: string },
+): string | undefined => {
+  if (value === undefined || value === '') return undefined;
+  if (option?.control === 'boolean') {
+    const fallback = option.default ?? 'false';
+    return value === fallback ? undefined : value;
+  }
+  return value;
+};
+
+/** The values the reader has entered, reduced to what the command carries. */
+export const emittedValues = (
+  entered: Record<string, string>,
+  options: readonly {
+    key: string;
+    control: OptionControl;
+    default?: string;
+  }[] = [],
+): Record<string, string> => {
+  const byKey = new Map(options.map((option) => [option.key, option]));
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(entered)) {
+    const emitted = emittedValue(value, byKey.get(key));
+    if (emitted !== undefined) out[key] = emitted;
+  }
+  return out;
+};
+
+const argumentTokens = (
+  config: CardConfig,
+  values: Record<string, string>,
+): CommandToken[] =>
+  config.positional.flatMap((key) => {
+    const value = values[key];
+    return value === undefined || value === ''
+      ? []
+      : [{ kind: 'argument' as const, key, text: quoteValue(value) }];
+  });
+
+const optionTokens = (
+  config: CardConfig,
+  values: Record<string, string>,
+): CommandToken[] => {
+  // Options the schema declares come in its order; anything else a page passes
+  // follows, so an option the schema doesn't declare still makes the command.
+  const keys = [
+    ...config.order,
+    ...Object.keys(values).filter((key) => !config.order.includes(key)),
+  ].filter((key) => !config.positional.includes(key));
+
+  return keys.flatMap((key) => {
+    const value = values[key];
+    if (value === undefined || value === '') return [];
+    const label = `--${key}=`;
+    const quoted = quoteValue(value);
+    return [
+      {
+        kind: 'option' as const,
+        key,
+        label,
+        value: quoted,
+        text: `${label}${quoted}`,
+      },
+    ];
+  });
+};
+
+export const buildCommandTokens = (
+  config: CardConfig,
+  { packageManager, values, dryRun }: CommandRequest,
+): CommandToken[] => {
+  const tokens: CommandToken[] = [];
+
+  if (config.kind === 'generator') {
+    tokens.push(
+      {
+        kind: 'exec',
+        text: buildPackageManagerExecCommand(packageManager, 'nx'),
+      },
+      { kind: 'subcommand', text: 'g' },
+      { kind: 'target', text: `${config.namespace}:${config.generator}` },
+    );
+  } else {
+    // Mirrors buildCreateNxWorkspaceCommand, which the MCP server renders the
+    // same command with — command-card.spec.ts holds the two to the same string.
+    tokens.push(
+      {
+        kind: 'exec',
+        text:
+          PACKAGE_MANAGER_COMMANDS[packageManager]?.create ??
+          `${packageManager} create`,
+      },
+      {
+        kind: 'target',
+        text: config.tag
+          ? `@aws/nx-workspace@${config.tag}`
+          : '@aws/nx-workspace',
+      },
+    );
+    // npm needs `--` before any flags, or it reads them as npm config.
+    if (packageManager === 'npm') {
+      tokens.push({ kind: 'subcommand', text: '--' });
+    }
+  }
+
+  tokens.push(
+    ...argumentTokens(config, values),
+    ...optionTokens(config, values),
+  );
+
+  if (config.kind === 'generator' && config.noInteractive) {
+    tokens.push({ kind: 'flag', text: '--no-interactive' });
+  }
+  if (config.kind === 'workspace' && config.extraArgs) {
+    tokens.push({ kind: 'flag', text: config.extraArgs });
+  }
+  if (dryRun) tokens.push({ kind: 'flag', text: '--dry-run' });
+
+  return tokens;
+};
+
+export const renderCommand = (tokens: readonly CommandToken[]) =>
+  tokens.map((token) => token.text).join(' ');

--- a/docs/src/lib/generator-options.ts
+++ b/docs/src/lib/generator-options.ts
@@ -1,0 +1,83 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * A generator's options, read off its schema in the order a reader meets them.
+ *
+ * Shared by the options reference panel and the run-generator command builder, so
+ * a generator's options are listed and offered in the same order by both.
+ */
+
+/** A JSON-schema property, narrowed to the parts the docs render. */
+export interface SchemaProperty {
+  type?: string;
+  enum?: unknown[];
+  default?: unknown;
+  description?: string;
+  'x-priority'?: string;
+}
+
+export interface GeneratorSchema {
+  properties?: Record<string, SchemaProperty>;
+  required?: string[];
+}
+
+/** How a value is entered for an option. */
+export type OptionControl = 'enum' | 'boolean' | 'number' | 'text';
+
+export interface GeneratorOption {
+  key: string;
+  control: OptionControl;
+  /** The type as documented: `enum` for a fixed set, else the JSON type. */
+  type: string;
+  /** The values an enum option accepts, in schema order. */
+  values: string[];
+  default?: string;
+  required: boolean;
+  description?: string;
+}
+
+/**
+ * Ordering buckets: what the reader has to supply, then what the generator marks
+ * important, then the rest, with anything marked internal last.
+ */
+const RANKS: Record<string, number> = { important: 1, normal: 2, internal: 3 };
+const REQUIRED_RANK = 0;
+
+const isEnum = (property: SchemaProperty) =>
+  Array.isArray(property.enum) && property.enum.length > 0;
+
+const controlFor = (property: SchemaProperty): OptionControl => {
+  if (isEnum(property)) return 'enum';
+  if (property.type === 'boolean') return 'boolean';
+  if (property.type === 'number' || property.type === 'integer')
+    return 'number';
+  return 'text';
+};
+
+export const readGeneratorOptions = (
+  schema: GeneratorSchema | undefined,
+): GeneratorOption[] => {
+  const required = new Set(schema?.required ?? []);
+  return (
+    Object.entries(schema?.properties ?? {})
+      .map(([key, property]) => ({
+        key,
+        control: controlFor(property),
+        type: isEnum(property) ? 'enum' : (property.type ?? 'string'),
+        values: (property.enum ?? []).map(String),
+        default:
+          property.default === undefined ? undefined : String(property.default),
+        required: required.has(key),
+        description: property.description,
+        rank: required.has(key)
+          ? REQUIRED_RANK
+          : (RANKS[property['x-priority'] ?? 'normal'] ?? RANKS.normal),
+      }))
+      // Stable, so schema order breaks ties within a bucket.
+      .sort((a, b) => a.rank - b.rank)
+      .map(({ rank: _rank, ...option }) => option)
+  );
+};

--- a/docs/src/styles/custom.css
+++ b/docs/src/styles/custom.css
@@ -642,6 +642,478 @@ p.badges > a {
 }
 
 /* ============================================================
+ * Command card — the run-generator and create-workspace commands
+ * ============================================================ */
+/* The one thing a reader came for, so it carries the accent rather than the
+   hairline the reference panels use, and a soft bloom lifts it off the page. */
+.command-card {
+  position: relative;
+  isolation: isolate;
+  margin: 1.25rem 0 1.75rem;
+  border: 1px solid color-mix(in oklab, var(--sl-color-accent) 45%, transparent);
+  border-radius: 0.6rem;
+  background: var(--sl-color-black);
+}
+
+.command-card::before {
+  content: '';
+  position: absolute;
+  z-index: -1;
+  inset: -1px;
+  border-radius: inherit;
+  background: radial-gradient(
+    80% 120% at 0% 0%,
+    color-mix(in oklab, var(--sl-color-accent) 22%, transparent),
+    transparent 60%
+  );
+  pointer-events: none;
+}
+
+.command-card-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.35rem 0.6rem;
+  margin: 0;
+  padding: 0.6rem 0.85rem;
+  border-bottom: 1px solid var(--sl-color-hairline);
+}
+
+/* The terminal glyph, framed like the landing page's card icons. */
+.command-card-mark {
+  display: inline-flex;
+  flex: none;
+  padding: 0.25rem;
+  border: 1px solid var(--sl-color-accent);
+  border-radius: 0.4rem;
+  background: var(--sl-color-accent-low);
+  color: var(--sl-color-text-accent);
+}
+
+.command-card-mark svg {
+  width: 1rem;
+  height: 1rem;
+}
+
+.command-card-title {
+  font-size: 0.95rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--sl-color-white);
+}
+
+.command-card-target {
+  margin-left: auto;
+  font-family: var(--__sl-font-mono), ui-monospace, monospace;
+  font-size: 0.72rem;
+  color: var(--sl-color-gray-3);
+}
+
+/* The tab bars sit inside the card, so they take the card's padding rather than
+   the prose margins Starlight gives them. */
+.command-card > starlight-tabs {
+  display: block;
+  padding: 0 0.85rem;
+}
+
+.command-card [role='tablist'] {
+  border-bottom-width: 1px;
+}
+
+.command-card .tablist-wrapper ~ [role='tabpanel'] {
+  margin-top: 0.75rem;
+}
+
+/* The command itself: a prompt line that rewrites as the options change. */
+.command-card-terminal {
+  position: relative;
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  margin-bottom: 0.85rem;
+  padding: 0.7rem 0.8rem;
+  border: 1px solid var(--sl-color-gray-5);
+  border-radius: 0.45rem;
+  background: var(--sl-color-gray-6);
+}
+
+.command-card-command {
+  flex: 1;
+  min-width: 0;
+  font-family: var(--__sl-font-mono), ui-monospace, monospace;
+  font-size: 0.82rem;
+  line-height: 1.7;
+  /* Wrapped continuations sit in from the prompt, the way a shell shows them. */
+  padding-left: 1.1rem;
+  text-indent: -1.1rem;
+  color: var(--sl-color-white);
+  /* A token too long for the line scrolls inside the block rather than breaking
+     across lines or widening the page. */
+  overflow-x: auto;
+  overscroll-behavior-x: contain;
+}
+
+/* Tokens stay whole, so the command only wraps where a shell would break it. */
+.command-card-token {
+  white-space: nowrap;
+}
+
+.command-card-prompt {
+  color: var(--sl-color-text-accent);
+  user-select: none;
+}
+
+.command-card-token.is-exec {
+  color: var(--sl-color-white);
+  font-weight: 600;
+}
+
+.command-card-token.is-subcommand {
+  color: var(--sl-color-gray-3);
+}
+
+.command-card-token.is-target {
+  color: var(--sl-color-text-accent);
+  font-weight: 600;
+}
+
+.command-card-token.is-flag,
+.command-card-token-label {
+  color: var(--sl-color-gray-3);
+}
+
+.command-card-token.is-argument,
+.command-card-token-value {
+  color: var(--sl-color-text-accent);
+}
+
+/* A flag the reader has just added arrives rather than blinking into place. */
+.command-card-token.is-new {
+  animation: command-card-token-in 180ms ease-out;
+}
+
+@keyframes command-card-token-in {
+  from {
+    opacity: 0;
+    transform: translateY(-0.15em);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .command-card-token.is-new {
+    animation: none;
+  }
+}
+
+.command-card-copy {
+  display: inline-flex;
+  flex: none;
+  align-items: center;
+  justify-content: center;
+  width: 1.7rem;
+  height: 1.7rem;
+  padding: 0;
+  border: 1px solid var(--sl-color-gray-5);
+  border-radius: 9999px;
+  background: var(--sl-color-black);
+  color: var(--sl-color-gray-3);
+  cursor: pointer;
+  transition:
+    color 150ms ease,
+    border-color 150ms ease;
+}
+
+.command-card-copy:hover {
+  border-color: var(--sl-color-accent);
+  color: var(--sl-color-white);
+}
+
+.command-card-copy-icon {
+  width: 0.85rem;
+  height: 0.85rem;
+}
+
+.command-card-copy-icon--check,
+.command-card-copy.is-copied .command-card-copy-icon--copy {
+  display: none;
+}
+
+.command-card-copy.is-copied .command-card-copy-icon--check {
+  display: inline;
+  color: var(--sl-color-text-accent);
+}
+
+/* The controls that write the command. */
+.command-card-builder {
+  border-top: 1px solid var(--sl-color-hairline);
+}
+
+/* The whole section opens and closes from its own heading, so the controls are
+   there to reach for without filling the page when they aren't wanted. */
+.command-card-builder-summary {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.35rem 0.6rem;
+  padding: 0.6rem 0.85rem;
+  font-size: 0.78rem;
+  cursor: pointer;
+  list-style: none;
+  transition: background-color 150ms ease;
+}
+
+.command-card-builder-summary::-webkit-details-marker {
+  display: none;
+}
+
+.command-card-builder-summary:hover {
+  background: var(--sl-color-gray-6);
+}
+
+.command-card-builder-summary:focus-visible {
+  outline: 2px solid var(--sl-color-accent);
+  outline-offset: -2px;
+}
+
+/* Points along when closed, down when open — the section's own state. */
+.command-card-chevron {
+  width: 0.75rem;
+  height: 0.75rem;
+  flex: none;
+  color: var(--sl-color-text-accent);
+  transition: transform 150ms ease;
+}
+
+.command-card-builder[open] .command-card-chevron {
+  transform: rotate(90deg);
+}
+
+.command-card-builder-title {
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: var(--sl-color-text-accent);
+}
+
+.command-card-builder-count {
+  padding: 0.02rem 0.35rem;
+  border: 1px solid var(--sl-color-hairline);
+  border-radius: 9999px;
+  font-family: var(--__sl-font-mono), ui-monospace, monospace;
+  font-size: 0.66rem;
+  color: var(--sl-color-gray-3);
+}
+
+.command-card-dry-run,
+.command-card-check {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  cursor: pointer;
+}
+
+.command-card-dry-run code,
+.command-card-check span {
+  font-family: var(--__sl-font-mono), ui-monospace, monospace;
+  font-size: 0.72rem;
+  color: var(--sl-color-gray-2);
+}
+
+.command-card-dry-run input,
+.command-card-check input {
+  width: 0.85rem;
+  height: 0.85rem;
+  margin: 0;
+  accent-color: var(--sl-color-accent);
+  cursor: pointer;
+}
+
+.command-card-dry-run code {
+  white-space: nowrap;
+}
+
+/* The dry-run switch, with the reason to reach for it beside it. */
+.command-card-footer {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.25rem 0.6rem;
+  margin: 0;
+  padding: 0.6rem 0.85rem;
+  border-top: 1px solid var(--sl-color-hairline);
+  font-size: 0.75rem;
+}
+
+.command-card-dry-run-help {
+  color: var(--sl-color-gray-3);
+}
+
+.command-card-reset {
+  margin-left: auto;
+  padding: 0;
+  border: none;
+  background: transparent;
+  font-size: 0.75rem;
+  color: var(--sl-color-text-accent);
+  cursor: pointer;
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 0.25em;
+}
+
+.command-card-reset[hidden] {
+  display: none;
+}
+
+/* Sized rather than counted, so the fields fall to one column as the page
+   narrows. */
+.command-card-fields {
+  padding: 0 0.85rem 0.85rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr));
+  gap: 0.6rem 1rem;
+}
+
+.command-card-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  min-width: 0;
+}
+
+.command-card-field-head {
+  display: flex;
+  align-items: baseline;
+  gap: 0.4rem;
+  margin: 0;
+}
+
+.command-card-field-name {
+  font-family: var(--__sl-font-mono), ui-monospace, monospace;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--sl-color-white);
+  cursor: pointer;
+}
+
+.command-card-field-required {
+  font-size: 0.6rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--sl-color-text-accent);
+}
+
+.command-card-input {
+  width: 100%;
+  padding: 0.25rem 0.5rem;
+  border: 1px solid var(--sl-color-gray-5);
+  border-radius: 0.35rem;
+  background: var(--sl-color-gray-6);
+  font-family: var(--__sl-font-mono), ui-monospace, monospace;
+  font-size: 0.78rem;
+  color: var(--sl-color-white);
+}
+
+.command-card-input::placeholder {
+  color: var(--sl-color-gray-4);
+}
+
+.command-card-input:focus-visible {
+  outline: none;
+  border-color: var(--sl-color-accent);
+  box-shadow: 0 0 0 3px
+    color-mix(in oklab, var(--sl-color-accent) 30%, transparent);
+}
+
+.command-card-pills {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.3rem;
+}
+
+.command-card-pill {
+  display: inline-flex;
+  padding: 0.1rem 0.45rem;
+  border: 1px solid var(--sl-color-hairline);
+  border-radius: 9999px;
+  background: var(--sl-color-gray-6);
+  font-family: var(--__sl-font-mono), ui-monospace, monospace;
+  font-size: 0.7rem;
+  line-height: 1.6;
+  color: var(--sl-color-gray-2);
+  cursor: pointer;
+  transition:
+    color 150ms ease,
+    border-color 150ms ease,
+    background-color 150ms ease;
+}
+
+.command-card-pill:hover {
+  border-color: var(--sl-color-accent);
+  color: var(--sl-color-white);
+}
+
+.command-card-pill:focus-visible {
+  outline: none;
+  border-color: var(--sl-color-accent);
+  box-shadow: 0 0 0 3px
+    color-mix(in oklab, var(--sl-color-accent) 30%, transparent);
+}
+
+.command-card-pill[aria-pressed='true'] {
+  border-color: var(--sl-color-accent);
+  background: var(--sl-color-accent-low);
+  font-weight: 600;
+  color: var(--sl-color-text-accent);
+}
+
+/* Long enums show a handful, matching the options reference panel. */
+.command-card-pill.is-overflow {
+  display: none;
+}
+
+.command-card-pills.is-expanded .command-card-pill.is-overflow,
+.command-card-pill.is-overflow[aria-pressed='true'] {
+  display: inline-flex;
+}
+
+.command-card-more-values {
+  padding: 0;
+  border: none;
+  background: transparent;
+  font-size: 0.68rem;
+  color: var(--sl-color-text-accent);
+  cursor: pointer;
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 0.25em;
+}
+
+/* A locked option belongs to a walkthrough step: it states its value rather than
+   inviting a change. */
+.command-card-field.is-locked .command-card-input,
+.command-card-field.is-locked .command-card-pill,
+.command-card-field.is-locked .command-card-check input {
+  cursor: default;
+}
+
+.command-card-field.is-locked .command-card-input {
+  border-style: dashed;
+  color: var(--sl-color-gray-2);
+}
+
+.command-card-field.is-locked .command-card-pill:hover {
+  border-color: var(--sl-color-hairline);
+  color: var(--sl-color-gray-2);
+}
+
+.command-card-field.is-locked .command-card-pill[aria-pressed='true']:hover {
+  border-color: var(--sl-color-accent);
+  color: var(--sl-color-text-accent);
+}
+
+/* ============================================================
  * Generator options — the reference panel on each guide
  * ============================================================ */
 /* A framed list rather than a full-width table: the options are reference


### PR DESCRIPTION
### Reason for this change

The command that runs a generator is what a reader comes to a guide for, but it rendered as a plain code block among the prose — no more prominent than any other snippet. And it was fixed: the only way to adapt it to your workspace was to copy it and edit the flags by hand, cross-referencing the options table further down the page.

The create-workspace command had the same problem, and neither command had any relationship with the option filter bar at the top of the guide, even though all three are views of the same set of generator options.

### Description of changes

Both commands now share a **command card** (`command-card.astro`, with `command-card-terminals.astro` for the command itself and `command-card-field.astro` for one option's control):

- **A card that reads as the focus of the page** — accent border with a soft bloom, a terminal glyph in the header, and the command as a `$` prompt line that wraps between tokens with a hanging indent, the way a shell breaks it. One terminal per package manager, inside the existing `cli-command` tab group so the choice still syncs across the site.
- **A control per option** — pills for a fixed set of values, a checkbox for a flag, a text or number box otherwise. Typing or clicking rewrites the command in all four package manager tabs at once; the option's value carries the accent in the rendered line, and a flag that has just appeared animates in (respecting `prefers-reduced-motion`). The Nx Console tab's parameter list follows the same values.
- **Options in the order the reader needs them** — required first, then `x-priority: important`, then the rest, with `internal` last. Shared with the options reference panel through a new `readGeneratorOptions`, so both list a generator's options the same way.
- **One collapsible section** headed `Build your command`, with a chevron that turns as it opens, the option count, and a `Reset` that appears once something has been changed. A `--dry-run` toggle replaces the separate dry-run disclosure.
- **Wired to the guide's filter bar in both directions** — picking an enum value in the command narrows the guide, and a value picked in the bar (or in the options panel that drives it) lands in the command. Options a page pins are exempt, since the guide's prose is written around them.
- **The builder starts collapsed**, so the command stays the focus and the controls are there when the reader wants them.
- **`readonly` for walkthrough steps** — the dungeon adventure tutorial pins every value; the quick start pins all but `iac` and `containers`, which the reader picks for their own workspace. A locked option states its value without offering to change it, and its section is headed `Options for this step` and starts collapsed.

Command assembly lives in `docs/src/lib/command-card.ts` and is imported by both the server render and the client script, so the first paint and every keystroke agree. Values containing spaces are now quoted, which fixes the `ts#nx-generator` step in the contribute-a-generator tutorial (`--description='Adds a procedure to a tRPC API'` — previously emitted unquoted, so copying it did not run).

Guides whose generator has no resolvable schema (a tutorial running a generator it just wrote, or a card with a custom namespace) render the command alone, as before.

### Description of how you validated changes

- `pnpm nx run docs:build` passes — 1540 pages built, all internal links valid.
- `pnpm nx run docs:test` passes, including 21 new tests over option ordering, command assembly, boolean handling and shell quoting. Four of them assert the workspace card renders exactly what `buildCreateNxWorkspaceCommand` renders, holding the card and the MCP server to the same string.
- **MCP server output verified unchanged**: rendered every generator's guide through `fetchGuidePagesForGenerator` on this branch and on `main` and diffed all 73 outputs. The only difference is the one intentional prose edit in the `ts#project` guide (`--catalog false` → `--catalog=false`, matching what the card now emits). `vitest run src/mcp-server` passes (159 tests).
- Checked the rendered commands are byte-identical to the previous component's output on the quick start, dungeon adventure, PDK migration blog and contribute-a-generator pages (the last two also cover `tag=` and an unknown generator).
- Exercised the interaction in the browser: typing, pills, checkboxes, long-enum expansion, `--dry-run`, reset, copy, and the filter-bar round trip (clicking `event` in the card sets the bar chip and highlights the options panel row). Reviewed in dark and light themes at 1280px and 420px, and confirmed the card introduces no page-level horizontal overflow on mobile.

### A note on the translated files

`readonly` reached the eight translated copies of the quick start and the `ts#project` guide through the Translate Documentation job, but not the dungeon adventure tutorial: that job retranslates a page's prose and skips a page whose prose hasn't changed, so a diff of component attributes alone leaves the translations behind. The tutorial's attributes are carried across by hand in the last commit, so the walkthrough reads the same in every language.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

