### PR TITLE
ci(workflows): track the last validated commit in a ref, and release from a docs push

### DIFF
--- a/.github/actions/docs-only-change/action.yml
+++ b/.github/actions/docs-only-change/action.yml
@@ -22,6 +22,5 @@ runs:
         # push has the script resolve its own base - see the script.
         BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || '' }}
         HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-        GITHUB_TOKEN: ${{ github.token }}
       # Node strips the types, so this job needs no dependencies installed.
       run: node ./scripts/docs-only-change.mts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,15 +35,20 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      actions: read
     outputs:
       docs_only: ${{ steps.docs_only.outputs.docs-only }}
+      skip_release: ${{ steps.should_skip_release.outputs.skip_release }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
       - id: docs_only
         uses: ./.github/actions/docs-only-change
+      # Read here rather than in the release job, which needs the answer to
+      # decide whether to run at all.
+      - name: Should skip release
+        id: should_skip_release
+        run: echo "skip_release=$(git log $(git describe --tags --abbrev=0)..HEAD --oneline | grep -qE 'feat\(?.*\)?:|fix\(?.*\)?:|revert\(?.*\)?:|perf\(?.*\)?:|deps\(?.*\)?:' && echo false || echo true)" >> $GITHUB_OUTPUT
   package:
     name: Package
     runs-on: codebuild-nx-plugin-for-aws-runner-${{ github.run_id }}-${{ github.run_attempt }}-large
@@ -413,17 +418,44 @@ jobs:
                 ;;
             esac
           done
+  # Records this commit as validated so the next push knows what it may skip -
+  # see scripts/docs-only-change.mts. A cancelled or failed run leaves the ref
+  # where it is, folding its commits into the next run's diff.
+  mark_validated:
+    name: Mark Validated
+    needs: [changes, package, build, unit_tests, smoke_tests_complete]
+    if: ${{ !cancelled() && github.event_name == 'push' && github.ref == 'refs/heads/main' && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+      - name: Move the last validated ref
+        env:
+          REF: refs/ci/last-validated
+        run: |
+          current=$(git ls-remote origin "$REF" | cut -f1)
+          # Only ever forwards, so a run finishing out of order cannot rewind it
+          # onto a commit whose successors are unvalidated.
+          if [ -n "$current" ] && ! git merge-base --is-ancestor "$current" HEAD; then
+            echo "$REF is at $current, which this commit does not descend from - leaving it"
+            exit 0
+          fi
+          git push origin "HEAD:$REF"
   release:
     name: Release
     needs: [changes, package, build, unit_tests, smoke_tests_complete]
-    # A docs only change releases nothing. It also skips the smoke tests, and a
+    # A docs only change releases nothing of its own, but it still has to publish
+    # anything an earlier run left unreleased - a run whose release was skipped
+    # because the branch had moved on, say. It also skips the smoke tests, and a
     # skip propagates to every job downstream of it unless that job opts out with
     # a status function of its own.
-    if: ${{ !cancelled() && needs.changes.outputs.docs_only != 'true' && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
+    if: ${{ !cancelled() && (needs.changes.outputs.docs_only != 'true' || needs.changes.outputs.skip_release != 'true') && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
     runs-on: ubuntu-22.04
     outputs:
       latest_commit: ${{ steps.git_remote.outputs.latest_commit }}
-      skip_release: ${{ steps.should_skip_release.outputs.skip_release }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -439,13 +471,10 @@ jobs:
       - name: Check for new commits
         id: git_remote
         run: echo "latest_commit=$(git ls-remote origin -h ${{ github.ref }} | cut -f1)" >> $GITHUB_OUTPUT
-      - name: Should skip release
-        id: should_skip_release
-        run: echo "skip_release=$(git log $(git describe --tags --abbrev=0)..HEAD --oneline | grep -qE 'feat\(?.*\)?:|fix\(?.*\)?:|revert\(?.*\)?:|perf\(?.*\)?:|deps\(?.*\)?:' && echo false || echo true)" >> $GITHUB_OUTPUT
       # Version, stamp migrations, tag + changelog, then publish (with retry on a
       # transient failure). The whole flow lives in scripts/release.ts.
       - name: Release
-        if: ${{ steps.should_skip_release.outputs.skip_release != 'true' && github.event_name == 'push' && steps.git_remote.outputs.latest_commit == github.sha }}
+        if: ${{ needs.changes.outputs.skip_release != 'true' && github.event_name == 'push' && steps.git_remote.outputs.latest_commit == github.sha }}
         env:
           # Publishing uses npm OIDC trusted publishing (no token needed).
           GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -35,7 +35,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      actions: read
     outputs:
       docs_only: ${{ steps.docs_only.outputs.docs-only }}
     steps:

--- a/scripts/docs-only-change.mts
+++ b/scripts/docs-only-change.mts
@@ -16,17 +16,13 @@ import { appendFileSync } from 'node:fs';
 
 const COMMIT_SHA = /^[0-9a-f]{40}$/;
 
-const {
-  BASE_SHA,
-  HEAD_SHA,
-  GITHUB_TOKEN,
-  GITHUB_API_URL = 'https://api.github.com',
-  GITHUB_EVENT_NAME,
-  GITHUB_REPOSITORY,
-  GITHUB_REF_NAME,
-  GITHUB_RUN_ID,
-  GITHUB_OUTPUT,
-} = process.env;
+/**
+ * Ref holding the last commit whose CI run went green, moved by the
+ * `mark_validated` job in ci.yml.
+ */
+const LAST_VALIDATED_REF = 'refs/ci/last-validated';
+
+const { BASE_SHA, HEAD_SHA, GITHUB_EVENT_NAME, GITHUB_OUTPUT } = process.env;
 
 const git = (...args: string[]) =>
   execFileSync('git', args, { encoding: 'utf-8' });
@@ -53,48 +49,16 @@ const isAncestorOf = (sha: string, descendant: string) => {
   }
 };
 
-const api = async (path: string) => {
-  const response = await fetch(`${GITHUB_API_URL}${path}`, {
-    headers: {
-      accept: 'application/vnd.github+json',
-      authorization: `Bearer ${GITHUB_TOKEN}`,
-    },
-  });
-  if (!response.ok) {
-    throw new Error(`${response.status} from ${path}`);
-  }
-  return response.json();
-};
-
 /**
- * The most recent commit on this branch whose CI run went green.
- *
- * A push compares against this rather than against the commit it displaced,
- * because a run that was cancelled - which is how a batch of pushes is usually
- * collapsed - leaves its commits untested. Comparing against the last green
- * commit folds those commits into the diff, so a docs push landing on top of
- * untested code still runs the smoke tests.
+ * A push compares against the last validated commit rather than against the
+ * commit it displaced: a run that was cancelled - which is how a batch of pushes
+ * is usually collapsed - leaves its commits untested, and the ref stays where it
+ * was until a run goes green. So those commits fold into the diff and a docs
+ * push landing on top of untested code still runs the smoke tests.
  */
-const lastValidatedCommit = async (headSha: string) => {
-  // Resolving the id from this run is exact; the same endpoint keyed on the
-  // workflow's file name can answer for a stale copy of the workflow.
-  const { workflow_id } = await api(
-    `/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}`,
-  );
-  const { workflow_runs } = await api(
-    `/repos/${GITHUB_REPOSITORY}/actions/workflows/${workflow_id}/runs` +
-      `?branch=${GITHUB_REF_NAME}&status=success&per_page=50`,
-  );
-  return (workflow_runs as { head_sha: string }[])
-    .map((run) => run.head_sha)
-    .find(
-      (sha) =>
-        sha !== headSha &&
-        isHeldCommit(sha) &&
-        // A run that finished out of order, or one from before a force push,
-        // says nothing about this commit.
-        isAncestorOf(sha, headSha),
-    );
+const lastValidatedCommit = () => {
+  const sha = git('ls-remote', 'origin', LAST_VALIDATED_REF).split(/\s/)[0];
+  return COMMIT_SHA.test(sha) ? sha : undefined;
 };
 
 const isDocsOnly = (baseSha: string, headSha: string) => {
@@ -106,30 +70,22 @@ const isDocsOnly = (baseSha: string, headSha: string) => {
   );
 };
 
-const resolveBaseSha = async (headSha: string) => {
+const resolveBaseSha = () => {
   if (BASE_SHA) {
     return BASE_SHA;
   }
-  if (GITHUB_EVENT_NAME !== 'push') {
-    return undefined;
-  }
-  try {
-    return await lastValidatedCommit(headSha);
-  } catch (e) {
-    console.log(`Could not resolve the last green commit: ${e}`);
-    return undefined;
-  }
+  return GITHUB_EVENT_NAME === 'push' ? lastValidatedCommit() : undefined;
 };
 
 // Without a pair of commits to compare - a manually dispatched run, a branch
-// with no green run behind it, a force push whose previous head is gone - the
+// with no green run behind it yet, a ref left behind by a force push - the
 // change is treated as touching more than the docs and everything runs.
-const baseSha = isHeldCommit(HEAD_SHA)
-  ? await resolveBaseSha(HEAD_SHA)
-  : undefined;
+const baseSha = resolveBaseSha();
 
 const docsOnly =
-  isHeldCommit(baseSha) && isHeldCommit(HEAD_SHA)
+  isHeldCommit(baseSha) &&
+  isHeldCommit(HEAD_SHA) &&
+  isAncestorOf(baseSha, HEAD_SHA)
     ? isDocsOnly(baseSha, HEAD_SHA)
     : false;
 


### PR DESCRIPTION
### Reason for this change

Two problems with the docs-only skip on `main`, both surfaced by real runs.

**1. A stale API response made a docs push run the whole suite.** [Run 34202837561](https://github.com/awslabs/nx-plugin-for-aws/actions/runs/34202837561) (`e757cb8`, docs only) compared against `6c3e900` — seven commits back — and ran all 57 smoke legs. It should have compared against `76161e5`. The base came from `GET /actions/workflows/{id}/runs?branch=main&status=success`, and that endpoint is eventually consistent: called twice minutes apart it returned month-old runs once and current runs the next time. At 08:07:48, when `Detect Changes` ran, it returned neither `d4ef5cd`'s run (green at 07:11:17) nor `76161e5`'s (green at 07:18:15), so the script fell back to a much older green ancestor. The direction is safe — an older base only widens the diff — but it defeats the optimisation exactly when it should apply.

**2. A docs push could swallow a pending release.** Push something releasable, then push docs on top:

- the releasable commit's own run declines to publish, because `latest_commit == github.sha` is false once the branch has moved on;
- the docs push skipped the release job outright, since #1239 gated it on `docs_only`.

So the release waited for the next push touching anything outside `docs/`. Nothing has actually been lost — every commit since `v1.0.0` is `docs`, `ci` or `chore`, so `skip_release` was true throughout — but with batched pushes this sequence is routine, not an edge case.

### Description of changes

**The last validated commit lives in a ref, not in the API.** A new `mark_validated` job pushes `refs/ci/last-validated` at the end of a green push run on `main`, and `scripts/docs-only-change.mts` reads it with `git ls-remote`. No API call, nothing to be stale, and the script loses its token, its workflow-id lookup and its `fetch` — the `changes` job drops `actions: read` again.

- The ref only ever moves forwards: if it points at a commit the current one does not descend from, the job leaves it alone, so a run finishing out of order cannot rewind it onto a commit whose successors are unvalidated.
- A cancelled or failed run leaves the ref where it was, so its commits fold into the next push's diff — the property #1239 added, now on a dependable signal.
- `mark_validated` needs `changes`, `package`, `build`, `unit_tests` and `smoke_tests_complete`, so "validated" means the whole suite passed, or was legitimately skipped for a docs only change.
- Before the ref exists — the first run after this merges — there is no base, so everything runs and the ref is created. `workflow_dispatch` neither reads nor moves it.

**A docs push releases whatever is still unreleased.** The `Should skip release` check moves into the `changes` job, which is early enough for the release job's own `if` to use it: the job is now skipped only when the change is docs only **and** there is nothing to release. The release job stops recomputing the same thing (its duplicate step and unused `skip_release` output are gone) and its publish step reads `needs.changes.outputs.skip_release`. The publish step's `latest_commit == github.sha` guard is untouched.

### Description of how you validated changes

All in a throwaway fork (`nx-plugin-for-aws/nxpaws-ci-skip-test`) carrying these workflows with `runs-on` and the long running step bodies stubbed, but `changes`, `smoke_tests_complete` and `mark_validated` verbatim, plus a ruleset requiring `Build` and `Smoke Tests Complete`, and tags so `git describe` behaves as it does here.

Pushes to `main`:

| Scenario | Compared against | Result |
| --- | --- | --- |
| First push, no ref yet | nothing | `docs-only=false`, full suite, **ref created** |
| Docs push after a green run | the ref | `docs-only=true`, 6 smoke jobs skipped, ref advanced |
| Releasable (`feat`) push | the ref | `docs-only=false`, 57 legs, `Release` ran |
| **Docs push while that release is still pending** | the ref | `docs-only=true` (smoke skipped) **and `Release` ran** — the fix |
| Docs push with nothing pending | the ref | `docs-only=true`, **`Release` skipped** — the behaviour #1239 asked for, preserved |
| Docs push on top of a **cancelled code** push | the ref, not the cancelled commit | `docs-only=false`, 57 legs, `Release` ran |
| Docs push on top of a **cancelled docs** push | two docs commits back | `docs-only=true`, still skipped — not over-conservative |
| `workflow_dispatch` | nothing | `docs-only=false`, 57 legs, `mark_validated` skipped |

Pull requests, unchanged by this PR and re-run against it:

| Scenario | Result |
| --- | --- |
| Docs only | `docs-only=true`, 6 jobs skipped, gate green, `CLEAN` |
| Docs + code | `docs-only=false`, all 54 legs |
| Code commit → run cancelled → docs commit | `docs-only=false`, all 54 legs |
| One smoke leg failing | `Smoke Tests Complete` **failed**, PR `BLOCKED` |

The ref's forward-only guard was also exercised directly in a scratch repository: first run creates it, an older commit finishing late is refused ("does not descend from"), a descendant advances it.

### Issue # (if applicable)

Follows up #1235 and #1239.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
