### PR TITLE
docs: pin the commands in the contribute-a-generator tutorial

### DIFF
--- a/docs/src/content/docs/en/get_started/tutorials/contribute-generator.mdx
+++ b/docs/src/content/docs/en/get_started/tutorials/contribute-generator.mdx
@@ -54,7 +54,7 @@ Let's create the new generator in `packages/nx-plugin/src/trpc/procedure`.
 
 We provide a generator for creating new generators so you can quickly scaffold your new generator! You can run this generator as follows:
 
-<RunGenerator generator="ts#nx-generator" requiredParameters={{ project: '@aws/nx-plugin', name: 'ts#trpc-api#procedure', directory: 'trpc/procedure', description: 'Adds a procedure to a tRPC API' }} />
+<RunGenerator generator="ts#nx-generator" requiredParameters={{ project: '@aws/nx-plugin', name: 'ts#trpc-api#procedure', directory: 'trpc/procedure', description: 'Adds a procedure to a tRPC API' }} readonly />
 
 You will notice the following files have been generated for you:
 
@@ -313,11 +313,11 @@ If you have completed the <Link path="get_started/tutorials/dungeon-game/overvie
 
 In a separate directory, create a new test workspace:
 
-<CreateNxWorkspaceCommand workspace="trpc-generator-test" />
+<CreateNxWorkspaceCommand workspace="trpc-generator-test" readonly />
 
 Next, let's generate a tRPC API to add the procedure to:
 
-<RunGenerator generator="ts#api" requiredParameters={{name:"test-api", framework:"trpc"}} noInteractive />
+<RunGenerator generator="ts#api" requiredParameters={{name:"test-api", framework:"trpc"}} noInteractive readonly />
 
 #### Link our local Nx Plugin for AWS
 
@@ -337,7 +337,7 @@ Notice above we linked to the compiled plugin in `dist/packages/nx-plugin` rathe
 
 Let's try the new generator:
 
-<RunGenerator generator="ts#trpc-api#procedure" />
+<RunGenerator generator="ts#trpc-api#procedure" readonly />
 
 :::note[Generator Not Showing]
 If you don't see the new generator in the list in VSCode, you might need to refresh the Nx workspace:
@@ -397,7 +397,7 @@ In practice, this process might look like:
 
 1. Create a new workspace
 
-    <CreateNxWorkspaceCommand workspace="my-project" />
+    <CreateNxWorkspaceCommand workspace="my-project" readonly />
   
 1. Run any generators that may be prerequisites to your new generator/feature/fix
 1. Commit your changes (`git commit`)

--- a/docs/src/content/docs/es/get_started/tutorials/contribute-generator.mdx
+++ b/docs/src/content/docs/es/get_started/tutorials/contribute-generator.mdx
@@ -54,7 +54,7 @@ Vamos a crear el nuevo generador en `packages/nx-plugin/src/trpc/procedure`.
 
 ¡Proporcionamos un generador para crear nuevos generadores para que puedas estructurar rápidamente tu nuevo generador! Puedes ejecutar este generador de la siguiente manera:
 
-<RunGenerator generator="ts#nx-generator" requiredParameters={{ project: '@aws/nx-plugin', name: 'ts#trpc-api#procedure', directory: 'trpc/procedure', description: 'Adds a procedure to a tRPC API' }} />
+<RunGenerator generator="ts#nx-generator" requiredParameters={{ project: '@aws/nx-plugin', name: 'ts#trpc-api#procedure', directory: 'trpc/procedure', description: 'Adds a procedure to a tRPC API' }} readonly />
 
 Notarás que se han generado los siguientes archivos para ti:
 
@@ -313,11 +313,11 @@ Si has completado el <Link path="get_started/tutorials/dungeon-game/overview">tu
 
 En un directorio separado, crea un nuevo workspace de prueba:
 
-<CreateNxWorkspaceCommand workspace="trpc-generator-test" />
+<CreateNxWorkspaceCommand workspace="trpc-generator-test" readonly />
 
 A continuación, generemos una API tRPC para agregar el procedimiento:
 
-<RunGenerator generator="ts#api" requiredParameters={{name:"test-api", framework:"trpc"}} noInteractive />
+<RunGenerator generator="ts#api" requiredParameters={{name:"test-api", framework:"trpc"}} noInteractive readonly />
 
 #### Vincular nuestro Nx Plugin for AWS local
 
@@ -337,7 +337,7 @@ Observa arriba que vinculamos al plugin compilado en `dist/packages/nx-plugin` e
 
 Probemos el nuevo generador:
 
-<RunGenerator generator="ts#trpc-api#procedure" />
+<RunGenerator generator="ts#trpc-api#procedure" readonly />
 
 :::note[Generador No Aparece]
 Si no ves el nuevo generador en la lista en VSCode, es posible que necesites actualizar el workspace Nx:
@@ -397,7 +397,7 @@ En la práctica, este proceso podría verse así:
 
 1. Crear un nuevo workspace
 
-    <CreateNxWorkspaceCommand workspace="my-project" />
+    <CreateNxWorkspaceCommand workspace="my-project" readonly />
   
 1. Ejecutar cualquier generador que pueda ser un requisito previo para tu nuevo generador/característica/corrección
 1. Confirmar tus cambios (`git commit`)

--- a/docs/src/content/docs/fr/get_started/tutorials/contribute-generator.mdx
+++ b/docs/src/content/docs/fr/get_started/tutorials/contribute-generator.mdx
@@ -54,7 +54,7 @@ Créons le nouveau générateur dans `packages/nx-plugin/src/trpc/procedure`.
 
 Nous fournissons un générateur pour créer de nouveaux générateurs afin que vous puissiez rapidement échafauder votre nouveau générateur ! Vous pouvez exécuter ce générateur comme suit :
 
-<RunGenerator generator="ts#nx-generator" requiredParameters={{ project: '@aws/nx-plugin', name: 'ts#trpc-api#procedure', directory: 'trpc/procedure', description: 'Adds a procedure to a tRPC API' }} />
+<RunGenerator generator="ts#nx-generator" requiredParameters={{ project: '@aws/nx-plugin', name: 'ts#trpc-api#procedure', directory: 'trpc/procedure', description: 'Adds a procedure to a tRPC API' }} readonly />
 
 Vous remarquerez que les fichiers suivants ont été générés pour vous :
 
@@ -313,11 +313,11 @@ Si vous avez terminé le <Link path="get_started/tutorials/dungeon-game/overview
 
 Dans un répertoire séparé, créez un nouvel espace de travail de test :
 
-<CreateNxWorkspaceCommand workspace="trpc-generator-test" />
+<CreateNxWorkspaceCommand workspace="trpc-generator-test" readonly />
 
 Ensuite, générons une API tRPC à laquelle ajouter la procédure :
 
-<RunGenerator generator="ts#api" requiredParameters={{name:"test-api", framework:"trpc"}} noInteractive />
+<RunGenerator generator="ts#api" requiredParameters={{name:"test-api", framework:"trpc"}} noInteractive readonly />
 
 #### Lier notre Nx Plugin for AWS local
 
@@ -337,7 +337,7 @@ Notez ci-dessus que nous avons lié au plugin compilé dans `dist/packages/nx-pl
 
 Essayons le nouveau générateur :
 
-<RunGenerator generator="ts#trpc-api#procedure" />
+<RunGenerator generator="ts#trpc-api#procedure" readonly />
 
 :::note[Générateur non affiché]
 Si vous ne voyez pas le nouveau générateur dans la liste dans VSCode, vous devrez peut-être actualiser l'espace de travail Nx :
@@ -397,7 +397,7 @@ En pratique, ce processus pourrait ressembler à :
 
 1. Créer un nouvel espace de travail
 
-    <CreateNxWorkspaceCommand workspace="my-project" />
+    <CreateNxWorkspaceCommand workspace="my-project" readonly />
   
 1. Exécuter tous les générateurs qui peuvent être des prérequis pour votre nouveau générateur/fonctionnalité/correction
 1. Valider vos modifications (`git commit`)

--- a/docs/src/content/docs/it/get_started/tutorials/contribute-generator.mdx
+++ b/docs/src/content/docs/it/get_started/tutorials/contribute-generator.mdx
@@ -54,7 +54,7 @@ Creiamo il nuovo generator in `packages/nx-plugin/src/trpc/procedure`.
 
 Forniamo un generator per creare nuovi generator in modo da poter scaffoldare rapidamente il tuo nuovo generator! Puoi eseguire questo generator come segue:
 
-<RunGenerator generator="ts#nx-generator" requiredParameters={{ project: '@aws/nx-plugin', name: 'ts#trpc-api#procedure', directory: 'trpc/procedure', description: 'Adds a procedure to a tRPC API' }} />
+<RunGenerator generator="ts#nx-generator" requiredParameters={{ project: '@aws/nx-plugin', name: 'ts#trpc-api#procedure', directory: 'trpc/procedure', description: 'Adds a procedure to a tRPC API' }} readonly />
 
 Noterai che i seguenti file sono stati generati per te:
 
@@ -313,11 +313,11 @@ Se hai completato il <Link path="/get_started/tutorials/dungeon-game/overview">t
 
 In una directory separata, crea un nuovo workspace di test:
 
-<CreateNxWorkspaceCommand workspace="trpc-generator-test" />
+<CreateNxWorkspaceCommand workspace="trpc-generator-test" readonly />
 
 Successivamente, generiamo un'API tRPC a cui aggiungere la procedura:
 
-<RunGenerator generator="ts#api" requiredParameters={{name:"test-api", framework:"trpc"}} noInteractive />
+<RunGenerator generator="ts#api" requiredParameters={{name:"test-api", framework:"trpc"}} noInteractive readonly />
 
 #### Collegare il nostro Nx Plugin for AWS locale
 
@@ -337,7 +337,7 @@ Nota che sopra abbiamo collegato il plugin compilato in `dist/packages/nx-plugin
 
 Proviamo il nuovo generator:
 
-<RunGenerator generator="ts#trpc-api#procedure" />
+<RunGenerator generator="ts#trpc-api#procedure" readonly />
 
 :::note[Generator Non Visualizzato]
 Se non vedi il nuovo generator nell'elenco in VSCode, potresti dover aggiornare il workspace Nx:
@@ -397,7 +397,7 @@ In pratica, questo processo potrebbe apparire così:
 
 1. Creare un nuovo workspace
 
-    <CreateNxWorkspaceCommand workspace="my-project" />
+    <CreateNxWorkspaceCommand workspace="my-project" readonly />
   
 1. Eseguire eventuali generator che potrebbero essere prerequisiti per il tuo nuovo generator/funzionalità/correzione
 1. Committare le tue modifiche (`git commit`)

--- a/docs/src/content/docs/jp/get_started/tutorials/contribute-generator.mdx
+++ b/docs/src/content/docs/jp/get_started/tutorials/contribute-generator.mdx
@@ -54,7 +54,7 @@ pnpm nx run-many --target build --all
 
 新しいジェネレーターを作成するためのジェネレーターを提供しているので、新しいジェネレーターを素早くスキャフォールドできます！このジェネレーターは次のように実行できます：
 
-<RunGenerator generator="ts#nx-generator" requiredParameters={{ project: '@aws/nx-plugin', name: 'ts#trpc-api#procedure', directory: 'trpc/procedure', description: 'Adds a procedure to a tRPC API' }} />
+<RunGenerator generator="ts#nx-generator" requiredParameters={{ project: '@aws/nx-plugin', name: 'ts#trpc-api#procedure', directory: 'trpc/procedure', description: 'Adds a procedure to a tRPC API' }} readonly />
 
 次のファイルが生成されたことがわかります：
 
@@ -313,11 +313,11 @@ pnpm nx compile @aws/nx-plugin
 
 別のディレクトリに、新しいテストワークスペースを作成します：
 
-<CreateNxWorkspaceCommand workspace="trpc-generator-test" />
+<CreateNxWorkspaceCommand workspace="trpc-generator-test" readonly />
 
 次に、プロシージャを追加する tRPC API を生成しましょう：
 
-<RunGenerator generator="ts#api" requiredParameters={{name:"test-api", framework:"trpc"}} noInteractive />
+<RunGenerator generator="ts#api" requiredParameters={{name:"test-api", framework:"trpc"}} noInteractive readonly />
 
 #### ローカルの Nx Plugin for AWS をリンク
 
@@ -337,7 +337,7 @@ pnpm nx compile @aws/nx-plugin
 
 新しいジェネレーターを試してみましょう：
 
-<RunGenerator generator="ts#trpc-api#procedure" />
+<RunGenerator generator="ts#trpc-api#procedure" readonly />
 
 :::note[ジェネレーターが表示されない]
 VSCode のリストに新しいジェネレーターが表示されない場合は、Nx ワークスペースをリフレッシュする必要があるかもしれません：
@@ -397,7 +397,7 @@ VSCode のリストに新しいジェネレーターが表示されない場合�
 
 1. 新しいワークスペースを作成
 
-    <CreateNxWorkspaceCommand workspace="my-project" />
+    <CreateNxWorkspaceCommand workspace="my-project" readonly />
   
 1. 新しいジェネレーター/機能/修正の前提条件となる可能性のあるジェネレーターを実行
 1. 変更をコミット（`git commit`）

--- a/docs/src/content/docs/ko/get_started/tutorials/contribute-generator.mdx
+++ b/docs/src/content/docs/ko/get_started/tutorials/contribute-generator.mdx
@@ -54,7 +54,7 @@ pnpm nx run-many --target build --all
 
 새로운 제너레이터를 빠르게 스캐폴딩할 수 있도록 제너레이터를 생성하는 제너레이터를 제공합니다! 다음과 같이 이 제너레이터를 실행할 수 있습니다:
 
-<RunGenerator generator="ts#nx-generator" requiredParameters={{ project: '@aws/nx-plugin', name: 'ts#trpc-api#procedure', directory: 'trpc/procedure', description: 'Adds a procedure to a tRPC API' }} />
+<RunGenerator generator="ts#nx-generator" requiredParameters={{ project: '@aws/nx-plugin', name: 'ts#trpc-api#procedure', directory: 'trpc/procedure', description: 'Adds a procedure to a tRPC API' }} readonly />
 
 다음 파일들이 생성된 것을 확인할 수 있습니다:
 
@@ -313,11 +313,11 @@ pnpm nx compile @aws/nx-plugin
 
 별도의 디렉토리에서 새로운 테스트 워크스페이스를 생성합니다:
 
-<CreateNxWorkspaceCommand workspace="trpc-generator-test" />
+<CreateNxWorkspaceCommand workspace="trpc-generator-test" readonly />
 
 다음으로 프로시저를 추가할 tRPC API를 생성해 봅시다:
 
-<RunGenerator generator="ts#api" requiredParameters={{name:"test-api", framework:"trpc"}} noInteractive />
+<RunGenerator generator="ts#api" requiredParameters={{name:"test-api", framework:"trpc"}} noInteractive readonly />
 
 #### 로컬 Nx Plugin for AWS 연결
 
@@ -337,7 +337,7 @@ pnpm nx compile @aws/nx-plugin
 
 새로운 제너레이터를 시도해 봅시다:
 
-<RunGenerator generator="ts#trpc-api#procedure" />
+<RunGenerator generator="ts#trpc-api#procedure" readonly />
 
 :::note[제너레이터가 표시되지 않음]
 VSCode의 목록에서 새로운 제너레이터가 보이지 않는 경우 Nx 워크스페이스를 새로 고쳐야 할 수 있습니다:
@@ -397,7 +397,7 @@ VSCode의 목록에서 새로운 제너레이터가 보이지 않는 경우 Nx �
 
 1. 새로운 워크스페이스 생성
 
-    <CreateNxWorkspaceCommand workspace="my-project" />
+    <CreateNxWorkspaceCommand workspace="my-project" readonly />
   
 1. 새로운 제너레이터/기능/수정의 전제 조건이 될 수 있는 제너레이터 실행
 1. 변경 사항 커밋 (`git commit`)

--- a/docs/src/content/docs/pt/get_started/tutorials/contribute-generator.mdx
+++ b/docs/src/content/docs/pt/get_started/tutorials/contribute-generator.mdx
@@ -54,7 +54,7 @@ Vamos criar o novo gerador em `packages/nx-plugin/src/trpc/procedure`.
 
 Fornecemos um gerador para criar novos geradores para que você possa rapidamente estruturar seu novo gerador! Você pode executar este gerador da seguinte forma:
 
-<RunGenerator generator="ts#nx-generator" requiredParameters={{ project: '@aws/nx-plugin', name: 'ts#trpc-api#procedure', directory: 'trpc/procedure', description: 'Adds a procedure to a tRPC API' }} />
+<RunGenerator generator="ts#nx-generator" requiredParameters={{ project: '@aws/nx-plugin', name: 'ts#trpc-api#procedure', directory: 'trpc/procedure', description: 'Adds a procedure to a tRPC API' }} readonly />
 
 Você notará que os seguintes arquivos foram gerados para você:
 
@@ -313,11 +313,11 @@ Se você completou o <Link path="get_started/tutorials/dungeon-game/overview">tu
 
 Em um diretório separado, crie um novo workspace de teste:
 
-<CreateNxWorkspaceCommand workspace="trpc-generator-test" />
+<CreateNxWorkspaceCommand workspace="trpc-generator-test" readonly />
 
 Em seguida, vamos gerar uma API tRPC para adicionar o procedimento:
 
-<RunGenerator generator="ts#api" requiredParameters={{name:"test-api", framework:"trpc"}} noInteractive />
+<RunGenerator generator="ts#api" requiredParameters={{name:"test-api", framework:"trpc"}} noInteractive readonly />
 
 #### Vincular nosso Nx Plugin for AWS local
 
@@ -337,7 +337,7 @@ Observe acima que vinculamos ao plugin compilado em `dist/packages/nx-plugin` em
 
 Vamos experimentar o novo gerador:
 
-<RunGenerator generator="ts#trpc-api#procedure" />
+<RunGenerator generator="ts#trpc-api#procedure" readonly />
 
 :::note[Gerador Não Aparecendo]
 Se você não vir o novo gerador na lista no VSCode, pode ser necessário atualizar o workspace Nx:
@@ -397,7 +397,7 @@ Na prática, este processo pode parecer com:
 
 1. Criar um novo workspace
 
-    <CreateNxWorkspaceCommand workspace="my-project" />
+    <CreateNxWorkspaceCommand workspace="my-project" readonly />
   
 1. Executar quaisquer geradores que possam ser pré-requisitos para seu novo gerador/recurso/correção
 1. Fazer commit de suas alterações (`git commit`)

--- a/docs/src/content/docs/vi/get_started/tutorials/contribute-generator.mdx
+++ b/docs/src/content/docs/vi/get_started/tutorials/contribute-generator.mdx
@@ -54,7 +54,7 @@ Hãy tạo generator mới trong `packages/nx-plugin/src/trpc/procedure`.
 
 Chúng tôi cung cấp một generator để tạo các generator mới giúp bạn có thể nhanh chóng scaffold generator mới của mình! Bạn có thể chạy generator này như sau:
 
-<RunGenerator generator="ts#nx-generator" requiredParameters={{ project: '@aws/nx-plugin', name: 'ts#trpc-api#procedure', directory: 'trpc/procedure', description: 'Adds a procedure to a tRPC API' }} />
+<RunGenerator generator="ts#nx-generator" requiredParameters={{ project: '@aws/nx-plugin', name: 'ts#trpc-api#procedure', directory: 'trpc/procedure', description: 'Adds a procedure to a tRPC API' }} readonly />
 
 Bạn sẽ thấy các file sau đã được tạo cho bạn:
 
@@ -313,11 +313,11 @@ Nếu bạn đã hoàn thành <Link path="get_started/tutorials/dungeon-game/ove
 
 Trong một thư mục riêng biệt, tạo một test workspace mới:
 
-<CreateNxWorkspaceCommand workspace="trpc-generator-test" />
+<CreateNxWorkspaceCommand workspace="trpc-generator-test" readonly />
 
 Tiếp theo, hãy tạo một tRPC API để thêm procedure vào:
 
-<RunGenerator generator="ts#api" requiredParameters={{name:"test-api", framework:"trpc"}} noInteractive />
+<RunGenerator generator="ts#api" requiredParameters={{name:"test-api", framework:"trpc"}} noInteractive readonly />
 
 #### Liên kết Nx Plugin for AWS cục bộ của chúng ta
 
@@ -337,7 +337,7 @@ Lưu ý ở trên chúng ta đã liên kết đến plugin đã compile trong `d
 
 Hãy thử generator mới:
 
-<RunGenerator generator="ts#trpc-api#procedure" />
+<RunGenerator generator="ts#trpc-api#procedure" readonly />
 
 :::note[Generator không Hiển thị]
 Nếu bạn không thấy generator mới trong danh sách trong VSCode, bạn có thể cần làm mới Nx workspace:
@@ -397,7 +397,7 @@ Trong thực tế, quy trình này có thể trông như sau:
 
 1. Tạo một workspace mới
 
-    <CreateNxWorkspaceCommand workspace="my-project" />
+    <CreateNxWorkspaceCommand workspace="my-project" readonly />
   
 1. Chạy bất kỳ generator nào có thể là điều kiện tiên quyết cho generator/tính năng/sửa lỗi mới của bạn
 1. Commit các thay đổi của bạn (`git commit`)

--- a/docs/src/content/docs/zh/get_started/tutorials/contribute-generator.mdx
+++ b/docs/src/content/docs/zh/get_started/tutorials/contribute-generator.mdx
@@ -54,7 +54,7 @@ pnpm nx run-many --target build --all
 
 我们提供了一个用于创建新生成器的生成器，这样您就可以快速搭建新生成器的脚手架！您可以按如下方式运行此生成器：
 
-<RunGenerator generator="ts#nx-generator" requiredParameters={{ project: '@aws/nx-plugin', name: 'ts#trpc-api#procedure', directory: 'trpc/procedure', description: 'Adds a procedure to a tRPC API' }} />
+<RunGenerator generator="ts#nx-generator" requiredParameters={{ project: '@aws/nx-plugin', name: 'ts#trpc-api#procedure', directory: 'trpc/procedure', description: 'Adds a procedure to a tRPC API' }} readonly />
 
 您会注意到已为您生成了以下文件：
 
@@ -313,11 +313,11 @@ pnpm nx compile @aws/nx-plugin
 
 在单独的目录中，创建一个新的测试工作区：
 
-<CreateNxWorkspaceCommand workspace="trpc-generator-test" />
+<CreateNxWorkspaceCommand workspace="trpc-generator-test" readonly />
 
 接下来，让我们生成一个 tRPC API 来添加过程：
 
-<RunGenerator generator="ts#api" requiredParameters={{name:"test-api", framework:"trpc"}} noInteractive />
+<RunGenerator generator="ts#api" requiredParameters={{name:"test-api", framework:"trpc"}} noInteractive readonly />
 
 #### 链接我们的本地 Nx Plugin for AWS
 
@@ -337,7 +337,7 @@ pnpm nx compile @aws/nx-plugin
 
 让我们尝试新的生成器：
 
-<RunGenerator generator="ts#trpc-api#procedure" />
+<RunGenerator generator="ts#trpc-api#procedure" readonly />
 
 :::note[生成器未显示]
 如果您在 VSCode 的列表中看不到新生成器，您可能需要刷新 Nx 工作区：
@@ -397,7 +397,7 @@ pnpm nx compile @aws/nx-plugin
 
 1. 创建一个新工作区
 
-    <CreateNxWorkspaceCommand workspace="my-project" />
+    <CreateNxWorkspaceCommand workspace="my-project" readonly />
   
 1. 运行可能是新生成器/功能/修复的先决条件的任何生成器
 1. 提交您的更改（`git commit`）


### PR DESCRIPTION
### Reason for this change

The contribute-a-generator tutorial walks a reader through writing one particular generator, and its prose is written around the values its steps pass: the generator's own name and directory (`ts#trpc-api#procedure`, `trpc/procedure`), the test workspace it is tried out in, and the tRPC API it is added to. Those were live controls, so a reader could edit a step's command and find the file paths in the next step no longer matched what they had generated.

The dungeon adventure and the quick start already pin their steps this way; this tutorial was left out when `readonly` landed.

### Description of changes

`readonly` on all five commands in the tutorial: the `ts#nx-generator` step that scaffolds the generator, the two workspace creates, the `ts#api` it is tried out against, and the run of the generator the reader has just written.

Each step now shows what it passes under `Options for this step`, collapsed, without offering to change it. The commands themselves are unchanged.

### Description of how you validated changes

- Read the rendered page back and confirmed all four schema-backed cards report `Options for this step` with every field locked (`project`, `name`, `description`, `directory`; `workspace`; `name`, `framework`; `workspace`), and that the fifth — the generator the tutorial writes, which no schema describes — still renders as the command alone.
- Diffed the rendered commands against `main`: identical.
- `pnpm nx run docs:build` passes — 1540 pages built, all internal links valid.

One note: this is an English-only edit, as the contributing guide asks. The translation job propagates component attributes when it retranslates a page, but skips a page whose prose hasn't changed, so the eight translated copies may need the same attributes carried across by hand — I'll check what the job does on this PR and follow up in it if needed, as with the dungeon adventure in #1240.

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
