### PR TITLE
docs: give every copy button the same look

### DIFF
--- a/docs/ec.config.mjs
+++ b/docs/ec.config.mjs
@@ -5,9 +5,9 @@
 import { defineEcConfig } from '@astrojs/starlight/expressive-code';
 
 import {
+  applySiteStyleOverrides,
   codeThemeDark,
   codeThemeLight,
-  restoreMarkerColors,
 } from './src/syntax/code-theme.ts';
 
 /**
@@ -20,7 +20,9 @@ export default defineEcConfig({
   themes: [codeThemeDark, codeThemeLight],
   /** Keeps the frames, tab bars and scrollbars on the site's own tokens. */
   useStarlightUiThemeColors: true,
-  customizeTheme: restoreMarkerColors,
+  customizeTheme: applySiteStyleOverrides,
+  /** The icon on the copy button, matching the command cards'. */
+  styleOverrides: { frames: { copyIcon: 'var(--copy-btn-icon)' } },
   /**
    * The palette is built to clear 4.6:1 against each mode's code background; the
    * default floor of 5.5 would lighten the deeper colours back out of the range

--- a/docs/src/styles/custom.css
+++ b/docs/src/styles/custom.css
@@ -86,6 +86,28 @@ starlight-file-tree,
   --command-dim: var(--sl-color-gray-2);
 }
 
+/* ============================================================
+ * Copy button
+ * One look for every "copy this" control — the command cards, the prompt
+ * blocks, and the button Expressive Code puts on a code block — so a reader
+ * reaches for the same thing wherever they are on the page.
+ * ============================================================ */
+:root {
+  --copy-btn-size: 1.7rem;
+  --copy-btn-icon-size: 0.85rem;
+  --copy-btn-border: var(--sl-color-gray-5);
+  --copy-btn-border-hover: var(--sl-color-accent);
+  --copy-btn-bg: var(--sl-color-black);
+  --copy-btn-fg: var(--sl-color-gray-3);
+  --copy-btn-fg-hover: var(--sl-color-white);
+  --copy-btn-fg-done: var(--sl-color-text-accent);
+
+  /* Drawn with a stroke rather than a fill so the two read as one set at this
+     size. Used as a mask, so the colour comes from the button. */
+  --copy-btn-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Crect x='9' y='9' width='13' height='13' rx='2' ry='2'/%3E%3Cpath d='M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1'/%3E%3C/svg%3E");
+  --copy-btn-icon-done: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='20 6 9 17 4 12'/%3E%3C/svg%3E");
+}
+
 div.hero {
   margin-bottom: -50px !important;
 }
@@ -328,14 +350,14 @@ main .content-panel:first-of-type {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 1.6rem;
-  height: 1.6rem;
+  width: var(--copy-btn-size);
+  height: var(--copy-btn-size);
   margin-left: auto;
   padding: 0;
-  border: 1px solid var(--sl-color-gray-5);
+  border: 1px solid var(--copy-btn-border);
   border-radius: 9999px;
-  background: transparent;
-  color: var(--sl-color-gray-3);
+  background: var(--copy-btn-bg);
+  color: var(--copy-btn-fg);
   cursor: pointer;
   transition:
     color 150ms ease,
@@ -343,13 +365,13 @@ main .content-panel:first-of-type {
 }
 
 .prompt-copy:hover {
-  color: var(--sl-color-white);
-  border-color: var(--sl-color-accent);
+  color: var(--copy-btn-fg-hover);
+  border-color: var(--copy-btn-border-hover);
 }
 
 .prompt-copy-icon {
-  width: 0.85rem;
-  height: 0.85rem;
+  width: var(--copy-btn-icon-size);
+  height: var(--copy-btn-icon-size);
 }
 
 .prompt-copy-icon--check,
@@ -359,7 +381,7 @@ main .content-panel:first-of-type {
 
 .prompt-copy.is-copied .prompt-copy-icon--check {
   display: inline;
-  color: var(--sl-color-text-accent);
+  color: var(--copy-btn-fg-done);
 }
 
 .prompt-body {
@@ -382,6 +404,76 @@ main .content-panel:first-of-type {
 div.expressive-code {
   max-height: 600px;
   overflow: auto;
+}
+
+/* ------------------------------------------------------------
+ * The copy button on a code block
+ * Expressive Code's own button is a rounded square that fades in on hover and
+ * confirms with a tooltip. The colours come from the theme's frame settings; the
+ * rest is here, because the shape, the resting visibility and the copied state
+ * aren't exposed as settings.
+ * ------------------------------------------------------------ */
+.expressive-code .copy button {
+  width: var(--copy-btn-size);
+  height: var(--copy-btn-size);
+  border-radius: 9999px;
+  background: var(--copy-btn-bg);
+  /* Present from the start, like the button on a command card. Nothing is
+     revealed by pointing at the block, so a reader on a touch screen or moving
+     by keyboard sees the same thing. */
+  opacity: 1;
+}
+
+/* EC keeps the button dim until the frame is hovered; the reveal is what is
+   being dropped, so both of its resting states are overridden. */
+@media (hover: hover) {
+  .expressive-code .copy button,
+  .expressive-code .frame:hover .copy button:not(:hover) {
+    width: var(--copy-btn-size);
+    height: var(--copy-btn-size);
+    opacity: 1;
+  }
+}
+
+.expressive-code .copy button::after {
+  margin: 0;
+  mask-image: var(--copy-btn-icon);
+  -webkit-mask-image: var(--copy-btn-icon);
+  mask-size: var(--copy-btn-icon-size);
+  -webkit-mask-size: var(--copy-btn-icon-size);
+  mask-position: center;
+  -webkit-mask-position: center;
+  transition: background-color 150ms ease;
+}
+
+.expressive-code .copy button:hover {
+  border-color: var(--copy-btn-border-hover);
+}
+
+.expressive-code .copy button:hover::before {
+  border-color: var(--copy-btn-border-hover);
+}
+
+.expressive-code .copy button:hover::after {
+  background-color: var(--copy-btn-fg-hover);
+}
+
+/* The confirmation: a check in the accent, in place of the tooltip, so it reads
+   the same as the command cards. The feedback element is the only signal the
+   copy succeeded — it is added to the live region beside the button. */
+.expressive-code .copy:has(.feedback.show) button::before {
+  border-color: var(--copy-btn-border-hover);
+}
+
+.expressive-code .copy:has(.feedback.show) button::after {
+  mask-image: var(--copy-btn-icon-done);
+  -webkit-mask-image: var(--copy-btn-icon-done);
+  background-color: var(--copy-btn-fg-done);
+}
+
+/* Left in the live region for assistive technology, but not drawn. */
+.expressive-code .copy .feedback {
+  opacity: 0;
 }
 
 div.container > h5 {
@@ -856,13 +948,13 @@ p.badges > a {
   flex: none;
   align-items: center;
   justify-content: center;
-  width: 1.7rem;
-  height: 1.7rem;
+  width: var(--copy-btn-size);
+  height: var(--copy-btn-size);
   padding: 0;
-  border: 1px solid var(--sl-color-gray-5);
+  border: 1px solid var(--copy-btn-border);
   border-radius: 9999px;
-  background: var(--sl-color-black);
-  color: var(--sl-color-gray-3);
+  background: var(--copy-btn-bg);
+  color: var(--copy-btn-fg);
   cursor: pointer;
   transition:
     color 150ms ease,
@@ -870,13 +962,13 @@ p.badges > a {
 }
 
 .command-card-copy:hover {
-  border-color: var(--sl-color-accent);
-  color: var(--sl-color-white);
+  border-color: var(--copy-btn-border-hover);
+  color: var(--copy-btn-fg-hover);
 }
 
 .command-card-copy-icon {
-  width: 0.85rem;
-  height: 0.85rem;
+  width: var(--copy-btn-icon-size);
+  height: var(--copy-btn-icon-size);
 }
 
 .command-card-copy-icon--check,
@@ -886,7 +978,7 @@ p.badges > a {
 
 .command-card-copy.is-copied .command-card-copy-icon--check {
   display: inline;
-  color: var(--sl-color-text-accent);
+  color: var(--copy-btn-fg-done);
 }
 
 /* The controls that write the command. */

--- a/docs/src/styles/graph-builder.css
+++ b/docs/src/styles/graph-builder.css
@@ -1519,18 +1519,22 @@
 }
 
 /* Icon alone, for a window's title bar. */
+/* The icon-only variant sits on a terminal box, so it takes the same look as the
+   copy button on a code block and on a command card. */
 .gb-copy-btn--icon {
-  width: 1.6rem;
-  height: 1.6rem;
+  width: var(--copy-btn-size);
+  height: var(--copy-btn-size);
   padding: 0;
   justify-content: center;
-  border-color: var(--gb-border);
-  background: transparent;
-  color: var(--gb-muted);
+  border-color: var(--copy-btn-border);
+  background: var(--copy-btn-bg);
+  color: var(--copy-btn-fg);
 }
 
 .gb-copy-btn--icon:hover:not(:disabled) {
-  border-color: var(--gb-accent);
+  border-color: var(--copy-btn-border-hover);
+  background: var(--copy-btn-bg);
+  color: var(--copy-btn-fg-hover);
 }
 
 .gb-copy-btn:hover:not(:disabled) {

--- a/docs/src/syntax/code-theme.ts
+++ b/docs/src/syntax/code-theme.ts
@@ -328,6 +328,26 @@ const markerColors = (c: Palette) => ({
   delDiffIndicatorColor: c.deleted,
 });
 
+/**
+ * The copy button, on the same tokens as the command cards' — see the copy
+ * button block in custom.css, which handles the shape and the copied state that
+ * these settings can't reach.
+ */
+const copyButtonColors = {
+  inlineButtonBorder: 'var(--copy-btn-border)',
+  inlineButtonBorderOpacity: '1',
+  inlineButtonForeground: 'var(--copy-btn-fg)',
+  /*
+   * The fill comes from the button itself (see custom.css). Expressive Code's own
+   * fill is an overlay element, which paints over the border and leaves the ring
+   * fainter than the one on a command card; turning it off lets the border show.
+   */
+  inlineButtonBackground: 'transparent',
+  inlineButtonBackgroundIdleOpacity: '0',
+  inlineButtonBackgroundHoverOrFocusOpacity: '0',
+  inlineButtonBackgroundActiveOpacity: '0',
+};
+
 const buildTheme = (type: 'dark' | 'light') => {
   const c = palette[type];
   const theme = new ExpressiveCodeTheme({
@@ -349,12 +369,17 @@ export const codeThemeDark = buildTheme('dark');
 export const codeThemeLight = buildTheme('light');
 
 /**
- * Re-applies the marker colours after Starlight has swapped in its own, which it
- * does on every theme it is handed.
+ * Re-applies the site's own values after Starlight has swapped in its own, which
+ * it does on every theme it is handed. The frames settings are merged rather
+ * than replaced, so the surfaces Starlight sets there are kept.
  */
-export const restoreMarkerColors = (theme: ExpressiveCodeTheme) => {
+export const applySiteStyleOverrides = (theme: ExpressiveCodeTheme) => {
   theme.styleOverrides.textMarkers = markerColors(
     palette[theme.type === 'light' ? 'light' : 'dark'],
   );
+  theme.styleOverrides.frames = {
+    ...theme.styleOverrides.frames,
+    ...copyButtonColors,
+  };
   return theme;
 };


### PR DESCRIPTION
### Reason for this change

There are four "copy this" controls in the docs and they didn't agree with each other.

The command cards and the prompt blocks had near-identical circles that differed by a tenth of a rem and a fill. The landing page's terminal boxes had a third variant, with no colour change on the glyph when hovered. And the button Expressive Code puts on every code block — the one a reader meets most often — was a rounded square that stayed invisible until you pointed at the block, then confirmed with a "Copied!" tooltip.

So the control that appears next to a generator command looked nothing like the control that appears on the snippet three paragraphs below it.

### Description of changes

A set of `--copy-btn-*` tokens in `custom.css` now describes the look once, and all four buttons read from it: a 1.7rem circle on the page's own surface, a hairline ring that takes the accent on hover while the glyph goes white, and a check in the accent to confirm.

<table>
<tr><td width="50%"><b>On a code block</b><br/><img src="https://raw.githubusercontent.com/awslabs/nx-plugin-for-aws/eff35df40596211ae5a9db9976c76dc4280e5c82/code-block.png" /></td>
<td width="50%"><b>On a generator command card</b><br/><img src="https://raw.githubusercontent.com/awslabs/nx-plugin-for-aws/eff35df40596211ae5a9db9976c76dc4280e5c82/command-card.png" /></td></tr>
</table>

The two, cropped from the rendered page and magnified 6× — command card on the left, code block on the right:

<img src="https://raw.githubusercontent.com/awslabs/nx-plugin-for-aws/eff35df40596211ae5a9db9976c76dc4280e5c82/compare.png" width="60%" />

Expressive Code's button reaches the shared look two ways, because only part of it is exposed as configuration:

- **Colours and the icon** come from the theme's `frames` settings (`inlineButtonBorder`, `inlineButtonForeground`, `copyIcon`, …), pointed at the tokens. Starlight sets `theme.styleOverrides.frames` itself, and a theme-level override beats a config-level one, so these are merged in `customizeTheme` alongside the text-marker colours — hence `restoreMarkerColors` becoming `applySiteStyleOverrides`. The merge is deliberate: the surfaces Starlight puts there are kept.
- **Shape, resting visibility and the copied state** are in CSS, since those aren't settings.

Two details worth calling out:

- Expressive Code's fill is an overlay element rendered as a child of the button, which paints over the `::before` that draws the border — the ring came out visibly fainter than the one on a command card beside it. The overlay is switched off and the button's own background used instead. This was only caught by cropping both buttons and comparing them magnified; the computed border colour was identical either way.
- The "Copied!" tooltip is no longer drawn, replaced by the check the other buttons use. The element stays in the live region so the copy is still announced.

The button is now present at rest rather than revealed on hover, matching the command cards. Expressive Code already reserves end padding on the first line for it, so nothing is overlapped, and a reader on a touch screen or moving by keyboard sees what a mouse user sees.

<img src="https://raw.githubusercontent.com/awslabs/nx-plugin-for-aws/eff35df40596211ae5a9db9976c76dc4280e5c82/terminal.png" width="60%" />

### Description of how you validated changes

- Compared the two buttons' computed geometry and colour token by token rather than by eye: both 27×27 px, `9999px` radius, 1px `rgb(53,56,65)` ring, `rgb(23,24,28)` fill, `rgb(136,140,150)` glyph at 13.6 px. Same exercise in light mode — background, border and glyph all identical between the two.
- Hover: glyph `rgb(255,255,255)`, ring on the accent, for both.
- Copied state: driven off the `.feedback.show` element Expressive Code's script adds. The clipboard API is unavailable in the headless browser, so the element was injected exactly as that script builds it — the glyph swaps to the check and takes `--sl-color-text-accent`, and the tooltip is not drawn.
- Checked the terminal-frame variant as well as plain code blocks, and the landing page's terminal boxes.
- `astro build`: 1540 pages, all internal links valid. `nx run docs:test`: 194 passed. `nx run-many --target lint --all`, `nx sync:check` and `biome check` all clean.

Screenshots are hosted on the `assets/copy-button-screenshots` branch, which is not part of this PR and can be deleted once merged.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
