### PR TITLE
docs: show the quick start CDK stack as a diff

### DIFF
--- a/docs/src/content/docs/en/get_started/quick-start.mdx
+++ b/docs/src/content/docs/en/get_started/quick-start.mdx
@@ -189,12 +189,12 @@ See the <Link path="guides/connection/react-trpc">React to tRPC connection guide
 <Fragment slot="cdk">
 Open `packages/infra/src/stacks/application-stack.ts` and add the following code:
 
-```typescript
-import {
-  DemoApi,
-  DemoWebsite,
-  UserIdentity,
-} from '@my-project/common-constructs';
+```diff lang="ts"
++import {
++  DemoApi,
++  DemoWebsite,
++  UserIdentity,
++} from '@my-project/common-constructs';
 import { Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 
@@ -202,13 +202,13 @@ export class ApplicationStack extends Stack {
   constructor(scope: Construct, id: string, props?: StackProps) {
     super(scope, id, props);
 
-    const identity = new UserIdentity(this, 'identity');
-    const api = new DemoApi(this, 'api', {
-      integrations: DemoApi.defaultIntegrations(this).build(),
-    });
-    api.grantInvokeAccess(identity.identityPool.authenticatedRole);
-
-    new DemoWebsite(this, 'website');
++    const identity = new UserIdentity(this, 'identity');
++    const api = new DemoApi(this, 'api', {
++      integrations: DemoApi.defaultIntegrations(this).build(),
++    });
++    api.grantInvokeAccess(identity.identityPool.authenticatedRole);
++
++    new DemoWebsite(this, 'website');
   }
 }
 ```

--- a/docs/src/content/docs/es/get_started/quick-start.mdx
+++ b/docs/src/content/docs/es/get_started/quick-start.mdx
@@ -189,12 +189,12 @@ Consulta la <Link path="guides/connection/react-trpc">guía de conexión de Reac
 <Fragment slot="cdk">
 Abre `packages/infra/src/stacks/application-stack.ts` y agrega el siguiente código:
 
-```typescript
-import {
-  DemoApi,
-  DemoWebsite,
-  UserIdentity,
-} from '@my-project/common-constructs';
+```diff lang="ts"
++import {
++  DemoApi,
++  DemoWebsite,
++  UserIdentity,
++} from '@my-project/common-constructs';
 import { Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 
@@ -202,13 +202,13 @@ export class ApplicationStack extends Stack {
   constructor(scope: Construct, id: string, props?: StackProps) {
     super(scope, id, props);
 
-    const identity = new UserIdentity(this, 'identity');
-    const api = new DemoApi(this, 'api', {
-      integrations: DemoApi.defaultIntegrations(this).build(),
-    });
-    api.grantInvokeAccess(identity.identityPool.authenticatedRole);
-
-    new DemoWebsite(this, 'website');
++    const identity = new UserIdentity(this, 'identity');
++    const api = new DemoApi(this, 'api', {
++      integrations: DemoApi.defaultIntegrations(this).build(),
++    });
++    api.grantInvokeAccess(identity.identityPool.authenticatedRole);
++
++    new DemoWebsite(this, 'website');
   }
 }
 ```

--- a/docs/src/content/docs/fr/get_started/quick-start.mdx
+++ b/docs/src/content/docs/fr/get_started/quick-start.mdx
@@ -189,12 +189,12 @@ Consultez le <Link path="guides/connection/react-trpc">guide de connexion React 
 <Fragment slot="cdk">
 Ouvrez `packages/infra/src/stacks/application-stack.ts` et ajoutez le code suivant :
 
-```typescript
-import {
-  DemoApi,
-  DemoWebsite,
-  UserIdentity,
-} from '@my-project/common-constructs';
+```diff lang="ts"
++import {
++  DemoApi,
++  DemoWebsite,
++  UserIdentity,
++} from '@my-project/common-constructs';
 import { Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 
@@ -202,13 +202,13 @@ export class ApplicationStack extends Stack {
   constructor(scope: Construct, id: string, props?: StackProps) {
     super(scope, id, props);
 
-    const identity = new UserIdentity(this, 'identity');
-    const api = new DemoApi(this, 'api', {
-      integrations: DemoApi.defaultIntegrations(this).build(),
-    });
-    api.grantInvokeAccess(identity.identityPool.authenticatedRole);
-
-    new DemoWebsite(this, 'website');
++    const identity = new UserIdentity(this, 'identity');
++    const api = new DemoApi(this, 'api', {
++      integrations: DemoApi.defaultIntegrations(this).build(),
++    });
++    api.grantInvokeAccess(identity.identityPool.authenticatedRole);
++
++    new DemoWebsite(this, 'website');
   }
 }
 ```

--- a/docs/src/content/docs/it/get_started/quick-start.mdx
+++ b/docs/src/content/docs/it/get_started/quick-start.mdx
@@ -189,12 +189,12 @@ Consulta la <Link path="guides/connection/react-trpc">guida alla connessione Rea
 <Fragment slot="cdk">
 Apri `packages/infra/src/stacks/application-stack.ts` e aggiungi il seguente codice:
 
-```typescript
-import {
-  DemoApi,
-  DemoWebsite,
-  UserIdentity,
-} from '@my-project/common-constructs';
+```diff lang="ts"
++import {
++  DemoApi,
++  DemoWebsite,
++  UserIdentity,
++} from '@my-project/common-constructs';
 import { Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 
@@ -202,13 +202,13 @@ export class ApplicationStack extends Stack {
   constructor(scope: Construct, id: string, props?: StackProps) {
     super(scope, id, props);
 
-    const identity = new UserIdentity(this, 'identity');
-    const api = new DemoApi(this, 'api', {
-      integrations: DemoApi.defaultIntegrations(this).build(),
-    });
-    api.grantInvokeAccess(identity.identityPool.authenticatedRole);
-
-    new DemoWebsite(this, 'website');
++    const identity = new UserIdentity(this, 'identity');
++    const api = new DemoApi(this, 'api', {
++      integrations: DemoApi.defaultIntegrations(this).build(),
++    });
++    api.grantInvokeAccess(identity.identityPool.authenticatedRole);
++
++    new DemoWebsite(this, 'website');
   }
 }
 ```

--- a/docs/src/content/docs/jp/get_started/quick-start.mdx
+++ b/docs/src/content/docs/jp/get_started/quick-start.mdx
@@ -189,12 +189,12 @@ function RouteComponent() {
 <Fragment slot="cdk">
 `packages/infra/src/stacks/application-stack.ts` を開き、以下のコードを追加します：
 
-```typescript
-import {
-  DemoApi,
-  DemoWebsite,
-  UserIdentity,
-} from '@my-project/common-constructs';
+```diff lang="ts"
++import {
++  DemoApi,
++  DemoWebsite,
++  UserIdentity,
++} from '@my-project/common-constructs';
 import { Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 
@@ -202,13 +202,13 @@ export class ApplicationStack extends Stack {
   constructor(scope: Construct, id: string, props?: StackProps) {
     super(scope, id, props);
 
-    const identity = new UserIdentity(this, 'identity');
-    const api = new DemoApi(this, 'api', {
-      integrations: DemoApi.defaultIntegrations(this).build(),
-    });
-    api.grantInvokeAccess(identity.identityPool.authenticatedRole);
-
-    new DemoWebsite(this, 'website');
++    const identity = new UserIdentity(this, 'identity');
++    const api = new DemoApi(this, 'api', {
++      integrations: DemoApi.defaultIntegrations(this).build(),
++    });
++    api.grantInvokeAccess(identity.identityPool.authenticatedRole);
++
++    new DemoWebsite(this, 'website');
   }
 }
 ```
@@ -287,6 +287,7 @@ output "user_pool_id" {
 これが、フルスタックアプリケーションをデプロイするために記述する必要のあるすべての Terraform です。
 </Fragment>
 </Infrastructure>
+
 
 ### インフラストラクチャをビルドしてデプロイする
 
@@ -432,3 +433,4 @@ aws cloudformation delete-stack --stack-name CDKToolkit --region <region>
 - <Link path="get_started/tutorials/dungeon-game/overview">Dungeon Adventure チュートリアル</Link> — このガイドよりも詳細なウォークスルーとして、フルスタック AI ダンジョンアドベンチャーゲームを構築します。
 - <Link path="guides/workspace">ワークスペース</Link> — ワークスペースのレイアウトと、ジェネレーターが共有する設定について説明します。
 - <Link path="get_started/existing-project">既存のプロジェクトに追加する</Link> — 既存のコードベースでプラグインを採用します。
+

--- a/docs/src/content/docs/ko/get_started/quick-start.mdx
+++ b/docs/src/content/docs/ko/get_started/quick-start.mdx
@@ -189,12 +189,12 @@ function RouteComponent() {
 <Fragment slot="cdk">
 `packages/infra/src/stacks/application-stack.ts`를 열고 다음 코드를 추가합니다:
 
-```typescript
-import {
-  DemoApi,
-  DemoWebsite,
-  UserIdentity,
-} from '@my-project/common-constructs';
+```diff lang="ts"
++import {
++  DemoApi,
++  DemoWebsite,
++  UserIdentity,
++} from '@my-project/common-constructs';
 import { Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 
@@ -202,13 +202,13 @@ export class ApplicationStack extends Stack {
   constructor(scope: Construct, id: string, props?: StackProps) {
     super(scope, id, props);
 
-    const identity = new UserIdentity(this, 'identity');
-    const api = new DemoApi(this, 'api', {
-      integrations: DemoApi.defaultIntegrations(this).build(),
-    });
-    api.grantInvokeAccess(identity.identityPool.authenticatedRole);
-
-    new DemoWebsite(this, 'website');
++    const identity = new UserIdentity(this, 'identity');
++    const api = new DemoApi(this, 'api', {
++      integrations: DemoApi.defaultIntegrations(this).build(),
++    });
++    api.grantInvokeAccess(identity.identityPool.authenticatedRole);
++
++    new DemoWebsite(this, 'website');
   }
 }
 ```

--- a/docs/src/content/docs/pt/get_started/quick-start.mdx
+++ b/docs/src/content/docs/pt/get_started/quick-start.mdx
@@ -189,12 +189,12 @@ Veja o <Link path="guides/connection/react-trpc">guia de conexão React para tRP
 <Fragment slot="cdk">
 Abra `packages/infra/src/stacks/application-stack.ts` e adicione o seguinte código:
 
-```typescript
-import {
-  DemoApi,
-  DemoWebsite,
-  UserIdentity,
-} from '@my-project/common-constructs';
+```diff lang="ts"
++import {
++  DemoApi,
++  DemoWebsite,
++  UserIdentity,
++} from '@my-project/common-constructs';
 import { Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 
@@ -202,13 +202,13 @@ export class ApplicationStack extends Stack {
   constructor(scope: Construct, id: string, props?: StackProps) {
     super(scope, id, props);
 
-    const identity = new UserIdentity(this, 'identity');
-    const api = new DemoApi(this, 'api', {
-      integrations: DemoApi.defaultIntegrations(this).build(),
-    });
-    api.grantInvokeAccess(identity.identityPool.authenticatedRole);
-
-    new DemoWebsite(this, 'website');
++    const identity = new UserIdentity(this, 'identity');
++    const api = new DemoApi(this, 'api', {
++      integrations: DemoApi.defaultIntegrations(this).build(),
++    });
++    api.grantInvokeAccess(identity.identityPool.authenticatedRole);
++
++    new DemoWebsite(this, 'website');
   }
 }
 ```

--- a/docs/src/content/docs/vi/get_started/quick-start.mdx
+++ b/docs/src/content/docs/vi/get_started/quick-start.mdx
@@ -189,12 +189,12 @@ Xem <Link path="guides/connection/react-trpc">hướng dẫn kết nối React v
 <Fragment slot="cdk">
 Mở `packages/infra/src/stacks/application-stack.ts` và thêm đoạn mã sau:
 
-```typescript
-import {
-  DemoApi,
-  DemoWebsite,
-  UserIdentity,
-} from '@my-project/common-constructs';
+```diff lang="ts"
++import {
++  DemoApi,
++  DemoWebsite,
++  UserIdentity,
++} from '@my-project/common-constructs';
 import { Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 
@@ -202,13 +202,13 @@ export class ApplicationStack extends Stack {
   constructor(scope: Construct, id: string, props?: StackProps) {
     super(scope, id, props);
 
-    const identity = new UserIdentity(this, 'identity');
-    const api = new DemoApi(this, 'api', {
-      integrations: DemoApi.defaultIntegrations(this).build(),
-    });
-    api.grantInvokeAccess(identity.identityPool.authenticatedRole);
-
-    new DemoWebsite(this, 'website');
++    const identity = new UserIdentity(this, 'identity');
++    const api = new DemoApi(this, 'api', {
++      integrations: DemoApi.defaultIntegrations(this).build(),
++    });
++    api.grantInvokeAccess(identity.identityPool.authenticatedRole);
++
++    new DemoWebsite(this, 'website');
   }
 }
 ```

--- a/docs/src/content/docs/zh/get_started/quick-start.mdx
+++ b/docs/src/content/docs/zh/get_started/quick-start.mdx
@@ -189,12 +189,12 @@ function RouteComponent() {
 <Fragment slot="cdk">
 打开 `packages/infra/src/stacks/application-stack.ts` 并添加以下代码:
 
-```typescript
-import {
-  DemoApi,
-  DemoWebsite,
-  UserIdentity,
-} from '@my-project/common-constructs';
+```diff lang="ts"
++import {
++  DemoApi,
++  DemoWebsite,
++  UserIdentity,
++} from '@my-project/common-constructs';
 import { Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 
@@ -202,13 +202,13 @@ export class ApplicationStack extends Stack {
   constructor(scope: Construct, id: string, props?: StackProps) {
     super(scope, id, props);
 
-    const identity = new UserIdentity(this, 'identity');
-    const api = new DemoApi(this, 'api', {
-      integrations: DemoApi.defaultIntegrations(this).build(),
-    });
-    api.grantInvokeAccess(identity.identityPool.authenticatedRole);
-
-    new DemoWebsite(this, 'website');
++    const identity = new UserIdentity(this, 'identity');
++    const api = new DemoApi(this, 'api', {
++      integrations: DemoApi.defaultIntegrations(this).build(),
++    });
++    api.grantInvokeAccess(identity.identityPool.authenticatedRole);
++
++    new DemoWebsite(this, 'website');
   }
 }
 ```


### PR DESCRIPTION
### Reason for this change

Step 4 of the quick start presented the finished `packages/infra/src/stacks/application-stack.ts` as a plain code block. The reader has just generated that file with `ts#infra`, so what they actually need is to see which lines to add to the scaffold they already have — instead they got a wall of code to diff against it in their head.

### Description of changes

Rendered the block as `diff lang="ts"`, with the additions measured against the stack the `ts#infra` generator actually vends (`packages/nx-plugin/src/infra/app/files/app/src/stacks/application-stack.ts.template`):

- the five `@my-project/common-constructs` import lines, and
- the seven body lines that create the identity, API and website.

Everything else is unchanged context. Only additions are marked — the removal of the generated `// The code that defines your stack goes here` comment is deliberately not shown, so the block still reads as the complete resulting file and pasting it wholesale gives the right result.

`lang="ts"` keeps TypeScript syntax highlighting inside the diff.

<details>
<summary>Why a plain fence rather than the <code>&lt;Diff&gt;</code> component</summary>

The repo has a `<Diff before={...} after={...} />` component, already used a little further up this page, and it was the obvious first choice. It renders with two columns of indentation stripped, though — `constructor(...)` lands at column 0 and the stack body at 2 instead of 4 — which is a pre-existing problem also visible on the existing `routes/index.tsx` diff on this page. Expressive Code handles the diff string correctly when given it directly, so the loss happens before the string reaches it. That is fixed separately in #1250; this page uses a plain fence, which renders correctly today.
</details>

### Description of how you validated changes

- `pnpm nx run docs:build` passes.
- Inspected the rendered `<figure>` in both the production build and the live dev server, confirming: indentation preserved exactly, `data-language="ts"`, the 12 intended lines carry the `ins` class, and no line carries `del`.
- Checked the diff's context lines against the generator template so the "before" state is the real generated file rather than an approximation.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
