### PR TITLE
docs: rule out the option values a generator won't accept

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -470,6 +470,19 @@ An option that only applies for certain values of another can say so in its `sch
 
 Keys are AND'd and a list of values is OR'd within a key, matching `<OptionFilter when={{…}}>`. Reach for it where a description already has to explain that an option is conditional (`"only applicable for the smithy framework"`), and leave the description saying so too — the MCP server renders descriptions, not `x-when`. The generator itself still has to validate or ignore what doesn't apply to the run it was given.
 
+Where it's one _value_ of an option that only applies sometimes, put the condition on the value with `x-value-when`:
+
+```json
+"infra": {
+  "type": "string",
+  "enum": ["rest-lambda", "http-lambda", "none"],
+  "default": "rest-lambda",
+  "x-value-when": { "http-lambda": { "framework": "trpc" } }
+}
+```
+
+A value the guide has ruled out is left off the list; one the reader's own choice rules out is disabled, with the condition in a tooltip. If picking it would leave the command invalid — because the value a run falls back to is the ruled-out one — the card names the first value that does apply, so what a guide shows always runs. Encode a constraint here whenever a generator throws on a combination (`session 'dynamodb-s3' is not implemented for the strands framework`) or quietly substitutes one (`ts#api` maps `http-lambda` to a REST API under Smithy), and evaluate it against the values a run would use: a condition on an option nobody has chosen is read against that option's own default.
+
 #### OptionFilter: conditional sections
 
 Wrap any content that only applies to a subset of option values in `<OptionFilter>`. On the docs site the reader picks their option values in the page's run-generator card — the same controls that build the command — and blocks that don't match are hidden, along with their table-of-contents entries; the MCP server drops mismatching blocks from the response when the agent passes `options`.

--- a/docs/src/components/command-card-field.astro
+++ b/docs/src/components/command-card-field.astro
@@ -78,6 +78,11 @@ const values = locked ? option.values.filter((v) => v === value) : option.values
             title={enumValue === option.default ? strings.defaultValue : undefined}
             data-option-pill={option.key}
             data-value={enumValue}
+            data-value-when={
+              option.valueWhen?.[enumValue]
+                ? JSON.stringify(option.valueWhen[enumValue])
+                : undefined
+            }
             aria-pressed={String(value === enumValue)}
             disabled={locked}
           >

--- a/docs/src/components/command-card.astro
+++ b/docs/src/components/command-card.astro
@@ -168,7 +168,11 @@ const isPinned = shown.every((option) => locked.has(option.key));
     type CardConfig,
     type CommandToken,
   } from '../lib/command-card';
-  import { isApplicable } from '../lib/generator-options';
+  import {
+    effectiveValues,
+    isApplicable,
+    isValueApplicable,
+  } from '../lib/generator-options';
   import { readPageSelection } from '../lib/page-options';
 
   /**
@@ -294,10 +298,14 @@ const isPinned = shown.every((option) => locked.has(option.key));
     // controls are disabled rather than removed, so the reader can see the
     // condition they'd have to change, and whatever was entered in it leaves the
     // command.
-    const applyApplicability = (values: Record<string, string>) => {
-      const dropped: string[] = [];
+    const applyApplicability = () => {
+      // Read against the values a run would use, so a condition on an option the
+      // reader hasn't touched is read against that option's own default.
+      const context = effectiveValues(entered(), config.options);
+      const dropped = new Set<string>();
+
       for (const option of config.options) {
-        const applies = isApplicable(option, values);
+        const applies = isApplicable(option, context);
         const field = fields.get(option.key);
         field?.classList.toggle('is-inapplicable', !applies);
         for (const control of field?.querySelectorAll<
@@ -310,15 +318,54 @@ const isPinned = shown.every((option) => locked.has(option.key));
             control.disabled = fixed || !applies;
           }
         }
-        if (!applies) dropped.push(option.key);
+        if (!applies) dropped.add(option.key);
       }
+
+      // One of an option's values can be ruled out on its own — an API's
+      // `http-lambda` under the Smithy framework.
+      for (const option of config.options) {
+        if (!option.valueWhen || dropped.has(option.key)) continue;
+        const owned = pills.filter(
+          (pill) => pill.dataset.optionPill === option.key,
+        );
+        const applicable = owned.filter((pill) =>
+          isValueApplicable(option, pill.dataset.value!, context),
+        );
+        for (const pill of owned) {
+          const applies = applicable.includes(pill);
+          pill.classList.toggle('is-inapplicable', !applies);
+          if (!locked.has(pill)) pill.disabled = !applies;
+          // A value that has just stopped applying is let go rather than left to
+          // make a command the generator would refuse.
+          if (!applies && pill.getAttribute('aria-pressed') === 'true') {
+            setPill(option.key, '');
+          }
+        }
+        // Where the value a run would fall back to is a ruled-out one, the command
+        // has to name a value that isn't, or the generator refuses it.
+        const chosen = owned.find(
+          (pill) => pill.getAttribute('aria-pressed') === 'true',
+        );
+        const fallback = chosen?.dataset.value ?? option.default ?? '';
+        if (
+          !locked.has(owned[0]) &&
+          applicable.length > 0 &&
+          fallback &&
+          !isValueApplicable(option, fallback, context)
+        ) {
+          setPill(option.key, applicable[0].dataset.value!);
+        }
+      }
+
       return Object.fromEntries(
-        Object.entries(values).filter(([key]) => !dropped.includes(key)),
+        Object.entries(emittedValues(entered(), config.options)).filter(
+          ([key]) => !dropped.has(key),
+        ),
       );
     };
 
     const render = () => {
-      const values = applyApplicability(emittedValues(entered(), config.options));
+      const values = applyApplicability();
       for (const block of blocks) {
         paint(
           block,

--- a/docs/src/components/generator-parameters.astro
+++ b/docs/src/components/generator-parameters.astro
@@ -17,7 +17,9 @@ import GeneratorsJson from '../../../packages/nx-plugin/generators.json';
 import schemaTranslations from '../i18n/schema-translations.json';
 import {
   describeWhen,
+  effectiveValues,
   isApplicable,
+  isValueApplicable,
   readGeneratorOptions,
 } from '../lib/generator-options';
 import { pinnedPageOptions, type PageWhen } from '../lib/page-options';
@@ -123,11 +125,16 @@ const pinnedByPage = pinnedPageOptions(
   (Astro.locals.starlightRoute?.entry?.data as { when?: PageWhen } | undefined)
     ?.when,
 );
+const forced = effectiveValues(pinnedByPage, []);
 const parameters = readGeneratorOptions(schema)
-  .filter((option) => isApplicable(option, pinnedByPage))
+  .filter((option) => isApplicable(option, forced))
   .map((option) => ({
     ...option,
     description: getDescription(option.key, option.description),
+    // A value the guide has ruled out is not one of this variant's choices.
+    values: option.values.filter((value) =>
+      isValueApplicable(option, value, forced),
+    ),
   }));
 ---
 
@@ -135,6 +142,13 @@ const parameters = readGeneratorOptions(schema)
   class="gen-params not-content"
   data-gen-params
   data-gen-params-pinned={JSON.stringify(pinnedByPage)}
+  data-gen-params-defaults={JSON.stringify(
+    Object.fromEntries(
+      parameters
+        .filter((parameter) => parameter.default !== undefined)
+        .map((parameter) => [parameter.key, parameter.default]),
+    ),
+  )}
 >
   <div class="gen-params-head">
     <span class="gen-params-title">{localeString('title')}</span>
@@ -181,10 +195,21 @@ const parameters = readGeneratorOptions(schema)
                     {
                       'is-overflow': index >= COLLAPSE_AFTER,
                       'is-default': value === parameter.default,
+                      'doc-tooltip': !!parameter.valueWhen?.[value],
                     },
                   ]}
                   title={value === parameter.default ? localeString('default') : undefined}
+                  data-tooltip={
+                    parameter.valueWhen?.[value]
+                      ? `${localeString('appliesWhen')}: ${describeWhen(parameter.valueWhen[value])}`
+                      : undefined
+                  }
                   data-gen-param-value={value}
+                  data-value-when={
+                    parameter.valueWhen?.[value]
+                      ? JSON.stringify(parameter.valueWhen[value])
+                      : undefined
+                  }
                 >
                   {value}
                 </span>
@@ -209,7 +234,11 @@ const parameters = readGeneratorOptions(schema)
 </div>
 
 <script>
-  import { isApplicable } from '../lib/generator-options';
+  import {
+    effectiveValues,
+    isApplicable,
+    isValueApplicable,
+  } from '../lib/generator-options';
 
   /**
    * Keeps the panel and the page's command in step, in both directions:
@@ -235,8 +264,15 @@ const parameters = readGeneratorOptions(schema)
       // The values the page itself is written around, which the reader's
       // selection adds to rather than replaces.
       let pinned: Record<string, string> = {};
+      let defaults: { key: string; default?: string }[] = [];
       try {
         pinned = JSON.parse(panel.dataset.genParamsPinned || '{}');
+        defaults = Object.entries(
+          JSON.parse(panel.dataset.genParamsDefaults || '{}') as Record<
+            string,
+            string
+          >,
+        ).map(([key, value]) => ({ key, default: value }));
       } catch {
         // A malformed value is nothing to act on.
       }
@@ -266,6 +302,8 @@ const parameters = readGeneratorOptions(schema)
         // Picking the value already set clears it, so the option goes back to
         // whatever the generator would prompt for.
         const choose = (chip: HTMLElement) => {
+          // A value another choice rules out isn't one to pick.
+          if (chip.classList.contains('is-inapplicable')) return;
           const value = chip.classList.contains('is-selected')
             ? ''
             : chip.dataset.genParamValue!;
@@ -290,7 +328,9 @@ const parameters = readGeneratorOptions(schema)
         values: Record<string, string>,
         command: Record<string, string>,
       ) => {
-        const context = { ...pinned, ...values };
+        // The values a run would use, so a condition on an option the reader
+        // hasn't touched is read against that option's own default.
+        const context = effectiveValues({ ...pinned, ...values }, defaults);
 
         for (const row of rows) {
           const when = row.dataset.genParamWhen;
@@ -308,6 +348,18 @@ const parameters = readGeneratorOptions(schema)
             if (chip.getAttribute('role') === 'button') {
               chip.setAttribute('aria-pressed', String(isSelected));
             }
+            // A value ruled out on its own — an API's `http-lambda` under the
+            // Smithy framework — reads as out of play like the option would.
+            const valueWhen = chip.dataset.valueWhen;
+            chip.classList.toggle(
+              'is-inapplicable',
+              !!valueWhen &&
+                !isValueApplicable(
+                  { valueWhen: { value: JSON.parse(valueWhen) } },
+                  'value',
+                  context,
+                ),
+            );
           }
         }
       };

--- a/docs/src/components/run-generator.astro
+++ b/docs/src/components/run-generator.astro
@@ -22,7 +22,9 @@ import {
 import { emittedValues, type GeneratorCardConfig } from '../lib/command-card';
 import { commandCardStrings } from '../lib/command-card-strings';
 import {
+  effectiveValues,
   isApplicable,
+  isValueApplicable,
   readGeneratorOptions,
   type GeneratorOption,
 } from '../lib/generator-options';
@@ -111,10 +113,24 @@ const locked = new Set(
 // has nothing to contribute — the Smithy namespace on the tRPC guide. One that
 // depends on a value the reader can still change stays, and the card disables it
 // while it doesn't apply.
-const forced: Record<string, string> = Object.fromEntries(
-  [...locked].map((key) => [key, initial[key]]).filter(([, value]) => !!value),
+// Only the options the guide fixes count as forced: the rest are the reader's to
+// choose, and the card follows along as they do.
+const forced = effectiveValues(
+  Object.fromEntries(
+    [...locked].map((key) => [key, initial[key]]).filter(([, value]) => !!value),
+  ),
+  options.filter((option) => locked.has(option.key)),
 );
-const applicable = options.filter((option) => isApplicable(option, forced));
+const applicable = options
+  .filter((option) => isApplicable(option, forced))
+  // A value the guide has ruled out is no choice at all: `http-lambda` can't
+  // apply on a guide written for the Smithy framework.
+  .map((option) => ({
+    ...option,
+    values: option.values.filter((value) =>
+      isValueApplicable(option, value, forced),
+    ),
+  }));
 
 const config: GeneratorCardConfig = {
   kind: 'generator',
@@ -125,12 +141,15 @@ const config: GeneratorCardConfig = {
   order: applicable.map((option) => option.key),
   // The options this guide pins, which a restored selection must not overwrite.
   prescribed: Object.keys(prescribed),
-  options: applicable.map(({ key, control, default: fallback, when }) => ({
-    key,
-    control,
-    default: fallback,
-    when,
-  })),
+  options: applicable.map(
+    ({ key, control, default: fallback, when, valueWhen }) => ({
+      key,
+      control,
+      default: fallback,
+      when,
+      valueWhen,
+    }),
+  ),
 };
 const inapplicable = new Set(
   options

--- a/docs/src/lib/command-card.spec.ts
+++ b/docs/src/lib/command-card.spec.ts
@@ -16,7 +16,9 @@ import {
 } from './command-card';
 import {
   describeWhen,
+  effectiveValues,
   isApplicable,
+  isValueApplicable,
   readGeneratorOptions,
 } from './generator-options';
 import { pinnedPageOptions } from './page-options';
@@ -141,6 +143,74 @@ describe('option applicability', () => {
     expect(describeWhen(auth.when ?? {})).toBe(
       'infra = agentcore | agentcore-ecr',
     );
+  });
+});
+
+describe('value applicability', () => {
+  const schema = {
+    properties: {
+      framework: { type: 'string', enum: ['trpc', 'smithy'], default: 'trpc' },
+      infra: {
+        type: 'string',
+        enum: ['rest-lambda', 'http-lambda', 'none'],
+        default: 'rest-lambda',
+        'x-value-when': { 'http-lambda': { framework: 'trpc' } },
+      },
+      session: {
+        type: 'string',
+        enum: ['s3', 'dynamodb-s3', 'in-memory'],
+        'x-value-when': { 'dynamodb-s3': { framework: ['langchain'] } },
+      },
+    },
+  };
+  const [framework, infra, session] = readGeneratorOptions(schema);
+
+  it('should normalise the condition on each value', () => {
+    expect(infra.valueWhen).toEqual({ 'http-lambda': { framework: ['trpc'] } });
+    expect(session.valueWhen).toEqual({
+      'dynamodb-s3': { framework: ['langchain'] },
+    });
+    expect(framework.valueWhen).toBeUndefined();
+  });
+
+  it('should apply a value with no condition of its own', () => {
+    expect(isValueApplicable(infra, 'none', { framework: 'smithy' })).toBe(
+      true,
+    );
+  });
+
+  it('should apply a conditional value under the values it names', () => {
+    expect(isValueApplicable(infra, 'http-lambda', { framework: 'trpc' })).toBe(
+      true,
+    );
+  });
+
+  it('should rule a conditional value out under any other value', () => {
+    expect(
+      isValueApplicable(infra, 'http-lambda', { framework: 'smithy' }),
+    ).toBe(false);
+  });
+
+  it('should read a condition against the values a run would use', () => {
+    // `--session=dynamodb-s3` alone fails: `framework` falls back to its default.
+    const values = effectiveValues({ session: 'dynamodb-s3' }, [
+      framework,
+      infra,
+      session,
+    ]);
+
+    expect(values).toEqual({
+      framework: 'trpc',
+      infra: 'rest-lambda',
+      session: 'dynamodb-s3',
+    });
+    expect(isValueApplicable(session, 'dynamodb-s3', values)).toBe(false);
+  });
+
+  it('should leave an entered value alone when working out what a run would use', () => {
+    expect(
+      effectiveValues({ framework: 'smithy' }, [framework, infra]),
+    ).toEqual({ framework: 'smithy', infra: 'rest-lambda' });
   });
 });
 

--- a/docs/src/lib/generator-options.ts
+++ b/docs/src/lib/generator-options.ts
@@ -20,9 +20,15 @@ export interface SchemaProperty {
   /**
    * The option values this option applies under, e.g. `{ "framework": "smithy" }`
    * on an option only the Smithy framework takes. AND across keys, OR within a
-   * key, and a key the reader hasn't chosen a value for has no opinion.
+   * key, and a key with no value chosen falls back to that option's own default.
    */
   'x-when'?: Record<string, string | string[]>;
+  /**
+   * The same, per value, for one of an option's values that only applies
+   * sometimes: `{ "http-lambda": { "framework": "trpc" } }` on the API's `infra`,
+   * which only Smithy's REST integration doesn't offer.
+   */
+  'x-value-when'?: Record<string, Record<string, string | string[]>>;
 }
 
 export interface GeneratorSchema {
@@ -45,6 +51,8 @@ export interface GeneratorOption {
   description?: string;
   /** Normalised `x-when`: the values this option applies under. */
   when?: Record<string, string[]>;
+  /** Normalised `x-value-when`: the values each of this option's values needs. */
+  valueWhen?: Record<string, Record<string, string[]>>;
 }
 
 /**
@@ -57,16 +65,33 @@ const REQUIRED_RANK = 0;
 const isEnum = (property: SchemaProperty) =>
   Array.isArray(property.enum) && property.enum.length > 0;
 
-/** Normalise `x-when` so a single value and a list of them read the same. */
+/** Normalise a predicate so a single value and a list of them read the same. */
+const normalisePredicate = (
+  when: Record<string, string | string[]>,
+): Record<string, string[]> =>
+  Object.fromEntries(
+    Object.entries(when).map(([key, value]) => [
+      key,
+      (Array.isArray(value) ? value : [value]).map(String),
+    ]),
+  );
+
 const whenOf = (
   property: SchemaProperty,
 ): Record<string, string[]> | undefined => {
   const when = property['x-when'];
-  if (!when) return undefined;
+  return when ? normalisePredicate(when) : undefined;
+};
+
+const valueWhenOf = (
+  property: SchemaProperty,
+): Record<string, Record<string, string[]>> | undefined => {
+  const valueWhen = property['x-value-when'];
+  if (!valueWhen) return undefined;
   return Object.fromEntries(
-    Object.entries(when).map(([key, value]) => [
-      key,
-      (Array.isArray(value) ? value : [value]).map(String),
+    Object.entries(valueWhen).map(([value, when]) => [
+      value,
+      normalisePredicate(when),
     ]),
   );
 };
@@ -95,6 +120,7 @@ export const readGeneratorOptions = (
         required: required.has(key),
         description: property.description,
         when: whenOf(property),
+        valueWhen: valueWhenOf(property),
         rank: required.has(key)
           ? REQUIRED_RANK
           : (RANKS[property['x-priority'] ?? 'normal'] ?? RANKS.normal),
@@ -106,22 +132,60 @@ export const readGeneratorOptions = (
 };
 
 /**
- * Whether an option applies given the values chosen so far.
- *
  * Mirrors `<OptionFilter when>`: AND across keys, OR within a key, and a key with
- * no value chosen doesn't rule the option out — the generator would prompt for it.
+ * no value at all doesn't rule anything out — the generator would prompt for it.
  */
-export const isApplicable = (
-  option: Pick<GeneratorOption, 'when'>,
+const matches = (
+  when: Record<string, string[]>,
   values: Record<string, string>,
 ): boolean => {
-  if (!option.when) return true;
-  for (const [key, allowed] of Object.entries(option.when)) {
+  for (const [key, allowed] of Object.entries(when)) {
     const value = values[key];
     if (value === undefined || value === '') continue;
     if (!allowed.includes(value)) return false;
   }
   return true;
+};
+
+/** Whether an option applies given the values a run would use. */
+export const isApplicable = (
+  option: Pick<GeneratorOption, 'when'>,
+  values: Record<string, string>,
+): boolean => (option.when ? matches(option.when, values) : true);
+
+/**
+ * Whether one of an option's values applies given the values a run would use.
+ *
+ * `ts#api` offers `infra=http-lambda`, which only the tRPC framework has an
+ * integration for — picking it alongside Smithy silently gets a REST API instead.
+ */
+export const isValueApplicable = (
+  option: Pick<GeneratorOption, 'valueWhen'>,
+  value: string,
+  values: Record<string, string>,
+): boolean => {
+  const when = option.valueWhen?.[value];
+  return when ? matches(when, values) : true;
+};
+
+/**
+ * The values a run would actually use: what the reader entered, falling back to
+ * each option's own default.
+ *
+ * A condition has to be read against these rather than against the entries alone:
+ * `py#agent --session=dynamodb-s3` fails on its own, because `framework` defaults
+ * to Strands, which has no DynamoDB session to save to.
+ */
+export const effectiveValues = (
+  entered: Record<string, string>,
+  options: readonly Pick<GeneratorOption, 'key' | 'default'>[],
+): Record<string, string> => {
+  const values: Record<string, string> = {};
+  for (const option of options) {
+    const value = entered[option.key] || option.default;
+    if (value) values[option.key] = value;
+  }
+  return { ...entered, ...values };
 };
 
 /** `key = a | b` for the values an option applies under, for a short label. */

--- a/docs/src/styles/custom.css
+++ b/docs/src/styles/custom.css
@@ -1529,6 +1529,19 @@ p.badges > a {
   color: var(--sl-color-text-accent);
 }
 
+/* One value of an option can be ruled out on its own — an API's `http-lambda`
+   under the Smithy framework — while the rest of the set still applies. */
+/* Still hoverable, since the tooltip is where the condition is spelled out. */
+.gen-param-value.is-inapplicable,
+.command-card-pill.is-inapplicable {
+  border-style: dashed;
+  opacity: 0.5;
+}
+
+.gen-param.is-interactive .gen-param-value.is-inapplicable {
+  cursor: default;
+}
+
 /* ============================================================
  * Option filter — the conditional sections of a guide
  * ============================================================ */

--- a/packages/nx-plugin/src/py/agent/schema.json
+++ b/packages/nx-plugin/src/py/agent/schema.json
@@ -67,6 +67,7 @@
       "description": "The storage used to persist session for your Agent. LangChain supports 's3' or 'dynamodb-s3'; Strands supports 's3'; 'in-memory' is valid for both.",
       "x-prompt": "How would you like to persist session for your Agent?",
       "enum": ["s3", "dynamodb-s3", "in-memory"],
+      "x-value-when": { "dynamodb-s3": { "framework": "langchain" } },
       "default": "s3",
       "x-priority": "important"
     },

--- a/packages/nx-plugin/src/ts/api/schema.json
+++ b/packages/nx-plugin/src/ts/api/schema.json
@@ -98,6 +98,7 @@
       "description": "The type of infrastructure to use to deploy this API.",
       "default": "rest-lambda",
       "enum": ["rest-lambda", "http-lambda", "none"],
+      "x-value-when": { "http-lambda": { "framework": "trpc" } },
       "x-prompt": "What infrastructure would you like to deploy your API with?",
       "x-priority": "important"
     },

--- a/packages/nx-plugin/src/ts/react-website/app/schema.json
+++ b/packages/nx-plugin/src/ts/react-website/app/schema.json
@@ -40,6 +40,7 @@
       "type": "string",
       "description": "The preferred UX provider.",
       "enum": ["none", "cloudscape", "shadcn"],
+      "x-value-when": { "shadcn": { "tailwind": "true" } },
       "x-priority": "important",
       "default": "shadcn",
       "x-prompt": {

--- a/packages/nx-plugin/src/ts/website/app/schema.json
+++ b/packages/nx-plugin/src/ts/website/app/schema.json
@@ -47,6 +47,7 @@
       "type": "string",
       "description": "The preferred UX provider.",
       "enum": ["none", "cloudscape", "shadcn"],
+      "x-value-when": { "shadcn": { "tailwind": "true" } },
       "x-priority": "important",
       "default": "shadcn",
       "x-prompt": {


### PR DESCRIPTION
### Reason for this change

A generator's schema lists every value an option can take across all the shapes that generator has, and some of those values only work alongside certain others. The docs offered them all, so a guide would happily build a command the generator won't accept:

- `ts#api --framework=smithy --infra=http-lambda` — the Smithy delegate only has a REST integration, so `ts#api` quietly maps `http-lambda` to `rest-lambda` and the reader gets a REST API they didn't ask for.
- `py#agent --session=dynamodb-s3` — fails outright, because `framework` falls back to Strands, which has no DynamoDB checkpointer to save to (`Unsupported combination: session 'dynamodb-s3' is not implemented for the strands framework`).
- `ts#website --tailwind=false` — fails, because `ux` falls back to `shadcn`, which is built on Tailwind (`Shadcn requires TailwindCSS to be enabled.`).

Those are the three combination constraints the generators enforce today; I swept `packages/nx-plugin/src` for thrown errors and silent substitutions to find them.

### Description of changes

**`x-value-when`** puts a condition on one value of an option, alongside `x-when` for a whole option:

```json
"infra": {
  "type": "string",
  "enum": ["rest-lambda", "http-lambda", "none"],
  "default": "rest-lambda",
  "x-value-when": { "http-lambda": { "framework": "trpc" } }
}
```

Same semantics as `x-when` and `<OptionFilter when={{…}}>`: AND across keys, OR within a key. Documented in CONTRIBUTING next to `x-when`, and encoded on `ts#api`'s `infra`, `py#agent`'s `session`, and `ux` on both `ts#website` and its React delegate.

The docs then treat a ruled-out value the way the last PR treats a ruled-out option:

- **Ruled out by the guide** — the value is left off the list. The Smithy guide's `infra` offers `rest-lambda` and `none`, which is all its integration has; the tRPC guide keeps all three.
- **Ruled out by the reader's own choice** — the pill is disabled and dashed, with the condition in a tooltip, in both the options panel and the command builder. A value that stops applying is let go rather than left to make a command that fails.
- **Where letting go isn't enough** — because the value a run falls back to is itself ruled out — the card names the first value that does apply, so what a guide shows always runs. Clearing `tailwind` on the website guide moves `ux` off `shadcn` (`--ux=none --tailwind=false`) instead of leaving a command the generator refuses.

**Conditions are read against the values a run would use**: what the reader entered, falling back to each option's own default. That's what the generator sees, and it's what makes `--session=dynamodb-s3` on its own read as invalid. This also sharpens the option-level conditions from the last PR — a condition on an option nobody has chosen is now read against that option's default rather than treated as "no opinion".

### Description of how you validated changes

- `pnpm nx run docs:build` passes — 1540 pages built, all internal links valid. `pnpm nx run docs:test` passes with 6 new tests over per-value normalisation, applicability and effective values (209 total).
- **MCP server output verified byte-identical** to the base branch across all 73 rendered generator guides — nothing reads `x-value-when` but the docs site.
- Walked each constraint in the browser:
  - Smithy guide: `infra` shows `rest-lambda` and `none` in both the panel and the builder; the tRPC guide shows all three.
  - `py#agent` guide: `dynamodb-s3` starts disabled (framework falls back to Strands), enables on picking `langchain`, and going back to `strands` drops `--session=dynamodb-s3` from the command, leaving `--framework=strands`.
  - React website guide: clearing `tailwind` disables and dashes `shadcn`, selects `ux=none`, and the command reads `--ux=none --tailwind=false`; re-ticking `tailwind` re-enables `shadcn`.
  - Confirmed the per-value tooltip reads "Only applies with these option values: tailwind = true" and that a ruled-out chip can still be hovered for it.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
