### PR TITLE
docs: tidy the workspace guide and quick start prompts

### DIFF
--- a/docs/src/content/docs/en/get_started/quick-start.mdx
+++ b/docs/src/content/docs/en/get_started/quick-start.mdx
@@ -33,7 +33,7 @@ Create an <Link path="guides/workspace">Nx workspace</Link> with the package man
 cd my-project
 ```
 
-You are prompted to choose your infrastructure as code provider, either [CDK](https://docs.aws.amazon.com/cdk/) or [Terraform](https://developer.hashicorp.com/terraform), and the container engine used by generators which build container images.
+You are prompted to choose your infrastructure as code provider, either [CDK](https://docs.aws.amazon.com/cdk/) or [Terraform](https://developer.hashicorp.com/terraform).
 
 ## Step 2: Build Your Application
 

--- a/docs/src/content/docs/en/guides/workspace.mdx
+++ b/docs/src/content/docs/en/guides/workspace.mdx
@@ -27,6 +27,7 @@ When you create a new workspace with `@aws/nx-plugin`, the preset generator sets
   - package.json Root package.json for your monorepo
   - nx.json Nx configuration (common targets, sync generators, caching)
   - tsconfig.base.json Root TypeScript configuration
+  - biome.json Biome configuration for linting and formatting
   - aws-nx-plugin.config.mts Nx Plugin for AWS configuration
   - .git-secrets/ Vendored git-secrets bash script for credential scanning
   - .gitallowed Patterns git-secrets treats as false positives
@@ -72,7 +73,7 @@ For details on how TypeScript and Python projects are set up, refer to the <Link
 
 ### Caching
 
-Nx caches the output of previously executed targets and replays them when the inputs haven't changed. This dramatically speeds up builds, tests, and linting — especially in CI. If you encounter stale or unexpected behaviour, reset the cache with:
+Nx caches the output of previously executed targets and replays them when the inputs haven't changed. This dramatically speeds up builds, tests, and linting. If you encounter stale or unexpected behaviour, reset the cache with:
 
 <NxCommands commands={['reset']} />
 
@@ -88,15 +89,7 @@ New workspaces set `parallel` in `nx.json`, which controls how many tasks Nx run
 }
 ```
 
-Lower it if you're building on a machine with fewer cores or limited memory:
-
-```json title="nx.json"
-{
-  "parallel": 3
-}
-```
-
-You can also override it per-invocation:
+Lower it if you're building on a machine with fewer cores or limited memory. You can also override it per-invocation:
 
 <NxCommands commands={['run-many --target build --parallel=4']} />
 
@@ -165,6 +158,10 @@ This will run the chosen target as well as the targets it depends on.
 ### Linting
 
 New workspaces are configured with [Biome](https://biomejs.dev/) for static analysis and code formatting. Running `lint` checks all projects for issues, and `lint --configuration=fix` auto-fixes them.
+
+### MCP Configuration
+
+The plugin's <Link path="get_started/building-with-ai">MCP server</Link> is configured as a project level MCP server for Claude Code, Cursor, Kiro, Gemini CLI, GitHub Copilot and OpenAI Codex, so your coding assistant can discover and run the plugin's generators without any setup. The configuration is committed with your workspace, giving everyone on your team the same setup. Remove any configurations for coding assistants you and your team do not use.
 
 ### Git Secrets
 

--- a/docs/src/content/docs/es/get_started/quick-start.mdx
+++ b/docs/src/content/docs/es/get_started/quick-start.mdx
@@ -33,7 +33,7 @@ Crea un <Link path="guides/workspace">espacio de trabajo Nx</Link> con el gestor
 cd my-project
 ```
 
-Se te solicita elegir tu proveedor de infraestructura como código, ya sea [CDK](https://docs.aws.amazon.com/cdk/) o [Terraform](https://developer.hashicorp.com/terraform), y el motor de contenedores utilizado por los generadores que construyen imágenes de contenedores.
+Se te solicita elegir tu proveedor de infraestructura como código, ya sea [CDK](https://docs.aws.amazon.com/cdk/) o [Terraform](https://developer.hashicorp.com/terraform).
 
 ## Paso 2: Construir tu Aplicación
 

--- a/docs/src/content/docs/es/guides/workspace.mdx
+++ b/docs/src/content/docs/es/guides/workspace.mdx
@@ -27,6 +27,7 @@ Cuando creas un nuevo workspace con `@aws/nx-plugin`, el generador preset config
   - package.json Root package.json for your monorepo
   - nx.json Nx configuration (common targets, sync generators, caching)
   - tsconfig.base.json Root TypeScript configuration
+  - biome.json Biome configuration for linting and formatting
   - aws-nx-plugin.config.mts Nx Plugin for AWS configuration
   - .git-secrets/ Vendored git-secrets bash script for credential scanning
   - .gitallowed Patterns git-secrets treats as false positives
@@ -72,7 +73,7 @@ Para detalles sobre cómo se configuran los proyectos de TypeScript y Python, co
 
 ### Caché
 
-Nx almacena en caché la salida de targets ejecutados previamente y los reproduce cuando las entradas no han cambiado. Esto acelera dramáticamente las construcciones, pruebas y linting — especialmente en CI. Si encuentras comportamiento obsoleto o inesperado, reinicia la caché con:
+Nx almacena en caché la salida de targets ejecutados previamente y los reproduce cuando las entradas no han cambiado. Esto acelera dramáticamente las construcciones, pruebas y linting. Si encuentras comportamiento obsoleto o inesperado, reinicia la caché con:
 
 <NxCommands commands={['reset']} />
 
@@ -88,15 +89,7 @@ Los nuevos workspaces establecen `parallel` en `nx.json`, que controla cuántas 
 }
 ```
 
-Redúcelo si estás construyendo en una máquina con menos núcleos o memoria limitada:
-
-```json title="nx.json"
-{
-  "parallel": 3
-}
-```
-
-También puedes anularlo por invocación:
+Redúcelo si estás construyendo en una máquina con menos núcleos o memoria limitada. También puedes anularlo por invocación:
 
 <NxCommands commands={['run-many --target build --parallel=4']} />
 
@@ -165,6 +158,10 @@ Esto ejecutará el target elegido así como los targets de los que depende.
 ### Linting
 
 Los nuevos workspaces están configurados con [Biome](https://biomejs.dev/) para análisis estático y formateo de código. Ejecutar `lint` verifica todos los proyectos en busca de problemas, y `lint --configuration=fix` los auto-corrige.
+
+### Configuración de MCP
+
+El <Link path="get_started/building-with-ai">servidor MCP</Link> del plugin está configurado como un servidor MCP a nivel de proyecto para Claude Code, Cursor, Kiro, Gemini CLI, GitHub Copilot y OpenAI Codex, por lo que tu asistente de codificación puede descubrir y ejecutar los generadores del plugin sin ninguna configuración. La configuración se confirma con tu workspace, dando a todos en tu equipo la misma configuración. Elimina cualquier configuración para asistentes de codificación que tú y tu equipo no usen.
 
 ### Git Secrets
 

--- a/docs/src/content/docs/fr/get_started/quick-start.mdx
+++ b/docs/src/content/docs/fr/get_started/quick-start.mdx
@@ -33,7 +33,7 @@ Créez un <Link path="guides/workspace">espace de travail Nx</Link> avec le gest
 cd my-project
 ```
 
-Vous êtes invité à choisir votre fournisseur d'infrastructure en tant que code, soit [CDK](https://docs.aws.amazon.com/cdk/) soit [Terraform](https://developer.hashicorp.com/terraform), et le moteur de conteneur utilisé par les générateurs qui construisent des images de conteneur.
+Vous êtes invité à choisir votre fournisseur d'infrastructure en tant que code, soit [CDK](https://docs.aws.amazon.com/cdk/) soit [Terraform](https://developer.hashicorp.com/terraform).
 
 ## Étape 2 : Construire votre application
 

--- a/docs/src/content/docs/fr/guides/workspace.mdx
+++ b/docs/src/content/docs/fr/guides/workspace.mdx
@@ -27,6 +27,7 @@ Lorsque vous créez un nouvel espace de travail avec `@aws/nx-plugin`, le géné
   - package.json Root package.json for your monorepo
   - nx.json Nx configuration (common targets, sync generators, caching)
   - tsconfig.base.json Root TypeScript configuration
+  - biome.json Biome configuration for linting and formatting
   - aws-nx-plugin.config.mts Nx Plugin for AWS configuration
   - .git-secrets/ Vendored git-secrets bash script for credential scanning
   - .gitallowed Patterns git-secrets treats as false positives
@@ -72,7 +73,7 @@ Pour plus de détails sur la configuration des projets TypeScript et Python, con
 
 ### Mise en cache
 
-Nx met en cache la sortie des targets précédemment exécutés et les rejoue lorsque les entrées n'ont pas changé. Cela accélère considérablement les builds, les tests et le linting — en particulier en CI. Si vous rencontrez un comportement obsolète ou inattendu, réinitialisez le cache avec :
+Nx met en cache la sortie des targets précédemment exécutés et les rejoue lorsque les entrées n'ont pas changé. Cela accélère considérablement les builds, les tests et le linting. Si vous rencontrez un comportement obsolète ou inattendu, réinitialisez le cache avec :
 
 <NxCommands commands={['reset']} />
 
@@ -88,15 +89,7 @@ Les nouveaux espaces de travail définissent `parallel` dans `nx.json`, qui cont
 }
 ```
 
-Réduisez-la si vous construisez sur une machine avec moins de cœurs ou une mémoire limitée :
-
-```json title="nx.json"
-{
-  "parallel": 3
-}
-```
-
-Vous pouvez également la remplacer par invocation :
+Réduisez-la si vous construisez sur une machine avec moins de cœurs ou une mémoire limitée. Vous pouvez également la remplacer par invocation :
 
 <NxCommands commands={['run-many --target build --parallel=4']} />
 
@@ -166,6 +159,10 @@ Cela exécutera le target choisi ainsi que les targets dont il dépend.
 
 Les nouveaux espaces de travail sont configurés avec [Biome](https://biomejs.dev/) pour l'analyse statique et le formatage du code. L'exécution de `lint` vérifie tous les projets pour détecter les problèmes, et `lint --configuration=fix` les corrige automatiquement.
 
+### Configuration MCP
+
+Le <Link path="get_started/building-with-ai">serveur MCP</Link> du plugin est configuré en tant que serveur MCP au niveau du projet pour Claude Code, Cursor, Kiro, Gemini CLI, GitHub Copilot et OpenAI Codex, afin que votre assistant de codage puisse découvrir et exécuter les générateurs du plugin sans aucune configuration. La configuration est commitée avec votre espace de travail, donnant à tous les membres de votre équipe la même configuration. Supprimez toutes les configurations pour les assistants de codage que vous et votre équipe n'utilisez pas.
+
 ### Git Secrets
 
 Les espaces de travail sont configurés avec des hooks de pré-commit [git-secrets](https://github.com/awslabs/git-secrets) qui analysent les fichiers mis en staging pour détecter les modèles d'identifiants AWS avant chaque commit. Cela empêche de commiter accidentellement des clés d'accès, des clés secrètes et d'autres valeurs sensibles.
@@ -226,3 +223,4 @@ export default {
 Le <Link path="guides/license">générateur de licence</Link> ajoute une clé `license` à ce même fichier pour configurer son propre comportement.
 
 Vous pouvez modifier n'importe quel paramètre à tout moment — les exécutions ultérieures du générateur récupéreront la nouvelle valeur.
+

--- a/docs/src/content/docs/it/get_started/quick-start.mdx
+++ b/docs/src/content/docs/it/get_started/quick-start.mdx
@@ -33,7 +33,7 @@ Crea un <Link path="guides/workspace">workspace Nx</Link> con il package manager
 cd my-project
 ```
 
-Ti viene richiesto di scegliere il tuo provider di infrastructure as code, [CDK](https://docs.aws.amazon.com/cdk/) o [Terraform](https://developer.hashicorp.com/terraform), e il motore di container utilizzato dai generatori che costruiscono immagini container.
+Ti viene richiesto di scegliere il tuo provider di infrastructure as code, [CDK](https://docs.aws.amazon.com/cdk/) o [Terraform](https://developer.hashicorp.com/terraform).
 
 ## Passaggio 2: Costruire la Tua Applicazione
 

--- a/docs/src/content/docs/it/guides/workspace.mdx
+++ b/docs/src/content/docs/it/guides/workspace.mdx
@@ -27,6 +27,7 @@ Quando crei un nuovo workspace con `@aws/nx-plugin`, il generatore preset config
   - package.json Root package.json for your monorepo
   - nx.json Nx configuration (common targets, sync generators, caching)
   - tsconfig.base.json Root TypeScript configuration
+  - biome.json Biome configuration for linting and formatting
   - aws-nx-plugin.config.mts Nx Plugin for AWS configuration
   - .git-secrets/ Vendored git-secrets bash script for credential scanning
   - .gitallowed Patterns git-secrets treats as false positives
@@ -72,7 +73,7 @@ Per i dettagli su come vengono configurati i progetti TypeScript e Python, consu
 
 ### Caching
 
-Nx memorizza nella cache l'output dei target eseguiti in precedenza e li riproduce quando gli input non sono cambiati. Questo velocizza notevolmente build, test e linting — specialmente in CI. Se riscontri comportamenti obsoleti o inaspettati, reimposta la cache con:
+Nx memorizza nella cache l'output dei target eseguiti in precedenza e li riproduce quando gli input non sono cambiati. Questo velocizza notevolmente build, test e linting. Se riscontri comportamenti obsoleti o inaspettati, reimposta la cache con:
 
 <NxCommands commands={['reset']} />
 
@@ -88,15 +89,7 @@ I nuovi workspace impostano `parallel` in `nx.json`, che controlla quante attivi
 }
 ```
 
-Abbassalo se stai costruendo su una macchina con meno core o memoria limitata:
-
-```json title="nx.json"
-{
-  "parallel": 3
-}
-```
-
-Puoi anche sovrascriverlo per singola invocazione:
+Abbassalo se stai costruendo su una macchina con meno core o memoria limitata. Puoi anche sovrascriverlo per singola invocazione:
 
 <NxCommands commands={['run-many --target build --parallel=4']} />
 
@@ -165,6 +158,10 @@ Questo eseguirà il target scelto così come i target da cui dipende.
 ### Linting
 
 I nuovi workspace sono configurati con [Biome](https://biomejs.dev/) per l'analisi statica e la formattazione del codice. L'esecuzione di `lint` controlla tutti i progetti per problemi, e `lint --configuration=fix` li corregge automaticamente.
+
+### Configurazione MCP
+
+Il <Link path="get_started/building-with-ai">server MCP</Link> del plugin è configurato come server MCP a livello di progetto per Claude Code, Cursor, Kiro, Gemini CLI, GitHub Copilot e OpenAI Codex, in modo che il tuo assistente di codifica possa scoprire ed eseguire i generatori del plugin senza alcuna configurazione. La configurazione viene committata con il tuo workspace, dando a tutti nel tuo team la stessa configurazione. Rimuovi le configurazioni per gli assistenti di codifica che tu e il tuo team non utilizzate.
 
 ### Git Secrets
 

--- a/docs/src/content/docs/jp/get_started/quick-start.mdx
+++ b/docs/src/content/docs/jp/get_started/quick-start.mdx
@@ -33,7 +33,7 @@ import Prompt from '@components/prompt.astro';
 cd my-project
 ```
 
-Infrastructure as Code プロバイダーとして [CDK](https://docs.aws.amazon.com/cdk/) または [Terraform](https://developer.hashicorp.com/terraform) のいずれかを選択し、コンテナイメージをビルドするジェネレーターで使用されるコンテナエンジンを選択するよう求められます。
+Infrastructure as Code プロバイダーとして [CDK](https://docs.aws.amazon.com/cdk/) または [Terraform](https://developer.hashicorp.com/terraform) のいずれかを選択するよう求められます。
 
 ## ステップ 2: アプリケーションを構築する
 

--- a/docs/src/content/docs/jp/guides/workspace.mdx
+++ b/docs/src/content/docs/jp/guides/workspace.mdx
@@ -27,6 +27,7 @@ import GeneratorParameters from '@components/generator-parameters.astro';
   - package.json Root package.json for your monorepo
   - nx.json Nx configuration (common targets, sync generators, caching)
   - tsconfig.base.json Root TypeScript configuration
+  - biome.json Biome configuration for linting and formatting
   - aws-nx-plugin.config.mts Nx Plugin for AWS configuration
   - .git-secrets/ Vendored git-secrets bash script for credential scanning
   - .gitallowed Patterns git-secrets treats as false positives
@@ -72,7 +73,7 @@ TypeScriptおよびPythonプロジェクトのセットアップ方法の詳細�
 
 ### キャッシング
 
-Nxは、以前に実行されたターゲットの出力をキャッシュし、入力が変更されていない場合にそれらを再生します。これにより、ビルド、テスト、リンティングが劇的に高速化されます。特にCIで効果的です。古いまたは予期しない動作が発生した場合は、次のコマンドでキャッシュをリセットしてください：
+Nxは、以前に実行されたターゲットの出力をキャッシュし、入力が変更されていない場合にそれらを再生します。これにより、ビルド、テスト、リンティングが劇的に高速化されます。古いまたは予期しない動作が発生した場合は、次のコマンドでキャッシュをリセットしてください：
 
 <NxCommands commands={['reset']} />
 
@@ -88,15 +89,7 @@ Nxは、以前に実行されたターゲットの出力をキャッシュし、
 }
 ```
 
-コア数が少ないマシンやメモリが限られている場合は、これを下げてください：
-
-```json title="nx.json"
-{
-  "parallel": 3
-}
-```
-
-また、実行ごとにオーバーライドすることもできます：
+コア数が少ないマシンやメモリが限られている場合は、これを下げてください。また、実行ごとにオーバーライドすることもできます：
 
 <NxCommands commands={['run-many --target build --parallel=4']} />
 
@@ -165,6 +158,10 @@ Pythonの観点からは、これはモノレポのルートに単一の`.venv`�
 ### リンティング
 
 新しいワークスペースは、静的解析とコードフォーマットのために[Biome](https://biomejs.dev/)で構成されています。`lint`を実行するとすべてのプロジェクトの問題がチェックされ、`lint --configuration=fix`で自動修正されます。
+
+### MCP設定
+
+プラグインの<Link path="get_started/building-with-ai">MCPサーバー</Link>は、Claude Code、Cursor、Kiro、Gemini CLI、GitHub Copilot、OpenAI Codex用のプロジェクトレベルのMCPサーバーとして設定されているため、コーディングアシスタントはセットアップなしでプラグインのジェネレーターを検出して実行できます。設定はワークスペースとともにコミットされるため、チームの全員が同じセットアップを利用できます。あなたとあなたのチームが使用しないコーディングアシスタントの設定は削除してください。
 
 ### Git Secrets
 

--- a/docs/src/content/docs/ko/get_started/quick-start.mdx
+++ b/docs/src/content/docs/ko/get_started/quick-start.mdx
@@ -33,7 +33,7 @@ import Prompt from '@components/prompt.astro';
 cd my-project
 ```
 
-코드형 인프라 제공자로 [CDK](https://docs.aws.amazon.com/cdk/) 또는 [Terraform](https://developer.hashicorp.com/terraform) 중 하나를 선택하고, 컨테이너 이미지를 빌드하는 제너레이터에서 사용하는 컨테이너 엔진을 선택하라는 메시지가 표시됩니다.
+코드형 인프라 제공자로 [CDK](https://docs.aws.amazon.com/cdk/) 또는 [Terraform](https://developer.hashicorp.com/terraform) 중 하나를 선택하라는 메시지가 표시됩니다.
 
 ## 2단계: 애플리케이션 빌드
 

--- a/docs/src/content/docs/ko/guides/workspace.mdx
+++ b/docs/src/content/docs/ko/guides/workspace.mdx
@@ -27,6 +27,7 @@ import GeneratorParameters from '@components/generator-parameters.astro';
   - package.json Root package.json for your monorepo
   - nx.json Nx configuration (common targets, sync generators, caching)
   - tsconfig.base.json Root TypeScript configuration
+  - biome.json Biome configuration for linting and formatting
   - aws-nx-plugin.config.mts Nx Plugin for AWS configuration
   - .git-secrets/ Vendored git-secrets bash script for credential scanning
   - .gitallowed Patterns git-secrets treats as false positives
@@ -72,7 +73,7 @@ TypeScript 및 Python 프로젝트가 설정되는 방법에 대한 자세한 �
 
 ### 캐싱
 
-Nx는 이전에 실행된 타겟의 출력을 캐시하고 입력이 변경되지 않았을 때 이를 재생합니다. 이는 특히 CI에서 빌드, 테스트 및 린팅 속도를 크게 향상시킵니다. 오래되거나 예상치 못한 동작이 발생하면 다음 명령으로 캐시를 재설정하세요:
+Nx는 이전에 실행된 타겟의 출력을 캐시하고 입력이 변경되지 않았을 때 이를 재생합니다. 이는 빌드, 테스트 및 린팅 속도를 크게 향상시킵니다. 오래되거나 예상치 못한 동작이 발생하면 다음 명령으로 캐시를 재설정하세요:
 
 <NxCommands commands={['reset']} />
 
@@ -88,15 +89,7 @@ Nx는 이전에 실행된 타겟의 출력을 캐시하고 입력이 변경되�
 }
 ```
 
-코어가 적거나 메모리가 제한된 머신에서 빌드하는 경우 이를 낮추세요:
-
-```json title="nx.json"
-{
-  "parallel": 3
-}
-```
-
-호출당 재정의할 수도 있습니다:
+코어가 적거나 메모리가 제한된 머신에서 빌드하는 경우 이를 낮추세요. 호출당 재정의할 수도 있습니다:
 
 <NxCommands commands={['run-many --target build --parallel=4']} />
 
@@ -165,6 +158,10 @@ Python 관점에서 이는 모노레포의 루트에 단일 `.venv`가 있고 �
 ### 린팅
 
 새 워크스페이스는 정적 분석 및 코드 포맷팅을 위해 [Biome](https://biomejs.dev/)으로 구성됩니다. `lint`를 실행하면 모든 프로젝트에서 문제를 확인하고, `lint --configuration=fix`는 이를 자동으로 수정합니다.
+
+### MCP 구성
+
+플러그인의 <Link path="get_started/building-with-ai">MCP 서버</Link>는 Claude Code, Cursor, Kiro, Gemini CLI, GitHub Copilot 및 OpenAI Codex를 위한 프로젝트 수준 MCP 서버로 구성되어 있어, 코딩 어시스턴트가 별도의 설정 없이 플러그인의 제너레이터를 발견하고 실행할 수 있습니다. 구성은 워크스페이스와 함께 커밋되므로 팀의 모든 사람이 동일한 설정을 갖게 됩니다. 귀하와 귀하의 팀이 사용하지 않는 코딩 어시스턴트에 대한 구성은 제거하세요.
 
 ### Git Secrets
 

--- a/docs/src/content/docs/pt/get_started/quick-start.mdx
+++ b/docs/src/content/docs/pt/get_started/quick-start.mdx
@@ -33,7 +33,7 @@ Crie um <Link path="guides/workspace">workspace Nx</Link> com o gerenciador de p
 cd my-project
 ```
 
-Você será solicitado a escolher seu provedor de infraestrutura como código, seja [CDK](https://docs.aws.amazon.com/cdk/) ou [Terraform](https://developer.hashicorp.com/terraform), e o mecanismo de contêiner usado pelos geradores que constroem imagens de contêiner.
+Você será solicitado a escolher seu provedor de infraestrutura como código, seja [CDK](https://docs.aws.amazon.com/cdk/) ou [Terraform](https://developer.hashicorp.com/terraform).
 
 ## Passo 2: Construir Sua Aplicação
 

--- a/docs/src/content/docs/pt/guides/workspace.mdx
+++ b/docs/src/content/docs/pt/guides/workspace.mdx
@@ -27,6 +27,7 @@ Quando você cria um novo workspace com `@aws/nx-plugin`, o gerador preset confi
   - package.json Root package.json for your monorepo
   - nx.json Nx configuration (common targets, sync generators, caching)
   - tsconfig.base.json Root TypeScript configuration
+  - biome.json Biome configuration for linting and formatting
   - aws-nx-plugin.config.mts Nx Plugin for AWS configuration
   - .git-secrets/ Vendored git-secrets bash script for credential scanning
   - .gitallowed Patterns git-secrets treats as false positives
@@ -72,7 +73,7 @@ Para detalhes sobre como projetos TypeScript e Python são configurados, consult
 
 ### Cache
 
-Nx faz cache da saída de targets executados anteriormente e os reproduz quando as entradas não mudaram. Isso acelera dramaticamente builds, testes e linting — especialmente em CI. Se você encontrar comportamento obsoleto ou inesperado, redefina o cache com:
+Nx faz cache da saída de targets executados anteriormente e os reproduz quando as entradas não mudaram. Isso acelera dramaticamente builds, testes e linting. Se você encontrar comportamento obsoleto ou inesperado, redefina o cache com:
 
 <NxCommands commands={['reset']} />
 
@@ -88,15 +89,7 @@ Novos workspaces definem `parallel` em `nx.json`, que controla quantas tarefas o
 }
 ```
 
-Reduza se você estiver construindo em uma máquina com menos núcleos ou memória limitada:
-
-```json title="nx.json"
-{
-  "parallel": 3
-}
-```
-
-Você também pode sobrescrever isso por invocação:
+Reduza se você estiver construindo em uma máquina com menos núcleos ou memória limitada. Você também pode sobrescrever isso por invocação:
 
 <NxCommands commands={['run-many --target build --parallel=4']} />
 
@@ -165,6 +158,10 @@ Isso executará o target escolhido, bem como os targets dos quais ele depende.
 ### Linting
 
 Novos workspaces são configurados com [Biome](https://biomejs.dev/) para análise estática e formatação de código. Executar `lint` verifica todos os projetos em busca de problemas, e `lint --configuration=fix` os corrige automaticamente.
+
+### Configuração MCP
+
+O <Link path="get_started/building-with-ai">servidor MCP</Link> do plugin é configurado como um servidor MCP de nível de projeto para Claude Code, Cursor, Kiro, Gemini CLI, GitHub Copilot e OpenAI Codex, para que seu assistente de codificação possa descobrir e executar os geradores do plugin sem nenhuma configuração. A configuração é commitada com seu workspace, dando a todos na sua equipe a mesma configuração. Remova quaisquer configurações para assistentes de codificação que você e sua equipe não usam.
 
 ### Git Secrets
 

--- a/docs/src/content/docs/vi/get_started/quick-start.mdx
+++ b/docs/src/content/docs/vi/get_started/quick-start.mdx
@@ -33,7 +33,7 @@ Tạo một <Link path="guides/workspace">Nx workspace</Link> với trình quả
 cd my-project
 ```
 
-Bạn sẽ được nhắc chọn nhà cung cấp infrastructure as code, có thể là [CDK](https://docs.aws.amazon.com/cdk/) hoặc [Terraform](https://developer.hashicorp.com/terraform), và container engine được sử dụng bởi các generators xây dựng container images.
+Bạn sẽ được nhắc chọn nhà cung cấp infrastructure as code, có thể là [CDK](https://docs.aws.amazon.com/cdk/) hoặc [Terraform](https://developer.hashicorp.com/terraform).
 
 ## Bước 2: Xây Dựng Ứng Dụng Của Bạn
 

--- a/docs/src/content/docs/vi/guides/workspace.mdx
+++ b/docs/src/content/docs/vi/guides/workspace.mdx
@@ -27,6 +27,7 @@ Khi bạn tạo một workspace mới với `@aws/nx-plugin`, preset generator s
   - package.json Root package.json for your monorepo
   - nx.json Nx configuration (common targets, sync generators, caching)
   - tsconfig.base.json Root TypeScript configuration
+  - biome.json Biome configuration for linting and formatting
   - aws-nx-plugin.config.mts Nx Plugin for AWS configuration
   - .git-secrets/ Vendored git-secrets bash script for credential scanning
   - .gitallowed Patterns git-secrets treats as false positives
@@ -72,7 +73,7 @@ Ví dụ, một `project.json` có thể định nghĩa một `build` target ph�
 
 ### Caching
 
-Nx lưu cache đầu ra của các target đã thực thi trước đó và phát lại chúng khi các đầu vào không thay đổi. Điều này tăng tốc đáng kể quá trình build, test và linting — đặc biệt trong CI. Nếu bạn gặp phải hành vi cũ hoặc không mong đợi, hãy đặt lại cache bằng:
+Nx lưu cache đầu ra của các target đã thực thi trước đó và phát lại chúng khi các đầu vào không thay đổi. Điều này tăng tốc đáng kể quá trình build, test và linting. Nếu bạn gặp phải hành vi cũ hoặc không mong đợi, hãy đặt lại cache bằng:
 
 <NxCommands commands={['reset']} />
 
@@ -88,15 +89,7 @@ Các workspace mới đặt `parallel` trong `nx.json`, điều khiển số lư
 }
 ```
 
-Giảm nó xuống nếu bạn đang build trên một máy có ít core hơn hoặc bộ nhớ hạn chế:
-
-```json title="nx.json"
-{
-  "parallel": 3
-}
-```
-
-Bạn cũng có thể ghi đè nó cho mỗi lần gọi:
+Giảm nó xuống nếu bạn đang build trên một máy có ít core hơn hoặc bộ nhớ hạn chế. Bạn cũng có thể ghi đè nó cho mỗi lần gọi:
 
 <NxCommands commands={['run-many --target build --parallel=4']} />
 
@@ -165,6 +158,10 @@ Ví dụ:
 ### Linting
 
 Các workspace mới được cấu hình với [Biome](https://biomejs.dev/) cho phân tích tĩnh và định dạng code. Chạy `lint` kiểm tra tất cả các project để tìm vấn đề, và `lint --configuration=fix` tự động sửa chúng.
+
+### Cấu hình MCP
+
+<Link path="get_started/building-with-ai">MCP server</Link> của plugin được cấu hình như một MCP server cấp project cho Claude Code, Cursor, Kiro, Gemini CLI, GitHub Copilot và OpenAI Codex, vì vậy trợ lý lập trình của bạn có thể khám phá và chạy các generator của plugin mà không cần thiết lập gì. Cấu hình được commit cùng với workspace của bạn, mang lại cho mọi người trong nhóm cùng một thiết lập. Xóa bất kỳ cấu hình nào cho các trợ lý lập trình mà bạn và nhóm của bạn không sử dụng.
 
 ### Git Secrets
 

--- a/docs/src/content/docs/zh/get_started/quick-start.mdx
+++ b/docs/src/content/docs/zh/get_started/quick-start.mdx
@@ -33,7 +33,7 @@ import Prompt from '@components/prompt.astro';
 cd my-project
 ```
 
-系统会提示您选择基础设施即代码提供商([CDK](https://docs.aws.amazon.com/cdk/) 或 [Terraform](https://developer.hashicorp.com/terraform))以及用于构建容器镜像的生成器所使用的容器引擎。
+系统会提示您选择基础设施即代码提供商,[CDK](https://docs.aws.amazon.com/cdk/) 或 [Terraform](https://developer.hashicorp.com/terraform)。
 
 ## 步骤 2:构建您的应用程序
 

--- a/docs/src/content/docs/zh/guides/workspace.mdx
+++ b/docs/src/content/docs/zh/guides/workspace.mdx
@@ -27,6 +27,7 @@ import GeneratorParameters from '@components/generator-parameters.astro';
   - package.json Root package.json for your monorepo
   - nx.json Nx configuration (common targets, sync generators, caching)
   - tsconfig.base.json Root TypeScript configuration
+  - biome.json Biome configuration for linting and formatting
   - aws-nx-plugin.config.mts Nx Plugin for AWS configuration
   - .git-secrets/ Vendored git-secrets bash script for credential scanning
   - .gitallowed Patterns git-secrets treats as false positives
@@ -72,7 +73,7 @@ Nx monorepo 由一个或多个项目组成，每个项目都有一个 `project.j
 
 ### 缓存
 
-Nx 缓存先前执行的目标的输出，并在输入未更改时重放它们。这大大加快了构建、测试和代码检查的速度——尤其是在 CI 中。如果您遇到过时或意外的行为，请使用以下命令重置缓存：
+Nx 缓存先前执行的目标的输出，并在输入未更改时重放它们。这大大加快了构建、测试和代码检查的速度。如果您遇到过时或意外的行为，请使用以下命令重置缓存：
 
 <NxCommands commands={['reset']} />
 
@@ -88,15 +89,7 @@ Nx 缓存先前执行的目标的输出，并在输入未更改时重放它们�
 }
 ```
 
-如果您在核心数较少或内存有限的机器上构建，请降低此值：
-
-```json title="nx.json"
-{
-  "parallel": 3
-}
-```
-
-您还可以在每次调用时覆盖它：
+如果您在核心数较少或内存有限的机器上构建，请降低此值。您还可以在每次调用时覆盖它：
 
 <NxCommands commands={['run-many --target build --parallel=4']} />
 
@@ -165,6 +158,10 @@ Nx 缓存先前执行的目标的输出，并在输入未更改时重放它们�
 ### 代码检查
 
 新工作区配置了 [Biome](https://biomejs.dev/) 用于静态分析和代码格式化。运行 `lint` 检查所有项目的问题，`lint --configuration=fix` 自动修复它们。
+
+### MCP 配置
+
+该插件的 <Link path="get_started/building-with-ai">MCP 服务器</Link>被配置为 Claude Code、Cursor、Kiro、Gemini CLI、GitHub Copilot 和 OpenAI Codex 的项目级 MCP 服务器，因此您的编码助手可以在无需任何设置的情况下发现并运行该插件的生成器。该配置与您的工作区一起提交，使您团队中的每个人都拥有相同的设置。删除您和您的团队不使用的编码助手的任何配置。
 
 ### Git Secrets
 


### PR DESCRIPTION
### Reason for this change

The workspace guide omitted `biome.json` from the workspace structure, said nothing about the MCP configuration the preset vends despite listing the files in the file tree, and spent two code samples on the `parallel` setting. The quick start also claimed Step 1 prompts for a container engine.

### Description of changes

- List `biome.json` in the workspace structure file tree.
- Add a **MCP Configuration** section under *What's Included*, covering the project level MCP server configuration written for each supported coding assistant, and noting that unused ones can be removed.
- Drop "— especially in CI" from the caching section.
- Remove the second `nx.json` sample in the parallelism section, folding the guidance into a sentence.
- Remove the container engine from the Step 1 prompt description in the quick start guide.

### Description of how you validated changes

Documentation-only change, so no tests apply. Relying on the docs build in CI to check the MDX.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*