### PR TITLE
docs: announce v1.0.0 on the blog

### DIFF
--- a/docs/src/components/header.astro
+++ b/docs/src/components/header.astro
@@ -10,16 +10,17 @@ import Search from 'virtual:starlight/components/Search';
 import SiteTitle from 'virtual:starlight/components/SiteTitle';
 import SocialIcons from 'virtual:starlight/components/SocialIcons';
 import ThemeSelect from 'virtual:starlight/components/ThemeSelect';
+import { isBlogPostListRoute } from '../lib/blog-route';
 
 const shouldRenderSearch =
   config.pagefind || config.components.Search !== '@astrojs/starlight/components/Search.astro';
 
-// starlight-blog hides the leading title panel on its blog routes via a scoped
+// starlight-blog hides the leading title panel on its post list via a scoped
 // `:global` rule, but under Astro 7 that rule leaks into the shared CSS and
 // hides the first panel (page title / splash hero) everywhere. custom.css
 // restores it globally; emit the hide rule inline here so it applies only on
-// blog routes, matching starlight-blog's intended layout.
-const isBlogRoute = /(^|\/)blog(\/|$)/.test(Astro.locals.starlightRoute.id);
+// the post list, matching starlight-blog's intended layout.
+const hideTitlePanel = isBlogPostListRoute(Astro.locals.starlightRoute.id);
 
 const locale = Astro.currentLocale || 'en';
 const graphBuilderHref = getRelativeLocaleUrl(
@@ -43,7 +44,7 @@ const graphBuilderLabel =
 ---
 
 {
-  isBlogRoute && (
+  hideTitlePanel && (
     <style
       is:inline
       set:html={

--- a/docs/src/components/markdown-content.astro
+++ b/docs/src/components/markdown-content.astro
@@ -3,7 +3,9 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import Default from '@astrojs/starlight/components/MarkdownContent.astro';
+import StarlightBlogContent from 'starlight-blog/components/MarkdownContent.astro';
+import StarlightVideosContent from 'starlight-videos/components/MarkdownContent.astro';
+import { isBlogPostRoute } from '../lib/blog-route';
 import {
   postProcessGuide,
   renderExperimentalWarning,
@@ -112,6 +114,17 @@ const showWorkspacePrerequisite =
   starlightRoute?.id?.includes('/guides/') === true &&
   (generatorFrontmatter !== undefined ||
     rawMdxForFilter.includes('<RunGenerator'));
+
+// starlight-blog renders the post date and authors, starlight-videos the video
+// player and transcript; both fall back to Starlight's own content rendering.
+// starlight-blog resolves posts per locale, so a locale still awaiting its
+// translation renders the English body on its own.
+const isLocalisedBlogPost =
+  isBlogPostRoute(starlightRoute?.id ?? '') &&
+  starlightRoute?.isFallback !== true;
+const Content = isLocalisedBlogPost
+  ? StarlightBlogContent
+  : StarlightVideosContent;
 ---
 
 {resolvedMarkdown && <div data-copy-markdown={resolvedMarkdown} style="display:none" />}
@@ -120,4 +133,4 @@ const showWorkspacePrerequisite =
   <PageOptions generatorId={generatorFrontmatter} rawMdx={rawMdxForFilter} />
 )}
 {showWorkspacePrerequisite && <Snippet name="workspace-prerequisite" />}
-<Default><slot /></Default>
+<Content><slot /></Content>

--- a/docs/src/content/docs/en/blog/migrating-from-aws-pdk.mdx
+++ b/docs/src/content/docs/en/blog/migrating-from-aws-pdk.mdx
@@ -1,7 +1,7 @@
 ---
 title: Migrating from AWS PDK
 description: Migrating to the Nx Plugin for AWS from the AWS Project Development Kit (PDK)
-date: 2025-09-26
+date: 2026-09-07
 authors:
  - jack
 ---
@@ -36,7 +36,7 @@ Note also that some features of PDK don't have exact equivalents. Refer to the [
 :::
 
 :::caution[Point-in-Time Guide]
-This is written as a point-of-time guide and will most likely not be updated as the Nx Plugin for AWS evolves. To compensate for this, the guide pins the version of `@aws/nx-plugin` to `1.0.0`. You can try with the latest version if following along, but there may be some deviations from the guide.
+This is written as a point-of-time guide and will most likely not be updated as the Nx Plugin for AWS evolves. To compensate for this, the guide pins the version of `@aws/nx-plugin` to `1.0.0`. You can try with the latest version if following along, but there may be some deviations from the guide. If you follow the guide with the pinned version, you can <Link path="get_started/upgrading">upgrade your workspace</Link> afterwards.
 :::
 
 ## Example Migration: Shopping List Application

--- a/docs/src/content/docs/en/blog/v1-0-0-released.mdx
+++ b/docs/src/content/docs/en/blog/v1-0-0-released.mdx
@@ -1,0 +1,16 @@
+---
+title: v1.0.0 Released
+description: The Nx Plugin for AWS reaches 1.0.0
+date: 2026-09-08
+authors:
+  - jack
+---
+import Link from '@components/link.astro';
+
+We're thrilled to announce that the Nx Plugin for AWS has reached [v1.0.0](https://github.com/awslabs/nx-plugin-for-aws/releases/tag/v1.0.0)! Since our first release we've been building towards a toolkit you can confidently start a production project with, and 1.0 is that milestone.
+
+A few highlights: generators are now idempotent, so re-running one is always safe and doesn't overwrite your code. <Link path="get_started/upgrading">`nx migrate @aws/nx-plugin`</Link> is fully supported, so the improvements we make upstream flow into your workspace as you bump versions. A new <Link path="get_started/existing-project">`init` generator</Link> lets you adopt the plugin in an existing Nx or non-Nx repo. There's Terraform support alongside CDK across generators, new DynamoDB and relational database generators, agents and MCP servers deployed to AgentCore Runtime by default with a new AgentCore Gateway generator, and a single `dev` target for local development. Generator names and options have been standardised, and the toolchain moves to Nx 23.2, ESM and Biome. Security defaults have been tightened too, with WAF, Cognito threat protection, an enforced CSP, API access logging and image scanning.
+
+For the full launch announcement, head over to the [AWS Open Source blog](https://aws.amazon.com/blogs/opensource/build-full-stack-aws-applications-in-minutes-with-ai-powered-scaffolding/).
+
+Thank you to everyone who has contributed, filed issues and given us feedback along the way — we're just getting started. As always, [post a discussion](https://github.com/awslabs/nx-plugin-for-aws/discussions) or [raise an issue](https://github.com/awslabs/nx-plugin-for-aws/issues) to let us know what you'd like to see next!

--- a/docs/src/content/docs/es/blog/migrating-from-aws-pdk.mdx
+++ b/docs/src/content/docs/es/blog/migrating-from-aws-pdk.mdx
@@ -1,7 +1,7 @@
 ---
 title: Migración desde AWS PDK
 description: Migración al Nx Plugin para AWS desde el AWS Project Development Kit (PDK)
-date: 2025-09-26
+date: 2026-09-07
 authors:
  - jack
 ---
@@ -36,7 +36,7 @@ Ten en cuenta también que algunas características de PDK no tienen equivalente
 :::
 
 :::caution[Guía en un Punto en el Tiempo]
-Esta guía está escrita como una guía en un punto en el tiempo y muy probablemente no se actualizará a medida que el Nx Plugin para AWS evolucione. Para compensar esto, la guía fija la versión de `@aws/nx-plugin` a `1.0.0`. Puedes intentar con la última versión si sigues la guía, pero puede haber algunas desviaciones de la misma.
+Esta guía está escrita como una guía en un punto en el tiempo y muy probablemente no se actualizará a medida que el Nx Plugin para AWS evolucione. Para compensar esto, la guía fija la versión de `@aws/nx-plugin` a `1.0.0`. Puedes intentar con la última versión si sigues la guía, pero puede haber algunas desviaciones de la misma. Si sigues la guía con la versión fijada, puedes <Link path="get_started/upgrading">actualizar tu espacio de trabajo</Link> después.
 :::
 
 ## Ejemplo de Migración: Aplicación de Lista de Compras

--- a/docs/src/content/docs/es/blog/v1-0-0-released.mdx
+++ b/docs/src/content/docs/es/blog/v1-0-0-released.mdx
@@ -1,0 +1,16 @@
+---
+title: v1.0.0 Lanzado
+description: El Nx Plugin for AWS alcanza la versión 1.0.0
+date: 2026-09-08
+authors:
+  - jack
+---
+import Link from '@components/link.astro';
+
+¡Estamos encantados de anunciar que el Nx Plugin for AWS ha alcanzado la versión [v1.0.0](https://github.com/awslabs/nx-plugin-for-aws/releases/tag/v1.0.0)! Desde nuestro primer lanzamiento hemos estado construyendo hacia un conjunto de herramientas con el que puedas iniciar con confianza un proyecto de producción, y 1.0 es ese hito.
+
+Algunos aspectos destacados: los generadores ahora son idempotentes, por lo que volver a ejecutar uno siempre es seguro y no sobrescribe tu código. <Link path="get_started/upgrading">`nx migrate @aws/nx-plugin`</Link> es totalmente compatible, por lo que las mejoras que hacemos upstream fluyen hacia tu espacio de trabajo a medida que actualizas las versiones. Un nuevo <Link path="get_started/existing-project">generador `init`</Link> te permite adoptar el plugin en un repositorio Nx o no-Nx existente. Hay soporte de Terraform junto con CDK en todos los generadores, nuevos generadores de DynamoDB y bases de datos relacionales, agentes y servidores MCP desplegados en AgentCore Runtime por defecto con un nuevo generador AgentCore Gateway, y un único target `dev` para desarrollo local. Los nombres y opciones de los generadores se han estandarizado, y la cadena de herramientas se mueve a Nx 23.2, ESM y Biome. Los valores predeterminados de seguridad también se han reforzado, con WAF, protección contra amenazas de Cognito, una CSP aplicada, registro de acceso a API y escaneo de imágenes.
+
+Para el anuncio de lanzamiento completo, dirígete al [blog de AWS Open Source](https://aws.amazon.com/blogs/opensource/build-full-stack-aws-applications-in-minutes-with-ai-powered-scaffolding/).
+
+Gracias a todos los que han contribuido, presentado problemas y nos han dado retroalimentación en el camino — apenas estamos comenzando. Como siempre, [publica una discusión](https://github.com/awslabs/nx-plugin-for-aws/discussions) o [abre un issue](https://github.com/awslabs/nx-plugin-for-aws/issues) para hacernos saber qué te gustaría ver a continuación!

--- a/docs/src/content/docs/fr/blog/migrating-from-aws-pdk.mdx
+++ b/docs/src/content/docs/fr/blog/migrating-from-aws-pdk.mdx
@@ -1,7 +1,7 @@
 ---
 title: Migration depuis AWS PDK
 description: Migration vers le Nx Plugin for AWS depuis l'AWS Project Development Kit (PDK)
-date: 2025-09-26
+date: 2026-09-07
 authors:
  - jack
 ---
@@ -36,7 +36,7 @@ Notez également que certaines fonctionnalités de PDK n'ont pas d'équivalents 
 :::
 
 :::caution[Guide ponctuel]
-Ce guide est rédigé comme un guide ponctuel et ne sera très probablement pas mis à jour au fur et à mesure de l'évolution du Nx Plugin for AWS. Pour compenser cela, le guide épingle la version de `@aws/nx-plugin` à `1.0.0`. Vous pouvez essayer avec la dernière version si vous suivez le guide, mais il peut y avoir quelques écarts par rapport au guide.
+Ce guide est rédigé comme un guide ponctuel et ne sera très probablement pas mis à jour au fur et à mesure de l'évolution du Nx Plugin for AWS. Pour compenser cela, le guide épingle la version de `@aws/nx-plugin` à `1.0.0`. Vous pouvez essayer avec la dernière version si vous suivez le guide, mais il peut y avoir quelques écarts par rapport au guide. Si vous suivez le guide avec la version épinglée, vous pouvez <Link path="get_started/upgrading">mettre à niveau votre espace de travail</Link> par la suite.
 :::
 
 ## Exemple de migration : Application de liste de courses

--- a/docs/src/content/docs/fr/blog/v1-0-0-released.mdx
+++ b/docs/src/content/docs/fr/blog/v1-0-0-released.mdx
@@ -1,0 +1,16 @@
+---
+title: v1.0.0 publié
+description: Le Nx Plugin for AWS atteint la version 1.0.0
+date: 2026-09-08
+authors:
+  - jack
+---
+import Link from '@components/link.astro';
+
+Nous sommes ravis d'annoncer que le Nx Plugin for AWS a atteint la version [v1.0.0](https://github.com/awslabs/nx-plugin-for-aws/releases/tag/v1.0.0) ! Depuis notre première version, nous avons travaillé à la création d'une boîte à outils avec laquelle vous pouvez démarrer un projet de production en toute confiance, et la version 1.0 représente cette étape importante.
+
+Quelques points forts : les générateurs sont désormais idempotents, donc réexécuter l'un d'eux est toujours sûr et n'écrase pas votre code. <Link path="get_started/upgrading">`nx migrate @aws/nx-plugin`</Link> est entièrement pris en charge, de sorte que les améliorations que nous apportons en amont se répercutent dans votre espace de travail au fur et à mesure que vous mettez à jour les versions. Un nouveau <Link path="get_started/existing-project">générateur `init`</Link> vous permet d'adopter le plugin dans un dépôt Nx ou non-Nx existant. Il y a le support de Terraform aux côtés de CDK dans tous les générateurs, de nouveaux générateurs de bases de données DynamoDB et relationnelles, des agents et des serveurs MCP déployés sur AgentCore Runtime par défaut avec un nouveau générateur AgentCore Gateway, et une seule cible `dev` pour le développement local. Les noms et options des générateurs ont été standardisés, et la chaîne d'outils passe à Nx 23.2, ESM et Biome. Les paramètres de sécurité par défaut ont également été renforcés, avec WAF, la protection contre les menaces Cognito, une CSP appliquée, la journalisation des accès API et l'analyse des images.
+
+Pour l'annonce complète du lancement, rendez-vous sur le [blog AWS Open Source](https://aws.amazon.com/blogs/opensource/build-full-stack-aws-applications-in-minutes-with-ai-powered-scaffolding/).
+
+Merci à tous ceux qui ont contribué, signalé des problèmes et nous ont fait part de leurs commentaires en cours de route — nous ne faisons que commencer. Comme toujours, [publiez une discussion](https://github.com/awslabs/nx-plugin-for-aws/discussions) ou [signalez un problème](https://github.com/awslabs/nx-plugin-for-aws/issues) pour nous faire savoir ce que vous aimeriez voir ensuite !

--- a/docs/src/content/docs/it/blog/migrating-from-aws-pdk.mdx
+++ b/docs/src/content/docs/it/blog/migrating-from-aws-pdk.mdx
@@ -1,7 +1,7 @@
 ---
 title: Migrazione da AWS PDK
 description: Migrazione al Nx Plugin for AWS dall'AWS Project Development Kit (PDK)
-date: 2025-09-26
+date: 2026-09-07
 authors:
  - jack
 ---
@@ -36,7 +36,7 @@ Nota anche che alcune funzionalità di PDK non hanno equivalenti esatti. Fai rif
 :::
 
 :::caution[Guida Temporale]
-Questa è scritta come una guida temporale e molto probabilmente non verrà aggiornata man mano che il Nx Plugin for AWS evolve. Per compensare questo, la guida fissa la versione di `@aws/nx-plugin` a `1.0.0`. Puoi provare con l'ultima versione se segui la guida, ma potrebbero esserci alcune deviazioni dalla guida.
+Questa è scritta come una guida temporale e molto probabilmente non verrà aggiornata man mano che il Nx Plugin for AWS evolve. Per compensare questo, la guida fissa la versione di `@aws/nx-plugin` a `1.0.0`. Puoi provare con l'ultima versione se segui la guida, ma potrebbero esserci alcune deviazioni dalla guida. Se segui la guida con la versione fissata, puoi <Link path="get_started/upgrading">aggiornare il tuo workspace</Link> successivamente.
 :::
 
 ## Esempio di Migrazione: Applicazione Shopping List
@@ -80,7 +80,7 @@ Questa sezione fornisce indicazioni per le funzionalità di PDK che non sono cop
 
 Come regola generale quando si passa da PDK, raccomandiamo di iniziare qualsiasi progetto con un Nx Workspace, date le sue somiglianze con il PDK Monorepo. Raccomandiamo anche di usare i nostri generatori come primitive su cui costruire qualsiasi nuovo tipo.
 
-<CreateNxWorkspaceCommand workspace="my-project" />
+<CreateNxWorkspaceCommand workspace="my-project" noOptions />
 
 ### CDK Graph
 

--- a/docs/src/content/docs/it/blog/v1-0-0-released.mdx
+++ b/docs/src/content/docs/it/blog/v1-0-0-released.mdx
@@ -1,0 +1,16 @@
+---
+title: Rilascio della v1.0.0
+description: Il Nx Plugin for AWS raggiunge la versione 1.0.0
+date: 2026-09-08
+authors:
+  - jack
+---
+import Link from '@components/link.astro';
+
+Siamo entusiasti di annunciare che il Nx Plugin for AWS ha raggiunto la [v1.0.0](https://github.com/awslabs/nx-plugin-for-aws/releases/tag/v1.0.0)! Dal nostro primo rilascio abbiamo lavorato per costruire un toolkit con cui poter avviare con fiducia un progetto di produzione, e la 1.0 rappresenta questa pietra miliare.
+
+Alcuni punti salienti: i generatori sono ora idempotenti, quindi rieseguirne uno è sempre sicuro e non sovrascrive il tuo codice. <Link path="get_started/upgrading">`nx migrate @aws/nx-plugin`</Link> è completamente supportato, quindi i miglioramenti che apportiamo a monte fluiscono nel tuo workspace man mano che aggiorni le versioni. Un nuovo <Link path="get_started/existing-project">generatore `init`</Link> ti consente di adottare il plugin in un repository Nx o non-Nx esistente. C'è il supporto Terraform insieme a CDK in tutti i generatori, nuovi generatori per database DynamoDB e relazionali, agenti e server MCP distribuiti su AgentCore Runtime per impostazione predefinita con un nuovo generatore AgentCore Gateway, e un singolo target `dev` per lo sviluppo locale. I nomi e le opzioni dei generatori sono stati standardizzati e la toolchain passa a Nx 23.2, ESM e Biome. Anche le impostazioni predefinite di sicurezza sono state rafforzate, con WAF, protezione dalle minacce Cognito, una CSP applicata, registrazione degli accessi API e scansione delle immagini.
+
+Per l'annuncio completo del lancio, visita il [blog AWS Open Source](https://aws.amazon.com/blogs/opensource/build-full-stack-aws-applications-in-minutes-with-ai-powered-scaffolding/).
+
+Grazie a tutti coloro che hanno contribuito, segnalato problemi e fornito feedback lungo il percorso — stiamo solo iniziando. Come sempre, [pubblica una discussione](https://github.com/awslabs/nx-plugin-for-aws/discussions) o [segnala un problema](https://github.com/awslabs/nx-plugin-for-aws/issues) per farci sapere cosa vorresti vedere in futuro!

--- a/docs/src/content/docs/jp/blog/migrating-from-aws-pdk.mdx
+++ b/docs/src/content/docs/jp/blog/migrating-from-aws-pdk.mdx
@@ -1,7 +1,7 @@
 ---
 title: AWS PDKからの移行
 description: AWS Project Development Kit (PDK)からNx Plugin for AWSへの移行
-date: 2025-09-26
+date: 2026-09-07
 authors:
  - jack
 ---
@@ -36,7 +36,7 @@ Nx Plugin for AWSへの移行により、PDKと比較して以下のメリット
 :::
 
 :::caution[特定時点のガイド]
-これは特定時点のガイドとして書かれており、Nx Plugin for AWSの進化に伴って更新される可能性は低いです。これを補うため、このガイドでは`@aws/nx-plugin`のバージョンを`1.0.0`に固定しています。最新バージョンで試すこともできますが、ガイドとの間にいくつかの相違がある可能性があります。
+これは特定時点のガイドとして書かれており、Nx Plugin for AWSの進化に伴って更新される可能性は低いです。これを補うため、このガイドでは`@aws/nx-plugin`のバージョンを`1.0.0`に固定しています。最新バージョンで試すこともできますが、ガイドとの間にいくつかの相違がある可能性があります。固定されたバージョンでガイドに従った場合は、その後<Link path="get_started/upgrading">ワークスペースをアップグレード</Link>できます。
 :::
 
 ## 移行例：ショッピングリストアプリケーション
@@ -54,7 +54,7 @@ Nx Plugin for AWSへの移行により、PDKと比較して以下のメリット
 
 まず、新しいプロジェクト用の新しいワークスペースを作成します。インプレース移行よりも極端ですが、このアプローチにより最もクリーンな最終結果が得られます。Nxワークスペースの作成は、PDKの`MonorepoTsProject`の使用と同等です：
 
-<CreateNxWorkspaceCommand workspace="shopping-list" iac="cdk" tag="1.0.0" />
+<CreateNxWorkspaceCommand workspace="shopping-list" iac="cdk" tag="1.0.0" noOptions />
 
 このコマンドで作成された`shopping-list`ディレクトリをお気に入りのIDEで開きます。
 

--- a/docs/src/content/docs/jp/blog/v1-0-0-released.mdx
+++ b/docs/src/content/docs/jp/blog/v1-0-0-released.mdx
@@ -1,0 +1,16 @@
+---
+title: v1.0.0 リリース
+description: Nx Plugin for AWS が 1.0.0 に到達
+date: 2026-09-08
+authors:
+  - jack
+---
+import Link from '@components/link.astro';
+
+Nx Plugin for AWS が [v1.0.0](https://github.com/awslabs/nx-plugin-for-aws/releases/tag/v1.0.0) に到達したことを発表できることを嬉しく思います！最初のリリース以来、本番プロジェクトを自信を持って開始できるツールキットの構築に取り組んできましたが、1.0 はそのマイルストーンです。
+
+いくつかのハイライト: ジェネレーターが冪等になり、再実行しても常に安全でコードを上書きしません。<Link path="get_started/upgrading">`nx migrate @aws/nx-plugin`</Link> が完全にサポートされ、バージョンを上げるにつれて、上流で行った改善がワークスペースに流れ込みます。新しい <Link path="get_started/existing-project">`init` ジェネレーター</Link> により、既存の Nx または非 Nx リポジトリでプラグインを採用できます。ジェネレーター全体で CDK と並んで Terraform がサポートされ、新しい DynamoDB とリレーショナルデータベースのジェネレーター、デフォルトで AgentCore Runtime にデプロイされるエージェントと MCP サーバー、新しい AgentCore Gateway ジェネレーター、そしてローカル開発用の単一の `dev` ターゲットがあります。ジェネレーターの名前とオプションが標準化され、ツールチェーンは Nx 23.2、ESM、Biome に移行しました。セキュリティのデフォルトも強化され、WAF、Cognito 脅威保護、強制 CSP、API アクセスログ、イメージスキャンが含まれています。
+
+完全なローンチアナウンスについては、[AWS Open Source ブログ](https://aws.amazon.com/blogs/opensource/build-full-stack-aws-applications-in-minutes-with-ai-powered-scaffolding/)をご覧ください。
+
+これまでに貢献し、問題を報告し、フィードバックをくださったすべての方に感謝します — 私たちはまだ始まったばかりです。いつものように、次に何を見たいか [ディスカッションを投稿](https://github.com/awslabs/nx-plugin-for-aws/discussions) するか、[問題を報告](https://github.com/awslabs/nx-plugin-for-aws/issues) してお知らせください！

--- a/docs/src/content/docs/ko/blog/migrating-from-aws-pdk.mdx
+++ b/docs/src/content/docs/ko/blog/migrating-from-aws-pdk.mdx
@@ -1,7 +1,7 @@
 ---
 title: AWS PDK에서 마이그레이션하기
 description: AWS Project Development Kit (PDK)에서 Nx Plugin for AWS로 마이그레이션하기
-date: 2025-09-26
+date: 2026-09-07
 authors:
  - jack
 ---
@@ -36,7 +36,7 @@ Nx Plugin for AWS로 마이그레이션하면 PDK 대비 다음과 같은 이점
 :::
 
 :::caution[특정 시점 가이드]
-이 가이드는 특정 시점의 가이드로 작성되었으며 Nx Plugin for AWS가 발전함에 따라 업데이트되지 않을 가능성이 높습니다. 이를 보완하기 위해 가이드는 `@aws/nx-plugin` 버전을 `1.0.0`로 고정합니다. 따라하실 때 최신 버전으로 시도할 수 있지만, 가이드와 약간의 차이가 있을 수 있습니다.
+이 가이드는 특정 시점의 가이드로 작성되었으며 Nx Plugin for AWS가 발전함에 따라 업데이트되지 않을 가능성이 높습니다. 이를 보완하기 위해 가이드는 `@aws/nx-plugin` 버전을 `1.0.0`로 고정합니다. 따라하실 때 최신 버전으로 시도할 수 있지만, 가이드와 약간의 차이가 있을 수 있습니다. 고정된 버전으로 가이드를 따라하는 경우, 나중에 <Link path="get_started/upgrading">워크스페이스를 업그레이드</Link>할 수 있습니다.
 :::
 
 ## 예제 마이그레이션: 쇼핑 목록 애플리케이션
@@ -80,7 +80,7 @@ Nx Plugin for AWS로 마이그레이션하면 PDK 대비 다음과 같은 이점
 
 PDK에서 이동할 때 일반적인 규칙으로, PDK Monorepo와의 유사성을 고려하여 Nx Workspace로 모든 프로젝트를 시작하는 것을 권장합니다. 또한 새로운 타입을 구축하는 기본 요소로 우리의 제너레이터를 사용하는 것을 권장합니다.
 
-<CreateNxWorkspaceCommand workspace="my-project" />
+<CreateNxWorkspaceCommand workspace="my-project" noOptions />
 
 ### CDK Graph
 

--- a/docs/src/content/docs/ko/blog/v1-0-0-released.mdx
+++ b/docs/src/content/docs/ko/blog/v1-0-0-released.mdx
@@ -1,0 +1,16 @@
+---
+title: v1.0.0 출시
+description: Nx Plugin for AWS가 1.0.0에 도달했습니다
+date: 2026-09-08
+authors:
+  - jack
+---
+import Link from '@components/link.astro';
+
+Nx Plugin for AWS가 [v1.0.0](https://github.com/awslabs/nx-plugin-for-aws/releases/tag/v1.0.0)에 도달했다는 소식을 알리게 되어 매우 기쁩니다! 첫 번째 릴리스 이후 프로덕션 프로젝트를 자신 있게 시작할 수 있는 툴킷을 구축해 왔으며, 1.0은 그 이정표입니다.
+
+몇 가지 주요 사항: 이제 제너레이터가 멱등성을 가지므로 재실행해도 항상 안전하며 코드를 덮어쓰지 않습니다. <Link path="get_started/upgrading">`nx migrate @aws/nx-plugin`</Link>이 완전히 지원되므로 버전을 올릴 때 업스트림에서 만든 개선 사항이 워크스페이스로 흘러들어갑니다. 새로운 <Link path="get_started/existing-project">`init` 제너레이터</Link>를 사용하면 기존 Nx 또는 비-Nx 리포지토리에서 플러그인을 채택할 수 있습니다. 제너레이터 전반에 걸쳐 CDK와 함께 Terraform 지원이 제공되고, 새로운 DynamoDB 및 관계형 데이터베이스 제너레이터가 추가되었으며, 에이전트와 MCP 서버가 기본적으로 AgentCore Runtime에 배포되고 새로운 AgentCore Gateway 제너레이터가 제공되며, 로컬 개발을 위한 단일 `dev` 타겟이 있습니다. 제너레이터 이름과 옵션이 표준화되었고, 툴체인이 Nx 23.2, ESM 및 Biome으로 이동했습니다. 보안 기본값도 강화되어 WAF, Cognito 위협 보호, 강제 CSP, API 액세스 로깅 및 이미지 스캐닝이 포함되었습니다.
+
+전체 출시 발표는 [AWS Open Source 블로그](https://aws.amazon.com/blogs/opensource/build-full-stack-aws-applications-in-minutes-with-ai-powered-scaffolding/)를 참조하세요.
+
+그동안 기여하고, 이슈를 제출하고, 피드백을 주신 모든 분들께 감사드립니다 — 이제 시작일 뿐입니다. 언제나처럼 다음에 보고 싶은 것을 알려주시려면 [토론을 게시](https://github.com/awslabs/nx-plugin-for-aws/discussions)하거나 [이슈를 제기](https://github.com/awslabs/nx-plugin-for-aws/issues)해 주세요!

--- a/docs/src/content/docs/pt/blog/migrating-from-aws-pdk.mdx
+++ b/docs/src/content/docs/pt/blog/migrating-from-aws-pdk.mdx
@@ -1,7 +1,7 @@
 ---
 title: Migrando do AWS PDK
 description: Migrando para o Nx Plugin for AWS a partir do AWS Project Development Kit (PDK)
-date: 2025-09-26
+date: 2026-09-07
 authors:
  - jack
 ---
@@ -36,7 +36,7 @@ Observe também que alguns recursos do PDK não têm equivalentes exatos. Consul
 :::
 
 :::caution[Guia de Momento Específico]
-Este guia foi escrito como um guia de momento específico e provavelmente não será atualizado conforme o Nx Plugin for AWS evolui. Para compensar isso, o guia fixa a versão do `@aws/nx-plugin` em `1.0.0`. Você pode tentar com a versão mais recente se estiver acompanhando, mas pode haver alguns desvios do guia.
+Este guia foi escrito como um guia de momento específico e provavelmente não será atualizado conforme o Nx Plugin for AWS evolui. Para compensar isso, o guia fixa a versão do `@aws/nx-plugin` em `1.0.0`. Você pode tentar com a versão mais recente se estiver acompanhando, mas pode haver alguns desvios do guia. Se você seguir o guia com a versão fixada, você pode <Link path="get_started/upgrading">atualizar seu workspace</Link> depois.
 :::
 
 ## Exemplo de Migração: Aplicação de Lista de Compras

--- a/docs/src/content/docs/pt/blog/v1-0-0-released.mdx
+++ b/docs/src/content/docs/pt/blog/v1-0-0-released.mdx
@@ -1,0 +1,16 @@
+---
+title: v1.0.0 Lançado
+description: O Nx Plugin for AWS alcança a versão 1.0.0
+date: 2026-09-08
+authors:
+  - jack
+---
+import Link from '@components/link.astro';
+
+Estamos entusiasmados em anunciar que o Nx Plugin for AWS alcançou a [v1.0.0](https://github.com/awslabs/nx-plugin-for-aws/releases/tag/v1.0.0)! Desde nosso primeiro lançamento, temos construído um conjunto de ferramentas com o qual você pode iniciar com confiança um projeto de produção, e a 1.0 é esse marco.
+
+Alguns destaques: os geradores agora são idempotentes, então executá-los novamente é sempre seguro e não sobrescreve seu código. <Link path="get_started/upgrading">`nx migrate @aws/nx-plugin`</Link> é totalmente suportado, então as melhorias que fazemos upstream fluem para seu workspace à medida que você atualiza as versões. Um novo <Link path="get_started/existing-project">gerador `init`</Link> permite que você adote o plugin em um repositório Nx ou não-Nx existente. Há suporte ao Terraform junto com CDK em todos os geradores, novos geradores de DynamoDB e banco de dados relacional, agentes e servidores MCP implantados no AgentCore Runtime por padrão com um novo gerador AgentCore Gateway, e um único target `dev` para desenvolvimento local. Os nomes e opções dos geradores foram padronizados, e a cadeia de ferramentas migra para Nx 23.2, ESM e Biome. Os padrões de segurança também foram reforçados, com WAF, proteção contra ameaças do Cognito, uma CSP aplicada, registro de acesso à API e verificação de imagens.
+
+Para o anúncio completo do lançamento, acesse o [blog AWS Open Source](https://aws.amazon.com/blogs/opensource/build-full-stack-aws-applications-in-minutes-with-ai-powered-scaffolding/).
+
+Obrigado a todos que contribuíram, registraram problemas e nos deram feedback ao longo do caminho — estamos apenas começando. Como sempre, [publique uma discussão](https://github.com/awslabs/nx-plugin-for-aws/discussions) ou [abra um problema](https://github.com/awslabs/nx-plugin-for-aws/issues) para nos informar o que você gostaria de ver a seguir!

--- a/docs/src/content/docs/vi/blog/migrating-from-aws-pdk.mdx
+++ b/docs/src/content/docs/vi/blog/migrating-from-aws-pdk.mdx
@@ -1,7 +1,7 @@
 ---
 title: Di chuyển từ AWS PDK
 description: Di chuyển sang Nx Plugin for AWS từ AWS Project Development Kit (PDK)
-date: 2025-09-26
+date: 2026-09-07
 authors:
  - jack
 ---
@@ -36,7 +36,7 @@ Cũng lưu ý rằng một số tính năng của PDK không có tương đươn
 :::
 
 :::caution[Hướng dẫn Tại Thời điểm]
-Đây được viết như một hướng dẫn tại thời điểm và rất có thể sẽ không được cập nhật khi Nx Plugin for AWS phát triển. Để bù đắp cho điều này, hướng dẫn ghim phiên bản của `@aws/nx-plugin` ở `1.0.0`. Bạn có thể thử với phiên bản mới nhất nếu làm theo, nhưng có thể có một số khác biệt so với hướng dẫn.
+Đây được viết như một hướng dẫn tại thời điểm và rất có thể sẽ không được cập nhật khi Nx Plugin for AWS phát triển. Để bù đắp cho điều này, hướng dẫn ghim phiên bản của `@aws/nx-plugin` ở `1.0.0`. Bạn có thể thử với phiên bản mới nhất nếu làm theo, nhưng có thể có một số khác biệt so với hướng dẫn. Nếu bạn làm theo hướng dẫn với phiên bản đã ghim, bạn có thể <Link path="get_started/upgrading">nâng cấp workspace của bạn</Link> sau đó.
 :::
 
 ## Ví dụ Di chuyển: Ứng dụng Danh sách Mua sắm
@@ -54,7 +54,7 @@ Trong hướng dẫn này, chúng ta sẽ sử dụng [Ứng dụng Danh sách M
 
 Để bắt đầu, chúng ta sẽ tạo một workspace mới cho dự án mới của chúng ta. Mặc dù cực đoan hơn so với di chuyển tại chỗ, cách tiếp cận này mang lại cho chúng ta kết quả cuối cùng sạch sẽ nhất. Tạo một Nx workspace tương đương với việc sử dụng `MonorepoTsProject` của PDK:
 
-<CreateNxWorkspaceCommand workspace="shopping-list" iac="cdk" tag="1.0.0" />
+<CreateNxWorkspaceCommand workspace="shopping-list" iac="cdk" tag="1.0.0" noOptions />
 
 Mở thư mục `shopping-list` mà lệnh này tạo ra trong IDE yêu thích của bạn.
 

--- a/docs/src/content/docs/vi/blog/v1-0-0-released.mdx
+++ b/docs/src/content/docs/vi/blog/v1-0-0-released.mdx
@@ -1,0 +1,16 @@
+---
+title: Phát hành v1.0.0
+description: Nx Plugin for AWS đạt phiên bản 1.0.0
+date: 2026-09-08
+authors:
+  - jack
+---
+import Link from '@components/link.astro';
+
+Chúng tôi vô cùng vui mừng thông báo rằng Nx Plugin for AWS đã đạt đến [v1.0.0](https://github.com/awslabs/nx-plugin-for-aws/releases/tag/v1.0.0)! Kể từ bản phát hành đầu tiên, chúng tôi đã xây dựng hướng tới một bộ công cụ mà bạn có thể tự tin bắt đầu một dự án production, và 1.0 chính là cột mốc đó.
+
+Một vài điểm nổi bật: các generator hiện đã idempotent, vì vậy việc chạy lại một generator luôn an toàn và không ghi đè code của bạn. <Link path="get_started/upgrading">`nx migrate @aws/nx-plugin`</Link> được hỗ trợ đầy đủ, do đó các cải tiến mà chúng tôi thực hiện upstream sẽ chảy vào workspace của bạn khi bạn nâng cấp phiên bản. Một <Link path="get_started/existing-project">`init` generator</Link> mới cho phép bạn áp dụng plugin vào một repo Nx hoặc không phải Nx hiện có. Có hỗ trợ Terraform cùng với CDK trên các generator, các generator DynamoDB và cơ sở dữ liệu quan hệ mới, các agent và MCP server được triển khai đến AgentCore Runtime theo mặc định với một generator AgentCore Gateway mới, và một target `dev` duy nhất cho phát triển local. Tên và tùy chọn của generator đã được chuẩn hóa, và toolchain chuyển sang Nx 23.2, ESM và Biome. Các mặc định bảo mật cũng đã được thắt chặt hơn, với WAF, bảo vệ mối đe dọa Cognito, CSP được thực thi, ghi log truy cập API và quét image.
+
+Để xem thông báo ra mắt đầy đủ, hãy truy cập [AWS Open Source blog](https://aws.amazon.com/blogs/opensource/build-full-stack-aws-applications-in-minutes-with-ai-powered-scaffolding/).
+
+Cảm ơn tất cả những người đã đóng góp, báo cáo vấn đề và đưa ra phản hồi cho chúng tôi trong suốt quá trình — chúng tôi mới chỉ bắt đầu. Như mọi khi, [đăng một thảo luận](https://github.com/awslabs/nx-plugin-for-aws/discussions) hoặc [tạo một issue](https://github.com/awslabs/nx-plugin-for-aws/issues) để cho chúng tôi biết bạn muốn thấy gì tiếp theo!

--- a/docs/src/content/docs/zh/blog/migrating-from-aws-pdk.mdx
+++ b/docs/src/content/docs/zh/blog/migrating-from-aws-pdk.mdx
@@ -1,7 +1,7 @@
 ---
 title: 从 AWS PDK 迁移
 description: 从 AWS Project Development Kit (PDK) 迁移到 Nx Plugin for AWS
-date: 2025-09-26
+date: 2026-09-07
 authors:
  - jack
 ---
@@ -36,7 +36,7 @@ import InstallCommand from '@components/install-command.astro';
 :::
 
 :::caution[时间点指南]
-这是作为时间点指南编写的，很可能不会随着 Nx Plugin for AWS 的发展而更新。为了弥补这一点，本指南将 `@aws/nx-plugin` 的版本固定为 `1.0.0`。如果您跟随操作，可以尝试使用最新版本，但可能会与指南有一些偏差。
+这是作为时间点指南编写的，很可能不会随着 Nx Plugin for AWS 的发展而更新。为了弥补这一点，本指南将 `@aws/nx-plugin` 的版本固定为 `1.0.0`。如果您跟随操作，可以尝试使用最新版本，但可能会与指南有一些偏差。如果您按照固定版本的指南操作，之后可以<Link path="get_started/upgrading">升级您的工作区</Link>。
 :::
 
 ## 示例迁移：购物清单应用程序
@@ -54,7 +54,7 @@ import InstallCommand from '@components/install-command.astro';
 
 首先，我们将为新项目创建一个新的工作区。虽然这比就地迁移更极端，但这种方法为我们提供了最干净的最终结果。创建 Nx 工作区相当于使用 PDK 的 `MonorepoTsProject`：
 
-<CreateNxWorkspaceCommand workspace="shopping-list" iac="cdk" tag="1.0.0" />
+<CreateNxWorkspaceCommand workspace="shopping-list" iac="cdk" tag="1.0.0" noOptions />
 
 在您喜欢的 IDE 中打开此命令创建的 `shopping-list` 目录。
 

--- a/docs/src/content/docs/zh/blog/v1-0-0-released.mdx
+++ b/docs/src/content/docs/zh/blog/v1-0-0-released.mdx
@@ -1,0 +1,16 @@
+---
+title: v1.0.0 发布
+description: Nx Plugin for AWS 达到 1.0.0 版本
+date: 2026-09-08
+authors:
+  - jack
+---
+import Link from '@components/link.astro';
+
+我们很高兴地宣布 Nx Plugin for AWS 已经达到 [v1.0.0](https://github.com/awslabs/nx-plugin-for-aws/releases/tag/v1.0.0) 版本！自首次发布以来，我们一直在构建一个您可以放心地用于启动生产项目的工具包，而 1.0 就是这个里程碑。
+
+一些亮点：生成器现在是幂等的，因此重新运行生成器始终是安全的，不会覆盖您的代码。<Link path="get_started/upgrading">`nx migrate @aws/nx-plugin`</Link> 得到完全支持，因此我们在上游所做的改进会随着您升级版本而流入您的工作区。新的 <Link path="get_started/existing-project">`init` 生成器</Link>让您可以在现有的 Nx 或非 Nx 仓库中采用该插件。生成器中除了 CDK 之外还支持 Terraform，新增了 DynamoDB 和关系数据库生成器，代理和 MCP 服务器默认部署到 AgentCore Runtime，并新增了 AgentCore Gateway 生成器，以及用于本地开发的单个 `dev` 目标。生成器名称和选项已标准化，工具链升级到 Nx 23.2、ESM 和 Biome。安全默认设置也得到了加强，包括 WAF、Cognito 威胁防护、强制执行的 CSP、API 访问日志记录和镜像扫描。
+
+有关完整的发布公告，请访问 [AWS Open Source 博客](https://aws.amazon.com/blogs/opensource/build-full-stack-aws-applications-in-minutes-with-ai-powered-scaffolding/)。
+
+感谢所有在此过程中做出贡献、提交问题和给予我们反馈的人——我们才刚刚开始。一如既往，请[发起讨论](https://github.com/awslabs/nx-plugin-for-aws/discussions)或[提出问题](https://github.com/awslabs/nx-plugin-for-aws/issues)，让我们知道您希望接下来看到什么！

--- a/docs/src/lib/blog-route.ts
+++ b/docs/src/lib/blog-route.ts
@@ -1,0 +1,25 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Route predicates for the pages starlight-blog owns, mirroring its own slug
+ * matching. Starlight applies a single override per component, so ours win over
+ * the plugin's and have to tell the blog routes apart themselves.
+ */
+const BLOG = /(?:^|\/)blog(?:\/|$)/;
+const BLOG_ROOT = /(?:^|\/)blog\/?$/;
+const BLOG_PAGINATION = /(?:^|\/)blog\/\d+\/?$/;
+const BLOG_TAG_OR_AUTHOR = /(?:^|\/)blog\/(?:tags|authors)\/.+$/;
+
+/** Every page starlight-blog owns: the post list, the posts, tags and authors. */
+const isBlogRoute = (id: string): boolean => BLOG.test(id);
+
+/** The paginated post list, which renders its own heading in place of a page title. */
+export const isBlogPostListRoute = (id: string): boolean =>
+  BLOG_ROOT.test(id) || BLOG_PAGINATION.test(id);
+
+/** An individual post, which carries a date and authors under its title. */
+export const isBlogPostRoute = (id: string): boolean =>
+  isBlogRoute(id) && !isBlogPostListRoute(id) && !BLOG_TAG_OR_AUTHOR.test(id);

--- a/docs/src/styles/custom.css
+++ b/docs/src/styles/custom.css
@@ -132,8 +132,8 @@ div.hero {
    to its blog list route, but under Astro 7 that global rule leaks into the
    shared CSS and hides the first content panel (page title or splash hero) on
    every page. Restore it here (the `main` prefix outspecifies the leaked
-   rule); header.astro re-emits the hide inline on blog routes only, preserving
-   starlight-blog's intended layout. */
+   rule); header.astro re-emits the hide inline on the post list only,
+   preserving starlight-blog's intended layout. */
 main .content-panel:first-of-type {
   display: block;
 }


### PR DESCRIPTION
### Reason for this change

v1.0.0 is out and there was no post announcing it. Two problems surfaced while writing it:

- Individual blog posts rendered without their title, date or author — the header only showed on the "all posts" page.
- The PDK migration guide is dated Sep 2025 but pins `@aws/nx-plugin` to `1.0.0`, and doesn't say what to do once you've followed it on a pinned version.

### Description of changes

**The post** — `docs/src/content/docs/en/blog/v1-0-0-released.mdx`, a few paragraphs by Jack. One paragraph covers the notable features from the [v1.0.0 release notes](https://github.com/awslabs/nx-plugin-for-aws/releases/tag/v1.0.0), linking the upgrading guide from `nx migrate @aws/nx-plugin` and the existing-project guide from the `init` generator, and pointing at the [AWS Open Source blog](https://aws.amazon.com/blogs/opensource/build-full-stack-aws-applications-in-minutes-with-ai-powered-scaffolding/) for the full launch announcement.

**The missing post header** — two independent causes:

1. Starlight applies one override per component, so `docs/src/components/markdown-content.astro` displaced the overrides `starlight-blog` and `starlight-videos` register (both log a warning at startup). The blog's date and authors never rendered, and the video player and transcript were being dropped the same way. `markdown-content.astro` now delegates to whichever of the two owns the route. `starlight-blog` resolves posts per locale, so locales still awaiting a translation fall through to Starlight's own rendering rather than failing the build.
2. `docs/src/components/header.astro` re-emitted the `content-panel:first-of-type{display:none}` rule `starlight-blog` scopes to its post list on *every* blog route, hiding the `<h1>` on posts and on tag and author pages. It's now scoped to the post list (blog root and pagination), which is what the plugin intends. The shared route predicates live in the new `docs/src/lib/blog-route.ts`.

**The PDK migration guide** — dated to the 1.0.0 release it pins, and the Point-in-Time caution now closes by linking the upgrading guide.

### Description of how you validated changes

- `pnpm nx run docs:build` passes (1549 pages) against the current `main`.
- Checked the built HTML per page kind: posts and the PDK guide have both an `h1` and `sl-blog-metadata`; the post list keeps its hide rule; tag and author pages no longer get it; untranslated locales render the body without the header instead of erroring.
- Viewed each page in a browser on a local dev server: post, post list, author page, a video page and the splash landing page all render as intended.

### Issue # (if applicable)

N/A.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*