### PR TITLE
fix(connection): let a cognito agent connect to a gateway

### DIFF
--- a/docs/src/lib/graph-builder/graph-builder.spec.ts
+++ b/docs/src/lib/graph-builder/graph-builder.spec.ts
@@ -1141,6 +1141,25 @@ describe('validate', () => {
       ]);
     });
 
+    // The agent's auth governs inbound requests to it, so it places no
+    // requirement on a gateway it reaches — it signs with SigV4 either way.
+    it('should accept a cognito agent reaching a gateway', () => {
+      const issues = validate(
+        graph(
+          [
+            node('a', 'ts#agent', {
+              name: 'agent',
+              hostName: 'app',
+              options: { auth: 'cognito' },
+            }),
+            node('g', 'agentcore-gateway', { name: 'gateway' }),
+          ],
+          [{ id: 'e1', source: 'a', target: 'g' }],
+        ),
+      );
+      expect(issues.filter((i) => i.message.includes('auth'))).toEqual([]);
+    });
+
     it('should reject a gateway connected to itself', () => {
       const issues = validate(
         graph(

--- a/packages/nx-plugin/src/connection/catalog-guard-parity.spec.ts
+++ b/packages/nx-plugin/src/connection/catalog-guard-parity.spec.ts
@@ -179,4 +179,50 @@ describe('catalog guard parity', () => {
       ).resolves.toBeDefined();
     });
   });
+
+  describe('agent -> gateway accepts a cognito agent', () => {
+    // The agent's auth governs inbound requests to it. Its outbound call to the
+    // gateway is SigV4-signed from its execution role, so pinning it to IAM
+    // would rule out a topology that works.
+    it.each([
+      ['ts#agent -> agentcore-gateway'],
+      ['py#agent -> agentcore-gateway'],
+    ])('is not constrained to iam for %s', (key) => {
+      expect(
+        constraintsFor(key).filter(
+          (c) => c.side === 'source' && c.option === 'auth',
+        ),
+      ).toEqual([]);
+    });
+
+    it('connects a cognito ts#agent to a gateway', async () => {
+      const tree = await setup();
+      await tsAgent(tree, 'cog-agent', 'ag-ui', 'cognito');
+      await gateway(tree, 'mcp-gw', 'mcp', 'iam');
+
+      await expect(
+        connectionGenerator(tree, {
+          sourceProject: 'ts-host',
+          sourceComponent: 'cog-agent',
+          targetProject: 'mcp-gw',
+          preferInstallDependencies: false,
+        }),
+      ).resolves.toBeDefined();
+    });
+
+    it('connects a cognito py#agent to a gateway', async () => {
+      const tree = await setup();
+      await pyAgent(tree, 'cog-agent', 'ag-ui', 'cognito');
+      await gateway(tree, 'mcp-gw', 'mcp', 'iam');
+
+      await expect(
+        connectionGenerator(tree, {
+          sourceProject: 'py_host',
+          sourceComponent: 'cog-agent',
+          targetProject: 'mcp-gw',
+          preferInstallDependencies: false,
+        }),
+      ).resolves.toBeDefined();
+    });
+  });
 });

--- a/packages/nx-plugin/src/connection/scaffold-catalog.ts
+++ b/packages/nx-plugin/src/connection/scaffold-catalog.ts
@@ -326,13 +326,10 @@ const AGENT_TO_MCP: readonly ConnectionConstraint[] = [
   },
 ];
 
+// The agent's own `auth` governs inbound requests to it, so it places no
+// requirement here — the agent signs its outbound call to the gateway with
+// SigV4 from its execution role either way.
 const AGENT_TO_GATEWAY: readonly ConnectionConstraint[] = [
-  {
-    side: 'source',
-    option: 'auth',
-    equals: 'iam',
-    reason: 'Only an IAM-authenticated agent can reach an IAM gateway.',
-  },
   {
     side: 'target',
     option: 'auth',

--- a/packages/nx-plugin/src/py/agent/gateway-connection/generator.spec.ts
+++ b/packages/nx-plugin/src/py/agent/gateway-connection/generator.spec.ts
@@ -304,17 +304,19 @@ dependencies = ["strands-agents"]
     );
   });
 
-  it('rejects non-IAM agent', async () => {
+  // The agent's auth governs inbound requests to it; its outbound call to the
+  // gateway is signed with SigV4 from its execution role either way.
+  it('connects a cognito agent', async () => {
     setupProjects();
     await expect(
       pyAgentGatewayConnectionGenerator(tree, {
         ...fullOptions(),
         sourceComponent: {
           ...fullOptions().sourceComponent,
-          auth: 'Cognito',
+          auth: 'cognito',
         } as any,
       }),
-    ).rejects.toThrow(/Only IAM-authenticated agents/);
+    ).resolves.toBeDefined();
   });
 
   it('should match snapshot for agent-connection core files', async () => {

--- a/packages/nx-plugin/src/py/agent/gateway-connection/generator.ts
+++ b/packages/nx-plugin/src/py/agent/gateway-connection/generator.ts
@@ -99,11 +99,6 @@ export const pyAgentGatewayConnectionGenerator = async (
       `Gateway '${gateway.name}' uses auth='${gateway.auth}'. Agent connections currently require the gateway to use IAM authentication.`,
     );
   }
-  if (agentComponent.auth && agentComponent.auth !== 'iam') {
-    throw new Error(
-      `Agent '${agentComponent.name}' uses auth='${agentComponent.auth}'. Only IAM-authenticated agents can connect to IAM gateways.`,
-    );
-  }
 
   const gatewayClassName = gateway.rc;
   const gatewaySnakeCase = snakeCase(gatewayClassName);

--- a/packages/nx-plugin/src/ts/agent/gateway-connection/generator.spec.ts
+++ b/packages/nx-plugin/src/ts/agent/gateway-connection/generator.spec.ts
@@ -299,17 +299,19 @@ export const getAgent = async (sessionId: string) =>
     );
   });
 
-  it('rejects non-IAM agent', async () => {
+  // The agent's auth governs inbound requests to it; its outbound call to the
+  // gateway is signed with SigV4 from its execution role either way.
+  it('connects a cognito agent', async () => {
     setupProjects();
     await expect(
       tsAgentGatewayConnectionGenerator(tree, {
         ...fullOptions(),
         sourceComponent: {
           ...fullOptions().sourceComponent,
-          auth: 'Cognito',
+          auth: 'cognito',
         } as any,
       }),
-    ).rejects.toThrow(/Only IAM-authenticated agents/);
+    ).resolves.toBeDefined();
   });
 
   it('should match snapshot for agent-connection src files', async () => {

--- a/packages/nx-plugin/src/ts/agent/gateway-connection/generator.ts
+++ b/packages/nx-plugin/src/ts/agent/gateway-connection/generator.ts
@@ -88,11 +88,6 @@ export const tsAgentGatewayConnectionGenerator = async (
       `Gateway '${gateway.name}' uses auth='${gateway.auth}'. Agent connections currently require the gateway to use IAM authentication.`,
     );
   }
-  if (agentComponent.auth && agentComponent.auth !== 'iam') {
-    throw new Error(
-      `Agent '${agentComponent.name}' uses auth='${agentComponent.auth}'. Only IAM-authenticated agents can connect to IAM gateways.`,
-    );
-  }
 
   const gatewayClassName = gateway.rc;
   const gatewayKebabCase = kebabCase(gatewayClassName);


### PR DESCRIPTION
### Reason for this change

An agent's `auth` option configures how **inbound** requests to the agent are authenticated. Its **outbound** call to an AgentCore Gateway is signed with SigV4 from the agent's own execution role, which every agent has regardless of its inbound auth — the vended gateway MCP client is byte-identical for `iam` and `cognito` agents (`agentcore_gateway_mcp_transport.py.template` always calls `sigv4_transport`, and the per-connection client branches only on `LOCAL_DEV`).

The `agent -> gateway` connection generators nonetheless rejected any agent whose `auth` was not `iam`:

```
Agent 'agent' uses auth='cognito'. Only IAM-authenticated agents can connect to IAM gateways.
```

`CONNECTION_CONSTRAINTS` declared the same rule, so the docs graph builder surfaced it while drawing:

```
agent: auth must be 'iam' for this connection — Only an IAM-authenticated agent can reach an IAM gateway.
```

This ruled out a topology that works, and a natural one: a Cognito agent fronting a website (so the browser authenticates with a JWT) that also reaches a gateway for its tools. Satisfying the guard forced `--auth=iam` on the agent, meaning the browser SigV4-signs to the runtime with identity-pool credentials purely to satisfy an unrelated outbound hop.

Three things confirm the guard had no basis:

- The sibling `agent -> mcp-server` connection uses the same SigV4 transport and constrains only the **target** (`py/agent/mcp-connection/generator.ts`), with no source-auth guard.
- Neither connection guide documented the restriction. Both already explain the opposite — "the agent signs its requests with SigV4 using its own execution role".
- AgentCore runtimes configured with `customJWTAuthorizer` still get an execution role, and each runtime gets a workload identity that maintains a consistent identity "whether they're using IAM roles for AWS resource access, OAuth 2.0 tokens for external service integration, or API keys".

The guard looks like the `gateway -> agent` rule transplanted onto the wrong direction — there the agent's `auth` genuinely is load-bearing, since `addAgent` picks `JWT_PASSTHROUGH` vs `GATEWAY_IAM_ROLE` from it.

### Description of changes

- Removed the source-side `auth` constraint from `AGENT_TO_GATEWAY` in `scaffold-catalog.ts`, so the docs graph builder no longer reports it.
- Removed the matching `throw` from `py/agent/gateway-connection/generator.ts` and `ts/agent/gateway-connection/generator.ts`.
- The requirements on the gateway itself are unchanged: it must serve the `mcp` protocol and authenticate with IAM.

### Description of how you validated changes

**Unit tests**

- Both `rejects non-IAM agent` tests became positive `connects a cognito agent` tests.
- Added an `agent -> gateway accepts a cognito agent` block to `catalog-guard-parity.spec.ts`, which pins the catalogue entry *and* scaffolds a real cognito agent plus gateway and runs the connection generator, for both TypeScript and Python. That file exists to catch drift between the catalogue and the generator guards, so it fails if either half regresses.
- Added a graph-builder validation test asserting a cognito agent drawn to a gateway raises no auth issue.
- Full suite green: 4508 plugin tests, 213 docs tests, `build --all`, `lint --all`.
- The e2e generator matrix is unaffected: its two cognito agents are deployed standalone and never connected to a gateway.

**Deployed to AWS**

Built a workspace with the locally compiled plugin and deployed it, to confirm the topology the guard forbade actually works end to end:

```bash
pnpm nx g @aws/nx-plugin:py#project py-app --type=application
pnpm nx g @aws/nx-plugin:py#agent --project=py_app --name=agent --auth=cognito --protocol=ag-ui
pnpm nx g @aws/nx-plugin:agentcore-gateway mcp-gateway          # protocol=mcp, auth=iam
pnpm nx g @aws/nx-plugin:py#mcp-server --project=py_app --name=python-mcp
pnpm nx g @aws/nx-plugin:connection --sourceProject=mcp-gateway --targetProject=py_app --targetComponent=python-mcp
pnpm nx g @aws/nx-plugin:connection --sourceProject=py_app --targetProject=mcp-gateway --sourceComponent=agent
```

The last command is the one that threw before this change. The deployed runtime confirms both halves of the argument — Cognito inbound auth *and* an execution role on the same runtime:

```json
{
  "auth": { "customJWTAuthorizer": {
    "discoveryUrl": "https://cognito-idp.us-east-1.amazonaws.com/us-east-1_.../.well-known/openid-configuration",
    "allowedClients": ["..."] } },
  "role": "arn:aws:iam::...:role/...-AgentExecutionRole..."
}
```

Invoking that runtime with a Cognito JWT (`Authorization: Bearer <token>`, HTTP 200) had the agent list and call the gateway's tools over its SigV4-signed connection. The tool name is the gateway's namespaced form, so the call demonstrably went through the Gateway rather than direct to the MCP server:

```
data: {"type":"TOOL_CALL_START","toolCallName":"python-mcp___add", ...}
data: {"type":"TOOL_CALL_RESULT","content":"1378", ...}
data: {"type":"RUN_FINISHED","outcome":{"type":"success"}}
```

All provisioned resources were torn down afterwards.

### Issue # (if applicable)

N/A — found while reviewing a graph built with the docs graph builder.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
