### PR TITLE
docs: keep code samples intact in diffs and copied markdown

### DIFF
--- a/docs/src/components/markdown-content.astro
+++ b/docs/src/components/markdown-content.astro
@@ -13,6 +13,8 @@ import {
   buildGeneratorInfoList,
   findGeneratorsJsonEntry,
 } from '../../../packages/nx-plugin/src/utils/generators';
+import { parseMdx } from '../../../packages/nx-plugin/src/mcp-server/guide-pipeline';
+import { stripFrontmatterAndEsm } from '../../../packages/nx-plugin/src/mcp-server/mdx-ast';
 import ExperimentalBanner from './experimental-banner.astro';
 import OptionFilterBar from './option-filter-bar.astro';
 import Snippet from './snippet.astro';
@@ -56,12 +58,9 @@ if (!isSnippet && starlightRoute?.entry?.id) {
       const pluginDir = path.resolve(docsDir, '..', 'packages', 'nx-plugin');
       const generators = buildGeneratorInfoList(pluginDir);
 
-      // Strip frontmatter and imports from MDX content
-      const stripMdxPreamble = (content: string) =>
-        content
-          .replace(/^---\n[\s\S]*?\n---\n/, '')
-          .replace(/^import\s+.*$\n?/gm, '')
-          .trim();
+      // Strip frontmatter and ESM statements from MDX content
+      const stripMdxPreamble = async (content: string) =>
+        stripFrontmatterAndEsm(content, await parseMdx(content));
 
       // Create a local filesystem snippet provider (reads from en locale)
       const snippetsDir = path.join(docsContentDir, 'en', 'snippets');
@@ -74,16 +73,7 @@ if (!isSnippet && starlightRoute?.entry?.id) {
         }
       };
 
-      // Strip frontmatter
-      const frontmatterEnd = rawMdx.match(/^---\n[\s\S]*?\n---\n/);
-      const bodyWithoutFrontmatter = frontmatterEnd
-        ? rawMdx.slice(frontmatterEnd[0].length)
-        : rawMdx;
-
-      // Strip import statements
-      const bodyWithoutImports = bodyWithoutFrontmatter
-        .replace(/^import\s+.*$\n?/gm, '')
-        .trim();
+      const bodyWithoutImports = await stripMdxPreamble(rawMdx);
 
       // Run the same resolution as the MCP server
       const processed = await postProcessGuide(

--- a/docs/src/content/docs/en/get_started/quick-start.mdx
+++ b/docs/src/content/docs/en/get_started/quick-start.mdx
@@ -13,7 +13,6 @@ import RunGenerator from '@components/run-generator.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Infrastructure from '@components/infrastructure.astro';
 import EmbeddedGraph from '@components/embedded-graph.astro';
-import Diff from '@components/diff.astro';
 import Prompt from '@components/prompt.astro';
 
 This guide walks you through the basics of installing and using `@aws/nx-plugin` to rapidly build projects on AWS.
@@ -128,54 +127,39 @@ Connecting the website to the API added a `useDemoApi` hook, which returns a [tR
 
 Update `packages/demo-website/src/routes/index.tsx` to call the API's `echo` procedure, showing a spinner while the request is in flight:
 
-<Diff lang="tsx" before={`import { createFileRoute } from '@tanstack/react-router';
-
-export const Route = createFileRoute('/')({
-  component: RouteComponent,
-});
-
-function RouteComponent() {
-  return (
-    <div className="text-center">
-      <header>
-        <h1>Welcome</h1>
-        <p>Welcome to your new React website!</p>
-      </header>
-    </div>
-  );
-}
-`} after={`import { useQuery } from '@tanstack/react-query';
+```diff lang="tsx"
++import { useQuery } from '@tanstack/react-query';
 import { createFileRoute } from '@tanstack/react-router';
-import { Spinner } from '../components/spinner';
-import { useDemoApi } from '../hooks/useDemoApi';
++import { Spinner } from '../components/spinner';
++import { useDemoApi } from '../hooks/useDemoApi';
 
 export const Route = createFileRoute('/')({
   component: RouteComponent,
 });
 
 function RouteComponent() {
-  const trpc = useDemoApi();
-  const echo = useQuery(
-    trpc.echo.queryOptions({ message: 'Hello from the API!' }),
-  );
-
++  const trpc = useDemoApi();
++  const echo = useQuery(
++    trpc.echo.queryOptions({ message: 'Hello from the API!' }),
++  );
++
   return (
     <div className="text-center">
       <header>
         <h1>Welcome</h1>
         <p>Welcome to your new React website!</p>
       </header>
-      {echo.isLoading ? (
-        <Spinner />
-      ) : echo.error ? (
-        <p>Error: {echo.error.message}</p>
-      ) : (
-        <p>{echo.data?.message}</p>
-      )}
++      {echo.isLoading ? (
++        <Spinner />
++      ) : echo.error ? (
++        <p>Error: {echo.error.message}</p>
++      ) : (
++        <p>{echo.data?.message}</p>
++      )}
     </div>
   );
 }
-`} />
+```
 
 Save the file and the page reloads with the message your API echoed back. The call is type-safe end to end — rename `message` in `packages/demo-api/src/schema/echo.ts` and your website stops compiling until you follow the change through.
 

--- a/docs/src/content/docs/es/get_started/quick-start.mdx
+++ b/docs/src/content/docs/es/get_started/quick-start.mdx
@@ -13,7 +13,6 @@ import RunGenerator from '@components/run-generator.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Infrastructure from '@components/infrastructure.astro';
 import EmbeddedGraph from '@components/embedded-graph.astro';
-import Diff from '@components/diff.astro';
 import Prompt from '@components/prompt.astro';
 
 Esta guía te lleva a través de los conceptos básicos de instalación y uso de `@aws/nx-plugin` para construir proyectos rápidamente en AWS.
@@ -128,54 +127,39 @@ Conectar el sitio web a la API agregó un hook `useDemoApi`, que devuelve un [pr
 
 Actualiza `packages/demo-website/src/routes/index.tsx` para llamar al procedimiento `echo` de la API, mostrando un spinner mientras la solicitud está en curso:
 
-<Diff lang="tsx" before={`import { createFileRoute } from '@tanstack/react-router';
-
-export const Route = createFileRoute('/')({
-  component: RouteComponent,
-});
-
-function RouteComponent() {
-  return (
-    <div className="text-center">
-      <header>
-        <h1>Welcome</h1>
-        <p>Welcome to your new React website!</p>
-      </header>
-    </div>
-  );
-}
-`} after={`import { useQuery } from '@tanstack/react-query';
+```diff lang="tsx"
++import { useQuery } from '@tanstack/react-query';
 import { createFileRoute } from '@tanstack/react-router';
-import { Spinner } from '../components/spinner';
-import { useDemoApi } from '../hooks/useDemoApi';
++import { Spinner } from '../components/spinner';
++import { useDemoApi } from '../hooks/useDemoApi';
 
 export const Route = createFileRoute('/')({
   component: RouteComponent,
 });
 
 function RouteComponent() {
-  const trpc = useDemoApi();
-  const echo = useQuery(
-    trpc.echo.queryOptions({ message: 'Hello from the API!' }),
-  );
-
++  const trpc = useDemoApi();
++  const echo = useQuery(
++    trpc.echo.queryOptions({ message: 'Hello from the API!' }),
++  );
++
   return (
     <div className="text-center">
       <header>
         <h1>Welcome</h1>
         <p>Welcome to your new React website!</p>
       </header>
-      {echo.isLoading ? (
-        <Spinner />
-      ) : echo.error ? (
-        <p>Error: {echo.error.message}</p>
-      ) : (
-        <p>{echo.data?.message}</p>
-      )}
++      {echo.isLoading ? (
++        <Spinner />
++      ) : echo.error ? (
++        <p>Error: {echo.error.message}</p>
++      ) : (
++        <p>{echo.data?.message}</p>
++      )}
     </div>
   );
 }
-`} />
+```
 
 Guarda el archivo y la página se recarga con el mensaje que tu API devolvió. La llamada es segura de tipos de extremo a extremo — renombra `message` en `packages/demo-api/src/schema/echo.ts` y tu sitio web dejará de compilar hasta que sigas el cambio.
 

--- a/docs/src/content/docs/fr/get_started/quick-start.mdx
+++ b/docs/src/content/docs/fr/get_started/quick-start.mdx
@@ -13,7 +13,6 @@ import RunGenerator from '@components/run-generator.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Infrastructure from '@components/infrastructure.astro';
 import EmbeddedGraph from '@components/embedded-graph.astro';
-import Diff from '@components/diff.astro';
 import Prompt from '@components/prompt.astro';
 
 Ce guide vous présente les bases de l'installation et de l'utilisation de `@aws/nx-plugin` pour créer rapidement des projets sur AWS.
@@ -128,54 +127,39 @@ La connexion du site web à l'API a ajouté un hook `useDemoApi`, qui renvoie un
 
 Mettez à jour `packages/demo-website/src/routes/index.tsx` pour appeler la procédure `echo` de l'API, en affichant un spinner pendant que la requête est en cours :
 
-<Diff lang="tsx" before={`import { createFileRoute } from '@tanstack/react-router';
-
-export const Route = createFileRoute('/')({
-  component: RouteComponent,
-});
-
-function RouteComponent() {
-  return (
-    <div className="text-center">
-      <header>
-        <h1>Welcome</h1>
-        <p>Welcome to your new React website!</p>
-      </header>
-    </div>
-  );
-}
-`} after={`import { useQuery } from '@tanstack/react-query';
+```diff lang="tsx"
++import { useQuery } from '@tanstack/react-query';
 import { createFileRoute } from '@tanstack/react-router';
-import { Spinner } from '../components/spinner';
-import { useDemoApi } from '../hooks/useDemoApi';
++import { Spinner } from '../components/spinner';
++import { useDemoApi } from '../hooks/useDemoApi';
 
 export const Route = createFileRoute('/')({
   component: RouteComponent,
 });
 
 function RouteComponent() {
-  const trpc = useDemoApi();
-  const echo = useQuery(
-    trpc.echo.queryOptions({ message: 'Hello from the API!' }),
-  );
-
++  const trpc = useDemoApi();
++  const echo = useQuery(
++    trpc.echo.queryOptions({ message: 'Hello from the API!' }),
++  );
++
   return (
     <div className="text-center">
       <header>
         <h1>Welcome</h1>
         <p>Welcome to your new React website!</p>
       </header>
-      {echo.isLoading ? (
-        <Spinner />
-      ) : echo.error ? (
-        <p>Error: {echo.error.message}</p>
-      ) : (
-        <p>{echo.data?.message}</p>
-      )}
++      {echo.isLoading ? (
++        <Spinner />
++      ) : echo.error ? (
++        <p>Error: {echo.error.message}</p>
++      ) : (
++        <p>{echo.data?.message}</p>
++      )}
     </div>
   );
 }
-`} />
+```
 
 Enregistrez le fichier et la page se recharge avec le message que votre API a renvoyé. L'appel est sécurisé de bout en bout — renommez `message` dans `packages/demo-api/src/schema/echo.ts` et votre site web cesse de compiler jusqu'à ce que vous suiviez le changement.
 

--- a/docs/src/content/docs/it/get_started/quick-start.mdx
+++ b/docs/src/content/docs/it/get_started/quick-start.mdx
@@ -13,7 +13,6 @@ import RunGenerator from '@components/run-generator.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Infrastructure from '@components/infrastructure.astro';
 import EmbeddedGraph from '@components/embedded-graph.astro';
-import Diff from '@components/diff.astro';
 import Prompt from '@components/prompt.astro';
 
 Questa guida ti accompagna attraverso le basi dell'installazione e dell'utilizzo di `@aws/nx-plugin` per costruire rapidamente progetti su AWS.
@@ -128,54 +127,39 @@ Connettere il sito web all'API ha aggiunto un hook `useDemoApi`, che restituisce
 
 Aggiorna `packages/demo-website/src/routes/index.tsx` per chiamare la procedura `echo` dell'API, mostrando uno spinner mentre la richiesta è in corso:
 
-<Diff lang="tsx" before={`import { createFileRoute } from '@tanstack/react-router';
-
-export const Route = createFileRoute('/')({
-  component: RouteComponent,
-});
-
-function RouteComponent() {
-  return (
-    <div className="text-center">
-      <header>
-        <h1>Welcome</h1>
-        <p>Welcome to your new React website!</p>
-      </header>
-    </div>
-  );
-}
-`} after={`import { useQuery } from '@tanstack/react-query';
+```diff lang="tsx"
++import { useQuery } from '@tanstack/react-query';
 import { createFileRoute } from '@tanstack/react-router';
-import { Spinner } from '../components/spinner';
-import { useDemoApi } from '../hooks/useDemoApi';
++import { Spinner } from '../components/spinner';
++import { useDemoApi } from '../hooks/useDemoApi';
 
 export const Route = createFileRoute('/')({
   component: RouteComponent,
 });
 
 function RouteComponent() {
-  const trpc = useDemoApi();
-  const echo = useQuery(
-    trpc.echo.queryOptions({ message: 'Hello from the API!' }),
-  );
-
++  const trpc = useDemoApi();
++  const echo = useQuery(
++    trpc.echo.queryOptions({ message: 'Hello from the API!' }),
++  );
++
   return (
     <div className="text-center">
       <header>
         <h1>Welcome</h1>
         <p>Welcome to your new React website!</p>
       </header>
-      {echo.isLoading ? (
-        <Spinner />
-      ) : echo.error ? (
-        <p>Error: {echo.error.message}</p>
-      ) : (
-        <p>{echo.data?.message}</p>
-      )}
++      {echo.isLoading ? (
++        <Spinner />
++      ) : echo.error ? (
++        <p>Error: {echo.error.message}</p>
++      ) : (
++        <p>{echo.data?.message}</p>
++      )}
     </div>
   );
 }
-`} />
+```
 
 Salva il file e la pagina si ricarica con il messaggio che la tua API ha restituito. La chiamata è type-safe end-to-end — rinomina `message` in `packages/demo-api/src/schema/echo.ts` e il tuo sito web smette di compilare finché non segui la modifica.
 

--- a/docs/src/content/docs/jp/get_started/quick-start.mdx
+++ b/docs/src/content/docs/jp/get_started/quick-start.mdx
@@ -13,7 +13,6 @@ import RunGenerator from '@components/run-generator.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Infrastructure from '@components/infrastructure.astro';
 import EmbeddedGraph from '@components/embedded-graph.astro';
-import Diff from '@components/diff.astro';
 import Prompt from '@components/prompt.astro';
 
 このガイドでは、`@aws/nx-plugin` をインストールして使用し、AWS 上でプロジェクトを迅速に構築するための基本を説明します。
@@ -128,54 +127,39 @@ Infrastructure as Code プロバイダーとして [CDK](https://docs.aws.amazon
 
 `packages/demo-website/src/routes/index.tsx` を更新して、API の `echo` プロシージャを呼び出し、リクエストの実行中にスピナーを表示します：
 
-<Diff lang="tsx" before={`import { createFileRoute } from '@tanstack/react-router';
-
-export const Route = createFileRoute('/')({
-  component: RouteComponent,
-});
-
-function RouteComponent() {
-  return (
-    <div className="text-center">
-      <header>
-        <h1>Welcome</h1>
-        <p>Welcome to your new React website!</p>
-      </header>
-    </div>
-  );
-}
-`} after={`import { useQuery } from '@tanstack/react-query';
+```diff lang="tsx"
++import { useQuery } from '@tanstack/react-query';
 import { createFileRoute } from '@tanstack/react-router';
-import { Spinner } from '../components/spinner';
-import { useDemoApi } from '../hooks/useDemoApi';
++import { Spinner } from '../components/spinner';
++import { useDemoApi } from '../hooks/useDemoApi';
 
 export const Route = createFileRoute('/')({
   component: RouteComponent,
 });
 
 function RouteComponent() {
-  const trpc = useDemoApi();
-  const echo = useQuery(
-    trpc.echo.queryOptions({ message: 'Hello from the API!' }),
-  );
-
++  const trpc = useDemoApi();
++  const echo = useQuery(
++    trpc.echo.queryOptions({ message: 'Hello from the API!' }),
++  );
++
   return (
     <div className="text-center">
       <header>
         <h1>Welcome</h1>
         <p>Welcome to your new React website!</p>
       </header>
-      {echo.isLoading ? (
-        <Spinner />
-      ) : echo.error ? (
-        <p>Error: {echo.error.message}</p>
-      ) : (
-        <p>{echo.data?.message}</p>
-      )}
++      {echo.isLoading ? (
++        <Spinner />
++      ) : echo.error ? (
++        <p>Error: {echo.error.message}</p>
++      ) : (
++        <p>{echo.data?.message}</p>
++      )}
     </div>
   );
 }
-`} />
+```
 
 ファイルを保存すると、API がエコーバックしたメッセージでページがリロードされます。呼び出しはエンドツーエンドで型安全です — `packages/demo-api/src/schema/echo.ts` の `message` の名前を変更すると、変更を追跡するまでウェブサイトのコンパイルが停止します。
 

--- a/docs/src/content/docs/ko/get_started/quick-start.mdx
+++ b/docs/src/content/docs/ko/get_started/quick-start.mdx
@@ -13,7 +13,6 @@ import RunGenerator from '@components/run-generator.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Infrastructure from '@components/infrastructure.astro';
 import EmbeddedGraph from '@components/embedded-graph.astro';
-import Diff from '@components/diff.astro';
 import Prompt from '@components/prompt.astro';
 
 이 가이드는 `@aws/nx-plugin`을 설치하고 사용하여 AWS에서 프로젝트를 빠르게 구축하는 기본 사항을 안내합니다.
@@ -128,54 +127,39 @@ cd my-project
 
 `packages/demo-website/src/routes/index.tsx`를 업데이트하여 API의 `echo` 프로시저를 호출하고, 요청이 진행 중일 때 스피너를 표시합니다:
 
-<Diff lang="tsx" before={`import { createFileRoute } from '@tanstack/react-router';
-
-export const Route = createFileRoute('/')({
-  component: RouteComponent,
-});
-
-function RouteComponent() {
-  return (
-    <div className="text-center">
-      <header>
-        <h1>Welcome</h1>
-        <p>Welcome to your new React website!</p>
-      </header>
-    </div>
-  );
-}
-`} after={`import { useQuery } from '@tanstack/react-query';
+```diff lang="tsx"
++import { useQuery } from '@tanstack/react-query';
 import { createFileRoute } from '@tanstack/react-router';
-import { Spinner } from '../components/spinner';
-import { useDemoApi } from '../hooks/useDemoApi';
++import { Spinner } from '../components/spinner';
++import { useDemoApi } from '../hooks/useDemoApi';
 
 export const Route = createFileRoute('/')({
   component: RouteComponent,
 });
 
 function RouteComponent() {
-  const trpc = useDemoApi();
-  const echo = useQuery(
-    trpc.echo.queryOptions({ message: 'Hello from the API!' }),
-  );
-
++  const trpc = useDemoApi();
++  const echo = useQuery(
++    trpc.echo.queryOptions({ message: 'Hello from the API!' }),
++  );
++
   return (
     <div className="text-center">
       <header>
         <h1>Welcome</h1>
         <p>Welcome to your new React website!</p>
       </header>
-      {echo.isLoading ? (
-        <Spinner />
-      ) : echo.error ? (
-        <p>Error: {echo.error.message}</p>
-      ) : (
-        <p>{echo.data?.message}</p>
-      )}
++      {echo.isLoading ? (
++        <Spinner />
++      ) : echo.error ? (
++        <p>Error: {echo.error.message}</p>
++      ) : (
++        <p>{echo.data?.message}</p>
++      )}
     </div>
   );
 }
-`} />
+```
 
 파일을 저장하면 API가 에코한 메시지와 함께 페이지가 다시 로드됩니다. 호출은 엔드 투 엔드로 타입 안전합니다 — `packages/demo-api/src/schema/echo.ts`에서 `message`의 이름을 변경하면 변경 사항을 따라갈 때까지 웹사이트 컴파일이 중지됩니다.
 

--- a/docs/src/content/docs/pt/get_started/quick-start.mdx
+++ b/docs/src/content/docs/pt/get_started/quick-start.mdx
@@ -13,7 +13,6 @@ import RunGenerator from '@components/run-generator.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Infrastructure from '@components/infrastructure.astro';
 import EmbeddedGraph from '@components/embedded-graph.astro';
-import Diff from '@components/diff.astro';
 import Prompt from '@components/prompt.astro';
 
 Este guia orienta você pelos conceitos básicos de instalação e uso do `@aws/nx-plugin` para construir projetos rapidamente na AWS.
@@ -128,54 +127,39 @@ Conectar o website à API adicionou um hook `useDemoApi`, que retorna um [proxy 
 
 Atualize `packages/demo-website/src/routes/index.tsx` para chamar o procedimento `echo` da API, mostrando um spinner enquanto a requisição está em andamento:
 
-<Diff lang="tsx" before={`import { createFileRoute } from '@tanstack/react-router';
-
-export const Route = createFileRoute('/')({
-  component: RouteComponent,
-});
-
-function RouteComponent() {
-  return (
-    <div className="text-center">
-      <header>
-        <h1>Welcome</h1>
-        <p>Welcome to your new React website!</p>
-      </header>
-    </div>
-  );
-}
-`} after={`import { useQuery } from '@tanstack/react-query';
+```diff lang="tsx"
++import { useQuery } from '@tanstack/react-query';
 import { createFileRoute } from '@tanstack/react-router';
-import { Spinner } from '../components/spinner';
-import { useDemoApi } from '../hooks/useDemoApi';
++import { Spinner } from '../components/spinner';
++import { useDemoApi } from '../hooks/useDemoApi';
 
 export const Route = createFileRoute('/')({
   component: RouteComponent,
 });
 
 function RouteComponent() {
-  const trpc = useDemoApi();
-  const echo = useQuery(
-    trpc.echo.queryOptions({ message: 'Hello from the API!' }),
-  );
-
++  const trpc = useDemoApi();
++  const echo = useQuery(
++    trpc.echo.queryOptions({ message: 'Hello from the API!' }),
++  );
++
   return (
     <div className="text-center">
       <header>
         <h1>Welcome</h1>
         <p>Welcome to your new React website!</p>
       </header>
-      {echo.isLoading ? (
-        <Spinner />
-      ) : echo.error ? (
-        <p>Error: {echo.error.message}</p>
-      ) : (
-        <p>{echo.data?.message}</p>
-      )}
++      {echo.isLoading ? (
++        <Spinner />
++      ) : echo.error ? (
++        <p>Error: {echo.error.message}</p>
++      ) : (
++        <p>{echo.data?.message}</p>
++      )}
     </div>
   );
 }
-`} />
+```
 
 Salve o arquivo e a página recarrega com a mensagem que sua API ecoou de volta. A chamada é type-safe de ponta a ponta — renomeie `message` em `packages/demo-api/src/schema/echo.ts` e seu website para de compilar até que você siga a mudança.
 

--- a/docs/src/content/docs/vi/get_started/quick-start.mdx
+++ b/docs/src/content/docs/vi/get_started/quick-start.mdx
@@ -13,7 +13,6 @@ import RunGenerator from '@components/run-generator.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Infrastructure from '@components/infrastructure.astro';
 import EmbeddedGraph from '@components/embedded-graph.astro';
-import Diff from '@components/diff.astro';
 import Prompt from '@components/prompt.astro';
 
 Hướng dẫn này sẽ giúp bạn làm quen với các bước cơ bản để cài đặt và sử dụng `@aws/nx-plugin` nhằm xây dựng các dự án trên AWS một cách nhanh chóng.
@@ -128,54 +127,39 @@ Kết nối website với API đã thêm một hook `useDemoApi`, trả về m�
 
 Cập nhật `packages/demo-website/src/routes/index.tsx` để gọi procedure `echo` của API, hiển thị spinner trong khi request đang được thực hiện:
 
-<Diff lang="tsx" before={`import { createFileRoute } from '@tanstack/react-router';
-
-export const Route = createFileRoute('/')({
-  component: RouteComponent,
-});
-
-function RouteComponent() {
-  return (
-    <div className="text-center">
-      <header>
-        <h1>Welcome</h1>
-        <p>Welcome to your new React website!</p>
-      </header>
-    </div>
-  );
-}
-`} after={`import { useQuery } from '@tanstack/react-query';
+```diff lang="tsx"
++import { useQuery } from '@tanstack/react-query';
 import { createFileRoute } from '@tanstack/react-router';
-import { Spinner } from '../components/spinner';
-import { useDemoApi } from '../hooks/useDemoApi';
++import { Spinner } from '../components/spinner';
++import { useDemoApi } from '../hooks/useDemoApi';
 
 export const Route = createFileRoute('/')({
   component: RouteComponent,
 });
 
 function RouteComponent() {
-  const trpc = useDemoApi();
-  const echo = useQuery(
-    trpc.echo.queryOptions({ message: 'Hello from the API!' }),
-  );
-
++  const trpc = useDemoApi();
++  const echo = useQuery(
++    trpc.echo.queryOptions({ message: 'Hello from the API!' }),
++  );
++
   return (
     <div className="text-center">
       <header>
         <h1>Welcome</h1>
         <p>Welcome to your new React website!</p>
       </header>
-      {echo.isLoading ? (
-        <Spinner />
-      ) : echo.error ? (
-        <p>Error: {echo.error.message}</p>
-      ) : (
-        <p>{echo.data?.message}</p>
-      )}
++      {echo.isLoading ? (
++        <Spinner />
++      ) : echo.error ? (
++        <p>Error: {echo.error.message}</p>
++      ) : (
++        <p>{echo.data?.message}</p>
++      )}
     </div>
   );
 }
-`} />
+```
 
 Lưu tệp và trang sẽ tải lại với thông điệp mà API của bạn đã echo trả về. Cuộc gọi này an toàn về kiểu từ đầu đến cuối — đổi tên `message` trong `packages/demo-api/src/schema/echo.ts` và website của bạn sẽ ngừng biên dịch cho đến khi bạn thực hiện thay đổi xuyên suốt.
 

--- a/docs/src/content/docs/zh/get_started/quick-start.mdx
+++ b/docs/src/content/docs/zh/get_started/quick-start.mdx
@@ -13,7 +13,6 @@ import RunGenerator from '@components/run-generator.astro';
 import NxCommands from '@components/nx-commands.astro';
 import Infrastructure from '@components/infrastructure.astro';
 import EmbeddedGraph from '@components/embedded-graph.astro';
-import Diff from '@components/diff.astro';
 import Prompt from '@components/prompt.astro';
 
 本指南将引导您了解安装和使用 `@aws/nx-plugin` 在 AWS 上快速构建项目的基础知识。
@@ -128,54 +127,39 @@ cd my-project
 
 更新 `packages/demo-website/src/routes/index.tsx` 以调用 API 的 `echo` 过程,在请求进行时显示加载动画:
 
-<Diff lang="tsx" before={`import { createFileRoute } from '@tanstack/react-router';
-
-export const Route = createFileRoute('/')({
-  component: RouteComponent,
-});
-
-function RouteComponent() {
-  return (
-    <div className="text-center">
-      <header>
-        <h1>Welcome</h1>
-        <p>Welcome to your new React website!</p>
-      </header>
-    </div>
-  );
-}
-`} after={`import { useQuery } from '@tanstack/react-query';
+```diff lang="tsx"
++import { useQuery } from '@tanstack/react-query';
 import { createFileRoute } from '@tanstack/react-router';
-import { Spinner } from '../components/spinner';
-import { useDemoApi } from '../hooks/useDemoApi';
++import { Spinner } from '../components/spinner';
++import { useDemoApi } from '../hooks/useDemoApi';
 
 export const Route = createFileRoute('/')({
   component: RouteComponent,
 });
 
 function RouteComponent() {
-  const trpc = useDemoApi();
-  const echo = useQuery(
-    trpc.echo.queryOptions({ message: 'Hello from the API!' }),
-  );
-
++  const trpc = useDemoApi();
++  const echo = useQuery(
++    trpc.echo.queryOptions({ message: 'Hello from the API!' }),
++  );
++
   return (
     <div className="text-center">
       <header>
         <h1>Welcome</h1>
         <p>Welcome to your new React website!</p>
       </header>
-      {echo.isLoading ? (
-        <Spinner />
-      ) : echo.error ? (
-        <p>Error: {echo.error.message}</p>
-      ) : (
-        <p>{echo.data?.message}</p>
-      )}
++      {echo.isLoading ? (
++        <Spinner />
++      ) : echo.error ? (
++        <p>Error: {echo.error.message}</p>
++      ) : (
++        <p>{echo.data?.message}</p>
++      )}
     </div>
   );
 }
-`} />
+```
 
 保存文件,页面将重新加载并显示您的 API 回显的消息。该调用是端到端类型安全的——在 `packages/demo-api/src/schema/echo.ts` 中重命名 `message`,您的网站将停止编译,直到您完成更改。
 

--- a/packages/nx-plugin/src/mcp-server/mdx-ast.spec.ts
+++ b/packages/nx-plugin/src/mcp-server/mdx-ast.spec.ts
@@ -1,0 +1,86 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { parseMdx } from './guide-pipeline.js';
+import { stripFrontmatterAndEsm } from './mdx-ast.js';
+
+const strip = async (raw: string) =>
+  stripFrontmatterAndEsm(raw, await parseMdx(raw));
+
+describe('stripFrontmatterAndEsm', () => {
+  it('removes the frontmatter', async () => {
+    expect(await strip('---\ntitle: My Page\n---\n\nContent\n')).toBe(
+      'Content',
+    );
+  });
+
+  it('removes import and export statements', async () => {
+    const raw = [
+      '---',
+      'title: My Page',
+      '---',
+      "import Link from '@components/link.astro';",
+      '',
+      'export const code = `const a = 1;`;',
+      '',
+      'Content',
+      '',
+    ].join('\n');
+
+    expect(await strip(raw)).toBe('Content');
+  });
+
+  it('keeps import statements inside fenced code blocks', async () => {
+    const raw = [
+      '---',
+      'title: My Page',
+      '---',
+      "import Link from '@components/link.astro';",
+      '',
+      'Add the import:',
+      '',
+      '```ts',
+      "import { Stack } from 'aws-cdk-lib';",
+      "import { Construct } from 'constructs';",
+      '',
+      'export class MyStack extends Stack {}',
+      '```',
+      '',
+    ].join('\n');
+
+    const result = await strip(raw);
+
+    expect(result).not.toContain('@components/link.astro');
+    expect(result).toContain("import { Stack } from 'aws-cdk-lib';");
+    expect(result).toContain("import { Construct } from 'constructs';");
+    expect(result).toContain('export class MyStack extends Stack {}');
+  });
+
+  it('keeps import statements inside a JSX attribute template literal', async () => {
+    const raw = [
+      '---',
+      'title: My Page',
+      '---',
+      "import Diff from '@components/diff.astro';",
+      '',
+      "<Diff before={`import { a } from 'a';",
+      '',
+      'export const b = 1;',
+      '`} />',
+      '',
+    ].join('\n');
+
+    const result = await strip(raw);
+
+    expect(result).not.toContain('@components/diff.astro');
+    expect(result).toContain("import { a } from 'a';");
+    expect(result).toContain('export const b = 1;');
+  });
+
+  it('leaves content untouched when there is no preamble', async () => {
+    expect(await strip('Just content\n')).toBe('Just content');
+  });
+});

--- a/packages/nx-plugin/src/mcp-server/mdx-ast.ts
+++ b/packages/nx-plugin/src/mcp-server/mdx-ast.ts
@@ -124,3 +124,26 @@ export const extractFrontmatter = (
       : {};
   return { data, bodyOffset: node.position?.end.offset ?? 0 };
 };
+
+/**
+ * Remove the frontmatter and every ESM `import`/`export` statement from an MDX
+ * source, leaving the content behind. The statements are located through the
+ * parsed tree, so `import` and `export` lines that appear inside code samples
+ * or template literals are kept — they are content, not preamble.
+ */
+export const stripFrontmatterAndEsm = (raw: string, tree: Root): string => {
+  const cuts = tree.children
+    .filter((c) => c.type === 'yaml' || c.type === 'mdxjsEsm')
+    .map((c) => c.position)
+    .filter(
+      (p): p is NonNullable<typeof p> =>
+        p?.start.offset !== undefined && p?.end.offset !== undefined,
+    );
+  let result = '';
+  let cursor = 0;
+  for (const { start, end } of cuts) {
+    result += raw.slice(cursor, start.offset);
+    cursor = end.offset!;
+  }
+  return (result + raw.slice(cursor)).trim();
+};


### PR DESCRIPTION
### Reason for this change

Two separate defects were silently corrupting code samples in the docs. Both turned up while reworking the quick start's CDK sample in #1247.

**1. The quick start's route diff rendered with its indentation flattened**

That diff was built with the `<Diff>` component, which takes `before`/`after` as inline template literals in JSX attributes. MDX strips two columns of indentation from every *continuation* line of a multi-line template literal written inline in a JSX attribute or child expression, so the sample rendered with its nesting collapsed — `component: RouteComponent,` at column 0, the hook body at 2 instead of 4:

```
 |export const Route = createFileRoute('/')({
 |component: RouteComponent,          <- should be indented 2
 |});
 |function RouteComponent() {
+|const trpc = useDemoApi();          <- should be indented 2
+|const echo = useQuery(
+|  trpc.echo.queryOptions(...),      <- should be indented 4
```

This is upstream MDX behaviour, not something in this repo. Reproduced against plain `@mdx-js/mdx` 3.1.1 with no Astro, Starlight or repo plugins in the pipeline:

| Where the template literal lives | Result |
| --- | --- |
| JSX attribute expression — `before={\`…\`}` | de-indented by 2 |
| JSX child expression — `{\`…\`}` | de-indented by 2 |
| Fenced code block | **verbatim** |

**2. "Copy as Markdown" deleted every `import` line from code samples**

`markdown-content.astro` stripped the MDX preamble with `/^import\s+.*$\n?/gm`, which matches anywhere in the document, not just the preamble. Every `import` line inside a code sample was deleted from the copied markdown, and multi-line imports were left as dangling brace bodies:

```
  deleteShoppingListHandler,
} from './handlers.js';
```

So anyone copying a guide into an AI assistant got samples with their imports quietly removed.

### Description of changes

**The route diff**

Written inline as a `diff lang="tsx"` fenced block, which MDX passes through untouched. The rendered lines are identical to what `<Diff>` computed — the sample has no removals, so `<Diff>` was already rendering it as a single diff block rather than the `+`/`+-` tabs — but the indentation now survives, and the block reaches the copied markdown as a real diff instead of a component call. `diff.astro` is unchanged.

**Copied markdown**

- Added `stripFrontmatterAndEsm(raw, tree)` to `mcp-server/mdx-ast.ts`, alongside the existing `extractFrontmatter`. It locates the frontmatter and `mdxjsEsm` nodes in the parsed tree and cuts exactly their source ranges, so `import`/`export` lines inside fenced code blocks and template literals are left alone — they are content.
- `markdown-content.astro` uses it for both the page body and the snippet provider, replacing both copies of the regex.

### Description of how you validated changes

- New `mdx-ast.spec.ts` covers `stripFrontmatterAndEsm`: frontmatter removal, preamble `import`/`export` removal, and retention of `import`/`export` lines inside a fenced code block and inside a JSX attribute template literal (the two cases the regex broke).
- `pnpm nx run @aws/nx-plugin:test` — 4499 tests across 253 files pass.
- `pnpm nx run-many --target build --all` — all tasks pass, including lint, format and `docs:build` with link validation.
- Inspected the rendered `<figure>` in both a production build and the dev server: `data-language="tsx"`, indentation preserved at every level, the same 12 lines marked as insertions, no line marked as a deletion.
- Inspected the `data-copy-markdown` payload in the production build: the preamble imports are gone, the diff arrives as a fenced block, and `import { Stack, StackProps } from 'aws-cdk-lib';`, `import { Construct } from 'constructs';` and the multi-line `import { DemoApi, … }` inside the Step 4 sample are all retained. They were all being deleted before.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
