### PR TITLE
docs: add a polyglot full-stack example to the graph builder

### DIFF
--- a/docs/src/components/command-card-field.astro
+++ b/docs/src/components/command-card-field.astro
@@ -49,6 +49,7 @@ const values = locked ? option.values.filter((v) => v === value) : option.values
       option.when && (
         <span
           class="command-card-field-when doc-tooltip"
+          role="note"
           data-tooltip={strings.appliesWhen}
           aria-label={`${strings.appliesWhen}: ${describeWhen(option.when)}`}
         >

--- a/docs/src/components/generator-parameters.astro
+++ b/docs/src/components/generator-parameters.astro
@@ -170,6 +170,7 @@ const parameters = readGeneratorOptions(schema)
           {parameter.when && (
             <span
               class="gen-param-when doc-tooltip"
+              role="note"
               data-tooltip={localeString('appliesWhen')}
               aria-label={`${localeString('appliesWhen')}: ${describeWhen(parameter.when)}`}
             >

--- a/docs/src/components/graph-builder/graph-builder.tsx
+++ b/docs/src/components/graph-builder/graph-builder.tsx
@@ -17,6 +17,7 @@ import {
   type GraphNode,
   validate,
 } from '../../lib/graph-builder/model';
+import { reconcileNode } from '../../lib/graph-builder/node-options';
 import { readPackageManager } from '../../lib/package-manager';
 import { Canvas } from './canvas';
 import {
@@ -315,7 +316,13 @@ export const GraphBuilder = () => {
         ...current,
         nodes: current.nodes.map((node) =>
           node.id === id
-            ? { ...node, options: { ...node.options, [option]: value } }
+            ? // Setting one option can rule another out — a gateway with no
+              // infrastructure has nothing to authenticate — so the rest are put
+              // right here, where the change lands.
+              reconcileNode(
+                { ...node, options: { ...node.options, [option]: value } },
+                nodeType(node.type),
+              )
             : node,
         ),
       }));

--- a/docs/src/components/graph-builder/inspector.tsx
+++ b/docs/src/components/graph-builder/inspector.tsx
@@ -2,9 +2,19 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
+
+import { describeWhen } from '../../lib/generator-options';
 import { nodeType } from '../../lib/graph-builder/catalog';
 import type { GraphNode, Issue } from '../../lib/graph-builder/model';
+import {
+  effectiveNodeOptions,
+  propertyApplies,
+  propertyValueApplies,
+} from '../../lib/graph-builder/node-options';
 import { NodeLogo } from './node-logo';
+
+/** What a condition badge says when the pointer rests on it. */
+const APPLIES_WHEN = 'Only applies with these option values';
 
 interface Props {
   node: GraphNode | undefined;
@@ -39,6 +49,9 @@ export const Inspector = ({
 
   const type = nodeType(node.type);
   const nodeIssues = issues.filter((issue) => issue.nodeId === node.id);
+  // What a run of this node's generator would use, which is what its options'
+  // conditions are read against.
+  const values = effectiveNodeOptions(type, node.options);
   // Important options first — the generator marks the ones that change what it
   // produces — then the rest, so the panel opens on what matters.
   const properties = [
@@ -143,20 +156,39 @@ export const Inspector = ({
       {properties.map((property) => {
         const id = `gb-${node.id}-${property.name}`;
         const value = node.options[property.name] ?? property.default ?? '';
+        const applies = propertyApplies(property, values);
+        const fieldClass = `gb-field${applies ? '' : ' is-inapplicable'}`;
+        const condition = property.when && (
+          <span
+            className="command-card-field-when doc-tooltip"
+            role="note"
+            data-tooltip={APPLIES_WHEN}
+            aria-label={`${APPLIES_WHEN}: ${describeWhen(
+              property.when as Record<string, string[]>,
+            )}`}
+          >
+            {describeWhen(property.when as Record<string, string[]>)}
+          </span>
+        );
 
         if (property.type === 'boolean') {
           return (
-            <div className="gb-field gb-field--switch" key={property.name}>
+            <div
+              className={`${fieldClass} gb-field--switch`}
+              key={property.name}
+            >
               <label className="command-card-check" htmlFor={id}>
                 <input
                   id={id}
                   type="checkbox"
                   checked={value === true}
+                  disabled={!applies}
                   onChange={(event) =>
                     onOptionChange(property.name, event.target.checked)
                   }
                 />
                 <span className="command-card-field-name">{property.name}</span>
+                {condition}
               </label>
               {property.description && (
                 <p className="gb-field-hint">{property.description}</p>
@@ -170,25 +202,52 @@ export const Inspector = ({
           // a select, and takes the same vertical space.
           if (property.enum.length <= 3) {
             return (
-              <div className="gb-field" key={property.name}>
-                <span className="command-card-field-name">{property.name}</span>
+              <div className={fieldClass} key={property.name}>
+                <p className="gb-field-head">
+                  <span className="command-card-field-name">
+                    {property.name}
+                  </span>
+                  {condition}
+                </p>
                 <fieldset
                   className="command-card-pills"
                   aria-label={property.name}
                 >
-                  {property.enum.map((option) => (
-                    <button
-                      key={option}
-                      type="button"
-                      className={`command-card-pill${
-                        option === property.default ? ' is-default' : ''
-                      }`}
-                      aria-pressed={value === option}
-                      onClick={() => onOptionChange(property.name, option)}
-                    >
-                      {option}
-                    </button>
-                  ))}
+                  {property.enum.map((option) => {
+                    const valueApplies = propertyValueApplies(
+                      property,
+                      option,
+                      values,
+                    );
+                    return (
+                      <button
+                        key={option}
+                        type="button"
+                        className={[
+                          'command-card-pill',
+                          option === property.default ? 'is-default' : '',
+                          valueApplies ? '' : 'is-inapplicable',
+                        ]
+                          .filter(Boolean)
+                          .join(' ')}
+                        aria-pressed={value === option}
+                        disabled={!applies || !valueApplies}
+                        title={
+                          valueApplies
+                            ? undefined
+                            : `${APPLIES_WHEN}: ${describeWhen(
+                                (property.valueWhen?.[option] ?? {}) as Record<
+                                  string,
+                                  string[]
+                                >,
+                              )}`
+                        }
+                        onClick={() => onOptionChange(property.name, option)}
+                      >
+                        {option}
+                      </button>
+                    );
+                  })}
                 </fieldset>
                 {property.description && (
                   <p className="gb-field-hint">{property.description}</p>
@@ -197,23 +256,31 @@ export const Inspector = ({
             );
           }
           return (
-            <div className="gb-field" key={property.name}>
-              <label className="command-card-field-name" htmlFor={id}>
-                {property.name}
-              </label>
+            <div className={fieldClass} key={property.name}>
+              <p className="gb-field-head">
+                <label className="command-card-field-name" htmlFor={id}>
+                  {property.name}
+                </label>
+                {condition}
+              </p>
               <select
                 id={id}
                 className="gb-select"
                 value={String(value)}
+                disabled={!applies}
                 onChange={(event) =>
                   onOptionChange(property.name, event.target.value)
                 }
               >
-                {property.enum.map((option) => (
-                  <option key={option} value={option}>
-                    {option}
-                  </option>
-                ))}
+                {property.enum
+                  .filter((option) =>
+                    propertyValueApplies(property, option, values),
+                  )
+                  .map((option) => (
+                    <option key={option} value={option}>
+                      {option}
+                    </option>
+                  ))}
               </select>
               {property.description && (
                 <p className="gb-field-hint">{property.description}</p>
@@ -223,10 +290,13 @@ export const Inspector = ({
         }
 
         return (
-          <div className="gb-field" key={property.name}>
-            <label className="command-card-field-name" htmlFor={id}>
-              {property.name}
-            </label>
+          <div className={fieldClass} key={property.name}>
+            <p className="gb-field-head">
+              <label className="command-card-field-name" htmlFor={id}>
+                {property.name}
+              </label>
+              {condition}
+            </p>
             <input
               id={id}
               className="command-card-input"
@@ -234,6 +304,7 @@ export const Inspector = ({
               value={String(value)}
               spellCheck={false}
               autoComplete="off"
+              readOnly={!applies}
               placeholder={
                 property.default !== undefined ? String(property.default) : ''
               }

--- a/docs/src/components/graph-builder/presets.ts
+++ b/docs/src/components/graph-builder/presets.ts
@@ -224,6 +224,51 @@ export const PRESETS: readonly Preset[] = [
     ],
   },
   {
+    id: 'polyglot-full-stack',
+    label: 'Polyglot full-stack app',
+    description:
+      'A React frontend over a tRPC API and a Python AG-UI agent, whose TypeScript and Python tools sit behind an AgentCore Gateway, sharing a DynamoDB table.',
+    prompt:
+      'Build a full-stack app: a React frontend with a tRPC API and a Python AG-UI agent, TypeScript and Python MCP servers behind an AgentCore Gateway, and a DynamoDB table the API and the TypeScript tools share.',
+    nodes: [
+      { type: 'ts#react-website', name: 'frontend', column: 0, row: 0 },
+      { type: 'ts#trpc-api', name: 'backend', column: 1, row: 0 },
+      { type: 'agentcore-gateway', name: 'mcp-gateway', column: 2, row: 1 },
+      { type: 'ts#dynamodb', name: 'dynamodb', column: 2, row: 0 },
+      {
+        type: 'py#agent',
+        name: 'agent',
+        hostName: 'py-app',
+        options: { protocol: 'ag-ui' },
+        column: 1,
+        row: 1,
+      },
+      {
+        type: 'ts#mcp-server',
+        name: 'typescript-mcp',
+        hostName: 'app',
+        column: 3,
+        row: 1,
+      },
+      {
+        type: 'py#mcp-server',
+        name: 'python-mcp',
+        hostName: 'py-app',
+        column: 3,
+        row: 2,
+      },
+    ],
+    edges: [
+      ['frontend', 'backend'],
+      ['frontend', 'agent'],
+      ['agent', 'mcp-gateway'],
+      ['mcp-gateway', 'typescript-mcp'],
+      ['mcp-gateway', 'python-mcp'],
+      ['typescript-mcp', 'dynamodb'],
+      ['backend', 'dynamodb'],
+    ],
+  },
+  {
     id: 'gateway-fronted-agents',
     label: 'Gateway-fronted agents',
     description:

--- a/docs/src/lib/graph-builder/catalog.ts
+++ b/docs/src/lib/graph-builder/catalog.ts
@@ -14,6 +14,11 @@ import {
   schemaPathOf,
 } from '../../../../packages/nx-plugin/src/connection/scaffold-catalog';
 import { SUPPORTED_CONNECTIONS } from '../../../../packages/nx-plugin/src/connection/supported-connections';
+import {
+  isApplicable,
+  isValueApplicable,
+  readGeneratorOptions,
+} from '../generator-options';
 
 /**
  * The graph builder's catalogue of node types and edges, derived at build time
@@ -35,6 +40,12 @@ export interface NodeProperty {
   readonly required: boolean;
   /** Whether the generator marks this as an important option. */
   readonly important: boolean;
+  /** The option values this one applies under, from the schema's `x-when`. */
+  readonly when?: Readonly<Record<string, readonly string[]>>;
+  /** The values each of this option's own values needs, from `x-value-when`. */
+  readonly valueWhen?: Readonly<
+    Record<string, Readonly<Record<string, readonly string[]>>>
+  >;
 }
 
 /** A node type the user can drag onto the canvas. */
@@ -140,22 +151,42 @@ const toProperties = (
   variantOptions: Readonly<Record<string, string>>,
 ): NodeProperty[] => {
   const required = new Set(schema.required ?? []);
+  // Read through the same reader the guides use, so `x-when` and `x-value-when`
+  // mean here what they mean there.
+  const options = new Map(
+    readGeneratorOptions(schema).map((option) => [option.key, option]),
+  );
+  // Choosing this node type has already answered the variant options, so an
+  // option that can't apply under them is not one of this type's — the Smithy
+  // namespace on a tRPC API. Only those count as answered: an option the reader
+  // can still change stays, and the inspector disables it while it doesn't apply.
+  const fixed: Record<string, string> = { ...variantOptions };
+
   return Object.entries(schema.properties ?? {})
     .filter(
       ([name, prop]) =>
         !HIDDEN_OPTIONS.has(name) &&
         !(name in variantOptions) &&
-        (prop.type === 'string' || prop.type === 'boolean'),
+        (prop.type === 'string' || prop.type === 'boolean') &&
+        isApplicable(options.get(name) ?? {}, fixed),
     )
-    .map(([name, prop]) => ({
-      name,
-      type: prop.type,
-      ...(prop.description ? { description: prop.description } : {}),
-      ...(prop.enum ? { enum: prop.enum as string[] } : {}),
-      ...(prop.default !== undefined ? { default: prop.default } : {}),
-      required: required.has(name),
-      important: prop['x-priority'] === 'important',
-    }));
+    .map(([name, prop]) => {
+      const option = options.get(name);
+      const values = (prop.enum ?? []).filter((value) =>
+        isValueApplicable(option ?? {}, value, fixed),
+      );
+      return {
+        name,
+        type: prop.type as 'string' | 'boolean',
+        ...(prop.description ? { description: prop.description } : {}),
+        ...(prop.enum ? { enum: values } : {}),
+        ...(prop.default !== undefined ? { default: prop.default } : {}),
+        required: required.has(name),
+        important: prop['x-priority'] === 'important',
+        ...(option?.when ? { when: option.when } : {}),
+        ...(option?.valueWhen ? { valueWhen: option.valueWhen } : {}),
+      } as NodeProperty;
+    });
 };
 
 /**

--- a/docs/src/lib/graph-builder/commands.ts
+++ b/docs/src/lib/graph-builder/commands.ts
@@ -17,6 +17,11 @@ import {
 } from '../../../../packages/nx-plugin/src/utils/names';
 import { INFRA_PROJECT_NAME, type NodeType, nodeType } from './catalog';
 import type { Graph, GraphEdge, GraphNode } from './model';
+import {
+  effectiveNodeOptions,
+  propertyApplies,
+  propertyValueApplies,
+} from './node-options';
 
 /**
  * Turn a graph into the commands that scaffold it: one to create the workspace,
@@ -105,6 +110,18 @@ const shouldEmit = (
   if (option in type.variantOptions) return true;
   if (!(option in options)) return false;
   const property = type.properties.find((p) => p.name === option);
+  // An option the rest of the values rule out would make a command the generator
+  // refuses. The builder puts a node's options right as they change, so this only
+  // catches what a preset carries in.
+  if (property) {
+    const values = effectiveNodeOptions(type, options);
+    if (
+      !propertyApplies(property, values) ||
+      !propertyValueApplies(property, String(options[option]), values)
+    ) {
+      return false;
+    }
+  }
   return options[option] !== property?.default;
 };
 

--- a/docs/src/lib/graph-builder/node-options.spec.ts
+++ b/docs/src/lib/graph-builder/node-options.spec.ts
@@ -1,0 +1,101 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { describe, expect, it } from 'vitest';
+import { nodeType } from './catalog';
+import {
+  effectiveNodeOptions,
+  propertyApplies,
+  propertyValueApplies,
+  reconcileNodeOptions,
+} from './node-options';
+
+/**
+ * The builder reads a schema's conditions the way the guides do, so a graph can
+ * only hand over commands the generators accept.
+ */
+describe('conditional node options', () => {
+  it('should leave an option a node type rules out off the type altogether', () => {
+    // The Smithy namespace can never apply to a tRPC API: choosing the node type
+    // answered `framework`.
+    const trpc = nodeType('ts#trpc-api');
+    const smithy = nodeType('ts#smithy-api');
+
+    expect(trpc.properties.map((p) => p.name)).not.toContain('namespace');
+    expect(smithy.properties.map((p) => p.name)).toContain('namespace');
+  });
+
+  it('should leave a value a node type rules out off its option', () => {
+    // Smithy has no HTTP API integration, so its `infra` offers neither.
+    const infra = nodeType('ts#smithy-api').properties.find(
+      (p) => p.name === 'infra',
+    );
+
+    expect(infra?.enum).toEqual(['rest-lambda', 'none']);
+    expect(
+      nodeType('ts#trpc-api').properties.find((p) => p.name === 'infra')?.enum,
+    ).toEqual(['rest-lambda', 'http-lambda', 'none']);
+  });
+
+  it('should read a condition against the values a run would use', () => {
+    const gateway = nodeType('agentcore-gateway');
+    const auth = gateway.properties.find((p) => p.name === 'auth');
+    if (!auth) throw new Error('the gateway has no auth option');
+
+    // Nothing chosen: `infra` falls back to hosting the gateway, so auth applies.
+    expect(propertyApplies(auth, effectiveNodeOptions(gateway, {}))).toBe(true);
+    // With no infrastructure there is nothing to authenticate.
+    expect(
+      propertyApplies(auth, effectiveNodeOptions(gateway, { infra: 'none' })),
+    ).toBe(false);
+  });
+
+  it('should drop an option the rest of the values rule out', () => {
+    const gateway = nodeType('agentcore-gateway');
+
+    expect(
+      reconcileNodeOptions(gateway, { infra: 'none', auth: 'cognito' }),
+    ).toEqual({ infra: 'none' });
+  });
+
+  it('should keep an option that still applies', () => {
+    const gateway = nodeType('agentcore-gateway');
+
+    expect(
+      reconcileNodeOptions(gateway, { infra: 'agentcore', auth: 'cognito' }),
+    ).toEqual({ infra: 'agentcore', auth: 'cognito' });
+  });
+
+  it('should let go of a value another choice rules out', () => {
+    const agent = nodeType('py#agent');
+    const session = agent.properties.find((p) => p.name === 'session');
+    if (!session) throw new Error('the agent has no session option');
+
+    // Only the LangChain agent has a DynamoDB checkpointer to save to.
+    expect(
+      propertyValueApplies(
+        session,
+        'dynamodb-s3',
+        effectiveNodeOptions(agent, { framework: 'langchain' }),
+      ),
+    ).toBe(true);
+    expect(
+      reconcileNodeOptions(agent, {
+        framework: 'strands',
+        session: 'dynamodb-s3',
+      }),
+    ).toEqual({ framework: 'strands' });
+  });
+
+  it('should name a value that applies where the fallback does not', () => {
+    // Clearing Tailwind rules out shadcn, which a website falls back to, so the
+    // command has to name a UX that doesn't need it.
+    const website = nodeType('ts#react-website');
+    const reconciled = reconcileNodeOptions(website, { tailwind: false });
+
+    expect(reconciled.tailwind).toBe(false);
+    expect(reconciled.ux).toBeDefined();
+    expect(reconciled.ux).not.toBe('shadcn');
+  });
+});

--- a/docs/src/lib/graph-builder/node-options.ts
+++ b/docs/src/lib/graph-builder/node-options.ts
@@ -1,0 +1,110 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { isApplicable, isValueApplicable } from '../generator-options';
+import type { NodeProperty, NodeType } from './catalog';
+import type { GraphNode } from './model';
+
+/**
+ * Which of a node's options apply, given the values it is set to.
+ *
+ * A generator's schema can say that an option only applies for certain values of
+ * another (`x-when`), or that one of an option's values does (`x-value-when`) —
+ * a gateway's `auth` needs infrastructure to authenticate, and only a LangChain
+ * agent has a DynamoDB session to save to. The builder reads those the way the
+ * guides do, so a graph can only hand over commands the generators accept.
+ *
+ * The options a node type fixes are already gone from `type.properties`, dropped
+ * where the type's own variant options rule them out. What's left is what the
+ * reader chooses, and can therefore rule out as they go.
+ */
+
+/** The values a run of this node's generator would use, as strings. */
+export const effectiveNodeOptions = (
+  type: NodeType,
+  options: Readonly<Record<string, string | boolean>>,
+): Record<string, string> => {
+  const values: Record<string, string> = Object.fromEntries(
+    Object.entries(type.variantOptions),
+  );
+  for (const property of type.properties) {
+    const value = options[property.name] ?? property.default;
+    if (value !== undefined && value !== '')
+      values[property.name] = String(value);
+  }
+  for (const [key, value] of Object.entries(options)) {
+    if (value !== undefined && value !== '') values[key] = String(value);
+  }
+  return values;
+};
+
+const asOption = (property: NodeProperty) => ({
+  when: property.when as Record<string, string[]> | undefined,
+  valueWhen: property.valueWhen as
+    | Record<string, Record<string, string[]>>
+    | undefined,
+});
+
+/** Whether an option applies given what the node is set to. */
+export const propertyApplies = (
+  property: NodeProperty,
+  values: Record<string, string>,
+): boolean => isApplicable(asOption(property), values);
+
+/** Whether one of an option's values applies given what the node is set to. */
+export const propertyValueApplies = (
+  property: NodeProperty,
+  value: string,
+  values: Record<string, string>,
+): boolean => isValueApplicable(asOption(property), value, values);
+
+/**
+ * A node's options with anything the rest of them rules out put right: an option
+ * that no longer applies is dropped, and a value that no longer applies gives way
+ * to one that does — where the value a run would fall back to is ruled out too,
+ * the option has to name one that isn't, or the generator refuses the command.
+ *
+ * Called whenever an option changes, so the graph is always one the commands can
+ * be emitted from.
+ */
+export const reconcileNodeOptions = (
+  type: NodeType,
+  options: Readonly<Record<string, string | boolean>>,
+): Record<string, string | boolean> => {
+  const next: Record<string, string | boolean> = { ...options };
+  const values = effectiveNodeOptions(type, options);
+
+  for (const property of type.properties) {
+    if (!propertyApplies(property, values)) {
+      delete next[property.name];
+      continue;
+    }
+    if (!property.enum || property.enum.length === 0) continue;
+
+    const applicable = property.enum.filter((value) =>
+      propertyValueApplies(property, value, values),
+    );
+    if (applicable.length === 0) continue;
+
+    const chosen = next[property.name];
+    if (chosen !== undefined && !applicable.includes(String(chosen))) {
+      delete next[property.name];
+    }
+    const fallback = String(next[property.name] ?? property.default ?? '');
+    if (fallback && !applicable.includes(fallback)) {
+      next[property.name] = applicable[0];
+    }
+  }
+
+  return next;
+};
+
+/** The same, for a node. */
+export const reconcileNode = (node: GraphNode, type: NodeType): GraphNode => {
+  const options = reconcileNodeOptions(type, node.options);
+  return Object.keys(options).length === Object.keys(node.options).length &&
+    Object.entries(options).every(([key, value]) => node.options[key] === value)
+    ? node
+    : { ...node, options };
+};

--- a/docs/src/lib/graph-builder/presets.spec.ts
+++ b/docs/src/lib/graph-builder/presets.spec.ts
@@ -9,7 +9,7 @@ import {
   SHOWCASE_PRESET_IDS,
 } from '../../components/graph-builder/presets';
 import { nodeType } from './catalog';
-import { emitCommands } from './commands';
+import { emitCommands, toScriptLines } from './commands';
 import { validate } from './model';
 import {
   effectiveNodeOptions,
@@ -52,6 +52,43 @@ describe('graph builder presets', () => {
       );
     },
   );
+
+  // The polyglot example is the widest spread of the plugin in one graph, and the
+  // commands it hands over are the ones a reader runs, so they are pinned here in
+  // full: a change to the emitter or the catalogue that rewrites them shows up as
+  // a diff rather than as a workspace that doesn't build.
+  it('should emit the commands the polyglot full-stack example is written around', () => {
+    const preset = PRESETS.find((p) => p.id === 'polyglot-full-stack');
+    if (!preset) throw new Error('the polyglot preset is missing');
+    const lines = toScriptLines(buildPresetGraph(preset), {
+      workspace: 'my-project',
+      packageManager: 'pnpm',
+      iac: 'cdk',
+    });
+
+    expect(lines.map((line) => line.command)).toEqual([
+      'pnpm create @aws/nx-workspace my-project --iac=cdk --interactive=false',
+      'cd my-project',
+      'pnpm nx g @aws/nx-plugin:py#project py-app --type=application --no-interactive',
+      'pnpm nx g @aws/nx-plugin:ts#project app --no-interactive',
+      'pnpm nx g @aws/nx-plugin:ts#website frontend --framework=react --no-interactive',
+      'pnpm nx g @aws/nx-plugin:ts#website#auth --project=frontend --no-interactive',
+      'pnpm nx g @aws/nx-plugin:ts#api backend --framework=trpc --no-interactive',
+      'pnpm nx g @aws/nx-plugin:agentcore-gateway mcp-gateway --no-interactive',
+      'pnpm nx g @aws/nx-plugin:ts#dynamodb dynamodb --no-interactive',
+      'pnpm nx g @aws/nx-plugin:py#agent --project=py_app --name=agent --protocol=ag-ui --no-interactive',
+      'pnpm nx g @aws/nx-plugin:ts#mcp-server --project=app --name=typescript-mcp --no-interactive',
+      'pnpm nx g @aws/nx-plugin:py#mcp-server --project=py_app --name=python-mcp --no-interactive',
+      'pnpm nx g @aws/nx-plugin:connection --sourceProject=frontend --targetProject=backend --no-interactive',
+      'pnpm nx g @aws/nx-plugin:connection --sourceProject=frontend --targetProject=py_app --targetComponent=agent --no-interactive',
+      'pnpm nx g @aws/nx-plugin:connection --sourceProject=py_app --targetProject=mcp-gateway --sourceComponent=agent --no-interactive',
+      'pnpm nx g @aws/nx-plugin:connection --sourceProject=mcp-gateway --targetProject=app --targetComponent=typescript-mcp --no-interactive',
+      'pnpm nx g @aws/nx-plugin:connection --sourceProject=mcp-gateway --targetProject=py_app --targetComponent=python-mcp --no-interactive',
+      'pnpm nx g @aws/nx-plugin:connection --sourceProject=app --targetProject=dynamodb --sourceComponent=typescript-mcp --no-interactive',
+      'pnpm nx g @aws/nx-plugin:connection --sourceProject=backend --targetProject=dynamodb --no-interactive',
+      'pnpm nx g @aws/nx-plugin:ts#infra infra --no-interactive',
+    ]);
+  });
 
   // Every option a preset pins has to be one the node still takes, and one the
   // generator would accept alongside the rest.

--- a/docs/src/lib/graph-builder/presets.spec.ts
+++ b/docs/src/lib/graph-builder/presets.spec.ts
@@ -8,8 +8,14 @@ import {
   PRESETS,
   SHOWCASE_PRESET_IDS,
 } from '../../components/graph-builder/presets';
+import { nodeType } from './catalog';
 import { emitCommands } from './commands';
 import { validate } from './model';
+import {
+  effectiveNodeOptions,
+  propertyApplies,
+  propertyValueApplies,
+} from './node-options';
 
 /**
  * A preset is a starting point users load and scaffold as-is, so every one must
@@ -44,6 +50,32 @@ describe('graph builder presets', () => {
       expect(commands.length).toBeGreaterThanOrEqual(
         preset.nodes.length + preset.edges.length + 2,
       );
+    },
+  );
+
+  // Every option a preset pins has to be one the node still takes, and one the
+  // generator would accept alongside the rest.
+  it.each(PRESETS.map((preset) => [preset.id, preset] as const))(
+    'should only pin options that apply for the %s preset',
+    (_id, preset) => {
+      for (const node of preset.nodes) {
+        const type = nodeType(node.type);
+        const values = effectiveNodeOptions(type, node.options ?? {});
+        for (const [option, value] of Object.entries(node.options ?? {})) {
+          const property = type.properties.find((p) => p.name === option);
+          if (!property) {
+            throw new Error(`${node.type} has no ${option} option`);
+          }
+          expect(
+            propertyApplies(property, values),
+            `${node.type}'s ${option} does not apply`,
+          ).toBe(true);
+          expect(
+            propertyValueApplies(property, String(value), values),
+            `${node.type}'s ${option}=${value} does not apply`,
+          ).toBe(true);
+        }
+      }
     },
   );
 

--- a/docs/src/styles/graph-builder.css
+++ b/docs/src/styles/graph-builder.css
@@ -1356,6 +1356,32 @@
     color-mix(in oklab, var(--sl-color-accent) 30%, transparent);
 }
 
+/* The option's name and, where it has one, the condition it applies under. */
+.gb-field-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.2rem 0.4rem;
+  margin: 0;
+}
+
+/* An option another choice rules out keeps its place, so the condition it needs
+   stays readable — the same treatment the guides' cards give it. */
+.gb-field.is-inapplicable {
+  opacity: 0.55;
+}
+
+.gb-field.is-inapplicable .command-card-pills,
+.gb-field.is-inapplicable .command-card-check {
+  pointer-events: none;
+}
+
+.gb-field.is-inapplicable .command-card-field-when {
+  border-style: solid;
+  border-color: var(--sl-color-accent);
+  color: var(--sl-color-text-accent);
+}
+
 .gb-field-hint {
   margin: 0;
   font-size: 0.72rem;

--- a/packages/nx-plugin/src/connection/scaffold-catalog.ts
+++ b/packages/nx-plugin/src/connection/scaffold-catalog.ts
@@ -95,6 +95,10 @@ export type GeneratorSchema = {
       enum?: string[];
       default?: unknown;
       'x-priority'?: string;
+      /** The option values this option applies under. */
+      'x-when'?: Record<string, string | string[]>;
+      /** The same, per value, where one of an option's values applies sometimes. */
+      'x-value-when'?: Record<string, Record<string, string | string[]>>;
     }
   >;
   required?: string[];


### PR DESCRIPTION
> Stacked on #1254 — the diff shows only this change once that merges.

### Reason for this change

The graph builder's presets cover a stack at a time — a tRPC web app, a FastAPI web app, an agentic app, agents behind a gateway — but none of them shows both languages at once, which is what a workspace built on this plugin tends to become.

### Description of changes

A **Polyglot full-stack app** preset: a React frontend over a tRPC API and a Python AG-UI agent, whose TypeScript and Python MCP servers sit behind an AgentCore Gateway, with a DynamoDB table the API and the TypeScript tools share. Eight components across two languages and seven connections, in one graph a reader can load and take apart.

It scaffolds as:

```bash
pnpm create @aws/nx-workspace my-project --iac=cdk --interactive=false
cd my-project
pnpm nx g @aws/nx-plugin:py#project py-app --type=application --no-interactive
pnpm nx g @aws/nx-plugin:ts#project app --no-interactive
pnpm nx g @aws/nx-plugin:ts#website frontend --framework=react --no-interactive
pnpm nx g @aws/nx-plugin:ts#website#auth --project=frontend --no-interactive
pnpm nx g @aws/nx-plugin:ts#api backend --framework=trpc --no-interactive
pnpm nx g @aws/nx-plugin:agentcore-gateway mcp-gateway --no-interactive
pnpm nx g @aws/nx-plugin:ts#dynamodb dynamodb --no-interactive
pnpm nx g @aws/nx-plugin:py#agent --project=py_app --name=agent --protocol=ag-ui --no-interactive
pnpm nx g @aws/nx-plugin:ts#mcp-server --project=app --name=typescript-mcp --no-interactive
pnpm nx g @aws/nx-plugin:py#mcp-server --project=py_app --name=python-mcp --no-interactive
pnpm nx g @aws/nx-plugin:connection --sourceProject=frontend --targetProject=backend --no-interactive
pnpm nx g @aws/nx-plugin:connection --sourceProject=frontend --targetProject=py_app --targetComponent=agent --no-interactive
pnpm nx g @aws/nx-plugin:connection --sourceProject=py_app --targetProject=mcp-gateway --sourceComponent=agent --no-interactive
pnpm nx g @aws/nx-plugin:connection --sourceProject=mcp-gateway --targetProject=app --targetComponent=typescript-mcp --no-interactive
pnpm nx g @aws/nx-plugin:connection --sourceProject=mcp-gateway --targetProject=py_app --targetComponent=python-mcp --no-interactive
pnpm nx g @aws/nx-plugin:connection --sourceProject=app --targetProject=dynamodb --sourceComponent=typescript-mcp --no-interactive
pnpm nx g @aws/nx-plugin:connection --sourceProject=backend --targetProject=dynamodb --no-interactive
pnpm nx g @aws/nx-plugin:ts#infra infra --no-interactive
```

Those commands are pinned in full by a test. They're what a reader runs, so a change to the emitter or the catalogue that rewrites them should show up as a diff rather than as a workspace that doesn't build.

The preset is not added to the landing page's showcase rotation — it's a bigger graph than that stage reads well at.

### Description of how you validated changes

- `pnpm nx run docs:test` passes (231 tests): the new command-pinning test, and the existing checks that every preset builds a valid graph, resolves every connection it names, and only pins options its node types still take.
- Loaded it in the builder and read the transcript, which matches the script above line for line — including the snake-cased `py_app` project references, the automatic website-auth follow-up and the trailing infra project.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
