### PR TITLE
docs: set inline references in the code samples' face and size

### DIFF
--- a/docs/src/styles/custom.css
+++ b/docs/src/styles/custom.css
@@ -32,6 +32,22 @@ starlight-file-tree,
   font-variant-ligatures: none;
 }
 
+/* `pnpm --version` in a sentence is the same text as `pnpm --version` in a
+   sample, so it is set in the same face at the same size. Starlight takes inline
+   code a step smaller than the code font, which at this face reads as a second,
+   narrower mono rather than the same one; and it leaves `<kbd>` and `<samp>` on
+   whichever mono the browser falls back to, which is a different face again. */
+.sl-markdown-content :is(code, kbd, samp):not(:where(.not-content *)) {
+  font-family: var(--__sl-font-mono), ui-monospace, monospace;
+  font-size: var(--sl-text-code);
+}
+
+/* A heading's code stays at the heading's size — Starlight's own rule, restated
+   because the rule above would otherwise outrank it. */
+.sl-markdown-content :is(h1, h2, h3, h4, h5, h6) :is(code, kbd, samp) {
+  font-size: inherit;
+}
+
 .site-title span {
   font-family: var(--__sl-font-mono), ui-monospace, monospace;
   font-weight: 500;


### PR DESCRIPTION
### Reason for this change

`pnpm --version` in a sentence is the same text as `pnpm --version` in a sample, but it wasn't set the same way.

Two things were off, and neither is the typeface — inline code has been on the site's mono face since it was self-hosted. What differed was everything else about how it was set:

- **Inline code took `--sl-text-code-sm`**, a step below the code font size (13px against 14px). At this face the narrower setting reads as a second, similar-but-narrower mono rather than the same one, which is what makes a reference in a sentence look unrelated to the sample below it.
- **`<kbd>` and `<samp>` were left on whichever mono the browser falls back to**, which really is a different face. Visible on the graph builder guide, where `Delete` sits in a sentence a few words away from inline code in another typeface.

### Description of changes

Both now take the mono face and the code font size, so a fixed-width reference in the prose is set exactly as the same characters would be in a sample.

The size step on inline code — the prerequisites list, which is where this is most noticeable:

<img src="https://raw.githubusercontent.com/awslabs/nx-plugin-for-aws/32e0f69cbd6ec39e2491c5e32e43d1dc3cf6f9d4/inline-size.png" width="70%" />

`<kbd>` on the graph builder guide, magnified 5×. Before it is the browser's default mono at prose size; after it is the site's face at the code size:

<img src="https://raw.githubusercontent.com/awslabs/nx-plugin-for-aws/32e0f69cbd6ec39e2491c5e32e43d1dc3cf6f9d4/kbd-face.png" width="80%" />

A heading's code still inherits the heading's size. That is Starlight's own rule, restated here because the new one would otherwise outrank it — headings sit outside a cascade layer once this stylesheet touches them.

Starlight's search shortcut hint is deliberately left alone: it is chrome rather than a reference in the prose, and the sans face is intentional there.

Two things I did **not** change, in case they come up in review:

- **The chip's background.** Inline code sits on `--sl-color-bg-inline-code`, which is a step lighter than a code block's surface. Starlight tunes that token per mode for legibility against the page, and matching it to the block surface makes the chip nearly disappear in light mode. That felt like a separate design decision from the one asked for here.
- **The text colour.** Inline code tracks the prose colour, which keeps a reference from shouting louder than the sentence containing it.

### Description of how you validated changes

- Confirmed the premise before changing anything: measured the resolved face for every `code`, `kbd` and `samp` element across ten pages by comparing rendered glyph advance against JetBrains Mono directly, rather than trusting the declared `font-family`. Inline `code` already resolved to the site's face everywhere; the only content element that didn't was the `<kbd>` on the graph builder guide.
- After the change, inline code and a code block both report `14px` and both resolve to JetBrains Mono. Same for `<kbd>`.
- Checked the heading guard on `get_started/existing-project`, which has four headings containing code: code reports `24px`, matching its `h4`.
- Verified on the **built** output via `astro preview`, not just the dev server — cascade order between layered Starlight styles and this stylesheet has differed between the two before.
- `astro build`: 1540 pages, all internal links valid. `nx run docs:test`: 203 passed. `nx run-many --target lint --all`, `nx sync:check` and `biome check` all clean.

Screenshots are hosted on the `assets/inline-code-font-screenshots` branch, which is not part of this PR and can be deleted once merged.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
