### PR TITLE
docs: read a schema's conditions in the graph builder too

### DIFF
--- a/docs/src/components/command-card-field.astro
+++ b/docs/src/components/command-card-field.astro
@@ -49,6 +49,7 @@ const values = locked ? option.values.filter((v) => v === value) : option.values
       option.when && (
         <span
           class="command-card-field-when doc-tooltip"
+          role="note"
           data-tooltip={strings.appliesWhen}
           aria-label={`${strings.appliesWhen}: ${describeWhen(option.when)}`}
         >

--- a/docs/src/components/generator-parameters.astro
+++ b/docs/src/components/generator-parameters.astro
@@ -170,6 +170,7 @@ const parameters = readGeneratorOptions(schema)
           {parameter.when && (
             <span
               class="gen-param-when doc-tooltip"
+              role="note"
               data-tooltip={localeString('appliesWhen')}
               aria-label={`${localeString('appliesWhen')}: ${describeWhen(parameter.when)}`}
             >

--- a/docs/src/components/graph-builder/graph-builder.tsx
+++ b/docs/src/components/graph-builder/graph-builder.tsx
@@ -17,6 +17,7 @@ import {
   type GraphNode,
   validate,
 } from '../../lib/graph-builder/model';
+import { reconcileNode } from '../../lib/graph-builder/node-options';
 import { readPackageManager } from '../../lib/package-manager';
 import { Canvas } from './canvas';
 import {
@@ -315,7 +316,13 @@ export const GraphBuilder = () => {
         ...current,
         nodes: current.nodes.map((node) =>
           node.id === id
-            ? { ...node, options: { ...node.options, [option]: value } }
+            ? // Setting one option can rule another out — a gateway with no
+              // infrastructure has nothing to authenticate — so the rest are put
+              // right here, where the change lands.
+              reconcileNode(
+                { ...node, options: { ...node.options, [option]: value } },
+                nodeType(node.type),
+              )
             : node,
         ),
       }));

--- a/docs/src/components/graph-builder/inspector.tsx
+++ b/docs/src/components/graph-builder/inspector.tsx
@@ -2,9 +2,19 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
+
+import { describeWhen } from '../../lib/generator-options';
 import { nodeType } from '../../lib/graph-builder/catalog';
 import type { GraphNode, Issue } from '../../lib/graph-builder/model';
+import {
+  effectiveNodeOptions,
+  propertyApplies,
+  propertyValueApplies,
+} from '../../lib/graph-builder/node-options';
 import { NodeLogo } from './node-logo';
+
+/** What a condition badge says when the pointer rests on it. */
+const APPLIES_WHEN = 'Only applies with these option values';
 
 interface Props {
   node: GraphNode | undefined;
@@ -39,6 +49,9 @@ export const Inspector = ({
 
   const type = nodeType(node.type);
   const nodeIssues = issues.filter((issue) => issue.nodeId === node.id);
+  // What a run of this node's generator would use, which is what its options'
+  // conditions are read against.
+  const values = effectiveNodeOptions(type, node.options);
   // Important options first — the generator marks the ones that change what it
   // produces — then the rest, so the panel opens on what matters.
   const properties = [
@@ -143,20 +156,39 @@ export const Inspector = ({
       {properties.map((property) => {
         const id = `gb-${node.id}-${property.name}`;
         const value = node.options[property.name] ?? property.default ?? '';
+        const applies = propertyApplies(property, values);
+        const fieldClass = `gb-field${applies ? '' : ' is-inapplicable'}`;
+        const condition = property.when && (
+          <span
+            className="command-card-field-when doc-tooltip"
+            role="note"
+            data-tooltip={APPLIES_WHEN}
+            aria-label={`${APPLIES_WHEN}: ${describeWhen(
+              property.when as Record<string, string[]>,
+            )}`}
+          >
+            {describeWhen(property.when as Record<string, string[]>)}
+          </span>
+        );
 
         if (property.type === 'boolean') {
           return (
-            <div className="gb-field gb-field--switch" key={property.name}>
+            <div
+              className={`${fieldClass} gb-field--switch`}
+              key={property.name}
+            >
               <label className="command-card-check" htmlFor={id}>
                 <input
                   id={id}
                   type="checkbox"
                   checked={value === true}
+                  disabled={!applies}
                   onChange={(event) =>
                     onOptionChange(property.name, event.target.checked)
                   }
                 />
                 <span className="command-card-field-name">{property.name}</span>
+                {condition}
               </label>
               {property.description && (
                 <p className="gb-field-hint">{property.description}</p>
@@ -170,25 +202,52 @@ export const Inspector = ({
           // a select, and takes the same vertical space.
           if (property.enum.length <= 3) {
             return (
-              <div className="gb-field" key={property.name}>
-                <span className="command-card-field-name">{property.name}</span>
+              <div className={fieldClass} key={property.name}>
+                <p className="gb-field-head">
+                  <span className="command-card-field-name">
+                    {property.name}
+                  </span>
+                  {condition}
+                </p>
                 <fieldset
                   className="command-card-pills"
                   aria-label={property.name}
                 >
-                  {property.enum.map((option) => (
-                    <button
-                      key={option}
-                      type="button"
-                      className={`command-card-pill${
-                        option === property.default ? ' is-default' : ''
-                      }`}
-                      aria-pressed={value === option}
-                      onClick={() => onOptionChange(property.name, option)}
-                    >
-                      {option}
-                    </button>
-                  ))}
+                  {property.enum.map((option) => {
+                    const valueApplies = propertyValueApplies(
+                      property,
+                      option,
+                      values,
+                    );
+                    return (
+                      <button
+                        key={option}
+                        type="button"
+                        className={[
+                          'command-card-pill',
+                          option === property.default ? 'is-default' : '',
+                          valueApplies ? '' : 'is-inapplicable',
+                        ]
+                          .filter(Boolean)
+                          .join(' ')}
+                        aria-pressed={value === option}
+                        disabled={!applies || !valueApplies}
+                        title={
+                          valueApplies
+                            ? undefined
+                            : `${APPLIES_WHEN}: ${describeWhen(
+                                (property.valueWhen?.[option] ?? {}) as Record<
+                                  string,
+                                  string[]
+                                >,
+                              )}`
+                        }
+                        onClick={() => onOptionChange(property.name, option)}
+                      >
+                        {option}
+                      </button>
+                    );
+                  })}
                 </fieldset>
                 {property.description && (
                   <p className="gb-field-hint">{property.description}</p>
@@ -197,23 +256,31 @@ export const Inspector = ({
             );
           }
           return (
-            <div className="gb-field" key={property.name}>
-              <label className="command-card-field-name" htmlFor={id}>
-                {property.name}
-              </label>
+            <div className={fieldClass} key={property.name}>
+              <p className="gb-field-head">
+                <label className="command-card-field-name" htmlFor={id}>
+                  {property.name}
+                </label>
+                {condition}
+              </p>
               <select
                 id={id}
                 className="gb-select"
                 value={String(value)}
+                disabled={!applies}
                 onChange={(event) =>
                   onOptionChange(property.name, event.target.value)
                 }
               >
-                {property.enum.map((option) => (
-                  <option key={option} value={option}>
-                    {option}
-                  </option>
-                ))}
+                {property.enum
+                  .filter((option) =>
+                    propertyValueApplies(property, option, values),
+                  )
+                  .map((option) => (
+                    <option key={option} value={option}>
+                      {option}
+                    </option>
+                  ))}
               </select>
               {property.description && (
                 <p className="gb-field-hint">{property.description}</p>
@@ -223,10 +290,13 @@ export const Inspector = ({
         }
 
         return (
-          <div className="gb-field" key={property.name}>
-            <label className="command-card-field-name" htmlFor={id}>
-              {property.name}
-            </label>
+          <div className={fieldClass} key={property.name}>
+            <p className="gb-field-head">
+              <label className="command-card-field-name" htmlFor={id}>
+                {property.name}
+              </label>
+              {condition}
+            </p>
             <input
               id={id}
               className="command-card-input"
@@ -234,6 +304,7 @@ export const Inspector = ({
               value={String(value)}
               spellCheck={false}
               autoComplete="off"
+              readOnly={!applies}
               placeholder={
                 property.default !== undefined ? String(property.default) : ''
               }

--- a/docs/src/lib/graph-builder/catalog.ts
+++ b/docs/src/lib/graph-builder/catalog.ts
@@ -14,6 +14,11 @@ import {
   schemaPathOf,
 } from '../../../../packages/nx-plugin/src/connection/scaffold-catalog';
 import { SUPPORTED_CONNECTIONS } from '../../../../packages/nx-plugin/src/connection/supported-connections';
+import {
+  isApplicable,
+  isValueApplicable,
+  readGeneratorOptions,
+} from '../generator-options';
 
 /**
  * The graph builder's catalogue of node types and edges, derived at build time
@@ -35,6 +40,12 @@ export interface NodeProperty {
   readonly required: boolean;
   /** Whether the generator marks this as an important option. */
   readonly important: boolean;
+  /** The option values this one applies under, from the schema's `x-when`. */
+  readonly when?: Readonly<Record<string, readonly string[]>>;
+  /** The values each of this option's own values needs, from `x-value-when`. */
+  readonly valueWhen?: Readonly<
+    Record<string, Readonly<Record<string, readonly string[]>>>
+  >;
 }
 
 /** A node type the user can drag onto the canvas. */
@@ -140,22 +151,42 @@ const toProperties = (
   variantOptions: Readonly<Record<string, string>>,
 ): NodeProperty[] => {
   const required = new Set(schema.required ?? []);
+  // Read through the same reader the guides use, so `x-when` and `x-value-when`
+  // mean here what they mean there.
+  const options = new Map(
+    readGeneratorOptions(schema).map((option) => [option.key, option]),
+  );
+  // Choosing this node type has already answered the variant options, so an
+  // option that can't apply under them is not one of this type's — the Smithy
+  // namespace on a tRPC API. Only those count as answered: an option the reader
+  // can still change stays, and the inspector disables it while it doesn't apply.
+  const fixed: Record<string, string> = { ...variantOptions };
+
   return Object.entries(schema.properties ?? {})
     .filter(
       ([name, prop]) =>
         !HIDDEN_OPTIONS.has(name) &&
         !(name in variantOptions) &&
-        (prop.type === 'string' || prop.type === 'boolean'),
+        (prop.type === 'string' || prop.type === 'boolean') &&
+        isApplicable(options.get(name) ?? {}, fixed),
     )
-    .map(([name, prop]) => ({
-      name,
-      type: prop.type,
-      ...(prop.description ? { description: prop.description } : {}),
-      ...(prop.enum ? { enum: prop.enum as string[] } : {}),
-      ...(prop.default !== undefined ? { default: prop.default } : {}),
-      required: required.has(name),
-      important: prop['x-priority'] === 'important',
-    }));
+    .map(([name, prop]) => {
+      const option = options.get(name);
+      const values = (prop.enum ?? []).filter((value) =>
+        isValueApplicable(option ?? {}, value, fixed),
+      );
+      return {
+        name,
+        type: prop.type as 'string' | 'boolean',
+        ...(prop.description ? { description: prop.description } : {}),
+        ...(prop.enum ? { enum: values } : {}),
+        ...(prop.default !== undefined ? { default: prop.default } : {}),
+        required: required.has(name),
+        important: prop['x-priority'] === 'important',
+        ...(option?.when ? { when: option.when } : {}),
+        ...(option?.valueWhen ? { valueWhen: option.valueWhen } : {}),
+      } as NodeProperty;
+    });
 };
 
 /**

--- a/docs/src/lib/graph-builder/commands.ts
+++ b/docs/src/lib/graph-builder/commands.ts
@@ -17,6 +17,11 @@ import {
 } from '../../../../packages/nx-plugin/src/utils/names';
 import { INFRA_PROJECT_NAME, type NodeType, nodeType } from './catalog';
 import type { Graph, GraphEdge, GraphNode } from './model';
+import {
+  effectiveNodeOptions,
+  propertyApplies,
+  propertyValueApplies,
+} from './node-options';
 
 /**
  * Turn a graph into the commands that scaffold it: one to create the workspace,
@@ -105,6 +110,18 @@ const shouldEmit = (
   if (option in type.variantOptions) return true;
   if (!(option in options)) return false;
   const property = type.properties.find((p) => p.name === option);
+  // An option the rest of the values rule out would make a command the generator
+  // refuses. The builder puts a node's options right as they change, so this only
+  // catches what a preset carries in.
+  if (property) {
+    const values = effectiveNodeOptions(type, options);
+    if (
+      !propertyApplies(property, values) ||
+      !propertyValueApplies(property, String(options[option]), values)
+    ) {
+      return false;
+    }
+  }
   return options[option] !== property?.default;
 };
 

--- a/docs/src/lib/graph-builder/node-options.spec.ts
+++ b/docs/src/lib/graph-builder/node-options.spec.ts
@@ -1,0 +1,101 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { describe, expect, it } from 'vitest';
+import { nodeType } from './catalog';
+import {
+  effectiveNodeOptions,
+  propertyApplies,
+  propertyValueApplies,
+  reconcileNodeOptions,
+} from './node-options';
+
+/**
+ * The builder reads a schema's conditions the way the guides do, so a graph can
+ * only hand over commands the generators accept.
+ */
+describe('conditional node options', () => {
+  it('should leave an option a node type rules out off the type altogether', () => {
+    // The Smithy namespace can never apply to a tRPC API: choosing the node type
+    // answered `framework`.
+    const trpc = nodeType('ts#trpc-api');
+    const smithy = nodeType('ts#smithy-api');
+
+    expect(trpc.properties.map((p) => p.name)).not.toContain('namespace');
+    expect(smithy.properties.map((p) => p.name)).toContain('namespace');
+  });
+
+  it('should leave a value a node type rules out off its option', () => {
+    // Smithy has no HTTP API integration, so its `infra` offers neither.
+    const infra = nodeType('ts#smithy-api').properties.find(
+      (p) => p.name === 'infra',
+    );
+
+    expect(infra?.enum).toEqual(['rest-lambda', 'none']);
+    expect(
+      nodeType('ts#trpc-api').properties.find((p) => p.name === 'infra')?.enum,
+    ).toEqual(['rest-lambda', 'http-lambda', 'none']);
+  });
+
+  it('should read a condition against the values a run would use', () => {
+    const gateway = nodeType('agentcore-gateway');
+    const auth = gateway.properties.find((p) => p.name === 'auth');
+    if (!auth) throw new Error('the gateway has no auth option');
+
+    // Nothing chosen: `infra` falls back to hosting the gateway, so auth applies.
+    expect(propertyApplies(auth, effectiveNodeOptions(gateway, {}))).toBe(true);
+    // With no infrastructure there is nothing to authenticate.
+    expect(
+      propertyApplies(auth, effectiveNodeOptions(gateway, { infra: 'none' })),
+    ).toBe(false);
+  });
+
+  it('should drop an option the rest of the values rule out', () => {
+    const gateway = nodeType('agentcore-gateway');
+
+    expect(
+      reconcileNodeOptions(gateway, { infra: 'none', auth: 'cognito' }),
+    ).toEqual({ infra: 'none' });
+  });
+
+  it('should keep an option that still applies', () => {
+    const gateway = nodeType('agentcore-gateway');
+
+    expect(
+      reconcileNodeOptions(gateway, { infra: 'agentcore', auth: 'cognito' }),
+    ).toEqual({ infra: 'agentcore', auth: 'cognito' });
+  });
+
+  it('should let go of a value another choice rules out', () => {
+    const agent = nodeType('py#agent');
+    const session = agent.properties.find((p) => p.name === 'session');
+    if (!session) throw new Error('the agent has no session option');
+
+    // Only the LangChain agent has a DynamoDB checkpointer to save to.
+    expect(
+      propertyValueApplies(
+        session,
+        'dynamodb-s3',
+        effectiveNodeOptions(agent, { framework: 'langchain' }),
+      ),
+    ).toBe(true);
+    expect(
+      reconcileNodeOptions(agent, {
+        framework: 'strands',
+        session: 'dynamodb-s3',
+      }),
+    ).toEqual({ framework: 'strands' });
+  });
+
+  it('should name a value that applies where the fallback does not', () => {
+    // Clearing Tailwind rules out shadcn, which a website falls back to, so the
+    // command has to name a UX that doesn't need it.
+    const website = nodeType('ts#react-website');
+    const reconciled = reconcileNodeOptions(website, { tailwind: false });
+
+    expect(reconciled.tailwind).toBe(false);
+    expect(reconciled.ux).toBeDefined();
+    expect(reconciled.ux).not.toBe('shadcn');
+  });
+});

--- a/docs/src/lib/graph-builder/node-options.ts
+++ b/docs/src/lib/graph-builder/node-options.ts
@@ -1,0 +1,110 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { isApplicable, isValueApplicable } from '../generator-options';
+import type { NodeProperty, NodeType } from './catalog';
+import type { GraphNode } from './model';
+
+/**
+ * Which of a node's options apply, given the values it is set to.
+ *
+ * A generator's schema can say that an option only applies for certain values of
+ * another (`x-when`), or that one of an option's values does (`x-value-when`) —
+ * a gateway's `auth` needs infrastructure to authenticate, and only a LangChain
+ * agent has a DynamoDB session to save to. The builder reads those the way the
+ * guides do, so a graph can only hand over commands the generators accept.
+ *
+ * The options a node type fixes are already gone from `type.properties`, dropped
+ * where the type's own variant options rule them out. What's left is what the
+ * reader chooses, and can therefore rule out as they go.
+ */
+
+/** The values a run of this node's generator would use, as strings. */
+export const effectiveNodeOptions = (
+  type: NodeType,
+  options: Readonly<Record<string, string | boolean>>,
+): Record<string, string> => {
+  const values: Record<string, string> = Object.fromEntries(
+    Object.entries(type.variantOptions),
+  );
+  for (const property of type.properties) {
+    const value = options[property.name] ?? property.default;
+    if (value !== undefined && value !== '')
+      values[property.name] = String(value);
+  }
+  for (const [key, value] of Object.entries(options)) {
+    if (value !== undefined && value !== '') values[key] = String(value);
+  }
+  return values;
+};
+
+const asOption = (property: NodeProperty) => ({
+  when: property.when as Record<string, string[]> | undefined,
+  valueWhen: property.valueWhen as
+    | Record<string, Record<string, string[]>>
+    | undefined,
+});
+
+/** Whether an option applies given what the node is set to. */
+export const propertyApplies = (
+  property: NodeProperty,
+  values: Record<string, string>,
+): boolean => isApplicable(asOption(property), values);
+
+/** Whether one of an option's values applies given what the node is set to. */
+export const propertyValueApplies = (
+  property: NodeProperty,
+  value: string,
+  values: Record<string, string>,
+): boolean => isValueApplicable(asOption(property), value, values);
+
+/**
+ * A node's options with anything the rest of them rules out put right: an option
+ * that no longer applies is dropped, and a value that no longer applies gives way
+ * to one that does — where the value a run would fall back to is ruled out too,
+ * the option has to name one that isn't, or the generator refuses the command.
+ *
+ * Called whenever an option changes, so the graph is always one the commands can
+ * be emitted from.
+ */
+export const reconcileNodeOptions = (
+  type: NodeType,
+  options: Readonly<Record<string, string | boolean>>,
+): Record<string, string | boolean> => {
+  const next: Record<string, string | boolean> = { ...options };
+  const values = effectiveNodeOptions(type, options);
+
+  for (const property of type.properties) {
+    if (!propertyApplies(property, values)) {
+      delete next[property.name];
+      continue;
+    }
+    if (!property.enum || property.enum.length === 0) continue;
+
+    const applicable = property.enum.filter((value) =>
+      propertyValueApplies(property, value, values),
+    );
+    if (applicable.length === 0) continue;
+
+    const chosen = next[property.name];
+    if (chosen !== undefined && !applicable.includes(String(chosen))) {
+      delete next[property.name];
+    }
+    const fallback = String(next[property.name] ?? property.default ?? '');
+    if (fallback && !applicable.includes(fallback)) {
+      next[property.name] = applicable[0];
+    }
+  }
+
+  return next;
+};
+
+/** The same, for a node. */
+export const reconcileNode = (node: GraphNode, type: NodeType): GraphNode => {
+  const options = reconcileNodeOptions(type, node.options);
+  return Object.keys(options).length === Object.keys(node.options).length &&
+    Object.entries(options).every(([key, value]) => node.options[key] === value)
+    ? node
+    : { ...node, options };
+};

--- a/docs/src/lib/graph-builder/presets.spec.ts
+++ b/docs/src/lib/graph-builder/presets.spec.ts
@@ -8,8 +8,14 @@ import {
   PRESETS,
   SHOWCASE_PRESET_IDS,
 } from '../../components/graph-builder/presets';
+import { nodeType } from './catalog';
 import { emitCommands } from './commands';
 import { validate } from './model';
+import {
+  effectiveNodeOptions,
+  propertyApplies,
+  propertyValueApplies,
+} from './node-options';
 
 /**
  * A preset is a starting point users load and scaffold as-is, so every one must
@@ -44,6 +50,32 @@ describe('graph builder presets', () => {
       expect(commands.length).toBeGreaterThanOrEqual(
         preset.nodes.length + preset.edges.length + 2,
       );
+    },
+  );
+
+  // Every option a preset pins has to be one the node still takes, and one the
+  // generator would accept alongside the rest.
+  it.each(PRESETS.map((preset) => [preset.id, preset] as const))(
+    'should only pin options that apply for the %s preset',
+    (_id, preset) => {
+      for (const node of preset.nodes) {
+        const type = nodeType(node.type);
+        const values = effectiveNodeOptions(type, node.options ?? {});
+        for (const [option, value] of Object.entries(node.options ?? {})) {
+          const property = type.properties.find((p) => p.name === option);
+          if (!property) {
+            throw new Error(`${node.type} has no ${option} option`);
+          }
+          expect(
+            propertyApplies(property, values),
+            `${node.type}'s ${option} does not apply`,
+          ).toBe(true);
+          expect(
+            propertyValueApplies(property, String(value), values),
+            `${node.type}'s ${option}=${value} does not apply`,
+          ).toBe(true);
+        }
+      }
     },
   );
 

--- a/docs/src/styles/graph-builder.css
+++ b/docs/src/styles/graph-builder.css
@@ -1356,6 +1356,32 @@
     color-mix(in oklab, var(--sl-color-accent) 30%, transparent);
 }
 
+/* The option's name and, where it has one, the condition it applies under. */
+.gb-field-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.2rem 0.4rem;
+  margin: 0;
+}
+
+/* An option another choice rules out keeps its place, so the condition it needs
+   stays readable — the same treatment the guides' cards give it. */
+.gb-field.is-inapplicable {
+  opacity: 0.55;
+}
+
+.gb-field.is-inapplicable .command-card-pills,
+.gb-field.is-inapplicable .command-card-check {
+  pointer-events: none;
+}
+
+.gb-field.is-inapplicable .command-card-field-when {
+  border-style: solid;
+  border-color: var(--sl-color-accent);
+  color: var(--sl-color-text-accent);
+}
+
 .gb-field-hint {
   margin: 0;
   font-size: 0.72rem;

--- a/packages/nx-plugin/src/connection/scaffold-catalog.ts
+++ b/packages/nx-plugin/src/connection/scaffold-catalog.ts
@@ -95,6 +95,10 @@ export type GeneratorSchema = {
       enum?: string[];
       default?: unknown;
       'x-priority'?: string;
+      /** The option values this option applies under. */
+      'x-when'?: Record<string, string | string[]>;
+      /** The same, per value, where one of an option's values applies sometimes. */
+      'x-value-when'?: Record<string, Record<string, string | string[]>>;
     }
   >;
   required?: string[];


### PR DESCRIPTION
### Reason for this change

#1249 taught the guides to read a schema's conditions: an option a generator can't take under the values in play is dropped, and one the reader's own choice rules out is disabled with its condition shown. The graph builder never learned any of it — it offered every option and every value its schemas list, so a graph could hand over commands the generators refuse or quietly rewrite:

- `--auth=cognito` for a gateway with `--infra=none`, which has nothing to authenticate.
- A Smithy API on `--infra=http-lambda`, which Smithy has no integration for (`ts#api` silently maps it to REST).
- A website with `--tailwind=false`, whose UX falls back to shadcn, which is built on Tailwind.

### Description of changes

The builder reads `x-when` and `x-value-when` through the same reader the guides use (`readGeneratorOptions`), and applies them at the three places that matter:

- **The node type.** Choosing a type answers its variant options, so an option or a value they rule out isn't one that type has: a tRPC API node has no `namespace`, and a Smithy API node's `infra` offers `rest-lambda` and `none`. Only the variant options count as answered — an option the reader can still change stays on the type, since they may yet choose the value that brings it into play.
- **The properties panel.** What the reader chooses can rule the rest out as they go, so those options dim, their controls disable, and their condition shows in the accent with a tooltip — the same treatment a guide's card gives them. A single ruled-out value dashes and disables just that pill.
- **The graph itself.** A node's options are put right as they change (`reconcileNode`): an option that no longer applies is dropped, a value that no longer applies gives way to one that does, and where the value a run would fall back to is ruled out the option names one that isn't — clearing a website's Tailwind moves its UX off shadcn. The emitter checks the same, so a preset can't carry in what a generator would refuse.

### Description of how you validated changes

- `pnpm nx run docs:build` passes — 1540 pages built, all internal links valid. `pnpm nx run docs:test` passes with 7 new tests (223 total), and the plugin's MCP server and scaffold-catalogue suites pass (183).
- A test walks every preset and asserts each option it pins is one the node type still has, and applies alongside the rest of that node's values.
- Walked the conditions in the browser on a gateway node: `--auth=cognito` with infrastructure, then switching to `infra=none` dims `auth`, disables its pills, shows `infra = agentcore` in the accent with the tooltip, and drops `--auth` from the command. Checked a tRPC API node has no `namespace` and a Smithy one's `infra` offers only two values.
- `biome check` clean on every file added or changed, with `commands.ts` back to its four pre-existing findings.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
