### PR TITLE
docs: add missing generators to README's generator table

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,22 +90,29 @@ pnpm nx g @aws/nx-plugin:ts#infra
 
 | Generator            | Description                                                                                                                              |
 | -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `init`               | Configure an existing Nx workspace to use the plugin                                                                                     |
 | `ts#project`         | TypeScript library                                                                                                                       |
 | `ts#api`             | TypeScript API (tRPC or Smithy) with API Gateway + Lambda + [Powertools](https://github.com/aws-powertools/powertools-lambda-typescript) |
 | `ts#rdb`             | Relational databases with Aurora RDS                                                                                                     |
+| `ts#dynamodb`        | Type-safe DynamoDB single-table design (TypeScript, ElectroDB)                                                                           |
 | `ts#website`         | React app (Vite)                                                                                                                         |
 | `ts#website#auth`    | Add Cognito auth to a website                                                                                                            |
 | `ts#infra`           | AWS CDK infrastructure project                                                                                                           |
 | `ts#lambda-function` | TypeScript Lambda with type-safe event sources                                                                                           |
 | `ts#mcp-server`      | MCP server (TypeScript)                                                                                                                  |
+| `ts#dcr-proxy`       | OAuth DCR proxy construct for Cognito-authenticated MCP servers                                                                          |
 | `ts#agent`           | [Strands Agent](https://strandsagents.com/) (TypeScript)                                                                                 |
 | `ts#nx-generator`    | Nx generator scaffold                                                                                                                    |
+| `ts#docs`            | Documentation site (Astro + Starlight)                                                                                                   |
 | `smithy#project`     | Smithy model project — a service model, or a shape library shared between Smithy projects                                                |
 | `py#project`         | Python project (uv)                                                                                                                      |
 | `py#api`             | Python API (FastAPI) with API Gateway + Lambda + [Powertools](https://github.com/aws-powertools/powertools-lambda-python)                |
+| `py#rdb`             | Relational databases with Aurora RDS (Python)                                                                                            |
+| `py#dynamodb`        | Python DynamoDB project                                                                                                                   |
 | `py#lambda-function` | Python Lambda with type-safe event sources                                                                                               |
 | `py#mcp-server`      | MCP server (Python)                                                                                                                      |
 | `py#agent`           | [Strands Agent](https://strandsagents.com/) (Python)                                                                                     |
+| `agentcore-gateway`  | [AgentCore Gateway](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/gateway.html) project                                  |
 | `agentcore-harness`  | [AgentCore Harness](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/harness.html) agent loop (experimental)                |
 | `connection`         | Connect projects together (e.g. frontend to API)                                                                                         |
 | `terraform#project`  | Terraform project                                                                                                                        |

--- a/packages/nx-plugin/README.md
+++ b/packages/nx-plugin/README.md
@@ -90,22 +90,29 @@ pnpm nx g @aws/nx-plugin:ts#infra
 
 | Generator            | Description                                                                                                                              |
 | -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `init`               | Configure an existing Nx workspace to use the plugin                                                                                     |
 | `ts#project`         | TypeScript library                                                                                                                       |
 | `ts#api`             | TypeScript API (tRPC or Smithy) with API Gateway + Lambda + [Powertools](https://github.com/aws-powertools/powertools-lambda-typescript) |
 | `ts#rdb`             | Relational databases with Aurora RDS                                                                                                     |
+| `ts#dynamodb`        | Type-safe DynamoDB single-table design (TypeScript, ElectroDB)                                                                           |
 | `ts#website`         | React app (Vite)                                                                                                                         |
 | `ts#website#auth`    | Add Cognito auth to a website                                                                                                            |
 | `ts#infra`           | AWS CDK infrastructure project                                                                                                           |
 | `ts#lambda-function` | TypeScript Lambda with type-safe event sources                                                                                           |
 | `ts#mcp-server`      | MCP server (TypeScript)                                                                                                                  |
+| `ts#dcr-proxy`       | OAuth DCR proxy construct for Cognito-authenticated MCP servers                                                                          |
 | `ts#agent`           | [Strands Agent](https://strandsagents.com/) (TypeScript)                                                                                 |
 | `ts#nx-generator`    | Nx generator scaffold                                                                                                                    |
+| `ts#docs`            | Documentation site (Astro + Starlight)                                                                                                   |
 | `smithy#project`     | Smithy model project — a service model, or a shape library shared between Smithy projects                                                |
 | `py#project`         | Python project (uv)                                                                                                                      |
 | `py#api`             | Python API (FastAPI) with API Gateway + Lambda + [Powertools](https://github.com/aws-powertools/powertools-lambda-python)                |
+| `py#rdb`             | Relational databases with Aurora RDS (Python)                                                                                            |
+| `py#dynamodb`        | Python DynamoDB project                                                                                                                   |
 | `py#lambda-function` | Python Lambda with type-safe event sources                                                                                               |
 | `py#mcp-server`      | MCP server (Python)                                                                                                                      |
 | `py#agent`           | [Strands Agent](https://strandsagents.com/) (Python)                                                                                     |
+| `agentcore-gateway`  | [AgentCore Gateway](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/gateway.html) project                                  |
 | `agentcore-harness`  | [AgentCore Harness](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/harness.html) agent loop (experimental)                |
 | `connection`         | Connect projects together (e.g. frontend to API)                                                                                         |
 | `terraform#project`  | Terraform project                                                                                                                        |


### PR DESCRIPTION
### Reason for this change

The "Available Generators" table in README.md had drifted out of sync with `packages/nx-plugin/generators.json`. Several public (non-hidden) generators added since the table was last touched were missing, even though they each have dedicated docs guide pages — `init`, `ts#dynamodb`, `ts#dcr-proxy`, `ts#docs`, `py#rdb`, `py#dynamodb`, and `agentcore-gateway`.

### Description of changes

Added the missing rows to the generator table (both `packages/nx-plugin/README.md`, the source of truth, and the root `README.md` copy), keeping the existing grouping/style. Left out `ts#nx-plugin` and `ts#nx-migration` since those are meta generators for building/maintaining your own Nx plugin rather than for building an AWS application, consistent with the table's existing scope.

### Description of how you validated changes

Docs-only change; no code/tests affected. Cross-checked the full list of non-hidden generators in `generators.json` against the table, and confirmed the added generators' docs guide pages already exist (including translated locales).

### Issue # (if applicable)

N/A

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/nx-plugin-for-aws/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/awslabs/nx-plugin-for-aws/blob/main/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*