### PR TITLE
docs: reorder the landing page's reasons and lead with the foundation

### DIFF
--- a/docs/src/content/docs/en/index.mdx
+++ b/docs/src/content/docs/en/index.mdx
@@ -38,10 +38,10 @@ import Link from "@components/link.astro";
   <h2 class="landing-heading">Why @aws/nx-plugin?</h2>
   <WhyGrid>
     <WhyCard title="Full-stack in minutes" icon="layers">Websites, APIs, agents, databases, and infrastructure in CDK or Terraform, all scaffolded and wired together.</WhyCard>
-    <WhyCard title="Build with AI" icon="sparkle">An MCP server ships with the plugin so your AI assistant can scaffold and connect projects for you.</WhyCard>
-    <WhyCard title="Type-safe, end to end" icon="shield">Shared types flow from your API through to your frontend. Refactor with confidence.</WhyCard>
-    <WhyCard title="Runs on your machine" icon="terminal">One command starts your website, APIs, agents and databases locally, hot-reloading, long before anything is deployed.</WhyCard>
     <WhyCard title="Your code, your way" icon="pencil">A head start, not a framework. Code is yours to modify, and <Link path="get_started/upgrading">migrations</Link> keep you up to date as the plugin improves.</WhyCard>
+    <WhyCard title="Runs on your machine" icon="terminal">One command starts your website, APIs, agents and databases locally, hot-reloading, long before anything is deployed.</WhyCard>
+    <WhyCard title="Secure, observable and type-safe" icon="shield">Start with a robust foundation so you or your AI assistant can focus on what makes your application different.</WhyCard>
+    <WhyCard title="Build with AI" icon="sparkle">An MCP server ships with the plugin so your AI assistant can scaffold and connect projects for you.</WhyCard>
   </WhyGrid>
 </div>
 

--- a/docs/src/content/docs/es/index.mdx
+++ b/docs/src/content/docs/es/index.mdx
@@ -38,10 +38,10 @@ import Link from "@components/link.astro";
   <h2 class="landing-heading">¿Por qué @aws/nx-plugin?</h2>
   <WhyGrid>
     <WhyCard title="Full-stack en minutos" icon="layers">Sitios web, APIs, agentes, bases de datos e infraestructura en CDK o Terraform, todo creado y conectado automáticamente.</WhyCard>
-    <WhyCard title="Construir con IA" icon="sparkle">Un servidor MCP se incluye con el plugin para que tu asistente de IA pueda crear y conectar proyectos por ti.</WhyCard>
-    <WhyCard title="Seguridad de tipos, de extremo a extremo" icon="shield">Los tipos compartidos fluyen desde tu API hasta tu frontend. Refactoriza con confianza.</WhyCard>
-    <WhyCard title="Se ejecuta en tu máquina" icon="terminal">Un comando inicia tu sitio web, APIs, agentes y bases de datos localmente, con recarga en caliente, mucho antes de que se despliegue nada.</WhyCard>
     <WhyCard title="Tu código, a tu manera" icon="pencil">Un buen comienzo, no un framework. El código es tuyo para modificar, y las <Link path="get_started/upgrading">migraciones</Link> te mantienen actualizado a medida que el plugin mejora.</WhyCard>
+    <WhyCard title="Se ejecuta en tu máquina" icon="terminal">Un comando inicia tu sitio web, APIs, agentes y bases de datos localmente, con recarga en caliente, mucho antes de que se despliegue nada.</WhyCard>
+    <WhyCard title="Seguro, observable y con seguridad de tipos" icon="shield">Comienza con una base robusta para que tú o tu asistente de IA puedan enfocarse en lo que hace diferente a tu aplicación.</WhyCard>
+    <WhyCard title="Construir con IA" icon="sparkle">Un servidor MCP se incluye con el plugin para que tu asistente de IA pueda crear y conectar proyectos por ti.</WhyCard>
   </WhyGrid>
 </div>
 

--- a/docs/src/content/docs/fr/index.mdx
+++ b/docs/src/content/docs/fr/index.mdx
@@ -38,10 +38,10 @@ import Link from "@components/link.astro";
   <h2 class="landing-heading">Pourquoi @aws/nx-plugin ?</h2>
   <WhyGrid>
     <WhyCard title="Full-stack en quelques minutes" icon="layers">Sites web, API, agents, bases de données et infrastructure en CDK ou Terraform, tous générés et connectés ensemble.</WhyCard>
-    <WhyCard title="Créer avec l'IA" icon="sparkle">Un serveur MCP est fourni avec le plugin pour que votre assistant IA puisse générer et connecter des projets pour vous.</WhyCard>
-    <WhyCard title="Type-safe, de bout en bout" icon="shield">Les types partagés circulent de votre API jusqu'à votre frontend. Refactorisez en toute confiance.</WhyCard>
-    <WhyCard title="Fonctionne sur votre machine" icon="terminal">Une seule commande démarre votre site web, vos API, agents et bases de données localement, avec rechargement à chaud, bien avant tout déploiement.</WhyCard>
     <WhyCard title="Votre code, à votre façon" icon="pencil">Une longueur d'avance, pas un framework. Le code est à vous pour le modifier, et les <Link path="get_started/upgrading">migrations</Link> vous maintiennent à jour au fur et à mesure que le plugin s'améliore.</WhyCard>
+    <WhyCard title="Fonctionne sur votre machine" icon="terminal">Une seule commande démarre votre site web, vos API, agents et bases de données localement, avec rechargement à chaud, bien avant tout déploiement.</WhyCard>
+    <WhyCard title="Sécurisé, observable et type-safe" icon="shield">Commencez avec une base solide afin que vous ou votre assistant IA puissiez vous concentrer sur ce qui rend votre application différente.</WhyCard>
+    <WhyCard title="Créer avec l'IA" icon="sparkle">Un serveur MCP est fourni avec le plugin pour que votre assistant IA puisse générer et connecter des projets pour vous.</WhyCard>
   </WhyGrid>
 </div>
 

--- a/docs/src/content/docs/it/index.mdx
+++ b/docs/src/content/docs/it/index.mdx
@@ -38,10 +38,10 @@ import Link from "@components/link.astro";
   <h2 class="landing-heading">Perché @aws/nx-plugin?</h2>
   <WhyGrid>
     <WhyCard title="Full-stack in minuti" icon="layers">Siti web, API, agenti, database e infrastruttura in CDK o Terraform, tutto generato e collegato insieme.</WhyCard>
-    <WhyCard title="Crea con l'AI" icon="sparkle">Un server MCP è incluso nel plugin così il tuo assistente AI può generare e collegare progetti per te.</WhyCard>
-    <WhyCard title="Type-safe, end to end" icon="shield">I tipi condivisi fluiscono dalla tua API fino al frontend. Refactorizza con fiducia.</WhyCard>
-    <WhyCard title="Esegui sulla tua macchina" icon="terminal">Un comando avvia il tuo sito web, API, agenti e database localmente, con hot-reloading, molto prima che qualcosa venga distribuito.</WhyCard>
     <WhyCard title="Il tuo codice, a modo tuo" icon="pencil">Un vantaggio iniziale, non un framework. Il codice è tuo da modificare, e le <Link path="get_started/upgrading">migrazioni</Link> ti mantengono aggiornato mentre il plugin migliora.</WhyCard>
+    <WhyCard title="Esegui sulla tua macchina" icon="terminal">Un comando avvia il tuo sito web, API, agenti e database localmente, con hot-reloading, molto prima che qualcosa venga distribuito.</WhyCard>
+    <WhyCard title="Sicuro, osservabile e type-safe" icon="shield">Inizia con una base solida così tu o il tuo assistente AI potete concentrarvi su ciò che rende la tua applicazione diversa.</WhyCard>
+    <WhyCard title="Crea con l'AI" icon="sparkle">Un server MCP è incluso nel plugin così il tuo assistente AI può generare e collegare progetti per te.</WhyCard>
   </WhyGrid>
 </div>
 

--- a/docs/src/content/docs/jp/index.mdx
+++ b/docs/src/content/docs/jp/index.mdx
@@ -38,10 +38,10 @@ import Link from "@components/link.astro";
   <h2 class="landing-heading">なぜ @aws/nx-plugin なのか？</h2>
   <WhyGrid>
     <WhyCard title="数分でフルスタック" icon="layers">ウェブサイト、API、エージェント、データベース、そしてCDKまたはTerraformのインフラストラクチャ、すべてスキャフォールドされ、接続されます。</WhyCard>
-    <WhyCard title="AIで構築" icon="sparkle">プラグインにはMCPサーバーが付属しているため、AIアシスタントがプロジェクトをスキャフォールドして接続できます。</WhyCard>
-    <WhyCard title="エンドツーエンドで型安全" icon="shield">共有型がAPIからフロントエンドまで流れます。自信を持ってリファクタリングできます。</WhyCard>
-    <WhyCard title="あなたのマシンで実行" icon="terminal">1つのコマンドで、ウェブサイト、API、エージェント、データベースをローカルで起動し、何もデプロイされるずっと前からホットリロードで動作します。</WhyCard>
     <WhyCard title="あなたのコード、あなたのやり方" icon="pencil">スタートダッシュを提供しますが、フレームワークではありません。コードはあなたが変更できるものであり、<Link path="get_started/upgrading">マイグレーション</Link>はプラグインの改善に合わせて最新の状態を保ちます。</WhyCard>
+    <WhyCard title="あなたのマシンで実行" icon="terminal">1つのコマンドで、ウェブサイト、API、エージェント、データベースをローカルで起動し、何もデプロイされるずっと前からホットリロードで動作します。</WhyCard>
+    <WhyCard title="安全で、可観測性があり、型安全" icon="shield">堅牢な基盤から始めることで、あなたやあなたのAIアシスタントは、アプリケーションを差別化する要素に集中できます。</WhyCard>
+    <WhyCard title="AIで構築" icon="sparkle">プラグインにはMCPサーバーが付属しているため、AIアシスタントがプロジェクトをスキャフォールドして接続できます。</WhyCard>
   </WhyGrid>
 </div>
 

--- a/docs/src/content/docs/ko/index.mdx
+++ b/docs/src/content/docs/ko/index.mdx
@@ -38,10 +38,10 @@ import Link from "@components/link.astro";
   <h2 class="landing-heading">왜 @aws/nx-plugin인가요?</h2>
   <WhyGrid>
     <WhyCard title="몇 분 만에 풀스택" icon="layers">웹사이트, API, 에이전트, 데이터베이스 및 CDK 또는 Terraform의 인프라, 모두 스캐폴딩되고 함께 연결됩니다.</WhyCard>
-    <WhyCard title="AI로 빌드하기" icon="sparkle">플러그인과 함께 제공되는 MCP 서버를 통해 AI 어시스턴트가 프로젝트를 스캐폴딩하고 연결할 수 있습니다.</WhyCard>
-    <WhyCard title="엔드 투 엔드 타입 안전성" icon="shield">공유 타입이 API에서 프론트엔드로 흐릅니다. 자신감 있게 리팩토링하세요.</WhyCard>
-    <WhyCard title="당신의 머신에서 실행" icon="terminal">하나의 명령어로 웹사이트, API, 에이전트 및 데이터베이스를 로컬에서 시작하고, 배포되기 훨씬 전에 핫 리로딩됩니다.</WhyCard>
     <WhyCard title="당신의 코드, 당신의 방식" icon="pencil">프레임워크가 아닌 시작점을 제공합니다. 코드는 당신이 수정할 수 있으며, <Link path="get_started/upgrading">마이그레이션</Link>은 플러그인이 개선됨에 따라 최신 상태를 유지합니다.</WhyCard>
+    <WhyCard title="당신의 머신에서 실행" icon="terminal">하나의 명령어로 웹사이트, API, 에이전트 및 데이터베이스를 로컬에서 시작하고, 배포되기 훨씬 전에 핫 리로딩됩니다.</WhyCard>
+    <WhyCard title="안전하고, 관찰 가능하며, 타입 안전" icon="shield">견고한 기반으로 시작하여 당신이나 AI 어시스턴트가 애플리케이션을 차별화하는 요소에 집중할 수 있습니다.</WhyCard>
+    <WhyCard title="AI로 빌드하기" icon="sparkle">플러그인과 함께 제공되는 MCP 서버를 통해 AI 어시스턴트가 프로젝트를 스캐폴딩하고 연결할 수 있습니다.</WhyCard>
   </WhyGrid>
 </div>
 

--- a/docs/src/content/docs/pt/index.mdx
+++ b/docs/src/content/docs/pt/index.mdx
@@ -38,10 +38,10 @@ import Link from "@components/link.astro";
   <h2 class="landing-heading">Por que @aws/nx-plugin?</h2>
   <WhyGrid>
     <WhyCard title="Full-stack em minutos" icon="layers">Websites, APIs, agentes, bancos de dados e infraestrutura em CDK ou Terraform, tudo criado e conectado junto.</WhyCard>
-    <WhyCard title="Construir com IA" icon="sparkle">Um servidor MCP vem com o plugin para que seu assistente de IA possa criar e conectar projetos para você.</WhyCard>
-    <WhyCard title="Type-safe, de ponta a ponta" icon="shield">Tipos compartilhados fluem da sua API até o seu frontend. Refatore com confiança.</WhyCard>
-    <WhyCard title="Roda na sua máquina" icon="terminal">Um comando inicia seu website, APIs, agentes e bancos de dados localmente, com hot-reloading, muito antes de qualquer coisa ser implantada.</WhyCard>
     <WhyCard title="Seu código, do seu jeito" icon="pencil">Um ponto de partida, não um framework. O código é seu para modificar, e <Link path="get_started/upgrading">migrations</Link> mantêm você atualizado conforme o plugin melhora.</WhyCard>
+    <WhyCard title="Roda na sua máquina" icon="terminal">Um comando inicia seu website, APIs, agentes e bancos de dados localmente, com hot-reloading, muito antes de qualquer coisa ser implantada.</WhyCard>
+    <WhyCard title="Seguro, observável e type-safe" icon="shield">Comece com uma base robusta para que você ou seu assistente de IA possam se concentrar no que torna sua aplicação diferente.</WhyCard>
+    <WhyCard title="Construir com IA" icon="sparkle">Um servidor MCP vem com o plugin para que seu assistente de IA possa criar e conectar projetos para você.</WhyCard>
   </WhyGrid>
 </div>
 
@@ -49,4 +49,3 @@ import Link from "@components/link.astro";
   <h2 class="landing-heading">Obrigado aos nossos incríveis contribuidores!</h2>
   <ContributorList githubRepo="awslabs/nx-plugin-for-aws" />
 </div>
-

--- a/docs/src/content/docs/vi/index.mdx
+++ b/docs/src/content/docs/vi/index.mdx
@@ -38,10 +38,10 @@ import Link from "@components/link.astro";
   <h2 class="landing-heading">Tại sao chọn @aws/nx-plugin?</h2>
   <WhyGrid>
     <WhyCard title="Full-stack trong vài phút" icon="layers">Website, API, agent, cơ sở dữ liệu và cơ sở hạ tầng trong CDK hoặc Terraform, tất cả được tạo và kết nối với nhau.</WhyCard>
-    <WhyCard title="Xây dựng với AI" icon="sparkle">Một MCP server đi kèm với plugin để trợ lý AI của bạn có thể tạo và kết nối các dự án cho bạn.</WhyCard>
-    <WhyCard title="Type-safe, từ đầu đến cuối" icon="shield">Các kiểu dữ liệu được chia sẻ từ API của bạn đến frontend. Refactor với sự tự tin.</WhyCard>
-    <WhyCard title="Chạy trên máy của bạn" icon="terminal">Một lệnh khởi động website, API, agent và cơ sở dữ liệu của bạn cục bộ, hot-reloading, rất lâu trước khi bất cứ thứ gì được triển khai.</WhyCard>
     <WhyCard title="Mã của bạn, theo cách của bạn" icon="pencil">Một khởi đầu nhanh, không phải một framework. Mã nguồn là của bạn để chỉnh sửa, và <Link path="get_started/upgrading">migrations</Link> giữ cho bạn cập nhật khi plugin được cải thiện.</WhyCard>
+    <WhyCard title="Chạy trên máy của bạn" icon="terminal">Một lệnh khởi động website, API, agent và cơ sở dữ liệu của bạn cục bộ, hot-reloading, rất lâu trước khi bất cứ thứ gì được triển khai.</WhyCard>
+    <WhyCard title="An toàn, có thể quan sát và type-safe" icon="shield">Bắt đầu với một nền tảng vững chắc để bạn hoặc trợ lý AI của bạn có thể tập trung vào những gì làm cho ứng dụng của bạn khác biệt.</WhyCard>
+    <WhyCard title="Xây dựng với AI" icon="sparkle">Một MCP server đi kèm với plugin để trợ lý AI của bạn có thể tạo và kết nối các dự án cho bạn.</WhyCard>
   </WhyGrid>
 </div>
 

--- a/docs/src/content/docs/zh/index.mdx
+++ b/docs/src/content/docs/zh/index.mdx
@@ -38,10 +38,10 @@ import Link from "@components/link.astro";
   <h2 class="landing-heading">为什么选择 @aws/nx-plugin？</h2>
   <WhyGrid>
     <WhyCard title="几分钟内完成全栈开发" icon="layers">网站、API、代理、数据库以及 CDK 或 Terraform 中的基础设施，全部搭建完成并连接在一起。</WhyCard>
-    <WhyCard title="使用 AI 构建" icon="sparkle">插件附带 MCP 服务器，因此您的 AI 助手可以为您搭建和连接项目。</WhyCard>
-    <WhyCard title="端到端类型安全" icon="shield">共享类型从您的 API 流向前端。放心重构。</WhyCard>
-    <WhyCard title="在您的机器上运行" icon="terminal">一条命令即可在本地启动您的网站、API、代理和数据库，支持热重载，远在任何内容部署之前。</WhyCard>
     <WhyCard title="您的代码，您的方式" icon="pencil">一个良好的开端，而不是一个框架。代码属于您可以修改，而<Link path="get_started/upgrading">迁移</Link>会随着插件的改进让您保持最新。</WhyCard>
+    <WhyCard title="在您的机器上运行" icon="terminal">一条命令即可在本地启动您的网站、API、代理和数据库，支持热重载，远在任何内容部署之前。</WhyCard>
+    <WhyCard title="安全、可观测且类型安全" icon="shield">从强大的基础开始，这样您或您的 AI 助手就可以专注于使您的应用程序与众不同的地方。</WhyCard>
+    <WhyCard title="使用 AI 构建" icon="sparkle">插件附带 MCP 服务器，因此您的 AI 助手可以为您搭建和连接项目。</WhyCard>
   </WhyGrid>
 </div>
 


### PR DESCRIPTION
### Reason for this change

The "Why @aws/nx-plugin?" band led with "Build with AI", putting an assistant integration ahead of what the plugin itself gives you. "Type-safe, end to end" also undersold the vended code: projects come with IAM/Cognito authentication, Checkov scanning, and Powertools logging, metrics and X-Ray tracing, not just shared types.

### Description of changes

- Reorders the cards: full-stack, your code your way, runs on your machine, the foundation, then build with AI.
- Renames the type-safety card to "Secure, observable and type-safe", with copy framing it as a foundation that frees you or your assistant to focus on what makes the application different.

### Description of how you validated changes

`pnpm nx run docs:build` passes.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
