### PR TITLE
chore(docs): render a card's command with the values its guide passes

### DIFF
--- a/docs/src/components/run-generator.astro
+++ b/docs/src/components/run-generator.astro
@@ -19,12 +19,13 @@ import {
   createSchemaLookup,
   resolveGeneratorsJson,
 } from '../../../packages/nx-plugin/src/mcp-server/schema-registry';
-import { emittedValues, type GeneratorCardConfig } from '../lib/command-card';
+import {
+  resolveCardOptions,
+  type GeneratorCardConfig,
+} from '../lib/command-card';
 import { commandCardStrings } from '../lib/command-card-strings';
 import {
   effectiveValues,
-  isApplicable,
-  isValueApplicable,
   readGeneratorOptions,
   type GeneratorOption,
 } from '../lib/generator-options';
@@ -121,16 +122,10 @@ const forced = effectiveValues(
   ),
   options.filter((option) => locked.has(option.key)),
 );
-const applicable = options
-  .filter((option) => isApplicable(option, forced))
-  // A value the guide has ruled out is no choice at all: `http-lambda` can't
-  // apply on a guide written for the Smithy framework.
-  .map((option) => ({
-    ...option,
-    values: option.values.filter((value) =>
-      isValueApplicable(option, value, forced),
-    ),
-  }));
+// An option the guide's own values rule out is not one the reader can reach, and
+// nor is a value they rule out — `http-lambda` can't apply on a guide written for
+// the Smithy framework.
+const { applicable, values } = resolveCardOptions(options, forced, initial);
 
 const config: GeneratorCardConfig = {
   kind: 'generator',
@@ -151,17 +146,6 @@ const config: GeneratorCardConfig = {
     }),
   ),
 };
-const inapplicable = new Set(
-  options
-    .filter((option) => !applicable.includes(option))
-    .map((option) => option.key),
-);
-const values = emittedValues(
-  Object.fromEntries(
-    Object.entries(initial).filter(([key]) => !inapplicable.has(key)),
-  ),
-  applicable,
-);
 
 const vscodeStrings = {
   installPlugin: {

--- a/docs/src/lib/command-card.spec.ts
+++ b/docs/src/lib/command-card.spec.ts
@@ -12,6 +12,7 @@ import {
   type GeneratorCardConfig,
   quoteValue,
   renderCommand,
+  resolveCardOptions,
   type WorkspaceCardConfig,
 } from './command-card';
 import {
@@ -365,6 +366,65 @@ describe('create workspace command', () => {
     ).toBe(
       'pnpm create @aws/nx-workspace my-project --iac=terraform --containers=finch',
     );
+  });
+});
+
+describe("resolving a card's options", () => {
+  const options = readGeneratorOptions({
+    properties: {
+      name: { type: 'string' },
+      framework: { type: 'string', enum: ['trpc', 'smithy'], default: 'trpc' },
+      namespace: { type: 'string', 'x-when': { framework: 'smithy' } },
+      infra: {
+        type: 'string',
+        enum: ['rest-lambda', 'http-lambda', 'none'],
+        default: 'rest-lambda',
+        'x-value-when': { 'http-lambda': { framework: 'trpc' } },
+      },
+    },
+    required: ['name'],
+  });
+
+  it('should carry the values a page passes onto its command', () => {
+    const { values } = resolveCardOptions(
+      options,
+      {},
+      {
+        name: 'demo-api',
+        framework: 'trpc',
+      },
+    );
+
+    expect(values).toEqual({ name: 'demo-api', framework: 'trpc' });
+  });
+
+  it('should carry a value for an option the schema does not declare', () => {
+    const { values } = resolveCardOptions(options, {}, { extra: 'yes' });
+
+    expect(values).toEqual({ extra: 'yes' });
+  });
+
+  it('should drop an option the page has ruled out, and its value with it', () => {
+    const { applicable, values } = resolveCardOptions(
+      options,
+      { framework: 'trpc' },
+      { name: 'demo-api', namespace: 'com.example' },
+    );
+
+    expect(applicable.map((option) => option.key)).not.toContain('namespace');
+    expect(values).toEqual({ name: 'demo-api' });
+  });
+
+  it('should drop a value the page has ruled out from its option', () => {
+    const { applicable } = resolveCardOptions(
+      options,
+      { framework: 'smithy' },
+      {},
+    );
+    const infra = applicable.find((option) => option.key === 'infra');
+
+    expect(infra?.values).toEqual(['rest-lambda', 'none']);
+    expect(applicable.map((option) => option.key)).toContain('namespace');
   });
 });
 

--- a/docs/src/lib/command-card.ts
+++ b/docs/src/lib/command-card.ts
@@ -6,7 +6,12 @@ import {
   buildPackageManagerExecCommand,
   PACKAGE_MANAGER_COMMANDS,
 } from '../../../packages/nx-plugin/src/utils/commands';
-import type { GeneratorOption, OptionControl } from './generator-options';
+import {
+  type GeneratorOption,
+  isApplicable,
+  isValueApplicable,
+  type OptionControl,
+} from './generator-options';
 
 /**
  * The command a card shows, assembled from the option values the reader entered.
@@ -115,6 +120,50 @@ export const emittedValues = (
     if (emitted !== undefined) out[key] = emitted;
   }
   return out;
+};
+
+/**
+ * The options a card offers, and the values its command carries, given the values
+ * the page fixes.
+ *
+ * An option the fixed values rule out is not one the reader can reach, so it goes
+ * along with anything entered in it, and a value they rule out leaves that
+ * option's list. Kept here, and keyed by option name rather than by object, since
+ * filtering an option's values means rebuilding it.
+ */
+export const resolveCardOptions = (
+  options: readonly GeneratorOption[],
+  forced: Record<string, string>,
+  entered: Record<string, string>,
+): { applicable: GeneratorOption[]; values: Record<string, string> } => {
+  const applies = new Set(
+    options
+      .filter((option) => isApplicable(option, forced))
+      .map((option) => option.key),
+  );
+  const applicable = options
+    .filter((option) => applies.has(option.key))
+    .map((option) => ({
+      ...option,
+      values: option.values.filter((value) =>
+        isValueApplicable(option, value, forced),
+      ),
+    }));
+  const known = new Set(options.map((option) => option.key));
+
+  return {
+    applicable,
+    values: emittedValues(
+      Object.fromEntries(
+        // A page can pass an option the schema doesn't declare, which no
+        // condition can rule out.
+        Object.entries(entered).filter(
+          ([key]) => applies.has(key) || !known.has(key),
+        ),
+      ),
+      applicable,
+    ),
+  };
 };
 
 const argumentTokens = (


### PR DESCRIPTION
### Reason for this change

Housekeeping rather than a fix: nothing about the site looks wrong for this, since the card's script repairs it on load. But every run-generator card has been rendering its command without the options the guide passes. The quick start's first step, in the HTML the server sends:

```bash
pnpm nx g @aws/nx-plugin:ts#api --no-interactive
```

where it should read:

```bash
pnpm nx g @aws/nx-plugin:ts#api demo-api --framework=trpc --no-interactive
```

The card's script rebuilds the command from its controls the moment it hydrates, so the page a reader ends up looking at is right — which is why this got past the browser checks in #1249, and why there is nothing to see on the live site. What's affected is narrow: a reader with JavaScript off, anything reading the HTML without running it, and the instant before hydration.

Introduced in #1249: ruling out the options a guide's own values can't reach meant rebuilding each option to filter its values, and the ruled-out set was then computed by looking for the *original* option objects in the *rebuilt* list. Nothing matched, so every option counted as ruled out and every value was dropped from the command.

### Description of changes

The work moves out of the component into `resolveCardOptions` in `lib/command-card.ts`, which keys on the option name rather than on object identity and returns both the options the card offers and the values its command carries. `run-generator.astro` calls it.

Four tests cover what the component itself can't be tested for:

- the values a page passes reach the command,
- a value for an option the schema doesn't declare still reaches it,
- an option the page has ruled out is dropped along with anything entered in it,
- and a value the page has ruled out leaves its option's list while the option stays.

### Description of how you validated changes

- `pnpm nx run docs:build` passes — 1540 pages built, all internal links valid. `pnpm nx run docs:test` passes (227 tests, 4 new).
- Read the server-rendered HTML back for the pages that show the range of cases, and each now carries its full command: the quick start (`ts#api demo-api --framework=trpc --no-interactive`), the tRPC guide (`--framework=trpc`), the contribute-a-generator tutorial (`--project=@aws/nx-plugin --name=ts#trpc-api#procedure --description='Adds a procedure to a tRPC API' --directory=trpc/procedure`), and a guide that passes nothing (`ts#lambda-function` alone, as it should be).
- Checked it in a real browser both ways, against the built site and against the live one, driving Chrome over CDP with `Emulation.setScriptExecutionDisabled` for the scripts-off case:

  | | JavaScript on | JavaScript off |
  |---|---|---|
  | live site (without this change) | `ts#api demo-api --framework=trpc --no-interactive` | `ts#api --no-interactive` |
  | built site (with it) | `ts#api demo-api --framework=trpc --no-interactive` | `ts#api demo-api --framework=trpc --no-interactive` |

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
