### PR TITLE
docs: disable a conditional option rather than hiding it, and explain the badge

### DIFF
--- a/docs/src/components/command-card-field.astro
+++ b/docs/src/components/command-card-field.astro
@@ -13,7 +13,7 @@
  * something. A locked option belongs to a walkthrough whose prose is written
  * around it, so it shows its value without offering to change it.
  */
-import type { GeneratorOption } from '../lib/generator-options';
+import { describeWhen, type GeneratorOption } from '../lib/generator-options';
 
 interface Props {
   option: GeneratorOption;
@@ -28,6 +28,7 @@ interface Props {
     showAll: string;
     showFewer: string;
     defaultValue: string;
+    appliesWhen: string;
   };
 }
 
@@ -44,6 +45,17 @@ const values = locked ? option.values.filter((v) => v === value) : option.values
 >
   <p class="command-card-field-head">
     <label class="command-card-field-name" for={id}>{option.key}</label>
+    {
+      option.when && (
+        <span
+          class="command-card-field-when doc-tooltip"
+          data-tooltip={strings.appliesWhen}
+          aria-label={`${strings.appliesWhen}: ${describeWhen(option.when)}`}
+        >
+          {describeWhen(option.when)}
+        </span>
+      )
+    }
     {
       option.required && (
         <span class="command-card-field-required">{strings.required}</span>

--- a/docs/src/components/command-card.astro
+++ b/docs/src/components/command-card.astro
@@ -202,6 +202,12 @@ const isPinned = shown.every((option) => locked.has(option.key));
         card.querySelectorAll<HTMLElement>('[data-command-card-field]'),
       ).map((field) => [field.dataset.commandCardField!, field]),
     );
+    // The controls the guide itself fixes, which stay that way whatever applies.
+    const locked = new Set<HTMLInputElement | HTMLButtonElement>([
+      ...inputs.filter((input) => input.readOnly),
+      ...checks.filter((check) => check.disabled),
+      ...pills.filter((pill) => pill.disabled),
+    ]);
     const dryRun = card.querySelector<HTMLInputElement>(
       '[data-command-card-dry-run]',
     );
@@ -283,15 +289,27 @@ const isPinned = shown.every((option) => locked.has(option.key));
       }
     };
 
-    // An option only applies under some values of another — the Smithy namespace
-    // under `framework=smithy`. Its control goes when it stops applying, and so
-    // does whatever was entered in it.
+    // An option only applies under some values of another — a gateway's `auth`
+    // under an `infra` that hosts something. While another choice rules it out its
+    // controls are disabled rather than removed, so the reader can see the
+    // condition they'd have to change, and whatever was entered in it leaves the
+    // command.
     const applyApplicability = (values: Record<string, string>) => {
       const dropped: string[] = [];
       for (const option of config.options) {
         const applies = isApplicable(option, values);
         const field = fields.get(option.key);
-        if (field) field.hidden = !applies;
+        field?.classList.toggle('is-inapplicable', !applies);
+        for (const control of field?.querySelectorAll<
+          HTMLInputElement | HTMLButtonElement
+        >('[data-option-pill], [data-option-check], [data-option-input]') ?? []) {
+          const fixed = locked.has(control);
+          if (control instanceof HTMLInputElement && control.type === 'text') {
+            control.readOnly = fixed || !applies;
+          } else {
+            control.disabled = fixed || !applies;
+          }
+        }
         if (!applies) dropped.push(option.key);
       }
       return Object.fromEntries(

--- a/docs/src/components/create-nx-workspace-command.astro
+++ b/docs/src/components/create-nx-workspace-command.astro
@@ -11,6 +11,8 @@
  *
  * `readonly` marks a walkthrough step whose prose is written around the values it
  * passes, leaving `editable` the options the reader still chooses for themselves.
+ * `noOptions` drops the option controls altogether, for a command recorded at a
+ * point in time — a migration write-up — which shouldn't follow later renames.
  */
 import {
   createSchemaLookup,
@@ -34,6 +36,7 @@ const {
   values: pinnedValues = {},
   readonly = false,
   editable = [],
+  noOptions = false,
 } = Astro.props;
 const locale = Astro.currentLocale || 'en';
 const strings = commandCardStrings(locale);
@@ -48,17 +51,17 @@ const NAME_OPTION: GeneratorOption = {
   required: true,
 };
 
-let options: GeneratorOption[] = [NAME_OPTION];
+let options: GeneratorOption[] = noOptions ? [] : [NAME_OPTION];
 try {
   const generatorsJson = resolveGeneratorsJson(process.cwd());
-  if (generatorsJson) {
+  if (generatorsJson && !noOptions) {
     options = [
       NAME_OPTION,
       ...readGeneratorOptions(createSchemaLookup(generatorsJson)('preset')),
     ];
   }
 } catch {
-  options = [NAME_OPTION];
+  options = noOptions ? [] : [NAME_OPTION];
 }
 
 const prescribed: Record<string, string> = Object.fromEntries(
@@ -66,13 +69,18 @@ const prescribed: Record<string, string> = Object.fromEntries(
     .filter(([, value]) => value !== undefined)
     .map(([key, value]) => [key, String(value)]),
 );
-const initial: Record<string, string> = Object.fromEntries(
-  options.map((option) => [
-    option.key,
-    prescribed[option.key] ??
-      (option.control === 'boolean' ? option.default ?? 'false' : ''),
-  ]),
-);
+const initial: Record<string, string> = {
+  // A pinned value still makes the command where the card offers no control for
+  // it — the workspace name on a point-in-time command.
+  ...prescribed,
+  ...Object.fromEntries(
+    options.map((option) => [
+      option.key,
+      prescribed[option.key] ??
+        (option.control === 'boolean' ? (option.default ?? 'false') : ''),
+    ]),
+  ),
+};
 const locked = new Set(
   readonly
     ? options

--- a/docs/src/components/generator-parameters.astro
+++ b/docs/src/components/generator-parameters.astro
@@ -138,9 +138,7 @@ const parameters = readGeneratorOptions(schema)
 >
   <div class="gen-params-head">
     <span class="gen-params-title">{localeString('title')}</span>
-    <span class="gen-params-count">
-      <span data-gen-params-count>{parameters.length}</span> {localeString('options')}
-    </span>
+    <span class="gen-params-count">{parameters.length} {localeString('options')}</span>
   </div>
   <dl class="gen-params-list">
     {parameters.map((parameter) => (
@@ -156,7 +154,11 @@ const parameters = readGeneratorOptions(schema)
           )}
           <span class="gen-param-type">{parameter.type}</span>
           {parameter.when && (
-            <span class="gen-param-when" title={localeString('appliesWhen')}>
+            <span
+              class="gen-param-when doc-tooltip"
+              data-tooltip={localeString('appliesWhen')}
+              aria-label={`${localeString('appliesWhen')}: ${describeWhen(parameter.when)}`}
+            >
               {describeWhen(parameter.when)}
             </span>
           )}
@@ -230,7 +232,6 @@ const parameters = readGeneratorOptions(schema)
       const rows = Array.from(
         panel.querySelectorAll<HTMLElement>('[data-gen-param]'),
       );
-      const count = panel.querySelector<HTMLElement>('[data-gen-params-count]');
       // The values the page itself is written around, which the reader's
       // selection adds to rather than replaces.
       let pinned: Record<string, string> = {};
@@ -291,13 +292,11 @@ const parameters = readGeneratorOptions(schema)
       ) => {
         const context = { ...pinned, ...values };
 
-        let shown = 0;
         for (const row of rows) {
           const when = row.dataset.genParamWhen;
           const applies =
             !when || isApplicable({ when: JSON.parse(when) }, context);
-          row.hidden = !applies;
-          if (applies) shown += 1;
+          row.classList.toggle('is-inapplicable', !applies);
 
           const carried = command[row.dataset.genParam!];
           row.classList.toggle('is-filtered', !!carried);
@@ -311,7 +310,6 @@ const parameters = readGeneratorOptions(schema)
             }
           }
         }
-        if (count) count.textContent = String(shown);
       };
 
       document.addEventListener('npfa:page-options', (event) => {

--- a/docs/src/components/run-generator.astro
+++ b/docs/src/components/run-generator.astro
@@ -11,6 +11,8 @@
  * flags, shortening the command without changing what the Nx Console lists.
  * `readonly` marks a walkthrough step whose prose is written around the values it
  * passes, leaving `editable` the options the reader still chooses for themselves.
+ * `noOptions` drops the option controls altogether, for a command recorded at a
+ * point in time — a migration write-up — which shouldn't follow later renames.
  */
 import { Steps, TabItem, Tabs } from '@astrojs/starlight/components';
 import {
@@ -36,6 +38,7 @@ const {
   noInteractive = false,
   readonly = false,
   editable = [],
+  noOptions = false,
 } = Astro.props;
 const locale = Astro.currentLocale || 'en';
 const strings = commandCardStrings(locale);
@@ -45,7 +48,7 @@ const strings = commandCardStrings(locale);
 let options: GeneratorOption[] = [];
 try {
   const generatorsJson = resolveGeneratorsJson(process.cwd());
-  if (generatorsJson && namespace === '@aws/nx-plugin') {
+  if (generatorsJson && namespace === '@aws/nx-plugin' && !noOptions) {
     options = readGeneratorOptions(
       createSchemaLookup(generatorsJson)(generator),
     );
@@ -104,10 +107,14 @@ const locked = new Set(
     ),
 );
 
-// An option that doesn't apply under the values this page is written around has
-// nothing to contribute — the Smithy namespace on the tRPC guide.
-const context = { ...pinnedByPage, ...prescribed };
-const applicable = options.filter((option) => isApplicable(option, context));
+// An option that can't apply, because the guide fixes the value it depends on,
+// has nothing to contribute — the Smithy namespace on the tRPC guide. One that
+// depends on a value the reader can still change stays, and the card disables it
+// while it doesn't apply.
+const forced: Record<string, string> = Object.fromEntries(
+  [...locked].map((key) => [key, initial[key]]).filter(([, value]) => !!value),
+);
+const applicable = options.filter((option) => isApplicable(option, forced));
 
 const config: GeneratorCardConfig = {
   kind: 'generator',

--- a/docs/src/content/docs/en/blog/migrating-from-aws-pdk.mdx
+++ b/docs/src/content/docs/en/blog/migrating-from-aws-pdk.mdx
@@ -54,7 +54,7 @@ The shopping list application consists of the following PDK project types:
 
 To start, we'll create a new workspace for our new project. While more extreme than an in-place migration, this approach gives us the cleanest end result. Creating an Nx workspace is equivalent to using PDK's `MonorepoTsProject`:
 
-<CreateNxWorkspaceCommand workspace="shopping-list" iac="cdk" tag="1.0.0" />
+<CreateNxWorkspaceCommand workspace="shopping-list" iac="cdk" tag="1.0.0" noOptions />
 
 Open up the `shopping-list` directory this command creates in your favourite IDE.
 
@@ -80,7 +80,7 @@ This section provides guidance for features of PDK that aren't covered by the ex
 
 As a general rule when moving from PDK, we recommend starting any project with an Nx Workspace, given its similarities to the PDK Monorepo. We also recommend using our generators as the primitives on which to build any new types.
 
-<CreateNxWorkspaceCommand workspace="my-project" />
+<CreateNxWorkspaceCommand workspace="my-project" noOptions />
 
 ### CDK Graph
 

--- a/docs/src/content/docs/en/snippets/pdk-migration/example/01-migrate-api.mdx
+++ b/docs/src/content/docs/en/snippets/pdk-migration/example/01-migrate-api.mdx
@@ -26,7 +26,7 @@ If you used OpenAPI or TypeSpec as your modelling language, or have handlers imp
 
 Run the <Link path="/guides/ts-smithy-api">`ts#api` generator</Link> with `framework` set to `smithy` to set up your api project in `packages/api`:
 
-<RunGenerator generator="ts#api" noInteractive requiredParameters={{ name: 'api', framework: 'smithy', namespace: 'com.aws', auth: 'iam' }} />
+<RunGenerator generator="ts#api" noInteractive requiredParameters={{ name: 'api', framework: 'smithy', namespace: 'com.aws', auth: 'iam' }} noOptions />
 
 You will notice this generates a `model` project, as well as a `backend` project. The `model` project contains your Smithy model, and `backend` contains your server implementation.
 

--- a/docs/src/content/docs/en/snippets/pdk-migration/example/02-migrate-website.mdx
+++ b/docs/src/content/docs/en/snippets/pdk-migration/example/02-migrate-website.mdx
@@ -20,13 +20,13 @@ As part of the migration, we will also move from PDK's configured React Router t
 
 Run the <Link path="/guides/react-website">`ts#website` generator</Link> with `framework` set to `react` to set up your website project in `packages/website`. Since the shopping list application is built with CloudScape components, we also set `ux` to `cloudscape` (the default is `shadcn`):
 
-<RunGenerator generator="ts#website" noInteractive requiredParameters={{ name: 'website', framework: 'react', ux: 'cloudscape' }} />
+<RunGenerator generator="ts#website" noInteractive requiredParameters={{ name: 'website', framework: 'react', ux: 'cloudscape' }} noOptions />
 
 #### Add Cognito Authentication
 
 The React website generator above doesn't bundle cognito authentication by default like `CloudscapeReactTsWebsiteProject`, instead it's added explicitly via the <Link path="/guides/react-website-auth">`ts#website#auth` generator</Link>.
 
-<RunGenerator generator="ts#website#auth" noInteractive requiredParameters={{ project: 'website', cognitoDomain: 'shopping-list' }} />
+<RunGenerator generator="ts#website#auth" noInteractive requiredParameters={{ project: 'website', cognitoDomain: 'shopping-list' }} noOptions />
 
 This adds React components which manage the appropriate redirects to ensure users log in using the Cognito hosted UI. This also adds a CDK construct to deploy the Cognito resources in `packages/common/constructs`, called `UserIdentity`.
 
@@ -51,7 +51,7 @@ In PDK you could pass the vended Projen projects to one another to trigger integ
 
 With the Nx Plugin for AWS, API integration is supported via the <Link path="/guides/connection">`connection` generator</Link>. Next, we use this generator so that our website can invoke our Smithy API:
 
-<RunGenerator generator="connection" noInteractive requiredParameters={{ sourceProject: 'website', targetProject: 'api' }} />
+<RunGenerator generator="connection" noInteractive requiredParameters={{ sourceProject: 'website', targetProject: 'api' }} noOptions />
 
 This generates the necessary client providers and build targets for your website to call your API via a generated TypeScript client.
 

--- a/docs/src/content/docs/en/snippets/pdk-migration/example/03-migrate-infra.mdx
+++ b/docs/src/content/docs/en/snippets/pdk-migration/example/03-migrate-infra.mdx
@@ -22,7 +22,7 @@ A big advantage of the Nx Plugin for AWS over PDK is that the CDK constructs it 
 
 Run the <Link path="/guides/typescript-infrastructure">`ts#infra` generator</Link> to set up your infrastructure project in `packages/infra`:
 
-<RunGenerator generator="ts#infra" noInteractive requiredParameters={{ name: 'infra' }} />
+<RunGenerator generator="ts#infra" noInteractive requiredParameters={{ name: 'infra' }} noOptions />
 
 #### Migrate the CDK Infrastructure
 

--- a/docs/src/content/docs/en/snippets/pdk-migration/faq/type-safe-api.mdx
+++ b/docs/src/content/docs/en/snippets/pdk-migration/faq/type-safe-api.mdx
@@ -79,7 +79,7 @@ Type Safe API provided a Projen project type named `SmithyShapeLibraryProject` w
 
 The equivalent is the <Link path="/guides/smithy-project">`smithy#project` generator</Link> with `type` set to `shapes`:
 
-<RunGenerator generator="smithy#project" requiredParameters={{ name: 'my-shapes', type: 'shapes' }} />
+<RunGenerator generator="smithy#project" requiredParameters={{ name: 'my-shapes', type: 'shapes' }} noOptions />
 
 Move the shapes from your `SmithyShapeLibraryProject` into the generated project's `src` folder, then refer to the <Link path="/guides/smithy-project#depending-on-a-shape-library">Smithy project guide</Link> for how to wire the library up as a dependency of your API's model.
 

--- a/docs/src/content/docs/es/blog/migrating-from-aws-pdk.mdx
+++ b/docs/src/content/docs/es/blog/migrating-from-aws-pdk.mdx
@@ -36,7 +36,7 @@ Ten en cuenta también que algunas características de PDK no tienen equivalente
 :::
 
 :::caution[Guía en un Punto en el Tiempo]
-Esta guía está escrita como una guía en un punto en el tiempo y muy probablemente no se actualizará a medida que el Nx Plugin para AWS evolucione. Para compensar esto, la guía fija la versión de `@aws/nx-plugin` a `1.0.0-rc.47`. Puedes intentar con la última versión si sigues la guía, pero puede haber algunas desviaciones de la misma.
+Esta guía está escrita como una guía en un punto en el tiempo y muy probablemente no se actualizará a medida que el Nx Plugin para AWS evolucione. Para compensar esto, la guía fija la versión de `@aws/nx-plugin` a `1.0.0`. Puedes intentar con la última versión si sigues la guía, pero puede haber algunas desviaciones de la misma.
 :::
 
 ## Ejemplo de Migración: Aplicación de Lista de Compras
@@ -54,7 +54,7 @@ La aplicación de lista de compras consiste en los siguientes tipos de proyecto 
 
 Para comenzar, crearemos un nuevo espacio de trabajo para nuestro nuevo proyecto. Aunque es más extremo que una migración in situ, este enfoque nos da el resultado final más limpio. Crear un espacio de trabajo Nx es equivalente a usar el `MonorepoTsProject` de PDK:
 
-<CreateNxWorkspaceCommand workspace="shopping-list" iac="cdk" tag="1.0.0" />
+<CreateNxWorkspaceCommand workspace="shopping-list" iac="cdk" tag="1.0.0" noOptions />
 
 Abre el directorio `shopping-list` que este comando crea en tu IDE favorito.
 
@@ -80,7 +80,7 @@ Esta sección proporciona orientación para características de PDK que no está
 
 Como regla general al pasar de PDK, recomendamos comenzar cualquier proyecto con un Espacio de Trabajo Nx, dadas sus similitudes con el Monorepo de PDK. También recomendamos usar nuestros generadores como las primitivas sobre las cuales construir cualquier nuevo tipo.
 
-<CreateNxWorkspaceCommand workspace="my-project" />
+<CreateNxWorkspaceCommand workspace="my-project" noOptions />
 
 ### CDK Graph
 

--- a/docs/src/content/docs/es/snippets/pdk-migration/example/01-migrate-api.mdx
+++ b/docs/src/content/docs/es/snippets/pdk-migration/example/01-migrate-api.mdx
@@ -26,7 +26,7 @@ Si utilizaste OpenAPI o TypeSpec como tu lenguaje de modelado, o tienes manejado
 
 Ejecuta el <Link path="/guides/ts-smithy-api">generador `ts#api`</Link> con `framework` establecido en `smithy` para configurar tu proyecto de api en `packages/api`:
 
-<RunGenerator generator="ts#api" noInteractive requiredParameters={{ name: 'api', framework: 'smithy', namespace: 'com.aws', auth: 'iam' }} />
+<RunGenerator generator="ts#api" noInteractive requiredParameters={{ name: 'api', framework: 'smithy', namespace: 'com.aws', auth: 'iam' }} noOptions />
 
 Notarás que esto genera un proyecto `model`, así como un proyecto `backend`. El proyecto `model` contiene tu modelo Smithy, y `backend` contiene tu implementación del servidor.
 

--- a/docs/src/content/docs/es/snippets/pdk-migration/example/02-migrate-website.mdx
+++ b/docs/src/content/docs/es/snippets/pdk-migration/example/02-migrate-website.mdx
@@ -20,13 +20,13 @@ Como parte de la migración, también pasaremos del React Router configurado de 
 
 Ejecuta el <Link path="/guides/react-website">generador `ts#website`</Link> con `framework` establecido en `react` para configurar tu proyecto de sitio web en `packages/website`. Dado que la aplicación de lista de compras está construida con componentes CloudScape, también establecemos `ux` en `cloudscape` (el valor predeterminado es `shadcn`):
 
-<RunGenerator generator="ts#website" noInteractive requiredParameters={{ name: 'website', framework: 'react', ux: 'cloudscape' }} />
+<RunGenerator generator="ts#website" noInteractive requiredParameters={{ name: 'website', framework: 'react', ux: 'cloudscape' }} noOptions />
 
 #### Agregar Autenticación Cognito
 
 El generador de sitio web React anterior no incluye autenticación cognito por defecto como `CloudscapeReactTsWebsiteProject`, en su lugar se agrega explícitamente a través del <Link path="/guides/react-website-auth">generador `ts#website#auth`</Link>.
 
-<RunGenerator generator="ts#website#auth" noInteractive requiredParameters={{ project: 'website', cognitoDomain: 'shopping-list' }} />
+<RunGenerator generator="ts#website#auth" noInteractive requiredParameters={{ project: 'website', cognitoDomain: 'shopping-list' }} noOptions />
 
 Esto agrega componentes React que gestionan las redirecciones apropiadas para garantizar que los usuarios inicien sesión utilizando la interfaz de usuario alojada de Cognito. Esto también agrega una construcción CDK para implementar los recursos de Cognito en `packages/common/constructs`, llamada `UserIdentity`.
 
@@ -51,7 +51,7 @@ En PDK podías pasar los proyectos Projen proporcionados entre sí para activar 
 
 Con el Nx Plugin for AWS, la integración de API es compatible a través del <Link path="/guides/connection">generador `connection`</Link>. A continuación, usamos este generador para que nuestro sitio web pueda invocar nuestra API Smithy:
 
-<RunGenerator generator="connection" noInteractive requiredParameters={{ sourceProject: 'website', targetProject: 'api' }} />
+<RunGenerator generator="connection" noInteractive requiredParameters={{ sourceProject: 'website', targetProject: 'api' }} noOptions />
 
 Esto genera los proveedores de cliente necesarios y los objetivos de compilación para que tu sitio web llame a tu API a través de un cliente TypeScript generado.
 

--- a/docs/src/content/docs/es/snippets/pdk-migration/example/03-migrate-infra.mdx
+++ b/docs/src/content/docs/es/snippets/pdk-migration/example/03-migrate-infra.mdx
@@ -22,7 +22,7 @@ Una gran ventaja de Nx Plugin for AWS sobre PDK es que las construcciones CDK qu
 
 Ejecuta el <Link path="/guides/typescript-infrastructure">generador `ts#infra`</Link> para configurar tu proyecto de infraestructura en `packages/infra`:
 
-<RunGenerator generator="ts#infra" noInteractive requiredParameters={{ name: 'infra' }} />
+<RunGenerator generator="ts#infra" noInteractive requiredParameters={{ name: 'infra' }} noOptions />
 
 #### Migrar la Infraestructura CDK
 

--- a/docs/src/content/docs/es/snippets/pdk-migration/faq/type-safe-api.mdx
+++ b/docs/src/content/docs/es/snippets/pdk-migration/faq/type-safe-api.mdx
@@ -79,7 +79,7 @@ Type Safe API proporcionaba un tipo de proyecto Projen llamado `SmithyShapeLibra
 
 El equivalente es el <Link path="/guides/smithy-project">generador `smithy#project`</Link> con `type` configurado como `shapes`:
 
-<RunGenerator generator="smithy#project" requiredParameters={{ name: 'my-shapes', type: 'shapes' }} />
+<RunGenerator generator="smithy#project" requiredParameters={{ name: 'my-shapes', type: 'shapes' }} noOptions />
 
 Mueve las formas de tu `SmithyShapeLibraryProject` a la carpeta `src` del proyecto generado, luego consulta la <Link path="/guides/smithy-project#depending-on-a-shape-library">guía del proyecto Smithy</Link> para saber cómo conectar la biblioteca como una dependencia del modelo de tu API.
 

--- a/docs/src/content/docs/fr/blog/migrating-from-aws-pdk.mdx
+++ b/docs/src/content/docs/fr/blog/migrating-from-aws-pdk.mdx
@@ -36,7 +36,7 @@ Notez également que certaines fonctionnalités de PDK n'ont pas d'équivalents 
 :::
 
 :::caution[Guide ponctuel]
-Ce guide est rédigé comme un guide ponctuel et ne sera très probablement pas mis à jour au fur et à mesure de l'évolution du Nx Plugin for AWS. Pour compenser cela, le guide épingle la version de `@aws/nx-plugin` à `1.0.0-rc.47`. Vous pouvez essayer avec la dernière version si vous suivez le guide, mais il peut y avoir quelques écarts par rapport au guide.
+Ce guide est rédigé comme un guide ponctuel et ne sera très probablement pas mis à jour au fur et à mesure de l'évolution du Nx Plugin for AWS. Pour compenser cela, le guide épingle la version de `@aws/nx-plugin` à `1.0.0`. Vous pouvez essayer avec la dernière version si vous suivez le guide, mais il peut y avoir quelques écarts par rapport au guide.
 :::
 
 ## Exemple de migration : Application de liste de courses
@@ -54,7 +54,7 @@ L'application de liste de courses se compose des types de projets PDK suivants :
 
 Pour commencer, nous allons créer un nouvel espace de travail pour notre nouveau projet. Bien que plus extrême qu'une migration sur place, cette approche nous donne le résultat final le plus propre. Créer un espace de travail Nx équivaut à utiliser le `MonorepoTsProject` de PDK :
 
-<CreateNxWorkspaceCommand workspace="shopping-list" iac="cdk" tag="1.0.0" />
+<CreateNxWorkspaceCommand workspace="shopping-list" iac="cdk" tag="1.0.0" noOptions />
 
 Ouvrez le répertoire `shopping-list` créé par cette commande dans votre IDE préféré.
 
@@ -80,7 +80,7 @@ Cette section fournit des conseils pour les fonctionnalités de PDK qui ne sont 
 
 En règle générale lors du passage de PDK, nous recommandons de commencer tout projet avec un espace de travail Nx, compte tenu de ses similitudes avec le Monorepo PDK. Nous recommandons également d'utiliser nos générateurs comme primitives sur lesquelles construire de nouveaux types.
 
-<CreateNxWorkspaceCommand workspace="my-project" />
+<CreateNxWorkspaceCommand workspace="my-project" noOptions />
 
 ### CDK Graph
 

--- a/docs/src/content/docs/fr/snippets/pdk-migration/example/01-migrate-api.mdx
+++ b/docs/src/content/docs/fr/snippets/pdk-migration/example/01-migrate-api.mdx
@@ -26,7 +26,7 @@ Si vous avez utilisé OpenAPI ou TypeSpec comme langage de modélisation, ou si 
 
 Exécutez le <Link path="/guides/ts-smithy-api">générateur `ts#api`</Link> avec `framework` défini sur `smithy` pour configurer votre projet d'API dans `packages/api` :
 
-<RunGenerator generator="ts#api" noInteractive requiredParameters={{ name: 'api', framework: 'smithy', namespace: 'com.aws', auth: 'iam' }} />
+<RunGenerator generator="ts#api" noInteractive requiredParameters={{ name: 'api', framework: 'smithy', namespace: 'com.aws', auth: 'iam' }} noOptions />
 
 Vous remarquerez que cela génère un projet `model`, ainsi qu'un projet `backend`. Le projet `model` contient votre modèle Smithy, et `backend` contient votre implémentation serveur.
 

--- a/docs/src/content/docs/fr/snippets/pdk-migration/example/02-migrate-website.mdx
+++ b/docs/src/content/docs/fr/snippets/pdk-migration/example/02-migrate-website.mdx
@@ -51,7 +51,7 @@ Dans PDK, vous pouviez passer les projets Projen fournis les uns aux autres pour
 
 Avec le Nx Plugin for AWS, l'intégration d'API est prise en charge via le <Link path="/guides/connection">générateur `connection`</Link>. Ensuite, nous utilisons ce générateur pour que notre site web puisse invoquer notre API Smithy :
 
-<RunGenerator generator="connection" noInteractive requiredParameters={{ sourceProject: 'website', targetProject: 'api' }} />
+<RunGenerator generator="connection" noInteractive requiredParameters={{ sourceProject: 'website', targetProject: 'api' }} noOptions />
 
 Cela génère les fournisseurs de clients nécessaires et les cibles de build pour que votre site web puisse appeler votre API via un client TypeScript généré.
 

--- a/docs/src/content/docs/fr/snippets/pdk-migration/example/03-migrate-infra.mdx
+++ b/docs/src/content/docs/fr/snippets/pdk-migration/example/03-migrate-infra.mdx
@@ -22,7 +22,7 @@ Un grand avantage du Nx Plugin for AWS par rapport à PDK est que les constructs
 
 Exécutez le <Link path="/guides/typescript-infrastructure">générateur `ts#infra`</Link> pour configurer votre projet d'infrastructure dans `packages/infra` :
 
-<RunGenerator generator="ts#infra" noInteractive requiredParameters={{ name: 'infra' }} />
+<RunGenerator generator="ts#infra" noInteractive requiredParameters={{ name: 'infra' }} noOptions />
 
 #### Migrer l'infrastructure CDK
 

--- a/docs/src/content/docs/fr/snippets/pdk-migration/faq/type-safe-api.mdx
+++ b/docs/src/content/docs/fr/snippets/pdk-migration/faq/type-safe-api.mdx
@@ -79,7 +79,7 @@ Type Safe API fournissait un type de projet Projen nommé `SmithyShapeLibraryPro
 
 L'équivalent est le <Link path="/guides/smithy-project">générateur `smithy#project`</Link> avec `type` défini sur `shapes` :
 
-<RunGenerator generator="smithy#project" requiredParameters={{ name: 'my-shapes', type: 'shapes' }} />
+<RunGenerator generator="smithy#project" requiredParameters={{ name: 'my-shapes', type: 'shapes' }} noOptions />
 
 Déplacez les formes de votre `SmithyShapeLibraryProject` dans le dossier `src` du projet généré, puis référez-vous au <Link path="/guides/smithy-project#depending-on-a-shape-library">guide du projet Smithy</Link> pour savoir comment connecter la bibliothèque en tant que dépendance du modèle de votre API.
 

--- a/docs/src/content/docs/it/blog/migrating-from-aws-pdk.mdx
+++ b/docs/src/content/docs/it/blog/migrating-from-aws-pdk.mdx
@@ -54,7 +54,7 @@ L'applicazione shopping list consiste nei seguenti tipi di progetto PDK:
 
 Per iniziare, creeremo un nuovo workspace per il nostro nuovo progetto. Sebbene più estremo di una migrazione in loco, questo approccio ci dà il risultato finale più pulito. Creare un workspace Nx è equivalente a usare il `MonorepoTsProject` di PDK:
 
-<CreateNxWorkspaceCommand workspace="shopping-list" iac="cdk" tag="1.0.0" />
+<CreateNxWorkspaceCommand workspace="shopping-list" iac="cdk" tag="1.0.0" noOptions />
 
 Apri la directory `shopping-list` che questo comando crea nel tuo IDE preferito.
 

--- a/docs/src/content/docs/it/snippets/pdk-migration/example/01-migrate-api.mdx
+++ b/docs/src/content/docs/it/snippets/pdk-migration/example/01-migrate-api.mdx
@@ -26,7 +26,7 @@ Se hai utilizzato OpenAPI o TypeSpec come linguaggio di modellazione, o hai hand
 
 Esegui il <Link path="/guides/ts-smithy-api">generatore `ts#api`</Link> con `framework` impostato su `smithy` per configurare il tuo progetto API in `packages/api`:
 
-<RunGenerator generator="ts#api" noInteractive requiredParameters={{ name: 'api', framework: 'smithy', namespace: 'com.aws', auth: 'iam' }} />
+<RunGenerator generator="ts#api" noInteractive requiredParameters={{ name: 'api', framework: 'smithy', namespace: 'com.aws', auth: 'iam' }} noOptions />
 
 Noterai che questo genera un progetto `model`, così come un progetto `backend`. Il progetto `model` contiene il tuo modello Smithy, e `backend` contiene l'implementazione del server.
 

--- a/docs/src/content/docs/it/snippets/pdk-migration/example/02-migrate-website.mdx
+++ b/docs/src/content/docs/it/snippets/pdk-migration/example/02-migrate-website.mdx
@@ -20,13 +20,13 @@ Come parte della migrazione, passeremo anche da React Router configurato in PDK 
 
 Esegui il <Link path="/guides/react-website">generatore `ts#website`</Link> con `framework` impostato su `react` per configurare il tuo progetto website in `packages/website`. Poiché l'applicazione shopping list è costruita con componenti CloudScape, impostiamo anche `ux` su `cloudscape` (il valore predefinito è `shadcn`):
 
-<RunGenerator generator="ts#website" noInteractive requiredParameters={{ name: 'website', framework: 'react', ux: 'cloudscape' }} />
+<RunGenerator generator="ts#website" noInteractive requiredParameters={{ name: 'website', framework: 'react', ux: 'cloudscape' }} noOptions />
 
 #### Aggiungere l'Autenticazione Cognito
 
 Il generatore React website sopra non include l'autenticazione cognito per impostazione predefinita come `CloudscapeReactTsWebsiteProject`, invece viene aggiunta esplicitamente tramite il <Link path="/guides/react-website-auth">generatore `ts#website#auth`</Link>.
 
-<RunGenerator generator="ts#website#auth" noInteractive requiredParameters={{ project: 'website', cognitoDomain: 'shopping-list' }} />
+<RunGenerator generator="ts#website#auth" noInteractive requiredParameters={{ project: 'website', cognitoDomain: 'shopping-list' }} noOptions />
 
 Questo aggiunge componenti React che gestiscono i reindirizzamenti appropriati per garantire che gli utenti effettuino il login utilizzando l'interfaccia utente ospitata di Cognito. Questo aggiunge anche un costrutto CDK per distribuire le risorse Cognito in `packages/common/constructs`, chiamato `UserIdentity`.
 
@@ -51,7 +51,7 @@ In PDK potevi passare i progetti Projen forniti l'uno all'altro per attivare la 
 
 Con Nx Plugin for AWS, l'integrazione API è supportata tramite il <Link path="/guides/connection">generatore `connection`</Link>. Successivamente, utilizziamo questo generatore in modo che il nostro sito web possa invocare la nostra API Smithy:
 
-<RunGenerator generator="connection" noInteractive requiredParameters={{ sourceProject: 'website', targetProject: 'api' }} />
+<RunGenerator generator="connection" noInteractive requiredParameters={{ sourceProject: 'website', targetProject: 'api' }} noOptions />
 
 Questo genera i provider client necessari e i target di build per consentire al tuo sito web di chiamare la tua API tramite un client TypeScript generato.
 

--- a/docs/src/content/docs/it/snippets/pdk-migration/example/03-migrate-infra.mdx
+++ b/docs/src/content/docs/it/snippets/pdk-migration/example/03-migrate-infra.mdx
@@ -22,7 +22,7 @@ Un grande vantaggio di Nx Plugin for AWS rispetto a PDK è che i costrutti CDK c
 
 Esegui il <Link path="/guides/typescript-infrastructure">generatore `ts#infra`</Link> per configurare il tuo progetto di infrastruttura in `packages/infra`:
 
-<RunGenerator generator="ts#infra" noInteractive requiredParameters={{ name: 'infra' }} />
+<RunGenerator generator="ts#infra" noInteractive requiredParameters={{ name: 'infra' }} noOptions />
 
 #### Migrare l'Infrastruttura CDK
 
@@ -159,7 +159,4 @@ Costruiamo ora il progetto ora che abbiamo migrato tutte le parti rilevanti dell
 Potresti vedere un errore di build dovuto a problemi di lint. Questi possono solitamente essere corretti automaticamente:
 
 <PackageManagerShortCommand commands={["lint"]} />
-:::nte essere corretti automaticamente:
-
-<NxCommands commands={["run-many --target lint --configuration=fix"]} />
 :::

--- a/docs/src/content/docs/it/snippets/pdk-migration/faq/type-safe-api.mdx
+++ b/docs/src/content/docs/it/snippets/pdk-migration/faq/type-safe-api.mdx
@@ -79,7 +79,7 @@ Type Safe API forniva un tipo di progetto Projen chiamato `SmithyShapeLibraryPro
 
 L'equivalente è il <Link path="/guides/smithy-project">generatore `smithy#project`</Link> con `type` impostato su `shapes`:
 
-<RunGenerator generator="smithy#project" requiredParameters={{ name: 'my-shapes', type: 'shapes' }} />
+<RunGenerator generator="smithy#project" requiredParameters={{ name: 'my-shapes', type: 'shapes' }} noOptions />
 
 Sposta le forme dal tuo `SmithyShapeLibraryProject` nella cartella `src` del progetto generato, quindi fai riferimento alla <Link path="/guides/smithy-project#depending-on-a-shape-library">guida del progetto Smithy</Link> per come collegare la libreria come dipendenza del modello della tua API.
 

--- a/docs/src/content/docs/jp/blog/migrating-from-aws-pdk.mdx
+++ b/docs/src/content/docs/jp/blog/migrating-from-aws-pdk.mdx
@@ -80,7 +80,7 @@ Nx Plugin for AWSへの移行により、PDKと比較して以下のメリット
 
 PDKから移行する際の一般的なルールとして、PDK Monorepoとの類似性を考慮して、Nx Workspaceでプロジェクトを開始することをお勧めします。また、新しいタイプを構築する際の基本要素として、当社のジェネレーターを使用することをお勧めします。
 
-<CreateNxWorkspaceCommand workspace="my-project" />
+<CreateNxWorkspaceCommand workspace="my-project" noOptions />
 
 ### CDK Graph
 

--- a/docs/src/content/docs/jp/snippets/pdk-migration/example/01-migrate-api.mdx
+++ b/docs/src/content/docs/jp/snippets/pdk-migration/example/01-migrate-api.mdx
@@ -26,7 +26,7 @@ import PackageManagerShortCommand from '@components/package-manager-short-comman
 
 <Link path="/guides/ts-smithy-api">`ts#api` ジェネレーター</Link>を `framework` を `smithy` に設定して実行し、`packages/api` にAPIプロジェクトをセットアップします：
 
-<RunGenerator generator="ts#api" noInteractive requiredParameters={{ name: 'api', framework: 'smithy', namespace: 'com.aws', auth: 'iam' }} />
+<RunGenerator generator="ts#api" noInteractive requiredParameters={{ name: 'api', framework: 'smithy', namespace: 'com.aws', auth: 'iam' }} noOptions />
 
 これにより、`model` プロジェクトと `backend` プロジェクトが生成されることがわかります。`model` プロジェクトにはSmithyモデルが含まれ、`backend` にはサーバー実装が含まれます。
 

--- a/docs/src/content/docs/jp/snippets/pdk-migration/example/02-migrate-website.mdx
+++ b/docs/src/content/docs/jp/snippets/pdk-migration/example/02-migrate-website.mdx
@@ -20,13 +20,13 @@ import PackageManagerShortCommand from '@components/package-manager-short-comman
 
 <Link path="/guides/react-website">`ts#website` ジェネレーター</Link> を `framework` を `react` に設定して実行し、`packages/website` にウェブサイトプロジェクトをセットアップします。ショッピングリストアプリケーションは CloudScape コンポーネントで構築されているため、`ux` を `cloudscape` に設定します（デフォルトは `shadcn` です）：
 
-<RunGenerator generator="ts#website" noInteractive requiredParameters={{ name: 'website', framework: 'react', ux: 'cloudscape' }} />
+<RunGenerator generator="ts#website" noInteractive requiredParameters={{ name: 'website', framework: 'react', ux: 'cloudscape' }} noOptions />
 
 #### Cognito 認証の追加
 
 上記の React ウェブサイトジェネレーターは、`CloudscapeReactTsWebsiteProject` のようにデフォルトで cognito 認証をバンドルしていません。代わりに、<Link path="/guides/react-website-auth">`ts#website#auth` ジェネレーター</Link> を介して明示的に追加されます。
 
-<RunGenerator generator="ts#website#auth" noInteractive requiredParameters={{ project: 'website', cognitoDomain: 'shopping-list' }} />
+<RunGenerator generator="ts#website#auth" noInteractive requiredParameters={{ project: 'website', cognitoDomain: 'shopping-list' }} noOptions />
 
 これにより、Cognito ホストUI を使用してユーザーがログインするための適切なリダイレクトを管理する React コンポーネントが追加されます。また、`packages/common/constructs` に Cognito リソースをデプロイするための CDK コンストラクト（`UserIdentity` と呼ばれる）も追加されます。
 
@@ -51,7 +51,7 @@ PDK では、生成された Projen プロジェクトを相互に渡して統�
 
 Nx Plugin for AWS では、API 統合は <Link path="/guides/connection">`connection` ジェネレーター</Link> を介してサポートされています。次に、このジェネレーターを使用して、ウェブサイトが Smithy API を呼び出せるようにします：
 
-<RunGenerator generator="connection" noInteractive requiredParameters={{ sourceProject: 'website', targetProject: 'api' }} />
+<RunGenerator generator="connection" noInteractive requiredParameters={{ sourceProject: 'website', targetProject: 'api' }} noOptions />
 
 これにより、生成された TypeScript クライアントを介してウェブサイトが API を呼び出すために必要なクライアントプロバイダーとビルドターゲットが生成されます。
 

--- a/docs/src/content/docs/jp/snippets/pdk-migration/example/03-migrate-infra.mdx
+++ b/docs/src/content/docs/jp/snippets/pdk-migration/example/03-migrate-infra.mdx
@@ -22,7 +22,7 @@ Nx Plugin for AWS が PDK よりも優れている大きな利点は、提供さ
 
 <Link path="/guides/typescript-infrastructure">`ts#infra` ジェネレーター</Link>を実行して、`packages/infra` にインフラストラクチャプロジェクトをセットアップします：
 
-<RunGenerator generator="ts#infra" noInteractive requiredParameters={{ name: 'infra' }} />
+<RunGenerator generator="ts#infra" noInteractive requiredParameters={{ name: 'infra' }} noOptions />
 
 #### CDK インフラストラクチャの移行
 

--- a/docs/src/content/docs/jp/snippets/pdk-migration/faq/type-safe-api.mdx
+++ b/docs/src/content/docs/jp/snippets/pdk-migration/faq/type-safe-api.mdx
@@ -79,7 +79,7 @@ Type Safe API は、複数の Smithy ベースの API で再利用できる Smit
 
 同等のものは、`type` を `shapes` に設定した <Link path="/guides/smithy-project">`smithy#project` ジェネレーター</Link>です：
 
-<RunGenerator generator="smithy#project" requiredParameters={{ name: 'my-shapes', type: 'shapes' }} />
+<RunGenerator generator="smithy#project" requiredParameters={{ name: 'my-shapes', type: 'shapes' }} noOptions />
 
 `SmithyShapeLibraryProject` からシェイプを生成されたプロジェクトの `src` フォルダーに移動し、ライブラリを API のモデルの依存関係として接続する方法については、<Link path="/guides/smithy-project#depending-on-a-shape-library">Smithy プロジェクトガイド</Link>を参照してください。
 

--- a/docs/src/content/docs/ko/blog/migrating-from-aws-pdk.mdx
+++ b/docs/src/content/docs/ko/blog/migrating-from-aws-pdk.mdx
@@ -54,7 +54,7 @@ Nx Plugin for AWS로 마이그레이션하면 PDK 대비 다음과 같은 이점
 
 시작하려면 새 프로젝트를 위한 새 워크스페이스를 생성합니다. 제자리 마이그레이션보다 더 극단적이지만, 이 접근 방식은 가장 깔끔한 최종 결과를 제공합니다. Nx 워크스페이스를 생성하는 것은 PDK의 `MonorepoTsProject`를 사용하는 것과 동등합니다:
 
-<CreateNxWorkspaceCommand workspace="shopping-list" iac="cdk" tag="1.0.0" />
+<CreateNxWorkspaceCommand workspace="shopping-list" iac="cdk" tag="1.0.0" noOptions />
 
 이 명령이 생성하는 `shopping-list` 디렉토리를 선호하는 IDE에서 엽니다.
 

--- a/docs/src/content/docs/ko/snippets/pdk-migration/example/01-migrate-api.mdx
+++ b/docs/src/content/docs/ko/snippets/pdk-migration/example/01-migrate-api.mdx
@@ -26,7 +26,7 @@ import PackageManagerShortCommand from '@components/package-manager-short-comman
 
 `framework`를 `smithy`로 설정하여 <Link path="/guides/ts-smithy-api">`ts#api` 제너레이터</Link>를 실행하여 `packages/api`에 API 프로젝트를 설정합니다:
 
-<RunGenerator generator="ts#api" noInteractive requiredParameters={{ name: 'api', framework: 'smithy', namespace: 'com.aws', auth: 'iam' }} />
+<RunGenerator generator="ts#api" noInteractive requiredParameters={{ name: 'api', framework: 'smithy', namespace: 'com.aws', auth: 'iam' }} noOptions />
 
 이렇게 하면 `model` 프로젝트와 `backend` 프로젝트가 생성됩니다. `model` 프로젝트에는 Smithy 모델이 포함되고, `backend`에는 서버 구현이 포함됩니다.
 

--- a/docs/src/content/docs/ko/snippets/pdk-migration/example/02-migrate-website.mdx
+++ b/docs/src/content/docs/ko/snippets/pdk-migration/example/02-migrate-website.mdx
@@ -20,13 +20,13 @@ import PackageManagerShortCommand from '@components/package-manager-short-comman
 
 `packages/website`에 웹사이트 프로젝트를 설정하기 위해 `framework`를 `react`로 설정하여 <Link path="/guides/react-website">`ts#website` 생성기</Link>를 실행합니다. 쇼핑 리스트 애플리케이션은 CloudScape 컴포넌트로 구축되었으므로 `ux`를 `cloudscape`로 설정합니다(기본값은 `shadcn`입니다):
 
-<RunGenerator generator="ts#website" noInteractive requiredParameters={{ name: 'website', framework: 'react', ux: 'cloudscape' }} />
+<RunGenerator generator="ts#website" noInteractive requiredParameters={{ name: 'website', framework: 'react', ux: 'cloudscape' }} noOptions />
 
 #### Cognito 인증 추가
 
 위의 React 웹사이트 생성기는 `CloudscapeReactTsWebsiteProject`처럼 기본적으로 cognito 인증을 번들로 제공하지 않으며, 대신 <Link path="/guides/react-website-auth">`ts#website#auth` 생성기</Link>를 통해 명시적으로 추가됩니다.
 
-<RunGenerator generator="ts#website#auth" noInteractive requiredParameters={{ project: 'website', cognitoDomain: 'shopping-list' }} />
+<RunGenerator generator="ts#website#auth" noInteractive requiredParameters={{ project: 'website', cognitoDomain: 'shopping-list' }} noOptions />
 
 이것은 사용자가 Cognito 호스팅 UI를 사용하여 로그인하도록 적절한 리디렉션을 관리하는 React 컴포넌트를 추가합니다. 또한 `UserIdentity`라는 `packages/common/constructs`에 Cognito 리소스를 배포하기 위한 CDK 구성을 추가합니다.
 
@@ -51,7 +51,7 @@ PDK에서는 제공된 Projen 프로젝트를 서로 전달하여 통합 코드�
 
 Nx Plugin for AWS에서는 API 통합이 <Link path="/guides/connection">`connection` 생성기</Link>를 통해 지원됩니다. 다음으로, 웹사이트가 Smithy API를 호출할 수 있도록 이 생성기를 사용합니다:
 
-<RunGenerator generator="connection" noInteractive requiredParameters={{ sourceProject: 'website', targetProject: 'api' }} />
+<RunGenerator generator="connection" noInteractive requiredParameters={{ sourceProject: 'website', targetProject: 'api' }} noOptions />
 
 이것은 웹사이트가 생성된 TypeScript 클라이언트를 통해 API를 호출하는 데 필요한 클라이언트 프로바이더와 빌드 타겟을 생성합니다.
 

--- a/docs/src/content/docs/ko/snippets/pdk-migration/example/03-migrate-infra.mdx
+++ b/docs/src/content/docs/ko/snippets/pdk-migration/example/03-migrate-infra.mdx
@@ -22,7 +22,7 @@ Nx Plugin for AWS가 PDK보다 가진 큰 장점은 제공하는 CDK 구성 요�
 
 <Link path="/guides/typescript-infrastructure">`ts#infra` 생성기</Link>를 실행하여 `packages/infra`에 인프라스트럭처 프로젝트를 설정합니다:
 
-<RunGenerator generator="ts#infra" noInteractive requiredParameters={{ name: 'infra' }} />
+<RunGenerator generator="ts#infra" noInteractive requiredParameters={{ name: 'infra' }} noOptions />
 
 #### CDK 인프라스트럭처 마이그레이션
 

--- a/docs/src/content/docs/ko/snippets/pdk-migration/faq/type-safe-api.mdx
+++ b/docs/src/content/docs/ko/snippets/pdk-migration/faq/type-safe-api.mdx
@@ -79,7 +79,7 @@ Type Safe API는 여러 Smithy 기반 API에서 재사용할 수 있는 Smithy �
 
 이에 해당하는 것은 `type`을 `shapes`로 설정한 <Link path="/guides/smithy-project">`smithy#project` 생성기</Link>입니다:
 
-<RunGenerator generator="smithy#project" requiredParameters={{ name: 'my-shapes', type: 'shapes' }} />
+<RunGenerator generator="smithy#project" requiredParameters={{ name: 'my-shapes', type: 'shapes' }} noOptions />
 
 `SmithyShapeLibraryProject`의 shape를 생성된 프로젝트의 `src` 폴더로 이동한 다음, API 모델의 의존성으로 라이브러리를 연결하는 방법에 대해서는 <Link path="/guides/smithy-project#depending-on-a-shape-library">Smithy 프로젝트 가이드</Link>를 참조하세요.
 

--- a/docs/src/content/docs/pt/blog/migrating-from-aws-pdk.mdx
+++ b/docs/src/content/docs/pt/blog/migrating-from-aws-pdk.mdx
@@ -36,7 +36,7 @@ Observe também que alguns recursos do PDK não têm equivalentes exatos. Consul
 :::
 
 :::caution[Guia de Momento Específico]
-Este guia foi escrito como um guia de momento específico e provavelmente não será atualizado conforme o Nx Plugin for AWS evolui. Para compensar isso, o guia fixa a versão do `@aws/nx-plugin` em `1.0.0-rc.47`. Você pode tentar com a versão mais recente se estiver acompanhando, mas pode haver alguns desvios do guia.
+Este guia foi escrito como um guia de momento específico e provavelmente não será atualizado conforme o Nx Plugin for AWS evolui. Para compensar isso, o guia fixa a versão do `@aws/nx-plugin` em `1.0.0`. Você pode tentar com a versão mais recente se estiver acompanhando, mas pode haver alguns desvios do guia.
 :::
 
 ## Exemplo de Migração: Aplicação de Lista de Compras
@@ -54,7 +54,7 @@ A aplicação de lista de compras consiste nos seguintes tipos de projeto PDK:
 
 Para começar, criaremos um novo workspace para nosso novo projeto. Embora seja mais extremo do que uma migração no local, essa abordagem nos dá o resultado final mais limpo. Criar um workspace Nx é equivalente a usar o `MonorepoTsProject` do PDK:
 
-<CreateNxWorkspaceCommand workspace="shopping-list" iac="cdk" tag="1.0.0" />
+<CreateNxWorkspaceCommand workspace="shopping-list" iac="cdk" tag="1.0.0" noOptions />
 
 Abra o diretório `shopping-list` que este comando cria no seu IDE favorito.
 
@@ -80,7 +80,7 @@ Esta seção fornece orientações para recursos do PDK que não são cobertos p
 
 Como regra geral ao migrar do PDK, recomendamos iniciar qualquer projeto com um Nx Workspace, dadas suas semelhanças com o PDK Monorepo. Também recomendamos usar nossos geradores como primitivos sobre os quais construir quaisquer novos tipos.
 
-<CreateNxWorkspaceCommand workspace="my-project" />
+<CreateNxWorkspaceCommand workspace="my-project" noOptions />
 
 ### CDK Graph
 

--- a/docs/src/content/docs/pt/snippets/pdk-migration/example/01-migrate-api.mdx
+++ b/docs/src/content/docs/pt/snippets/pdk-migration/example/01-migrate-api.mdx
@@ -26,7 +26,7 @@ Se você usou OpenAPI ou TypeSpec como sua linguagem de modelagem, ou tem handle
 
 Execute o <Link path="/guides/ts-smithy-api">gerador `ts#api`</Link> com `framework` definido como `smithy` para configurar seu projeto de api em `packages/api`:
 
-<RunGenerator generator="ts#api" noInteractive requiredParameters={{ name: 'api', framework: 'smithy', namespace: 'com.aws', auth: 'iam' }} />
+<RunGenerator generator="ts#api" noInteractive requiredParameters={{ name: 'api', framework: 'smithy', namespace: 'com.aws', auth: 'iam' }} noOptions />
 
 Você notará que isso gera um projeto `model`, bem como um projeto `backend`. O projeto `model` contém seu modelo Smithy, e `backend` contém sua implementação de servidor.
 

--- a/docs/src/content/docs/pt/snippets/pdk-migration/example/02-migrate-website.mdx
+++ b/docs/src/content/docs/pt/snippets/pdk-migration/example/02-migrate-website.mdx
@@ -20,13 +20,13 @@ Como parte da migração, também migraremos do React Router configurado pelo PD
 
 Execute o <Link path="/guides/react-website">gerador `ts#website`</Link> com `framework` definido como `react` para configurar seu projeto de website em `packages/website`. Como a aplicação de lista de compras é construída com componentes CloudScape, também definimos `ux` como `cloudscape` (o padrão é `shadcn`):
 
-<RunGenerator generator="ts#website" noInteractive requiredParameters={{ name: 'website', framework: 'react', ux: 'cloudscape' }} />
+<RunGenerator generator="ts#website" noInteractive requiredParameters={{ name: 'website', framework: 'react', ux: 'cloudscape' }} noOptions />
 
 #### Adicionar Autenticação Cognito
 
 O gerador de website React acima não inclui autenticação cognito por padrão como o `CloudscapeReactTsWebsiteProject`, em vez disso, é adicionado explicitamente através do <Link path="/guides/react-website-auth">gerador `ts#website#auth`</Link>.
 
-<RunGenerator generator="ts#website#auth" noInteractive requiredParameters={{ project: 'website', cognitoDomain: 'shopping-list' }} />
+<RunGenerator generator="ts#website#auth" noInteractive requiredParameters={{ project: 'website', cognitoDomain: 'shopping-list' }} noOptions />
 
 Isso adiciona componentes React que gerenciam os redirecionamentos apropriados para garantir que os usuários façam login usando a UI hospedada do Cognito. Isso também adiciona um construto CDK para implantar os recursos do Cognito em `packages/common/constructs`, chamado `UserIdentity`.
 
@@ -51,7 +51,7 @@ No PDK, você podia passar os projetos Projen fornecidos uns aos outros para aci
 
 Com o Nx Plugin for AWS, a integração de API é suportada através do <Link path="/guides/connection">gerador `connection`</Link>. Em seguida, usamos este gerador para que nosso website possa invocar nossa API Smithy:
 
-<RunGenerator generator="connection" noInteractive requiredParameters={{ sourceProject: 'website', targetProject: 'api' }} />
+<RunGenerator generator="connection" noInteractive requiredParameters={{ sourceProject: 'website', targetProject: 'api' }} noOptions />
 
 Isso gera os provedores de cliente necessários e alvos de build para que seu website chame sua API através de um cliente TypeScript gerado.
 

--- a/docs/src/content/docs/pt/snippets/pdk-migration/example/03-migrate-infra.mdx
+++ b/docs/src/content/docs/pt/snippets/pdk-migration/example/03-migrate-infra.mdx
@@ -22,7 +22,7 @@ Uma grande vantagem do Nx Plugin for AWS sobre o PDK é que os constructs CDK qu
 
 Execute o <Link path="/guides/typescript-infrastructure">gerador `ts#infra`</Link> para configurar seu projeto de infraestrutura em `packages/infra`:
 
-<RunGenerator generator="ts#infra" noInteractive requiredParameters={{ name: 'infra' }} />
+<RunGenerator generator="ts#infra" noInteractive requiredParameters={{ name: 'infra' }} noOptions />
 
 #### Migrar a Infraestrutura CDK
 

--- a/docs/src/content/docs/pt/snippets/pdk-migration/faq/type-safe-api.mdx
+++ b/docs/src/content/docs/pt/snippets/pdk-migration/faq/type-safe-api.mdx
@@ -79,7 +79,7 @@ Type Safe API forneceu um tipo de projeto Projen chamado `SmithyShapeLibraryProj
 
 O equivalente é o <Link path="/guides/smithy-project">gerador `smithy#project`</Link> com `type` definido como `shapes`:
 
-<RunGenerator generator="smithy#project" requiredParameters={{ name: 'my-shapes', type: 'shapes' }} />
+<RunGenerator generator="smithy#project" requiredParameters={{ name: 'my-shapes', type: 'shapes' }} noOptions />
 
 Mova as shapes do seu `SmithyShapeLibraryProject` para a pasta `src` do projeto gerado, então consulte o <Link path="/guides/smithy-project#depending-on-a-shape-library">guia do projeto Smithy</Link> para como conectar a biblioteca como uma dependência do modelo da sua API.
 

--- a/docs/src/content/docs/vi/blog/migrating-from-aws-pdk.mdx
+++ b/docs/src/content/docs/vi/blog/migrating-from-aws-pdk.mdx
@@ -80,7 +80,7 @@ Phần này cung cấp hướng dẫn cho các tính năng của PDK không đư
 
 Như một quy tắc chung khi chuyển từ PDK, chúng tôi khuyến nghị bắt đầu bất kỳ dự án nào với một Nx Workspace, do sự tương đồng của nó với PDK Monorepo. Chúng tôi cũng khuyến nghị sử dụng các generator của chúng tôi làm nền tảng để xây dựng bất kỳ loại mới nào.
 
-<CreateNxWorkspaceCommand workspace="my-project" />
+<CreateNxWorkspaceCommand workspace="my-project" noOptions />
 
 ### CDK Graph
 

--- a/docs/src/content/docs/vi/snippets/pdk-migration/example/01-migrate-api.mdx
+++ b/docs/src/content/docs/vi/snippets/pdk-migration/example/01-migrate-api.mdx
@@ -26,7 +26,7 @@ Nếu bạn đã sử dụng OpenAPI hoặc TypeSpec làm ngôn ngữ mô hình 
 
 Chạy <Link path="/guides/ts-smithy-api">generator `ts#api`</Link> với `framework` được đặt thành `smithy` để thiết lập dự án api của bạn trong `packages/api`:
 
-<RunGenerator generator="ts#api" noInteractive requiredParameters={{ name: 'api', framework: 'smithy', namespace: 'com.aws', auth: 'iam' }} />
+<RunGenerator generator="ts#api" noInteractive requiredParameters={{ name: 'api', framework: 'smithy', namespace: 'com.aws', auth: 'iam' }} noOptions />
 
 Bạn sẽ nhận thấy điều này tạo ra một dự án `model`, cũng như một dự án `backend`. Dự án `model` chứa mô hình Smithy của bạn, và `backend` chứa triển khai máy chủ của bạn.
 

--- a/docs/src/content/docs/vi/snippets/pdk-migration/example/02-migrate-website.mdx
+++ b/docs/src/content/docs/vi/snippets/pdk-migration/example/02-migrate-website.mdx
@@ -20,13 +20,13 @@ Là một phần của quá trình di chuyển, chúng ta cũng sẽ chuyển t�
 
 Chạy <Link path="/guides/react-website">generator `ts#website`</Link> với `framework` được đặt thành `react` để thiết lập dự án website của bạn trong `packages/website`. Vì ứng dụng danh sách mua sắm được xây dựng với các component CloudScape, chúng ta cũng đặt `ux` thành `cloudscape` (mặc định là `shadcn`):
 
-<RunGenerator generator="ts#website" noInteractive requiredParameters={{ name: 'website', framework: 'react', ux: 'cloudscape' }} />
+<RunGenerator generator="ts#website" noInteractive requiredParameters={{ name: 'website', framework: 'react', ux: 'cloudscape' }} noOptions />
 
 #### Thêm Xác thực Cognito
 
 Generator React website ở trên không tích hợp sẵn xác thực cognito như `CloudscapeReactTsWebsiteProject`, thay vào đó nó được thêm một cách rõ ràng thông qua <Link path="/guides/react-website-auth">generator `ts#website#auth`</Link>.
 
-<RunGenerator generator="ts#website#auth" noInteractive requiredParameters={{ project: 'website', cognitoDomain: 'shopping-list' }} />
+<RunGenerator generator="ts#website#auth" noInteractive requiredParameters={{ project: 'website', cognitoDomain: 'shopping-list' }} noOptions />
 
 Điều này thêm các component React quản lý các chuyển hướng thích hợp để đảm bảo người dùng đăng nhập bằng giao diện Cognito hosted UI. Điều này cũng thêm một construct CDK để triển khai các tài nguyên Cognito trong `packages/common/constructs`, được gọi là `UserIdentity`.
 
@@ -51,7 +51,7 @@ Trong PDK, bạn có thể truyền các dự án Projen được cung cấp cho
 
 Với Nx Plugin for AWS, tích hợp API được hỗ trợ thông qua <Link path="/guides/connection">generator `connection`</Link>. Tiếp theo, chúng ta sử dụng generator này để website của chúng ta có thể gọi Smithy API của chúng ta:
 
-<RunGenerator generator="connection" noInteractive requiredParameters={{ sourceProject: 'website', targetProject: 'api' }} />
+<RunGenerator generator="connection" noInteractive requiredParameters={{ sourceProject: 'website', targetProject: 'api' }} noOptions />
 
 Điều này tạo ra các provider client cần thiết và các target build để website của bạn có thể gọi API của bạn thông qua một client TypeScript được tạo ra.
 

--- a/docs/src/content/docs/vi/snippets/pdk-migration/example/03-migrate-infra.mdx
+++ b/docs/src/content/docs/vi/snippets/pdk-migration/example/03-migrate-infra.mdx
@@ -22,7 +22,7 @@ Một lợi thế lớn của Nx Plugin for AWS so với PDK là các construct 
 
 Chạy <Link path="/guides/typescript-infrastructure">trình tạo `ts#infra`</Link> để thiết lập dự án cơ sở hạ tầng của bạn trong `packages/infra`:
 
-<RunGenerator generator="ts#infra" noInteractive requiredParameters={{ name: 'infra' }} />
+<RunGenerator generator="ts#infra" noInteractive requiredParameters={{ name: 'infra' }} noOptions />
 
 #### Di chuyển Cơ sở hạ tầng CDK
 

--- a/docs/src/content/docs/vi/snippets/pdk-migration/faq/type-safe-api.mdx
+++ b/docs/src/content/docs/vi/snippets/pdk-migration/faq/type-safe-api.mdx
@@ -79,7 +79,7 @@ Type Safe API cung cấp một loại dự án Projen có tên `SmithyShapeLibra
 
 Tương đương là <Link path="/guides/smithy-project">generator `smithy#project`</Link> với `type` được đặt thành `shapes`:
 
-<RunGenerator generator="smithy#project" requiredParameters={{ name: 'my-shapes', type: 'shapes' }} />
+<RunGenerator generator="smithy#project" requiredParameters={{ name: 'my-shapes', type: 'shapes' }} noOptions />
 
 Di chuyển các shapes từ `SmithyShapeLibraryProject` của bạn vào thư mục `src` của dự án được tạo, sau đó tham khảo <Link path="/guides/smithy-project#depending-on-a-shape-library">hướng dẫn dự án Smithy</Link> để biết cách kết nối thư viện như một dependency của model API của bạn.
 

--- a/docs/src/content/docs/zh/blog/migrating-from-aws-pdk.mdx
+++ b/docs/src/content/docs/zh/blog/migrating-from-aws-pdk.mdx
@@ -80,7 +80,7 @@ import InstallCommand from '@components/install-command.astro';
 
 作为从 PDK 迁移的一般规则，我们建议使用 Nx Workspace 启动任何项目，因为它与 PDK Monorepo 相似。我们还建议使用我们的生成器作为构建任何新类型的基础。
 
-<CreateNxWorkspaceCommand workspace="my-project" />
+<CreateNxWorkspaceCommand workspace="my-project" noOptions />
 
 ### CDK Graph
 

--- a/docs/src/content/docs/zh/snippets/pdk-migration/example/01-migrate-api.mdx
+++ b/docs/src/content/docs/zh/snippets/pdk-migration/example/01-migrate-api.mdx
@@ -26,7 +26,7 @@ import PackageManagerShortCommand from '@components/package-manager-short-comman
 
 运行 <Link path="/guides/ts-smithy-api">`ts#api` 生成器</Link>，将 `framework` 设置为 `smithy`，以在 `packages/api` 中设置您的 api 项目：
 
-<RunGenerator generator="ts#api" noInteractive requiredParameters={{ name: 'api', framework: 'smithy', namespace: 'com.aws', auth: 'iam' }} />
+<RunGenerator generator="ts#api" noInteractive requiredParameters={{ name: 'api', framework: 'smithy', namespace: 'com.aws', auth: 'iam' }} noOptions />
 
 您会注意到这会生成一个 `model` 项目以及一个 `backend` 项目。`model` 项目包含您的 Smithy 模型，`backend` 包含您的服务器实现。
 

--- a/docs/src/content/docs/zh/snippets/pdk-migration/example/02-migrate-website.mdx
+++ b/docs/src/content/docs/zh/snippets/pdk-migration/example/02-migrate-website.mdx
@@ -20,13 +20,13 @@ import PackageManagerShortCommand from '@components/package-manager-short-comman
 
 运行 <Link path="/guides/react-website">`ts#website` 生成器</Link>，将 `framework` 设置为 `react`，以在 `packages/website` 中设置您的网站项目。由于购物清单应用程序是使用 CloudScape 组件构建的，我们还将 `ux` 设置为 `cloudscape`（默认值为 `shadcn`）：
 
-<RunGenerator generator="ts#website" noInteractive requiredParameters={{ name: 'website', framework: 'react', ux: 'cloudscape' }} />
+<RunGenerator generator="ts#website" noInteractive requiredParameters={{ name: 'website', framework: 'react', ux: 'cloudscape' }} noOptions />
 
 #### 添加 Cognito 身份验证
 
 上面的 React 网站生成器默认不像 `CloudscapeReactTsWebsiteProject` 那样捆绑 cognito 身份验证，而是通过 <Link path="/guides/react-website-auth">`ts#website#auth` 生成器</Link>显式添加。
 
-<RunGenerator generator="ts#website#auth" noInteractive requiredParameters={{ project: 'website', cognitoDomain: 'shopping-list' }} />
+<RunGenerator generator="ts#website#auth" noInteractive requiredParameters={{ project: 'website', cognitoDomain: 'shopping-list' }} noOptions />
 
 这会添加 React 组件来管理适当的重定向，以确保用户使用 Cognito 托管 UI 登录。这还会在 `packages/common/constructs` 中添加一个 CDK 构造来部署 Cognito 资源，称为 `UserIdentity`。
 
@@ -51,7 +51,7 @@ RuntimeConfig.ensure(this).set('connection', 'cognitoProps', {
 
 使用 Nx Plugin for AWS，API 集成通过 <Link path="/guides/connection">`connection` 生成器</Link>支持。接下来，我们使用此生成器，以便我们的网站可以调用我们的 Smithy API：
 
-<RunGenerator generator="connection" noInteractive requiredParameters={{ sourceProject: 'website', targetProject: 'api' }} />
+<RunGenerator generator="connection" noInteractive requiredParameters={{ sourceProject: 'website', targetProject: 'api' }} noOptions />
 
 这会为您的网站生成必要的客户端提供程序和构建目标，以通过生成的 TypeScript 客户端调用您的 API。
 

--- a/docs/src/content/docs/zh/snippets/pdk-migration/example/03-migrate-infra.mdx
+++ b/docs/src/content/docs/zh/snippets/pdk-migration/example/03-migrate-infra.mdx
@@ -22,7 +22,7 @@ Nx Plugin for AWS 相对于 PDK 的一大优势是，它提供的 CDK 构造是�
 
 运行 <Link path="/guides/typescript-infrastructure">`ts#infra` 生成器</Link>在 `packages/infra` 中设置您的基础设施项目：
 
-<RunGenerator generator="ts#infra" noInteractive requiredParameters={{ name: 'infra' }} />
+<RunGenerator generator="ts#infra" noInteractive requiredParameters={{ name: 'infra' }} noOptions />
 
 #### 迁移 CDK 基础设施
 

--- a/docs/src/content/docs/zh/snippets/pdk-migration/faq/type-safe-api.mdx
+++ b/docs/src/content/docs/zh/snippets/pdk-migration/faq/type-safe-api.mdx
@@ -79,7 +79,7 @@ Type Safe API 提供了一个名为 `SmithyShapeLibraryProject` 的 Projen 项�
 
 等效的是将 `type` 设置为 `shapes` 的 <Link path="/guides/smithy-project">`smithy#project` 生成器</Link>：
 
-<RunGenerator generator="smithy#project" requiredParameters={{ name: 'my-shapes', type: 'shapes' }} />
+<RunGenerator generator="smithy#project" requiredParameters={{ name: 'my-shapes', type: 'shapes' }} noOptions />
 
 将您的 `SmithyShapeLibraryProject` 中的形状移动到生成项目的 `src` 文件夹中，然后参考 <Link path="/guides/smithy-project#depending-on-a-shape-library">Smithy 项目指南</Link>了解如何将库连接为 API 模型的依赖项。
 

--- a/docs/src/lib/command-card-strings.ts
+++ b/docs/src/lib/command-card-strings.ts
@@ -76,6 +76,17 @@ const STRINGS = {
     zh: '默认值',
     vi: 'Mặc định',
   },
+  appliesWhen: {
+    en: 'Only applies with these option values',
+    jp: 'これらのオプション値の場合のみ適用されます',
+    ko: '이 옵션 값에서만 적용됩니다',
+    fr: "Ne s'applique qu'avec ces valeurs d'options",
+    it: 'Si applica solo con questi valori delle opzioni',
+    es: 'Solo se aplica con estos valores de opciones',
+    pt: 'Aplica-se apenas com estes valores de opções',
+    zh: '仅在这些选项值下适用',
+    vi: 'Chỉ áp dụng với các giá trị tùy chọn này',
+  },
   reset: {
     en: 'Reset',
     jp: 'リセット',

--- a/docs/src/styles/custom.css
+++ b/docs/src/styles/custom.css
@@ -1345,18 +1345,58 @@ p.badges > a {
 }
 
 /* An option only some choices take, e.g. the Smithy namespace. */
-.gen-param-when {
+.gen-param-when,
+.command-card-field-when {
   padding: 0.02rem 0.35rem;
   border: 1px dashed var(--sl-color-gray-4);
   border-radius: 9999px;
   font-family: var(--__sl-font-mono), ui-monospace, monospace;
   font-size: 0.64rem;
   color: var(--sl-color-gray-3);
-  cursor: help;
 }
 
-.gen-param[hidden] {
-  display: none;
+/* ============================================================
+ * Tooltip — the explanation behind a badge
+ * ============================================================ */
+/* Explains a badge without the native tooltip's delay, and reads on focus too. */
+.doc-tooltip {
+  position: relative;
+}
+
+.doc-tooltip::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  bottom: calc(100% + 0.3rem);
+  left: 0;
+  z-index: 20;
+  width: max-content;
+  max-width: 15rem;
+  padding: 0.3rem 0.45rem;
+  border: 1px solid var(--sl-color-hairline);
+  border-radius: 0.35rem;
+  background: var(--sl-color-black);
+  box-shadow: 0 10px 24px -14px rgb(0 0 0 / 0.6);
+  font-family: var(--sl-font);
+  font-size: 0.7rem;
+  line-height: 1.4;
+  white-space: normal;
+  color: var(--sl-color-gray-2);
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 120ms ease;
+  pointer-events: none;
+}
+
+.doc-tooltip:hover::after,
+.doc-tooltip:focus-visible::after {
+  opacity: 1;
+  visibility: visible;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .doc-tooltip::after {
+    transition: none;
+  }
 }
 
 .gen-param-default {
@@ -1467,6 +1507,26 @@ p.badges > a {
 
 .gen-param-more:hover {
   text-decoration-thickness: 2px;
+}
+
+/* An option ruled out by another choice keeps its place, so the condition it
+   needs stays readable, but reads as out of play. */
+.gen-param.is-inapplicable,
+.command-card-field.is-inapplicable {
+  opacity: 0.55;
+}
+
+.gen-param.is-inapplicable .gen-param-values,
+.command-card-field.is-inapplicable .command-card-pills,
+.command-card-field.is-inapplicable .command-card-check {
+  pointer-events: none;
+}
+
+.gen-param.is-inapplicable .gen-param-when,
+.command-card-field.is-inapplicable .command-card-field-when {
+  border-style: solid;
+  border-color: var(--sl-color-accent);
+  color: var(--sl-color-text-accent);
 }
 
 /* ============================================================


### PR DESCRIPTION
### Reason for this change

Three things from reviewing the option controls in #1243:

- **A conditional option vanished.** An option gated on another — a gateway's `auth`, which needs infrastructure to authenticate — disappeared the moment another choice ruled it out, taking with it any hint of what to change to get it back. Hiding is right when the guide itself fixes the value it depends on (the tRPC guide can never take the Smithy `namespace`), but not when the reader is the one who chose.
- **The condition badge had a `?` cursor and no tooltip.** It carried a `title`, which no tooltip seemed to surface.
- **Point-in-time commands were customisable.** The PDK migration write-up and its snippets record the commands as they were actually run; offering controls over them invites the reader to edit a historical command, and ties the page to option names that may since have been renamed.

### Description of changes

**Ruled out, not removed.** An option the reader's own choice rules out stays in place: dimmed, controls disabled, and its condition badge picked out in the accent so what would have to change is readable. This is in both the options panel and the command builder, and the option's value still leaves the command while it doesn't apply. An option whose dependency the guide fixes is still left out entirely — the split is now precisely "fixed by the guide" (drop it) versus "chosen by the reader" (disable it), where the first is measured against the options the card actually locks rather than everything the page passes.

**A tooltip that appears.** The badge gets a normal cursor and a `.doc-tooltip` of its own, shown on hover or focus with no browser delay, and an `aria-label` carrying the same sentence for assistive tech. The condition badge is now shown in the command builder too, not just the options panel, so the dependency reads where the control is.

**`noOptions`.** `<RunGenerator>` and `<CreateNxWorkspaceCommand>` take `noOptions`, which renders the command and nothing else — no controls, no options section. Applied to the PDK migration blog post and its four snippets.

### Description of how you validated changes

- `pnpm nx run docs:build` passes — 1540 pages built, all internal links valid. `pnpm nx run docs:test` passes (203 tests).
- **MCP server output verified byte-identical** to `main` across all 73 rendered generator guides.
- On the `ts#agent` guide, setting `infra` to `none` now dims `auth` in both the panel and the builder, disables its pills, highlights `infra = agentcore | agentcore-ecr`, and drops `--auth` from the command; clearing `infra` brings it all back. The tRPC guide still omits `namespace` entirely and locks `framework`.
- Confirmed the badge's tooltip appears on hover in both places, and that the cursor is the normal pointer.
- The PDK blog page renders 8 commands with 0 option controls and 0 builder sections. Its commands are unchanged except one, where the flags now follow the order the page passes them rather than schema order: `ts#api … --framework=smithy --namespace=com.aws --auth=iam` (was `--auth=iam --namespace=com.aws`). No semantic change, and with `noOptions` the page's own order is the only order there is.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
